### PR TITLE
fix: mobile image gallery goes full-bleed and hides its chrome on tap

### DIFF
--- a/apps/frontend/src/components/gallery/pdf-viewer.tsx
+++ b/apps/frontend/src/components/gallery/pdf-viewer.tsx
@@ -71,9 +71,11 @@ export function PdfViewer({ url, filename, variant = "gallery" }: PdfViewerProps
     return isInline ? (
       <div className="w-full">{renderer}</div>
     ) : (
-      <div data-gallery-text-viewer="true" className="absolute inset-0 pb-16 pt-14 sm:py-16">
-        {renderer}
-      </div>
+      // No data-gallery-text-viewer here: the marker lives on the renderer's
+      // inner scroll region (mirroring markdown/html/text) so the reserved
+      // pt-14/pb-16 strips stay valid chrome-toggle tap zones — marking this
+      // full-bleed wrapper made PDF slides untappable, stranding hidden chrome.
+      <div className="absolute inset-0 pb-16 pt-14 sm:py-16">{renderer}</div>
     )
   }
 

--- a/apps/frontend/src/components/image-gallery.chrome-toggle.test.tsx
+++ b/apps/frontend/src/components/image-gallery.chrome-toggle.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor, within, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { MediaGalleryProvider } from "@/contexts"
+import { attachmentsApi } from "@/api"
+import { AttachmentList } from "@/components/timeline/attachment-list"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as inputModeModule from "@/hooks/use-input-mode"
+import * as touchCapableModule from "@/hooks/use-touch-capable"
+import type { AttachmentSummary } from "@threa/types"
+
+const WIDTH = 400
+let offsetWidthSpy: PropertyDescriptor | undefined
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.spyOn(attachmentsApi, "getDownloadUrl").mockResolvedValue("https://example.com/img")
+  vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
+  vi.spyOn(touchCapableModule, "useTouchCapable").mockReturnValue(true)
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+  offsetWidthSpy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth")
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", { configurable: true, get: () => WIDTH })
+})
+
+afterEach(() => {
+  if (offsetWidthSpy) Object.defineProperty(HTMLElement.prototype, "offsetWidth", offsetWidthSpy)
+})
+
+const img = (id: string, filename: string): AttachmentSummary => ({
+  id,
+  filename,
+  mimeType: "image/png",
+  sizeBytes: 1024,
+})
+
+function renderGallery() {
+  const attachments = [img("img_1", "photo1.png"), img("img_2", "photo2.png"), img("img_3", "photo3.png")]
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/s",
+        element: (
+          <MediaGalleryProvider>
+            <AttachmentList attachments={attachments} workspaceId="ws_1" />
+          </MediaGalleryProvider>
+        ),
+      },
+    ],
+    { initialEntries: ["/s"] }
+  )
+  render(<RouterProvider router={router} />)
+}
+
+/** The touch tap surface: the strip's clipping container, which owns onClick. */
+function tapContainer(): HTMLElement {
+  const dialog = screen.getByRole("dialog")
+  const strip = dialog.querySelector<HTMLElement>('div[style*="will-change"]')
+  const container = strip?.parentElement
+  if (!container) throw new Error("tap container not found")
+  // jsdom rects are all zeros; the tap handler derives its left/right/middle
+  // zone from the container rect, so give it a real one.
+  container.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: WIDTH,
+      bottom: 800,
+      width: WIDTH,
+      height: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect
+  return container
+}
+
+function closeButton(): HTMLElement {
+  return within(screen.getByRole("dialog")).getByRole("button", { name: /close/i, hidden: true })
+}
+
+describe("MediaGallery touch chrome toggle", () => {
+  it("hides and re-shows the action bar on a middle tap, and resets to visible on reopen", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+    expect(closeButton().closest("[inert]")).toBeNull()
+
+    // Middle tap hides the chrome (action bar becomes inert, filename bar hidden).
+    fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
+    expect(closeButton().closest("[inert]")).not.toBeNull()
+
+    // Middle tap again brings it back.
+    fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
+    expect(closeButton().closest("[inert]")).toBeNull()
+
+    // Hide, close via Escape, reopen: chrome must reset to visible.
+    fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
+    expect(closeButton().closest("[inert]")).not.toBeNull()
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+    expect(closeButton().closest("[inert]")).toBeNull()
+  })
+
+  it("keeps edge taps as navigation, not chrome toggles", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByText("2 / 3")).toBeInTheDocument())
+
+    // Left-zone tap navigates back and leaves the chrome alone.
+    fireEvent.click(tapContainer(), { clientX: WIDTH * 0.1 })
+    await waitFor(() => expect(screen.getByText("1 / 3")).toBeInTheDocument())
+    expect(closeButton().closest("[inert]")).toBeNull()
+
+    // At the first slide there is no prev — the same left-zone tap now toggles.
+    fireEvent.click(tapContainer(), { clientX: WIDTH * 0.1 })
+    expect(closeButton().closest("[inert]")).not.toBeNull()
+  })
+})

