### PR TITLE
feat(public-api): Threa-Version header versioning — dated versions pinned per key (Phase 1)

### DIFF
--- a/.agents/skills/threa-public-api/SKILL.md
+++ b/.agents/skills/threa-public-api/SKILL.md
@@ -52,6 +52,17 @@ return 403). The key is bound to one workspace; the `{workspaceId}` in the
 path must match it. Each endpoint requires a permission scope (column
 below) — a missing scope returns 403/404.
 
+## Versioning
+
+The API is versioned by date (e.g. `2026-07-12`). Each key is pinned to a
+version when it is minted, and that pin applies to every request, so you do not
+need to send anything. Pass `Threa-Version: <date>` to override the pin for a
+single request; a valid header wins over the pin. An unknown value returns
+`400` with code `INVALID_API_VERSION` and the known versions in the error.
+Every response echoes the resolved version in a `Threa-Version` response
+header. The `/api/v1` path prefix is stable and does not change with versions.
+The generated changelog is `docs/public-api/CHANGELOG.md`.
+
 ## Workspace & stream IDs
 
 Threa app URLs encode both IDs — copy them straight out:

--- a/.agents/skills/threa-public-api/SKILL.md
+++ b/.agents/skills/threa-public-api/SKILL.md
@@ -59,8 +59,8 @@ version when it is minted, and that pin applies to every request, so you do not
 need to send anything. Pass `Threa-Version: <date>` to override the pin for a
 single request; a valid header wins over the pin. An unknown value returns
 `400` with code `INVALID_API_VERSION` and the known versions in the error.
-Every response echoes the resolved version in a `Threa-Version` response
-header. The `/api/v1` path prefix is stable and does not change with versions.
+Every response that resolved a version echoes it in a `Threa-Version`
+response header (the 400 for an unknown version has none to echo). The `/api/v1` path prefix is stable and does not change with versions.
 The generated changelog is `docs/public-api/CHANGELOG.md`.
 
 `GET .../me` reports the key's version state as `data.apiVersion`

--- a/.agents/skills/threa-public-api/SKILL.md
+++ b/.agents/skills/threa-public-api/SKILL.md
@@ -63,6 +63,12 @@ Every response echoes the resolved version in a `Threa-Version` response
 header. The `/api/v1` path prefix is stable and does not change with versions.
 The generated changelog is `docs/public-api/CHANGELOG.md`.
 
+`GET .../me` reports the key's version state as `data.apiVersion`
+(`{ pinned, resolved, current, supported }`; `pinned: null` means the key is
+unpinned and tracks the current version). The pin is changed via the app's key
+management API (`PATCH` the key with `{"apiVersion": "<date>"}` or
+`{"apiVersion": null}` to unpin), not via the public API.
+
 ## Workspace & stream IDs
 
 Threa app URLs encode both IDs — copy them straight out:

--- a/apps/backend/scripts/generate-api-docs.ts
+++ b/apps/backend/scripts/generate-api-docs.ts
@@ -12,7 +12,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs"
 import * as prettier from "prettier"
 import { PUBLIC_API_ROUTES, errorSchema } from "../src/features/public-api/routes"
 import { API_VERSIONS, CURRENT_API_VERSION, VERSION_CHANGES } from "../src/features/public-api/versions"
-import { API_KEY_ELIGIBLE_PICKER_SCOPES } from "@threa/types"
+import { API_KEY_ELIGIBLE_PICKER_SCOPES, THREA_VERSION_HEADER } from "@threa/types"
 
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..")
 const OUTPUT_PATH = resolve(REPO_ROOT, "docs/public-api/openapi.json")
