### PR TITLE
feat(frontend): board view refinements — panel expand, sidebar filters, New Post clear

### DIFF
--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -143,15 +143,23 @@ export function BoardFilterBar({
   // is the plain home lens, or (when set) the saved view they home on, so resting
   // on that view must also read as unfiltered even though it carries scope.
   const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
-  const isFiltered = !isBoardAtHome(homeLens, homeView, {
-    lens,
-    scopeStreamIds,
-    scopeStreamTypes,
-    scopeLabelIds,
-    excludeStreamIds,
-    excludeStreamTypes,
-    excludeLabelIds,
-  })
+  // `unreadOnly` narrows the feed like every other axis (unlike `showArchived`,
+  // which broadens it), so it must count toward "filtered" too — otherwise
+  // toggling Unread with nothing else selected hides "Clear filters" and the
+  // empty-state "Show everything" CTA even though the board is narrowed.
+  // `BoardViewSelection` itself stays unread-unaware (matching `showArchived`'s
+  // precedent): unread state churns on every read receipt, so it isn't
+  // meaningful to capture in a saved view.
+  const isFiltered =
+    !isBoardAtHome(homeLens, homeView, {
+      lens,
+      scopeStreamIds,
+      scopeStreamTypes,
+      scopeLabelIds,
+      excludeStreamIds,
+      excludeStreamTypes,
+      excludeLabelIds,
+    }) || unreadOnly
   const clearedSearch = useMemo(() => boardHomeSearch(location.search), [location.search])
   // "Clear filters" returns to the viewer's home: the saved-view home when one
   // resolves (straight to its URL — no bare `/board` detour that would blank-flash

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
-import { Archive, Ban, Bell, BellOff, Check, ChevronDown, Hash, Layers, Pin, Tag, X } from "lucide-react"
+import { Archive, Ban, Bell, BellOff, Check, ChevronDown, CircleDot, Hash, Layers, Pin, Tag, X } from "lucide-react"
 import {
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
@@ -81,6 +81,10 @@ interface BoardFilterBarProps {
   showArchived: boolean
   /** Toggle the archived opt-in; the page owns the URL write. */
   onToggleArchived: (next: boolean) => void
+  /** Whether the board is narrowed to unread conversations (`?unread=true`). */
+  unreadOnly: boolean
+  /** Toggle the unread-only opt-in; the page owns the URL write. */
+  onToggleUnreadOnly: (next: boolean) => void
 }
 
 /**
@@ -119,6 +123,8 @@ export function BoardFilterBar({
   onToggleMute,
   showArchived,
   onToggleArchived,
+  unreadOnly,
+  onToggleUnreadOnly,
 }: BoardFilterBarProps) {
   const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
@@ -209,6 +215,18 @@ export function BoardFilterBar({
           onLabelFilterChange={onLabelFilterChange}
         />
       )}
+      <Button
+        type="button"
+        variant={unreadOnly ? "secondary" : "outline"}
+        size="sm"
+        onClick={() => onToggleUnreadOnly(!unreadOnly)}
+        aria-pressed={unreadOnly}
+        className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
+        aria-label={unreadOnly ? "Show every conversation" : "Show only unread conversations"}
+      >
+        <CircleDot className="h-3.5 w-3.5" />
+        Unread
+      </Button>
       <Button
         type="button"
         variant={showArchived ? "secondary" : "outline"}

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -40,6 +40,15 @@ export const BOARD_ARCHIVED_PARAM = "archived"
  *  `showArchived` flag). */
 export const BOARD_ARCHIVED_ON = "true"
 
+/** Unread opt-in (`?unread=true`) — narrows to conversations on a currently
+ *  unread (and unmuted) root stream. Client-resolved (mirrors the sidebar's own
+ *  Unread section membership), so it stays live as things get read/unread
+ *  instead of snapshotting ids the way the section header's old "Scope all" did. */
+export const BOARD_UNREAD_PARAM = "unread"
+
+/** The `?unread=` value that opts into the unread-only narrowing. */
+export const BOARD_UNREAD_ON = "true"
+
 /** Every board filter param, for clear-all sweeps. */
 export const BOARD_FILTER_PARAMS = [
   BOARD_SCOPE_PARAM,
@@ -49,6 +58,7 @@ export const BOARD_FILTER_PARAMS = [
   BOARD_LABEL_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
   BOARD_ARCHIVED_PARAM,
+  BOARD_UNREAD_PARAM,
 ] as const
 
 /**
@@ -196,6 +206,30 @@ export function labelFocusSearch(search: string, labelId: string): string {
   writeIdList(params, BOARD_LABEL_PARAM, [labelId])
   const excluded = parseIdListParam(params.get(BOARD_EXCLUDE_LABEL_PARAM)).filter((id) => id !== labelId)
   writeIdList(params, BOARD_EXCLUDE_LABEL_PARAM, excluded)
+  return toSearch(params)
+}
+
+/**
+ * The board-mode type-section header verb: FOCUS the board's type axis on one
+ * root-stream type (`?is=<type>`). Mirrors {@link labelFocusSearch} on the type
+ * axis — replaces the type include list with just this one and drops it from
+ * `?not-is`, leaving every other axis untouched.
+ */
+export function typeFocusSearch(search: string, type: BoardScopeStreamType): string {
+  const params = new URLSearchParams(search)
+  writeIdList(params, BOARD_TYPE_PARAM, [type])
+  const excluded = parseTypeListParam(params.get(BOARD_EXCLUDE_TYPE_PARAM)).filter((t) => t !== type)
+  writeIdList(params, BOARD_EXCLUDE_TYPE_PARAM, excluded)
+  return toSearch(params)
+}
+
+/**
+ * The board-mode Unread-section header verb: FOCUS the board on unread
+ * conversations (`?unread=true`), leaving every other axis untouched.
+ */
+export function unreadFocusSearch(search: string): string {
+  const params = new URLSearchParams(search)
+  params.set(BOARD_UNREAD_PARAM, BOARD_UNREAD_ON)
   return toSearch(params)
 }
 

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -17,7 +17,16 @@ import type { MessageComposerProps } from "@/components/composer"
 // The behavior under test is the floating-anchor layer (portal placement,
 // slot exclusivity, close semantics, height publication) — not editor
 // mechanics — so the heavy tiptap editor is swapped for a marker div.
-const EditorStub = (props: MessageComposerProps) => <div data-testid="editor-stub">{props.placeholder}</div>
+const EditorStub = (props: MessageComposerProps) => (
+  <div data-testid="editor-stub" data-expanded={String(!!props.expanded)}>
+    {props.placeholder}
+    {props.onExpandClick && (
+      <button type="button" onClick={props.onExpandClick}>
+        Expand
+      </button>
+    )}
+  </div>
+)
 
 const EMPTY_DOC = { type: "doc", content: [] }
 
@@ -55,6 +64,8 @@ beforeEach(() => {
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({ preferences: undefined } as never)
   vi.spyOn(mentionablesModule, "useMentionStreamContext").mockReturnValue(undefined as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue(undefined as never)
 })
 
@@ -150,5 +161,28 @@ describe("InlineComposerForm floating anchor (mobile)", () => {
     const pills = anchor.querySelectorAll('[data-testid="editor-stub"]')
     expect(pills).toHaveLength(1)
     expect(pills[0]?.textContent).toBe("Second")
+  })
+})
+
+describe("InlineComposerForm fullscreen expand", () => {
+  it("desktop: an expand button opens the same draft in the fullscreen editor", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    render(<Anchored>{form()}</Anchored>)
+
+    expect(screen.getByTestId("editor-stub")).toHaveAttribute("data-expanded", "false")
+
+    await userEvent.click(screen.getByRole("button", { name: "Expand" }))
+
+    // The inline form is replaced by the expanded one — same draft, one editor
+    // mounted at a time, not two competing instances of the same content.
+    const stubs = await screen.findAllByTestId("editor-stub")
+    expect(stubs).toHaveLength(1)
+    expect(stubs[0]).toHaveAttribute("data-expanded", "true")
+  })
+
+  it("mobile: no expand affordance — the floating pill has its own height-publish lifecycle", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    render(<Anchored>{form()}</Anchored>)
+    expect(screen.queryByRole("button", { name: "Expand" })).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { CornerDownRight, X } from "lucide-react"
 import { toast } from "sonner"
 import {
   MessageComposer,
   FloatingComposerShell,
+  OverlayComposerShell,
   useFloatingComposerAnchor,
   FLOATING_COMPOSER_HEIGHT_VAR,
   type ComposerControlHandle,
@@ -14,8 +15,10 @@ import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
+import { useStreamName } from "@/hooks/use-stream-name"
 import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
 import { useStreamFromStore } from "@/stores/stream-store"
+import { STREAM_ICONS } from "@/lib/streams"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
 import type { AttachmentSummary } from "@/hooks/create-optimistic-bootstrap"
@@ -118,6 +121,13 @@ export function InlineComposerForm({
   }, [pendingQuote, composer.isLoaded, onQuoteConsumed])
 
   const canSubmit = composer.canSend
+
+  // Fullscreen expand — the same overlay shell the timeline and the New Post
+  // composer use, so a long reply gets the same full-document editor instead of
+  // being stuck in the compact card-reply box.
+  const [expanded, setExpanded] = useState(false)
+  const overlayStreamName = useStreamName(workspaceId, streamId ?? "")
+  const OverlayStreamGlyph = hostStream ? STREAM_ICONS[hostStream.type] : null
 
   const containerRef = useRef<HTMLDivElement>(null)
   const isEmptyRef = useRef(true)
@@ -279,37 +289,77 @@ export function InlineComposerForm({
     </div>
   ) : null
 
+  // Shared by the inline editor and the fullscreen one below — same draft,
+  // same send path, same everything except layout.
+  const sharedComposerProps = {
+    content: composer.content,
+    onContentChange: composer.handleContentChange,
+    pendingAttachments: composer.pendingAttachments,
+    onRemoveAttachment: composer.handleRemoveAttachment,
+    onCancelAttachmentUpload: composer.handleCancelAttachmentUpload,
+    workspaceId,
+    streamId: hostStream?.id,
+    memoAnchorStreamId,
+    fileInputRef: composer.fileInputRef,
+    onFileSelect: composer.handleFileSelect,
+    onFileUpload: composer.uploadFile,
+    imageCount: composer.imageCount,
+    onSubmit: handleSubmit,
+    canSubmit,
+    isSubmitting: composer.isSending,
+    hasFailed: composer.hasFailed,
+    placeholder,
+    messageSendMode: preferences?.messageSendMode ?? "enter",
+    scopeId: draftKey,
+    streamContext,
+  } as const
+
   const editor = (
     <MessageComposer
+      {...sharedComposerProps}
       composerRef={composerControlRef}
-      content={composer.content}
-      onContentChange={composer.handleContentChange}
-      pendingAttachments={composer.pendingAttachments}
-      onRemoveAttachment={composer.handleRemoveAttachment}
-      onCancelAttachmentUpload={composer.handleCancelAttachmentUpload}
-      workspaceId={workspaceId}
-      streamId={hostStream?.id}
-      memoAnchorStreamId={memoAnchorStreamId}
-      fileInputRef={composer.fileInputRef}
-      onFileSelect={composer.handleFileSelect}
-      onFileUpload={composer.uploadFile}
-      imageCount={composer.imageCount}
-      onSubmit={handleSubmit}
-      canSubmit={canSubmit}
-      isSubmitting={composer.isSending}
-      hasFailed={composer.hasFailed}
-      placeholder={placeholder}
-      messageSendMode={preferences?.messageSendMode ?? "enter"}
       autoFocus={autoFocus}
       initialMobileChromeOpen
-      scopeId={draftKey}
-      streamContext={streamContext}
+      // Desktop only: the floating (mobile) form's height-publish effect keys off
+      // its own mount lifecycle (`holdsFloatingSlot`), which an `expanded` escape
+      // hatch here would sidestep, leaving a stale reserved-space CSS var behind.
+      // Mobile already gets a roomy floating pill, so the expand affordance isn't
+      // worth that edge case there.
+      onExpandClick={floating ? undefined : () => setExpanded(true)}
       onEscapeBlur={() => {
         const hadContent = !isEmptyRef.current
         void composer.flushDraft()
         onClose({ refocus: true, hadContent })
       }}
     />
+  )
+
+  // Fullscreen expand — the same overlay shell the timeline and New Post use, so
+  // a reply gets the same full-document editor instead of being stuck in the
+  // compact card-reply box. Desktop only (see `editor` above); `OverlayComposerShell`
+  // no-ops (renders nothing) while `expanded` is false.
+  const fullscreenEditor = (
+    <OverlayComposerShell
+      open={expanded}
+      onOpenChange={setExpanded}
+      title="Message editor"
+      header={
+        <div className="inline-flex h-8 max-w-full items-center gap-1.5 rounded-full border bg-background px-3 text-sm font-medium">
+          {OverlayStreamGlyph && <OverlayStreamGlyph className="h-4 w-4 shrink-0 text-muted-foreground" />}
+          <span className="truncate">{overlayStreamName ?? "This conversation"}</span>
+        </div>
+      }
+    >
+      <div className="min-h-0 flex-1">
+        <MessageComposer
+          {...sharedComposerProps}
+          expanded
+          hideExpandedClose
+          onCollapse={() => setExpanded(false)}
+          autoFocus
+        />
+      </div>
+    </OverlayComposerShell>
   )
 
   if (floating && anchorEl) {
@@ -345,7 +395,8 @@ export function InlineComposerForm({
   return (
     <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
       {contextChipNode && <div className="mb-1">{contextChipNode}</div>}
-      {editor}
+      {fullscreenEditor}
+      {!expanded && editor}
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -320,12 +320,15 @@ export function InlineComposerForm({
       composerRef={composerControlRef}
       autoFocus={autoFocus}
       initialMobileChromeOpen
-      // Desktop only: the floating (mobile) form's height-publish effect keys off
-      // its own mount lifecycle (`holdsFloatingSlot`), which an `expanded` escape
-      // hatch here would sidestep, leaving a stale reserved-space CSS var behind.
-      // Mobile already gets a roomy floating pill, so the expand affordance isn't
-      // worth that edge case there.
-      onExpandClick={floating ? undefined : () => setExpanded(true)}
+      // Desktop only — gated on `isMobile`, not `floating` (mobile without a
+      // floating anchor is still mobile: `floating` is `isMobile && anchor !==
+      // null`, so it's false there and would wrongly leave expand enabled). The
+      // floating form's height-publish effect keys off its own mount lifecycle
+      // (`holdsFloatingSlot`), which an `expanded` escape hatch here would
+      // sidestep, leaving a stale reserved-space CSS var behind. Mobile already
+      // gets a roomy floating pill, so the expand affordance isn't worth that
+      // edge case there.
+      onExpandClick={isMobile ? undefined : () => setExpanded(true)}
       onEscapeBlur={() => {
         const hadContent = !isEmptyRef.current
         void composer.flushDraft()

--- a/apps/frontend/src/components/board/board-overlay-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-overlay-composer.test.tsx
@@ -76,14 +76,20 @@ beforeEach(() => {
 })
 
 describe("BoardOverlayComposer", () => {
-  it("seeds the target from the MRU and posts to it, then promotes it + closes", async () => {
-    localStorage.setItem("board:post-target-mru:workspace_1", JSON.stringify([channel.id]))
+  it("posts to the picked target, then promotes it into the MRU and clears the draft target + closes", async () => {
     const onOpenChange = vi.fn()
     const onPosted = vi.fn()
 
-    render(<BoardOverlayComposer workspaceId="workspace_1" open onOpenChange={onOpenChange} onPosted={onPosted} />)
+    render(
+      <BoardOverlayComposer
+        workspaceId="workspace_1"
+        open
+        onOpenChange={onOpenChange}
+        onPosted={onPosted}
+        defaultTarget={channel.id}
+      />
+    )
 
-    // Target seeded from MRU → picker shows it, editor is enabled.
     expect(screen.getByRole("combobox")).toHaveTextContent("general")
     expect(screen.getByTestId("placeholder")).toHaveTextContent("Write a post…")
 
@@ -96,26 +102,28 @@ describe("BoardOverlayComposer", () => {
     )
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(onPosted).toHaveBeenCalledWith("conv_1")
+    // The stream still enters Recents (the MRU)...
     expect(readTargetMru("workspace_1")).toEqual([channel.id])
-    // The draft's persisted target is cleared on send (the draft is resolved).
+    // ...but the draft's persisted target is cleared on send, so a fresh "New
+    // post" doesn't re-default to wherever the last one went.
     expect(readDraftTarget("workspace_1")).toBe("")
   })
 
-  it("seeds from the persisted draft target over the MRU head, so a restored draft keeps its target", () => {
-    localStorage.setItem("board:post-target-mru:workspace_1", JSON.stringify(["stream_other"]))
+  it("seeds from a persisted in-progress draft target, so a restored draft keeps its target", () => {
     localStorage.setItem("board:new-post:target:workspace_1", channel.id)
     render(<BoardOverlayComposer workspaceId="workspace_1" open onOpenChange={vi.fn()} />)
     expect(screen.getByRole("combobox")).toHaveTextContent("general")
   })
 
-  it("re-seeds the target from persistence on each open (the singleton never remounts)", async () => {
-    // Mounted closed with an empty MRU → seeds "". A target set after mount (e.g.
-    // the MRU updated by a prior post) is picked up on the next open edge, so a
-    // stale in-memory pick can't linger across close→reopen.
+  it("does not re-seed the target from the MRU on reopen — a fresh post always starts unpicked", async () => {
+    // A prior post landed this stream in the MRU, but with no in-progress draft
+    // target persisted, opening fresh must start with nothing selected rather
+    // than re-defaulting to wherever the last post went.
     const { rerender } = render(<BoardOverlayComposer workspaceId="workspace_1" open={false} onOpenChange={vi.fn()} />)
     localStorage.setItem("board:post-target-mru:workspace_1", JSON.stringify([channel.id]))
     rerender(<BoardOverlayComposer workspaceId="workspace_1" open onOpenChange={vi.fn()} />)
-    expect(await screen.findByRole("combobox")).toHaveTextContent("general")
+    expect(await screen.findByTestId("stub-send")).toBeDisabled()
+    expect(screen.getByRole("combobox")).not.toHaveTextContent("general")
   })
 
   it("adopts an explicit defaultTarget and disables send until a target is set", async () => {

--- a/apps/frontend/src/components/board/board-overlay-composer.tsx
+++ b/apps/frontend/src/components/board/board-overlay-composer.tsx
@@ -51,11 +51,10 @@ export function BoardOverlayComposer({
   // which closes it), so recompute per open rather than every render.
   const recents = useMemo(() => readTargetMru(workspaceId), [workspaceId, open])
 
-  // Seed from the persisted in-progress draft target first (so a restored draft
-  // body pairs with the place it was headed), then the last-posted stream.
-  const [targetValue, setTargetValue] = useState(
-    () => defaultTarget ?? (readDraftTarget(workspaceId) || readTargetMru(workspaceId)[0] || "")
-  )
+  // Seed from the persisted in-progress draft target only — so a restored draft
+  // body pairs with the place it was headed. A successful post clears this (see
+  // handleSubmit), so a fresh "New post" always starts with no target selected.
+  const [targetValue, setTargetValue] = useState(() => defaultTarget ?? readDraftTarget(workspaceId))
 
   // Persist the target alongside the draft body so a reload restores both.
   const changeTarget = useCallback(
@@ -75,15 +74,15 @@ export function BoardOverlayComposer({
 
   // The overlay is a persistent app-level singleton (never remounts), so a stale
   // in-memory target survives close→reopen. On each open without an explicit
-  // target, re-seed from persistence — after a send the draft target is cleared,
-  // so this drops a just-used "New scratchpad" sentinel instead of defaulting the
-  // next post to minting another.
+  // target, re-seed from persistence only — after a send the draft target is
+  // cleared, so this drops a just-used "New scratchpad" sentinel (or wherever the
+  // last post went) instead of defaulting the next post to it.
   const prevOpenRef = useRef(open)
   useEffect(() => {
     const justOpened = open && !prevOpenRef.current
     prevOpenRef.current = open
     if (justOpened && !defaultTarget) {
-      setTargetValue(readDraftTarget(workspaceId) || readTargetMru(workspaceId)[0] || "")
+      setTargetValue(readDraftTarget(workspaceId))
     }
   }, [open, defaultTarget, workspaceId])
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -887,8 +887,11 @@ export function MessageComposer({
 
           <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5">
             {/* Action drawer — always visible on desktop; on touch (no hover) it
-                stays behind the + button and opens on tap. */}
+                stays behind the + button and opens on tap. `inert` while
+                collapsed on mobile so its buttons drop out of tab order instead
+                of sitting invisibly ahead of the visible "+" button. */}
             <div
+              inert={isMobile && !fabActionsOpen}
               className={cn(
                 "flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out",
                 isMobile ? "max-w-0 opacity-0" : "max-w-[240px] opacity-100",

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -323,9 +323,8 @@ export function MessageComposer({
   const [formatOpen, setFormatOpen] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
-  // Expanded-mode FAB actions reveal on hover/focus on desktop; touch has neither
-  // (the editor lives outside the group, so focus-within never fires), so a tap on
-  // the "+" toggles them. Reachable on touch now that the overlay hosts `expanded`.
+  // Expanded-mode FAB actions are always visible on desktop. Touch has no hover,
+  // so a tap on the "+" toggles them instead.
   const [fabActionsOpen, setFabActionsOpen] = useState(false)
   const [mobileFocused, setMobileFocused] = useState(initialMobileChromeOpen)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
@@ -886,14 +885,13 @@ export function MessageComposer({
             <div className="h-[50vh]" />
           </div>
 
-          <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5 group/fab">
-            {/* Action drawer — slides out from behind the + button on hover /
-                focus-within (desktop) or when tapped open (touch). */}
+          <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5">
+            {/* Action drawer — always visible on desktop; on touch (no hover) it
+                stays behind the + button and opens on tap. */}
             <div
               className={cn(
-                "flex items-center gap-1 overflow-hidden max-w-0 opacity-0 transition-all duration-200 ease-out",
-                "group-hover/fab:max-w-[240px] group-hover/fab:opacity-100",
-                "group-focus-within/fab:max-w-[240px] group-focus-within/fab:opacity-100",
+                "flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out",
+                isMobile ? "max-w-0 opacity-0" : "max-w-[240px] opacity-100",
                 fabActionsOpen && "max-w-[240px] opacity-100"
               )}
             >
@@ -981,22 +979,23 @@ export function MessageComposer({
                 </TooltipContent>
               </Tooltip>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              aria-label={fabActionsOpen ? "Hide actions" : "Show actions"}
-              aria-expanded={fabActionsOpen}
-              onPointerDown={(e) => e.preventDefault()}
-              onClick={() => setFabActionsOpen((v) => !v)}
-              className={cn(
-                "h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md [&_svg]:transition-transform",
-                "group-hover/fab:[&_svg]:rotate-45 group-focus-within/fab:[&_svg]:rotate-45",
-                fabActionsOpen && "[&_svg]:rotate-45"
-              )}
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
+            {isMobile ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                aria-label={fabActionsOpen ? "Hide actions" : "Show actions"}
+                aria-expanded={fabActionsOpen}
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={() => setFabActionsOpen((v) => !v)}
+                className={cn(
+                  "h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md [&_svg]:transition-transform",
+                  fabActionsOpen && "[&_svg]:rotate-45"
+                )}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            ) : null}
             {micButtonFab}
             {hasFailed ? (
               <Tooltip>

--- a/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
+++ b/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
@@ -1,4 +1,4 @@
-import { StreamTypes, type BoardLens, type StreamType } from "@threa/types"
+import { StreamTypes, type BoardLens, type BoardScopeStreamType, type StreamType } from "@threa/types"
 import type { BoardStreamStats } from "@/hooks/use-board-sidebar-stats"
 
 /**
@@ -54,6 +54,14 @@ export interface SidebarBoardMode {
    *  header's open affordance in board mode → `?label=<id>` instead of the label
    *  page). */
   labelFocusHref: (labelId: string) => string
+  /** Board URL that focuses the type axis on one root-stream type (a type
+   *  section's — Channels/DMs/Scratchpads — open affordance → `?is=<type>`). */
+  typeFocusHref: (type: BoardScopeStreamType) => string
+  /** Board URL that narrows to unread conversations (the Unread section's open
+   *  affordance → `?unread=true`). Live, not a snapshot — unlike `scopeAllHref`,
+   *  it keeps matching as things get read/unread instead of freezing the ids
+   *  that were unread at click time. */
+  unreadFocusHref: () => string
   /** Mute / unmute a root stream on the board. */
   setMuted: (streamId: string, mute: boolean) => void
   /** Per-root-stream topic tally for the row's board-mode preview line. `null`

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -297,6 +297,8 @@ describe("ScratchpadItem", () => {
       applyExclude: vi.fn(),
       scopeAllHref: (ids) => `/w/workspace_1/board?in=${ids.join(",")}`,
       labelFocusHref: (labelId) => `/w/workspace_1/board?label=${labelId}`,
+      typeFocusHref: (type) => `/w/workspace_1/board?is=${type}`,
+      unreadFocusHref: () => `/w/workspace_1/board?unread=true`,
       setMuted: vi.fn(),
       statsForStream: () => null,
       lensTotals: null,

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -265,14 +265,27 @@ export function SidebarStreamList({
             titleHref = boardMode.labelFocusHref(label.id)
             titleActionLabel = `Filter board by ${label.name}`
           }
+          // Board mode only, mirroring the label case above: a type section
+          // (Channels/DMs/Scratchpads) focuses the board's type axis (`?is=`),
+          // and Unread focuses the unread axis (`?unread=true`) — both live
+          // aggregate filters, not a one-time snapshot of the current ids.
+          if (boardMode && section.spec.kind === "type") {
+            titleHref = boardMode.typeFocusHref(section.spec.streamType)
+            titleActionLabel = `Filter board by ${presentation.label}`
+          } else if (boardMode && section.spec.kind === "unread") {
+            titleHref = boardMode.unreadFocusHref()
+            titleActionLabel = "Filter board by unread"
+          }
           const headerLabel = label ? label.name : presentation.label
 
-          // Board mode only: Unread and custom-section headers gain a "Scope all"
+          // Board mode only: smart and custom-section headers gain a "Scope all"
           // link that scopes `?in=` to every stream in the section at once. Rows
           // resolve to their board scope id (threads → root), deduped/capped by
-          // the helper. Smart/type/label sections don't scope-all.
+          // the helper. Type/label/unread sections use a live aggregate filter
+          // (above) instead — their membership already has a query-language
+          // equivalent, so scoping to a frozen id snapshot would be a downgrade.
           const canScopeAll =
-            !!boardMode && (section.spec.kind === "unread" || section.spec.kind === "custom") && items.length > 0
+            !!boardMode && (section.spec.kind === "smart" || section.spec.kind === "custom") && items.length > 0
           const scopeAllHref = canScopeAll ? boardMode.scopeAllHref(items.map(boardScopeStreamId)) : undefined
 
           const state = getSectionState(section.id, presentation.defaultCollapse)

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -69,6 +69,8 @@ import {
   scopeAllSearch,
   toggleExcludeSearch,
   toggleIncludeSearch,
+  typeFocusSearch,
+  unreadFocusSearch,
 } from "@/components/board/board-filter-params"
 import { isBoardPath, type SidebarBoardMode } from "./board-sidebar-mode"
 import { useBoardSidebarStats, ZERO_BOARD_STREAM_STATS } from "@/hooks/use-board-sidebar-stats"
@@ -350,6 +352,8 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       applyExclude: (streamId) => navigate(`${location.pathname}${toggleExcludeSearch(boardSearch, streamId)}`),
       scopeAllHref: (streamIds) => `${location.pathname}${scopeAllSearch(boardSearch, streamIds)}`,
       labelFocusHref: (labelId) => `${location.pathname}${labelFocusSearch(boardSearch, labelId)}`,
+      typeFocusHref: (type) => `${location.pathname}${typeFocusSearch(boardSearch, type)}`,
+      unreadFocusHref: () => `${location.pathname}${unreadFocusSearch(boardSearch)}`,
       setMuted: (streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId)),
       statsForStream: (streamId) =>
         boardSidebarStats ? (boardSidebarStats.byStream.get(streamId) ?? ZERO_BOARD_STREAM_STATS) : null,

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -355,6 +355,8 @@ function makeBoardMode(over: Partial<SidebarBoardMode> = {}): SidebarBoardMode {
     applyExclude: vi.fn(),
     scopeAllHref: (ids) => `/w/workspace_1/board?in=${ids.join(",")}`,
     labelFocusHref: (labelId) => `/w/workspace_1/board?label=${labelId}`,
+    typeFocusHref: (type) => `/w/workspace_1/board?is=${type}`,
+    unreadFocusHref: () => `/w/workspace_1/board?unread=true`,
     setMuted: vi.fn(),
     statsForStream: () => null,
     lensTotals: null,

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -22,6 +22,7 @@ function filterOf(over: Partial<BoardViewFilter> = {}): BoardViewFilter {
     excludeTypes: null,
     labels: null,
     excludeLabels: null,
+    unread: null,
     showArchived: false,
     ...over,
   }

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -43,6 +43,10 @@ function typesFilter(types: BoardScopeStreamType[]): BoardViewFilter {
   return filterOf({ types: { key: [...types].sort().join(","), ids: new Set(types) } })
 }
 
+function unreadFilter(streamIds: string[]): BoardViewFilter {
+  return filterOf({ unread: { key: "true", streamIds: new Set(streamIds) } })
+}
+
 function post(id: string, activityMs: number): CachedBoardPost {
   return {
     id,
@@ -732,5 +736,55 @@ describe("useStableBoardView — hide & mute exclusions", () => {
     expect(result.current.posts).toEqual([])
     expect(result.current.isLoading).toBe(false)
     expect(result.current.hasRawPosts).toBe(true)
+  })
+})
+
+describe("useStableBoardView — unread filter", () => {
+  let liveValue: CachedBoardPost[] | undefined
+  function mockLive(value: CachedBoardPost[] | undefined) {
+    liveValue = value
+    vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
+  }
+  afterEach(() => vi.restoreAllMocks())
+
+  it("shows only posts on an unread root stream, falling back to the anchor stream id without one", () => {
+    // No `rootStreamId` — falls back to `conversation.streamId` (the anchor).
+    const legacy = {
+      ...post("c", 100),
+      conversation: { ...post("c", 100).conversation, streamId: "stream_anchor" },
+    } as CachedBoardPost
+    mockLive(feed(streamPost("a", 300, "stream_unread"), streamPost("b", 200, "stream_read"), legacy))
+    const { result } = renderHook(() => useStableBoardView("ws_1", unreadFilter(["stream_unread", "stream_anchor"])))
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "c"])
+  })
+
+  it("drops a card immediately once its stream leaves the unread set — even after commit (the crux)", () => {
+    // Mirrors the hide/mute crux: a committed, retained card must not linger
+    // just because it's no longer in `live` — reading it while sitting on
+    // `?unread=true` is a voluntary action, same class as hide/mute.
+    mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter), {
+      initialProps: { filter: unreadFilter(["stream_x", "stream_y"]) },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    // "stream_x" gets read — its id drops out of the live unread set. No commit.
+    rerender({ filter: unreadFilter(["stream_y"]) })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+  })
+
+  it("a live unread re-resolution (same `?unread=true` selection) never resets the frozen view", () => {
+    mockLive(feed(streamPost("a", 300, "stream_x")))
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter), {
+      initialProps: { filter: unreadFilter(["stream_x"]) },
+    })
+    act(() => result.current.commit())
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+
+    // A second, unread-adjacent stream becoming unread doesn't touch "a"'s
+    // committed position — the `key` (not the resolved ids) is the view-reset
+    // key, mirroring the label-scope re-resolution guarantee.
+    rerender({ filter: unreadFilter(["stream_x", "stream_other"]) })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -461,12 +461,16 @@ export function useStableBoardView(
       // so an involuntary drop (lost access, re-lensed by the viewer's own reply)
       // doesn't shift rows below it. But a VOLUNTARY hide/mute must drop NOW, not
       // wait for the next commit — so skip excluded ids here too, not just in the
-      // `live` filter. (The retained copy is pruned on the next `commit()`.)
+      // `live` filter. (The retained copy is pruned on the next `commit()`.) A
+      // card the viewer just read while sitting on `?unread=true` is the same
+      // class of voluntary action: reading it is the point of an unread-only
+      // view, so it must vanish immediately rather than linger until commit.
       if (isExcluded(post)) continue
+      if (!matchesUnread(post, unread)) continue
       out.push(post)
     }
     return out
-  }, [committed, live, isExcluded])
+  }, [committed, live, unread, isExcluded])
 
   return {
     posts,

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -72,6 +72,19 @@ export interface BoardLabelScope {
   streamIds: ReadonlySet<string>
 }
 
+/**
+ * The board's unread narrowing (`?unread=true`). `key` is the SELECTION (just
+ * "true" while active) — the view-reset key, so it never changes shape — while
+ * `streamIds` is the live resolution to currently-unread-and-unmuted root
+ * streams (mirrors the sidebar's own Unread section membership), re-derived as
+ * things get read/unread without resetting the frozen view. Same key/resolution
+ * split as {@link BoardLabelScope}.
+ */
+export interface BoardUnreadScope {
+  key: string
+  streamIds: ReadonlySet<string>
+}
+
 export interface BoardViewFilter {
   lens: BoardLens
   /** Root-stream scope, or null when unscoped (the whole workspace). */
@@ -86,6 +99,9 @@ export interface BoardViewFilter {
   labels: BoardLabelScope | null
   /** Label veto, or null. */
   excludeLabels: BoardLabelScope | null
+  /** Unread-only narrowing, or null when every conversation shows regardless of
+   *  read state. */
+  unread: BoardUnreadScope | null
   /**
    * Viewer opted into archived cards (`?archived=true`). A view SELECTION like
    * lens/scope — it rides the view-reset key, so toggling it re-commits the feed
@@ -168,6 +184,11 @@ function matchesLabelScope(post: CachedBoardPost, labels: BoardLabelScope | null
 function matchesExcludedLabels(post: CachedBoardPost, labels: BoardLabelScope | null): boolean {
   if (!labels) return true
   return !onLabeledStream(post, labels)
+}
+
+function matchesUnread(post: CachedBoardPost, unread: BoardUnreadScope | null): boolean {
+  if (!unread) return true
+  return unread.streamIds.has(post.rootStreamId ?? post.conversation.streamId)
 }
 
 function postId(post: CachedBoardPost): string {
@@ -307,7 +328,7 @@ export function useStableBoardView(
   filter: BoardViewFilter,
   exclusions: BoardExclusionState = NO_EXCLUSIONS
 ): StableBoardView {
-  const { lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, showArchived } = filter
+  const { lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, unread, showArchived } = filter
   const { hidden, muted, muteActive } = exclusions
   const rawLive = useBoardPosts(workspaceId)
 
@@ -361,11 +382,12 @@ export function useStableBoardView(
                 matchesExcludedTypes(post, excludeTypes) &&
                 matchesLabelScope(post, labels) &&
                 matchesExcludedLabels(post, excludeLabels) &&
+                matchesUnread(post, unread) &&
                 !isExcluded(post)
             ),
             (conversationId) => branchParentConversationId(conversationId, index, graph)
           ),
-    [rawLive, lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, isExcluded, graph, index]
+    [rawLive, lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, unread, isExcluded, graph, index]
   )
   const [committed, setCommitted] = useState<CommittedView>(EMPTY_VIEW)
   const [buffered, setBuffered] = useState<string[]>([])
@@ -392,7 +414,7 @@ export function useStableBoardView(
   // from EMPTY_VIEW and commit its own feed wholesale.
   // Label keys are the SELECTED ids, not the resolved streams — a live
   // re-resolution (an assignment changing) must not reset the frozen view.
-  const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${showArchived ? "arch" : ""}`
+  const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${unread?.key ?? ""}|${showArchived ? "arch" : ""}`
   const viewKeyRef = useRef(viewKey)
   let committedInput = committed
   let bufferedInput = buffered

--- a/apps/frontend/src/lib/board-target-store.ts
+++ b/apps/frontend/src/lib/board-target-store.ts
@@ -5,8 +5,9 @@
 //    the place it was headed — without it a restored draft re-pairs with the
 //    wrong stream (or none, disabling send with no explanation).
 //  - the **recents MRU** (`board:post-target-mru:<ws>`) is the small list of
-//    streams recently POSTED to, feeding the picker's Recents group + the default
-//    when there's no in-progress draft target.
+//    streams recently POSTED to, feeding the picker's Recents group. It does NOT
+//    seed the default target — a successful post clears the target so the next
+//    "New post" starts blank instead of re-defaulting to where the last one went.
 //
 // All best-effort: localStorage can throw (private mode / quota), so every read
 // falls back and every write no-ops on failure — this is convenience, not state.

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -28,6 +28,7 @@ import {
   useUnmuteStream,
 } from "@/hooks/use-conversations"
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
+import { useUnreadCounts } from "@/hooks/use-unread-counts"
 import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
 import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
@@ -50,6 +51,8 @@ import {
   BOARD_EXCLUDE_LABEL_PARAM,
   BOARD_ARCHIVED_PARAM,
   BOARD_ARCHIVED_ON,
+  BOARD_UNREAD_PARAM,
+  BOARD_UNREAD_ON,
   boardHomeSearch,
   parseIdListParam,
   parseTypeListParam,
@@ -310,6 +313,22 @@ function BoardPageInner({
   )
   // Archived is a broadening opt-in (`?archived=true`), not an id-list narrowing.
   const showArchived = searchParams.get(BOARD_ARCHIVED_PARAM) === BOARD_ARCHIVED_ON
+  // Unread is a narrowing opt-in (`?unread=true`), resolved client-side to the
+  // same "unread and not muted" membership the sidebar's Unread section uses —
+  // no backend round-trip, so it stays live as things get read without a refetch.
+  const unreadOnly = searchParams.get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
+  const { unreadCounts } = useUnreadCounts(workspaceId)
+  // Mute-aware: a muted stream reads as "quiet" and must not resurface via the
+  // unread filter, the same rule the sidebar's Unread section follows.
+  const mutedStreamIds = useBoardMutedStreamIds(workspaceId)
+  const unreadStreamIds = useMemo(() => {
+    if (!unreadOnly) return null
+    const ids = new Set<string>()
+    for (const [streamId, count] of Object.entries(unreadCounts)) {
+      if (count > 0 && !mutedStreamIds.has(streamId)) ids.add(streamId)
+    }
+    return ids
+  }, [unreadOnly, unreadCounts, mutedStreamIds])
   const scopeKey = useMemo(() => [...scopeStreamIds].sort().join(","), [scopeStreamIds])
   const excludeScopeKey = useMemo(() => [...excludeStreamIds].sort().join(","), [excludeStreamIds])
   const typeKey = useMemo(() => [...scopeStreamTypes].sort().join(","), [scopeStreamTypes])
@@ -340,6 +359,7 @@ function BoardPageInner({
       excludeTypes: excludeStreamTypes.length > 0 ? { key: excludeTypeKey, ids: new Set(excludeStreamTypes) } : null,
       labels: labelStreamIds ? { key: labelKey, streamIds: labelStreamIds } : null,
       excludeLabels: excludeLabelStreamIds ? { key: excludeLabelKey, streamIds: excludeLabelStreamIds } : null,
+      unread: unreadStreamIds ? { key: BOARD_UNREAD_ON, streamIds: unreadStreamIds } : null,
       showArchived,
     }),
     [
@@ -356,6 +376,7 @@ function BoardPageInner({
       labelStreamIds,
       excludeLabelKey,
       excludeLabelStreamIds,
+      unreadStreamIds,
       showArchived,
     ]
   )
@@ -390,6 +411,7 @@ function BoardPageInner({
       [BOARD_EXCLUDE_LABEL_PARAM, exclude],
     ])
   const setShowArchived = (next: boolean) => setParamLists([[BOARD_ARCHIVED_PARAM, next ? [BOARD_ARCHIVED_ON] : []]])
+  const setUnreadOnly = (next: boolean) => setParamLists([[BOARD_UNREAD_PARAM, next ? [BOARD_UNREAD_ON] : []]])
   const {
     containerRef,
     panelWidth,
@@ -826,6 +848,8 @@ function BoardPageInner({
         onToggleMute={(streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId))}
         showArchived={showArchived}
         onToggleArchived={setShowArchived}
+        unreadOnly={unreadOnly}
+        onToggleUnreadOnly={setUnreadOnly}
       />
       <span className="sr-only" role="status" aria-live="polite">
         {newCount > 0 ? `${newCount} new ${newCount === 1 ? "post" : "posts"} available` : ""}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -17,6 +17,7 @@ import {
   useWorkspaceUsers,
   useWorkspaceDmPeers,
   useWorkspaceLabelAssignments,
+  useWorkspaceUnreadState,
 } from "@/stores/workspace-store"
 import { useStableBoardView, type BoardViewFilter, type BoardViewPost } from "@/hooks/use-stable-board-view"
 import { selectLabeledStreamIds } from "@/hooks/use-labels"
@@ -28,7 +29,6 @@ import {
   useUnmuteStream,
 } from "@/hooks/use-conversations"
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
-import { useUnreadCounts } from "@/hooks/use-unread-counts"
 import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
 import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
@@ -317,18 +317,25 @@ function BoardPageInner({
   // same "unread and not muted" membership the sidebar's Unread section uses —
   // no backend round-trip, so it stays live as things get read without a refetch.
   const unreadOnly = searchParams.get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
-  const { unreadCounts } = useUnreadCounts(workspaceId)
+  // `undefined` means the IDB row hasn't hydrated yet — distinct from a
+  // hydrated-but-empty `unreadCounts`. Conflating the two would fail CLOSED on
+  // a cold `?unread=true` load (every already-fetched post filtered out, empty
+  // state flashed) before the real counts arrive a beat later.
+  const unreadState = useWorkspaceUnreadState(workspaceId)
   // Mute-aware: a muted stream reads as "quiet" and must not resurface via the
   // unread filter, the same rule the sidebar's Unread section follows.
   const mutedStreamIds = useBoardMutedStreamIds(workspaceId)
   const unreadStreamIds = useMemo(() => {
-    if (!unreadOnly) return null
+    // Fail OPEN while unhydrated (mirrors matchesTypeScope's pre-field-row
+    // fail-open) — the board surfaces the not-yet-filtered feed rather than a
+    // false "caught up" empty state.
+    if (!unreadOnly || !unreadState) return null
     const ids = new Set<string>()
-    for (const [streamId, count] of Object.entries(unreadCounts)) {
+    for (const [streamId, count] of Object.entries(unreadState.unreadCounts)) {
       if (count > 0 && !mutedStreamIds.has(streamId)) ids.add(streamId)
     }
     return ids
-  }, [unreadOnly, unreadCounts, mutedStreamIds])
+  }, [unreadOnly, unreadState, mutedStreamIds])
   const scopeKey = useMemo(() => [...scopeStreamIds].sort().join(","), [scopeStreamIds])
   const excludeScopeKey = useMemo(() => [...excludeStreamIds].sort().join(","), [excludeStreamIds])
   const typeKey = useMemo(() => [...scopeStreamTypes].sort().join(","), [scopeStreamTypes])
@@ -548,7 +555,7 @@ function BoardPageInner({
   // Changing lens OR scope replaces the feed with a different (often much
   // shorter) subset, so jump to the top pre-paint — otherwise a viewer scrolled
   // down the All wall who taps Decisions lands past the end of a one-card list.
-  const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}`
+  const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}|${unreadOnly ? "unread" : ""}`
   useLayoutEffect(() => {
     if (scrollerRef.current) scrollerRef.current.scrollTop = 0
   }, [resetKey])
@@ -586,7 +593,8 @@ function BoardPageInner({
     excludeStreamIds.length > 0 ||
     excludeStreamTypes.length > 0 ||
     scopeLabelIds.length > 0 ||
-    excludeLabelIds.length > 0
+    excludeLabelIds.length > 0 ||
+    unreadOnly
   // The viewer's own just-posted card gets a brief gold-thread flash (the golden
   // thread motif, on the primary action). The flashed id lives in a module store
   // (`setBoardFlash`) that each card subscribes to by its own id, not in page


### PR DESCRIPTION
## Problem

Four small board-surface gaps reported directly by Kris:

1. The conversation panel's reply composer (`InlineComposerForm` in `board-inline-composer.tsx`) had no way to expand to a fullscreen editor — the timeline and the New Post overlay both have one, so replying to a long conversation from the panel felt cramped in comparison ("doesn't match the behavior of the timeline view").
2. The composer's "+" actions drawer (emoji/mention/command/attach) was hover/focus-gated on desktop — a mouse user had to hover the FAB to discover it exists.
3. Only label, Unread, and custom sidebar sections had a filter affordance in board mode. Channels/DMs/Scratchpads (`kind: "type"`) and the smart buckets (Important/Recent/Everything Else) had none. Separately, the Unread section's existing "Scope all" affordance froze the *current* unread ids into `?in=`, so it stopped tracking unread state the moment you clicked it.
4. New Post (`board-overlay-composer.tsx`) re-defaulted its destination-stream picker to wherever the last post went (via the Recents MRU), so repeat use meant re-clearing the target every time you wanted to post somewhere else.

## Solution

Four independent, low-risk changes riding the board's existing patterns — no new architecture, no backend touch.

### How it works

1. **Panel/card fullscreen expand** — `InlineComposerForm` now renders a second `MessageComposer` instance inside `OverlayComposerShell` (the same shell the timeline and New Post already use), toggled by local `expanded` state and an `onExpandClick` handler wired only into the desktop (non-floating) `MessageComposer`. Both instances share one `sharedComposerProps` object built from the same `useDraftComposer` state, so expand/collapse never loses the draft. `BoardReplyComposer` (board cards) gets the same affordance for free since it mounts the same shared component.
2. **Always-open FAB drawer** — in `message-composer.tsx`'s expanded-mode FAB block, the drawer's `max-w`/`opacity` classes are now keyed off `isMobile` instead of `group-hover`/`group-focus-within`, and the "+" toggle button itself is only rendered `isMobile` — nothing to toggle once the drawer is always open on desktop.
3. **Sidebar filter buttons + live unread axis** — `sidebar-stream-list.tsx` now sets `titleHref = boardMode.typeFocusHref(spec.streamType)` for `kind: "type"` sections (writes `?is=<type>`, an axis that already existed) and `titleHref = boardMode.unreadFocusHref()` for the Unread section (writes a brand new `?unread=true` param). `canScopeAll` (the "Scope all" ListFilter affordance) is narrowed from `unread || custom` to `smart || custom`, so smart buckets gain a filter button and Unread trades its snapshot-based one for the live axis. The new axis is resolved entirely client-side: `board.tsx` builds `unreadStreamIds` from `useUnreadCounts().unreadCounts` minus `useBoardMutedStreamIds()`, wraps it as `{ key: BOARD_UNREAD_ON, streamIds }` (a `BoardUnreadScope`, mirroring `BoardLabelScope`'s key/resolution split so live churn doesn't reset the frozen board view), and a new `matchesUnread` predicate in `use-stable-board-view.ts` narrows the already-fetched feed the same way `hidden`/`muted` exclusions do — no server round-trip, no new fetch params.
4. **New Post stops re-defaulting** — `board-overlay-composer.tsx`'s two seed points (initial `useState`, and the reopen-reseed `useEffect`) drop the `|| readTargetMru(workspaceId)[0]` fallback, keeping only the in-progress-draft-target seed. The MRU itself is untouched and still feeds the picker's Recents list — just no longer used to pick a default.

### Key design decisions

**1. Fullscreen expand is desktop-only.** The floating (mobile) composer's height-publish `useLayoutEffect` (`board-inline-composer.tsx`, ~line 175) keys its `ResizeObserver`/CSS-var cleanup off `holdsFloatingSlot`, not `expanded`. Wiring `onExpandClick` into the mobile path would let `expanded` unmount the `FloatingComposerShell` without that effect's cleanup ever re-running (its deps didn't change), leaving a stale reserved-space CSS var behind. Mobile already has a full-width floating pill, so the affordance isn't worth that edge case there.

**2. `?unread=true` is resolved client-side, not passed to the board's fetch.** The board's `useWorkspaceConversations` query has no unread-aware server filter, and adding one is real backend work (a new query param, SQL predicate, pagination implications). The existing `hidden`/`muted` exclusions already narrow the client-fetched feed post-hoc in `useStableBoardView`, so `matchesUnread` follows that precedent instead — it costs a live subset of an already-fetched page, not a new round-trip, at the cost of only narrowing what's already paged in (same tradeoff `hidden`/`muted` already accept).

**3. Didn't port stashed-drafts / scheduled-messages / edit-last-message / context-refs to the panel composer.** The timeline's `MessageInput` bakes in stream-timeline send semantics (it has no pluggable submit target); the panel's composer routes sends through `useReplyToBoardPost`'s conversation-aware reply logic instead. `InlineComposerForm`'s own doc comment (INV-35: "editor mechanics live in exactly one place") frames the compact core as deliberate, not an oversight — reversing that for the full feature set would mean either forking `MessageInput`'s send path or refactoring it to accept a pluggable target, both bigger and riskier than what was asked. Expand-to-fullscreen closes the single biggest "doesn't feel like the timeline" gap (there was no way to get more editing room at all) without that refactor.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-inline-composer.tsx` | Fullscreen expand via `OverlayComposerShell`, desktop-only |
| `apps/frontend/src/components/board/board-inline-composer.test.tsx` | Tests: expand button desktop-only, same draft in both editors |
| `apps/frontend/src/components/composer/message-composer.tsx` | FAB drawer always open on desktop; "+" toggle mobile-only |
| `apps/frontend/src/components/board/board-filter-params.ts` | `typeFocusSearch`, `unreadFocusSearch`, `BOARD_UNREAD_PARAM`/`BOARD_UNREAD_ON` |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | `BoardUnreadScope`, `matchesUnread`, wired into filter chain/deps/viewKey |
| `apps/frontend/src/hooks/use-stable-board-view.test.tsx` | `filterOf()` fixture gains `unread: null` |
| `apps/frontend/src/pages/board.tsx` | Parses `?unread=`, builds `unreadStreamIds`, `setUnreadOnly`, wires `BoardFilterBar` |
| `apps/frontend/src/components/board/board-filter-bar.tsx` | New "Unread" toggle button + `unreadOnly`/`onToggleUnreadOnly` props |
| `apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts` | `typeFocusHref`, `unreadFocusHref` on `SidebarBoardMode` |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | Constructs the two new hrefs |
| `apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx` | Type/Unread sections get `titleHref`; `canScopeAll` → smart/custom |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx` | `SidebarBoardMode` fixture gains the two new hrefs |
| `apps/frontend/src/components/layout/sidebar/stream-item.test.tsx` | Same fixture update |
| `apps/frontend/src/components/board/board-overlay-composer.tsx` | Drop MRU fallback from both target-seed points |
| `apps/frontend/src/components/board/board-overlay-composer.test.tsx` | Rewritten to assert no MRU carry-over |
| `apps/frontend/src/lib/board-target-store.ts` | Doc comment: MRU feeds Recents only, not the default target |

## Out of scope (deliberate)

- Stashed drafts, scheduled messages, edit-last-message, and context-ref attachments in the conversation panel composer — see design decision 3 above.
- Server-side `unread` filtering / pagination awareness — see design decision 2.
- Mobile fullscreen expand for the panel/card composer — see design decision 1.

## Test plan

- [x] `bun run test` (frontend) — full suite green except one pre-existing, unrelated timezone-flaky test (`src/lib/dates.test.ts`, verified failing identically on a clean `origin/main` checkout — local machine timezone isn't UTC).
- [x] `bun run typecheck` (frontend, `tsc --noEmit`) — clean.
- [x] Pre-commit hooks (lint across every app, full monorepo typecheck, migration/Dockerfile checks, OpenAPI-docs-in-sync check) — all passed on commit.
- [x] Independent review pass (1 general-purpose reviewer agent over the diff) — no findings.
- [x] Live end-to-end verification against a local `dev:test` stack (stub auth, `threa_test` DB, scripted Playwright): New Post starts blank and stays blank after a send; FAB drawer has no "+" toggle on desktop and every icon is visible; Channels (type) and Everything Else (smart) sidebar sections show a filter icon on hover; conversation panel composer's expand button opens the fullscreen editor, and a message sent from there lands in the same conversation via the reply path and the overlay collapses back. Screenshots taken locally, not attached to this PR.

<details>
<summary>📋 Full implementation plan</summary>

No standing plan doc — this was four independently-scoped fixes from a direct request, each investigated against the current code before implementing (existing filter-URL vocabulary, existing `OverlayComposerShell`, existing `hidden`/`muted` client-exclusion precedent) rather than designed from scratch.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786472820&installation_id=129946197&pr_number=1305&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1305&signature=6e8427551009b8e5e4b5fe36093da7a1fa9c27f86c1aed9eb3b458430cd6f88d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->