--- a/apps/frontend/src/components/image-gallery.chrome-toggle.test.tsx
+++ b/apps/frontend/src/components/image-gallery.chrome-toggle.test.tsx
@@ -8,9 +8,16 @@ import { AttachmentList } from "@/components/timeline/attachment-list"
 import * as useMobileModule from "@/hooks/use-mobile"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import * as touchCapableModule from "@/hooks/use-touch-capable"
+import { DOUBLE_TAP_MS } from "@/hooks/use-zoom-pan"
 import type { AttachmentSummary } from "@threa/types"
 
 const WIDTH = 400
+
+// The toggle is deferred past the double-tap window; anything that should NOT
+// have fired needs a real-time wait comfortably past it before asserting.
+const AFTER_WINDOW = DOUBLE_TAP_MS + 150
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
 let offsetWidthSpy: PropertyDescriptor | undefined
 
 beforeEach(() => {
@@ -75,35 +82,61 @@ function tapContainer(): HTMLElement {
   return container
 }
 
+/** ZoomableImage's viewport (only the current image slide mounts it). jsdom's
+ *  cssstyle drops `touch-action`, so locate it via the main img's alt — the
+ *  zoomable viewport is its direct parent (it owns the gesture listeners). */
+function zoomContainer(): HTMLElement {
+  const img = within(screen.getByRole("dialog")).getByAltText("photo2.png")
+  const container = img.parentElement
+  if (!container) throw new Error("zoom container not found")
+  return container
+}
+
 function closeButton(): HTMLElement {
   return within(screen.getByRole("dialog")).getByRole("button", { name: /close/i, hidden: true })
 }
 
+const chromeHidden = () => closeButton().closest("[inert]") !== null
+
 describe("MediaGallery touch chrome toggle", () => {
-  it("hides and re-shows the action bar on a middle tap, and resets to visible on reopen", async () => {
+  it("hides and re-shows the chrome on a single middle tap, and resets to visible on reopen", async () => {
     const user = userEvent.setup()
     renderGallery()
 
     await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
-    expect(closeButton().closest("[inert]")).toBeNull()
+    expect(chromeHidden()).toBe(false)
 
-    // Middle tap hides the chrome (action bar becomes inert, filename bar hidden).
+    // Single middle tap hides the chrome once the double-tap window passes.
     fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
-    expect(closeButton().closest("[inert]")).not.toBeNull()
+    expect(chromeHidden()).toBe(false) // deferred, not immediate
+    await waitFor(() => expect(chromeHidden()).toBe(true))
 
-    // Middle tap again brings it back.
+    // Tap again brings it back.
     fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
-    expect(closeButton().closest("[inert]")).toBeNull()
+    await waitFor(() => expect(chromeHidden()).toBe(false))
 
     // Hide, close via Escape, reopen: chrome must reset to visible.
     fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
-    expect(closeButton().closest("[inert]")).not.toBeNull()
+    await waitFor(() => expect(chromeHidden()).toBe(true))
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
     await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
-    expect(closeButton().closest("[inert]")).toBeNull()
+    expect(chromeHidden()).toBe(false)
+  })
+
+  it("treats two quick taps as a double-tap: no toggle fires", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+
+    fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
+    fireEvent.click(tapContainer(), { clientX: WIDTH / 2 })
+    await sleep(AFTER_WINDOW)
+    expect(chromeHidden()).toBe(false)
   })
 
   it("keeps edge taps as navigation, not chrome toggles", async () => {
@@ -113,13 +146,39 @@ describe("MediaGallery touch chrome toggle", () => {
     await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
     await waitFor(() => expect(screen.getByText("2 / 3")).toBeInTheDocument())
 
-    // Left-zone tap navigates back and leaves the chrome alone.
+    // Left-zone tap navigates back immediately and never toggles.
     fireEvent.click(tapContainer(), { clientX: WIDTH * 0.1 })
     await waitFor(() => expect(screen.getByText("1 / 3")).toBeInTheDocument())
-    expect(closeButton().closest("[inert]")).toBeNull()
+    await sleep(AFTER_WINDOW)
+    expect(chromeHidden()).toBe(false)
 
     // At the first slide there is no prev — the same left-zone tap now toggles.
     fireEvent.click(tapContainer(), { clientX: WIDTH * 0.1 })
-    expect(closeButton().closest("[inert]")).not.toBeNull()
+    await waitFor(() => expect(chromeHidden()).toBe(true))
+  })
+
+  it("zoom never hides the chrome, taps toggle while zoomed, and zooming out re-shows it", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByText("2 / 3")).toBeInTheDocument())
+    // ZoomableImage mounts only once the slide's full-resolution URL resolves.
+    await waitFor(() => zoomContainer())
+
+    // Double-click zoom (the desktop analogue of double-tap; same commit path)
+    // leaves visible chrome alone.
+    fireEvent.dblClick(zoomContainer(), { clientX: 100, clientY: 100 })
+    await sleep(AFTER_WINDOW)
+    expect(chromeHidden()).toBe(false)
+
+    // While zoomed, an edge tap toggles instead of navigating.
+    fireEvent.click(tapContainer(), { clientX: WIDTH * 0.1 })
+    await waitFor(() => expect(chromeHidden()).toBe(true))
+    expect(screen.getByText("2 / 3")).toBeInTheDocument()
+
+    // Zooming all the way back out re-shows the chrome immediately.
+    fireEvent.dblClick(zoomContainer(), { clientX: 100, clientY: 100 })
+    await waitFor(() => expect(chromeHidden()).toBe(false))
   })
 })

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -34,6 +34,7 @@ import { isLinkPreviewGalleryId } from "@/components/gallery/link-preview-galler
 import { isPendingGalleryId } from "@/components/gallery/pending-gallery-id"
 import { buildEmbedPlaybackSrc } from "@/components/gallery/video-embed"
 import type { VideoPreviewProvider } from "@threa/types"
+import { DOUBLE_TAP_MS } from "@/hooks/use-zoom-pan"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
 import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
 import { HtmlViewer } from "@/components/gallery/html-viewer"
@@ -401,10 +402,20 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // navigation within a session — if the user is reading raw markdown and
   // arrows over to the next markdown file, they probably want raw there too.
   const [rawMode, setRawMode] = useState(false)
-  // Touch layout: tapping the media toggles the gallery's own chrome (action
-  // bar, filename bar) so the image can be viewed with nothing on top of it.
+  // Touch layout: a single tap on the media (zoomed or not) toggles the
+  // gallery's own chrome (action bar, filename bar) so the image can be viewed
+  // with nothing on top of it. Zoom gestures never hide it — the toggle is
+  // deferred past the double-tap window so the first tap of a double-tap zoom
+  // doesn't fire it — and zooming all the way back out always re-shows it.
   // Persists across swipes; resets to visible on every open.
   const [chromeVisible, setChromeVisible] = useState(true)
+  const pendingChromeToggleRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelPendingChromeToggle = useCallback(() => {
+    if (pendingChromeToggleRef.current) {
+      clearTimeout(pendingChromeToggleRef.current)
+      pendingChromeToggleRef.current = null
+    }
+  }, [])
   // containerWidth drives both slide sizing and strip transform calculations on mobile
   const [containerWidth, setContainerWidth] = useState(0)
 
@@ -420,6 +431,17 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // read the current zoom state without stale closures.
   const isZoomedRef = useRef(false)
   isZoomedRef.current = isZoomed
+  const handleZoomChange = useCallback(
+    (zoomed: boolean) => {
+      setIsZoomed(zoomed)
+      // A double-tap zoom's first tap has a chrome toggle in flight — a zoom
+      // must never flip the chrome, so kill it. Zooming back out to 1× always
+      // brings the chrome back.
+      cancelPendingChromeToggle()
+      if (!zoomed) setChromeVisible(true)
+    },
+    [cancelPendingChromeToggle]
+  )
 
   // Pub/sub for scale so the percent display in ZoomControls can update at
   // 60fps during pinch without re-rendering this component (PR #384 pattern:
@@ -471,11 +493,12 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   useLayoutEffect(() => {
     if (isOpen && !prevOpen.current) {
       setCurrentIndex(initialIndex)
+      cancelPendingChromeToggle()
       setChromeVisible(true)
       justOpened.current = true
     }
     prevOpen.current = isOpen
-  }, [isOpen, initialIndex])
+  }, [isOpen, initialIndex, cancelPendingChromeToggle])
 
   // Re-anchor currentIndex when the items array shifts underneath it.
   const viewedIdRef = useRef<string | null>(null)