@@ -281,7 +281,7 @@ function buildSpec() {
     components: {
       parameters: {
         ThreaVersion: {
-          name: "Threa-Version",
+          name: THREA_VERSION_HEADER,
           in: "header",
           required: false,
           schema: { type: "string", enum: [...API_VERSIONS] },

--- a/apps/backend/scripts/generate-api-docs.ts
+++ b/apps/backend/scripts/generate-api-docs.ts
@@ -11,11 +11,18 @@ import { resolve, dirname } from "path"
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs"
 import * as prettier from "prettier"
 import { PUBLIC_API_ROUTES, errorSchema } from "../src/features/public-api/routes"
+import { API_VERSIONS, CURRENT_API_VERSION, VERSION_CHANGES } from "../src/features/public-api/versions"
 import { API_KEY_ELIGIBLE_PICKER_SCOPES } from "@threa/types"
 
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..")
 const OUTPUT_PATH = resolve(REPO_ROOT, "docs/public-api/openapi.json")
+const CHANGELOG_PATH = resolve(REPO_ROOT, "docs/public-api/CHANGELOG.md")
 const CHECK_MODE = process.argv.includes("--check")
+
+// The epoch version predates the version-change machinery, so it has no module
+// in VERSION_CHANGES; seed its changelog entry here.
+const EPOCH_VERSION = API_VERSIONS[0]
+const EPOCH_CHANGELOG_DESCRIPTION = "Initial versioned API."
 
 // ---------------------------------------------------------------------------
 // Zod → JSON Schema conversion
@@ -110,8 +117,10 @@ function buildSpec() {
     // Security — list required scopes
     operation.security = [{ apiKey: route.scopes }]
 
-    // Parameters (path + query)
-    const parameters: unknown[] = []
+    // Parameters (path + query). Threa-Version leads every operation via a
+    // shared component so the versioning header is documented once and referenced
+    // everywhere.
+    const parameters: unknown[] = [{ $ref: "#/components/parameters/ThreaVersion" }]
 
     if (route.parameters) {
       for (const p of route.parameters) {
@@ -224,7 +233,7 @@ function buildSpec() {
     openapi: "3.0.3",
     info: {
       title: "Threa Public API",
-      version: "1.0.0",
+      version: CURRENT_API_VERSION,
       description: [
         "The Threa Public API lets you programmatically read and write messages, list streams, search, and more.",
         "",
@@ -270,6 +279,22 @@ function buildSpec() {
     security: [{ apiKey: [] }],
     paths,
     components: {
+      parameters: {
+        ThreaVersion: {
+          name: "Threa-Version",
+          in: "header",
+          required: false,
+          schema: { type: "string", enum: [...API_VERSIONS] },
+          description: [
+            "Selects the dated API version for this request. Each API key is pinned to a",
+            "version when it is minted, and that pin applies when the header is absent. Send",
+            "this header to override the pin per request (a valid header always wins). The",
+            "value must be an exact member of the enum; an unknown or malformed value returns",
+            "400 with code INVALID_API_VERSION and the known versions in the error. Every",
+            "response echoes the resolved version in a Threa-Version response header.",
+          ].join(" "),
+        },
+      },
       securitySchemes: {
         apiKey: {
           type: "http",
@@ -284,6 +309,30 @@ function buildSpec() {
 }
 
 // ---------------------------------------------------------------------------
+// Changelog
+// ---------------------------------------------------------------------------
+
+// Newest version first, with the epoch (which has no change module) last.
+function buildChangelog(): string {
+  const entries = [...VERSION_CHANGES]
+    .sort((a, b) => (a.version < b.version ? 1 : -1))
+    .map((change) => {
+      const ops = [...change.operations].sort()
+      const affected = ops.length > 0 ? `\n\nAffected operations: ${ops.join(", ")}` : ""
+      return `## ${change.version}\n\n${change.description}${affected}`
+    })
+  entries.push(`## ${EPOCH_VERSION}\n\n${EPOCH_CHANGELOG_DESCRIPTION}`)
+  return [
+    "# Threa Public API changelog",
+    "",
+    "Generated from the version-change modules. Do not edit by hand.",
+    "",
+    entries.join("\n\n"),
+    "",
+  ].join("\n")
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -293,21 +342,33 @@ const json = await prettier.format(JSON.stringify(spec), {
   ...prettierConfig,
   filepath: OUTPUT_PATH,
 })
+const changelog = await prettier.format(buildChangelog(), {
+  ...prettierConfig,
+  filepath: CHANGELOG_PATH,
+})
+
+const outputs = [
+  { path: OUTPUT_PATH, contents: json, label: "OpenAPI spec" },
+  { path: CHANGELOG_PATH, contents: changelog, label: "changelog" },
+]
 
 if (CHECK_MODE) {
-  if (!existsSync(OUTPUT_PATH)) {
-    console.error(`OpenAPI spec not found at ${OUTPUT_PATH}. Run: bun apps/backend/scripts/generate-api-docs.ts`)
-    process.exit(1)
+  for (const { path, contents, label } of outputs) {
+    if (!existsSync(path)) {
+      console.error(`${label} not found at ${path}. Run: bun apps/backend/scripts/generate-api-docs.ts`)
+      process.exit(1)
+    }
+    if (readFileSync(path, "utf-8") !== contents) {
+      console.error(`${label} is out of date. Run: bun apps/backend/scripts/generate-api-docs.ts`)
+      process.exit(1)
+    }
   }
-  const existing = readFileSync(OUTPUT_PATH, "utf-8")
-  if (existing !== json) {
-    console.error("OpenAPI spec is out of date. Run: bun apps/backend/scripts/generate-api-docs.ts")
-    process.exit(1)
-  }
-  console.log("OpenAPI spec is up to date.")
+  console.log("OpenAPI spec and changelog are up to date.")
   process.exit(0)
 }
 
-mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
-writeFileSync(OUTPUT_PATH, json)
-console.log(`Wrote OpenAPI spec to ${OUTPUT_PATH}`)
+for (const { path, contents, label } of outputs) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, contents)
+  console.log(`Wrote ${label} to ${path}`)
+}

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -5,7 +5,7 @@ import helmet from "helmet"
 import cookieParser from "cookie-parser"
 import pinoHttp from "pino-http"
 import { randomUUID } from "crypto"
-import { INTERNAL_API_KEY_HEADER } from "@threa/types"
+import { INTERNAL_API_KEY_HEADER, THREA_VERSION_HEADER } from "@threa/types"
 import { logger } from "./lib/logger"
 import { bigIntReplacer } from "@threa/backend-common"
 import { createMetricsMiddleware } from "./middleware/metrics"
@@ -61,7 +61,7 @@ export function createApp(options: CreateAppOptions): Express {
       credentials: true,
       // Cross-origin callers (developer playground) must be able to read the
       // resolved public API version the gate echoes back.
-      exposedHeaders: ["Threa-Version"],
+      exposedHeaders: [THREA_VERSION_HEADER],
     })
   )
   app.use(cookieParser())

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,6 +9,7 @@ import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import { logger } from "./lib/logger"
 import { bigIntReplacer } from "@threa/backend-common"
 import { createMetricsMiddleware } from "./middleware/metrics"
+import type { ApiVersionLog } from "./middleware/api-version"
 import { createCorsOriginChecker } from "./lib/cors"
 
 interface CreateAppOptions {
@@ -54,7 +55,15 @@ export function createApp(options: CreateAppOptions): Express {
     })
   )
 
-  app.use(cors({ origin: createCorsOriginChecker(options.corsAllowedOrigins), credentials: true }))
+  app.use(
+    cors({
+      origin: createCorsOriginChecker(options.corsAllowedOrigins),
+      credentials: true,
+      // Cross-origin callers (developer playground) must be able to read the
+      // resolved public API version the gate echoes back.
+      exposedHeaders: ["Threa-Version"],
+    })
+  )
   app.use(cookieParser())
   app.use(express.json({ limit: "10mb" }))
   app.use(express.urlencoded({ extended: true, limit: "10mb" }))
@@ -71,6 +80,10 @@ export function createApp(options: CreateAppOptions): Express {
         return "silent"
       },
       genReqId: (req) => (req.headers["x-request-id"] as string) || randomUUID(),
+      // Public API version telemetry — the api-version gate stashes the requested
+      // version, its source (header override vs key pin), the key id, and the
+      // operationId on res.locals; empty object for every non-public-API request.
+      customProps: (_req, res) => (res as { locals?: { apiVersionLog?: ApiVersionLog } }).locals?.apiVersionLog ?? {},
       redact: {
         // The default pino-http req serializer logs the full headers object, so
         // every secret-bearing header must be redacted here or it lands in the

--- a/apps/backend/src/db/migrations/20260712112325_public_api_version_pin.sql
+++ b/apps/backend/src/db/migrations/20260712112325_public_api_version_pin.sql
@@ -1,0 +1,13 @@
+-- Public API header versioning (Phase 1): pin each API key to the dated wire
+-- version it was minted against. The resolved version is header-overridable per
+-- request, but the pin is the floor when no `Threa-Version` header is sent.
+--
+-- `TEXT`, validated in code against API_VERSIONS (INV-3 no DB enums). Existing
+-- keys already speak today's shapes, which ARE the epoch version, so backfill
+-- every pre-existing row to the epoch. New rows are written CURRENT_API_VERSION
+-- by the key services. Workspace-scoped tables (INV-8); no FKs (INV-1).
+ALTER TABLE user_api_keys ADD COLUMN IF NOT EXISTS api_version TEXT;
+ALTER TABLE bot_api_keys ADD COLUMN IF NOT EXISTS api_version TEXT;
+
+UPDATE user_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;
+UPDATE bot_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;

--- a/apps/backend/src/db/migrations/20260712152857_api_version_insert_default.sql
+++ b/apps/backend/src/db/migrations/20260712152857_api_version_insert_default.sql
@@ -1,0 +1,14 @@
+-- Close the rolling-deploy window on api_version pinning: instances running
+-- pre-column code INSERT without api_version, which lands NULL — and NULL now
+-- means "deliberately unpinned, tracks the current version". A DEFAULT makes
+-- those old-code mints epoch-pinned like every other pre-existing key; new
+-- code always writes the pin explicitly, so the DEFAULT is only ever hit by
+-- code that predates the column.
+ALTER TABLE user_api_keys ALTER COLUMN api_version SET DEFAULT '2026-07-12';
+ALTER TABLE bot_api_keys ALTER COLUMN api_version SET DEFAULT '2026-07-12';
+
+-- Rows minted by old code between the first backfill and this statement (same
+-- deploy). Deliberate unpins cannot exist yet: the detach feature ships with
+-- the code this migration precedes.
+UPDATE user_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;
+UPDATE bot_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;

--- a/apps/backend/src/features/bot-runtimes/socket-auth.test.ts
+++ b/apps/backend/src/features/bot-runtimes/socket-auth.test.ts
@@ -21,6 +21,7 @@ function makeKey(overrides: Partial<ValidatedBotApiKey> = {}): ValidatedBotApiKe
     botId: "bot_alice",
     name: "default",
     scopes: new Set([WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE]),
+    apiVersion: "2026-07-12",
     ...overrides,
   }
 }

--- a/apps/backend/src/features/bot-runtimes/socket-auth.test.ts
+++ b/apps/backend/src/features/bot-runtimes/socket-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test"
 import type { Socket } from "socket.io"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import type { BotApiKeyService, ValidatedBotApiKey } from "../public-api"
+import { CURRENT_API_VERSION } from "../public-api"
 import { createBotSocketAuthMiddleware } from "./socket-auth"
 
 function fakeSocket(opts: { token?: string; headerAuth?: string } = {}): Socket {
@@ -21,7 +22,7 @@ function makeKey(overrides: Partial<ValidatedBotApiKey> = {}): ValidatedBotApiKe
     botId: "bot_alice",
     name: "default",
     scopes: new Set([WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE]),
-    apiVersion: "2026-07-12",
+    apiVersion: CURRENT_API_VERSION,
     ...overrides,
   }
 }

--- a/apps/backend/src/features/public-api/bot-api-key-repository.ts
+++ b/apps/backend/src/features/public-api/bot-api-key-repository.ts
@@ -102,6 +102,22 @@ export const BotApiKeyRepository = {
     return result.rows[0] ? mapRow(result.rows[0]) : null
   },
 
+  async updateApiVersionOwned(
+    db: Querier,
+    workspaceId: string,
+    botId: string,
+    id: string,
+    apiVersion: string | null
+  ): Promise<BotApiKeyRow | null> {
+    const result = await db.query<Record<string, unknown>>(sql`
+      UPDATE bot_api_keys
+      SET api_version = ${apiVersion}
+      WHERE id = ${id} AND workspace_id = ${workspaceId} AND bot_id = ${botId} AND revoked_at IS NULL
+      RETURNING ${sql.raw(SELECT_FIELDS)}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
   async revokeOwned(
     db: Querier,
     workspaceId: string,

--- a/apps/backend/src/features/public-api/bot-api-key-repository.ts
+++ b/apps/backend/src/features/public-api/bot-api-key-repository.ts
@@ -9,6 +9,7 @@ export interface BotApiKeyRow {
   keyHash: string
   keyPrefix: string
   scopes: string[]
+  apiVersion: string | null
   lastUsedAt: Date | null
   expiresAt: Date | null
   revokedAt: Date | null
@@ -17,7 +18,7 @@ export interface BotApiKeyRow {
 
 const SELECT_FIELDS = `
   id, workspace_id, bot_id, name, key_hash, key_prefix, scopes,
-  last_used_at, expires_at, revoked_at, created_at
+  api_version, last_used_at, expires_at, revoked_at, created_at
 `
 
 function mapRow(row: Record<string, unknown>): BotApiKeyRow {
@@ -29,6 +30,7 @@ function mapRow(row: Record<string, unknown>): BotApiKeyRow {
     keyHash: row.key_hash as string,
     keyPrefix: row.key_prefix as string,
     scopes: row.scopes as string[],
+    apiVersion: row.api_version as string | null,
     lastUsedAt: row.last_used_at as Date | null,
     expiresAt: row.expires_at as Date | null,
     revokedAt: row.revoked_at as Date | null,
@@ -47,14 +49,15 @@ export const BotApiKeyRepository = {
       keyHash: string
       keyPrefix: string
       scopes: string[]
+      apiVersion: string
       expiresAt: Date | null
     }
   ): Promise<BotApiKeyRow> {
     const result = await db.query<Record<string, unknown>>(sql`
-      INSERT INTO bot_api_keys (id, workspace_id, bot_id, name, key_hash, key_prefix, scopes, expires_at)
+      INSERT INTO bot_api_keys (id, workspace_id, bot_id, name, key_hash, key_prefix, scopes, api_version, expires_at)
       VALUES (
         ${params.id}, ${params.workspaceId}, ${params.botId}, ${params.name},
-        ${params.keyHash}, ${params.keyPrefix}, ${params.scopes}, ${params.expiresAt}
+        ${params.keyHash}, ${params.keyPrefix}, ${params.scopes}, ${params.apiVersion}, ${params.expiresAt}
       )
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)

--- a/apps/backend/src/features/public-api/bot-api-key-repository.ts
+++ b/apps/backend/src/features/public-api/bot-api-key-repository.ts
@@ -1,5 +1,6 @@
 import { sql } from "../../db"
 import type { Querier } from "../../db"
+import type { ApiVersion } from "./versions"
 
 export interface BotApiKeyRow {
   id: string
@@ -49,7 +50,7 @@ export const BotApiKeyRepository = {
       keyHash: string
       keyPrefix: string
       scopes: string[]
-      apiVersion: string
+      apiVersion: ApiVersion
       expiresAt: Date | null
     }
   ): Promise<BotApiKeyRow> {
@@ -107,7 +108,7 @@ export const BotApiKeyRepository = {
     workspaceId: string,
     botId: string,
     id: string,
-    apiVersion: string | null
+    apiVersion: ApiVersion | null
   ): Promise<BotApiKeyRow | null> {
     const result = await db.query<Record<string, unknown>>(sql`
       UPDATE bot_api_keys

--- a/apps/backend/src/features/public-api/bot-api-key-service.ts
+++ b/apps/backend/src/features/public-api/bot-api-key-service.ts
@@ -6,6 +6,7 @@ import { botApiKeyId } from "../../lib/id"
 import { HttpError } from "@threa/backend-common"
 import type { WorkspacePermissionSlug } from "@threa/types"
 import { API_KEY_ELIGIBLE_SCOPES, BOT_KEY_PREFIX } from "@threa/types"
+import { CURRENT_API_VERSION, type ApiVersion } from "./versions"
 
 const KEY_BYTE_LENGTH = 32
 const STORED_PREFIX_LENGTH = 8
@@ -39,6 +40,8 @@ export interface ValidatedBotApiKey {
   botId: string
   name: string
   scopes: Set<string>
+  /** Wire version the key is pinned to; the version gate's floor when no header is sent. */
+  apiVersion: ApiVersion
 }
 
 export class BotApiKeyService {
@@ -98,6 +101,7 @@ export class BotApiKeyService {
         keyHash,
         keyPrefix,
         scopes: params.scopes,
+        apiVersion: CURRENT_API_VERSION,
         expiresAt: params.expiresAt,
       })
     })
@@ -167,6 +171,7 @@ export class BotApiKeyService {
       botId: match.botId,
       name: match.name,
       scopes: new Set(match.scopes),
+      apiVersion: (match.apiVersion ?? CURRENT_API_VERSION) as ApiVersion,
     }
   }
 }

--- a/apps/backend/src/features/public-api/bot-api-key-service.ts
+++ b/apps/backend/src/features/public-api/bot-api-key-service.ts
@@ -40,8 +40,8 @@ export interface ValidatedBotApiKey {
   botId: string
   name: string
   scopes: Set<string>
-  /** Wire version the key is pinned to; the version gate's floor when no header is sent. */
-  apiVersion: ApiVersion
+  /** Pinned wire version, or null when unpinned — the version gate then resolves to the current version. */
+  apiVersion: ApiVersion | null
 }
 
 export class BotApiKeyService {
@@ -133,6 +133,26 @@ export class BotApiKeyService {
     return row
   }
 
+  async updateApiVersion(params: {
+    workspaceId: string
+    botId: string
+    keyId: string
+    /** A supported version to pin to, or null to unpin (the key then tracks the current version). */
+    apiVersion: ApiVersion | null
+  }): Promise<BotApiKeyRow> {
+    const row = await BotApiKeyRepository.updateApiVersionOwned(
+      this.pool,
+      params.workspaceId,
+      params.botId,
+      params.keyId,
+      params.apiVersion
+    )
+    if (!row) {
+      throw new HttpError("API key not found", { status: 404, code: "NOT_FOUND" })
+    }
+    return row
+  }
+
   async revokeKey(workspaceId: string, botId: string, keyId: string): Promise<void> {
     const result = await BotApiKeyRepository.revokeOwned(this.pool, workspaceId, botId, keyId)
     if (result === "not_found") {
@@ -171,7 +191,7 @@ export class BotApiKeyService {
       botId: match.botId,
       name: match.name,
       scopes: new Set(match.scopes),
-      apiVersion: (match.apiVersion ?? CURRENT_API_VERSION) as ApiVersion,
+      apiVersion: match.apiVersion as ApiVersion | null,
     }
   }
 }

--- a/apps/backend/src/features/public-api/bot-handlers.ts
+++ b/apps/backend/src/features/public-api/bot-handlers.ts
@@ -16,6 +16,7 @@ import { OutboxRepository } from "../../lib/outbox"
 import { HttpError } from "@threa/backend-common"
 import { isUniqueViolation } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
+import { API_VERSIONS, type ApiVersion } from "./versions"
 import {
   API_KEY_ELIGIBLE_SCOPES,
   BOT_TRAITS,
@@ -60,9 +61,15 @@ const createBotKeySchema = z.object({
     }),
 })
 
-const updateBotKeySchema = z.object({
-  scopes: z.array(z.enum(API_KEY_ELIGIBLE_SCOPES)).min(1, "at least one scope is required"),
-})
+const updateBotKeySchema = z
+  .object({
+    scopes: z.array(z.enum(API_KEY_ELIGIBLE_SCOPES)).min(1, "at least one scope is required").optional(),
+    // A supported version pins the key; null unpins it (the key then tracks the current version).
+    apiVersion: z.enum(API_VERSIONS).nullable().optional(),
+  })
+  .refine((data) => data.scopes !== undefined || data.apiVersion !== undefined, {
+    message: "provide scopes and/or apiVersion",
+  })
 
 function serializeBotKey(row: BotApiKeyRow): BotApiKey {
   return {
@@ -71,6 +78,7 @@ function serializeBotKey(row: BotApiKeyRow): BotApiKey {
     name: row.name,
     keyPrefix: row.keyPrefix,
     scopes: row.scopes as WorkspacePermissionSlug[],
+    apiVersion: row.apiVersion,
     lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
     expiresAt: row.expiresAt?.toISOString() ?? null,
     revokedAt: row.revokedAt?.toISOString() ?? null,
@@ -349,13 +357,24 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
       const workspaceId = req.workspaceId!
       const { botId: id, keyId } = req.params
       const data = validateRequest(updateBotKeySchema, req.body)
-      const row = await botApiKeyService.updateScopes({
-        workspaceId,
-        botId: id,
-        keyId,
-        scopes: data.scopes as WorkspacePermissionSlug[],
-      })
-      res.json({ data: serializeBotKey(row) })
+      let row: BotApiKeyRow | undefined
+      if (data.scopes !== undefined) {
+        row = await botApiKeyService.updateScopes({
+          workspaceId,
+          botId: id,
+          keyId,
+          scopes: data.scopes as WorkspacePermissionSlug[],
+        })
+      }
+      if (data.apiVersion !== undefined) {
+        row = await botApiKeyService.updateApiVersion({
+          workspaceId,
+          botId: id,
+          keyId,
+          apiVersion: data.apiVersion as ApiVersion | null,
+        })
+      }
+      res.json({ data: serializeBotKey(row!) })
     },
 
     /** POST /api/workspaces/:workspaceId/bots/:botId/keys/:keyId/revoke */

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -115,6 +115,7 @@ import type {
   WireLabel,
   WireLabelAssignment,
 } from "./routes"
+import { API_VERSIONS, CURRENT_API_VERSION } from "./versions"
 import {
   publicSearchSchema,
   listStreamsSchema,
@@ -2322,6 +2323,16 @@ export function createPublicApiHandlers({
     async getMe(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
+      // Version introspection for agents: the key's pin (null = unpinned,
+      // tracks current), what this request resolved to (req.apiVersion, set by
+      // the version gate), and the full supported list.
+      const apiVersion = {
+        pinned: req.userApiKey ? req.userApiKey.apiVersion : (req.botApiKey?.apiVersion ?? null),
+        resolved: req.apiVersion ?? CURRENT_API_VERSION,
+        current: CURRENT_API_VERSION,
+        supported: [...API_VERSIONS],
+      }
+
       if (req.userApiKey) {
         const user = req.user!
         res.json({
@@ -2329,6 +2340,7 @@ export function createPublicApiHandlers({
             kind: "user",
             workspaceId,
             userId: user.id,
+            apiVersion,
           },
         })
         return
@@ -2347,6 +2359,7 @@ export function createPublicApiHandlers({
             botType: bot.type,
             traits: bot.traits,
             ownerUserId: bot.ownerUserId,
+            apiVersion,
           },
         })
         return

--- a/apps/backend/src/features/public-api/index.ts
+++ b/apps/backend/src/features/public-api/index.ts
@@ -1,5 +1,7 @@
 export { createPublicApiHandlers, serializeBot, type PublicApiDeps } from "./handlers"
 export { createDelegationPublicApiHandlers } from "./delegation-handlers"
+export { PUBLIC_API_ROUTES, type OperationId } from "./routes"
+export { toExpressPath, assertHandlerParity } from "./mount"
 export { createBotRuntimeWriteOps, type BotRuntimeWriteOpsDeps } from "./runtime-write-ops"
 export { serializeTraceStep, botInvocationStepEvents, BotInvocationTraceSink } from "./trace-steps"
 export {

--- a/apps/backend/src/features/public-api/index.ts
+++ b/apps/backend/src/features/public-api/index.ts
@@ -2,6 +2,7 @@ export { createPublicApiHandlers, serializeBot, type PublicApiDeps } from "./han
 export { createDelegationPublicApiHandlers } from "./delegation-handlers"
 export { PUBLIC_API_ROUTES, type OperationId } from "./routes"
 export { toExpressPath, assertHandlerParity } from "./mount"
+export { API_VERSIONS, CURRENT_API_VERSION, parseApiVersion, type ApiVersion } from "./versions"
 export { createBotRuntimeWriteOps, type BotRuntimeWriteOpsDeps } from "./runtime-write-ops"
 export { serializeTraceStep, botInvocationStepEvents, BotInvocationTraceSink } from "./trace-steps"
 export {

--- a/apps/backend/src/features/public-api/mount.test.ts
+++ b/apps/backend/src/features/public-api/mount.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test"
+import { assertHandlerParity, toExpressPath } from "./mount"
+import { PUBLIC_API_ROUTES } from "./routes"
+
+describe("toExpressPath", () => {
+  it("converts OpenAPI path params to Express params", () => {
+    expect(toExpressPath("/api/v1/workspaces/{workspaceId}/streams/{streamId}/messages")).toBe(
+      "/api/v1/workspaces/:workspaceId/streams/:streamId/messages"
+    )
+  })
+
+  it("leaves paths without params unchanged", () => {
+    expect(toExpressPath("/api/v1/workspaces/{workspaceId}/labels/assignments")).toBe(
+      "/api/v1/workspaces/:workspaceId/labels/assignments"
+    )
+  })
+})
+
+describe("assertHandlerParity", () => {
+  const registryIds = PUBLIC_API_ROUTES.map((route) => route.operationId)
+
+  it("passes when handler keys exactly cover the registry", () => {
+    expect(() => assertHandlerParity(registryIds)).not.toThrow()
+  })
+
+  it("throws when a registry route has no handler", () => {
+    const missingOne = registryIds.filter((id) => id !== "sendMessage")
+    expect(() => assertHandlerParity(missingOne)).toThrow(/missing handlers: sendMessage/)
+  })
+
+  it("throws when a handler has no registry route", () => {
+    expect(() => assertHandlerParity([...registryIds, "ghostOperation"])).toThrow(
+      /without a registry route: ghostOperation/
+    )
+  })
+})

--- a/apps/backend/src/features/public-api/mount.ts
+++ b/apps/backend/src/features/public-api/mount.ts
@@ -1,0 +1,27 @@
+import { PUBLIC_API_ROUTES } from "./routes"
+
+/** Convert an OpenAPI path template (`{param}`) to an Express path (`:param`). */
+export function toExpressPath(openApiPath: string): string {
+  return openApiPath.replace(/\{(\w+)\}/g, ":$1")
+}
+
+/**
+ * Throws if the handler map and the route registry disagree: a registry route
+ * with no handler, or a handler for an operation the registry never declares.
+ * The registry is the SSOT (it also generates the OpenAPI spec); this keeps the
+ * hand-written handler map from silently drifting out of sync at boot.
+ */
+export function assertHandlerParity(handlerOperationIds: Iterable<string>): void {
+  const registryIds = new Set<string>(PUBLIC_API_ROUTES.map((route) => route.operationId))
+  const handlerIds = new Set<string>(handlerOperationIds)
+
+  const missing = [...registryIds].filter((id) => !handlerIds.has(id))
+  if (missing.length > 0) {
+    throw new Error(`Public API routes missing handlers: ${missing.join(", ")}`)
+  }
+
+  const extra = [...handlerIds].filter((id) => !registryIds.has(id))
+  if (extra.length > 0) {
+    throw new Error(`Public API handlers without a registry route: ${extra.join(", ")}`)
+  }
+}

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -606,10 +606,58 @@ const delegationTokenHeaderParam = {
   description: "Per-claim token from the delegation claim response (binds the caller to its claim).",
 }
 
+export type OperationId =
+  | "searchMessages"
+  | "searchMemos"
+  | "getMemo"
+  | "uploadAttachment"
+  | "searchAttachments"
+  | "getAttachment"
+  | "getAttachmentDownloadUrl"
+  | "upsertBotRuntimePresence"
+  | "createBotRuntimeSession"
+  | "getBotOwnerE2eKey"
+  | "provisionStreamE2eKeyWraps"
+  | "renameBotRuntimeSession"
+  | "rebindBotRuntimeSession"
+  | "claimBotInvocation"
+  | "renewBotInvocationClaim"
+  | "recordBotInvocationStep"
+  | "startBotInvocationSealedStep"
+  | "recordBotInvocationSealedStep"
+  | "sendBotInvocationSealedMessage"
+  | "completeBotInvocationSealed"
+  | "completeBotInvocation"
+  | "failBotInvocation"
+  | "listDelegations"
+  | "claimDelegation"
+  | "heartbeatDelegation"
+  | "reportDelegationStatus"
+  | "completeDelegation"
+  | "failDelegation"
+  | "listStreams"
+  | "getStream"
+  | "updateStream"
+  | "listMembers"
+  | "listMessages"
+  | "sendMessage"
+  | "findMessagesByMetadata"
+  | "updateMessage"
+  | "deleteMessage"
+  | "listUsers"
+  | "listLabels"
+  | "createLabel"
+  | "assignLabel"
+  | "unassignLabel"
+  | "updateLabel"
+  | "deleteLabel"
+  | "getMe"
+  | "listMyBots"
+
 export interface PublicApiRoute {
   method: "get" | "post" | "patch" | "delete"
   path: string
-  operationId: string
+  operationId: OperationId
   summary: string
   description?: string
   tags: string[]
@@ -1217,6 +1265,9 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     responseSchema: dataEnvelope(labelSchema),
     successStatus: 201,
   },
+  // Literal `assignments` routes precede the `/{labelId}` CRUD entries below:
+  // registry order is mount order, so a `:labelId` param route registered first
+  // would capture `assignments` as an id.
   {
     method: "post",
     path: "/api/v1/workspaces/{workspaceId}/labels/assignments",

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -528,6 +528,7 @@ const sealedInterimMessageSchema = z.object({ messageId: z.string() })
 
 const errorSchema = z.object({
   error: z.string(),
+  code: z.string().optional().describe("Machine-readable error code, e.g. INVALID_API_VERSION"),
   details: z.record(z.string(), z.array(z.string())).optional(),
 })
 

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -227,11 +227,22 @@ const botSchema = z.discriminatedUnion("type", [sharedBotSchema, personalBotSche
 // share `kind: "bot"` but split on `botType`. z.union handles the three-way
 // shape correctly; the generated OpenAPI uses `oneOf`, which clients narrow
 // on `kind` first and then `botType` for the bot branch.
+const apiVersionInfoSchema = z.object({
+  pinned: z
+    .string()
+    .nullable()
+    .describe("The key's pinned version, or null when the key is unpinned and tracks the current version"),
+  resolved: z.string().describe("Version this request resolved to (header override, else pin, else current)"),
+  current: z.string().describe("The latest API version"),
+  supported: z.array(z.string()).describe("All versions the API currently accepts"),
+})
+
 const principalSchema = z.union([
   z.object({
     kind: z.literal("user"),
     workspaceId: z.string(),
     userId: z.string(),
+    apiVersion: apiVersionInfoSchema,
   }),
   z.object({
     kind: z.literal("bot"),
@@ -240,6 +251,7 @@ const principalSchema = z.union([
     botType: z.literal("shared"),
     traits: z.array(z.enum(BOT_TRAITS)),
     ownerUserId: z.null(),
+    apiVersion: apiVersionInfoSchema,
   }),
   z.object({
     kind: z.literal("bot"),
@@ -248,6 +260,7 @@ const principalSchema = z.union([
     botType: z.literal("personal"),
     traits: z.array(z.enum(BOT_TRAITS)),
     ownerUserId: z.string(),
+    apiVersion: apiVersionInfoSchema,
   }),
 ])
 
@@ -1336,7 +1349,8 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     summary: "Get the authenticated principal",
     description:
       "Returns a discriminated union describing the authenticated principal — either the API-key owner " +
-      '(`kind: "user"`) or the bot whose key is in use (`kind: "bot"`). Used by clients (e.g. the ' +
+      '(`kind: "user"`) or the bot whose key is in use (`kind: "bot"`). Also reports the key\'s API version ' +
+      "pin, the version this request resolved to, and the supported versions. Used by clients (e.g. the " +
       "OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
     tags: ["Identity"],
     scopes: [],

--- a/apps/backend/src/features/public-api/versions/index.test.ts
+++ b/apps/backend/src/features/public-api/versions/index.test.ts
@@ -14,15 +14,17 @@ describe("parseApiVersion", () => {
   })
 
   test("throws 400 INVALID_API_VERSION on an unknown version, listing known versions", () => {
+    let thrown: unknown
     try {
       parseApiVersion("2020-01-01")
-      throw new Error("expected parseApiVersion to throw")
     } catch (err) {
-      const e = err as { status?: number; code?: string; message?: string }
-      expect(e.status).toBe(400)
-      expect(e.code).toBe("INVALID_API_VERSION")
-      expect(e.message).toContain(API_VERSIONS.join(", "))
+      thrown = err
     }
+    expect(thrown).toMatchObject({
+      status: 400,
+      code: "INVALID_API_VERSION",
+      message: expect.stringContaining(API_VERSIONS.join(", ")),
+    })
   })
 
   test("throws on a malformed / non-date value", () => {
@@ -53,5 +55,15 @@ describe("assertChangesAscending", () => {
 describe("changesAfter", () => {
   test("returns no changes in the Phase-1 steady state (empty registry)", () => {
     expect(changesAfter(CURRENT_API_VERSION)).toEqual([])
+  })
+
+  test("returns only strictly-newer changes, in registry order", () => {
+    const a = change("2026-08-01")
+    const b = change("2026-11-01")
+    const c = change("2027-01-01")
+    expect(changesAfter("2026-07-12" as never, [a, b, c])).toEqual([a, b, c])
+    // Equal is excluded — a caller pinned AT a change's version already has it.
+    expect(changesAfter("2026-11-01" as never, [a, b, c])).toEqual([c])
+    expect(changesAfter("2027-01-01" as never, [a, b, c])).toEqual([])
   })
 })

--- a/apps/backend/src/features/public-api/versions/index.test.ts
+++ b/apps/backend/src/features/public-api/versions/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import {
+  API_VERSIONS,
+  CURRENT_API_VERSION,
+  assertChangesAscending,
+  changesAfter,
+  parseApiVersion,
+  type VersionChange,
+} from "./index"
+
+describe("parseApiVersion", () => {
+  test("returns a known version unchanged", () => {
+    expect(parseApiVersion(CURRENT_API_VERSION)).toBe(CURRENT_API_VERSION)
+  })
+
+  test("throws 400 INVALID_API_VERSION on an unknown version, listing known versions", () => {
+    try {
+      parseApiVersion("2020-01-01")
+      throw new Error("expected parseApiVersion to throw")
+    } catch (err) {
+      const e = err as { status?: number; code?: string; message?: string }
+      expect(e.status).toBe(400)
+      expect(e.code).toBe("INVALID_API_VERSION")
+      expect(e.message).toContain(API_VERSIONS.join(", "))
+    }
+  })
+
+  test("throws on a malformed / non-date value", () => {
+    for (const bad of ["latest", "", "2026-7-12", "not-a-date"]) {
+      expect(() => parseApiVersion(bad)).toThrow()
+    }
+  })
+})
+
+const change = (version: string, ops: string[] = []): VersionChange => ({
+  version: version as VersionChange["version"],
+  description: `change ${version}`,
+  operations: new Set(ops as never[]),
+})
+
+describe("assertChangesAscending", () => {
+  test("accepts empty and strictly-ascending lists", () => {
+    expect(() => assertChangesAscending([])).not.toThrow()
+    expect(() => assertChangesAscending([change("2026-07-12"), change("2026-11-01")])).not.toThrow()
+  })
+
+  test("rejects equal or descending versions", () => {
+    expect(() => assertChangesAscending([change("2026-11-01"), change("2026-11-01")])).toThrow()
+    expect(() => assertChangesAscending([change("2026-11-01"), change("2026-07-12")])).toThrow()
+  })
+})
+
+describe("changesAfter", () => {
+  test("returns no changes in the Phase-1 steady state (empty registry)", () => {
+    expect(changesAfter(CURRENT_API_VERSION)).toEqual([])
+  })
+})

--- a/apps/backend/src/features/public-api/versions/index.ts
+++ b/apps/backend/src/features/public-api/versions/index.ts
@@ -1,0 +1,39 @@
+import { HttpError } from "@threa/backend-common"
+import { API_VERSIONS, CURRENT_API_VERSION, type ApiVersion, type VersionChange } from "./types"
+
+/** Ascending by version. Startup assertion enforces ordering + known dates. */
+export const VERSION_CHANGES: VersionChange[] = [
+  // Populated when the first real breaking change ships (see design doc §8).
+]
+
+/** Throws unless every change is strictly newer than the one before it. */
+export function assertChangesAscending(changes: readonly VersionChange[]): void {
+  for (let i = 1; i < changes.length; i++) {
+    if (changes[i - 1].version >= changes[i].version) {
+      throw new Error("VERSION_CHANGES must be strictly ascending by version")
+    }
+  }
+}
+
+assertChangesAscending(VERSION_CHANGES)
+
+const KNOWN = new Set<string>(API_VERSIONS)
+
+export function parseApiVersion(raw: string): ApiVersion {
+  if (!KNOWN.has(raw)) {
+    throw new HttpError(`Unknown API version "${raw}". Known versions: ${API_VERSIONS.join(", ")}`, {
+      status: 400,
+      code: "INVALID_API_VERSION",
+    })
+  }
+  return raw as ApiVersion
+}
+
+/** Changes the caller is behind on, i.e. with version strictly newer than theirs. */
+export function changesAfter(clientVersion: ApiVersion): VersionChange[] {
+  // ISO dates compare lexicographically — no Date parsing.
+  return VERSION_CHANGES.filter((c) => c.version > clientVersion)
+}
+
+export { API_VERSIONS, CURRENT_API_VERSION }
+export type { ApiVersion, VersionChange, VersionChangeContext } from "./types"

--- a/apps/backend/src/features/public-api/versions/index.ts
+++ b/apps/backend/src/features/public-api/versions/index.ts
@@ -30,9 +30,9 @@ export function parseApiVersion(raw: string): ApiVersion {
 }
 
 /** Changes the caller is behind on, i.e. with version strictly newer than theirs. */
-export function changesAfter(clientVersion: ApiVersion): VersionChange[] {
+export function changesAfter(clientVersion: ApiVersion, changes: readonly VersionChange[] = VERSION_CHANGES) {
   // ISO dates compare lexicographically — no Date parsing.
-  return VERSION_CHANGES.filter((c) => c.version > clientVersion)
+  return changes.filter((c) => c.version > clientVersion)
 }
 
 export { API_VERSIONS, CURRENT_API_VERSION }

--- a/apps/backend/src/features/public-api/versions/types.ts
+++ b/apps/backend/src/features/public-api/versions/types.ts
@@ -1,0 +1,27 @@
+import type { OperationId } from "../routes"
+
+/** Dated public API versions, ascending. The first entry is the epoch. */
+export const API_VERSIONS = ["2026-07-12"] as const
+export type ApiVersion = (typeof API_VERSIONS)[number]
+export const CURRENT_API_VERSION: ApiVersion = API_VERSIONS[API_VERSIONS.length - 1]
+
+export interface VersionChangeContext {
+  operationId: OperationId
+}
+
+/**
+ * One dated, breaking change. `version` is the date the NEW behavior became
+ * default; callers pinned BEFORE it get the transforms applied. Transforms
+ * translate between this version's shape and the previous one: upgradeRequest
+ * lifts an old-shape request to the new shape, downgradeResponse lowers a
+ * new-shape payload to the old shape. Both must be pure.
+ */
+export interface VersionChange {
+  version: ApiVersion
+  /** One-line summary for the generated CHANGELOG. */
+  description: string
+  /** Operations whose requests/responses this change touches. */
+  operations: ReadonlySet<OperationId>
+  upgradeRequest?: (body: unknown, ctx: VersionChangeContext) => unknown
+  downgradeResponse?: (payload: unknown, ctx: VersionChangeContext) => unknown
+}

--- a/apps/backend/src/features/user-api-keys/handlers.ts
+++ b/apps/backend/src/features/user-api-keys/handlers.ts
@@ -4,6 +4,7 @@ import { validateRequest } from "../../lib/validation"
 import type { UserApiKeyService } from "./service"
 import type { UserApiKeyRow } from "./repository"
 import { API_KEY_ELIGIBLE_SCOPES, type WorkspacePermissionSlug, type UserApiKey } from "@threa/types"
+import { API_VERSIONS, type ApiVersion } from "../public-api/versions"
 
 const createKeySchema = z.object({
   name: z.string().min(1, "name is required").max(100),
@@ -18,9 +19,15 @@ const createKeySchema = z.object({
     }),
 })
 
-const updateKeySchema = z.object({
-  scopes: z.array(z.enum(API_KEY_ELIGIBLE_SCOPES)).min(1, "at least one scope is required"),
-})
+const updateKeySchema = z
+  .object({
+    scopes: z.array(z.enum(API_KEY_ELIGIBLE_SCOPES)).min(1, "at least one scope is required").optional(),
+    // A supported version pins the key; null unpins it (the key then tracks the current version).
+    apiVersion: z.enum(API_VERSIONS).nullable().optional(),
+  })
+  .refine((data) => data.scopes !== undefined || data.apiVersion !== undefined, {
+    message: "provide scopes and/or apiVersion",
+  })
 
 const revokeKeySchema = z.object({
   keyId: z.string().min(1),
@@ -32,6 +39,7 @@ function serializeKey(row: UserApiKeyRow): UserApiKey {
     name: row.name,
     keyPrefix: row.keyPrefix,
     scopes: row.scopes as WorkspacePermissionSlug[],
+    apiVersion: row.apiVersion,
     lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
     expiresAt: row.expiresAt?.toISOString() ?? null,
     revokedAt: row.revokedAt?.toISOString() ?? null,
@@ -77,13 +85,24 @@ export function createUserApiKeyHandlers({ userApiKeyService }: Dependencies) {
 
       const data = validateRequest(updateKeySchema, req.body)
 
-      const row = await userApiKeyService.updateScopes({
-        workspaceId,
-        userId,
-        keyId,
-        scopes: data.scopes as WorkspacePermissionSlug[],
-      })
-      res.json({ key: serializeKey(row) })
+      let row: UserApiKeyRow | undefined
+      if (data.scopes !== undefined) {
+        row = await userApiKeyService.updateScopes({
+          workspaceId,
+          userId,
+          keyId,
+          scopes: data.scopes as WorkspacePermissionSlug[],
+        })
+      }
+      if (data.apiVersion !== undefined) {
+        row = await userApiKeyService.updateApiVersion({
+          workspaceId,
+          userId,
+          keyId,
+          apiVersion: data.apiVersion as ApiVersion | null,
+        })
+      }
+      res.json({ key: serializeKey(row!) })
     },
 
     async revoke(req: Request, res: Response) {

--- a/apps/backend/src/features/user-api-keys/repository.ts
+++ b/apps/backend/src/features/user-api-keys/repository.ts
@@ -111,6 +111,22 @@ export const UserApiKeyRepository = {
     return result.rows[0] ? mapRow(result.rows[0]) : null
   },
 
+  async updateApiVersionOwned(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    id: string,
+    apiVersion: string | null
+  ): Promise<UserApiKeyRow | null> {
+    const result = await db.query<Record<string, unknown>>(sql`
+      UPDATE user_api_keys
+      SET api_version = ${apiVersion}
+      WHERE id = ${id} AND workspace_id = ${workspaceId} AND user_id = ${userId} AND revoked_at IS NULL
+      RETURNING ${sql.raw(SELECT_FIELDS)}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
   async revokeOwned(
     db: Querier,
     workspaceId: string,

--- a/apps/backend/src/features/user-api-keys/repository.ts
+++ b/apps/backend/src/features/user-api-keys/repository.ts
@@ -9,6 +9,7 @@ export interface UserApiKeyRow {
   keyHash: string
   keyPrefix: string
   scopes: string[]
+  apiVersion: string | null
   lastUsedAt: Date | null
   expiresAt: Date | null
   revokedAt: Date | null
@@ -17,7 +18,7 @@ export interface UserApiKeyRow {
 
 const SELECT_FIELDS = `
   id, workspace_id, user_id, name, key_hash, key_prefix, scopes,
-  last_used_at, expires_at, revoked_at, created_at
+  api_version, last_used_at, expires_at, revoked_at, created_at
 `
 
 function mapRow(row: Record<string, unknown>): UserApiKeyRow {
@@ -29,6 +30,7 @@ function mapRow(row: Record<string, unknown>): UserApiKeyRow {
     keyHash: row.key_hash as string,
     keyPrefix: row.key_prefix as string,
     scopes: row.scopes as string[],
+    apiVersion: row.api_version as string | null,
     lastUsedAt: row.last_used_at as Date | null,
     expiresAt: row.expires_at as Date | null,
     revokedAt: row.revoked_at as Date | null,
@@ -47,14 +49,15 @@ export const UserApiKeyRepository = {
       keyHash: string
       keyPrefix: string
       scopes: string[]
+      apiVersion: string
       expiresAt: Date | null
     }
   ): Promise<UserApiKeyRow> {
     const result = await db.query<Record<string, unknown>>(sql`
-      INSERT INTO user_api_keys (id, workspace_id, user_id, name, key_hash, key_prefix, scopes, expires_at)
+      INSERT INTO user_api_keys (id, workspace_id, user_id, name, key_hash, key_prefix, scopes, api_version, expires_at)
       VALUES (
         ${params.id}, ${params.workspaceId}, ${params.userId}, ${params.name},
-        ${params.keyHash}, ${params.keyPrefix}, ${params.scopes}, ${params.expiresAt}
+        ${params.keyHash}, ${params.keyPrefix}, ${params.scopes}, ${params.apiVersion}, ${params.expiresAt}
       )
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)

--- a/apps/backend/src/features/user-api-keys/repository.ts
+++ b/apps/backend/src/features/user-api-keys/repository.ts
@@ -1,5 +1,6 @@
 import { sql } from "../../db"
 import type { Querier } from "../../db"
+import type { ApiVersion } from "../public-api/versions"
 
 export interface UserApiKeyRow {
   id: string
@@ -49,7 +50,7 @@ export const UserApiKeyRepository = {
       keyHash: string
       keyPrefix: string
       scopes: string[]
-      apiVersion: string
+      apiVersion: ApiVersion
       expiresAt: Date | null
     }
   ): Promise<UserApiKeyRow> {
@@ -116,7 +117,7 @@ export const UserApiKeyRepository = {
     workspaceId: string,
     userId: string,
     id: string,
-    apiVersion: string | null
+    apiVersion: ApiVersion | null
   ): Promise<UserApiKeyRow | null> {
     const result = await db.query<Record<string, unknown>>(sql`
       UPDATE user_api_keys

--- a/apps/backend/src/features/user-api-keys/service.ts
+++ b/apps/backend/src/features/user-api-keys/service.ts
@@ -41,8 +41,8 @@ export interface ValidatedUserApiKey {
   userId: string
   name: string
   scopes: Set<string>
-  /** Wire version the key is pinned to; the version gate's floor when no header is sent. */
-  apiVersion: ApiVersion
+  /** Pinned wire version, or null when unpinned — the version gate then resolves to the current version. */
+  apiVersion: ApiVersion | null
 }
 
 export class UserApiKeyService {
@@ -124,6 +124,26 @@ export class UserApiKeyService {
     return row
   }
 
+  async updateApiVersion(params: {
+    workspaceId: string
+    userId: string
+    keyId: string
+    /** A supported version to pin to, or null to unpin (the key then tracks the current version). */
+    apiVersion: ApiVersion | null
+  }): Promise<UserApiKeyRow> {
+    const row = await UserApiKeyRepository.updateApiVersionOwned(
+      this.pool,
+      params.workspaceId,
+      params.userId,
+      params.keyId,
+      params.apiVersion
+    )
+    if (!row) {
+      throw new HttpError("API key not found", { status: 404, code: "NOT_FOUND" })
+    }
+    return row
+  }
+
   async revokeKey(workspaceId: string, userId: string, keyId: string): Promise<void> {
     const result = await UserApiKeyRepository.revokeOwned(this.pool, workspaceId, userId, keyId)
     if (result === "not_found") {
@@ -162,7 +182,7 @@ export class UserApiKeyService {
       userId: match.userId,
       name: match.name,
       scopes: new Set(match.scopes),
-      apiVersion: (match.apiVersion ?? CURRENT_API_VERSION) as ApiVersion,
+      apiVersion: match.apiVersion as ApiVersion | null,
     }
   }
 }

--- a/apps/backend/src/features/user-api-keys/service.ts
+++ b/apps/backend/src/features/user-api-keys/service.ts
@@ -6,6 +6,7 @@ import { userApiKeyId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
 import type { WorkspacePermissionSlug } from "@threa/types"
 import { API_KEY_ELIGIBLE_SCOPES } from "@threa/types"
+import { CURRENT_API_VERSION, type ApiVersion } from "../public-api/versions"
 
 const KEY_PREFIX = "threa_uk_"
 const KEY_BYTE_LENGTH = 32 // 256-bit random key
@@ -40,6 +41,8 @@ export interface ValidatedUserApiKey {
   userId: string
   name: string
   scopes: Set<string>
+  /** Wire version the key is pinned to; the version gate's floor when no header is sent. */
+  apiVersion: ApiVersion
 }
 
 export class UserApiKeyService {
@@ -89,6 +92,7 @@ export class UserApiKeyService {
         keyHash,
         keyPrefix,
         scopes: params.scopes,
+        apiVersion: CURRENT_API_VERSION,
         expiresAt: params.expiresAt,
       })
     })
@@ -158,6 +162,7 @@ export class UserApiKeyService {
       userId: match.userId,
       name: match.name,
       scopes: new Set(match.scopes),
+      apiVersion: (match.apiVersion ?? CURRENT_API_VERSION) as ApiVersion,
     }
   }
 }

--- a/apps/backend/src/lib/observability/metrics.ts
+++ b/apps/backend/src/lib/observability/metrics.ts
@@ -103,6 +103,16 @@ export const httpRequestsTotal = new Counter({
   registers: [registry],
 })
 
+// Happy-path request logs are silenced (customLogLevel), so version adoption
+// tracking — "who still runs an old pin" ahead of a sunset — lives here, not
+// in the logs. The logs only carry version context on 4xx/5xx.
+export const publicApiVersionRequests = new Counter({
+  name: "public_api_version_requests_total",
+  help: "Public API requests by resolved wire version and how it was resolved",
+  labelNames: ["version", "source"],
+  registers: [registry],
+})
+
 export const httpRequestDuration = new Histogram({
   name: "http_request_duration_seconds",
   help: "HTTP request duration in seconds",

--- a/apps/backend/src/middleware/api-version.test.ts
+++ b/apps/backend/src/middleware/api-version.test.ts
@@ -34,8 +34,11 @@ function makeReqRes(opts: {
   return { req, res, jsonCalls, setHeaders }
 }
 
+let changesAfterSpy: ReturnType<typeof spyOn> | null = null
+
 afterEach(() => {
-  spyOn(versions, "changesAfter").mockRestore()
+  changesAfterSpy?.mockRestore()
+  changesAfterSpy = null
 })
 
 describe("createApiVersionGate — resolution precedence", () => {
@@ -117,7 +120,7 @@ describe("createApiVersionGate — transform pipeline", () => {
     }
     // changesAfter returns ascending order; the gate applies upgrades in that
     // order and downgrades in reverse.
-    spyOn(versions, "changesAfter").mockReturnValue([older, newer])
+    changesAfterSpy = spyOn(versions, "changesAfter").mockReturnValue([older, newer])
 
     const gate = createApiVersionGate("listMessages")
     const { req, res, jsonCalls } = makeReqRes({
@@ -140,7 +143,7 @@ describe("createApiVersionGate — transform pipeline", () => {
       operations: new Set(["sendMessage"]),
       upgradeRequest: (body) => ({ ...(body as object), touched: true }),
     }
-    spyOn(versions, "changesAfter").mockReturnValue([foreign])
+    changesAfterSpy = spyOn(versions, "changesAfter").mockReturnValue([foreign])
 
     const gate = createApiVersionGate("listMessages")
     const { req } = makeReqRes({ userApiKey: { id: "uak_1", apiVersion: CURRENT_API_VERSION }, body: { base: true } })

--- a/apps/backend/src/middleware/api-version.test.ts
+++ b/apps/backend/src/middleware/api-version.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import type { NextFunction, Request, Response } from "express"
+import { createApiVersionGate } from "./api-version"
+import * as versions from "../features/public-api/versions"
+import { CURRENT_API_VERSION, type VersionChange } from "../features/public-api/versions"
+
+function makeReqRes(opts: {
+  header?: string
+  userApiKey?: { id: string; apiVersion: string }
+  botApiKey?: { id: string; apiVersion: string }
+  body?: unknown
+}) {
+  const headers: Record<string, string | undefined> = { "threa-version": opts.header }
+  const req = {
+    header: (name: string) => headers[name.toLowerCase()],
+    userApiKey: opts.userApiKey,
+    botApiKey: opts.botApiKey,
+    body: opts.body,
+  } as unknown as Request
+
+  const jsonCalls: unknown[] = []
+  const setHeaders: Record<string, unknown> = {}
+  const res = {
+    locals: {} as Record<string, unknown>,
+    setHeader: (name: string, value: unknown) => {
+      setHeaders[name] = value
+    },
+    json: (payload: unknown) => {
+      jsonCalls.push(payload)
+      return res
+    },
+  } as unknown as Response
+
+  return { req, res, jsonCalls, setHeaders }
+}
+
+afterEach(() => {
+  spyOn(versions, "changesAfter").mockRestore()
+})
+
+describe("createApiVersionGate — resolution precedence", () => {
+  test("header override beats the key pin", () => {
+    const gate = createApiVersionGate("listMessages")
+    const { req, res, setHeaders } = makeReqRes({
+      header: CURRENT_API_VERSION,
+      userApiKey: { id: "uak_1", apiVersion: "2099-01-01" },
+    })
+    let err: unknown = "unset"
+    gate(req, res, ((e?: unknown) => (err = e)) as NextFunction)
+
+    expect(err).toBeUndefined()
+    expect(req.apiVersion).toBe(CURRENT_API_VERSION)
+    expect(setHeaders["Threa-Version"]).toBe(CURRENT_API_VERSION)
+    expect(res.locals.apiVersionLog).toEqual({
+      apiVersion: CURRENT_API_VERSION,
+      versionSource: "header",
+      keyId: "uak_1",
+      operationId: "listMessages",
+    })
+  })
+
+  test("falls back to the user key pin when no header is sent", () => {
+    const gate = createApiVersionGate("listMessages")
+    const { req, res } = makeReqRes({ userApiKey: { id: "uak_1", apiVersion: "2099-01-01" } })
+    gate(req, res, (() => {}) as NextFunction)
+
+    expect(req.apiVersion as string).toBe("2099-01-01")
+    expect(res.locals.apiVersionLog).toMatchObject({ versionSource: "key", keyId: "uak_1" })
+  })
+
+  test("falls back to the bot key pin when no header is sent", () => {
+    const gate = createApiVersionGate("sendMessage")
+    const { req, res } = makeReqRes({ botApiKey: { id: "bak_1", apiVersion: CURRENT_API_VERSION } })
+    gate(req, res, (() => {}) as NextFunction)
+
+    expect(req.apiVersion).toBe(CURRENT_API_VERSION)
+    expect(res.locals.apiVersionLog).toMatchObject({ versionSource: "key", keyId: "bak_1" })
+  })
+
+  test("falls back to CURRENT when neither header nor key context is present", () => {
+    const gate = createApiVersionGate("listMessages")
+    const { req, res } = makeReqRes({})
+    gate(req, res, (() => {}) as NextFunction)
+
+    expect(req.apiVersion).toBe(CURRENT_API_VERSION)
+    expect(res.locals.apiVersionLog).toMatchObject({ keyId: null })
+  })
+
+  test("throws INVALID_API_VERSION on an unknown header", () => {
+    const gate = createApiVersionGate("listMessages")
+    const { req, res } = makeReqRes({ header: "1999-01-01" })
+    expect(() => gate(req, res, (() => {}) as NextFunction)).toThrow(/Unknown API version/)
+  })
+})
+
+describe("createApiVersionGate — transform pipeline", () => {
+  test("upgrades the request oldest→newest and downgrades the response newest→oldest", () => {
+    const older: VersionChange = {
+      version: "2026-11-01" as VersionChange["version"],
+      description: "older",
+      operations: new Set(["listMessages"]),
+      upgradeRequest: (body) => ({ ...(body as object), older: true }),
+      downgradeResponse: (payload) => {
+        const arr = (payload as { steps: string[] }).steps
+        return { steps: [...arr, "down-older"] }
+      },
+    }
+    const newer: VersionChange = {
+      version: "2026-12-01" as VersionChange["version"],
+      description: "newer",
+      operations: new Set(["listMessages"]),
+      upgradeRequest: (body) => ({ ...(body as object), newer: true }),
+      downgradeResponse: (payload) => {
+        const arr = (payload as { steps: string[] }).steps
+        return { steps: [...arr, "down-newer"] }
+      },
+    }
+    // changesAfter returns ascending order; the gate applies upgrades in that
+    // order and downgrades in reverse.
+    spyOn(versions, "changesAfter").mockReturnValue([older, newer])
+
+    const gate = createApiVersionGate("listMessages")
+    const { req, res, jsonCalls } = makeReqRes({
+      userApiKey: { id: "uak_1", apiVersion: CURRENT_API_VERSION },
+      body: { base: true },
+    })
+    gate(req, res, (() => {}) as NextFunction)
+
+    expect(req.body).toEqual({ base: true, older: true, newer: true })
+
+    res.json({ steps: ["handler"] })
+    expect(jsonCalls).toHaveLength(1)
+    expect(jsonCalls[0]).toEqual({ steps: ["handler", "down-newer", "down-older"] })
+  })
+
+  test("does not wrap res.json when no change targets the operation", () => {
+    const foreign: VersionChange = {
+      version: "2026-11-01" as VersionChange["version"],
+      description: "unrelated",
+      operations: new Set(["sendMessage"]),
+      upgradeRequest: (body) => ({ ...(body as object), touched: true }),
+    }
+    spyOn(versions, "changesAfter").mockReturnValue([foreign])
+
+    const gate = createApiVersionGate("listMessages")
+    const { req } = makeReqRes({ userApiKey: { id: "uak_1", apiVersion: CURRENT_API_VERSION }, body: { base: true } })
+    const { res, jsonCalls } = makeReqRes({})
+    gate(req, res, (() => {}) as NextFunction)
+
+    expect(req.body).toEqual({ base: true })
+    res.json({ untouched: true })
+    expect(jsonCalls[0]).toEqual({ untouched: true })
+  })
+})

--- a/apps/backend/src/middleware/api-version.ts
+++ b/apps/backend/src/middleware/api-version.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from "express"
+import { THREA_VERSION_HEADER } from "@threa/types"
 import type { OperationId } from "../features/public-api/routes"
 import * as versions from "../features/public-api/versions"
 import type { ApiVersion } from "../features/public-api/versions"
@@ -38,7 +39,7 @@ export interface ApiVersionLog {
  */
 export function createApiVersionGate(operationId: OperationId) {
   return function apiVersionGate(req: Request, res: Response, next: NextFunction): void {
-    const header = req.header("Threa-Version")
+    const header = req.header(THREA_VERSION_HEADER)
     const pinned = req.userApiKey?.apiVersion ?? req.botApiKey?.apiVersion ?? versions.CURRENT_API_VERSION
 
     // Stashed BEFORE parsing so the INVALID_API_VERSION 400 log still carries
@@ -56,7 +57,7 @@ export function createApiVersionGate(operationId: OperationId) {
     const version = header ? versions.parseApiVersion(header) : pinned
 
     req.apiVersion = version
-    res.setHeader("Threa-Version", version)
+    res.setHeader(THREA_VERSION_HEADER, version)
     publicApiVersionRequests.inc({ version, source: log.versionSource })
 
     const pending = versions.changesAfter(version).filter((c) => c.operations.has(operationId))

--- a/apps/backend/src/middleware/api-version.ts
+++ b/apps/backend/src/middleware/api-version.ts
@@ -1,0 +1,80 @@
+import type { NextFunction, Request, Response } from "express"
+import type { OperationId } from "../features/public-api/routes"
+import * as versions from "../features/public-api/versions"
+import type { ApiVersion } from "../features/public-api/versions"
+import { publicApiVersionRequests } from "../lib/observability/metrics"
+
+declare global {
+  namespace Express {
+    interface Request {
+      /** Resolved public API wire version for this request (header override > key pin). */
+      apiVersion?: ApiVersion
+    }
+  }
+}
+
+/**
+ * Version context stashed on res.locals for the pino-http customProps hook in
+ * app.ts. `apiVersion` is the raw requested value, not the parsed ApiVersion,
+ * so a rejected `Threa-Version` header still logs what the caller sent.
+ */
+export interface ApiVersionLog {
+  apiVersion: string
+  versionSource: "header" | "key"
+  keyId: string | null
+  operationId: OperationId
+}
+
+/**
+ * Resolves the request's public API version (header override beats the key's
+ * pin), echoes it in the response `Threa-Version` header, and — when the caller
+ * is behind on breaking changes — upgrades the request oldest→newest before the
+ * handler's Zod validation and downgrades the response newest→oldest via a
+ * `res.json` wrap. In the Phase-1 steady state (`VERSION_CHANGES` empty) this is
+ * a pure pass-through that only sets `req.apiVersion` and the echo header.
+ *
+ * Mounted per-route by the registry loop, after publicApiAuth (needs the
+ * validated key for the pin) and before the scope check + handler.
+ */
+export function createApiVersionGate(operationId: OperationId) {
+  return function apiVersionGate(req: Request, res: Response, next: NextFunction): void {
+    const header = req.header("Threa-Version")
+    const pinned = req.userApiKey?.apiVersion ?? req.botApiKey?.apiVersion ?? versions.CURRENT_API_VERSION
+
+    // Stashed BEFORE parsing so the INVALID_API_VERSION 400 log still carries
+    // the offending header value and key context.
+    const log: ApiVersionLog = {
+      apiVersion: header ?? pinned,
+      versionSource: header ? "header" : "key",
+      keyId: req.userApiKey?.id ?? req.botApiKey?.id ?? null,
+      operationId,
+    }
+    res.locals.apiVersionLog = log
+
+    // parseApiVersion throws HttpError(400 INVALID_API_VERSION) on an unknown
+    // header; Express forwards the synchronous throw to the error handler.
+    const version = header ? versions.parseApiVersion(header) : pinned
+
+    req.apiVersion = version
+    res.setHeader("Threa-Version", version)
+    publicApiVersionRequests.inc({ version, source: log.versionSource })
+
+    const pending = versions.changesAfter(version).filter((c) => c.operations.has(operationId))
+    if (pending.length === 0) return next()
+
+    for (const change of pending) {
+      if (change.upgradeRequest) req.body = change.upgradeRequest(req.body, { operationId })
+    }
+
+    const json = res.json.bind(res)
+    res.json = (payload: unknown) => {
+      let out = payload
+      for (let i = pending.length - 1; i >= 0; i--) {
+        const change = pending[i]
+        if (change.downgradeResponse) out = change.downgradeResponse(out, { operationId })
+      }
+      return json(out)
+    }
+    next()
+  }
+}

--- a/apps/backend/src/middleware/public-api-auth.test.ts
+++ b/apps/backend/src/middleware/public-api-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { NextFunction, Request, Response } from "express"
 import { createPublicApiAuthMiddleware, requireApiKeyScope } from "./public-api-auth"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { CURRENT_API_VERSION } from "../features/public-api/versions"
 
 function createPoolStub() {
   return {
@@ -298,7 +299,7 @@ describe("requireApiKeyScope", () => {
       userId: "user_1",
       name: "Test",
       scopes: new Set(["messages:search"]),
-      apiVersion: "2026-07-12",
+      apiVersion: CURRENT_API_VERSION,
     }
 
     let nextCalled = false
@@ -322,7 +323,7 @@ describe("requireApiKeyScope", () => {
       botId: "bot_1",
       name: "Bot Key",
       scopes: new Set(["messages:write"]),
-      apiVersion: "2026-07-12",
+      apiVersion: CURRENT_API_VERSION,
     }
 
     let nextCalled = false
@@ -346,7 +347,7 @@ describe("requireApiKeyScope", () => {
       userId: "user_1",
       name: "Test",
       scopes: new Set(["streams:read"]),
-      apiVersion: "2026-07-12",
+      apiVersion: CURRENT_API_VERSION,
     }
 
     let error: any = null
@@ -368,7 +369,7 @@ describe("requireApiKeyScope", () => {
       botId: "bot_1",
       name: "Bot Key",
       scopes: new Set(["messages:read"]),
-      apiVersion: "2026-07-12",
+      apiVersion: CURRENT_API_VERSION,
     }
 
     let error: any = null

--- a/apps/backend/src/middleware/public-api-auth.test.ts
+++ b/apps/backend/src/middleware/public-api-auth.test.ts
@@ -298,6 +298,7 @@ describe("requireApiKeyScope", () => {
       userId: "user_1",
       name: "Test",
       scopes: new Set(["messages:search"]),
+      apiVersion: "2026-07-12",
     }
 
     let nextCalled = false
@@ -321,6 +322,7 @@ describe("requireApiKeyScope", () => {
       botId: "bot_1",
       name: "Bot Key",
       scopes: new Set(["messages:write"]),
+      apiVersion: "2026-07-12",
     }
 
     let nextCalled = false
@@ -344,6 +346,7 @@ describe("requireApiKeyScope", () => {
       userId: "user_1",
       name: "Test",
       scopes: new Set(["streams:read"]),
+      apiVersion: "2026-07-12",
     }
 
     let error: any = null
@@ -365,6 +368,7 @@ describe("requireApiKeyScope", () => {
       botId: "bot_1",
       name: "Bot Key",
       scopes: new Set(["messages:read"]),
+      apiVersion: "2026-07-12",
     }
 
     let error: any = null

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -52,7 +52,15 @@ import {
 import { createLinkPreviewHandlers } from "./features/link-previews"
 import { createGiphyHandlers } from "./features/giphy"
 import { createWorkspaceIntegrationHandlers } from "./features/workspace-integrations"
-import { createPublicApiHandlers, createBotHandlers, createDelegationPublicApiHandlers } from "./features/public-api"
+import {
+  createPublicApiHandlers,
+  createBotHandlers,
+  createDelegationPublicApiHandlers,
+  PUBLIC_API_ROUTES,
+  type OperationId,
+  toExpressPath,
+  assertHandlerParity,
+} from "./features/public-api"
 import { BotRuntimeService, type BotRuntimeWriteOps } from "./features/bot-runtimes"
 import { createUserApiKeyHandlers, type UserApiKeyService } from "./features/user-api-keys"
 import { createVoiceTranscriptionHandlers, type VoiceTranscriptionService } from "./features/voice-transcription"
@@ -932,289 +940,67 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   })
   const publicMiddleware = [rateLimits.publicApiWorkspace, rateLimits.publicApiKey, publicAuth] as const
 
-  app.post(
-    "/api/v1/workspaces/:workspaceId/messages/search",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_SEARCH),
-    publicApi.searchMessages
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/memos/search",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MEMOS_READ),
-    publicApi.searchMemos
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/memos/:memoId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MEMOS_READ),
-    publicApi.getMemo
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/attachments",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_WRITE),
-    rateLimits.upload,
-    upload,
-    publicApi.uploadAttachment
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/attachments/search",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_READ),
-    publicApi.searchAttachments
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/attachments/:attachmentId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_READ),
-    publicApi.getAttachment
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/attachments/:attachmentId/url",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_READ),
-    publicApi.getAttachmentDownloadUrl
-  )
+  const publicHandlers: Record<OperationId, RequestHandler | RequestHandler[]> = {
+    searchMessages: publicApi.searchMessages,
+    searchMemos: publicApi.searchMemos,
+    getMemo: publicApi.getMemo,
+    uploadAttachment: [rateLimits.upload, upload, publicApi.uploadAttachment],
+    searchAttachments: publicApi.searchAttachments,
+    getAttachment: publicApi.getAttachment,
+    getAttachmentDownloadUrl: publicApi.getAttachmentDownloadUrl,
+    upsertBotRuntimePresence: publicApi.upsertBotRuntimePresence,
+    createBotRuntimeSession: publicApi.createBotRuntimeSession,
+    getBotOwnerE2eKey: publicApi.getBotOwnerE2eKey,
+    provisionStreamE2eKeyWraps: publicApi.provisionStreamE2eKeyWraps,
+    renameBotRuntimeSession: publicApi.renameBotRuntimeSession,
+    rebindBotRuntimeSession: publicApi.rebindBotRuntimeSession,
+    claimBotInvocation: publicApi.claimBotInvocation,
+    renewBotInvocationClaim: publicApi.renewBotInvocationClaim,
+    recordBotInvocationStep: publicApi.recordBotInvocationStep,
+    startBotInvocationSealedStep: publicApi.startBotInvocationSealedStep,
+    recordBotInvocationSealedStep: publicApi.recordBotInvocationSealedStep,
+    sendBotInvocationSealedMessage: publicApi.sendBotInvocationSealedMessage,
+    completeBotInvocationSealed: publicApi.completeBotInvocationSealed,
+    completeBotInvocation: publicApi.completeBotInvocation,
+    failBotInvocation: publicApi.failBotInvocation,
+    listDelegations: delegationPublicApi.listDelegations,
+    claimDelegation: delegationPublicApi.claimDelegation,
+    heartbeatDelegation: delegationPublicApi.heartbeatDelegation,
+    reportDelegationStatus: delegationPublicApi.reportDelegationStatus,
+    completeDelegation: delegationPublicApi.completeDelegation,
+    failDelegation: delegationPublicApi.failDelegation,
+    listStreams: publicApi.listStreams,
+    getStream: publicApi.getStream,
+    updateStream: publicApi.updateStream,
+    listMembers: publicApi.listMembers,
+    listMessages: publicApi.listMessages,
+    sendMessage: publicApi.sendMessage,
+    findMessagesByMetadata: publicApi.findMessagesByMetadata,
+    updateMessage: publicApi.updateMessage,
+    deleteMessage: publicApi.deleteMessage,
+    listUsers: publicApi.listUsers,
+    listLabels: publicApi.listLabels,
+    createLabel: publicApi.createLabel,
+    assignLabel: publicApi.assignLabel,
+    unassignLabel: publicApi.unassignLabel,
+    updateLabel: publicApi.updateLabel,
+    deleteLabel: publicApi.deleteLabel,
+    getMe: publicApi.getMe,
+    listMyBots: publicApi.listMyBots,
+  }
 
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-runtime/presence",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.upsertBotRuntimePresence
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-runtime/sessions",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.createBotRuntimeSession
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/bot-runtime/owner-e2e-key",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.getBotOwnerE2eKey
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.provisionStreamE2eKeyWraps
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-runtime/sessions/rename",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.renameBotRuntimeSession
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-runtime/sessions/rebind",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
-    publicApi.rebindBotRuntimeSession
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/claim",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.claimBotInvocation
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/renew",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.renewBotInvocationClaim
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/steps",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.recordBotInvocationStep
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-steps/started",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.startBotInvocationSealedStep
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-steps",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.recordBotInvocationSealedStep
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-messages",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.sendBotInvocationSealedMessage
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-complete",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.completeBotInvocationSealed
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/complete",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.completeBotInvocation
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/fail",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
-    publicApi.failBotInvocation
-  )
+  assertHandlerParity(Object.keys(publicHandlers))
 
-  // Delegations (roadmap 5.3) — the agent lifecycle over delegated tasks.
-  // Both key kinds (identity resolved in the handlers: user key posts results
-  // as the user, workspace key as the bot); claim mints the token, later
-  // transitions authenticate via X-Threa-Callback-Token.
-  app.get(
-    "/api/v1/workspaces/:workspaceId/delegations",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_READ),
-    delegationPublicApi.listDelegations
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/delegations/:delegationId/claim",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE),
-    delegationPublicApi.claimDelegation
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/delegations/:delegationId/heartbeat",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE),
-    delegationPublicApi.heartbeatDelegation
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/delegations/:delegationId/status",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE),
-    delegationPublicApi.reportDelegationStatus
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/delegations/:delegationId/complete",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE),
-    delegationPublicApi.completeDelegation
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/delegations/:delegationId/fail",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE),
-    delegationPublicApi.failDelegation
-  )
-
-  app.get(
-    "/api/v1/workspaces/:workspaceId/streams",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.STREAMS_READ),
-    publicApi.listStreams
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.STREAMS_READ),
-    publicApi.getStream
-  )
-  app.patch(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.STREAMS_WRITE),
-    publicApi.updateStream
-  )
-  app.get(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId/members",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.STREAMS_READ),
-    publicApi.listMembers
-  )
-
-  app.get(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId/messages",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_READ),
-    publicApi.listMessages
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/streams/:streamId/messages",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE),
-    publicApi.sendMessage
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/messages/find-by-metadata",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_READ),
-    publicApi.findMessagesByMetadata
-  )
-  app.patch(
-    "/api/v1/workspaces/:workspaceId/messages/:messageId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE),
-    publicApi.updateMessage
-  )
-  app.delete(
-    "/api/v1/workspaces/:workspaceId/messages/:messageId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE),
-    publicApi.deleteMessage
-  )
-
-  app.get(
-    "/api/v1/workspaces/:workspaceId/users",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.USERS_READ),
-    publicApi.listUsers
-  )
-
-  app.get(
-    "/api/v1/workspaces/:workspaceId/labels",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_READ),
-    publicApi.listLabels
-  )
-  app.post(
-    "/api/v1/workspaces/:workspaceId/labels",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE),
-    publicApi.createLabel
-  )
-  // Name-based assignment routes are registered before the `/:labelId` CRUD
-  // routes so the literal `assignments` segment isn't captured as a label id.
-  app.post(
-    "/api/v1/workspaces/:workspaceId/labels/assignments",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE),
-    publicApi.assignLabel
-  )
-  app.delete(
-    "/api/v1/workspaces/:workspaceId/labels/assignments",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE),
-    publicApi.unassignLabel
-  )
-  app.patch(
-    "/api/v1/workspaces/:workspaceId/labels/:labelId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE),
-    publicApi.updateLabel
-  )
-  app.delete(
-    "/api/v1/workspaces/:workspaceId/labels/:labelId",
-    ...publicMiddleware,
-    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE),
-    publicApi.deleteLabel
-  )
-
-  // Identity — no scope check. Authentication alone is sufficient for a key
-  // to introspect itself and (for user keys) enumerate the owner's personal bots.
-  app.get("/api/v1/workspaces/:workspaceId/me", ...publicMiddleware, publicApi.getMe)
-  app.get("/api/v1/workspaces/:workspaceId/me/bots", ...publicMiddleware, publicApi.listMyBots)
+  for (const route of PUBLIC_API_ROUTES) {
+    const handler = publicHandlers[route.operationId]
+    const scopeGuard = route.scopes.length > 0 ? [requireApiKeyScope(...route.scopes)] : []
+    app[route.method](
+      toExpressPath(route.path),
+      ...publicMiddleware,
+      ...scopeGuard,
+      ...(Array.isArray(handler) ? handler : [handler])
+    )
+  }
 
   app.use(errorHandler)
 }

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -79,6 +79,7 @@ import {
   type ApiKeyService,
 } from "@threa/backend-common"
 import { createPublicApiAuthMiddleware, requireApiKeyScope } from "./middleware/public-api-auth"
+import { createApiVersionGate } from "./middleware/api-version"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import type { WorkspaceService } from "./features/workspaces"
 import type { StreamService } from "./features/streams"
@@ -997,6 +998,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app[route.method](
       toExpressPath(route.path),
       ...publicMiddleware,
+      createApiVersionGate(route.operationId),
       ...scopeGuard,
       ...(Array.isArray(handler) ? handler : [handler])
     )

--- a/apps/backend/tests/e2e/public-api-versioning.test.ts
+++ b/apps/backend/tests/e2e/public-api-versioning.test.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E tests for public API header versioning (Phase 1).
+ *
+ * Verifies the `Threa-Version` echo header, header-override-beats-pin
+ * precedence, the 400 on an unknown version, and that freshly minted keys
+ * carry the epoch pin in the database.
+ *
+ * Run with: bun test --preload ./tests/setup.ts tests/e2e/public-api-versioning.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { Pool } from "pg"
+import { TestClient, createWorkspace, loginAs } from "../client"
+import { createTestPool } from "../integration/setup"
+import { CURRENT_API_VERSION } from "../../src/features/public-api/versions"
+
+const testRunId = Math.random().toString(36).substring(7)
+const baseUrl = () => process.env.TEST_BASE_URL || "http://localhost:3001"
+
+interface Ctx {
+  workspaceId: string
+  botKey: string
+  botKeyId: string
+  userKeyId: string
+}
+
+async function createBotKey(client: TestClient, workspaceId: string, botId: string, name: string, scopes: string[]) {
+  const res = await client.post<{ value: string; id?: string }>(`/api/workspaces/${workspaceId}/bots/${botId}/keys`, {
+    name,
+    scopes,
+  })
+  return (res.data as { value: string }).value
+}
+
+let pool: Pool
+
+async function setup(): Promise<Ctx> {
+  const client = new TestClient()
+  await loginAs(client, `ver-${testRunId}@test.com`, `VerUser ${testRunId}`)
+  const workspace = await createWorkspace(client, `Ver WS ${testRunId}`)
+
+  const botRes = await client.post(`/api/workspaces/${workspace.id}/bots`, {
+    type: "shared",
+    name: `Ver Bot ${testRunId}`,
+    slug: `ver-bot-${testRunId}`,
+  })
+  const botId = (botRes.data as { data: { id: string } }).data.id
+  const botKey = await createBotKey(client, workspace.id, botId, "ver", ["messages:read"])
+
+  const userKeyRes = await client.post<{ key: { id: string }; value: string }>(
+    `/api/workspaces/${workspace.id}/user-api-keys`,
+    { name: `ver-user-${testRunId}`, scopes: ["messages:search"] }
+  )
+  const userKeyId = (userKeyRes.data as { key: { id: string } }).key.id
+
+  const { rows } = await pool.query<{ id: string }>(
+    `SELECT id FROM bot_api_keys WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [workspace.id]
+  )
+
+  return { workspaceId: workspace.id, botKey, botKeyId: rows[0].id, userKeyId }
+}
+
+describe("Public API header versioning", () => {
+  let ctx: Ctx
+
+  beforeAll(async () => {
+    pool = createTestPool()
+    ctx = await setup()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("echoes the resolved version and defaults to the key pin when no header is sent", async () => {
+    const res = await fetch(`${baseUrl()}/api/v1/workspaces/${ctx.workspaceId}/me`, {
+      headers: { Authorization: `Bearer ${ctx.botKey}` },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Threa-Version")).toBe(CURRENT_API_VERSION)
+  })
+
+  test("a valid header override is accepted and echoed", async () => {
+    const res = await fetch(`${baseUrl()}/api/v1/workspaces/${ctx.workspaceId}/me`, {
+      headers: { Authorization: `Bearer ${ctx.botKey}`, "Threa-Version": CURRENT_API_VERSION },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Threa-Version")).toBe(CURRENT_API_VERSION)
+  })
+
+  test("an unknown version header is rejected with 400 INVALID_API_VERSION", async () => {
+    const res = await fetch(`${baseUrl()}/api/v1/workspaces/${ctx.workspaceId}/me`, {
+      headers: { Authorization: `Bearer ${ctx.botKey}`, "Threa-Version": "2099-01-01" },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { code?: string }
+    expect(body.code).toBe("INVALID_API_VERSION")
+  })
+
+  test("a freshly minted bot key row carries the epoch pin", async () => {
+    const { rows } = await pool.query<{ api_version: string }>(`SELECT api_version FROM bot_api_keys WHERE id = $1`, [
+      ctx.botKeyId,
+    ])
+    expect(rows[0].api_version).toBe(CURRENT_API_VERSION)
+  })
+
+  test("a freshly minted user key row carries the epoch pin", async () => {
+    const { rows } = await pool.query<{ api_version: string }>(`SELECT api_version FROM user_api_keys WHERE id = $1`, [
+      ctx.userKeyId,
+    ])
+    expect(rows[0].api_version).toBe(CURRENT_API_VERSION)
+  })
+})

--- a/apps/backend/tests/e2e/public-api-versioning.test.ts
+++ b/apps/backend/tests/e2e/public-api-versioning.test.ts
@@ -18,9 +18,11 @@ const testRunId = Math.random().toString(36).substring(7)
 const baseUrl = () => process.env.TEST_BASE_URL || "http://localhost:3001"
 
 interface Ctx {
+  client: TestClient
   workspaceId: string
   botKey: string
   botKeyId: string
+  userKey: string
   userKeyId: string
 }
 
@@ -36,8 +38,18 @@ let pool: Pool
 
 async function setup(): Promise<Ctx> {
   const client = new TestClient()
-  await loginAs(client, `ver-${testRunId}@test.com`, `VerUser ${testRunId}`)
+  const workosUser = await loginAs(client, `ver-${testRunId}@test.com`, `VerUser ${testRunId}`)
   const workspace = await createWorkspace(client, `Ver WS ${testRunId}`)
+
+  // User-key auth clamps scopes against the owner's live workspace permissions
+  // (workspace_user_permissions, synced from the control-plane in production).
+  // The e2e harness has no control-plane, so seed the owner's mirror row —
+  // without it every user-key request 401s OWNER_INACTIVE.
+  await pool.query(
+    `INSERT INTO workspace_user_permissions (workspace_id, workos_user_id, role_slugs, status, last_event_at)
+     VALUES ($1, $2, '{owner}', 'active', now()) ON CONFLICT DO NOTHING`,
+    [workspace.id, workosUser.id]
+  )
 
   const botRes = await client.post(`/api/workspaces/${workspace.id}/bots`, {
     type: "shared",
@@ -51,14 +63,37 @@ async function setup(): Promise<Ctx> {
     `/api/workspaces/${workspace.id}/user-api-keys`,
     { name: `ver-user-${testRunId}`, scopes: ["messages:search"] }
   )
-  const userKeyId = (userKeyRes.data as { key: { id: string } }).key.id
+  const userKeyBody = userKeyRes.data as { key: { id: string }; value: string }
 
   const { rows } = await pool.query<{ id: string }>(
     `SELECT id FROM bot_api_keys WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 1`,
     [workspace.id]
   )
 
-  return { workspaceId: workspace.id, botKey, botKeyId: rows[0].id, userKeyId }
+  return {
+    client,
+    workspaceId: workspace.id,
+    botKey,
+    botKeyId: rows[0].id,
+    userKey: userKeyBody.value,
+    userKeyId: userKeyBody.key.id,
+  }
+}
+
+interface MeApiVersion {
+  pinned: string | null
+  resolved: string
+  current: string
+  supported: string[]
+}
+
+async function fetchMeApiVersion(workspaceId: string, key: string): Promise<MeApiVersion> {
+  const res = await fetch(`${baseUrl()}/api/v1/workspaces/${workspaceId}/me`, {
+    headers: { Authorization: `Bearer ${key}` },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { data: { apiVersion: MeApiVersion } }
+  return body.data.apiVersion
 }
 
 describe("Public API header versioning", () => {
@@ -110,5 +145,74 @@ describe("Public API header versioning", () => {
       ctx.userKeyId,
     ])
     expect(rows[0].api_version).toBe(CURRENT_API_VERSION)
+  })
+
+  test("/me reports the pin, resolved version, current version, and supported list", async () => {
+    const info = await fetchMeApiVersion(ctx.workspaceId, ctx.userKey)
+    expect(info).toEqual({
+      pinned: CURRENT_API_VERSION,
+      resolved: CURRENT_API_VERSION,
+      current: CURRENT_API_VERSION,
+      supported: [CURRENT_API_VERSION],
+    })
+  })
+
+  test("detaching the pin (apiVersion: null) makes the key track current and /me reports pinned: null", async () => {
+    const patch = await ctx.client.patch<{ key: { apiVersion: string | null } }>(
+      `/api/workspaces/${ctx.workspaceId}/user-api-keys/${ctx.userKeyId}`,
+      { apiVersion: null }
+    )
+    expect((patch.data as { key: { apiVersion: string | null } }).key.apiVersion).toBeNull()
+
+    const info = await fetchMeApiVersion(ctx.workspaceId, ctx.userKey)
+    expect(info.pinned).toBeNull()
+    expect(info.resolved).toBe(CURRENT_API_VERSION)
+
+    const { rows } = await pool.query<{ api_version: string | null }>(
+      `SELECT api_version FROM user_api_keys WHERE id = $1`,
+      [ctx.userKeyId]
+    )
+    expect(rows[0].api_version).toBeNull()
+  })
+
+  test("re-pinning to a supported version is reflected on the key and /me", async () => {
+    const patch = await ctx.client.patch<{ key: { apiVersion: string | null } }>(
+      `/api/workspaces/${ctx.workspaceId}/user-api-keys/${ctx.userKeyId}`,
+      { apiVersion: CURRENT_API_VERSION }
+    )
+    expect((patch.data as { key: { apiVersion: string | null } }).key.apiVersion).toBe(CURRENT_API_VERSION)
+
+    const info = await fetchMeApiVersion(ctx.workspaceId, ctx.userKey)
+    expect(info.pinned).toBe(CURRENT_API_VERSION)
+  })
+
+  test("pinning to an unsupported version is rejected", async () => {
+    const res = await ctx.client.patch(`/api/workspaces/${ctx.workspaceId}/user-api-keys/${ctx.userKeyId}`, {
+      apiVersion: "2099-01-01",
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test("bot keys detach and re-pin through the bot key PATCH", async () => {
+    const { rows: bots } = await pool.query<{ bot_id: string }>(`SELECT bot_id FROM bot_api_keys WHERE id = $1`, [
+      ctx.botKeyId,
+    ])
+    const botId = bots[0].bot_id
+
+    const detach = await ctx.client.patch<{ data: { apiVersion: string | null } }>(
+      `/api/workspaces/${ctx.workspaceId}/bots/${botId}/keys/${ctx.botKeyId}`,
+      { apiVersion: null }
+    )
+    expect((detach.data as { data: { apiVersion: string | null } }).data.apiVersion).toBeNull()
+
+    const info = await fetchMeApiVersion(ctx.workspaceId, ctx.botKey)
+    expect(info.pinned).toBeNull()
+    expect(info.resolved).toBe(CURRENT_API_VERSION)
+
+    const repin = await ctx.client.patch<{ data: { apiVersion: string | null } }>(
+      `/api/workspaces/${ctx.workspaceId}/bots/${botId}/keys/${ctx.botKeyId}`,
+      { apiVersion: CURRENT_API_VERSION }
+    )
+    expect((repin.data as { data: { apiVersion: string | null } }).data.apiVersion).toBe(CURRENT_API_VERSION)
   })
 })

--- a/apps/public-site/scripts/build-llms.ts
+++ b/apps/public-site/scripts/build-llms.ts
@@ -69,6 +69,14 @@ const PAGES: Page[] = [
       "The message content format: standard markdown plus the user:/channel:/attachment:/memo: link schemes for mentions, channels, files, and memos.",
   },
   {
+    route: "/developers/versioning",
+    html: "developers/versioning/index.html",
+    md: "developers/versioning.md",
+    title: "Versioning",
+    blurb:
+      "Date-based API versions pinned per key at mint, overridable with the Threa-Version header, breaking vs additive changes, and the support window.",
+  },
+  {
     route: "/developers/operations",
     html: "developers/operations/index.html",
     md: "developers/operations.md",

--- a/apps/public-site/src/layouts/DocsLayout.astro
+++ b/apps/public-site/src/layouts/DocsLayout.astro
@@ -34,6 +34,7 @@ const nav = [
     items: [
       { slug: "reference", label: "API reference", href: "/developers/reference" },
       { slug: "markdown", label: "Markdown", href: "/developers/markdown" },
+      { slug: "versioning", label: "Versioning", href: "/developers/versioning" },
       { slug: "operations", label: "Operations", href: "/developers/operations" },
     ],
   },

--- a/apps/public-site/src/pages/developers/index.astro
+++ b/apps/public-site/src/pages/developers/index.astro
@@ -33,8 +33,8 @@ import CodeBlock from "../../components/CodeBlock.astro"
 
   <h2>Base URL</h2>
   <p>
-    The API lives at <code>https://app.threa.io</code>, versioned under
-    <code>/api/v1</code> and scoped to a workspace:
+    The API lives at <code>https://app.threa.io</code> under the stable
+    <code>/api/v1</code> prefix, scoped to a workspace:
     <code>/api/v1/workspaces/&#123;workspaceId&#125;/…</code>. Your workspace ID is
     in the app URL, after <code>/w/</code>.
   </p>

--- a/apps/public-site/src/pages/developers/reference.astro
+++ b/apps/public-site/src/pages/developers/reference.astro
@@ -144,10 +144,14 @@ const sections = groups.flatMap((g) =>
     the read-only examples run against your own workspace as you read.
   </p>
   <p>
-    The base is <code>https://app.threa.io</code>, versioned under <code>/api/v1</code>
-    and scoped to a workspace: <code>/api/v1/workspaces/&#123;workspaceId&#125;/…</code>.
-    Every request authenticates with <code>Authorization: Bearer &lt;key&gt;</code>.
-    Error shapes, paging, idempotency, and rate limits live in
+    The base is <code>https://app.threa.io</code>, under the stable
+    <code>/api/v1</code> prefix and scoped to a workspace:
+    <code>/api/v1/workspaces/&#123;workspaceId&#125;/…</code>. The <code>v1</code>
+    segment does not move as the API evolves; versions are dated and selected with
+    the <code>Threa-Version</code> header, described in
+    <a class="link" href="/developers/versioning">Versioning</a>. Every request
+    authenticates with <code>Authorization: Bearer &lt;key&gt;</code>. Error
+    shapes, paging, idempotency, and rate limits live in
     <a class="link" href="/developers/operations">Operations</a>.
   </p>
 

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -80,9 +80,10 @@ const changelog: ChangelogEntry[] = changelogRaw
     The value must be one of the known versions exactly. An unknown or malformed
     value returns <code>400</code> with the code <code>INVALID_API_VERSION</code>
     and the list of known versions in the error, so a typo fails loudly instead of
-    being treated as the latest. Every response echoes the version that was used in
-    a <code>Threa-Version</code> response header, so you can always confirm which
-    shapes you received.
+    being treated as the latest. Every response that resolved a version echoes it
+    in a <code>Threa-Version</code> response header, so you can always confirm
+    which shapes you received. The <code>400</code> for an unknown version has no
+    resolved version, so it carries no echo header.
   </p>
   <CodeBlock
     lang="json"

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -33,6 +33,7 @@ const changelog: ChangelogEntry[] = changelogRaw
   sections={[
     { id: "how-it-works", label: "How it works" },
     { id: "the-header", label: "The header" },
+    { id: "pins", label: "Reading and changing the pin" },
     { id: "breaking-vs-additive", label: "Breaking vs additive" },
     { id: "support-window", label: "Support window" },
     { id: "the-path-prefix", label: "The path prefix" },
@@ -91,6 +92,41 @@ const changelog: ChangelogEntry[] = changelogRaw
   "code": "INVALID_API_VERSION"
 }`}
   />
+
+  <h2 id="pins">Reading and changing the pin</h2>
+  <p>
+    <code>GET /api/v1/workspaces/&#123;workspaceId&#125;/me</code> reports the key's
+    version state alongside its identity, so an agent can discover its pin with a
+    call it already makes:
+  </p>
+  <CodeBlock
+    lang="json"
+    label="apiVersion block in the /me response"
+    code={`{
+  "data": {
+    "kind": "user",
+    "workspaceId": "ws_...",
+    "userId": "usr_...",
+    "apiVersion": {
+      "pinned": "${currentVersion}",
+      "resolved": "${currentVersion}",
+      "current": "${currentVersion}",
+      "supported": ["${currentVersion}"]
+    }
+  }
+}`}
+  />
+  <p>
+    <code>pinned</code> is the key's pin, or <code>null</code> when the key is
+    unpinned. <code>resolved</code> is the version this request used.
+  </p>
+  <p>
+    The pin is changed from the key management API in the app, by the key's owner.
+    <code>PATCH</code> the key with <code>&#123;"apiVersion": "&lt;date&gt;"&#125;</code> to pin it to a
+    supported version, or <code>&#123;"apiVersion": null&#125;</code> to unpin it. An unpinned key
+    always uses the current version, including future ones with breaking changes,
+    so unpin only if you update your integration as versions ship.
+  </p>
 
   <h2 id="breaking-vs-additive">Breaking vs additive changes</h2>
   <p>

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -1,0 +1,151 @@
+---
+import DocsLayout from "../../layouts/DocsLayout.astro"
+import CodeBlock from "../../components/CodeBlock.astro"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+// The current version and the changelog both come from the generated files, so
+// this page can't drift from what the API actually serves.
+const specPath = fileURLToPath(new URL("../../../../../docs/public-api/openapi.json", import.meta.url))
+const spec = JSON.parse(readFileSync(specPath, "utf8"))
+const currentVersion: string = spec.info.version
+
+const changelogPath = fileURLToPath(new URL("../../../../../docs/public-api/CHANGELOG.md", import.meta.url))
+const changelogRaw = readFileSync(changelogPath, "utf8")
+
+interface ChangelogEntry {
+  version: string
+  body: string
+}
+const changelog: ChangelogEntry[] = changelogRaw
+  .split(/^## /m)
+  .slice(1)
+  .map((chunk) => {
+    const [version, ...rest] = chunk.split("\n")
+    return { version: version.trim(), body: rest.join("\n").trim() }
+  })
+---
+
+<DocsLayout
+  title="Versioning · Threa Developers"
+  description="How Threa API versions work: date-based versions, pinned per key at mint, overridable with the Threa-Version header, with a support window of at least twelve months."
+  current="versioning"
+  sections={[
+    { id: "how-it-works", label: "How it works" },
+    { id: "the-header", label: "The header" },
+    { id: "breaking-vs-additive", label: "Breaking vs additive" },
+    { id: "support-window", label: "Support window" },
+    { id: "the-path-prefix", label: "The path prefix" },
+    { id: "changelog", label: "Changelog" },
+  ]}
+>
+  <p class="eyebrow">Versioning</p>
+  <h1>API <span class="accent">versions</span>.</h1>
+  <p class="lead">
+    Threa versions the API by date. Each key is pinned to a version when you
+    create it, so your integration keeps seeing the same shapes until you decide
+    to move. When a version introduces a breaking change, your key stays on the
+    older one and you opt in when you are ready.
+  </p>
+
+  <h2 id="how-it-works">How it works</h2>
+  <p>
+    A version is a date. The current version is <code>{currentVersion}</code>.
+    When you create an API key it is pinned to
+    whatever version is current at that moment, and that pin decides which shapes
+    the key sees on every request. You do not have to send anything for this to
+    work.
+  </p>
+  <p>
+    When we later ship a version with a breaking change, existing keys are
+    unaffected. You test the new version by sending the <code>Threa-Version</code>
+    header on individual requests, and when your integration is ready you either
+    send that header everywhere or create a new key pinned to the newer version.
+  </p>
+
+  <h2 id="the-header">The header</h2>
+  <p>
+    Send <code>Threa-Version</code> with a version date to override your key's pin
+    for a single request. A valid header takes precedence over the pin.
+  </p>
+  <CodeBlock
+    lang="bash"
+    label="override the pin for one request"
+    code={`curl {{baseUrl}}/api/v1/workspaces/{{workspaceId}}/streams \\
+  -H "Authorization: Bearer {{apiKey}}" \\
+  -H "Threa-Version: ${currentVersion}"`}
+  />
+  <p>
+    The value must be one of the known versions exactly. An unknown or malformed
+    value returns <code>400</code> with the code <code>INVALID_API_VERSION</code>
+    and the list of known versions in the error, so a typo fails loudly instead of
+    being treated as the latest. Every response echoes the version that was used in
+    a <code>Threa-Version</code> response header, so you can always confirm which
+    shapes you received.
+  </p>
+  <CodeBlock
+    lang="json"
+    label="400 on an unknown version"
+    code={`{
+  "error": "Unknown API version \\"2020-01-01\\". Known versions: ${currentVersion}",
+  "code": "INVALID_API_VERSION"
+}`}
+  />
+
+  <h2 id="breaking-vs-additive">Breaking vs additive changes</h2>
+  <p>
+    Additive changes do not get a new version and can arrive on your current one at
+    any time. Plan for them. These are new endpoints, new optional request fields,
+    new response fields, and new values in response enums that are documented as
+    open sets. Write your client so an unexpected field or enum value is ignored
+    rather than rejected.
+  </p>
+  <p>
+    Breaking changes get a new dated version and never reach a key pinned to an
+    earlier one. A change is breaking when it removes or renames a field, changes a
+    field's type or meaning, tightens request validation, changes a default, or
+    changes an error code or status. This is the same split Stripe uses.
+  </p>
+  <table class="docs-table">
+    <thead><tr><th>Change</th><th>New version?</th></tr></thead>
+    <tbody>
+      <tr><td>New endpoint</td><td>No</td></tr>
+      <tr><td>New optional request field</td><td>No</td></tr>
+      <tr><td>New response field</td><td>No</td></tr>
+      <tr><td>New value in an open response enum</td><td>No</td></tr>
+      <tr><td>Removing or renaming a field</td><td>Yes</td></tr>
+      <tr><td>Changing a field's type or meaning</td><td>Yes</td></tr>
+      <tr><td>Tightening request validation</td><td>Yes</td></tr>
+      <tr><td>Changing a default value</td><td>Yes</td></tr>
+      <tr><td>Changing an error code or status</td><td>Yes</td></tr>
+    </tbody>
+  </table>
+
+  <h2 id="support-window">Support window</h2>
+  <p>
+    A version stays supported for at least twelve months after it is succeeded, so
+    a key pinned to an older version keeps working for that long once a newer
+    version ships. That gives you time to test and migrate on your own schedule.
+  </p>
+
+  <h2 id="the-path-prefix">The path prefix</h2>
+  <p>
+    The URL prefix does not change with versions. Every endpoint stays under
+    <code>/api/v1</code>, and the <code>Threa-Version</code> header carries the
+    version. The <code>v1</code> segment is a stable prefix, so paths you hardcode
+    today keep working. Version negotiation happens entirely through the header and
+    the key's pin.
+  </p>
+
+  <h2 id="changelog">Changelog</h2>
+  <p>
+    Each dated version is listed here with what changed. The current version is
+    <code>{currentVersion}</code>.
+  </p>
+  {changelog.map((entry) => (
+    <Fragment>
+      <h3 id={`v-${entry.version}`}>{entry.version}</h3>
+      <p>{entry.body}</p>
+    </Fragment>
+  ))}
+</DocsLayout>

--- a/docs/plans/public-api-header-versioning.md
+++ b/docs/plans/public-api-header-versioning.md
@@ -370,6 +370,8 @@ Shipping it:
 
 That module is the template for every future breaking change: ~40 lines, no handler edits, no route edits.
 
+One constraint every `downgradeResponse` must respect: the `res.json` wrap sees **every** payload the route emits for a behind-version caller, including the error envelope (`{ error, code }`) produced by `errorHandler` after the wrap is installed. Transforms must pass through payloads that don't match the success shape untouched (the example above does this implicitly — it only rewrites the `data` field it finds). Add a golden test for the error path when the transform destructures the envelope.
+
 ## 9. Example implementation C — the path move (Phase 2)
 
 Backend, in `src/routes.ts` before the public mount loop:

--- a/docs/plans/public-api-header-versioning.md
+++ b/docs/plans/public-api-header-versioning.md
@@ -374,6 +374,11 @@ That module is the template for every future breaking change: ~40 lines, no hand
 
 One constraint every `downgradeResponse` must respect: the `res.json` wrap sees **every** payload the route emits for a behind-version caller, including the error envelope (`{ error, code }`) produced by `errorHandler` after the wrap is installed. Transforms must pass through payloads that don't match the success shape untouched (the example above does this implicitly — it only rewrites the `data` field it finds). Add a golden test for the error path when the transform destructures the envelope.
 
+Two more substrate constraints for change authors (adversarial review 2026-07-12):
+
+- **`upgradeRequest` receives `req.body` only.** A change that alters the shape of a query-parameter operation (`requestIn: "query"`) has nothing to transform today — extend the gate with a query-upgrade hook in the same PR that ships the first such change; do not ship a query-shape change assuming the body hook covers it.
+- **Multipart operations parse after the gate.** For `uploadAttachment`, multer runs downstream of the version gate, so `req.body` is empty at upgrade time and is later replaced by multer. A change touching a multipart operation's fields cannot use `upgradeRequest`; it needs a post-multer hook.
+
 ## 9. Example implementation C — the path move (Phase 2)
 
 Backend, in `src/routes.ts` before the public mount loop:

--- a/docs/plans/public-api-header-versioning.md
+++ b/docs/plans/public-api-header-versioning.md
@@ -61,6 +61,8 @@ UPDATE bot_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;
 
 (Epoch = ship date of Phase 1, fixed at `2026-07-12`.) New keys are minted at the then-current version. `TEXT`, validated in code against the version list (INV-3). No user-facing version picker for now — a key's pin is upgradeable later via the existing key-management PATCH if we ever want it; do not build UI speculatively (INV-36).
 
+A key can also be **unpinned** (`api_version = NULL`, follow-up to Kris's 2026-07-12 request): the resolution chain then lands on `CURRENT_API_VERSION`, so the key always speaks the latest shapes, breaking changes included. Detach/re-pin is a management-plane operation — `PATCH` on the app API's key endpoints with `apiVersion: "<date>" | null` — and `GET /api/v1/.../me` reports `apiVersion: { pinned, resolved, current, supported }` so an agent can discover its pin. Changing the pin deliberately stays off the public API: an agent may discover it is behind, not silently rewrite its own wire contract.
+
 An integrator's upgrade story: their key is pinned at 2026-07-12; when we ship the 2026-11-01 version, nothing changes for them; they test with `Threa-Version: 2026-11-01` on individual requests; when ready, they either send the header everywhere or mint a new key.
 
 ### 2.3 What counts as a breaking change (needs a new version) vs not

--- a/docs/plans/public-api-header-versioning.md
+++ b/docs/plans/public-api-header-versioning.md
@@ -80,7 +80,7 @@ Handlers and serializers always produce/consume the **latest** shape. Each dated
 
 Changes are scoped by `operationId` (the registry already names every endpoint). A change touching a shared wire resource (e.g. the message object appears in `listMessages`, `sendMessage`, `searchMessages`, `findMessagesByMetadata`) declares one transform function and lists the operations it applies to — explicit and compile-checked rather than a magic deep-walker.
 
-```
+```text
 apps/backend/src/features/public-api/versions/
   index.ts                        # ordered registry + resolution helpers
   types.ts                        # ApiVersion, VersionChange

--- a/docs/plans/public-api-header-versioning.md
+++ b/docs/plans/public-api-header-versioning.md
@@ -1,0 +1,435 @@
+# Public API: Stripe-style header versioning
+
+Status: implemented, PR pending (2026-07-12, see §11). Epoch version `2026-07-12`. Scope: **Phase 1 only** — header versioning on the existing `/api/v1` paths; the bare-path move (Phase 2) is skipped for now. Branch: `feat/reconsider-public-api`.
+
+## TL;DR recommendation
+
+1. **Version via `Threa-Version: YYYY-MM-DD` header**, pinned per API key at mint time, header override per request. Handlers always speak the latest shape; dated **version-change modules** downgrade responses / upgrade requests for older callers. This is Phase 1 and is independent of any URL change.
+2. **URL cleanup is severable and optional — and was decided against for now (§11).** Stripe itself never dropped `/v1`; their header versioning coexists with a frozen path prefix, and we do the same. The bare-path design (public at `/api/workspaces/...`, credential-dispatched against the app API, `/api/v1` as a rewriting alias for ≥6 months) is retained in §4/§9 as reference should it be revisited.
+3. **Unify the plumbing, not the surface.** One namespace, one principal model, shared services (already true) — but the public surface stays a curated registry with its own wire schemas. "Not gatekeeping" is served by making endpoint promotion a ~30-line recipe, not by freezing the fast-moving app API into a public contract.
+
+---
+
+## 1. Current state (verified inventory)
+
+Four URL planes on the regional backend (`apps/backend/src/routes.ts`):
+
+| Plane              | Prefix                               | Auth                                        | Notes                                           |
+| ------------------ | ------------------------------------ | ------------------------------------------- | ----------------------------------------------- |
+| App API            | `/api/...`                           | session cookie                              | ~200 routes, changes with every frontend deploy |
+| Public API         | `/api/v1/...`                        | `Bearer threa_uk_*` / `threa_bk_*` + scopes | ~50 routes, curated wire shapes                 |
+| Service-to-service | `/internal/...`                      | shared secrets                              | control-plane → backend, enclave callbacks      |
+| Ops                | `/readyz`, `/metrics`, `/debug/pool` | ops gate                                    |                                                 |
+
+Load-bearing facts for this design:
+
+- **Route registry is already the SSOT**: `apps/backend/src/features/public-api/routes.ts` (`PUBLIC_API_ROUTES`, line 592) declares method/path/operationId/scopes/request+response Zod schemas per endpoint; `apps/backend/scripts/generate-api-docs.ts` generates `docs/public-api/openapi.json` from it with a `--check` drift gate. The Express registrations in `src/routes.ts:911-1154` duplicate it by hand.
+- **workspace-router** (`apps/workspace-router/src/index.ts`): `PUBLIC_API_ROUTE_RE = /^\/api\/v1\/workspaces\/([^/]+)/` (line 53) and `WORKSPACE_ROUTE_RE = /^\/api\/workspaces\/([^/]+)/` (line 51) both feed `routeWorkspaceRequest`, which parses the **workspace id from the path** to resolve the region. The staging hostname-pin guard terminates all `/api/*` paths (line 167). Consequences: the workspace id must stay positionally extractable, and paths must stay under `/api/` — so "bare" means `/api/workspaces/...`, not `/workspaces/...`.
+- **External clients each build paths in one helper**: `extensions/bot-runtime-client/src/transport.ts:449` (`v1Path`), `extensions/remote-session/src/client.ts:147` (`buildPath`), `extensions/pi-remote/src/threa-remote.ts` (~25 literals joined at line 628). All store an origin `baseUrl` defaulting to `https://app.threa.io`.
+- **Frontend** routes every call through one `apiFetch` wrapper (`apps/frontend/src/api/client.ts:57`), with `/api/workspaces/...` literals in ~56 files.
+- **CORS is one global policy** (`app.ts:57`): allowlist + `credentials: true` for everything. No public/app split exists — but the developers playground on the public site does in-browser calls, so the public API needs cross-origin reachability the app API must never get with credentials.
+- **Scope failures return 404** (existence-hiding) in `requireApiKeyScope` (`middleware/public-api-auth.ts:126`).
+- **No versioning machinery exists** — `info.version: "1.0.0"` in the OpenAPI spec is decorative. Greenfield.
+- Other consumers to update when paths move: `.github/workflows/{notify,staging}.yml` (curl `/api/v1`), `.agents/skills/threa-public-api/SKILL.md`, `update-pi-remote-plugin/SKILL.md`, `apps/public-site/src/pages/developers/*.astro` (hand-written prose hardcoding `/api/v1`), `apps/backend/tests/e2e/public-api-*.test.ts`, `apps/backend/tests/client.ts:907`.
+
+---
+
+## 2. Version scheme
+
+### 2.1 The header
+
+`Threa-Version: 2026-07-12` — date-based, like `Stripe-Version` / `Anthropic-Version`. No `X-` prefix (RFC 6648; the existing `X-Threa-*` headers are internal plumbing and stay as they are).
+
+Resolution precedence, applied by middleware after key auth:
+
+1. `Threa-Version` request header, if present. Must be an exact member of the known-versions list — **not** free-form dates. Unknown, malformed, or future value → `400 INVALID_API_VERSION` with the known versions in the error body (fail loudly, INV-11; silently clamping a typo'd date to "latest" is exactly the corruption-hiding fallback we ban).
+2. The key's pinned `api_version` (always present after the backfill migration).
+
+Every response echoes the resolved version: `Threa-Version: 2026-07-12`, and it's added to `Access-Control-Expose-Headers`.
+
+### 2.2 Pinning at key mint
+
+New `api_version TEXT` column on `user_api_keys` and `bot_api_keys` (append-only migration under `apps/backend/src/db/migrations/`):
+
+```sql
+ALTER TABLE user_api_keys ADD COLUMN api_version TEXT;
+ALTER TABLE bot_api_keys ADD COLUMN api_version TEXT;
+-- Existing keys speak today's shapes, which *are* the epoch version.
+UPDATE user_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;
+UPDATE bot_api_keys SET api_version = '2026-07-12' WHERE api_version IS NULL;
+```
+
+(Epoch = ship date of Phase 1, fixed at `2026-07-12`.) New keys are minted at the then-current version. `TEXT`, validated in code against the version list (INV-3). No user-facing version picker for now — a key's pin is upgradeable later via the existing key-management PATCH if we ever want it; do not build UI speculatively (INV-36).
+
+An integrator's upgrade story: their key is pinned at 2026-07-12; when we ship the 2026-11-01 version, nothing changes for them; they test with `Threa-Version: 2026-11-01` on individual requests; when ready, they either send the header everywhere or mint a new key.
+
+### 2.3 What counts as a breaking change (needs a new version) vs not
+
+Additive = no new version: new endpoints, new optional request fields, new response fields, new enum values _in responses documented as open sets_. Breaking = new dated version + change module: removing/renaming a field, changing a type or semantics, tightening request validation, changing a default, changing an error code/status. Same taxonomy Stripe uses; goes verbatim into the developer docs.
+
+---
+
+## 3. Version-change machinery
+
+Handlers and serializers always produce/consume the **latest** shape. Each dated version is defined by a module describing how to translate between it and the version after it. At request time:
+
+- **Request upgrade**: apply changes _newer than the client's version_, oldest→newest, to `req.body`/`req.query` before the handler's Zod validation runs.
+- **Response downgrade**: apply the same changes newest→oldest to the outgoing payload, via a `res.json` wrap installed by the version middleware.
+
+Changes are scoped by `operationId` (the registry already names every endpoint). A change touching a shared wire resource (e.g. the message object appears in `listMessages`, `sendMessage`, `searchMessages`, `findMessagesByMetadata`) declares one transform function and lists the operations it applies to — explicit and compile-checked rather than a magic deep-walker.
+
+```
+apps/backend/src/features/public-api/versions/
+  index.ts                        # ordered registry + resolution helpers
+  types.ts                        # ApiVersion, VersionChange
+  2026-11-01-stream-name.ts       # one module per dated version (example, §8)
+  2026-11-01-stream-name.test.ts  # golden request/response pairs per version
+```
+
+### 3.1 Registry-driven route mounting (prerequisite refactor)
+
+Today `src/routes.ts:911-1154` hand-duplicates the registry. Phase 1 replaces those ~250 lines with a mount loop, which is also the only sane place to attach the version gate:
+
+- `PUBLIC_API_ROUTES` stays the SSOT; Express paths derived from the OpenAPI-style ones (`{workspaceId}` → `:workspaceId`).
+- A handler map `Record<OperationId, RequestHandler | RequestHandler[]>` (array for the multipart upload route that needs `rateLimits.upload` + `upload` in the chain), checked for exhaustiveness at startup — a registry entry without a handler or vice versa throws at boot, killing the drift-check class entirely.
+- Scopes come from the registry, so `requireApiKeyScope` can't disagree with the docs.
+
+This refactor is behavior-neutral and independently shippable as PR 1 of the phase.
+
+---
+
+## 4. URL schema (Phase 2, severable)
+
+### 4.1 Recommended endgame: one `/api` namespace, credential-dispatched
+
+- **Public API**: `/api/workspaces/:workspaceId/...` (bare — the `v1` segment dies).
+- **App API**: unchanged, `/api/workspaces/:workspaceId/...`. No frontend migration at all.
+- **Dispatch**: a guard at the top of the public router: if `Authorization` doesn't start with `Bearer threa_`, `next("router")` — the request falls through to the app routes. Bearer-`threa_*` requests that match no public route also fall through (so e.g. bot-runtime-client's existing call to the app-plane `GET /api/workspaces/:id/config` keeps working). Explicit Bearer always wins over an also-present cookie.
+- **`/internal`** stays exactly what it is (service-to-service). The instinct to move the app API under `/internal` would conflict with that established meaning; the credential dispatch makes moving the app API unnecessary anyway.
+- **`/api/v1` alias**: a rewrite middleware (`req.url = req.url.replace(/^\/api\/v1\//, "/api/")`) mounted before the public router, adding `Deprecation: true` and a `Sunset` header once a removal date is picked. Kept ≥6 months, removed when telemetry says it's quiet.
+- **workspace-router**: `WORKSPACE_ROUTE_RE` already matches the bare form; keep `PUBLIC_API_ROUTE_RE` until the alias dies, then delete it. Staging guard unaffected (still `/api/`).
+
+Trade-off to accept with open eyes: during overlap, the _same URL_ (`GET /api/workspaces/:id/streams`) returns the curated public wire shape to a key and the rich app shape to a cookie. That's unusual as API design goes, but it's coherent here: the public shape is the versioned contract, the app shape is a private implementation detail that happens to share a path. The `Threa-Version` echo header makes it unambiguous which plane answered. If this smells too strong, the fallback is simply keeping `/api/v1` forever, Stripe-style — everything else in this document works identically.
+
+Why not fully bare (`/workspaces/...`)? The router's staging pin terminates on `/api/` (index.ts:167) and would route bare paths to the frontend Pages proxy; and every consumer already carries `/api`. Cost with no benefit.
+
+### 4.2 CORS split
+
+Preflights carry no `Authorization`, so OPTIONS can't credential-dispatch. Policy that works for both planes on shared paths:
+
+- Origin on the app allowlist → current behavior (reflect origin, `credentials: true`).
+- Any other origin → reflect origin, `credentials: false`, allow `Authorization, Content-Type, Threa-Version, Idempotency-Key`-style headers.
+
+Cookies never flow cross-origin (browser enforces via the no-credentials grant), keys are never _ambient_ (an attacker page can't use a victim's key without possessing it), so opening origins for the keyed plane is safe and is what the developers-playground "Run" button needs anyway.
+
+---
+
+## 5. Public/app unification: plumbing yes, surface no
+
+**Recommended: do not unify the handler surface.** Reasons:
+
+- The app API co-evolves with the frontend weekly (same deploy, same repo — it's not a contract, it's a function call across HTTP). Making it public freezes it under the compatibility guarantee and every product iteration starts paying the version-module tax. That's the "mess up when moving fast" risk you named, made structural.
+- The public wire is deliberately narrower: `sanitize.ts`, curated serializers, scope gating, existence-hiding 404s. Dual-auth'ing the app handlers would leak app-shape internals to keys by default — the unsafe direction.
+
+**What to unify instead** (this is where footprint/deviation actually shrinks):
+
+- **Namespace** (§4): one `/api`, credential-dispatched.
+- **Principal model**: fold `req.userApiKey` / `req.botApiKey` / session into one `req.principal = { kind: "session" | "user_key" | "bot_key", userId?, botId?, scopes }`. App routes can then adopt scope checks incrementally; services stay principal-agnostic (they already are).
+- **Services** — already shared; public handlers delegate to the same `EventService`/`StreamService`/etc. Deviation risk lives in serializers, which is exactly where the versioned contract needs it to live.
+- **Promotion recipe** — "not gatekeeping" operationalized. Making an app capability public = one registry entry (path/scopes/schemas), one serializer (or reuse), one handler delegating to the existing service, tests. ~30 lines + docs regen. Document this recipe in `docs/public-api/` and treat "should this be public?" as a per-endpoint product decision with a cheap yes.
+
+Endgame option (later, not now): individual routes whose public and app shapes genuinely converge can collapse into a single registration served to both principals. The architecture above permits it per-route; nothing forces it.
+
+---
+
+## 6. Grace & deprecation policy
+
+- **API versions**: supported ≥12 months after being succeeded. With the current integrator count this costs near-nothing; revisit the window when the version-module count grows.
+- **`/api/v1` path alias**: ≥6 months, `Deprecation`/`Sunset` headers from day one, removal gated on telemetry.
+- **Telemetry**: log `{ apiVersion, versionSource: "header"|"key", keyId, operationId }` per public request (extend the existing request logging), so "who still sends v1 paths / old versions" is a log query, not a guess.
+- **Changelog**: `docs/public-api/CHANGELOG.md` generated from the version modules' `description`/`changelog` fields by `generate-api-docs.ts`, rendered on the developers site next to the reference.
+
+---
+
+## 7. Example implementation A — the versioning substrate
+
+Everything below is written to drop into the existing idioms (factories, `HttpError`, Zod, INV-51 colocation).
+
+### 7.1 `features/public-api/versions/types.ts`
+
+```ts
+import type { OperationId } from "../routes"
+
+/** Dated public API versions, ascending. The first entry is the epoch. */
+export const API_VERSIONS = ["2026-07-12"] as const
+export type ApiVersion = (typeof API_VERSIONS)[number]
+export const CURRENT_API_VERSION: ApiVersion = API_VERSIONS[API_VERSIONS.length - 1]
+
+export interface VersionChangeContext {
+  operationId: OperationId
+}
+
+/**
+ * One dated, breaking change. `version` is the date the NEW behavior became
+ * default; callers pinned BEFORE it get the transforms applied.
+ * Transforms translate between this version's shape and the previous one:
+ * upgradeRequest lifts an old-shape request to the new shape, downgradeResponse
+ * lowers a new-shape payload to the old shape. Both must be pure.
+ */
+export interface VersionChange {
+  version: ApiVersion
+  /** One-line summary for the generated CHANGELOG. */
+  description: string
+  /** Operations whose requests/responses this change touches. */
+  operations: ReadonlySet<OperationId>
+  upgradeRequest?: (body: unknown, ctx: VersionChangeContext) => unknown
+  downgradeResponse?: (payload: unknown, ctx: VersionChangeContext) => unknown
+}
+```
+
+(`OperationId` = a union derived from the registry: `export type OperationId = (typeof PUBLIC_API_ROUTES)[number]["operationId"]` once the registry is `as const`-friendly, or a string union maintained beside it.)
+
+### 7.2 `features/public-api/versions/index.ts`
+
+```ts
+import { HttpError } from "@threa/backend-common"
+import { API_VERSIONS, CURRENT_API_VERSION, type ApiVersion, type VersionChange } from "./types"
+
+/** Ascending by version. Startup assertion enforces ordering + known dates. */
+export const VERSION_CHANGES: VersionChange[] = [
+  // e.g. streamNameChange (§8) once the first real change ships
+]
+
+for (let i = 1; i < VERSION_CHANGES.length; i++) {
+  if (VERSION_CHANGES[i - 1].version >= VERSION_CHANGES[i].version) {
+    throw new Error("VERSION_CHANGES must be strictly ascending by version")
+  }
+}
+
+const KNOWN = new Set<string>(API_VERSIONS)
+
+export function parseApiVersion(raw: string): ApiVersion {
+  if (!KNOWN.has(raw)) {
+    throw new HttpError(`Unknown API version "${raw}". Known versions: ${API_VERSIONS.join(", ")}`, {
+      status: 400,
+      code: "INVALID_API_VERSION",
+    })
+  }
+  return raw as ApiVersion
+}
+
+/** Changes the caller is behind on, i.e. with version strictly newer than theirs. */
+export function changesAfter(clientVersion: ApiVersion): VersionChange[] {
+  // ISO dates compare lexicographically — no Date parsing.
+  return VERSION_CHANGES.filter((c) => c.version > clientVersion)
+}
+
+export { API_VERSIONS, CURRENT_API_VERSION }
+export type { ApiVersion }
+```
+
+### 7.3 Version gate middleware — `middleware/api-version.ts`
+
+Mounted per-route by the registry loop, _after_ `publicApiAuth` (needs the validated key for the pin) and _before_ the handler.
+
+```ts
+import type { NextFunction, Request, Response } from "express"
+import type { OperationId } from "../features/public-api/routes"
+import { changesAfter, parseApiVersion, CURRENT_API_VERSION, type ApiVersion } from "../features/public-api/versions"
+
+declare global {
+  namespace Express {
+    interface Request {
+      apiVersion?: ApiVersion
+    }
+  }
+}
+
+export function createApiVersionGate(operationId: OperationId) {
+  return function apiVersionGate(req: Request, res: Response, next: NextFunction): void {
+    const header = req.header("Threa-Version")
+    const pinned = req.userApiKey?.apiVersion ?? req.botApiKey?.apiVersion ?? CURRENT_API_VERSION
+    const version = header ? parseApiVersion(header) : pinned
+
+    req.apiVersion = version
+    res.setHeader("Threa-Version", version)
+
+    const pending = changesAfter(version).filter((c) => c.operations.has(operationId))
+    if (pending.length === 0) return next()
+
+    // Upgrade the request oldest→newest so the handler's Zod validation sees
+    // the current shape.
+    for (const change of pending) {
+      if (change.upgradeRequest) req.body = change.upgradeRequest(req.body, { operationId })
+    }
+
+    // Downgrade the response newest→oldest on the way out.
+    const json = res.json.bind(res)
+    res.json = (payload: unknown) => {
+      let out = payload
+      for (let i = pending.length - 1; i >= 0; i--) {
+        const change = pending[i]
+        if (change.downgradeResponse) out = change.downgradeResponse(out, { operationId })
+      }
+      return json(out)
+    }
+    next()
+  }
+}
+```
+
+`ValidatedUserApiKey` / `ValidatedBotApiKey` gain `apiVersion: ApiVersion` (read in the same `SELECT` the services already do), and the create paths write `CURRENT_API_VERSION`.
+
+### 7.4 Registry-driven mounting — replaces `src/routes.ts:911-1154`
+
+```ts
+import { PUBLIC_API_ROUTES, type OperationId } from "./features/public-api/routes"
+import { createApiVersionGate } from "./middleware/api-version"
+
+function toExpressPath(openApiPath: string): string {
+  return openApiPath.replace(/\{(\w+)\}/g, ":$1")
+}
+
+const publicHandlers: Record<OperationId, RequestHandler | RequestHandler[]> = {
+  searchMessages: publicApi.searchMessages,
+  sendMessage: publicApi.sendMessage,
+  uploadAttachment: [rateLimits.upload, upload, publicApi.uploadAttachment],
+  // ... every operationId; exhaustiveness enforced by the Record type
+}
+
+for (const route of PUBLIC_API_ROUTES) {
+  const handler = publicHandlers[route.operationId]
+  if (!handler) throw new Error(`No handler for public API operation ${route.operationId}`)
+  app[route.method](
+    toExpressPath(route.path),
+    ...publicMiddleware,
+    createApiVersionGate(route.operationId),
+    requireApiKeyScope(...route.scopes),
+    ...(Array.isArray(handler) ? handler : [handler])
+  )
+}
+```
+
+The `Record<OperationId, ...>` type makes a missing handler a compile error and the boot-time throw catches a registry/handler mismatch in dev before any request. The pre-commit OpenAPI drift check stays; the _route_ drift check becomes structural.
+
+### 7.5 OpenAPI generator changes
+
+- `info.version` = `CURRENT_API_VERSION`.
+- A global `Threa-Version` header parameter (optional, enum of `API_VERSIONS`) added to every operation via `components.parameters`.
+- Emit `docs/public-api/CHANGELOG.md` from `VERSION_CHANGES` (version, description, affected operations).
+- Spec documents only the current version (Stripe does the same); older shapes live in the changelog + version modules. Per-version spec generation is possible later (changes could carry schema patches) — deferred, YAGNI until an integrator asks.
+
+---
+
+## 8. Example implementation B — a worked version change
+
+Scenario: we rename `displayName` → `name` on the stream wire object (it's the only public resource using `displayName`; every other resource says `name`). Touches every operation that returns a stream and the `updateStream` request body.
+
+`features/public-api/versions/2026-11-01-stream-name.ts`:
+
+```ts
+import type { VersionChange } from "./types"
+
+const OPERATIONS = new Set(["listStreams", "getStream", "updateStream"] as const)
+
+function renameInStream(stream: Record<string, unknown>): Record<string, unknown> {
+  const { name, ...rest } = stream
+  return { ...rest, displayName: name }
+}
+
+export const streamNameChange: VersionChange = {
+  version: "2026-11-01",
+  description: "Stream objects: `displayName` renamed to `name`; `PATCH streams/:id` accepts `name`.",
+  operations: OPERATIONS,
+
+  // Old callers PATCH { displayName } — lift it to the current { name } shape
+  // before the handler's Zod schema (which only knows `name`) validates it.
+  upgradeRequest(body, { operationId }) {
+    if (operationId !== "updateStream" || typeof body !== "object" || body === null) return body
+    const { displayName, ...rest } = body as Record<string, unknown>
+    return displayName === undefined ? body : { ...rest, name: displayName }
+  },
+
+  // Handlers emit { name }; old callers see { displayName }.
+  downgradeResponse(payload, { operationId }) {
+    const envelope = payload as { data: unknown }
+    if (operationId === "listStreams") {
+      return { ...envelope, data: (envelope.data as Record<string, unknown>[]).map(renameInStream) }
+    }
+    return { ...envelope, data: renameInStream(envelope.data as Record<string, unknown>) }
+  },
+}
+```
+
+Shipping it:
+
+1. Append `"2026-11-01"` to `API_VERSIONS`; register `streamNameChange` in `VERSION_CHANGES`.
+2. Rename the field in `streamSchema` + `serializeStream` (registry + serializer only — handlers untouched).
+3. Regenerate the spec; the changelog entry falls out of `description`.
+4. Golden tests (`2026-11-01-stream-name.test.ts`): one e2e-ish pair per direction — `GET streams` with `Threa-Version: 2026-07-12` asserts `displayName` and no `name`; with `2026-11-01` asserts the inverse; `PATCH` with old header + `{ displayName }` succeeds and renames. Assert the echo header both ways.
+
+That module is the template for every future breaking change: ~40 lines, no handler edits, no route edits.
+
+## 9. Example implementation C — the path move (Phase 2)
+
+Backend, in `src/routes.ts` before the public mount loop:
+
+```ts
+// Legacy /api/v1 alias — public API paths went bare (see
+// docs/plans/public-api-header-versioning.md). Remove after sunset.
+app.use((req, res, next) => {
+  if (req.url.startsWith("/api/v1/")) {
+    req.url = "/api" + req.url.slice("/api/v1".length)
+    res.setHeader("Deprecation", "true")
+    // res.setHeader("Sunset", "<HTTP-date once picked>")
+  }
+  next()
+})
+```
+
+Registry paths change `"/api/v1/workspaces/{workspaceId}/..."` → `"/api/workspaces/{workspaceId}/..."`; spec regen picks it up. The credential guard heads the public mount loop:
+
+```ts
+const publicRouter = express.Router()
+publicRouter.use((req, _res, next) => {
+  const auth = req.headers.authorization
+  if (!auth?.startsWith("Bearer threa_")) return next("router") // fall through to app routes
+  next()
+})
+// ...mount loop from §7.4 targets publicRouter; app.use(publicRouter) before app routes
+```
+
+Client side, one helper each — e.g. `extensions/bot-runtime-client/src/transport.ts`:
+
+```ts
+private v1Path(suffix: string): string {
+  return `/api/workspaces/${this.workspaceId}${suffix}`   // was /api/v1/workspaces
+}
+// and in the fetch wrapper:
+headers: { ...headers, "Threa-Version": THREA_API_VERSION }
+```
+
+Same one-line change in `remote-session/src/client.ts:147` and `pi-remote/src/threa-remote.ts` (its ~25 literals share the `config.baseUrl` join at line 628 — a `wsPath()` helper extraction is the tidy version). Then the docs/CI sweep: `public-site/src/pages/developers/*.astro`, `threa-public-api` + `update-pi-remote-plugin` skills, `.github/workflows/{notify,staging}.yml`, backend e2e tests + `tests/client.ts`.
+
+---
+
+## 10. Rollout
+
+**Phase 1 — versioning substrate (no wire change, no URL change):**
+
+1. PR: registry-driven mounting (§7.4), behavior-neutral.
+2. PR: `api_version` columns + pin-at-mint + `Threa-Version` resolution/echo + version-gate middleware + telemetry fields. `API_VERSIONS = [epoch]`, `VERSION_CHANGES = []` — the machinery runs but transforms nothing.
+3. PR: OpenAPI/docs — header documented, changelog scaffold, deprecation-policy page on the developers site.
+
+**Phase 2 — bare paths (optional, decide separately):** alias middleware + credential guard + registry path change + client/docs/CI sweep + CORS split (§4.2). Router: keep both regexes until sunset.
+
+**Phase 3 — first real version change:** use §8 as the template. Nothing needs to exist before a real need arrives.
+
+**Testing:** golden per-change tests (§8.4); an invariant test over `API_VERSIONS`/`VERSION_CHANGES` ordering; e2e: unknown version → 400, header override beats pin, echo header, `/api/v1` alias equivalence during Phase 2 (`public-api-openapi.test.ts` runs against both prefixes until sunset).
+
+## 11. Decisions (Kris, 2026-07-11)
+
+1. **Phase 2: skipped for now.** `/api/v1` stays as a frozen path prefix, Stripe's own choice. Header versioning (Phase 1) proceeds on the existing paths. §4 and §9 are kept as the reference design should this be revisited; nothing in Phase 1 forecloses it.
+2. **Dual-shape same-URL: dissolved by (1).** Kris's concern — same URL serving different shapes is confusing for agents and developers deciding what should be served — is a real argument and reinforces the skip. One URL = one shape stands.
+3. **Version support window: ≥12 months** after a version is succeeded.
+4. **Key-pin UI: deferred** (INV-36). Pinning itself still ships in Phase 1 (`api_version` column, pin-at-mint, header override); only the settings-UI surfacing waits until a second version exists.

--- a/docs/public-api/CHANGELOG.md
+++ b/docs/public-api/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Threa Public API changelog
+
+Generated from the version-change modules. Do not edit by hand.
+
+## 2026-07-12
+
+Initial versioned API.

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -5300,7 +5300,7 @@
         "operationId": "getMe",
         "summary": "Get the authenticated principal",
         "tags": ["Identity"],
-        "description": "Returns a discriminated union describing the authenticated principal — either the API-key owner (`kind: \"user\"`) or the bot whose key is in use (`kind: \"bot\"`). Used by clients (e.g. the OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
+        "description": "Returns a discriminated union describing the authenticated principal — either the API-key owner (`kind: \"user\"`) or the bot whose key is in use (`kind: \"bot\"`). Also reports the key's API version pin, the version this request resolved to, and the supported versions. Used by clients (e.g. the OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
         "security": [{ "apiKey": [] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -5328,9 +5328,30 @@
                           "properties": {
                             "kind": { "type": "string", "const": "user" },
                             "workspaceId": { "type": "string" },
-                            "userId": { "type": "string" }
+                            "userId": { "type": "string" },
+                            "apiVersion": {
+                              "type": "object",
+                              "properties": {
+                                "pinned": {
+                                  "anyOf": [{ "type": "string" }, { "type": "null" }],
+                                  "description": "The key's pinned version, or null when the key is unpinned and tracks the current version"
+                                },
+                                "resolved": {
+                                  "type": "string",
+                                  "description": "Version this request resolved to (header override, else pin, else current)"
+                                },
+                                "current": { "type": "string", "description": "The latest API version" },
+                                "supported": {
+                                  "type": "array",
+                                  "items": { "type": "string" },
+                                  "description": "All versions the API currently accepts"
+                                }
+                              },
+                              "required": ["pinned", "resolved", "current", "supported"],
+                              "additionalProperties": false
+                            }
                           },
-                          "required": ["kind", "workspaceId", "userId"],
+                          "required": ["kind", "workspaceId", "userId", "apiVersion"],
                           "additionalProperties": false
                         },
                         {
@@ -5344,9 +5365,38 @@
                               "type": "array",
                               "items": { "type": "string", "enum": ["mentionable", "active-scratchpad"] }
                             },
-                            "ownerUserId": { "type": "null" }
+                            "ownerUserId": { "type": "null" },
+                            "apiVersion": {
+                              "type": "object",
+                              "properties": {
+                                "pinned": {
+                                  "anyOf": [{ "type": "string" }, { "type": "null" }],
+                                  "description": "The key's pinned version, or null when the key is unpinned and tracks the current version"
+                                },
+                                "resolved": {
+                                  "type": "string",
+                                  "description": "Version this request resolved to (header override, else pin, else current)"
+                                },
+                                "current": { "type": "string", "description": "The latest API version" },
+                                "supported": {
+                                  "type": "array",
+                                  "items": { "type": "string" },
+                                  "description": "All versions the API currently accepts"
+                                }
+                              },
+                              "required": ["pinned", "resolved", "current", "supported"],
+                              "additionalProperties": false
+                            }
                           },
-                          "required": ["kind", "workspaceId", "botId", "botType", "traits", "ownerUserId"],
+                          "required": [
+                            "kind",
+                            "workspaceId",
+                            "botId",
+                            "botType",
+                            "traits",
+                            "ownerUserId",
+                            "apiVersion"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -5360,9 +5410,38 @@
                               "type": "array",
                               "items": { "type": "string", "enum": ["mentionable", "active-scratchpad"] }
                             },
-                            "ownerUserId": { "type": "string" }
+                            "ownerUserId": { "type": "string" },
+                            "apiVersion": {
+                              "type": "object",
+                              "properties": {
+                                "pinned": {
+                                  "anyOf": [{ "type": "string" }, { "type": "null" }],
+                                  "description": "The key's pinned version, or null when the key is unpinned and tracks the current version"
+                                },
+                                "resolved": {
+                                  "type": "string",
+                                  "description": "Version this request resolved to (header override, else pin, else current)"
+                                },
+                                "current": { "type": "string", "description": "The latest API version" },
+                                "supported": {
+                                  "type": "array",
+                                  "items": { "type": "string" },
+                                  "description": "All versions the API currently accepts"
+                                }
+                              },
+                              "required": ["pinned", "resolved", "current", "supported"],
+                              "additionalProperties": false
+                            }
                           },
-                          "required": ["kind", "workspaceId", "botId", "botType", "traits", "ownerUserId"],
+                          "required": [
+                            "kind",
+                            "workspaceId",
+                            "botId",
+                            "botType",
+                            "traits",
+                            "ownerUserId",
+                            "apiVersion"
+                          ],
                           "additionalProperties": false
                         }
                       ]

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -119,6 +119,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -310,6 +314,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -508,6 +516,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -596,6 +608,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -706,6 +722,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -819,6 +839,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -895,6 +919,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1033,6 +1061,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1133,6 +1165,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1198,6 +1234,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1317,6 +1357,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1415,6 +1459,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1506,6 +1554,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1780,6 +1832,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1873,6 +1929,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -1993,6 +2053,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2148,6 +2212,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2304,6 +2372,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2435,6 +2507,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2577,6 +2653,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2813,6 +2893,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2903,6 +2987,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -2992,6 +3080,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3107,6 +3199,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3131,6 +3227,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3208,6 +3308,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3315,6 +3419,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3434,6 +3542,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3542,6 +3654,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3639,6 +3755,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3727,6 +3847,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3829,6 +3953,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -3919,6 +4047,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4072,6 +4204,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4226,6 +4362,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4390,6 +4530,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4533,6 +4677,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4584,6 +4732,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4670,6 +4822,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4798,6 +4954,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -4906,6 +5066,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5047,6 +5211,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5109,6 +5277,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5226,6 +5398,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5277,6 +5453,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5462,6 +5642,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },
@@ -5567,6 +5751,10 @@
                   "type": "object",
                   "properties": {
                     "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
                     "details": {
                       "type": "object",
                       "propertyNames": { "type": "string" },

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Threa Public API",
-    "version": "1.0.0",
+    "version": "2026-07-12",
     "description": "The Threa Public API lets you programmatically read and write messages, list streams, search, and more.\n\n## Authentication\n\nAll requests require a Bearer token in the `Authorization` header:\n\n```\nAuthorization: Bearer threa_uk_your_api_key_here\n```\n\nKeys use two prefixes. A **personal access key** (`threa_uk_…`) carries a member's own\nidentity and access; any member creates one in the Threa app under **Settings > API keys**.\nA **bot key** (`threa_bk_…`) belongs to a bot with its own identity in the workspace —\neither a personal bot or a shared workspace bot — and is minted from the bot's settings\n(personal bots by their owner, shared bots by an admin).\nEach key is scoped to a workspace and granted specific permissions (scopes).\n\nHuman-readable docs: https://threa.io/developers (agent-friendly mirror: https://threa.io/llms.txt).\n\n## Scopes\n\nAPI keys are granted specific scopes that control access:\n\n- `messages:search` — Grants access to search messages in public streams in a workspace. Application level stream grants can extend permissions to private streams.\n- `streams:read` — Grants access to list and search accessible streams in a workspace.\n- `messages:read` — Grants access to read messages in accessible streams.\n- `messages:write` — Grants access to send, update, and delete messages in accessible streams.\n- `users:read` — Grants access to list and search workspace users.\n- `memos:read` — Grants access to search preserved workspace memos and inspect their provenance.\n- `attachments:read` — Grants access to search accessible attachments, inspect extracted content, and fetch download URLs.\n- `attachments:write` — Grants access to upload and replace attachments in accessible streams.\n- `labels:read` — Grants access to list workspace labels and their assignments on accessible resources.\n- `labels:write` — Grants access to create, edit, archive, join, and apply labels to accessible resources such as streams.\n- `bot-runtime:read` — Grants access to read bot runtime presence and invocation state.\n- `bot-runtime:write` — Grants access to heartbeat bot runtime presence and link runtime sessions.\n- `bot-invocations:read` — Grants access to read bot invocation state.\n- `bot-invocations:write` — Grants access to claim, complete, or fail bot invocations.\n- `delegations:read` — Grants access to list delegated tasks in accessible streams, including open tasks ready to claim.\n- `delegations:write` — Grants an agent access to claim delegated tasks and report progress, completion (posting the result as the key's identity), or failure.\n\n## Rate Limits\n\nRequests are rate-limited per workspace and per API key. Rate limit headers are included in responses.\n\n## Pagination\n\nList endpoints return paginated results with `hasMore` and `cursor` fields.\nPass the `cursor` value as the `after` query parameter to fetch the next page."
   },
   "servers": [{ "url": "https://app.threa.io", "description": "Production" }],
@@ -16,6 +16,7 @@
         "description": "Full-text and optional semantic search across accessible streams.",
         "security": [{ "apiKey": ["messages:search"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -143,6 +144,7 @@
         "description": "Search preserved workspace memos with semantic, exact, or recent-first retrieval.",
         "security": [{ "apiKey": ["memos:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -333,6 +335,7 @@
         "description": "Retrieve a memo together with source stream and source message provenance.",
         "security": [{ "apiKey": ["memos:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -531,6 +534,7 @@
         "description": "Upload a file as multipart/form-data using field `file`. Include the returned attachment id in message markdown as `attachment:<id>` to attach it to a message.",
         "security": [{ "apiKey": ["attachments:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -617,6 +621,7 @@
         "description": "Search accessible attachments by filename or extracted content.",
         "security": [{ "apiKey": ["attachments:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -726,6 +731,7 @@
         "description": "Retrieve attachment metadata and extracted content for an accessible attachment.",
         "security": [{ "apiKey": ["attachments:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -839,6 +845,7 @@
         "description": "Create a short-lived signed URL for an accessible attachment.",
         "security": [{ "apiKey": ["attachments:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -913,6 +920,7 @@
         "tags": ["Bot runtimes"],
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1049,6 +1057,7 @@
         "tags": ["Bot runtimes"],
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1149,6 +1158,7 @@
         "description": "The bot owner's active UIK (key id + base64 X25519 public key). A sealed harness fetches this before creating an end-to-end-encrypted session so it can wrap the generation-0 stream key to the owner. 404 when the owner has not set up encryption.",
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1214,6 +1224,7 @@
         "description": "Phase two of harness-created E2E scratchpads: stores the stream-key wraps (owner UIK + the harness's own BIK) minted against the stream id returned by session create. Bot-actor-only, current generation only, and only while the generation has no wraps — slots are immutable, so a replay cannot splice keys.",
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1331,6 +1342,7 @@
         "tags": ["Bot runtimes"],
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1428,6 +1440,7 @@
         "tags": ["Bot runtimes"],
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1518,6 +1531,7 @@
         "tags": ["Bot invocations"],
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1790,6 +1804,7 @@
         "tags": ["Bot invocations"],
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -1883,6 +1898,7 @@
         "tags": ["Bot invocations"],
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2003,6 +2019,7 @@
         "description": "Sealed variant of the trace-step start, for an owner-granted E2E bot harness: the content is ciphertext the server never decrypts. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2157,6 +2174,7 @@
         "description": "Sealed variant of the trace-step finalize, for an owner-granted E2E bot harness: sets the sealed content + completion on the step opened at sealed-steps/started (or inserts a completed row if the start was dropped). Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2312,6 +2330,7 @@
         "description": "Sealed variant of a mid-turn bot message, for an owner-granted E2E bot harness: posts one sealed interim message (ciphertext the server never decrypts) into the claim's stream before the turn completes — progress notes, permission prompts, early acks. The client-minted messageId binds the seal AAD and dedupes retries. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2442,6 +2461,7 @@
         "description": "Sealed variant of the completion, for an owner-granted E2E bot harness: persists the turn's final sealed reply (ciphertext the server never decrypts) or noResponse, flips the claim, and finalizes the agent session. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2582,6 +2602,7 @@
         "tags": ["Bot invocations"],
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2817,6 +2838,7 @@
         "tags": ["Bot invocations"],
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2907,6 +2929,7 @@
         "description": "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
         "security": [{ "apiKey": ["delegations:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -2994,6 +3017,7 @@
         "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once — send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3130,6 +3154,7 @@
         "description": "Push the claim's expiry forward while the local agent is still working. Liveness only — no status change on the card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3209,6 +3234,7 @@
         "description": "Mark the delegation running and put a free-text progress note on its card (each report replaces the previous note; the claim TTL renews). Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3315,6 +3341,7 @@
         "description": "Complete the claimed delegation. When resultMarkdown is given, the result is posted to the delegation's stream in the same transaction as the completion — authored as the key's user (with via-API provenance) for a user-scoped key, or as the bot for a workspace key. It enters the normal message pipeline, so workspace memory captures the outcome. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3433,6 +3460,7 @@
         "description": "Mark the claimed delegation failed, recording why on its card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3540,6 +3568,7 @@
         "description": "List streams accessible to this API key, with optional type and text filters.",
         "security": [{ "apiKey": ["streams:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3634,6 +3663,7 @@
         "tags": ["Streams"],
         "security": [{ "apiKey": ["streams:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3721,6 +3751,7 @@
         "description": "Set the stream's description from markdown (parsed to rich text, same as message content). Send an empty string to clear it. User-scoped keys attribute the change to the key owner; workspace-scoped keys to the bot.",
         "security": [{ "apiKey": ["streams:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3823,6 +3854,7 @@
         "tags": ["Streams"],
         "security": [{ "apiKey": ["streams:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -3912,6 +3944,7 @@
         "description": "Cursor-paginated message list. Use `before` or `after` sequence numbers.",
         "security": [{ "apiKey": ["messages:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4062,6 +4095,7 @@
         "description": "Send a message. Workspace-scoped keys send as a bot; user-scoped keys send on behalf of the key owner.",
         "security": [{ "apiKey": ["messages:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4217,6 +4251,7 @@
         "description": "Find non-deleted messages whose `metadata` contains all the given key/value pairs (AND-containment). Useful for dedup flows — e.g. 'has a message already been posted for this GitHub PR event?'.",
         "security": [{ "apiKey": ["messages:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4380,6 +4415,7 @@
         "description": "Update a message you previously sent via API.",
         "security": [{ "apiKey": ["messages:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4521,6 +4557,7 @@
         "description": "Delete a message you previously sent via API.",
         "security": [{ "apiKey": ["messages:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4573,6 +4610,7 @@
         "description": "List users in the workspace with optional text search and cursor pagination.",
         "security": [{ "apiKey": ["users:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4657,6 +4695,7 @@
         "description": "The key actor's labels (every label is private to its owner) and their resource assignments.",
         "security": [{ "apiKey": ["labels:read"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4782,6 +4821,7 @@
         "description": "Find-or-create a label owned by the key actor (a user or a bot), keyed by its name. Posting an existing name returns that label and applies any appearance fields supplied — labels are identified by their text, so this is idempotent.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -4891,6 +4931,7 @@
         "description": "Attach a label to a resource the key actor can reach, identifying the label by its text: the label is found-or-created for the actor, then assigned. `resourceType` is the polymorphic target (`stream` today) so the same endpoint labels any future resource without a wire change.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5030,6 +5071,7 @@
         "description": "Remove the key actor's assignment of a label (identified by its text) from a resource.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5093,6 +5135,7 @@
         "description": "Update a label the key actor created.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5207,6 +5250,7 @@
         "description": "Archive a label the key actor created and remove its assignments.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5259,6 +5303,7 @@
         "description": "Returns a discriminated union describing the authenticated principal — either the API-key owner (`kind: \"user\"`) or the bot whose key is in use (`kind: \"bot\"`). Used by clients (e.g. the OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
         "security": [{ "apiKey": [] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5363,6 +5408,7 @@
         "description": "For user-scoped keys: lists the authenticated user's personal bots, optionally filtered by trait. Used by the frontend to enumerate quick-switcher commands. Bot-scoped keys receive 403.",
         "security": [{ "apiKey": [] }],
         "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
           {
             "name": "workspaceId",
             "in": "path",
@@ -5461,6 +5507,15 @@
     }
   },
   "components": {
+    "parameters": {
+      "ThreaVersion": {
+        "name": "Threa-Version",
+        "in": "header",
+        "required": false,
+        "schema": { "type": "string", "enum": ["2026-07-12"] },
+        "description": "Selects the dated API version for this request. Each API key is pinned to a version when it is minted, and that pin applies when the header is absent. Send this header to override the pin per request (a valid header always wins). The value must be an exact member of the enum; an unknown or malformed value returns 400 with code INVALID_API_VERSION and the known versions in the error. Every response echoes the resolved version in a Threa-Version response header."
+      }
+    },
     "securitySchemes": {
       "apiKey": {
         "type": "http",

--- a/packages/types/src/api-keys.ts
+++ b/packages/types/src/api-keys.ts
@@ -67,6 +67,8 @@ export interface UserApiKey {
   name: string
   keyPrefix: string
   scopes: WorkspacePermissionSlug[]
+  /** Pinned public API version (YYYY-MM-DD); null when unpinned (tracks the current version) */
+  apiVersion: string | null
   lastUsedAt: string | null
   expiresAt: string | null
   revokedAt: string | null
@@ -89,6 +91,8 @@ export interface BotApiKey {
   name: string
   keyPrefix: string
   scopes: WorkspacePermissionSlug[]
+  /** Pinned public API version (YYYY-MM-DD); null when unpinned (tracks the current version) */
+  apiVersion: string | null
   lastUsedAt: string | null
   expiresAt: string | null
   revokedAt: string | null

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1053,6 +1053,11 @@ export const ENCLAVE_CALLBACK_TOKEN_HEADER = "X-Enclave-Callback-Token"
 // bot transport, shared by every sealed-capable external driver.
 export const THREA_CALLBACK_TOKEN_HEADER = "X-Threa-Callback-Token"
 
+// Public API wire-version negotiation: on requests it overrides the key's
+// pinned version; on responses it echoes the resolved version. No X- prefix —
+// it's a documented public header, named like Stripe-Version.
+export const THREA_VERSION_HEADER = "Threa-Version"
+
 // Original client-facing host (e.g. `admin.threa.io`, `pr-204-staging.threa.io`)
 // carried from the Cloudflare routers to the control-plane.
 //

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -240,6 +240,8 @@ export {
   INTERNAL_API_KEY_HEADER,
   ENCLAVE_CALLBACK_TOKEN_HEADER,
   THREA_CALLBACK_TOKEN_HEADER,
+  // Public API version negotiation
+  THREA_VERSION_HEADER,
   // Original client host forwarded through the CF routers (survives Railway)
   ORIGINAL_HOST_HEADER,
   // Socket heartbeat


### PR DESCRIPTION
## Problem

The public API's only versioning story was the `/api/v1` path segment — a promise of a `/api/v2` URL migration nobody wants to make. Iterating a wire shape today means either breaking integrators or never changing anything. Meanwhile the ~55 public routes were hand-mounted in `src/routes.ts`, duplicating the `PUBLIC_API_ROUTES` registry (the OpenAPI SSOT) entry by entry, with only a generator `--check` guarding the drift.

Design doc (included in this PR): `docs/plans/public-api-header-versioning.md`. Decisions locked with Kris 2026-07-11: Stripe-style header versioning, Phase 1 only — `/api/v1` stays forever as a frozen prefix (Stripe's own choice), no bare-path move, no credential dispatcher.

## Solution

Dated wire versions negotiated per request via a `Threa-Version` header, pinned per API key at mint. Handlers and serializers always speak the latest shape; a breaking change ships as a dated `VersionChange` module whose transforms upgrade old requests and downgrade responses for older callers. Phase 1 ships the machinery with zero transforms registered — behavior-identical for every existing caller, no client updates needed.

### How it works

1. **Registry-driven mounting** (`506d6bd9`) — the hand-mounted block in `src/routes.ts` is replaced by a handler map `Record<OperationId, RequestHandler | RequestHandler[]>` plus a loop over `PUBLIC_API_ROUTES`. `OperationId` is a 46-member union tied to `PublicApiRoute.operationId`, so a registry entry without a handler (or vice versa) is a compile error; `assertHandlerParity` (`features/public-api/mount.ts`) rethrows the residual case at boot. Registry order is mount order (the `labels/assignments`-before-`/:labelId` constraint is documented at the registry entries). Scopes now come from the registry, so `requireApiKeyScope` cannot disagree with the published spec. Net −220 lines, behavior-neutral: spec byte-identical, e2e suites unchanged.
2. **Version resolution** (`aecc7acc`) — `createApiVersionGate(operationId)` (`middleware/api-version.ts`) mounts between `publicApiAuth` and the scope guard. A valid `Threa-Version` header beats the key's pin; an unknown/malformed value throws `400 INVALID_API_VERSION` listing the known versions (no silent clamping, INV-11); every response echoes the resolved version in a `Threa-Version` response header (CORS-exposed via `exposedHeaders` for the developers playground).
3. **Key pinning** — migration `20260712112325_public_api_version_pin.sql` adds `api_version TEXT` to `user_api_keys` and `bot_api_keys` and backfills existing rows to the epoch `2026-07-12` (their shapes ARE the epoch). Both key services write `CURRENT_API_VERSION` at mint and return `apiVersion` on the validated key; a NULL pin coalesces to current rather than crashing (unreachable after backfill + mint-writes).
4. **Transform pipeline** — `versions/types.ts` defines `VersionChange` (`upgradeRequest`/`downgradeResponse`, scoped by an `operations` set); `versions/index.ts` holds `API_VERSIONS = ["2026-07-12"]`, `VERSION_CHANGES = []` (module-load ordering assertion), `parseApiVersion`, `changesAfter` (lexicographic date compare, no `Date` parsing). The gate applies pending changes oldest→newest to `req.body` and newest→oldest via a `res.json` wrap — a pure pass-through while `VERSION_CHANGES` is empty. The pipeline is exercised in unit tests via a synthetic change injected with `spyOn` against the namespace import (INV-48), not a registered module.
5. **Telemetry** — happy-path request logs are silenced in this backend (`customLogLevel` returns `"silent"` under 400), which would have made "who still runs an old pin" unanswerable from logs. Version adoption lives in a `public_api_version_requests_total{version,source}` Prometheus counter incremented in the gate; 4xx/5xx request logs additionally carry `{apiVersion, versionSource, keyId, operationId}` via `res.locals` + the pino-http `customProps` hook. The log context is stashed *before* header parsing so the `INVALID_API_VERSION` 400 logs the offending value.
6. **Spec + docs** (`6910e6d1`) — the generator emits `info.version = CURRENT_API_VERSION`, a shared `components.parameters.ThreaVersion` `$ref`'d as the first parameter of all 46 operations, and `docs/public-api/CHANGELOG.md` (rendered from `VERSION_CHANGES`, epoch entry seeded) under the same `--check` drift gate as the spec. New `/developers/versioning` page reads the current version and changelog from the generated files at build time so the page cannot drift; `reference`/`index` prose updated from "versioned under /api/v1" to the stable-prefix framing; `threa-public-api` skill documents the header.

### Key design decisions

**1. Header versioning without a URL migration.** Stripe never dropped `/v1`; its header versioning coexists with a frozen path prefix. Kris's ruling (design doc §11): skip the bare-path phase — the dual-shape-same-URL ambiguity it would introduce "could make it really confusing for agents and developers alike". The §4/§9 bare-path design stays in the doc as reference only.

**2. Pin at mint, override per request.** The alternative (absent header = latest) silently breaks every integrator on the first shipped change. With pinning, shipping a new version changes nothing for existing keys; integrators test with the header and move when ready. Unknown versions 400 rather than clamp — a typo'd date silently resolving to "latest" is exactly the masked-misconfiguration failure mode INV-11 bans.

**3. Handlers never branch on version.** Transforms live in dated modules at the edge (request-upgrade before Zod validation, response-downgrade on the way out), so handler/serializer code has exactly one shape to maintain and a future change is a ~40-line module + registry entry + golden tests (worked example: design doc §8).

**4. Metrics over logs for adoption tracking.** 2xx logs are policy-silenced here; a sunset decision needs data on *successful* old-version traffic, so the counter is the primary signal and log fields are the error-path supplement.

**5. Support window ≥12 months** after a version is succeeded (Kris, §11). Key-pin display in settings UI deferred until a second version exists (INV-36).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/public-api/mount.ts` (+ test) | `toExpressPath` (`{param}`→`:param`) + `assertHandlerParity` boot check |
| `apps/backend/src/features/public-api/versions/{types,index}.ts` (+ test) | Version list, `VersionChange` contract, parse/ordering/changesAfter |
| `apps/backend/src/middleware/api-version.ts` (+ test) | Per-route version gate: resolve, echo, transform pipeline, telemetry stash |
| `apps/backend/src/db/migrations/20260712112325_public_api_version_pin.sql` | `api_version` columns + epoch backfill |
| `apps/backend/tests/e2e/public-api-versioning.test.ts` | Echo, override-beats-pin, 400 on unknown, pin-at-mint over real HTTP |
| `apps/public-site/src/pages/developers/versioning.astro` | Versioning docs page, facts read from generated spec/changelog |
| `docs/public-api/CHANGELOG.md` | Generated changelog (same drift gate as openapi.json) |
| `docs/plans/public-api-header-versioning.md` | Accepted design doc incl. locked decisions + future-change template |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/routes.ts` | Hand-mounted public block → handler map + registry mount loop with version gate (−220 net) |
| `apps/backend/src/features/public-api/routes.ts` | `OperationId` union; `operationId` field typed against it; mount-order comment |
| `apps/backend/src/features/{user-api-keys,public-api}/…` key services/repos | `api_version` in SELECT/INSERT/Row/mapRow; `apiVersion` on validated keys; mint writes current |
| `apps/backend/src/app.ts` | CORS `exposedHeaders: ["Threa-Version"]`; pino `customProps` reads the gate's `res.locals` stash |
| `apps/backend/src/lib/observability/metrics.ts` | `public_api_version_requests_total{version,source}` counter |
| `apps/backend/scripts/generate-api-docs.ts` | `info.version`, shared ThreaVersion parameter, changelog emission + `--check` |
| `docs/public-api/openapi.json` | Regenerated |
| `apps/public-site/src/pages/developers/{index,reference}.astro`, `DocsLayout.astro`, `build-llms.ts` | Stable-prefix prose, nav entry, llms mirror for the new page |
| `.agents/skills/threa-public-api/SKILL.md` | Versioning subsection |

## Out of scope (deliberate)

- **Phase 2 (bare paths / credential dispatcher / `/api/v1` alias)** — decided against for now (§11); design retained in the doc.
- **Key-pin surfacing in settings UI** — deferred until a second version exists.
- **Per-version OpenAPI spec generation** — the spec documents the current version (Stripe does the same); older shapes live in the changelog + future change modules.
- **First real version change** — nothing registered; §8 of the doc is the template.

## Test plan

- [x] Full monorepo `bun run typecheck` — clean (all 14 workspaces)
- [x] Backend unit suite — 2757 pass, 0 fail
- [x] Backend e2e suite (full) — one failure: `conversations.test.ts` "returns conversations after message is sent", a 45s projection-wait in an app-API suite this diff doesn't touch; passes in isolation (8/8) — full-suite contention flake, not a regression
- [x] New suites: `public-api-versioning.test.ts` 5 pass; `api-version.test.ts` + `versions/index.test.ts` 13 pass; `mount.test.ts` 5 pass
- [x] `generate-api-docs.ts --check` green (step 1 spec byte-identical; step 3 regenerated + changelog under the same gate, verified to fail on mutation)
- [x] Live smoke on `dev:test` over real HTTP: pin governs (200 + `Threa-Version: 2026-07-12` echo), explicit header override (200 + echo), unknown version (400 `INVALID_API_VERSION` with known list, `Access-Control-Expose-Headers: Threa-Version` present), write path (201 through the gate), fresh key row pinned in DB, `/metrics` counter showing the exact expected `3 key / 1 header` split (the 400 correctly not counted)
- [x] Build shape: 3 sequential Opus implement→2-lens-verify→fix workflows (correctness+invariants, reusability+design); step 1 and 3 converged with zero findings round 1, step 2 had one finding (test-file typecheck) fixed in round 1; 5 remaining nits addressed by the coordinator (telemetry counter, 400-path log context, typed log shape, 3 copy/markup fixes)
- [ ] Playwright screenshot QA — skipped: no app-UI surface in this PR (public-site page verified via `astro build` + markdown mirror output)

<details>
<summary>📋 Full implementation plan</summary>

The full design is `docs/plans/public-api-header-versioning.md` (committed in this PR). Phase 1 scope as built:

1. **Registry-driven mounting** — behavior-neutral prerequisite; kills the hand-maintained route duplication and gives the version gate its per-route `operationId` attachment point.
2. **Versioning substrate** — migration + backfill (epoch `2026-07-12`), versions module (`API_VERSIONS`, `VERSION_CHANGES = []`, `parseApiVersion`, `changesAfter`), `createApiVersionGate` (header > pin, echo, transform pipeline), key pinning through both key services, counter + error-log telemetry, CORS exposure.
3. **Spec + docs** — ThreaVersion parameter on all operations, `info.version`, generated CHANGELOG under the drift gate, `/developers/versioning` page reading from generated files, prose/skill updates.

Not included (deliberate): Phase 2 bare paths, key-pin UI, per-version specs, any registered `VersionChange`. Decisions §11 of the doc: Phase 2 skipped, 12-month support window, pin UI deferred.

</details>

## Follow-up (same PR): pin detach + version discovery

Kris's 2026-07-12 request, commit `9f4e24b4`:

- **Detach/re-pin**: `api_version = NULL` now means *unpinned* — the key tracks the current version, breaking changes included (the gate's resolution chain already landed there for a missing pin; the semantics are now deliberate and the validated-key types carry `ApiVersion | null`). The key-management `PATCH` endpoints (user keys and bot keys) accept `apiVersion: "<date>" | null`; both validate against `API_VERSIONS` via Zod. Key wire shapes (`UserApiKey`/`BotApiKey`) gain `apiVersion`.
- **Discovery for agents**: `GET /api/v1/.../me` now reports `apiVersion: { pinned, resolved, current, supported }` — additive fields on the principal, no version bump. Changing the pin deliberately stays management-plane (app API, key owner): an agent can discover it is behind, not silently rewrite its own wire contract.
- Docs: `/developers/versioning` gains a "Reading and changing the pin" section; skill + design doc updated; spec regenerated.
- Tests: `public-api-versioning.test.ts` grew to 10 (detach → `/me` reports `pinned: null` + DB NULL, re-pin, 400 on unsupported pin, bot-key detach/re-pin path). Test-infra note: this suite is the first to exercise **user keys** over public HTTP e2e — it now seeds the owner's `workspace_user_permissions` mirror row, without which user-key auth 401s `OWNER_INACTIVE` (the harness has no control-plane to sync it).
- Verified: backend typecheck, 180 unit tests across touched dirs, 71 e2e (versioning/openapi/crud), spec+changelog drift gate, `astro build`.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786442680&installation_id=129946197&pr_number=1296&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1296&signature=50b9c2a0a5ff219090575ad5717f2196b2e35130d023fcd2ace1e127f03b414a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
