### PR TITLE
docs(public-api): deslopify the versioning docs + spec descriptions

### DIFF
--- a/apps/backend/scripts/generate-api-docs.ts
+++ b/apps/backend/scripts/generate-api-docs.ts
@@ -219,7 +219,7 @@ function buildSpec() {
 
     if (route.canReturn409) {
       responses["409"] = {
-        description: "Conflict — the resource is not in the state the operation requires",
+        description: "Conflict: the resource is not in the state the operation requires",
         content: { "application/json": { schema: errorJsonSchema } },
       }
     }
@@ -235,7 +235,7 @@ function buildSpec() {
       title: "Threa Public API",
       version: CURRENT_API_VERSION,
       description: [
-        "The Threa Public API lets you programmatically read and write messages, list streams, search, and more.",
+        "The Threa Public API lets you programmatically read and write messages, list streams, and search messages, memos, and attachments.",
         "",
         "## Authentication",
         "",
@@ -247,8 +247,8 @@ function buildSpec() {
         "",
         "Keys use two prefixes. A **personal access key** (`threa_uk_…`) carries a member's own",
         "identity and access; any member creates one in the Threa app under **Settings > API keys**.",
-        "A **bot key** (`threa_bk_…`) belongs to a bot with its own identity in the workspace —",
-        "either a personal bot or a shared workspace bot — and is minted from the bot's settings",
+        "A **bot key** (`threa_bk_…`) belongs to a bot with its own identity in the workspace",
+        "(a personal bot or a shared workspace bot) and is minted from the bot's settings",
         "(personal bots by their owner, shared bots by an admin).",
         "Each key is scoped to a workspace and granted specific permissions (scopes).",
         "",
@@ -258,7 +258,7 @@ function buildSpec() {
         "",
         "API keys are granted specific scopes that control access:",
         "",
-        ...API_KEY_ELIGIBLE_PICKER_SCOPES.map((p) => `- \`${p.slug}\` — ${p.description}`),
+        ...API_KEY_ELIGIBLE_PICKER_SCOPES.map((p) => `- \`${p.slug}\`: ${p.description}`),
         "",
         "## Rate Limits",
         "",
@@ -291,7 +291,7 @@ function buildSpec() {
             "this header to override the pin per request (a valid header always wins). The",
             "value must be an exact member of the enum; an unknown or malformed value returns",
             "400 with code INVALID_API_VERSION and the known versions in the error. Every",
-            "response echoes the resolved version in a Threa-Version response header.",
+            "response that resolved a version echoes it in a Threa-Version response header.",
           ].join(" "),
         },
       },

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -831,7 +831,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "provisionStreamE2eKeyWraps",
     summary: "Provision the generation-0 key wraps for a harness-created encrypted scratchpad",
     description:
-      "Phase two of harness-created E2E scratchpads: stores the stream-key wraps (owner UIK + the harness's own BIK) minted against the stream id returned by session create. Bot-actor-only, current generation only, and only while the generation has no wraps — slots are immutable, so a replay cannot splice keys.",
+      "Phase two of harness-created E2E scratchpads: stores the stream-key wraps (owner UIK + the harness's own BIK) minted against the stream id returned by session create. Bot-actor-only, current generation only, and only while the generation has no wraps. Slots are immutable, so a replay cannot splice keys.",
     tags: ["Bot runtimes"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE],
     parameters: [
@@ -957,7 +957,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "sendBotInvocationSealedMessage",
     summary: "Post a sealed interim message from an in-flight sealed bot invocation",
     description:
-      "Sealed variant of a mid-turn bot message, for an owner-granted E2E bot harness: posts one sealed interim message (ciphertext the server never decrypts) into the claim's stream before the turn completes — progress notes, permission prompts, early acks. The client-minted messageId binds the seal AAD and dedupes retries. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+      "Sealed variant of a mid-turn bot message, for an owner-granted E2E bot harness: posts one sealed interim message (ciphertext the server never decrypts) into the claim's stream before the turn completes: progress notes, permission prompts, early acks. The client-minted messageId binds the seal AAD and dedupes retries. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
     tags: ["Bot invocations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE],
     parameters: [
@@ -1042,7 +1042,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "claimDelegation",
     summary: "Claim an open delegation",
     description:
-      "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once — send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+      "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
     tags: ["Delegations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE],
     parameters: [workspaceIdParam, delegationIdParam],
@@ -1058,7 +1058,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "heartbeatDelegation",
     summary: "Renew a delegation claim",
     description:
-      "Push the claim's expiry forward while the local agent is still working. Liveness only — no status change on the card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
+      "Push the claim's expiry forward while the local agent is still working. Liveness only; no status change on the card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
     tags: ["Delegations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE],
     parameters: [workspaceIdParam, delegationIdParam, delegationTokenHeaderParam],
@@ -1086,7 +1086,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "completeDelegation",
     summary: "Complete a delegation",
     description:
-      "Complete the claimed delegation. When resultMarkdown is given, the result is posted to the delegation's stream in the same transaction as the completion — authored as the key's user (with via-API provenance) for a user-scoped key, or as the bot for a workspace key. It enters the normal message pipeline, so workspace memory captures the outcome. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
+      "Complete the claimed delegation. When resultMarkdown is given, the result is posted to the delegation's stream in the same transaction as the completion, authored as the key's user (with via-API provenance) for a user-scoped key, or as the bot for a workspace key. It enters the normal message pipeline, so workspace memory captures the outcome. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
     tags: ["Delegations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE],
     parameters: [workspaceIdParam, delegationIdParam, delegationTokenHeaderParam],
@@ -1201,7 +1201,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     summary: "Find messages by metadata",
     description:
       "Find non-deleted messages whose `metadata` contains all the given key/value pairs (AND-containment). " +
-      "Useful for dedup flows — e.g. 'has a message already been posted for this GitHub PR event?'.",
+      "Useful for dedup flows, e.g. 'has a message already been posted for this GitHub PR event?'.",
     tags: ["Messages"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.MESSAGES_READ],
     parameters: [workspaceIdParam],
@@ -1269,7 +1269,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     summary: "Create or update a label by name",
     description:
       "Find-or-create a label owned by the key actor (a user or a bot), keyed by its name. Posting an " +
-      "existing name returns that label and applies any appearance fields supplied — labels are identified " +
+      "existing name returns that label and applies any appearance fields supplied; labels are identified " +
       "by their text, so this is idempotent.",
     tags: ["Labels"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.LABELS_WRITE],
@@ -1349,7 +1349,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "getMe",
     summary: "Get the authenticated principal",
     description:
-      "Returns a discriminated union describing the authenticated principal — either the API-key owner " +
+      "Returns a discriminated union describing the authenticated principal: the API-key owner " +
       '(`kind: "user"`) or the bot whose key is in use (`kind: "bot"`). Also reports the key\'s API version ' +
       "pin, the version this request resolved to, and the supported versions. Used by clients (e.g. the " +
       "OpenClaw channel plugin) to verify their key and discover their identity after pairing.",

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -121,12 +121,34 @@ const changelog: ChangelogEntry[] = changelogRaw
     <code>pinned</code> is the key's pin, or <code>null</code> when the key is
     unpinned. <code>resolved</code> is the version this request used.
   </p>
+  <CodeBlock
+    lang="ts"
+    label="detect that a newer version exists"
+    code={`interface ApiVersionInfo {
+  pinned: string | null
+  resolved: string
+  current: string
+  supported: string[]
+}
+
+const res = await fetch("{{baseUrl}}/api/v1/workspaces/{{workspaceId}}/me", {
+  headers: { Authorization: "Bearer {{apiKey}}" },
+})
+const { data } = (await res.json()) as { data: { apiVersion: ApiVersionInfo } }
+
+if (data.apiVersion.resolved !== data.apiVersion.current) {
+  // A newer version exists. Test against it by sending
+  // "Threa-Version": data.apiVersion.current on individual requests.
+}`}
+  />
   <p>
-    The pin is changed from the key management API in the app, by the key's owner.
-    <code>PATCH</code> the key with <code>&#123;"apiVersion": "&lt;date&gt;"&#125;</code> to pin it to a
-    supported version, or <code>&#123;"apiVersion": null&#125;</code> to unpin it. An unpinned key
-    always uses the current version, including future ones with breaking changes,
-    so unpin only if you update your integration as versions ship.
+    Pins belong to the key's owner and are managed in the app, not through the
+    public API: <code>PATCH</code> the key in the workspace's key management with
+    <code>&#123;"apiVersion": "&lt;date&gt;"&#125;</code> to re-pin it, or
+    <code>&#123;"apiVersion": null&#125;</code> to unpin it. An unpinned key always
+    uses the current version, including future breaking changes, so unpin only if
+    you update your integration as versions ship. To adopt newer shapes without
+    touching the pin, send the header or create a new key.
   </p>
 
   <h2 id="breaking-vs-additive">Breaking vs additive changes</h2>
@@ -162,7 +184,7 @@ const changelog: ChangelogEntry[] = changelogRaw
   <p>
     A version stays supported for at least twelve months after it is succeeded, so
     a key pinned to an older version keeps working for that long once a newer
-    version ships. That gives you time to test and migrate on your own schedule.
+    version ships.
   </p>
 
   <h2 id="the-path-prefix">The path prefix</h2>

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Threa Public API",
     "version": "2026-07-12",
-    "description": "The Threa Public API lets you programmatically read and write messages, list streams, search, and more.\n\n## Authentication\n\nAll requests require a Bearer token in the `Authorization` header:\n\n```\nAuthorization: Bearer threa_uk_your_api_key_here\n```\n\nKeys use two prefixes. A **personal access key** (`threa_uk_…`) carries a member's own\nidentity and access; any member creates one in the Threa app under **Settings > API keys**.\nA **bot key** (`threa_bk_…`) belongs to a bot with its own identity in the workspace —\neither a personal bot or a shared workspace bot — and is minted from the bot's settings\n(personal bots by their owner, shared bots by an admin).\nEach key is scoped to a workspace and granted specific permissions (scopes).\n\nHuman-readable docs: https://threa.io/developers (agent-friendly mirror: https://threa.io/llms.txt).\n\n## Scopes\n\nAPI keys are granted specific scopes that control access:\n\n- `messages:search` — Grants access to search messages in public streams in a workspace. Application level stream grants can extend permissions to private streams.\n- `streams:read` — Grants access to list and search accessible streams in a workspace.\n- `messages:read` — Grants access to read messages in accessible streams.\n- `messages:write` — Grants access to send, update, and delete messages in accessible streams.\n- `users:read` — Grants access to list and search workspace users.\n- `memos:read` — Grants access to search preserved workspace memos and inspect their provenance.\n- `attachments:read` — Grants access to search accessible attachments, inspect extracted content, and fetch download URLs.\n- `attachments:write` — Grants access to upload and replace attachments in accessible streams.\n- `labels:read` — Grants access to list workspace labels and their assignments on accessible resources.\n- `labels:write` — Grants access to create, edit, archive, join, and apply labels to accessible resources such as streams.\n- `bot-runtime:read` — Grants access to read bot runtime presence and invocation state.\n- `bot-runtime:write` — Grants access to heartbeat bot runtime presence and link runtime sessions.\n- `bot-invocations:read` — Grants access to read bot invocation state.\n- `bot-invocations:write` — Grants access to claim, complete, or fail bot invocations.\n- `delegations:read` — Grants access to list delegated tasks in accessible streams, including open tasks ready to claim.\n- `delegations:write` — Grants an agent access to claim delegated tasks and report progress, completion (posting the result as the key's identity), or failure.\n\n## Rate Limits\n\nRequests are rate-limited per workspace and per API key. Rate limit headers are included in responses.\n\n## Pagination\n\nList endpoints return paginated results with `hasMore` and `cursor` fields.\nPass the `cursor` value as the `after` query parameter to fetch the next page."
+    "description": "The Threa Public API lets you programmatically read and write messages, list streams, and search messages, memos, and attachments.\n\n## Authentication\n\nAll requests require a Bearer token in the `Authorization` header:\n\n```\nAuthorization: Bearer threa_uk_your_api_key_here\n```\n\nKeys use two prefixes. A **personal access key** (`threa_uk_…`) carries a member's own\nidentity and access; any member creates one in the Threa app under **Settings > API keys**.\nA **bot key** (`threa_bk_…`) belongs to a bot with its own identity in the workspace\n(a personal bot or a shared workspace bot) and is minted from the bot's settings\n(personal bots by their owner, shared bots by an admin).\nEach key is scoped to a workspace and granted specific permissions (scopes).\n\nHuman-readable docs: https://threa.io/developers (agent-friendly mirror: https://threa.io/llms.txt).\n\n## Scopes\n\nAPI keys are granted specific scopes that control access:\n\n- `messages:search`: Grants access to search messages in public streams in a workspace. Application level stream grants can extend permissions to private streams.\n- `streams:read`: Grants access to list and search accessible streams in a workspace.\n- `messages:read`: Grants access to read messages in accessible streams.\n- `messages:write`: Grants access to send, update, and delete messages in accessible streams.\n- `users:read`: Grants access to list and search workspace users.\n- `memos:read`: Grants access to search preserved workspace memos and inspect their provenance.\n- `attachments:read`: Grants access to search accessible attachments, inspect extracted content, and fetch download URLs.\n- `attachments:write`: Grants access to upload and replace attachments in accessible streams.\n- `labels:read`: Grants access to list workspace labels and their assignments on accessible resources.\n- `labels:write`: Grants access to create, edit, archive, join, and apply labels to accessible resources such as streams.\n- `bot-runtime:read`: Grants access to read bot runtime presence and invocation state.\n- `bot-runtime:write`: Grants access to heartbeat bot runtime presence and link runtime sessions.\n- `bot-invocations:read`: Grants access to read bot invocation state.\n- `bot-invocations:write`: Grants access to claim, complete, or fail bot invocations.\n- `delegations:read`: Grants access to list delegated tasks in accessible streams, including open tasks ready to claim.\n- `delegations:write`: Grants an agent access to claim delegated tasks and report progress, completion (posting the result as the key's identity), or failure.\n\n## Rate Limits\n\nRequests are rate-limited per workspace and per API key. Rate limit headers are included in responses.\n\n## Pagination\n\nList endpoints return paginated results with `hasMore` and `cursor` fields.\nPass the `cursor` value as the `after` query parameter to fetch the next page."
   },
   "servers": [{ "url": "https://app.threa.io", "description": "Production" }],
   "security": [{ "apiKey": [] }],
@@ -1261,7 +1261,7 @@
         "operationId": "provisionStreamE2eKeyWraps",
         "summary": "Provision the generation-0 key wraps for a harness-created encrypted scratchpad",
         "tags": ["Bot runtimes"],
-        "description": "Phase two of harness-created E2E scratchpads: stores the stream-key wraps (owner UIK + the harness's own BIK) minted against the stream id returned by session create. Bot-actor-only, current generation only, and only while the generation has no wraps — slots are immutable, so a replay cannot splice keys.",
+        "description": "Phase two of harness-created E2E scratchpads: stores the stream-key wraps (owner UIK + the harness's own BIK) minted against the stream id returned by session create. Bot-actor-only, current generation only, and only while the generation has no wraps. Slots are immutable, so a replay cannot splice keys.",
         "security": [{ "apiKey": ["bot-runtime:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -2399,7 +2399,7 @@
         "operationId": "sendBotInvocationSealedMessage",
         "summary": "Post a sealed interim message from an in-flight sealed bot invocation",
         "tags": ["Bot invocations"],
-        "description": "Sealed variant of a mid-turn bot message, for an owner-granted E2E bot harness: posts one sealed interim message (ciphertext the server never decrypts) into the claim's stream before the turn completes — progress notes, permission prompts, early acks. The client-minted messageId binds the seal AAD and dedupes retries. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+        "description": "Sealed variant of a mid-turn bot message, for an owner-granted E2E bot harness: posts one sealed interim message (ciphertext the server never decrypts) into the claim's stream before the turn completes: progress notes, permission prompts, early acks. The client-minted messageId binds the seal AAD and dedupes retries. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["bot-invocations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3106,7 +3106,7 @@
         "operationId": "claimDelegation",
         "summary": "Claim an open delegation",
         "tags": ["Delegations"],
-        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once — send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3219,7 +3219,7 @@
           "403": { "description": "Insufficient permissions or inaccessible resource" },
           "404": { "description": "Resource not found" },
           "409": {
-            "description": "Conflict — the resource is not in the state the operation requires",
+            "description": "Conflict: the resource is not in the state the operation requires",
             "content": {
               "application/json": {
                 "schema": {
@@ -3251,7 +3251,7 @@
         "operationId": "heartbeatDelegation",
         "summary": "Renew a delegation claim",
         "tags": ["Delegations"],
-        "description": "Push the claim's expiry forward while the local agent is still working. Liveness only — no status change on the card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
+        "description": "Push the claim's expiry forward while the local agent is still working. Liveness only; no status change on the card. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3446,7 +3446,7 @@
         "operationId": "completeDelegation",
         "summary": "Complete a delegation",
         "tags": ["Delegations"],
-        "description": "Complete the claimed delegation. When resultMarkdown is given, the result is posted to the delegation's stream in the same transaction as the completion — authored as the key's user (with via-API provenance) for a user-scoped key, or as the bot for a workspace key. It enters the normal message pipeline, so workspace memory captures the outcome. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
+        "description": "Complete the claimed delegation. When resultMarkdown is given, the result is posted to the delegation's stream in the same transaction as the completion, authored as the key's user (with via-API provenance) for a user-scoped key, or as the bot for a workspace key. It enters the normal message pipeline, so workspace memory captures the outcome. Authenticated with the per-claim token in the X-Threa-Callback-Token header.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -4388,7 +4388,7 @@
         "operationId": "findMessagesByMetadata",
         "summary": "Find messages by metadata",
         "tags": ["Messages"],
-        "description": "Find non-deleted messages whose `metadata` contains all the given key/value pairs (AND-containment). Useful for dedup flows — e.g. 'has a message already been posted for this GitHub PR event?'.",
+        "description": "Find non-deleted messages whose `metadata` contains all the given key/value pairs (AND-containment). Useful for dedup flows, e.g. 'has a message already been posted for this GitHub PR event?'.",
         "security": [{ "apiKey": ["messages:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -4978,7 +4978,7 @@
         "operationId": "createLabel",
         "summary": "Create or update a label by name",
         "tags": ["Labels"],
-        "description": "Find-or-create a label owned by the key actor (a user or a bot), keyed by its name. Posting an existing name returns that label and applies any appearance fields supplied — labels are identified by their text, so this is idempotent.",
+        "description": "Find-or-create a label owned by the key actor (a user or a bot), keyed by its name. Posting an existing name returns that label and applies any appearance fields supplied; labels are identified by their text, so this is idempotent.",
         "security": [{ "apiKey": ["labels:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -5480,7 +5480,7 @@
         "operationId": "getMe",
         "summary": "Get the authenticated principal",
         "tags": ["Identity"],
-        "description": "Returns a discriminated union describing the authenticated principal — either the API-key owner (`kind: \"user\"`) or the bot whose key is in use (`kind: \"bot\"`). Also reports the key's API version pin, the version this request resolved to, and the supported versions. Used by clients (e.g. the OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
+        "description": "Returns a discriminated union describing the authenticated principal: the API-key owner (`kind: \"user\"`) or the bot whose key is in use (`kind: \"bot\"`). Also reports the key's API version pin, the version this request resolved to, and the supported versions. Used by clients (e.g. the OpenClaw channel plugin) to verify their key and discover their identity after pairing.",
         "security": [{ "apiKey": [] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -5780,7 +5780,7 @@
         "in": "header",
         "required": false,
         "schema": { "type": "string", "enum": ["2026-07-12"] },
-        "description": "Selects the dated API version for this request. Each API key is pinned to a version when it is minted, and that pin applies when the header is absent. Send this header to override the pin per request (a valid header always wins). The value must be an exact member of the enum; an unknown or malformed value returns 400 with code INVALID_API_VERSION and the known versions in the error. Every response echoes the resolved version in a Threa-Version response header."
+        "description": "Selects the dated API version for this request. Each API key is pinned to a version when it is minted, and that pin applies when the header is absent. Send this header to override the pin per request (a valid header always wins). The value must be an exact member of the enum; an unknown or malformed value returns 400 with code INVALID_API_VERSION and the known versions in the error. Every response that resolved a version echoes it in a Threa-Version response header."
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
## Problem

Post-merge audit of the versioning docs (Kris: is the public documentation deslopified and technically competent?). The page itself was structurally clean, but four things failed the bar, plus pre-existing slop in spec descriptions that render on the public reference.

## Solution

- `/developers/versioning`: the pin-change paragraph implied a publicly reachable interface; reframed honestly (pins are owner-side app operations, not public API; practical integrator routes are the header override or a new key). Added a typed TypeScript example (site `lang="ts"` + `{{placeholder}}` convention from recipes) showing how an agent detects a newer version via `/me`. Trimmed one filler sentence.
- OpenAPI `ThreaVersion` parameter description still overclaimed "every response echoes"; now matches the echo-on-resolved behavior fixed in #1296.
- Deslopify sweep of all rendered spec descriptions: every em-dash construction restructured (getMe, sealed-harness, delegations, labels, 409, bot-key intro, scope bullets) and the API intro drops "and more". Internal code comments untouched.

## Test plan

- [x] `generate-api-docs.ts --check` green after regen; zero em-dashes remain in `openapi.json`
- [x] `public-api-openapi.test.ts` — 22 pass
- [x] Backend typecheck clean; `astro build` green (10 pages, llms mirrors)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786457783&installation_id=129946197&pr_number=1301&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1301&signature=e597ff9bb8d3f87c019ae999ba1735f9e346de9ef5ec1da43431a83edf05a4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->