@@ -589,6 +612,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     () => () => {
       if (copyResetRef.current) clearTimeout(copyResetRef.current)
       if (downloadResetRef.current) clearTimeout(downloadResetRef.current)
+      if (pendingChromeToggleRef.current) clearTimeout(pendingChromeToggleRef.current)
     },
     []
   )
@@ -835,13 +859,12 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     [currentIndex, hasNext, hasPrev, items, onItemChange, onClose]
   )
 
-  // Touch: tap left/right zones to navigate; any other tap toggles the gallery
-  // chrome (suppressed after a committed swipe and disabled while zoomed so
-  // taps inside a zoomed image don't navigate or toggle).
+  // Touch: tap left/right zones to navigate (when not zoomed); any other tap
+  // toggles the gallery chrome, zoomed or not. Suppressed after a committed
+  // swipe.
   const handleMobileTap = useCallback(
     (e: React.MouseEvent) => {
       if (!inputModeTouch) return
-      if (isZoomedRef.current) return
       // Taps inside the text panel would hijack link clicks, text selection,
       // and code-block interactions. Taps in the surrounding margin still
       // navigate/toggle — that's the only way to flip between text slides on
@@ -856,18 +879,31 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
       }
       const rect = e.currentTarget.getBoundingClientRect()
       const zone = (e.clientX - rect.left) / rect.width
-      if (isMultiple && zone < 0.3 && hasPrev) goPrev()
-      else if (isMultiple && zone > 0.7 && hasNext) goNext()
-      else {
-        // Hiding makes the action bar inert; if focus is still on one of its
-        // buttons (Radix focuses the first one on open) the browser ejects
-        // focus to <body>, which the dialog's dismissable layer reads as
-        // focus-outside and closes the gallery. Park focus here first.
-        ;(e.currentTarget as HTMLElement).focus({ preventScroll: true })
-        setChromeVisible((v) => !v)
+      // While zoomed, taps never navigate — the whole surface is toggle.
+      const canNavigate = !isZoomedRef.current && isMultiple
+      if (canNavigate && zone < 0.3 && hasPrev) {
+        cancelPendingChromeToggle()
+        goPrev()
+      } else if (canNavigate && zone > 0.7 && hasNext) {
+        cancelPendingChromeToggle()
+        goNext()
+      } else if (pendingChromeToggleRef.current) {
+        // Second tap of a double-tap that didn't zoom (text-slide margin,
+        // video poster): a double-tap is never a toggle, so drop both taps.
+        cancelPendingChromeToggle()
+      } else {
+        pendingChromeToggleRef.current = setTimeout(() => {
+          pendingChromeToggleRef.current = null
+          // Hiding makes the action bar inert; if focus is still on one of its
+          // buttons (Radix focuses the first one on open) the browser ejects
+          // focus to <body>, which the dialog's dismissable layer reads as
+          // focus-outside and closes the gallery. Park focus here first.
+          containerRef.current?.focus({ preventScroll: true })
+          setChromeVisible((v) => !v)
+        }, DOUBLE_TAP_MS)
       }
     },
-    [inputModeTouch, isMultiple, hasPrev, hasNext, goPrev, goNext]
+    [inputModeTouch, isMultiple, hasPrev, hasNext, goPrev, goNext, cancelPendingChromeToggle]
   )
 
   const handleZoomIn = useCallback(() => zoomableRef.current?.zoomIn(), [])
