### PR TITLE
fix(frontend): duplicate message after reload-during-send — collapse orphaned optimistic rows at bootstrap

### DIFF
--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -611,6 +611,54 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect(await db.events.get("temp_conv")).toBeUndefined()
   })
 
+  it("seeds the decrypt cache from the optimistic plaintext when the bootstrap swaps in an encrypted server copy", async () => {
+    clearDecryptCache()
+    const streamId = "stream_reload_e2e"
+    const plaintextJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "secret" }] }] }
+
+    await db.events.put({
+      id: "temp_e2e",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "1752350000000",
+      _sequenceNum: 1752350000000,
+      eventType: "message_created",
+      payload: { messageId: "temp_e2e", contentMarkdown: "secret", contentJson: plaintextJson },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+    await db.pendingMessages.add({
+      clientId: "temp_e2e",
+      workspaceId: "ws_1",
+      streamId,
+      content: "secret",
+      contentFormat: "markdown",
+      createdAt: Date.now(),
+      retryCount: 0,
+    })
+
+    const serverCopy = makeEvent({ id: "evt_e2e_real", streamId, sequence: "100" })
+    serverCopy.payload = {
+      messageId: "msg_3",
+      clientMessageId: "temp_e2e",
+      contentMarkdown: "🔒 Encrypted",
+      contentJson: null,
+      ciphertext: "base64ciphertext",
+      envelope: { v: 2 },
+    }
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([serverCopy], streamId))
+
+    expect(await db.events.get("temp_e2e")).toBeUndefined()
+    expect(await db.events.get("evt_e2e_real")).toBeDefined()
+    const cached = getCachedDecryption("evt_e2e_real")
+    expect(cached?.status).toBe("decrypted")
+    expect(cached?.value?.contentMarkdown).toBe("secret")
+    expect(cached?.value?.contentJson).toEqual(plaintextJson)
+  })
+
   it("writes stream metadata to IDB", async () => {
     const streamId = "stream_meta"
     const bootstrap = makeBootstrap([], streamId)

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -532,6 +532,85 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect(await db.events.get("evt_A")).toBeDefined()
   })
 
