### PR TITLE
feat(public-api): API-key version pin display and control in workspace settings

### DIFF
--- a/apps/backend/src/features/public-api/versions/types.ts
+++ b/apps/backend/src/features/public-api/versions/types.ts
@@ -1,9 +1,10 @@
 import type { OperationId } from "../routes"
+import { API_VERSIONS, CURRENT_API_VERSION, type ApiVersion } from "@threa/types"
 
-/** Dated public API versions, ascending. The first entry is the epoch. */
-export const API_VERSIONS = ["2026-07-12"] as const
-export type ApiVersion = (typeof API_VERSIONS)[number]
-export const CURRENT_API_VERSION: ApiVersion = API_VERSIONS[API_VERSIONS.length - 1]
+// Version list lives in @threa/types so the frontend key-pin UI shares one
+// source of truth; the change-registry machinery below stays backend-only
+// because it references OperationId.
+export { API_VERSIONS, CURRENT_API_VERSION, type ApiVersion }
 
 export interface VersionChangeContext {
   operationId: OperationId

--- a/apps/frontend/src/api/bots.ts
+++ b/apps/frontend/src/api/bots.ts
@@ -76,6 +76,18 @@ export const botsApi = {
     return res.data
   },
 
+  async updateKeyVersion(
+    workspaceId: string,
+    botId: string,
+    keyId: string,
+    apiVersion: string | null
+  ): Promise<BotApiKey> {
+    const res = await api.patch<{ data: BotApiKey }>(`/api/workspaces/${workspaceId}/bots/${botId}/keys/${keyId}`, {
+      apiVersion,
+    })
+    return res.data
+  },
+
   async revokeKey(workspaceId: string, botId: string, keyId: string): Promise<void> {
     await api.post(`/api/workspaces/${workspaceId}/bots/${botId}/keys/${keyId}/revoke`)
   },

--- a/apps/frontend/src/api/workspaces.ts
+++ b/apps/frontend/src/api/workspaces.ts
@@ -173,6 +173,13 @@ export const workspacesApi = {
     return res.key
   },
 
+  async updateUserApiKeyVersion(workspaceId: string, keyId: string, apiVersion: string | null): Promise<UserApiKey> {
+    const res = await api.patch<{ key: UserApiKey }>(`/api/workspaces/${workspaceId}/user-api-keys/${keyId}`, {
+      apiVersion,
+    })
+    return res.key
+  },
+
   async revokeUserApiKey(workspaceId: string, keyId: string): Promise<void> {
     await api.post(`/api/workspaces/${workspaceId}/user-api-keys/${keyId}/revoke`)
   },

--- a/apps/frontend/src/components/workspace-settings/api-key-version-control.tsx
+++ b/apps/frontend/src/components/workspace-settings/api-key-version-control.tsx
@@ -1,0 +1,56 @@
+import { API_VERSIONS, CURRENT_API_VERSION } from "@threa/types"
+import { ChevronDown } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+// Sentinel for the "unpinned / track latest" choice — a radio group needs a
+// string value and null is the wire representation for it.
+const LATEST_VALUE = "__latest__"
+
+interface ApiKeyVersionControlProps {
+  /** Pinned version date, or null when the key tracks the current version. */
+  apiVersion: string | null
+  onChange: (apiVersion: string | null) => void
+  disabled?: boolean
+}
+
+export function ApiKeyVersionControl({ apiVersion, onChange, disabled }: ApiKeyVersionControlProps) {
+  const label = apiVersion ?? `Latest (${CURRENT_API_VERSION})`
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        disabled={disabled}
+        className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:text-foreground"
+      >
+        <span>API version:</span>
+        <span className="font-medium text-foreground/80">{label}</span>
+        <ChevronDown className="h-3 w-3" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-48">
+        <DropdownMenuLabel className="text-xs">Pin this key to an API version</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={apiVersion ?? LATEST_VALUE}
+          onValueChange={(value) => onChange(value === LATEST_VALUE ? null : value)}
+        >
+          <DropdownMenuRadioItem value={LATEST_VALUE} className="text-xs">
+            Always latest ({CURRENT_API_VERSION})
+          </DropdownMenuRadioItem>
+          {API_VERSIONS.map((version) => (
+            <DropdownMenuRadioItem key={version} value={version} className="text-xs font-mono">
+              {version}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/bot-keys-section.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-keys-section.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { CURRENT_API_VERSION, type BotApiKey } from "@threa/types"
+import { botsApi } from "@/api/bots"
+import * as useFormattedDateModule from "@/hooks/use-formatted-date"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { BotKeysSection } from "./bot-keys-section"
+
+function makeKey(overrides: Partial<BotApiKey> = {}): BotApiKey {
+  return {
+    id: "bak_1",
+    botId: "bot_1",
+    name: "production",
+    keyPrefix: "abcd",
+    scopes: ["messages:write"],
+    apiVersion: null,
+    lastUsedAt: null,
+    expiresAt: null,
+    revokedAt: null,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function renderSection(queryClient = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <BotKeysSection workspaceId="ws_1" botId="bot_1" isArchived={false} />
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe("BotKeysSection — API version pin", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(useFormattedDateModule, "useFormattedDate").mockReturnValue({
+      formatDate: (date: Date) => date.toISOString().slice(0, 10),
+      formatTime: (date: Date) => date.toISOString(),
+      formatRelative: (date: Date) => date.toISOString(),
+      formatFull: (date: Date) => date.toISOString(),
+    })
+  })
+
+  it("pins an unpinned bot key to a dated version", async () => {
+    vi.spyOn(botsApi, "listKeys").mockResolvedValue([makeKey({ apiVersion: null })])
+    const update = vi.spyOn(botsApi, "updateKeyVersion").mockResolvedValue(makeKey({ apiVersion: CURRENT_API_VERSION }))
+    const user = userEvent.setup()
+
+    renderSection()
+
+    const trigger = await screen.findByRole("button", {
+      name: new RegExp(`API version:.*Latest \\(${CURRENT_API_VERSION}\\)`),
+    })
+    await user.click(trigger)
+    await user.click(await screen.findByRole("menuitemradio", { name: CURRENT_API_VERSION }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", "bot_1", "bak_1", CURRENT_API_VERSION))
+  })
+
+  it("detaches a pinned bot key back to latest", async () => {
+    vi.spyOn(botsApi, "listKeys").mockResolvedValue([makeKey({ apiVersion: CURRENT_API_VERSION })])
+    const update = vi.spyOn(botsApi, "updateKeyVersion").mockResolvedValue(makeKey({ apiVersion: null }))
+    const user = userEvent.setup()
+
+    renderSection()
+
+    const trigger = await screen.findByRole("button", {
+      name: (name) => name.includes("API version") && name.includes(CURRENT_API_VERSION) && !name.includes("Latest"),
+    })
+    await user.click(trigger)
+    await user.click(await screen.findByRole("menuitemradio", { name: /Always latest/ }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", "bot_1", "bak_1", null))
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/bot-keys-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-keys-section.tsx
@@ -29,6 +29,7 @@ import {
   type BotApiKey,
 } from "@threa/types"
 import { Check, ChevronDown, Copy, Eye, EyeOff, Key, Plus, Trash2 } from "lucide-react"
+import { ApiKeyVersionControl } from "./api-key-version-control"
 
 const SCOPE_LABELS: Record<string, string> = Object.fromEntries(WORKSPACE_PERMISSIONS.map((p) => [p.slug, p.name]))
 
@@ -78,6 +79,14 @@ export function BotKeysSection({ workspaceId, botId, isArchived }: BotKeysSectio
     onSuccess: () => {
       setEditTarget(null)
       setEditScopes(new Set())
+      queryClient.invalidateQueries({ queryKey: keysQueryKey })
+    },
+  })
+
+  const updateVersionMutation = useMutation({
+    mutationFn: (params: { keyId: string; apiVersion: string | null }) =>
+      botsApi.updateKeyVersion(workspaceId, botId, params.keyId, params.apiVersion),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: keysQueryKey })
     },
   })
@@ -286,6 +295,13 @@ export function BotKeysSection({ workspaceId, botId, isArchived }: BotKeysSectio
                     </>
                   )}
                 </p>
+                <div className="mt-1">
+                  <ApiKeyVersionControl
+                    apiVersion={key.apiVersion}
+                    disabled={updateVersionMutation.isPending}
+                    onChange={(apiVersion) => updateVersionMutation.mutate({ keyId: key.id, apiVersion })}
+                  />
+                </div>
               </div>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -349,6 +365,9 @@ export function BotKeysSection({ workspaceId, botId, isArchived }: BotKeysSectio
 
       {updateScopesMutation.error && (
         <p className="text-sm text-destructive">Failed to update key scopes. Please try again.</p>
+      )}
+      {updateVersionMutation.error && (
+        <p className="text-sm text-destructive">Failed to update API version. Please try again.</p>
       )}
       {revokeKeyMutation.error && <p className="text-sm text-destructive">Failed to revoke key. Please try again.</p>}
 

--- a/apps/frontend/src/components/workspace-settings/user-api-keys-section.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/user-api-keys-section.test.tsx
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { CURRENT_API_VERSION, type UserApiKey } from "@threa/types"
+import { workspacesApi } from "@/api/workspaces"
+import * as useFormattedDateModule from "@/hooks/use-formatted-date"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { UserApiKeysSection } from "./user-api-keys-section"
+
+function makeKey(overrides: Partial<UserApiKey> = {}): UserApiKey {
+  return {
+    id: "uak_1",
+    name: "CI pipeline",
+    keyPrefix: "abcd",
+    scopes: ["messages:write"],
+    apiVersion: null,
+    lastUsedAt: null,
+    expiresAt: null,
+    revokedAt: null,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function renderSection(queryClient = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <UserApiKeysSection workspaceId="ws_1" />
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe("UserApiKeysSection — API version pin", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(useFormattedDateModule, "useFormattedDate").mockReturnValue({
+      formatDate: (date: Date) => date.toISOString().slice(0, 10),
+      formatTime: (date: Date) => date.toISOString(),
+      formatRelative: (date: Date) => date.toISOString(),
+      formatFull: (date: Date) => date.toISOString(),
+    })
+  })
+
+  it("shows the tracked-latest state for an unpinned key and pins it to a dated version", async () => {
+    vi.spyOn(workspacesApi, "listUserApiKeys").mockResolvedValue([makeKey({ apiVersion: null })])
+    const update = vi
+      .spyOn(workspacesApi, "updateUserApiKeyVersion")
+      .mockResolvedValue(makeKey({ apiVersion: CURRENT_API_VERSION }))
+    const user = userEvent.setup()
+
+    renderSection()
+
+    const trigger = await screen.findByRole("button", {
+      name: new RegExp(`API version:.*Latest \\(${CURRENT_API_VERSION}\\)`),
+    })
+    await user.click(trigger)
+
+    await user.click(await screen.findByRole("menuitemradio", { name: CURRENT_API_VERSION }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", "uak_1", CURRENT_API_VERSION))
+  })
+
+  it("shows the pinned date for a pinned key and detaches it back to latest", async () => {
+    vi.spyOn(workspacesApi, "listUserApiKeys").mockResolvedValue([makeKey({ apiVersion: CURRENT_API_VERSION })])
+    const update = vi.spyOn(workspacesApi, "updateUserApiKeyVersion").mockResolvedValue(makeKey({ apiVersion: null }))
+    const user = userEvent.setup()
+
+    renderSection()
+
+    const trigger = await screen.findByRole("button", {
+      name: (name) => name.includes("API version") && name.includes(CURRENT_API_VERSION) && !name.includes("Latest"),
+    })
+    await user.click(trigger)
+
+    await user.click(await screen.findByRole("menuitemradio", { name: /Always latest/ }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", "uak_1", null))
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/user-api-keys-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/user-api-keys-section.tsx
@@ -23,6 +23,7 @@ import {
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { API_KEY_ELIGIBLE_PICKER_SCOPES, WORKSPACE_PERMISSIONS, type WorkspacePermissionSlug } from "@threa/types"
 import { Check, ChevronDown, Copy, Key, Plus, Trash2, Eye, EyeOff } from "lucide-react"
+import { ApiKeyVersionControl } from "./api-key-version-control"
 
 // Full catalog drives SCOPE_LABELS so previously-issued keys with scopes
 // outside the eligible picker subset still render a human-readable name.
@@ -73,6 +74,14 @@ export function UserApiKeysSection({ workspaceId }: UserApiKeysSectionProps) {
     onSuccess: () => {
       setEditTarget(null)
       setEditScopes(new Set())
+      queryClient.invalidateQueries({ queryKey })
+    },
+  })
+
+  const updateVersionMutation = useMutation({
+    mutationFn: (params: { keyId: string; apiVersion: string | null }) =>
+      workspacesApi.updateUserApiKeyVersion(workspaceId, params.keyId, params.apiVersion),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey })
     },
   })
@@ -304,6 +313,13 @@ export function UserApiKeysSection({ workspaceId }: UserApiKeysSectionProps) {
                     </>
                   )}
                 </p>
+                <div className="mt-1">
+                  <ApiKeyVersionControl
+                    apiVersion={key.apiVersion}
+                    disabled={updateVersionMutation.isPending}
+                    onChange={(apiVersion) => updateVersionMutation.mutate({ keyId: key.id, apiVersion })}
+                  />
+                </div>
               </div>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -364,6 +380,9 @@ export function UserApiKeysSection({ workspaceId }: UserApiKeysSectionProps) {
 
       {updateScopesMutation.error && (
         <p className="text-sm text-destructive">Failed to update key scopes. Please try again.</p>
+      )}
+      {updateVersionMutation.error && (
+        <p className="text-sm text-destructive">Failed to update API version. Please try again.</p>
       )}
       {revokeMutation.error && <p className="text-sm text-destructive">Failed to revoke key. Please try again.</p>}
 

--- a/packages/types/src/api-versions.ts
+++ b/packages/types/src/api-versions.ts
@@ -1,0 +1,8 @@
+/**
+ * Dated public API versions for the `Threa-Version` header, ascending. The
+ * first entry is the epoch. Single source of truth shared by the backend
+ * versioning module and the frontend key-pin UI — do not fork this list.
+ */
+export const API_VERSIONS = ["2026-07-12"] as const
+export type ApiVersion = (typeof API_VERSIONS)[number]
+export const CURRENT_API_VERSION: ApiVersion = API_VERSIONS[API_VERSIONS.length - 1]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -926,6 +926,9 @@ export {
   type CreateBotApiKeyResponse,
 } from "./api-keys"
 
+// Dated public-API versions (Threa-Version header)
+export { API_VERSIONS, CURRENT_API_VERSION, type ApiVersion } from "./api-versions"
+
 // Workspace permissions catalog
 export {
   WORKSPACE_PERMISSION_SCOPES,


### PR DESCRIPTION
## Problem

Every API key carries a public-API version pin (`api_version`: a date, or NULL = track latest) since #1296, and the PATCH endpoints to change it shipped with the substrate — but nothing in the app shows it. An integrator can only discover their key's pin via `GET /me` on the public API, and changing it requires a hand-crafted PATCH. Kris's call: with the substrate live in prod, the settings UI should display and manage the pin (revisits the deferral in `docs/plans/public-api-header-versioning.md` §11.4).

## Solution

A quiet per-key version line in the two key surfaces of workspace settings, backed by the existing PATCH endpoints. The version list moves to `@threa/types` so frontend and backend share one source of truth.

### How it works

- `packages/types/src/api-versions.ts` (new) owns `API_VERSIONS`, `CURRENT_API_VERSION`, `ApiVersion`; the backend's `features/public-api/versions/types.ts` now re-exports them from `@threa/types` instead of defining them. The `OperationId`-bound change-registry machinery stays backend-only. No hardcoded dates in the frontend (INV-33).
- `ApiKeyVersionControl` (new, shared component): a Shadcn `DropdownMenu` with a radio group — "Always latest (2026-07-12)" plus each dated version. Trigger renders as an 11px metadata line (`API version: 2026-07-12` / `API version: Latest (2026-07-12)`) under the key's created/last-used line. A `__latest__` sentinel maps to `apiVersion: null` on the wire.
- `user-api-keys-section.tsx` and `bot-keys-section.tsx` each wire it to a TanStack mutation → `PATCH /api/workspaces/:ws/user-api-keys/:keyId` / `PATCH /api/workspaces/:ws/bots/:botId/keys/:keyId` with `{ apiVersion }` → `invalidateQueries`, mirroring the existing scope-edit mutations. Errors surface via the sections' existing destructive-text pattern.
- No success toast — the refetched row is the confirmation (INV-63). Radix `onValueChange` fires only on change, so re-selecting the current value issues no PATCH; the control disables while a PATCH is pending.

### Key design decisions

**1. Constants move to `@threa/types`, not duplicated or fetched.** The alternative — an endpoint exposing the version list — adds a fetch for data that is compile-time constant and ships with every deploy anyway. The backend module re-exports, so all existing backend imports (`./versions` barrel) are untouched.

**2. Keys keep showing their mint pin.** New keys are minted pinned to the current version (per the substrate design), so a fresh key shows `2026-07-12`, not "Latest". The control makes detaching a one-click choice rather than changing mint semantics.

## New files

| File | Purpose |
| ---- | ------- |
| `packages/types/src/api-versions.ts` | SSOT for `API_VERSIONS` / `CURRENT_API_VERSION` / `ApiVersion` |
| `apps/frontend/src/components/workspace-settings/api-key-version-control.tsx` | Shared dropdown control for both key kinds |
| `apps/frontend/src/components/workspace-settings/user-api-keys-section.test.tsx` | Mounts the real section; asserts pin + detach PATCH args |
| `apps/frontend/src/components/workspace-settings/bot-keys-section.test.tsx` | Same for the bot-key wire path |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/public-api/versions/types.ts` | Version constants now re-exported from `@threa/types` |
| `packages/types/src/index.ts` | Barrel export |
| `apps/frontend/src/api/workspaces.ts` | `updateUserApiKeyVersion` → PATCH `{ apiVersion }` |
| `apps/frontend/src/api/bots.ts` | `updateKeyVersion` → PATCH `{ apiVersion }` |
| `apps/frontend/src/components/workspace-settings/user-api-keys-section.tsx` | Version line + mutation on each active key row |
| `apps/frontend/src/components/workspace-settings/bot-keys-section.tsx` | Same |

## Out of scope (deliberate)

- No version column/filter in any list view, no bulk re-pin — one version exists today (INV-36).
- Archived-bot keys keep the control enabled, matching the section's existing edit-scopes/revoke behavior (only "New key" is gated on archive).

## Test plan

- [x] New component tests (both sections) — 4 pass; mount real components, open the dropdown, assert exact PATCH args for pin and detach (INV-39)
- [x] `bunx vitest run src/components/workspace-settings/ src/lib/no-happy-path-success-toast.test.ts` — 14 pass (INV-63 guard green)
- [x] `bun test apps/backend/src/features/public-api/versions/` — 7 pass
- [x] OpenAPI drift check (`generate-api-docs.ts --check`) — up to date
- [x] Full-monorepo typecheck + lint via pre-commit — green
- [x] Live browser verification (Playwright against `dev:test`): user key — fresh key shows mint pin `2026-07-12`; detach fires `PATCH {"apiVersion":null}` → 200, row flips to `Latest (2026-07-12)` and survives reload; re-pin fires `PATCH {"apiVersion":"2026-07-12"}` → 200. Bot key — same flow via `/bots/:botId/keys/:keyId` → 200. Zero toasts during the whole flow.
- [x] Pre-existing failure isolated, not introduced: `schemas.test.ts` TDZ error from a circular import in `routes.ts` fails identically on a clean stash of main.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786485646&installation_id=129946197&pr_number=1308&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1308&signature=9d993bb30eb963dd8c2512f9a04abdf63efe6dd86ca7dffaf1da81c552811dab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->