@@ -1030,7 +1066,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                           isActive={Math.abs(i - currentIndex) <= 1}
                           isCurrent={i === currentIndex}
                           zoomableRef={i === currentIndex && item.type === "image" ? zoomableRef : undefined}
-                          onZoomChange={i === currentIndex && item.type === "image" ? setIsZoomed : undefined}
+                          onZoomChange={i === currentIndex && item.type === "image" ? handleZoomChange : undefined}
                           onScaleChange={i === currentIndex && item.type === "image" ? publishScale : undefined}
                           rawMode={i === currentIndex ? rawMode : false}
                         />
@@ -1063,7 +1099,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                   <GalleryMediaContent
                     current={current}
                     zoomableRef={current.type === "image" ? zoomableRef : undefined}
-                    onZoomChange={current.type === "image" ? setIsZoomed : undefined}
+                    onZoomChange={current.type === "image" ? handleZoomChange : undefined}
                     onScaleChange={current.type === "image" ? publishScale : undefined}
                     rawMode={rawMode}
                   />

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -254,7 +254,7 @@ function GalleryMediaContent({
           className="relative max-w-full max-h-full overflow-hidden rounded-lg bg-black shadow-2xl"
           style={{
             aspectRatio: current.aspectRatio,
-            width: `min(100%, calc(85vh * ${current.aspectRatio}))`,
+            width: `min(100%, calc(85dvh * ${current.aspectRatio}))`,
           }}
         >
           <iframe
@@ -862,10 +862,11 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // so it stays readable against any backdrop
   // (image, video poster, markdown panel, sandboxed iframe). The text viewers
   // reserve their top inset (pt-14 / pt-16) so the pill never overlaps the
-  // panel chrome; `top-3 right-3` gives the pill visible breathing room from
-  // the screen edge instead of kissing it.
+  // panel chrome; the 0.75rem offsets (bumped by safe-area insets on notched
+  // devices) give the pill visible breathing room from the screen edge instead
+  // of kissing it.
   const actionBar = (
-    <div className="absolute top-3 right-3 z-10 flex items-center gap-1 rounded-full bg-black/55 px-1 py-0.5 shadow-lg backdrop-blur-sm">
+    <div className="absolute top-[max(0.75rem,env(safe-area-inset-top))] right-[max(0.75rem,env(safe-area-inset-right))] z-10 flex items-center gap-1 rounded-full bg-black/55 px-1 py-0.5 shadow-lg backdrop-blur-sm">
       {!isMobile && current?.type === "image" && (
         <ZoomControls
           subscribeScale={subscribeScale}
@@ -959,10 +960,11 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
       {!current ? null : (
         <DialogContent
           className={cn(
-            "p-0 max-sm:p-0 overflow-hidden bg-black/95 border-none",
-            "max-sm:inset-auto max-sm:left-1/2 max-sm:top-1/2 max-sm:-translate-x-1/2 max-sm:-translate-y-1/2",
-            "max-sm:max-w-[95vw] max-sm:h-[90vh] max-sm:rounded-lg",
-            isMobile ? "max-w-[95vw] h-[90vh]" : "max-w-[90vw] h-[90vh]"
+            // <sm keeps the base DialogContent full-bleed layout (inset-0), which
+            // tracks the dynamic viewport — a sized 90vh card measures the LARGE
+            // viewport, so expanding mobile browser chrome covered the top row.
+            "p-0 max-sm:p-0 max-sm:gap-0 overflow-hidden max-sm:overflow-hidden bg-black/95 border-none",
+            isMobile ? "sm:max-w-[95vw] sm:h-[90dvh]" : "sm:max-w-[90vw] sm:h-[90dvh]"
           )}
           hideCloseButton
         >
@@ -1011,7 +1013,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                 </div>
 
                 {/* Filename bar sits above the strip so it doesn't scroll with it */}
-                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4 pointer-events-none z-10">
+                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pointer-events-none z-10">
                   <span className="text-sm text-white">{current.filename}</span>
                 </div>
               </div>

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -401,6 +401,10 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // navigation within a session — if the user is reading raw markdown and
   // arrows over to the next markdown file, they probably want raw there too.
   const [rawMode, setRawMode] = useState(false)
+  // Touch layout: tapping the media toggles the gallery's own chrome (action
+  // bar, filename bar) so the image can be viewed with nothing on top of it.
+  // Persists across swipes; resets to visible on every open.
+  const [chromeVisible, setChromeVisible] = useState(true)
   // containerWidth drives both slide sizing and strip transform calculations on mobile
   const [containerWidth, setContainerWidth] = useState(0)
 
@@ -467,6 +471,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   useLayoutEffect(() => {
     if (isOpen && !prevOpen.current) {
       setCurrentIndex(initialIndex)
+      setChromeVisible(true)
       justOpened.current = true
     }
     prevOpen.current = isOpen
@@ -830,26 +835,37 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     [currentIndex, hasNext, hasPrev, items, onItemChange, onClose]
   )
 
-  // Touch: tap left/right zones to navigate (suppressed after a committed swipe
-  // and disabled while zoomed so taps inside a zoomed image don't navigate away).
+  // Touch: tap left/right zones to navigate; any other tap toggles the gallery
+  // chrome (suppressed after a committed swipe and disabled while zoomed so
+  // taps inside a zoomed image don't navigate or toggle).
   const handleMobileTap = useCallback(
     (e: React.MouseEvent) => {
-      if (!inputModeTouch || !isMultiple) return
+      if (!inputModeTouch) return
       if (isZoomedRef.current) return
-      // Tap-to-navigate inside the text panel would hijack link clicks, text
-      // selection, and code-block interactions. Taps in the surrounding margin
-      // still navigate — that's the only way to flip between text slides on
+      // Taps inside the text panel would hijack link clicks, text selection,
+      // and code-block interactions. Taps in the surrounding margin still
+      // navigate/toggle — that's the only way to flip between text slides on
       // mobile once swipe is relinquished to native scroll.
       const target = e.target as HTMLElement | null
       if (target?.closest("[data-gallery-text-viewer]")) return
+      // Taps on the native <video> controls are play/pause/seek, not toggles.
+      if (target?.closest("video")) return
       if (didSwipe.current) {
         didSwipe.current = false
         return
       }
       const rect = e.currentTarget.getBoundingClientRect()
       const zone = (e.clientX - rect.left) / rect.width
-      if (zone < 0.3 && hasPrev) goPrev()
-      else if (zone > 0.7 && hasNext) goNext()
+      if (isMultiple && zone < 0.3 && hasPrev) goPrev()
+      else if (isMultiple && zone > 0.7 && hasNext) goNext()
+      else {
+        // Hiding makes the action bar inert; if focus is still on one of its
+        // buttons (Radix focuses the first one on open) the browser ejects
+        // focus to <body>, which the dialog's dismissable layer reads as
+        // focus-outside and closes the gallery. Park focus here first.
+        ;(e.currentTarget as HTMLElement).focus({ preventScroll: true })
+        setChromeVisible((v) => !v)
+      }
     },
     [inputModeTouch, isMultiple, hasPrev, hasNext, goPrev, goNext]
   )
@@ -865,8 +881,18 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // panel chrome; the 0.75rem offsets (bumped by safe-area insets on notched
   // devices) give the pill visible breathing room from the screen edge instead
   // of kissing it.
+  const chromeHidden = inputModeTouch && !chromeVisible
   const actionBar = (
-    <div className="absolute top-[max(0.75rem,env(safe-area-inset-top))] right-[max(0.75rem,env(safe-area-inset-right))] z-10 flex items-center gap-1 rounded-full bg-black/55 px-1 py-0.5 shadow-lg backdrop-blur-sm">
+    <div
+      className={cn(
+        "absolute top-[max(0.75rem,env(safe-area-inset-top))] right-[max(0.75rem,env(safe-area-inset-right))] z-10 flex items-center gap-1 rounded-full bg-black/55 px-1 py-0.5 shadow-lg backdrop-blur-sm",
+        "transition-opacity duration-200",
+        chromeHidden && "pointer-events-none opacity-0"
+      )}
+      // inert (not just opacity-0) so hidden controls are unfocusable and
+      // invisible to assistive tech while the image is being viewed clean.
+      inert={chromeHidden || undefined}
+    >
       {!isMobile && current?.type === "image" && (
         <ZoomControls
           subscribeScale={subscribeScale}
@@ -984,7 +1010,8 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
                 <div
                   ref={setContainerNode}
-                  className="absolute inset-0 overflow-hidden"
+                  className="absolute inset-0 overflow-hidden outline-none"
+                  tabIndex={-1}
                   onTouchStart={handleTouchStart}
                   onTouchMove={handleTouchMove}
                   onTouchEnd={handleTouchEnd}
@@ -1013,7 +1040,14 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                 </div>
 
                 {/* Filename bar sits above the strip so it doesn't scroll with it */}
-                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pointer-events-none z-10">
+                <div
+                  className={cn(
+                    "absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pointer-events-none z-10",
+                    "transition-opacity duration-200",
+                    chromeHidden && "opacity-0"
+                  )}
+                  aria-hidden={chromeHidden || undefined}
+                >
                   <span className="text-sm text-white">{current.filename}</span>
                 </div>
               </div>

--- a/apps/frontend/src/hooks/use-zoom-pan.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.ts
@@ -4,6 +4,10 @@ export const ZOOM_MIN = 1
 export const ZOOM_MAX = 8
 export const ZOOM_STEP = 1.5
 export const DOUBLE_ZOOM = 2
+/** Two taps within this window (and 30px) are a double-tap zoom. Consumers that
+ *  act on single taps (the gallery chrome toggle) defer past this window so the
+ *  first tap of a double-tap never fires their action. */
+export const DOUBLE_TAP_MS = 300
 
 interface UseZoomPanOptions {
   containerRef: RefObject<HTMLElement | null>
@@ -428,7 +432,7 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange, onScaleChan
       const t = e.changedTouches[0]
       const dx = t.clientX - lastTapX
       const dy = t.clientY - lastTapY
-      const isDouble = now - lastTap < 300 && Math.hypot(dx, dy) < 30
+      const isDouble = now - lastTap < DOUBLE_TAP_MS && Math.hypot(dx, dy) < 30
       if (isDouble) {
         const rect = container!.getBoundingClientRect()
         const localX = t.clientX - rect.left


### PR DESCRIPTION
## Problem

Three iterations of mobile-gallery feedback (Kris, scratchpad hand-off):

1. **Browser chrome covered content.** The mobile gallery was a centered floating card sized `max-sm:h-[90vh] max-sm:max-w-[95vw]` (`apps/frontend/src/components/image-gallery.tsx`). `vh` measures the **large** viewport (browser chrome collapsed), while the card is centered inside the **dynamic** viewport — with the URL bar expanded the card overflowed and chrome covered the top of the image and the action bar. The override dated to the original gallery PR (#266).
2. **The gallery's own chrome sat on top of the image.** The action bar (copy/download/close pill) and the filename bar were always visible. Kris: "I want to hide it on tap … really get this all on the outermost zoomed-out layer."
3. **Zoom must not interact with the toggle.** Kris: "double tapping to zoom it stays, same as pinch … if I tap once the chrome should disappear, tap again, or zoom all the way out, the chrome should reappear."

## Solution

**Full-bleed mobile layout.** Drop the centered-card override and let the base `DialogContent` mobile layout apply: `max-sm:inset-0` on a `position: fixed` element tracks the dynamic viewport, so the gallery is always exactly the visible area. Desktop and ≥640px keep the centered dialog, now `90dvh` instead of `90vh` (identical on desktop, correct on landscape phones). `max-sm:gap-0` / `max-sm:overflow-hidden` cancel the base's mobile defaults (twMerge doesn't merge across breakpoint prefixes — noted in `dialog.tsx`). The video-embed width calc `85vh` → `85dvh` for the same reason.

**Single tap toggles the gallery chrome (touch layout).** A single tap on the media — anywhere that isn't a nav zone, the text panel, or a `<video>` — hides the action bar and filename bar with a 200ms fade; tap again restores them. Zoomed or not: while zoomed the nav zones are disabled, so the whole surface is toggle. Edge-zone tap navigation (unzoomed) and swipe are unchanged; the toggle resets to visible on every open.

**Zoom gestures never hide the chrome.** The toggle is deferred past the double-tap window (`DOUBLE_TAP_MS = 300`, now exported from `use-zoom-pan.ts` instead of being an inline magic number, INV-33) and cancelled the moment a zoom commits — so the first tap of a double-tap zoom never flips the chrome, and pinch (two touches) never schedules one. Zooming all the way back out (`onZoomChange(false)`, fired synchronously by `commit` in `use-zoom-pan`) always re-shows it.

### Key design decisions

**1. Deferred toggle instead of suppression-only.** `use-zoom-pan` `preventDefault()`s only the *second* tap's click — the first tap's click always lands. Acting on it immediately would flip the chrome at the start of every double-tap zoom. The 300ms deferral is the same trade every photo viewer makes (single-tap latency for double-tap disambiguation); two quick taps that *don't* zoom (text-slide margin, video poster) cancel each other, so a double-tap is never a toggle anywhere.

**2. Hidden chrome is `inert`, and focus is parked first.** `opacity-0` alone would leave invisible buttons tab-focusable and visible to AT, so the pill gets `inert`. But Radix focuses the first pill button on open, and making a focused subtree inert ejects focus to `<body>` — which Radix's dismissable layer reads as focus-outside and closes the dialog (found live; jsdom can't reproduce inert focus ejection). The toggle parks focus on the strip container (`tabIndex={-1}`) before flipping.

**3. Safe-area insets on the bars.** `index.html` sets `viewport-fit=cover`, so in standalone/PWA mode the notch and home indicator would overlap the action bar / filename bar. Both use `max(...)` with the env insets; on desktop the insets are 0 and the values collapse to the previous `0.75rem`/`1rem`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/image-gallery.chrome-toggle.test.tsx` | Mounts the real gallery (touch mocks): deferred single-tap hide/show, reset-on-reopen, double-tap never toggles, edge taps navigate, zoom keeps chrome + tap-while-zoomed toggles + zoom-out re-shows |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/image-gallery.tsx` | Mobile full-bleed layout (dynamic viewport); `90vh` → `90dvh`; deferred tap-to-toggle chrome (zoom-aware) with `inert` + focus parking; safe-area insets; `85vh` → `85dvh` in video-embed sizing |
| `apps/frontend/src/hooks/use-zoom-pan.ts` | Export `DOUBLE_TAP_MS` (replaces inline `300`) so the gallery toggle and the double-tap detector share one window |
| `apps/frontend/src/components/gallery/pdf-viewer.tsx` | Move the tap-exclusion marker off the full-bleed wrapper so PDF slides keep the chrome toggle reachable (opus review finding) |

## Out of scope (deliberate)

- Desktop keeps its always-visible chrome (hover already governs the arrows); the toggle is touch-layout only.
- Pre-existing hybrid-device quirk observed while verifying: opening the gallery with a mouse and then touching it flips `useInputMode` mid-dialog and Radix registers the layout swap as a pointer-down-outside, closing the dialog. Reproduces without this diff; not addressed here.

## Test plan

- [x] `bun run test -- image-gallery.chrome-toggle image-gallery.reopen media-gallery-context` — 9 pass
- [x] Full pre-commit lint/typecheck suite clean
- [x] Live-verified on dev:test (scripted Playwright touch session): open → chrome visible; double-tap → zoomed (screenshot) with chrome **still visible**; single tap while zoomed → hidden; double-tap zoom-out → chrome **reappears**; single tap at 1× → hidden. Layout: mobile 390×844 full-bleed `(0,0)`; desktop `1152×720` = 90vw×90dvh; landscape 90dvh centered.
- [ ] Real-device check of dynamic browser chrome collapse/expand and real pinch gestures — desktop Chromium can't emulate either; pinch never yields a click, so it cannot reach the toggle path by construction.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