+  it("collapses an optimistic row when the bootstrap carries its server copy (reload-during-send race)", async () => {
+    const streamId = "stream_reload_race"
+
+    // State a reload leaves behind when it interrupts the send pipeline after
+    // the server committed: the optimistic event AND its outbox row survive in
+    // IDB, the message:created echo was lost with the old page, and the
+    // queue's re-send hits the backend's idempotent replay (no new event → no
+    // echo ever). The bootstrap is the only remaining reconciliation point.
+    await db.events.put({
+      id: "temp_reload",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "1752350000000", // optimistic rows use Date.now() — sorts after every real event
+      _sequenceNum: 1752350000000,
+      eventType: "message_created",
+      payload: { messageId: "temp_reload", contentMarkdown: "hello" },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+    await db.pendingMessages.add({
+      clientId: "temp_reload",
+      workspaceId: "ws_1",
+      streamId,
+      content: "hello",
+      contentFormat: "markdown",
+      createdAt: Date.now(),
+      retryCount: 0,
+    })
+
+    const serverCopy = makeEvent({ id: "evt_real", streamId, sequence: "100" })
+    serverCopy.payload = { messageId: "msg_1", contentMarkdown: "hello", clientMessageId: "temp_reload" }
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([serverCopy], streamId))
+
+    expect(await db.events.get("evt_real")).toBeDefined()
+    expect(await db.events.get("temp_reload")).toBeUndefined()
+    expect(await db.pendingMessages.get("temp_reload")).toBeUndefined()
+  })
+
+  it("carries the optimistic row's conversationId onto the swapped-in server copy", async () => {
+    const streamId = "stream_reload_conv"
+
+    await db.events.put({
+      id: "temp_conv",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "1752350000000",
+      _sequenceNum: 1752350000000,
+      eventType: "message_created",
+      payload: { messageId: "temp_conv", contentMarkdown: "board reply", conversationId: "conv_1" },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+    // Outbox row still present (the reload case) — without it,
+    // cleanupStaleOptimisticEvents drops the temp row before the swap runs.
+    await db.pendingMessages.add({
+      clientId: "temp_conv",
+      workspaceId: "ws_1",
+      streamId,
+      content: "board reply",
+      contentFormat: "markdown",
+      createdAt: Date.now(),
+      retryCount: 0,
+    })
+
+    const serverCopy = makeEvent({ id: "evt_conv_real", streamId, sequence: "100" })
+    serverCopy.payload = { messageId: "msg_2", contentMarkdown: "board reply", clientMessageId: "temp_conv" }
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([serverCopy], streamId))
+
+    const swapped = await db.events.get("evt_conv_real")
+    expect((swapped?.payload as { conversationId?: string }).conversationId).toBe("conv_1")
+    expect(await db.events.get("temp_conv")).toBeUndefined()
+  })
+
   it("writes stream metadata to IDB", async () => {
     const streamId = "stream_meta"
     const bootstrap = makeBootstrap([], streamId)

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -263,6 +263,28 @@ async function writeBootstrapEventsAndStream(
       existingRows.filter((row): row is NonNullable<typeof row> => row != null).map((row) => [row.id, row] as const)
     )
 
+    // The bootstrap can carry the server copy of a message whose optimistic
+    // temp_* row is still in IDB: a reload can interrupt the send pipeline
+    // after the server committed, so the message:created echo that normally
+    // swaps optimistic → real (handleMessageCreated) died with the old page —
+    // and the queue's re-send hits the backend's idempotent replay path, which
+    // returns the existing message WITHOUT emitting a new event, so no echo
+    // ever comes. Without this swap both copies render until the next
+    // bootstrap whose cleanupStaleOptimisticEvents happens to run after the
+    // outbox row is gone. Mirror the echo swap here: real row written first
+    // (bulkPut below), optimistic row + outbox entry deleted after, E2E
+    // decrypt cache seeded from the optimistic plaintext.
+    const messageCreatedWithClientId = bootstrap.events
+      .filter((e) => e.eventType === "message_created")
+      .map((e) => ({ realEvent: e, clientMessageId: (e.payload as { clientMessageId?: string }).clientMessageId }))
+      .filter((pair): pair is { realEvent: StreamEvent; clientMessageId: string } => !!pair.clientMessageId)
+    const optimisticRows = await db.events.bulkGet(messageCreatedWithClientId.map((pair) => pair.clientMessageId))
+    const optimisticSwaps = messageCreatedWithClientId.flatMap(({ realEvent }, i) => {
+      const optimistic = optimisticRows[i]
+      return optimistic ? [{ realEvent, optimistic }] : []
+    })
+    const optimisticByRealEventId = new Map(optimisticSwaps.map((s) => [s.realEvent.id, s.optimistic] as const))
+
     const toWrite: CachedEvent[] = []
     for (const e of bootstrap.events) {
       const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
@@ -274,7 +296,21 @@ async function writeBootstrapEventsAndStream(
         continue
       }
       if (!existing) {
-        toWrite.push(base)
+        // Same carry as the echo swap: a board reply's conversationId lives
+        // only on the optimistic payload (the server event doesn't carry it),
+        // so bring it across or the card row blinks out until the
+        // conversation:updated aggregate lands.
+        const carriedConversationId = (
+          optimisticByRealEventId.get(e.id)?.payload as { conversationId?: string } | undefined
+        )?.conversationId
+        toWrite.push(
+          carriedConversationId && !(base.payload as { conversationId?: string }).conversationId
+            ? {
+                ...base,
+                payload: { ...(base.payload as Record<string, unknown>), conversationId: carriedConversationId },
+              }
+            : base
+        )
         continue
       }
       if (snapshotMs !== null && existing._patchedAt !== undefined && existing._patchedAt > snapshotMs) {
@@ -298,6 +334,19 @@ async function writeBootstrapEventsAndStream(
 
     if (toWrite.length > 0) {
       await db.events.bulkPut(toWrite)
+    }
+
+    // Real rows are in place (bulkPut above, or already present via a skipped
+    // rewrite) — now drop the optimistic copies and their outbox entries so a
+    // liveQuery frame never shows neither copy. Deleting the outbox row also
+    // stops the queue from replaying a send the server already committed.
+    for (const { realEvent, optimistic } of optimisticSwaps) {
+      await db.events.delete(optimistic.id)
+      await db.pendingMessages.delete(optimistic.id)
+      const plaintext = readPlaintextContent(optimistic.payload)
+      if (plaintext && isEncryptedPayload(realEvent.payload)) {
+        seedDecryption(realEvent.id, plaintext)
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Reloading the page right after sending a message can leave the message rendered **twice**, with the duplicate re-appearing under every subsequent message until a later resync clears it. Observed in prod by Pierre (DM thread, 2026-07-12): the version-deploy auto-reload first surfaced it, but a plain manual hard refresh right after send reproduces it too, and a re-focus (which triggers a resume bootstrap) heals it.

The race, step by step:

1. `sendMessage` (`use-stream-or-draft.ts`) writes two IDB rows: the outbox row `pendingMessages[temp_x]` and an optimistic `db.events[temp_x]` whose `sequence` is `Date.now()` (~13 digits) — it deliberately sorts after every real event, which is why the orphan "follows" each new message to the bottom of the timeline.
2. The queue drain (`use-message-queue.ts`) POSTs; on 200 it deletes the outbox row but intentionally leaves the optimistic event for the socket echo (`handleMessageCreated` in `stream-sync.ts`) to atomically swap for the real event.
3. A reload lands between the server committing the message and the client processing that echo. The outbox row survives into the new page.
4. The post-reload stream bootstrap runs while the outbox row still exists, so `cleanupStaleOptimisticEvents` keeps the temp row — and writes the real server event next to it. Both render.
5. The queue re-sends. `createMessageInTransaction` (`event-service.ts:489`) is idempotent (`ON CONFLICT (stream_id, client_message_id) DO NOTHING`) and returns the existing message **with zero writes — no new stream event, no outbox row, no socket echo**. The queue deletes the outbox row; the temp event is now orphaned with nothing left to remove it.
6. The next bootstrap (page-resume, reconnect, stream re-open) finally deletes the orphan via `cleanupStaleOptimisticEvents` — that's the "self-resolved on re-focus" Pierre saw.

The server-side idempotency worked (no duplicate row in Postgres). The failure is client-side: **the optimistic-row cleanup has exactly one trigger — the socket echo — and the idempotent replay produces no echo.**

## Solution

Make the bootstrap merge a reconciliation point for optimistic rows, mirroring the echo swap. `writeBootstrapEventsAndStream` (`stream-sync.ts`) now:

1. Collects bootstrap `message_created` events whose `payload.clientMessageId` matches an optimistic row in IDB (one `bulkGet`, same pattern as the existing `existingRows` lookup). The persisted event payload always carries `clientMessageId` when the sender provided one (`event-service.ts:680`), so bootstrap events have the same dedup key the echo uses.
2. Writes the real events first (the existing `bulkPut`), then deletes each matched optimistic row **and its `pendingMessages` outbox entry** — same order as `handleMessageCreated`, so a liveQuery frame never shows neither copy. All inside the existing transaction, which already spans `events` + `pendingMessages`.
3. Mirrors the echo swap's two side effects: carries the optimistic payload's `conversationId` onto the swapped-in server event (board replies otherwise blink out until `conversation:updated` lands) and seeds the E2E decrypt cache from the optimistic plaintext (`seedDecryption`) so a sealed message doesn't flash "decrypting".

Every bootstrap flavor goes through this path — stream open, page-resume (`refreshAfterConnectivityResume`), reconnect, HTTP warm, navigation refresh — so the duplicate can't outlive the first server-truth fetch. Deleting the outbox row also stops the queue from replaying a send the server already committed.

### Key design decisions

**1. Fix at the bootstrap merge, not the queue drain.** The drain could check for an existing real event after a successful POST, but it only has the message id, not the stream event — finding the event would need a payload scan, and it still wouldn't cover the case where the drain finishes before the bootstrap response lands. The bootstrap merge is where server truth already meets local state (it's where `cleanupStaleOptimisticEvents` and the freshness merge live), and fixing it there covers all orderings with one mechanism.

**2. Mirror the echo swap exactly rather than just deleting the temp row.** The echo swap has two non-obvious side effects (conversationId carry, decrypt-cache seed) that exist to prevent visible flicker. A bootstrap-time swap that skipped them would introduce those flickers in the newly covered path.

**3. `cleanupStaleOptimisticEvents` stays as-is.** It handles the complementary ordering (outbox row already gone → temp row is garbage). The new swap handles the outbox-row-still-present ordering. Together the two cover both sides of the drain/bootstrap race.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/stream-sync.ts` | Bootstrap merge collapses optimistic rows by `payload.clientMessageId`: bulkGet match → real events written → optimistic + outbox rows deleted in the same transaction, with conversationId carry and decrypt-cache seeding |
| `apps/frontend/src/sync/stream-sync.test.ts` | Two regression tests encoding the exact reload-race IDB state (orphaned temp event + outbox row + bootstrap carrying the server copy) |

## Out of scope (deliberate)

- **Backend replay behavior unchanged.** Emitting a fresh event on idempotent replay would double-broadcast to every other member; returning the existing message with no writes is correct — the client now reconciles.
- **`use-message-queue.ts` untouched.** Its "leave the optimistic event for the echo" contract still holds for the normal (non-reload) path; the bootstrap swap is the backstop when the echo can't come.

## Test plan

- [x] `bun run test src/sync/stream-sync.test.ts` — 68 pass (2 new regression tests)
- [x] `bun run test src/sync/ src/hooks/use-message-queue.test.ts src/contexts/pending-messages-context.test.tsx` — 377 pass
- [x] `bun run typecheck` — all workspaces clean
- [x] **Live before/after against `dev:test`** (scripted Playwright): seeded the exact post-reload orphan state (optimistic temp event + outbox row with `retryAfter` in the future, server already committed), reloaded. Unfixed baseline: message rendered twice, orphan rows persist. With fix: rendered once, both rows cleaned from IDB.
- [ ] The version-deploy reload trigger itself (`use-app-update.ts`) not exercised — the manual hard-refresh repro is the same race and the fix is reload-source-agnostic.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786482567&installation_id=129946197&pr_number=1306&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1306&signature=37774fc450b006b7f3fac44768fbe9bcc67e1533831c46a45195e78212c6b937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->