### PR TITLE
feat(frontend): stashed drafts + scheduled sends in the inline composer (board card, panel, branches)

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { useState, type ReactNode } from "react"
+import { useState, type ReactElement, type ReactNode } from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { InlineComposerForm } from "./board-inline-composer"
@@ -13,12 +13,18 @@ import * as mentionablesModule from "@/hooks/use-mentionables"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as streamStoreModule from "@/stores/stream-store"
 import type { MessageComposerProps } from "@/components/composer"
+import type { JSONContent } from "@threa/types"
 
 // The behavior under test is the floating-anchor layer (portal placement,
 // slot exclusivity, close semantics, height publication) — not editor
 // mechanics — so the heavy tiptap editor is swapped for a marker div.
 const EditorStub = (props: MessageComposerProps) => (
-  <div data-testid="editor-stub" data-expanded={String(!!props.expanded)}>
+  <div
+    data-testid="editor-stub"
+    data-expanded={String(!!props.expanded)}
+    data-has-stash={String(!!props.stashedDraftsTrigger && !!props.stashedDraftsTriggerFab && !!props.onStashDraft)}
+    data-has-schedule={String(!!props.scheduledMessagesTrigger && !!props.scheduledMessagesTriggerFab)}
+  >
     {props.placeholder}
     {props.onExpandClick && (
       <button type="button" onClick={props.onExpandClick}>
@@ -28,7 +34,7 @@ const EditorStub = (props: MessageComposerProps) => (
   </div>
 )
 
-const EMPTY_DOC = { type: "doc", content: [] }
+const EMPTY_DOC: JSONContent = { type: "doc", content: [] }
 
 function draftComposerStub() {
   return {
@@ -53,14 +59,38 @@ function draftComposerStub() {
   }
 }
 
+function stashComposerStub() {
+  return {
+    drafts: [],
+    handleStashDraft: vi.fn().mockResolvedValue(undefined),
+    handleRestoreStashed: vi.fn().mockResolvedValue(undefined),
+    handleDeleteStashed: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
 let flushDraft: ReturnType<typeof vi.fn>
+let composerStub: ReturnType<typeof draftComposerStub>
+let scheduleMutateAsync: ReturnType<typeof vi.fn>
+// vi.fn wrapper so tests can read the props the form rendered the editor with.
+let editorSpy: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   Element.prototype.scrollIntoView ??= () => {}
-  spyOnExport(composerModule, "MessageComposer").mockReturnValue(EditorStub as never)
+  editorSpy = vi.fn(EditorStub)
+  spyOnExport(composerModule, "MessageComposer").mockReturnValue(editorSpy as never)
   const stub = draftComposerStub()
+  composerStub = stub
   flushDraft = stub.flushDraft
   spyOnExport(hooksModule, "useDraftComposer").mockReturnValue((() => stub) as never)
+  // `useStashComposer` reaches for `useSearchParams` (the `?stash=` deep-link
+  // restore) and `useScheduleMessage` for the query client / sync engine — both
+  // out of scope here, so they're stubbed like the draft composer above.
+  const stash = stashComposerStub()
+  spyOnExport(hooksModule, "useStashComposer").mockReturnValue((() => stash) as never)
+  scheduleMutateAsync = vi.fn().mockResolvedValue(undefined)
+  spyOnExport(hooksModule, "useScheduleMessage").mockReturnValue((() => ({
+    mutateAsync: scheduleMutateAsync,
+  })) as never)
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({ preferences: undefined } as never)
   vi.spyOn(mentionablesModule, "useMentionStreamContext").mockReturnValue(undefined as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
@@ -184,5 +214,81 @@ describe("InlineComposerForm fullscreen expand", () => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
     render(<Anchored>{form()}</Anchored>)
     expect(screen.queryByRole("button", { name: "Expand" })).toBeNull()
+  })
+})
+
+describe("InlineComposerForm stash + schedule", () => {
+  beforeEach(() => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  })
+
+  /** The MessageComposer props the form last rendered with. */
+  const lastComposerProps = (): MessageComposerProps => editorSpy.mock.calls.at(-1)![0] as MessageComposerProps
+
+  it("always wires the stash pile; the schedule picker only with a declared target", () => {
+    const { rerender } = render(<Anchored>{form()}</Anchored>)
+    expect(screen.getByTestId("editor-stub")).toHaveAttribute("data-has-stash", "true")
+    expect(screen.getByTestId("editor-stub")).toHaveAttribute("data-has-schedule", "false")
+
+    rerender(<Anchored>{form({ scheduleTarget: { streamId: "stream_1", conversationId: "conv_1" } })}</Anchored>)
+    expect(screen.getByTestId("editor-stub")).toHaveAttribute("data-has-schedule", "true")
+  })
+
+  it("scheduling routes to the schedule mutation with the existing-conversation directive and closes", async () => {
+    composerStub.canSend = true
+    const onClose = vi.fn()
+    render(<Anchored>{form({ scheduleTarget: { streamId: "stream_1", conversationId: "conv_1" }, onClose })}</Anchored>)
+
+    const trigger = lastComposerProps().scheduledMessagesTrigger as ReactElement<{
+      onSchedule: (when: Date) => Promise<void>
+    }>
+    const when = new Date("2030-01-02T10:00:00.000Z")
+    await trigger.props.onSchedule(when)
+
+    expect(scheduleMutateAsync).toHaveBeenCalledWith({
+      streamId: "stream_1",
+      contentJson: EMPTY_DOC,
+      attachmentIds: undefined,
+      scheduledFor: when.toISOString(),
+      conversation: { intent: "existing", conversationId: "conv_1" },
+    })
+    expect(composerStub.resolveDraft).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledWith({ refocus: true })
+  })
+
+  it("restores the content and stays open when scheduling fails", async () => {
+    const typedDoc = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] }
+    composerStub.canSend = true
+    composerStub.content = typedDoc
+    scheduleMutateAsync.mockRejectedValueOnce(new Error("offline"))
+    const onClose = vi.fn()
+    render(<Anchored>{form({ scheduleTarget: { streamId: "stream_1", conversationId: "conv_1" }, onClose })}</Anchored>)
+
+    const trigger = lastComposerProps().scheduledMessagesTrigger as ReactElement<{
+      onSchedule: (when: Date) => Promise<void>
+    }>
+    await trigger.props.onSchedule(new Date("2030-01-02T10:00:00.000Z"))
+
+    // Cleared up front, restored on failure — nothing typed is lost.
+    expect(composerStub.setContent).toHaveBeenLastCalledWith(typedDoc)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(composerStub.resolveDraft).not.toHaveBeenCalled()
+  })
+
+  it("blocks scheduling into an E2E host with the reject message", async () => {
+    composerStub.canSend = true
+    vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue({ e2eEnabled: true } as never)
+    render(
+      <Anchored>
+        {form({ scheduleTarget: { streamId: "stream_1", conversationId: "conv_1" }, rejectE2e: "No E2E here" })}
+      </Anchored>
+    )
+
+    const trigger = lastComposerProps().scheduledMessagesTrigger as ReactElement<{
+      onSchedule: (when: Date) => Promise<void>
+    }>
+    await trigger.props.onSchedule(new Date("2030-01-02T10:00:00.000Z"))
+
+    expect(scheduleMutateAsync).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -70,6 +70,7 @@ function stashComposerStub() {
 
 let flushDraft: ReturnType<typeof vi.fn>
 let composerStub: ReturnType<typeof draftComposerStub>
+let stashStub: ReturnType<typeof stashComposerStub>
 let scheduleMutateAsync: ReturnType<typeof vi.fn>
 // vi.fn wrapper so tests can read the props the form rendered the editor with.
 let editorSpy: ReturnType<typeof vi.fn>
@@ -85,7 +86,8 @@ beforeEach(() => {
   // `useStashComposer` reaches for `useSearchParams` (the `?stash=` deep-link
   // restore) and `useScheduleMessage` for the query client / sync engine — both
   // out of scope here, so they're stubbed like the draft composer above.
-  const stash = stashComposerStub()
+  stashStub = stashComposerStub()
+  const stash = stashStub
   spyOnExport(hooksModule, "useStashComposer").mockReturnValue((() => stash) as never)
   scheduleMutateAsync = vi.fn().mockResolvedValue(undefined)
   spyOnExport(hooksModule, "useScheduleMessage").mockReturnValue((() => ({
@@ -214,6 +216,24 @@ describe("InlineComposerForm fullscreen expand", () => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
     render(<Anchored>{form()}</Anchored>)
     expect(screen.queryByRole("button", { name: "Expand" })).toBeNull()
+  })
+})
+
+describe("InlineComposerForm restore-on-mount", () => {
+  beforeEach(() => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  })
+
+  it("checks out the advertised stash row once the composer loads", async () => {
+    render(<Anchored>{form({ restoreStashedIdOnMount: "draft_adv" })}</Anchored>)
+    await waitFor(() => expect(stashStub.handleRestoreStashed).toHaveBeenCalledWith("draft_adv"))
+    expect(stashStub.handleRestoreStashed).toHaveBeenCalledTimes(1)
+  })
+
+  it("does nothing without a restore id", async () => {
+    render(<Anchored>{form()}</Anchored>)
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(stashStub.handleRestoreStashed).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -73,6 +73,13 @@ interface InlineComposerFormProps {
    * a new sub-topic or a still-pending branch — and the affordance is absent.
    */
   scheduleTarget?: { streamId: string; conversationId: string }
+  /**
+   * Stash row to check out once the composer mounts. Set by a resting
+   * affordance that advertised a stashed/roamed draft (the loaded pointer is
+   * device-local, so the row won't hydrate by itself) — opening must surface
+   * the very draft the affordance showed. Consumed once, on mount.
+   */
+  restoreStashedIdOnMount?: string | null
   /** Perform the send. Throws to keep the composer open and restore the draft. */
   onSubmit: (input: InlineComposerSubmit) => Promise<void>
   /** Collapse the composer (Escape / after-send / blur-when-empty). */
@@ -99,6 +106,7 @@ export function InlineComposerForm({
   onQuoteConsumed,
   rejectE2e,
   scheduleTarget,
+  restoreStashedIdOnMount,
   onSubmit,
   onClose,
 }: InlineComposerFormProps) {
@@ -120,6 +128,16 @@ export function InlineComposerForm({
   // switching cards without hijacking the ambient draft slot.
   const stash = useStashComposer(composer, workspaceId, draftKey)
   const scheduleMessage = useScheduleMessage(workspaceId)
+
+  // Check out the advertised stash row once (mount-captured; the guard ref, not
+  // the effect deps, enforces once — `stash` is a fresh object every render).
+  const restoreOnMountRef = useRef(restoreStashedIdOnMount ?? null)
+  useEffect(() => {
+    const id = restoreOnMountRef.current
+    if (!id || !composer.isLoaded) return
+    restoreOnMountRef.current = null
+    void stash.handleRestoreStashed(id)
+  }, [composer.isLoaded, stash])
 
   const composerControlRef = useRef<ComposerControlHandle | null>(null)
   const composerRef = useRef(composer)

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -80,6 +80,12 @@ interface InlineComposerFormProps {
    * the very draft the affordance showed. Consumed once, on mount.
    */
   restoreStashedIdOnMount?: string | null
+  /**
+   * Monotonic nonce: each increment focuses the editor. For always-mounted
+   * hosts (the desktop conversation panel), where "open the reply composer"
+   * requests can't be expressed as a mount.
+   */
+  focusSignal?: number
   /** Perform the send. Throws to keep the composer open and restore the draft. */
   onSubmit: (input: InlineComposerSubmit) => Promise<void>
   /** Collapse the composer (Escape / after-send / blur-when-empty). */
@@ -107,6 +113,7 @@ export function InlineComposerForm({
   rejectE2e,
   scheduleTarget,
   restoreStashedIdOnMount,
+  focusSignal,
   onSubmit,
   onClose,
 }: InlineComposerFormProps) {
@@ -138,6 +145,15 @@ export function InlineComposerForm({
     restoreOnMountRef.current = null
     void stash.handleRestoreStashed(id)
   }, [composer.isLoaded, stash])
+
+  // Focus-on-signal for always-mounted hosts (skip the mount value — focus on
+  // mount is `autoFocus`'s job).
+  const lastFocusSignalRef = useRef(focusSignal)
+  useEffect(() => {
+    if (focusSignal === undefined || focusSignal === lastFocusSignalRef.current) return
+    lastFocusSignalRef.current = focusSignal
+    composerControlRef.current?.focus()
+  }, [focusSignal])
 
   const composerControlRef = useRef<ComposerControlHandle | null>(null)
   const composerRef = useRef(composer)

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -6,13 +6,15 @@ import {
   MessageComposer,
   FloatingComposerShell,
   OverlayComposerShell,
+  ScheduledMessagesPicker,
+  StashedDraftsPicker,
   useFloatingComposerAnchor,
   FLOATING_COMPOSER_HEIGHT_VAR,
   type ComposerControlHandle,
 } from "@/components/composer"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
-import { useDraftComposer } from "@/hooks"
+import { useDraftComposer, useScheduleMessage, useStashComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -62,6 +64,15 @@ interface InlineComposerFormProps {
    * kept so nothing typed is lost.
    */
   rejectE2e?: string
+  /**
+   * Enables the schedule-send picker. A scheduled send can't run the call
+   * site's live routing at fire time, so the resolved target is declared up
+   * front: the stream the fired message posts into plus the conversation it
+   * files into (`{ intent: "existing" }`, matching the timeline composer's
+   * armed-reply scheduling). Omit where the target doesn't exist until send —
+   * a new sub-topic or a still-pending branch — and the affordance is absent.
+   */
+  scheduleTarget?: { streamId: string; conversationId: string }
   /** Perform the send. Throws to keep the composer open and restore the draft. */
   onSubmit: (input: InlineComposerSubmit) => Promise<void>
   /** Collapse the composer (Escape / after-send / blur-when-empty). */
@@ -87,6 +98,7 @@ export function InlineComposerForm({
   pendingQuote,
   onQuoteConsumed,
   rejectE2e,
+  scheduleTarget,
   onSubmit,
   onClose,
 }: InlineComposerFormProps) {
@@ -103,6 +115,11 @@ export function InlineComposerForm({
   const hostIsE2e = hostStream?.e2eEnabled === true || idbHostStream?.e2eEnabled === true
 
   const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
+  // "Save for later" pile scoped to this reply target — the same pointer-move
+  // stash the timeline composer has, so a half-written inline reply survives
+  // switching cards without hijacking the ambient draft slot.
+  const stash = useStashComposer(composer, workspaceId, draftKey)
+  const scheduleMessage = useScheduleMessage(workspaceId)
 
   const composerControlRef = useRef<ComposerControlHandle | null>(null)
   const composerRef = useRef(composer)
@@ -282,6 +299,67 @@ export function InlineComposerForm({
     }
   }
 
+  /**
+   * Schedule the current content for a future send. Mirrors `handleSubmit`
+   * (materialize refs, clear up front, restore on failure) but routes to the
+   * schedule API against the declared `scheduleTarget` instead of the call
+   * site's live routing — the fired message posts into the target stream and
+   * the assigner attaches it to the conversation by id.
+   */
+  const handleSchedule = async (when: Date) => {
+    if (!composer.canSend || !scheduleTarget) return
+
+    if (rejectE2e && hostIsE2e) {
+      toast.error(rejectE2e)
+      return
+    }
+
+    const pendingAttachments = composer.getPendingAttachmentsSnapshot()
+    const normalizedContent = materializePendingAttachmentReferences(composer.content, pendingAttachments)
+    const attachmentIds = extractUploadedAttachments(normalizedContent).map((a) => a.id)
+
+    composer.setIsSending(true)
+    composer.setContent(EMPTY_DOC)
+    try {
+      await scheduleMessage.mutateAsync({
+        streamId: scheduleTarget.streamId,
+        contentJson: normalizedContent,
+        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        scheduledFor: when.toISOString(),
+        conversation: { intent: "existing", conversationId: scheduleTarget.conversationId },
+      })
+      await composer.resolveDraft()
+      composer.clearAttachments()
+      onClose({ refocus: true })
+    } catch {
+      composer.setContent(normalizedContent)
+      toast.error("Couldn't schedule. Please try again.")
+    } finally {
+      composer.setIsSending(false)
+    }
+  }
+
+  // Inline drafts are plaintext (no `e2eStreamId` on the composer above), so the
+  // picker's own `contentJson` fallback previews suffice — no decrypt pass.
+  const stashPickerProps = {
+    drafts: stash.drafts,
+    canStashCurrent: composer.canSend,
+    onStashCurrent: stash.handleStashDraft,
+    onRestore: stash.handleRestoreStashed,
+    onDelete: stash.handleDeleteStashed,
+    controlsDisabled: composer.isSending,
+  } as const
+
+  const schedulePickerProps = scheduleTarget
+    ? ({
+        workspaceId,
+        streamId: scheduleTarget.streamId,
+        canSchedule: composer.canSend,
+        onSchedule: handleSchedule,
+        controlsDisabled: composer.isSending,
+      } as const)
+    : null
+
   const contextChipNode = contextChip ? (
     <div className="flex w-fit min-w-0 max-w-full items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
       <CornerDownRight className="h-3 w-3 shrink-0" />
@@ -312,6 +390,13 @@ export function InlineComposerForm({
     messageSendMode: preferences?.messageSendMode ?? "enter",
     scopeId: draftKey,
     streamContext,
+    onStashDraft: stash.handleStashDraft,
+    stashedDraftsTrigger: <StashedDraftsPicker {...stashPickerProps} />,
+    stashedDraftsTriggerFab: <StashedDraftsPicker {...stashPickerProps} size="fab" />,
+    scheduledMessagesTrigger: schedulePickerProps ? <ScheduledMessagesPicker {...schedulePickerProps} /> : undefined,
+    scheduledMessagesTriggerFab: schedulePickerProps ? (
+      <ScheduledMessagesPicker {...schedulePickerProps} size="fab" />
+    ) : undefined,
   } as const
 
   const editor = (

--- a/apps/frontend/src/components/board/board-reply-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { BoardReplyComposer } from "./board-reply-composer"
+import { spyOnExport } from "@/test"
+import * as inlineComposerModule from "@/components/board/board-inline-composer"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as hooksModule from "@/hooks"
+import * as conversationsModule from "@/hooks/use-conversations"
+import type { ComponentProps } from "react"
+import type { BoardPost } from "@threa/types"
+
+type InlineComposerFormProps = ComponentProps<typeof inlineComposerModule.InlineComposerForm>
+
+const post = {
+  conversation: { id: "conv_1", streamId: "stream_1", messageIds: ["msg_1"], topicSummary: "GPU budget" },
+  openingMessage: { id: "msg_1" },
+} as unknown as BoardPost
+
+// Marker stub: the form's mount + the props under test, without the editor.
+const FormStub = (props: InlineComposerFormProps) => (
+  <div
+    data-testid="form-stub"
+    data-auto-focus={String(props.autoFocus ?? true)}
+    data-restore={props.restoreStashedIdOnMount ?? ""}
+  />
+)
+
+let formSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  formSpy = vi.fn(FormStub)
+  spyOnExport(inlineComposerModule, "InlineComposerForm").mockReturnValue(formSpy as never)
+  vi.spyOn(conversationsModule, "useReplyToBoardPost").mockReturnValue({
+    mutateAsync: vi.fn(),
+  } as unknown as ReturnType<typeof conversationsModule.useReplyToBoardPost>)
+  spyOnExport(hooksModule, "useScopeDraftPreview").mockReturnValue((() => null) as never)
+})
+
+function mount(props: Partial<Parameters<typeof BoardReplyComposer>[0]> = {}) {
+  return render(
+    <BoardReplyComposer workspaceId="ws_1" post={post} hostStreamType="channel" lastActiveStreamId={null} {...props} />
+  )
+}
+
+describe("BoardReplyComposer desktopAlwaysOpen (thread-composer semantics)", () => {
+  it("desktop: mounts the form permanently — no resting button, no focus steal", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    mount({ desktopAlwaysOpen: true })
+    const form = screen.getByTestId("form-stub")
+    expect(form).toHaveAttribute("data-auto-focus", "false")
+    expect(screen.queryByRole("button", { name: "Write a reply…" })).toBeNull()
+  })
+
+  it("mobile: keeps the collapsed⇄focused pair (resting button first)", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    mount({ desktopAlwaysOpen: true })
+    expect(screen.queryByTestId("form-stub")).toBeNull()
+    expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
+  })
+
+  it("board-card default: collapsed, and opening carries the advertised stash row for check-out", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    spyOnExport(hooksModule, "useScopeDraftPreview").mockReturnValue((() => ({
+      draftId: "draft_adv",
+      preview: "roamed body",
+      attachmentCount: 0,
+      isCheckedOut: false,
+    })) as never)
+    mount()
+    const resting = screen.getByRole("button", { name: /roamed body/ })
+    await userEvent.click(resting)
+    expect(screen.getByTestId("form-stub")).toHaveAttribute("data-restore", "draft_adv")
+  })
+})

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -3,6 +3,7 @@ import { useQuoteReply, type QuoteReplyData } from "@/components/timeline/quote-
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
+import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import type { BoardPost } from "@threa/types"
 
 // Resting-affordance state. `draft` signals a persisted-but-collapsed reply, so
@@ -160,7 +161,7 @@ function BoardReplyComposerForm({
       workspaceId={workspaceId}
       streamId={streamId}
       memoAnchorStreamId={streamId}
-      draftKey={`board:reply:${post.conversation.id}`}
+      draftKey={boardReplyDraftKey(post.conversation.id)}
       placeholder="Write a reply…"
       contextChip={isMobile && contextChip ? `Replying in ${contextChip}` : undefined}
       pendingQuote={pendingQuote}

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { Paperclip, Pencil } from "lucide-react"
 import { useQuoteReply, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useScopeDraftPreview, type ScopeDraftPreview } from "@/hooks"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
 import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import type { BoardPost } from "@threa/types"
@@ -15,6 +17,29 @@ type RestingState = "idle" | "draft"
 const RESTING_LABEL: Record<RestingState, string> = {
   idle: "Write a reply…",
   draft: "Continue reply…",
+}
+
+/**
+ * The resting affordance's content when the scope holds an unsent draft: the
+ * draft's own first line, mirroring the mobile composer's collapsed preview
+ * bar — the draft is visible in place instead of hiding behind a generic
+ * label (discoverability ruling, Kris 2026-07-13). Shared by the bottom-reply
+ * button here and the branch-tail affordance.
+ */
+export function DraftRestingPreview({ draft }: { draft: ScopeDraftPreview }) {
+  return (
+    <span className="flex w-full min-w-0 items-center gap-2">
+      <Pencil aria-label="Unsent draft" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      {draft.preview ? (
+        <span className="min-w-0 flex-1 truncate text-foreground">{draft.preview}</span>
+      ) : (
+        <span className="flex min-w-0 flex-1 items-center gap-1 truncate text-muted-foreground">
+          <Paperclip className="h-3.5 w-3.5 shrink-0" />
+          {draft.attachmentCount} attachment{draft.attachmentCount === 1 ? "" : "s"}
+        </span>
+      )}
+    </span>
+  )
 }
 
 interface BoardReplyComposerProps {
@@ -57,6 +82,12 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
   const [resting, setResting] = useState<RestingState>("idle")
   const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // The scope's unsent draft, advertised on the resting button and — when it
+  // isn't checked out on this device (stashed / roamed) — checked out by the
+  // opening form so the click surfaces exactly what the button showed.
+  const scopeDraft = useScopeDraftPreview(props.workspaceId, boardReplyDraftKey(props.post.conversation.id))
+  const restoreStashedId = scopeDraft && !scopeDraft.isCheckedOut ? scopeDraft.draftId : null
 
   const { openReplySignal } = props
   useEffect(() => {
@@ -109,16 +140,26 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
         }}
         className="mt-3 flex w-full min-w-0 items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        {/* No leading icon: it would misalign the resting text against the open
-            composer's placeholder, and a state-dependent icon would shift the
-            label (INV-21). */}
-        <span className="truncate">{RESTING_LABEL[resting]}</span>
+        {/* With a draft: the draft's own first line (mobile collapsed-composer
+            presentation). Without: the plain invitation — no leading icon, so
+            the resting text aligns with the open composer's placeholder. */}
+        {scopeDraft ? (
+          <DraftRestingPreview draft={scopeDraft} />
+        ) : (
+          <span className="truncate">{RESTING_LABEL[resting]}</span>
+        )}
       </button>
     )
   }
 
   return (
-    <BoardReplyComposerForm {...props} onClose={close} pendingQuote={pendingQuote} onQuoteConsumed={onQuoteConsumed} />
+    <BoardReplyComposerForm
+      {...props}
+      onClose={close}
+      pendingQuote={pendingQuote}
+      onQuoteConsumed={onQuoteConsumed}
+      restoreStashedId={restoreStashedId}
+    />
   )
 }
 
@@ -131,10 +172,12 @@ function BoardReplyComposerForm({
   pendingQuote,
   onQuoteConsumed,
   contextChip,
+  restoreStashedId,
 }: BoardReplyComposerProps & {
   onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
   pendingQuote: QuoteReplyData | null
   onQuoteConsumed: () => void
+  restoreStashedId: string | null
 }) {
   const reply = useReplyToBoardPost(workspaceId)
   const isMobile = useIsMobile()
@@ -168,6 +211,7 @@ function BoardReplyComposerForm({
       onQuoteConsumed={onQuoteConsumed}
       rejectE2e="Encrypted notes can't be replied to from the board yet — open the note to reply there."
       scheduleTarget={{ streamId, conversationId: post.conversation.id }}
+      restoreStashedIdOnMount={restoreStashedId}
       onSubmit={onSubmit}
       onClose={onClose}
     />

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -166,6 +166,7 @@ function BoardReplyComposerForm({
       pendingQuote={pendingQuote}
       onQuoteConsumed={onQuoteConsumed}
       rejectE2e="Encrypted notes can't be replied to from the board yet — open the note to reply there."
+      scheduleTarget={{ streamId, conversationId: post.conversation.id }}
       onSubmit={onSubmit}
       onClose={onClose}
     />

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -67,6 +67,15 @@ interface BoardReplyComposerProps {
    * form keeps its context by position.
    */
   contextChip?: string
+  /**
+   * Thread-composer semantics for a dedicated conversation view (the panel):
+   * on desktop the composer is permanently mounted — only the open state, like
+   * a thread's — while mobile keeps its collapsed⇄focused pair. Off (the
+   * default) for board cards, where composers aren't kept mounted per card,
+   * and for the inline sub-conversation affordances (Kris's composer ruling,
+   * 2026-07-13).
+   */
+  desktopAlwaysOpen?: boolean
 }
 
 /**
@@ -82,6 +91,8 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
   const [resting, setResting] = useState<RestingState>("idle")
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const isMobile = useIsMobile()
+  const alwaysOpen = (props.desktopAlwaysOpen ?? false) && !isMobile
 
   // The scope's unsent draft, advertised on the resting button and — when it
   // isn't checked out on this device (stashed / roamed) — checked out by the
@@ -129,6 +140,25 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     setOpen(false)
   }, [])
 
+  // Always-open: the form never collapses — after a send / Escape / blur the
+  // editor simply stays, like a thread composer. Open-requests become focus
+  // requests, and the drafts-explorer `?stash=` restore is consumed by the
+  // mounted form's own URL effect (no mount to hang it on).
+  const noopClose = useCallback(() => {}, [])
+  if (alwaysOpen) {
+    return (
+      <BoardReplyComposerForm
+        {...props}
+        onClose={noopClose}
+        pendingQuote={pendingQuote}
+        onQuoteConsumed={onQuoteConsumed}
+        restoreStashedId={null}
+        autoFocus={false}
+        focusSignal={openReplySignal}
+      />
+    )
+  }
+
   if (!open) {
     return (
       <button
@@ -173,11 +203,15 @@ function BoardReplyComposerForm({
   onQuoteConsumed,
   contextChip,
   restoreStashedId,
+  autoFocus,
+  focusSignal,
 }: BoardReplyComposerProps & {
   onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
   pendingQuote: QuoteReplyData | null
   onQuoteConsumed: () => void
   restoreStashedId: string | null
+  autoFocus?: boolean
+  focusSignal?: number
 }) {
   const reply = useReplyToBoardPost(workspaceId)
   const isMobile = useIsMobile()
@@ -212,6 +246,8 @@ function BoardReplyComposerForm({
       rejectE2e="Encrypted notes can't be replied to from the board yet — open the note to reply there."
       scheduleTarget={{ streamId, conversationId: post.conversation.id }}
       restoreStashedIdOnMount={restoreStashedId}
+      autoFocus={autoFocus}
+      focusSignal={focusSignal}
       onSubmit={onSubmit}
       onClose={onClose}
     />

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { renderHook, waitFor } from "@testing-library/react"
+import { fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { createElement, type ReactNode } from "react"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
-import { upsertLoadedDraft, purgeScopeDrafts } from "@/hooks/use-draft-message"
+import { upsertLoadedDraft, purgeScopeDrafts, stashLoadedDraft } from "@/hooks/use-draft-message"
 import { useInlineBranchComposer } from "./use-inline-branch-composer"
 import type { ConversationGraph, StreamStructuralIndex } from "@/hooks/use-conversation-graph"
 
@@ -95,6 +95,28 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
     const { result } = mountHook(draftId)
     await waitFor(() =>
       expect(result.current.openComposer).toEqual({ kind: "new-subtopic", streamId: "stream_9", messageId: "msg_fork" })
+    )
+  })
+
+  it("marks a fork message carrying an unsent sub-topic draft and reopens the gesture with a restore", async () => {
+    const draftId = await seedDraft("board:subtopic:stream_9:msg_fork")
+    // Detach the loaded pointer — the row is a stash (roamed-draft shape), so
+    // reopening must carry it for an explicit check-out.
+    await stashLoadedDraft(workspaceId, "board:subtopic:stream_9:msg_fork")
+    const { result } = mountHook("draft_none")
+
+    // The indicator renders under the fork message once the index resolves.
+    await waitFor(() => expect(result.current.renderAfterMessage("msg_fork")).not.toBeNull())
+    render(<MemoryRouter>{result.current.renderAfterMessage("msg_fork")}</MemoryRouter>)
+    fireEvent.click(screen.getByText("hi"))
+
+    await waitFor(() =>
+      expect(result.current.openComposer).toEqual({
+        kind: "new-subtopic",
+        streamId: "stream_9",
+        messageId: "msg_fork",
+        restoreStashedId: draftId,
+      })
     )
   })
 

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -5,6 +5,7 @@ import { createElement, type ReactNode } from "react"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import { upsertLoadedDraft, purgeScopeDrafts, stashLoadedDraft } from "@/hooks/use-draft-message"
+import { useScopeDraftPreview } from "@/hooks"
 import { useInlineBranchComposer } from "./use-inline-branch-composer"
 import type { ConversationGraph, StreamStructuralIndex } from "@/hooks/use-conversation-graph"
 
@@ -68,6 +69,7 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
     for (const scope of [
       "board:branch-reply:conv_branch",
       "board:subtopic:stream_9:msg_fork",
+      "board:subtopic:stream_9:msg_fork_b",
       `board:reply:${PARENT_ID}`,
     ]) {
       await purgeScopeDrafts(workspaceId, scope)
@@ -118,6 +120,22 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
         restoreStashedId: draftId,
       })
     )
+  })
+
+  it("migrates a sub-topic draft onto the branch once it materializes, and never shows the indicator beside it", async () => {
+    // A draft to CREATE a sub-conversation under msg_fork_b, whose branch
+    // already exists (the fixture graph renders it) — the exact stash-before-
+    // materialize state from Kris's screenshots.
+    await seedDraft("board:subtopic:stream_9:msg_fork_b")
+    const { result } = mountHook("draft_none")
+
+    // The draft follows the branch onto its tail scope…
+    const probe = renderHook(() => useScopeDraftPreview(workspaceId, "board:branch-reply:conv_branch"), {
+      wrapper: wrapperWithStash("draft_none"),
+    })
+    await waitFor(() => expect(probe.result.current?.preview).toBe("hi"))
+    // …and the fork message renders no "create a sub-conversation" affordance.
+    expect(result.current.renderAfterMessage("msg_fork_b")).toBeNull()
   })
 
   it("ignores stash rows belonging to the panel's own reply scope", async () => {

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { createElement, type ReactNode } from "react"
+import { resetDraftStoreCache } from "@/stores/draft-store"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+import { upsertLoadedDraft, purgeScopeDrafts } from "@/hooks/use-draft-message"
+import { useInlineBranchComposer } from "./use-inline-branch-composer"
+import type { ConversationGraph, StreamStructuralIndex } from "@/hooks/use-conversation-graph"
+
+const workspaceId = "ws_1"
+const PARENT_ID = "conv_parent"
+
+// The branch thread forks off `msg_fork_b`, a member of the parent conversation
+// — the structural parenthood `collectBranchThreadStreamIds` walks (sub-topic
+// conversations carry no parentConversationId).
+const index = {
+  threadsByParentMessageId: new Map([["msg_fork_b", { id: "stream_thread_1" }]]),
+} as unknown as StreamStructuralIndex
+
+function makeGraph(): ConversationGraph {
+  const branchPost = {
+    id: "conv_branch",
+    workspaceId,
+    conversation: { id: "conv_branch", streamId: "stream_thread_1", messageIds: ["msg_branch_1"] },
+  }
+  return {
+    conversationByAnchorStreamId: new Map([["stream_thread_1", branchPost]]),
+    conversationIdByMemberMessageId: new Map([
+      ["msg_fork", PARENT_ID],
+      ["msg_fork_b", PARENT_ID],
+    ]),
+    conversationById: new Map([["conv_branch", branchPost]]),
+  } as unknown as ConversationGraph
+}
+
+function wrapperWithStash(stashId: string) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(MemoryRouter, { initialEntries: [`/?stash=${stashId}`] }, children)
+}
+
+async function seedDraft(scope: string): Promise<string> {
+  const row = await upsertLoadedDraft(workspaceId, scope, {
+    contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] },
+    attachments: [],
+  })
+  return row.id
+}
+
+function mountHook(stashId: string) {
+  return renderHook(
+    () =>
+      useInlineBranchComposer({
+        workspaceId,
+        conversationId: PARENT_ID,
+        memberMessageIds: ["msg_fork", "msg_fork_b"],
+        index,
+        graph: makeGraph(),
+      }),
+    { wrapper: wrapperWithStash(stashId) }
+  )
+}
+
+describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    for (const scope of [
+      "board:branch-reply:conv_branch",
+      "board:subtopic:stream_9:msg_fork",
+      `board:reply:${PARENT_ID}`,
+    ]) {
+      await purgeScopeDrafts(workspaceId, scope)
+    }
+    vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+      queueDraftMessage: vi.fn(),
+      currentUserId: "usr_me",
+    } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  })
+
+  it("auto-opens the branch-tail composer for a branch-reply stash owned by one of its branches", async () => {
+    const draftId = await seedDraft("board:branch-reply:conv_branch")
+    const { result } = mountHook(draftId)
+    await waitFor(() =>
+      expect(result.current.openComposer).toEqual({
+        kind: "branch-reply",
+        conversationId: "conv_branch",
+        threadStreamId: "stream_thread_1",
+      })
+    )
+  })
+
+  it("auto-opens the new-sub-topic composer for a subtopic stash forked from one of its member messages", async () => {
+    const draftId = await seedDraft("board:subtopic:stream_9:msg_fork")
+    const { result } = mountHook(draftId)
+    await waitFor(() =>
+      expect(result.current.openComposer).toEqual({ kind: "new-subtopic", streamId: "stream_9", messageId: "msg_fork" })
+    )
+  })
+
+  it("ignores stash rows belonging to the panel's own reply scope", async () => {
+    // A reply-scope stash is the conversation panel's to consume, not this
+    // surface's branch/sub-topic composers.
+    const draftId = await seedDraft(`board:reply:${PARENT_ID}`)
+    const { result } = mountHook(draftId)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(result.current.openComposer).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { Reply } from "lucide-react"
+import { CornerDownRight, Pencil, Reply } from "lucide-react"
 import { StreamTypes } from "@threa/types"
 import { useQueueDraftMessage } from "@/hooks/use-queue-draft-message"
-import { useStashParamDraftRow } from "@/hooks"
+import { useBoardSubtopicDraftIndex, useScopeDraftPreview, useStashParamDraftRow } from "@/hooks"
+import type { SubtopicDraftEntry } from "@/hooks"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+import { DraftRestingPreview } from "@/components/board/board-reply-composer"
 import { createDraftPanelId } from "@/contexts"
 import { collectBranchThreadStreamIds } from "@/hooks/use-conversation-graph"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
@@ -16,11 +18,79 @@ import type { RenderableMessage } from "@/components/message/message-item"
  *  opening another closes the first). Either a "new sub-topic" gesture under a
  *  message row, or a reply at a nested branch's tail. */
 export type OpenInlineComposer =
-  | { kind: "new-subtopic"; streamId: string; messageId: string }
-  | { kind: "branch-reply"; conversationId: string; threadStreamId: string }
+  | { kind: "new-subtopic"; streamId: string; messageId: string; restoreStashedId?: string | null }
+  | { kind: "branch-reply"; conversationId: string; threadStreamId: string; restoreStashedId?: string | null }
 
 const E2E_REPLY_MESSAGE = "Encrypted notes can't be replied to from the board yet — open the note to reply there."
 const E2E_SUBTOPIC_MESSAGE = "Can't start a sub-topic in an encrypted note here."
+
+/**
+ * The collapsed branch-tail affordance. With an unsent draft for the tail's
+ * scope it renders the draft's own first line as a composer-styled pill (the
+ * mobile collapsed presentation — the draft is visible in place); without one
+ * it stays the quiet "Reply" link. `onOpen` receives the stash row to check
+ * out when the advertised draft isn't loaded on this device.
+ */
+function BranchTailAffordance({
+  workspaceId,
+  scope,
+  onOpen,
+}: {
+  workspaceId: string
+  scope: string
+  onOpen: (restoreStashedId: string | null) => void
+}) {
+  const draft = useScopeDraftPreview(workspaceId, scope)
+  if (!draft) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpen(null)}
+        className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <Reply className="h-3.5 w-3.5 shrink-0" />
+        Reply
+      </button>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(draft.isCheckedOut ? null : draft.draftId)}
+      className="mt-3 flex w-full min-w-0 items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <DraftRestingPreview draft={draft} />
+    </button>
+  )
+}
+
+/**
+ * Marks a message row whose "new sub-topic" gesture holds an unsent draft
+ * while that composer is unmounted: the branch arrow + the draft's first line,
+ * clickable to reopen the gesture with the draft in it. Without this the
+ * draft is only discoverable through the context menu (Kris 2026-07-13).
+ */
+function SubtopicDraftIndicator({
+  entry,
+  onOpen,
+}: {
+  entry: SubtopicDraftEntry
+  onOpen: (restoreStashedId: string | null) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(entry.isCheckedOut ? null : entry.draftId)}
+      className="mt-2 flex w-fit min-w-0 max-w-full items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <CornerDownRight className="h-3.5 w-3.5 shrink-0" />
+      <Pencil aria-label="Unsent sub-topic draft" className="h-3 w-3 shrink-0" />
+      <span className="min-w-0 truncate">
+        {entry.preview || `${entry.attachmentCount} attachment${entry.attachmentCount === 1 ? "" : "s"}`}
+      </span>
+    </button>
+  )
+}
 
 /**
  * The inline reply + "new sub-topic" composers a conversation surface (board card
@@ -73,18 +143,24 @@ export function useInlineBranchComposer(params: {
 
   const closeComposer = useCallback(() => setOpenComposer(null), [])
   const openNewSubtopic = useCallback(
-    (streamId: string, messageId: string) => setOpenComposer({ kind: "new-subtopic", streamId, messageId }),
+    (streamId: string, messageId: string, restoreStashedId: string | null = null) =>
+      setOpenComposer({ kind: "new-subtopic", streamId, messageId, restoreStashedId }),
     []
   )
   const openBranchReply = useCallback(
-    (branch: BranchConversationView) =>
+    (branch: BranchConversationView, restoreStashedId: string | null = null) =>
       setOpenComposer({
         kind: "branch-reply",
         conversationId: branch.conversationId,
         threadStreamId: branch.threadStreamId,
+        restoreStashedId,
       }),
     []
   )
+
+  // Unsent sub-topic drafts by fork message id — marks the rows whose gesture
+  // composer is unmounted but holds a draft (rendered by `renderAfterMessage`).
+  const subtopicDraftIndex = useBoardSubtopicDraftIndex(workspaceId)
 
   const memberKey = memberMessageIds.join(",")
   const branchStreamIds = useMemo(
@@ -236,46 +312,58 @@ export function useInlineBranchComposer(params: {
 
   const renderAfterMessage = useCallback(
     (messageId: string): ReactNode => {
-      if (openComposer?.kind !== "new-subtopic" || openComposer.messageId !== messageId) return null
-      const { streamId } = openComposer
-      return (
-        <InlineComposerForm
-          workspaceId={workspaceId}
-          streamId={streamId}
-          memoAnchorStreamId={streamId}
-          draftKey={boardSubtopicDraftKey(streamId, messageId)}
-          placeholder="Start a sub-topic…"
-          rejectE2e={E2E_SUBTOPIC_MESSAGE}
-          onSubmit={(sendInput) => submitNewSubtopic(streamId, messageId, sendInput)}
-          onClose={closeComposer}
-        />
-      )
+      if (openComposer?.kind === "new-subtopic" && openComposer.messageId === messageId) {
+        const { streamId } = openComposer
+        return (
+          <InlineComposerForm
+            workspaceId={workspaceId}
+            streamId={streamId}
+            memoAnchorStreamId={streamId}
+            draftKey={boardSubtopicDraftKey(streamId, messageId)}
+            placeholder="Start a sub-topic…"
+            rejectE2e={E2E_SUBTOPIC_MESSAGE}
+            restoreStashedIdOnMount={openComposer.restoreStashedId ?? null}
+            onSubmit={(sendInput) => submitNewSubtopic(streamId, messageId, sendInput)}
+            onClose={closeComposer}
+          />
+        )
+      }
+      const entry = subtopicDraftIndex.get(messageId)
+      if (entry) {
+        return (
+          <SubtopicDraftIndicator
+            entry={entry}
+            onOpen={(restoreStashedId) => openNewSubtopic(entry.streamId, messageId, restoreStashedId)}
+          />
+        )
+      }
+      return null
     },
-    [openComposer, workspaceId, submitNewSubtopic, closeComposer]
+    [openComposer, workspaceId, submitNewSubtopic, closeComposer, subtopicDraftIndex, openNewSubtopic]
   )
 
   const renderBranchTail = useCallback(
     (branch: BranchConversationView): ReactNode => {
+      // A pending branch's conversation id is a synthetic draft-panel id that
+      // dies when the echo lands — a draft keyed by it would orphan at
+      // promotion. Key by the fork message (the sub-topic scope, the one
+      // stable identity across the hand-off); the send routes through the same
+      // converging sub-topic path either way. The collapsed affordance
+      // advertises the same scope so preview and hydrate can't diverge.
+      const pendingEntry = pendingEntryFor(branch)
+      const tailDraftKey = pendingEntry
+        ? boardSubtopicDraftKey(pendingEntry.streamId, pendingEntry.messageId)
+        : boardBranchReplyDraftKey(branch.conversationId)
       if (openComposer?.kind === "branch-reply" && openComposer.conversationId === branch.conversationId) {
         // A pending branch's thread may not exist yet — host the composer on the
         // parent stream (mention context + E2E gate), like the opening gesture.
-        const pendingEntry = pendingEntryFor(branch)
         const hostStreamId = pendingEntry?.streamId ?? branch.threadStreamId
         return (
           <InlineComposerForm
             workspaceId={workspaceId}
             streamId={hostStreamId}
             memoAnchorStreamId={hostStreamId}
-            // A pending branch's conversation id is a synthetic draft-panel id
-            // that dies when the echo lands — a draft keyed by it would orphan
-            // at promotion. Key by the fork message (the sub-topic scope, the
-            // one stable identity across the hand-off); the send routes through
-            // the same converging sub-topic path either way.
-            draftKey={
-              pendingEntry
-                ? boardSubtopicDraftKey(pendingEntry.streamId, pendingEntry.messageId)
-                : boardBranchReplyDraftKey(branch.conversationId)
-            }
+            draftKey={tailDraftKey}
             placeholder="Reply…"
             // A pending branch's `title` is the "New sub-topic" placeholder (the
             // real topic isn't extracted until the echo), so name the target
@@ -287,20 +375,18 @@ export function useInlineBranchComposer(params: {
             scheduleTarget={
               branch.pending ? undefined : { streamId: branch.threadStreamId, conversationId: branch.conversationId }
             }
+            restoreStashedIdOnMount={openComposer.restoreStashedId ?? null}
             onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
             onClose={closeComposer}
           />
         )
       }
       return (
-        <button
-          type="button"
-          onClick={() => openBranchReply(branch)}
-          className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <Reply className="h-3.5 w-3.5 shrink-0" />
-          Reply
-        </button>
+        <BranchTailAffordance
+          workspaceId={workspaceId}
+          scope={tailDraftKey}
+          onOpen={(restoreStashedId) => openBranchReply(branch, restoreStashedId)}
+        />
       )
     },
     [openComposer, workspaceId, submitBranchReply, closeComposer, openBranchReply, pendingEntryFor]

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -242,6 +242,11 @@ export function useInlineBranchComposer(params: {
             // generically rather than echoing the placeholder back.
             contextChip={branch.pending ? "Replying in this sub-topic" : `Replying in ${branch.title}`}
             rejectE2e={E2E_REPLY_MESSAGE}
+            // A pending branch's conversation id is a synthetic draft-panel id
+            // (no real target until the echo lands), so scheduling waits for it.
+            scheduleTarget={
+              branch.pending ? undefined : { streamId: branch.threadStreamId, conversationId: branch.conversationId }
+            }
             onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
             onClose={closeComposer}
           />

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { Reply } from "lucide-react"
 import { StreamTypes } from "@threa/types"
 import { useQueueDraftMessage } from "@/hooks/use-queue-draft-message"
+import { useStashParamDraftRow } from "@/hooks"
+import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { createDraftPanelId } from "@/contexts"
 import { collectBranchThreadStreamIds } from "@/hooks/use-conversation-graph"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
@@ -90,6 +92,33 @@ export function useInlineBranchComposer(params: {
     // memberMessageIds captured via memberKey (stable string, not the array ref).
     [conversationId, memberKey, index, graph]
   )
+
+  // A drafts-explorer deep link (`?stash=<draftId>`) targeting a branch-tail or
+  // new-sub-topic draft lands with those composers unmounted (they exist only
+  // while their gesture is open), so this surface opens the right one when the
+  // named draft's scope belongs to a branch/member of THIS conversation —
+  // ownership is structural (the branch threads this surface renders / the
+  // fork message's owning conversation), since sub-topic conversations carry no
+  // `parentConversationId`. The mounted form's own `useStashComposer` then
+  // restores the row and strips the param; the panel's bottom reply handles
+  // `board:reply:*` the same way.
+  const stashTarget = useStashParamDraftRow(workspaceId)
+  const consumedStashRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!stashTarget || consumedStashRef.current === stashTarget.draftId) return
+    const parsed = parseBoardDraftKey(stashTarget.scope)
+    if (!parsed || parsed.kind === "reply") return
+    if (parsed.kind === "branch-reply") {
+      const threadStreamId = graph.conversationById.get(parsed.conversationId)?.conversation.streamId
+      if (!threadStreamId || !branchStreamIds.includes(threadStreamId)) return
+      consumedStashRef.current = stashTarget.draftId
+      setOpenComposer({ kind: "branch-reply", conversationId: parsed.conversationId, threadStreamId })
+      return
+    }
+    if (graph.conversationIdByMemberMessageId.get(parsed.messageId) !== conversationId) return
+    consumedStashRef.current = stashTarget.draftId
+    setOpenComposer({ kind: "new-subtopic", streamId: parsed.streamId, messageId: parsed.messageId })
+  }, [stashTarget, graph, branchStreamIds, conversationId])
 
   // A pending sub-topic is handed to the graph path only once BOTH its thread
   // stream exists (promotion) AND the child conversation is cached — dropping it
@@ -230,13 +259,23 @@ export function useInlineBranchComposer(params: {
       if (openComposer?.kind === "branch-reply" && openComposer.conversationId === branch.conversationId) {
         // A pending branch's thread may not exist yet — host the composer on the
         // parent stream (mention context + E2E gate), like the opening gesture.
-        const hostStreamId = pendingEntryFor(branch)?.streamId ?? branch.threadStreamId
+        const pendingEntry = pendingEntryFor(branch)
+        const hostStreamId = pendingEntry?.streamId ?? branch.threadStreamId
         return (
           <InlineComposerForm
             workspaceId={workspaceId}
             streamId={hostStreamId}
             memoAnchorStreamId={hostStreamId}
-            draftKey={boardBranchReplyDraftKey(branch.conversationId)}
+            // A pending branch's conversation id is a synthetic draft-panel id
+            // that dies when the echo lands — a draft keyed by it would orphan
+            // at promotion. Key by the fork message (the sub-topic scope, the
+            // one stable identity across the hand-off); the send routes through
+            // the same converging sub-topic path either way.
+            draftKey={
+              pendingEntry
+                ? boardSubtopicDraftKey(pendingEntry.streamId, pendingEntry.messageId)
+                : boardBranchReplyDraftKey(branch.conversationId)
+            }
             placeholder="Reply…"
             // A pending branch's `title` is the "New sub-topic" placeholder (the
             // real topic isn't extracted until the echo), so name the target

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -5,6 +5,7 @@ import { useQueueDraftMessage } from "@/hooks/use-queue-draft-message"
 import { createDraftPanelId } from "@/contexts"
 import { collectBranchThreadStreamIds } from "@/hooks/use-conversation-graph"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
+import { boardBranchReplyDraftKey, boardSubtopicDraftKey } from "@/lib/board/draft-keys"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 import type { ConversationGraph, StreamStructuralIndex } from "@/hooks/use-conversation-graph"
 import type { RenderableMessage } from "@/components/message/message-item"
@@ -213,7 +214,7 @@ export function useInlineBranchComposer(params: {
           workspaceId={workspaceId}
           streamId={streamId}
           memoAnchorStreamId={streamId}
-          draftKey={`board:subtopic:${streamId}:${messageId}`}
+          draftKey={boardSubtopicDraftKey(streamId, messageId)}
           placeholder="Start a sub-topic…"
           rejectE2e={E2E_SUBTOPIC_MESSAGE}
           onSubmit={(sendInput) => submitNewSubtopic(streamId, messageId, sendInput)}
@@ -235,7 +236,7 @@ export function useInlineBranchComposer(params: {
             workspaceId={workspaceId}
             streamId={hostStreamId}
             memoAnchorStreamId={hostStreamId}
-            draftKey={`board:branch-reply:${branch.conversationId}`}
+            draftKey={boardBranchReplyDraftKey(branch.conversationId)}
             placeholder="Reply…"
             // A pending branch's `title` is the "New sub-topic" placeholder (the
             // real topic isn't extracted until the echo), so name the target

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { CornerDownRight, Pencil, Reply } from "lucide-react"
+import { CornerDownRight, Reply } from "lucide-react"
 import { StreamTypes } from "@threa/types"
 import { useQueueDraftMessage } from "@/hooks/use-queue-draft-message"
 import { useBoardSubtopicDraftIndex, useScopeDraftPreview, useStashParamDraftRow } from "@/hooks"
 import type { SubtopicDraftEntry } from "@/hooks"
+import { rescopeScopeDrafts } from "@/hooks/use-draft-message"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { DraftRestingPreview } from "@/components/board/board-reply-composer"
 import { createDraftPanelId } from "@/contexts"
@@ -66,9 +67,12 @@ function BranchTailAffordance({
 
 /**
  * Marks a message row whose "new sub-topic" gesture holds an unsent draft
- * while that composer is unmounted: the branch arrow + the draft's first line,
- * clickable to reopen the gesture with the draft in it. Without this the
- * draft is only discoverable through the context menu (Kris 2026-07-13).
+ * while that composer is unmounted: the branch arrow + the same draft pill the
+ * branch tail uses (one presentation for a sub-conversation draft whether or
+ * not the branch has materialized — Kris 2026-07-13), clickable to reopen the
+ * gesture with the draft in it. Rendered only while NO branch exists under the
+ * message; once one materializes, the draft is rescoped onto its tail (see the
+ * migration effect in the hook) so this and the branch never show together.
  */
 function SubtopicDraftIndicator({
   entry,
@@ -81,12 +85,11 @@ function SubtopicDraftIndicator({
     <button
       type="button"
       onClick={() => onOpen(entry.isCheckedOut ? null : entry.draftId)}
-      className="mt-2 flex w-fit min-w-0 max-w-full items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      className="mt-2 flex w-full min-w-0 items-center gap-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
     >
       <CornerDownRight className="h-3.5 w-3.5 shrink-0" />
-      <Pencil aria-label="Unsent sub-topic draft" className="h-3 w-3 shrink-0" />
-      <span className="min-w-0 truncate">
-        {entry.preview || `${entry.attachmentCount} attachment${entry.attachmentCount === 1 ? "" : "s"}`}
+      <span className="flex min-w-0 flex-1 items-center rounded-[16px] border border-input bg-card p-3">
+        <DraftRestingPreview draft={entry} />
       </span>
     </button>
   )
@@ -161,6 +164,26 @@ export function useInlineBranchComposer(params: {
   // Unsent sub-topic drafts by fork message id — marks the rows whose gesture
   // composer is unmounted but holds a draft (rendered by `renderAfterMessage`).
   const subtopicDraftIndex = useBoardSubtopicDraftIndex(workspaceId)
+
+  // A "new sub-topic" draft is a reply into a branch that doesn't exist yet;
+  // the moment the branch materializes they are the same target, so the draft
+  // follows it onto the branch scope (loaded pointer and stash siblings alike,
+  // server-mirrored). Without this a stash from before the branch existed
+  // lingers as a second "create a sub-conversation" affordance NEXT TO the
+  // branch it was for (Kris's screenshots, 2026-07-13). Skipped while this
+  // surface has an inline composer open — a live editor's flushes would race
+  // the move; the effect re-fires once it closes (or another surface, both are
+  // idempotent: the rescope no-ops on rows already moved).
+  useEffect(() => {
+    if (openComposer !== null) return
+    for (const entry of subtopicDraftIndex.values()) {
+      const thread = index.threadsByParentMessageId.get(entry.messageId)
+      if (!thread) continue
+      const branchPost = graph.conversationByAnchorStreamId.get(thread.id)
+      if (!branchPost) continue
+      void rescopeScopeDrafts(workspaceId, entry.scope, boardBranchReplyDraftKey(branchPost.id))
+    }
+  }, [subtopicDraftIndex, index, graph, workspaceId, openComposer])
 
   const memberKey = memberMessageIds.join(",")
   const branchStreamIds = useMemo(
@@ -330,6 +353,12 @@ export function useInlineBranchComposer(params: {
       }
       const entry = subtopicDraftIndex.get(messageId)
       if (entry) {
+        // A materialized branch owns this draft (the migration effect is moving
+        // it onto the tail); never render the "create a sub-conversation"
+        // affordance next to the sub-conversation it was for.
+        const thread = index.threadsByParentMessageId.get(messageId)
+        const materialized = thread !== undefined && graph.conversationByAnchorStreamId.has(thread.id)
+        if (materialized) return null
         return (
           <SubtopicDraftIndicator
             entry={entry}
@@ -339,7 +368,7 @@ export function useInlineBranchComposer(params: {
       }
       return null
     },
-    [openComposer, workspaceId, submitNewSubtopic, closeComposer, subtopicDraftIndex, openNewSubtopic]
+    [openComposer, workspaceId, submitNewSubtopic, closeComposer, subtopicDraftIndex, openNewSubtopic, index, graph]
   )
 
   const renderBranchTail = useCallback(

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -129,6 +129,12 @@ function mountPanel(opts: {
 }
 
 beforeEach(() => {
+  // Default composer stub: the real form (desktop always-open since the
+  // thread-semantics ruling) pulls auth/mention providers this harness doesn't
+  // mount. Tests that inspect composer props install their own spy.
+  vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation(() => (
+    <button type="button">Write a reply…</button>
+  ))
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
@@ -175,10 +181,16 @@ describe("ConversationPanel", () => {
     expect(getBoardPost).not.toHaveBeenCalled()
   })
 
-  it("offers a scoped reply affordance", async () => {
+  it("offers a scoped reply affordance with thread-composer semantics (desktop always-open)", async () => {
+    let captured: boolean | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      captured = props.desktopAlwaysOpen
+      return <button type="button">Write a reply…</button>
+    })
     mountPanel({ cached: asCached(makePost()) })
     await screen.findByText("Opening message body.")
     expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
+    expect(captured).toBe(true)
   })
 
   it("bumps openReplySignal on the composer when opened via 'Reply in conversation' (queued request)", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -24,6 +24,8 @@ import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as shareHandoffModule from "@/stores/share-handoff-store"
 import * as boardReplyComposerModule from "@/components/board/board-reply-composer"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+import * as stashedDraftsModule from "@/hooks/use-stashed-drafts"
+import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import {
   requestConversationReplyOpen,
   resetConversationReplyOpenStoreCache,
@@ -95,6 +97,8 @@ function mountPanel(opts: {
   getBoardMessages?: () => Promise<BoardPostMessage[]>
   /** `?m=` deep-link target appended to the panel URL. */
   highlightMessageId?: string
+  /** `?stash=` drafts-explorer restore param appended to the panel URL. */
+  stashParam?: string
 }) {
   const getBoardPost = vi.fn(opts.getBoardPost ?? (async () => makePost()))
   const getBoardMessages = vi.fn(
@@ -102,7 +106,9 @@ function mountPanel(opts: {
   )
   vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(opts.cached as never)
 
-  const mParam = opts.highlightMessageId ? `&m=${opts.highlightMessageId}` : ""
+  const mParam =
+    (opts.highlightMessageId ? `&m=${opts.highlightMessageId}` : "") +
+    (opts.stashParam ? `&stash=${opts.stashParam}` : "")
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
@@ -196,6 +202,46 @@ describe("ConversationPanel", () => {
       return <></>
     })
     mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    expect(captured).toBe(0)
+  })
+
+  it("opens the reply composer for a ?stash= deep link whose row belongs to its reply scope", async () => {
+    // The drafts explorer deep-links a stashed board reply to the panel; the
+    // collapsed resting affordance mounts no composer, so the panel itself must
+    // open the form for the stash restore to have a consumer.
+    vi.spyOn(stashedDraftsModule, "useStashedDrafts").mockImplementation(
+      (_ws, scope) =>
+        ({
+          drafts: scope === boardReplyDraftKey(CONVERSATION_ID) ? [{ id: "draft_owned" }] : [],
+          isLoaded: true,
+          deleteStashedDraft: vi.fn(),
+        }) as unknown as ReturnType<typeof stashedDraftsModule.useStashedDrafts>
+    )
+    let captured: number | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      captured = props.openReplySignal
+      return <></>
+    })
+    mountPanel({ cached: asCached(makePost()), stashParam: "draft_owned" })
+    await screen.findByText("Opening message body.")
+    await waitFor(() => expect(captured).toBe(1))
+  })
+
+  it("ignores a ?stash= param whose row is not in its reply scope's pile", async () => {
+    // A foreign scope's stash id (e.g. a thread draft on the same route) must be
+    // left for its own host — opening here would strand the restore.
+    vi.spyOn(stashedDraftsModule, "useStashedDrafts").mockReturnValue({
+      drafts: [],
+      isLoaded: true,
+      deleteStashedDraft: vi.fn(),
+    } as unknown as ReturnType<typeof stashedDraftsModule.useStashedDrafts>)
+    let captured: number | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      captured = props.openReplySignal
+      return <></>
+    })
+    mountPanel({ cached: asCached(makePost()), stashParam: "draft_foreign" })
     await screen.findByText("Opening message body.")
     expect(captured).toBe(0)
   })

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -55,6 +55,8 @@ import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
 import { useActors, useVisibleStreams } from "@/hooks"
+import { useStashedDrafts } from "@/hooks/use-stashed-drafts"
+import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useConversationService, usePanel, parseConversationPanel, useSidebar } from "@/contexts"
@@ -111,6 +113,24 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
     bump()
     return subscribeConversationReplyOpen(conversationId, bump)
   }, [conversationId])
+
+  // A drafts-explorer deep link (`?panel=conv:<id>&stash=<draftId>`) lands here
+  // with the reply form collapsed — no composer is mounted, so nothing would
+  // consume the restore. When the stash id belongs to THIS panel's reply scope,
+  // open the composer; the mounted form's own `useStashComposer` then restores
+  // the row and strips the param. Ownership-checked so a foreign scope's param
+  // (e.g. a thread draft on the same route) is left for its own host.
+  const [searchParams] = useSearchParams()
+  const stashParam = searchParams.get("stash")
+  const replyScope = conversationId ? boardReplyDraftKey(conversationId) : undefined
+  const stashedReplyDrafts = useStashedDrafts(workspaceId, stashParam ? replyScope : undefined)
+  const stashOpenedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!stashParam || stashOpenedRef.current === stashParam) return
+    if (!stashedReplyDrafts.drafts.some((draft) => draft.id === stashParam)) return
+    stashOpenedRef.current = stashParam
+    setOpenReplySignal((n) => n + 1)
+  }, [stashParam, stashedReplyDrafts.drafts])
 
   // Keep the conversation's streams (root + threads) caught up + joined while the
   // panel is open, so the rail is live and offline-first. Its own SyncEngine slot,

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -652,6 +652,9 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
             hostStreamType={hostStreamType}
             lastActiveStreamId={lastActiveStreamId}
             openReplySignal={openReplySignal}
+            // The panel is a dedicated conversation view — thread-composer
+            // semantics: always open on desktop, collapsed⇄focused on mobile.
+            desktopAlwaysOpen
           />
         </div>
       </QuoteReplyProvider>

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -55,7 +55,7 @@ export { useDraftMessage, getDraftMessageKey } from "./use-draft-message"
 
 export { useStashedDrafts, type UseStashedDraftsResult, type CachedDraft } from "./use-stashed-drafts"
 
-export { useStashComposer, type UseStashComposerResult } from "./use-stash-composer"
+export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } from "./use-stash-composer"
 
 export {
   useDecryptedDraftPreviews,

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -58,6 +58,13 @@ export { useStashedDrafts, type UseStashedDraftsResult, type CachedDraft } from 
 export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } from "./use-stash-composer"
 
 export {
+  useScopeDraftPreview,
+  useBoardSubtopicDraftIndex,
+  type ScopeDraftPreview,
+  type SubtopicDraftEntry,
+} from "./use-scope-draft-preview"
+
+export {
   useDecryptedDraftPreviews,
   type DraftPreview,
   type DraftPreviewStatus,

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -67,6 +67,7 @@ beforeEach(async () => {
   await db.composerLoaded.clear()
   await db.pendingOperations.clear()
   await db.draftScratchpads.clear()
+  await db.conversations.clear()
   // The drafts explorer now decrypts E2E previews via the shared cache, which
   // reads the viewer id + session; default them to "no viewer / locked" so these
   // plaintext-draft tests run without an AuthProvider (INV-48 namespace spyOn).
@@ -79,6 +80,82 @@ beforeEach(async () => {
     deviceTrusted: false,
     error: null,
   } as ReturnType<typeof e2eSessionStore.useE2eSession>)
+})
+
+describe("useAllDrafts board-composer drafts", () => {
+  async function seedConversation(conversationId: string, streamId: string, topicSummary: string | null) {
+    await db.conversations.put({
+      id: conversationId,
+      workspaceId,
+      _lastActivityMs: 1,
+      _cachedAt: 1,
+      conversation: { id: conversationId, streamId, topicSummary },
+    } as unknown as Parameters<typeof db.conversations.put>[0])
+  }
+
+  it("lists a stashed board reply with a panel deep link that carries the stash restore", async () => {
+    await seedConversation("conv_1", "stream_9", "GPU budget")
+    await db.drafts.add(syncedDraft({ id: "draft_b1", scope: "board:reply:conv_1" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts).toHaveLength(1))
+    expect(result.current.drafts[0]).toMatchObject({
+      id: "draft_b1",
+      displayName: "Reply in GPU budget",
+      streamId: "stream_9",
+      isStashed: true,
+      href: `/w/${workspaceId}/s/stream_9?panel=${encodeURIComponent("conv:conv_1")}&stash=draft_b1`,
+    })
+  })
+
+  it("lists a branch reply and a sub-topic draft, navigable but without a stash param (no mounted consumer)", async () => {
+    await seedConversation("conv_2", "stream_thread_1", "Sub topic")
+    await db.drafts.add(syncedDraft({ id: "draft_b2", scope: "board:branch-reply:conv_2" }))
+    await db.drafts.add(syncedDraft({ id: "draft_b3", scope: "board:subtopic:stream_9:msg_1", clientUpdatedAt: 900 }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts).toHaveLength(2))
+    expect(result.current.drafts[0]).toMatchObject({
+      id: "draft_b2",
+      displayName: "Reply in Sub topic",
+      href: `/w/${workspaceId}/s/stream_thread_1?panel=${encodeURIComponent("conv:conv_2")}`,
+    })
+    expect(result.current.drafts[1]).toMatchObject({
+      id: "draft_b3",
+      displayName: "New sub-topic",
+      href: `/w/${workspaceId}/s/stream_9?m=msg_1`,
+    })
+  })
+
+  it("still links (via the board route) while the conversation isn't cached, so roamed pickup never dead-ends", async () => {
+    await db.drafts.add(syncedDraft({ id: "draft_b4", scope: "board:reply:conv_uncached" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts).toHaveLength(1))
+    expect(result.current.drafts[0]).toMatchObject({
+      id: "draft_b4",
+      displayName: "Conversation reply",
+      href: `/w/${workspaceId}/board?panel=${encodeURIComponent("conv:conv_uncached")}&stash=draft_b4`,
+    })
+  })
+
+  it("counts board drafts in the sidebar summary without flagging a stream hint", async () => {
+    await db.drafts.add(syncedDraft({ id: "draft_b5", scope: "board:reply:conv_1" }))
+    await db.drafts.add(syncedDraft({ id: "draft_s9", scope: "stream:stream_1" }))
+    await db.composerLoaded.put({ scope: "stream:stream_1", workspaceId, draftId: "draft_s9" })
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useDraftSummary(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.draftCount).toBe(2))
+    expect(result.current.loadedDraftStreamIdSignature).toBe("stream_1")
+  })
 })
 
 describe("useAllDrafts deleteDraft", () => {

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -68,6 +68,7 @@ beforeEach(async () => {
   await db.pendingOperations.clear()
   await db.draftScratchpads.clear()
   await db.conversations.clear()
+  await db.streams.clear()
   // The drafts explorer now decrypts E2E previews via the shared cache, which
   // reads the viewer id + session; default them to "no viewer / locked" so these
   // plaintext-draft tests run without an AuthProvider (INV-48 namespace spyOn).
@@ -83,13 +84,18 @@ beforeEach(async () => {
 })
 
 describe("useAllDrafts board-composer drafts", () => {
-  async function seedConversation(conversationId: string, streamId: string, topicSummary: string | null) {
+  async function seedConversation(
+    conversationId: string,
+    streamId: string,
+    topicSummary: string | null,
+    extra: { parentConversationId?: string; messageIds?: string[] } = {}
+  ) {
     await db.conversations.put({
       id: conversationId,
       workspaceId,
       _lastActivityMs: 1,
       _cachedAt: 1,
-      conversation: { id: conversationId, streamId, topicSummary },
+      conversation: { id: conversationId, streamId, topicSummary, ...extra },
     } as unknown as Parameters<typeof db.conversations.put>[0])
   }
 
@@ -143,6 +149,48 @@ describe("useAllDrafts board-composer drafts", () => {
       displayName: "Conversation reply",
       href: `/w/${workspaceId}/board?panel=${encodeURIComponent("conv:conv_uncached")}&stash=draft_b4`,
     })
+  })
+
+  it("deep-links a branch reply to its PARENT conversation's panel with the stash restore", async () => {
+    // Parenthood is structural: the branch's anchor thread forks off a message
+    // that is a member of the parent conversation (no parentConversationId).
+    await seedConversation("conv_parent", "stream_9", "GPU budget", { messageIds: ["msg_fork_b"] })
+    await seedConversation("conv_branch", "stream_thread_1", "Sub topic")
+    await db.streams.put({
+      id: "stream_thread_1",
+      workspaceId,
+      type: "thread",
+      parentStreamId: "stream_9",
+      parentMessageId: "msg_fork_b",
+    } as unknown as Parameters<typeof db.streams.put>[0])
+    await db.drafts.add(syncedDraft({ id: "draft_b6", scope: "board:branch-reply:conv_branch" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() =>
+      expect(result.current.drafts[0]).toMatchObject({
+        id: "draft_b6",
+        displayName: "Reply in Sub topic",
+        href: `/w/${workspaceId}/s/stream_9?panel=${encodeURIComponent("conv:conv_parent")}&stash=draft_b6`,
+      })
+    )
+  })
+
+  it("deep-links a sub-topic draft to the conversation hosting its fork message, with the stash restore", async () => {
+    await seedConversation("conv_host", "stream_9", "GPU budget", { messageIds: ["msg_fork"] })
+    await db.drafts.add(syncedDraft({ id: "draft_b7", scope: "board:subtopic:stream_9:msg_fork" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() =>
+      expect(result.current.drafts[0]).toMatchObject({
+        id: "draft_b7",
+        displayName: "New sub-topic in GPU budget",
+        href: `/w/${workspaceId}/s/stream_9?panel=${encodeURIComponent("conv:conv_host")}&stash=draft_b7`,
+      })
+    )
   })
 
   it("counts board drafts in the sidebar summary without flagging a stream hint", async () => {

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -1,6 +1,8 @@
 import { useLiveQuery } from "dexie-react-hooks"
 import { useCallback, useMemo } from "react"
-import { db, type CachedDraft, type CachedStream } from "@/db"
+import { db, type CachedBoardPost, type CachedDraft, type CachedStream } from "@/db"
+import { createConversationPanelId } from "@/contexts"
+import { parseBoardDraftKey, type ParsedBoardDraftKey } from "@/lib/board/draft-keys"
 import {
   deleteDraftScratchpadFromCache,
   useComposerLoadedFromStore,
@@ -195,6 +197,56 @@ function resolveDraftLocation(
   }
 }
 
+/** A board draft's host stream type, for the explorer's type-driven rendering. */
+function streamDraftType(stream: CachedStream | undefined): DraftType {
+  return stream && isValidDraftType(stream.type) ? stream.type : "channel"
+}
+
+/**
+ * Location resolution for `board:*` draft scopes (the board's inline reply
+ * composers). Reply drafts deep-link to the conversation panel on the anchor
+ * stream's route (`?panel=conv:<id>`), which hosts the same composer scope and
+ * consumes a `?stash=` restore; sub-topic drafts link to the fork message in
+ * its timeline. A conversation not yet in the local cache (a roamed draft on a
+ * fresh device) keeps a generic label but still links — via the board route,
+ * whose panel fetches the post by id — so cross-device pickup never dead-ends.
+ */
+function resolveBoardDraftLocation(
+  parsed: ParsedBoardDraftKey,
+  workspaceId: string,
+  streamMap: Map<string, CachedStream>,
+  boardPostMap: Map<string, CachedBoardPost>
+): ResolvedDraftLocation {
+  if (parsed.kind === "subtopic") {
+    const stream = streamMap.get(parsed.streamId)
+    const displayName = stream ? `New sub-topic in ${streamLabel(stream, "sidebar")}` : "New sub-topic"
+    return {
+      draftType: streamDraftType(stream),
+      streamId: parsed.streamId,
+      displayName,
+      href: `/w/${workspaceId}/s/${parsed.streamId}?m=${parsed.messageId}`,
+      groupLabel: displayName,
+    }
+  }
+
+  const post = boardPostMap.get(parsed.conversationId)
+  const anchorStreamId = post?.conversation.streamId ?? null
+  const stream = anchorStreamId ? streamMap.get(anchorStreamId) : undefined
+  const target = post?.conversation.topicSummary ?? (stream ? streamLabel(stream, "sidebar") : null)
+  const displayName = target ? `Reply in ${target}` : "Conversation reply"
+  const panelParam = `panel=${encodeURIComponent(createConversationPanelId(parsed.conversationId))}`
+  const href = anchorStreamId
+    ? `/w/${workspaceId}/s/${anchorStreamId}?${panelParam}`
+    : `/w/${workspaceId}/board?${panelParam}`
+  return {
+    draftType: streamDraftType(stream),
+    streamId: anchorStreamId,
+    displayName,
+    href,
+    groupLabel: displayName,
+  }
+}
+
 /**
  * Stream ids whose composer holds a *loaded* (checked-in, non-stashed) draft,
  * derived from {@link useAllDrafts} output. A stashed draft holds no composer
@@ -289,6 +341,34 @@ export function useAllDrafts(workspaceId: string) {
     return map
   }, [cachedStreams])
 
+  // Conversations referenced by board-scoped drafts (`board:reply:` /
+  // `board:branch-reply:`), for location resolution. Keyed on the id set (not
+  // the drafts array) so a body keystroke doesn't re-fire the query.
+  const boardConversationIdKey = useMemo(() => {
+    const ids = new Set<string>()
+    for (const scope of scopesSignature.split("|")) {
+      const parsed = parseBoardDraftKey(scope)
+      if (parsed && parsed.kind !== "subtopic") ids.add(parsed.conversationId)
+    }
+    return [...ids].sort().join(",")
+  }, [scopesSignature])
+
+  const cachedBoardPosts = useLiveQuery(
+    async () => {
+      if (!boardConversationIdKey) return []
+      const rows = await db.conversations.bulkGet(boardConversationIdKey.split(","))
+      return rows.filter((row): row is CachedBoardPost => row !== undefined && row.workspaceId === workspaceId)
+    },
+    [boardConversationIdKey, workspaceId],
+    []
+  )
+
+  const boardPostMap = useMemo(() => {
+    const map = new Map<string, CachedBoardPost>()
+    for (const post of cachedBoardPosts ?? []) map.set(post.id, post)
+    return map
+  }, [cachedBoardPosts])
+
   // Build a map of messageId -> streamId for looking up parent messages
   // Thread drafts use payload.messageId as key, not event.id
   const messageToStreamMap = useMemo(() => {
@@ -369,26 +449,35 @@ export function useAllDrafts(workspaceId: string) {
       }
     }
 
-    // Every other draft — channels, DMs, threads — loaded (ambient) or stashed.
+    // Every other draft — channels, DMs, threads, board replies — loaded
+    // (ambient) or stashed.
     for (const draft of allDrafts) {
       const parsed = parseDraftMessageKey(draft.scope)
-      if (!parsed) continue
+      const board = parsed ? null : parseBoardDraftKey(draft.scope)
+      if (!parsed && !board) continue
 
       // Scratchpad-scoped drafts: the loaded one is handled above; any stash
       // siblings are skipped in the explorer until the scratchpad flow itself
       // supports them.
-      if (parsed.type === "stream" && isDraftId(parsed.id)) continue
+      if (parsed && parsed.type === "stream" && isDraftId(parsed.id)) continue
 
       if (!draftHasPayload(draft)) continue
 
-      const resolved = resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
+      const resolved = parsed
+        ? resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
+        : resolveBoardDraftLocation(board!, workspaceId, streamMap, boardPostMap)
       const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
 
       // A stashed row deep-links via `?stash=<draftId>` so the composer host
       // pops + restores it on mount; the loaded (ambient) row navigates plainly
-      // since its content is already checked out.
+      // since its content is already checked out. Only surfaces with a mounted
+      // consumer get the param: the stream composer, the thread panel, and the
+      // conversation panel's reply — a branch-tail or sub-topic composer is
+      // unmounted until its gesture opens, so those rows navigate plainly and
+      // the draft is picked up from that composer's own pile.
+      const supportsStashRestore = parsed !== null || board!.kind === "reply"
       const href =
-        isStashed && resolved.href
+        isStashed && resolved.href && supportsStashRestore
           ? resolved.href + (resolved.href.includes("?") ? "&" : "?") + `stash=${encodeURIComponent(draft.id)}`
           : resolved.href
 
@@ -412,7 +501,17 @@ export function useAllDrafts(workspaceId: string) {
     result.sort((a, b) => b.updatedAt - a.updatedAt)
 
     return result
-  }, [draftScratchpads, allDrafts, draftsById, loadedByScope, streamMap, messageToStreamMap, previewMap, workspaceId])
+  }, [
+    draftScratchpads,
+    allDrafts,
+    draftsById,
+    loadedByScope,
+    streamMap,
+    messageToStreamMap,
+    boardPostMap,
+    previewMap,
+    workspaceId,
+  ])
 
   // Delete a draft by its `UnifiedDraft.id`. Scratchpad rows carry a scratchpad
   // id; every other row carries a unified draft id — both `draft_`-prefixed, so
@@ -500,7 +599,13 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
 
     for (const draft of allDrafts) {
       const parsed = parseDraftMessageKey(draft.scope)
-      if (!parsed) continue
+      if (!parsed) {
+        // Board-composer drafts count toward the badge like any other (the
+        // explorer lists them), but carry no per-stream sidebar hint — the
+        // draft belongs to a conversation composer, not the stream's own.
+        if (parseBoardDraftKey(draft.scope) && draftHasPayload(draft)) draftCount++
+        continue
+      }
       // Scratchpad-scoped rows are counted above; skip them and their siblings.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
       if (!draftHasPayload(draft)) continue

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -204,28 +204,46 @@ function streamDraftType(stream: CachedStream | undefined): DraftType {
 
 /**
  * Location resolution for `board:*` draft scopes (the board's inline reply
- * composers). Reply drafts deep-link to the conversation panel on the anchor
- * stream's route (`?panel=conv:<id>`), which hosts the same composer scope and
- * consumes a `?stash=` restore; sub-topic drafts link to the fork message in
- * its timeline. A conversation not yet in the local cache (a roamed draft on a
- * fresh device) keeps a generic label but still links — via the board route,
- * whose panel fetches the post by id — so cross-device pickup never dead-ends.
+ * composers). Every kind deep-links to the conversation panel that HOSTS the
+ * draft's composer — a reply to its own conversation, a branch reply to the
+ * branch's parent, a sub-topic to the conversation containing the fork message
+ * — so the `?stash=` restore always lands where a consumer can auto-open the
+ * form. A conversation not yet in the local cache (a roamed draft on a fresh
+ * device) keeps a generic label but still links via the board route, whose
+ * panel fetches the post by id, so cross-device pickup never dead-ends.
+ * `supportsStashRestore` is false only where no consumer surface is known (a
+ * branch whose parent isn't resolvable, a fork message in no cached
+ * conversation) — those rows navigate plainly for manual pickup.
  */
 function resolveBoardDraftLocation(
   parsed: ParsedBoardDraftKey,
   workspaceId: string,
   streamMap: Map<string, CachedStream>,
-  boardPostMap: Map<string, CachedBoardPost>
-): ResolvedDraftLocation {
+  boardPostMap: Map<string, CachedBoardPost>,
+  subtopicHostByMessageId: Map<string, CachedBoardPost>,
+  parentPostByBranchConversationId: Map<string, CachedBoardPost>
+): ResolvedDraftLocation & { supportsStashRestore: boolean } {
+  const panelHref = (conversationId: string, anchorStreamId: string | null) => {
+    const panelParam = `panel=${encodeURIComponent(createConversationPanelId(conversationId))}`
+    return anchorStreamId
+      ? `/w/${workspaceId}/s/${anchorStreamId}?${panelParam}`
+      : `/w/${workspaceId}/board?${panelParam}`
+  }
+
   if (parsed.kind === "subtopic") {
+    const host = subtopicHostByMessageId.get(parsed.messageId)
     const stream = streamMap.get(parsed.streamId)
-    const displayName = stream ? `New sub-topic in ${streamLabel(stream, "sidebar")}` : "New sub-topic"
+    const context = host?.conversation.topicSummary ?? (stream ? streamLabel(stream, "sidebar") : null)
+    const displayName = context ? `New sub-topic in ${context}` : "New sub-topic"
     return {
       draftType: streamDraftType(stream),
       streamId: parsed.streamId,
       displayName,
-      href: `/w/${workspaceId}/s/${parsed.streamId}?m=${parsed.messageId}`,
+      href: host
+        ? panelHref(host.id, host.conversation.streamId)
+        : `/w/${workspaceId}/s/${parsed.streamId}?m=${parsed.messageId}`,
       groupLabel: displayName,
+      supportsStashRestore: host !== undefined,
     }
   }
 
@@ -234,17 +252,21 @@ function resolveBoardDraftLocation(
   const stream = anchorStreamId ? streamMap.get(anchorStreamId) : undefined
   const target = post?.conversation.topicSummary ?? (stream ? streamLabel(stream, "sidebar") : null)
   const displayName = target ? `Reply in ${target}` : "Conversation reply"
-  const panelParam = `panel=${encodeURIComponent(createConversationPanelId(parsed.conversationId))}`
-  const href = anchorStreamId
-    ? `/w/${workspaceId}/s/${anchorStreamId}?${panelParam}`
-    : `/w/${workspaceId}/board?${panelParam}`
-  return {
-    draftType: streamDraftType(stream),
-    streamId: anchorStreamId,
-    displayName,
-    href,
-    groupLabel: displayName,
+  const shared = { draftType: streamDraftType(stream), streamId: anchorStreamId, displayName, groupLabel: displayName }
+
+  if (parsed.kind === "branch-reply") {
+    // The branch-tail composer lives on the parent conversation's surface —
+    // derived structurally (anchor thread's parent message → its conversation).
+    const parent = parentPostByBranchConversationId.get(parsed.conversationId)
+    if (parent) {
+      return { ...shared, href: panelHref(parent.id, parent.conversation.streamId), supportsStashRestore: true }
+    }
+    // Parent unresolvable (branch or its thread not cached): the branch's own
+    // panel at least shows the conversation for manual pickup.
+    return { ...shared, href: panelHref(parsed.conversationId, anchorStreamId), supportsStashRestore: false }
   }
+
+  return { ...shared, href: panelHref(parsed.conversationId, anchorStreamId), supportsStashRestore: true }
 }
 
 /**
@@ -353,15 +375,86 @@ export function useAllDrafts(workspaceId: string) {
     return [...ids].sort().join(",")
   }, [scopesSignature])
 
-  const cachedBoardPosts = useLiveQuery(
-    async () => {
-      if (!boardConversationIdKey) return []
-      const rows = await db.conversations.bulkGet(boardConversationIdKey.split(","))
-      return rows.filter((row): row is CachedBoardPost => row !== undefined && row.workspaceId === workspaceId)
-    },
-    [boardConversationIdKey, workspaceId],
+  const boardBranchConversationIdKey = useMemo(() => {
+    const ids = new Set<string>()
+    for (const scope of scopesSignature.split("|")) {
+      const parsed = parseBoardDraftKey(scope)
+      if (parsed?.kind === "branch-reply") ids.add(parsed.conversationId)
+    }
+    return [...ids].sort().join(",")
+  }, [scopesSignature])
+
+  // Sub-topic drafts name only their fork message; branch drafts name a child
+  // conversation whose parent must be derived structurally (its anchor thread's
+  // parent message → the conversation holding it — sub-topic conversations
+  // carry no `parentConversationId`). Both resolve to the HOSTING conversation
+  // the explorer deep-links to, since that surface hosts the draft's composer.
+  const subtopicMessageIdKey = useMemo(() => {
+    const ids = new Set<string>()
+    for (const scope of scopesSignature.split("|")) {
+      const parsed = parseBoardDraftKey(scope)
+      if (parsed?.kind === "subtopic") ids.add(parsed.messageId)
+    }
+    return [...ids].sort().join(",")
+  }, [scopesSignature])
+
+  const emptyBoardContext = useMemo(
+    () => ({
+      posts: [] as CachedBoardPost[],
+      hostPostByMessageId: new Map<string, CachedBoardPost>(),
+      parentPostByBranchConversationId: new Map<string, CachedBoardPost>(),
+    }),
     []
   )
+
+  const boardDraftContext = useLiveQuery(
+    async () => {
+      if (!boardConversationIdKey && !subtopicMessageIdKey) return emptyBoardContext
+      const convIds = boardConversationIdKey ? boardConversationIdKey.split(",") : []
+      const branchIds = new Set(boardBranchConversationIdKey ? boardBranchConversationIdKey.split(",") : [])
+      const referencedRows = convIds.length > 0 ? await db.conversations.bulkGet(convIds) : []
+      const referenced = referencedRows.filter(
+        (row): row is CachedBoardPost => row !== undefined && row.workspaceId === workspaceId
+      )
+
+      const forkMessageIds = new Set(subtopicMessageIdKey ? subtopicMessageIdKey.split(",") : [])
+      const branchPosts = referenced.filter((row) => branchIds.has(row.id))
+      const threadRows =
+        branchPosts.length > 0 ? await db.streams.bulkGet(branchPosts.map((row) => row.conversation.streamId)) : []
+      const forkByBranchConversationId = new Map<string, string>()
+      branchPosts.forEach((row, i) => {
+        const parentMessageId = threadRows[i]?.parentMessageId
+        if (parentMessageId) {
+          forkByBranchConversationId.set(row.id, parentMessageId)
+          forkMessageIds.add(parentMessageId)
+        }
+      })
+
+      const hostPostByMessageId = new Map<string, CachedBoardPost>()
+      let hostRows: CachedBoardPost[] = []
+      if (forkMessageIds.size > 0) {
+        const rows = await db.conversations.where("workspaceId").equals(workspaceId).toArray()
+        hostRows = rows.filter((row) => row.conversation.messageIds?.some((id: string) => forkMessageIds.has(id)))
+        for (const post of hostRows) {
+          for (const id of post.conversation.messageIds ?? []) {
+            if (forkMessageIds.has(id)) hostPostByMessageId.set(id, post)
+          }
+        }
+      }
+      const parentPostByBranchConversationId = new Map<string, CachedBoardPost>()
+      for (const [branchId, forkId] of forkByBranchConversationId) {
+        const host = hostPostByMessageId.get(forkId)
+        if (host) parentPostByBranchConversationId.set(branchId, host)
+      }
+      return { posts: [...referenced, ...hostRows], hostPostByMessageId, parentPostByBranchConversationId }
+    },
+    [boardConversationIdKey, boardBranchConversationIdKey, subtopicMessageIdKey, workspaceId, emptyBoardContext],
+    emptyBoardContext
+  )
+
+  const cachedBoardPosts = boardDraftContext.posts
+  const subtopicHostByMessageId = boardDraftContext.hostPostByMessageId
+  const parentPostByBranchConversationId = boardDraftContext.parentPostByBranchConversationId
 
   const boardPostMap = useMemo(() => {
     const map = new Map<string, CachedBoardPost>()
@@ -463,19 +556,27 @@ export function useAllDrafts(workspaceId: string) {
 
       if (!draftHasPayload(draft)) continue
 
+      const boardResolved = board
+        ? resolveBoardDraftLocation(
+            board,
+            workspaceId,
+            streamMap,
+            boardPostMap,
+            subtopicHostByMessageId,
+            parentPostByBranchConversationId
+          )
+        : null
       const resolved = parsed
         ? resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
-        : resolveBoardDraftLocation(board!, workspaceId, streamMap, boardPostMap)
+        : boardResolved!
       const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
 
       // A stashed row deep-links via `?stash=<draftId>` so the composer host
-      // pops + restores it on mount; the loaded (ambient) row navigates plainly
-      // since its content is already checked out. Only surfaces with a mounted
-      // consumer get the param: the stream composer, the thread panel, and the
-      // conversation panel's reply — a branch-tail or sub-topic composer is
-      // unmounted until its gesture opens, so those rows navigate plainly and
-      // the draft is picked up from that composer's own pile.
-      const supportsStashRestore = parsed !== null || board!.kind === "reply"
+      // pops + restores it on arrival; the loaded (ambient) row navigates
+      // plainly since its content is already checked out. Board rows carry the
+      // param only when a consumer surface was resolved (see
+      // `resolveBoardDraftLocation`).
+      const supportsStashRestore = parsed !== null || boardResolved!.supportsStashRestore
       const href =
         isStashed && resolved.href && supportsStashRestore
           ? resolved.href + (resolved.href.includes("?") ? "&" : "?") + `stash=${encodeURIComponent(draft.id)}`
@@ -509,6 +610,8 @@ export function useAllDrafts(workspaceId: string) {
     streamMap,
     messageToStreamMap,
     boardPostMap,
+    subtopicHostByMessageId,
+    parentPostByBranchConversationId,
     previewMap,
     workspaceId,
   ])

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { JSONContent } from "@threa/types"
+import { db } from "@/db"
+import { useScopeDraftPreview, useBoardSubtopicDraftIndex } from "./use-scope-draft-preview"
+
+const workspaceId = "ws_1"
+const scope = "board:reply:conv_1"
+
+const doc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
+})
+
+async function seed(id: string, draftScope: string, text: string, clientUpdatedAt: number) {
+  await db.drafts.add({ id, workspaceId, scope: draftScope, contentJson: doc(text), attachments: [], clientUpdatedAt })
+}
+
+beforeEach(async () => {
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
+})
+
+describe("useScopeDraftPreview", () => {
+  it("returns null when the scope has no draft with payload", async () => {
+    await seed("draft_empty", scope, "", 1000)
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(result.current).toBeNull()
+  })
+
+  it("prefers the checked-out row over a newer stashed sibling", async () => {
+    await seed("draft_loaded", scope, "checked out body", 1000)
+    await seed("draft_stashed", scope, "newer stashed body", 2000)
+    await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_loaded" })
+
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() =>
+      expect(result.current).toMatchObject({ draftId: "draft_loaded", preview: "checked out body", isCheckedOut: true })
+    )
+  })
+
+  it("falls back to the newest row (not checked out) when the pointer is absent — the roamed-draft shape", async () => {
+    await seed("draft_old", scope, "older", 1000)
+    await seed("draft_new", scope, "newest roamed body", 2000)
+
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() =>
+      expect(result.current).toMatchObject({ draftId: "draft_new", preview: "newest roamed body", isCheckedOut: false })
+    )
+  })
+})
+
+describe("useBoardSubtopicDraftIndex", () => {
+  it("keys sub-topic drafts by their fork message id, ignoring other scopes", async () => {
+    await seed("draft_st", "board:subtopic:stream_9:msg_fork", "subtopic body", 1000)
+    await seed("draft_reply", "board:reply:conv_1", "reply body", 1000)
+
+    const { result } = renderHook(() => useBoardSubtopicDraftIndex(workspaceId))
+    await waitFor(() => expect(result.current.size).toBe(1))
+    expect(result.current.get("msg_fork")).toMatchObject({
+      draftId: "draft_st",
+      streamId: "stream_9",
+      scope: "board:subtopic:stream_9:msg_fork",
+      preview: "subtopic body",
+      isCheckedOut: false,
+    })
+  })
+})

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -1,0 +1,119 @@
+import { useLiveQuery } from "dexie-react-hooks"
+import { db, type CachedDraft } from "@/db"
+import { draftInlineText } from "@/lib/drafts/decryption"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+
+export interface ScopeDraftPreview {
+  draftId: string
+  /** One-line plain text of the draft body; "" for an attachment-only draft. */
+  preview: string
+  attachmentCount: number
+  /**
+   * True when the row is checked out into this device's composer (the ambient
+   * auto-save) — opening the composer hydrates it by itself. False for a
+   * stashed or roamed row (the loaded pointer is device-local), where the
+   * opener must restore the row explicitly for the advertised draft to appear.
+   */
+  isCheckedOut: boolean
+}
+
+function hasPayload(draft: CachedDraft): boolean {
+  return draft.ciphertext != null || !isEmptyContent(draft.contentJson) || (draft.attachments?.length ?? 0) > 0
+}
+
+function toPreview(best: CachedDraft, loadedDraftId: string | null): ScopeDraftPreview {
+  return {
+    draftId: best.id,
+    preview: draftInlineText(best.contentJson),
+    attachmentCount: best.attachments?.length ?? 0,
+    isCheckedOut: best.id === loadedDraftId,
+  }
+}
+
+/** The checked-out row when there is one, else the newest — what a resting
+ *  affordance should advertise. */
+function bestRow(rows: CachedDraft[], loadedDraftId: string | null): CachedDraft | null {
+  const withPayload = rows.filter(hasPayload)
+  if (withPayload.length === 0) return null
+  return (
+    withPayload.find((row) => row.id === loadedDraftId) ??
+    withPayload.reduce((a, b) => (b.clientUpdatedAt > a.clientUpdatedAt ? b : a))
+  )
+}
+
+/**
+ * The draft a collapsed composer affordance for `scope` should advertise —
+ * the same "your unsent text, one line" presentation the mobile composer's
+ * collapsed bar uses. A Dexie range query on the `[workspaceId+scope]` index
+ * (plus the scope's loaded pointer), so it re-fires only on this scope's own
+ * rows — cheap enough per board card. Null when the scope holds nothing worth
+ * showing.
+ */
+export function useScopeDraftPreview(workspaceId: string, scope: string): ScopeDraftPreview | null {
+  const result = useLiveQuery(
+    async () => {
+      const [rows, loaded] = await Promise.all([
+        db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray(),
+        db.composerLoaded.get(scope),
+      ])
+      const best = bestRow(rows, loaded?.draftId ?? null)
+      return best ? toPreview(best, loaded?.draftId ?? null) : null
+    },
+    [workspaceId, scope],
+    null
+  )
+  return result
+}
+
+export interface SubtopicDraftEntry extends ScopeDraftPreview {
+  scope: string
+  streamId: string
+  messageId: string
+}
+
+/**
+ * Every new-sub-topic draft in the workspace, keyed by its fork message id —
+ * so a conversation surface can mark the message rows that carry an unsent
+ * sub-topic draft while the gesture's composer is unmounted. One range query
+ * over the `board:subtopic:` scope prefix per surface (the rows are few and
+ * only change on draft edits under that prefix).
+ */
+export function useBoardSubtopicDraftIndex(workspaceId: string): Map<string, SubtopicDraftEntry> {
+  const result = useLiveQuery(
+    async () => {
+      const rows = await db.drafts
+        .where("[workspaceId+scope]")
+        .between([workspaceId, "board:subtopic:"], [workspaceId, "board:subtopic:\uffff"])
+        .toArray()
+      if (rows.length === 0) return new Map<string, SubtopicDraftEntry>()
+
+      const byScope = new Map<string, CachedDraft[]>()
+      for (const row of rows) {
+        const list = byScope.get(row.scope)
+        if (list) list.push(row)
+        else byScope.set(row.scope, [row])
+      }
+      const loadedRows = await db.composerLoaded.bulkGet([...byScope.keys()])
+      const loadedByScope = new Map([...byScope.keys()].map((scope, i) => [scope, loadedRows[i]?.draftId ?? null]))
+
+      const map = new Map<string, SubtopicDraftEntry>()
+      for (const [scope, scopeRows] of byScope) {
+        const parsed = parseBoardDraftKey(scope)
+        if (parsed?.kind !== "subtopic") continue
+        const best = bestRow(scopeRows, loadedByScope.get(scope) ?? null)
+        if (!best) continue
+        map.set(parsed.messageId, {
+          ...toPreview(best, loadedByScope.get(scope) ?? null),
+          scope,
+          streamId: parsed.streamId,
+          messageId: parsed.messageId,
+        })
+      }
+      return map
+    },
+    [workspaceId],
+    undefined
+  )
+  return result ?? new Map<string, SubtopicDraftEntry>()
+}

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -73,9 +73,9 @@ function wrapper({ children }: { children: ReactNode }) {
   return createElement(MemoryRouter, { initialEntries: ["/"] }, children)
 }
 
-function useRestoreHarness() {
-  const composer = useDraftComposer({ workspaceId, draftKey, scopeId: streamId })
-  const stash = useStashComposer(composer, workspaceId, draftKey)
+function useRestoreHarness(key: string = draftKey, scopeId: string = streamId) {
+  const composer = useDraftComposer({ workspaceId, draftKey: key, scopeId })
+  const stash = useStashComposer(composer, workspaceId, key)
   return { composer, stash }
 }
 
@@ -132,5 +132,28 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
     expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId)
     // 4) The previously-loaded ambient draft is preserved as a stash sibling (swap, not clobber).
     await waitFor(() => expect(result.current.stash.drafts.some((d) => d.id === ambientId)).toBe(true))
+  })
+
+  it("?stash= auto-restore is consumed only by the host whose scope owns the row", async () => {
+    const { bigId } = await seedStashAndAmbient()
+    const foreignKey = "board:reply:conv_1"
+
+    function urlWrapper({ children }: { children: ReactNode }) {
+      return createElement(MemoryRouter, { initialEntries: [`/?stash=${bigId}`] }, children)
+    }
+
+    // A host on a DIFFERENT scope must not consume the param: pointing its own
+    // loaded slot at the foreign row would split one draft across two composers.
+    const foreign = renderHook(() => useRestoreHarness(foreignKey, foreignKey), { wrapper: urlWrapper })
+    await waitFor(() => expect(foreign.result.current.composer.isLoaded).toBe(true))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+    expect((await db.composerLoaded.get(foreignKey))?.draftId).not.toBe(bigId)
+    foreign.unmount()
+
+    // The owning host consumes it and checks the row out.
+    renderHook(() => useRestoreHarness(), { wrapper: urlWrapper })
+    await waitFor(async () => expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId))
   })
 })

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "@/db"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { restoreStashedDraftToComposer, stashLoadedDraft } from "./use-draft-message"
 import { useStashedDrafts, type CachedDraft } from "./use-stashed-drafts"
@@ -31,6 +33,22 @@ export interface UseStashComposerResult {
  * plaintext ever leaving memory (E2EE-4) — so the pile works the same for
  * plaintext and E2E streams with no special-casing here.
  */
+/**
+ * The draft row named by the URL's `?stash=` param, for surfaces that must
+ * decide whether a deep-linked restore is theirs to host (e.g. a board card /
+ * conversation panel auto-opening a branch-tail composer). A Dexie point query
+ * on the one id — it re-fires only when that row changes, so it's cheap enough
+ * to mount per board card. Returns null when there is no param, the row hasn't
+ * synced yet, or it belongs to another workspace.
+ */
+export function useStashParamDraftRow(workspaceId: string): { draftId: string; scope: string } | null {
+  const [searchParams] = useSearchParams()
+  const draftId = searchParams.get("stash")
+  const row = useLiveQuery(() => (draftId ? db.drafts.get(draftId) : undefined), [draftId])
+  if (!draftId || !row || row.workspaceId !== workspaceId) return null
+  return { draftId, scope: row.scope }
+}
+
 export function useStashComposer(
   composer: DraftComposerState,
   workspaceId: string,

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -96,6 +96,12 @@ export function useStashComposer(
   useEffect(() => {
     const stashId = searchParams.get("stash")
     if (!stashId || !scope || !composer.isLoaded) return
+    // Only the host whose scope owns the row consumes the param. Several hosts
+    // can mount this hook at once (stream composer + thread panel + inline
+    // reply forms); restoring a foreign id would point THIS scope's loaded
+    // draft at another scope's row, splitting one draft across two composers.
+    // Skipping (without stripping) leaves the param for the owning host.
+    if (!stashedDrafts.drafts.some((draft) => draft.id === stashId)) return
     if (pendingStashRestoreRef.current === stashId) return
 
     pendingStashRestoreRef.current = stashId
@@ -112,7 +118,7 @@ export function useStashComposer(
         console.error("Failed to auto-restore stashed draft from URL", err)
       }
     )
-  }, [searchParams, setSearchParams, scope, composer.isLoaded, handleRestoreStashed])
+  }, [searchParams, setSearchParams, scope, composer.isLoaded, stashedDrafts.drafts, handleRestoreStashed])
 
   return {
     drafts: stashedDrafts.drafts,

--- a/apps/frontend/src/lib/board/draft-keys.ts
+++ b/apps/frontend/src/lib/board/draft-keys.ts
@@ -1,0 +1,47 @@
+/**
+ * Draft-scope keys for the board's inline composers (INV-33: one source of
+ * truth). Three surfaces persist drafts under `board:*` scopes, and the drafts
+ * explorer parses them back to a location — builders and parser live together
+ * so a key format change can't strand rows.
+ */
+
+const REPLY_PREFIX = "board:reply:"
+const BRANCH_REPLY_PREFIX = "board:branch-reply:"
+const SUBTOPIC_PREFIX = "board:subtopic:"
+
+/** The card/panel bottom "Write a reply…" composer, per conversation. */
+export function boardReplyDraftKey(conversationId: string): string {
+  return `${REPLY_PREFIX}${conversationId}`
+}
+
+/** A nested branch's tail reply composer, per branch conversation. */
+export function boardBranchReplyDraftKey(conversationId: string): string {
+  return `${BRANCH_REPLY_PREFIX}${conversationId}`
+}
+
+/** The "new sub-topic" gesture under a message row. */
+export function boardSubtopicDraftKey(streamId: string, messageId: string): string {
+  return `${SUBTOPIC_PREFIX}${streamId}:${messageId}`
+}
+
+export type ParsedBoardDraftKey =
+  | { kind: "reply" | "branch-reply"; conversationId: string }
+  | { kind: "subtopic"; streamId: string; messageId: string }
+
+export function parseBoardDraftKey(key: string): ParsedBoardDraftKey | null {
+  if (key.startsWith(REPLY_PREFIX)) {
+    const conversationId = key.slice(REPLY_PREFIX.length)
+    return conversationId ? { kind: "reply", conversationId } : null
+  }
+  if (key.startsWith(BRANCH_REPLY_PREFIX)) {
+    const conversationId = key.slice(BRANCH_REPLY_PREFIX.length)
+    return conversationId ? { kind: "branch-reply", conversationId } : null
+  }
+  if (key.startsWith(SUBTOPIC_PREFIX)) {
+    const rest = key.slice(SUBTOPIC_PREFIX.length)
+    const sep = rest.indexOf(":")
+    if (sep <= 0 || sep >= rest.length - 1) return null
+    return { kind: "subtopic", streamId: rest.slice(0, sep), messageId: rest.slice(sep + 1) }
+  }
+  return null
+}

--- a/apps/frontend/src/lib/board/draft-keys.ts
+++ b/apps/frontend/src/lib/board/draft-keys.ts
@@ -25,7 +25,8 @@ export function boardSubtopicDraftKey(streamId: string, messageId: string): stri
 }
 
 export type ParsedBoardDraftKey =
-  | { kind: "reply" | "branch-reply"; conversationId: string }
+  | { kind: "reply"; conversationId: string }
+  | { kind: "branch-reply"; conversationId: string }
   | { kind: "subtopic"; streamId: string; messageId: string }
 
 export function parseBoardDraftKey(key: string): ParsedBoardDraftKey | null {


### PR DESCRIPTION
## Problem

The shared inline composer core (`InlineComposerForm` in `board-inline-composer.tsx`) — mounted by the board card's bottom reply, the conversation panel's reply (opened from the board *or* a stream timeline), branch-tail replies, and the "new sub-topic" gesture — had neither stashed drafts nor scheduled sends, both of which the timeline's `MessageInput` has had for a while. Kris's follow-up on #1305: "I'm also missing scheduled messages and drafts in both views which sucks." #1305's design decision 3 deliberately left this out of scope; this PR is that follow-up.

## Solution

Wire both affordances into the shared core once, so all four surfaces inherit them — nothing is duplicated per call site.

### How it works

**Stashed drafts** — unconditional. `InlineComposerForm` binds `useStashComposer(composer, workspaceId, draftKey)` (the same hook `MessageInput` and `StreamPanel` use) and passes `onStashDraft` + `StashedDraftsPicker` (compact + fab variants) to `MessageComposer`, which also enables the remappable ⌘S stash shortcut. The pile is scoped per reply target (`board:reply:<conversationId>`, `board:branch-reply:<conversationId>`, `board:subtopic:<streamId>:<messageId>`). Inline drafts are plaintext (no `e2eStreamId` on the composer), so the picker's own `contentJson` fallback previews suffice — no decrypt pass.

**Scheduled sends** — gated on a new `scheduleTarget?: { streamId, conversationId }` prop. A scheduled send can't run the call site's live routing (`useReplyToBoardPost` resolves flat-reply vs. thread-conversion at send time), so the call site declares the resolved target up front and the fired message files by id: `handleSchedule` calls `useScheduleMessage` with `conversation: { intent: "existing", conversationId }` — the exact shape `MessageInput.handleSchedule` uses for an armed "Reply in conversation", relying on the same documented fire-time forwarding on `ScheduleMessageInput`. Who passes it:

- **Board/panel reply** (`board-reply-composer.tsx`): `{ streamId: post.conversation.streamId, conversationId: post.conversation.id }`.
- **Branch-tail reply** (`use-inline-branch-composer.tsx`): `{ streamId: branch.threadStreamId, conversationId: branch.conversationId }` — omitted while the branch is `pending` (its conversation id is a synthetic draft-panel id; nothing real to name).
- **New sub-topic**: omitted — the thread stream and conversation don't exist until send (`streamCreation` rides the live send only), so the affordance is absent rather than pretending.

`handleSchedule` mirrors `handleSubmit`'s mechanics: E2E reject gate (same `rejectE2e` toast), materialize pending attachment refs, clear the editor up front, restore on failure, `resolveDraft` + collapse the form on success (same as a send).

**Drafts explorer + cross-device pickup (commit 3, after Kris's dogfood report).** Board drafts always synced (the same server-backed `db.drafts` + operation queue every draft rides — `scope` is opaque on the wire), but `useAllDrafts`/`useDraftSummary` only parsed `stream:`/`thread:` scopes, so `board:*` rows were invisible in the `/drafts` explorer and the sidebar quick-link count — and since inbound sync never sets the device-local `composerLoaded` pointer, the explorer's `?stash=` deep link is the *designed* cross-device pickup path, making roamed board drafts effectively unreachable. Now: a new `lib/board/draft-keys.ts` is the single source of truth for the three scope keys (INV-33; composer call sites use its builders); `useAllDrafts` resolves them via `db.conversations` — a reply draft lists as "Reply in \<topic\>" and deep-links to the conversation panel on the anchor stream's route (`?panel=conv:<id>&stash=<draftId>` when stashed), falling back to the board route (whose panel fetches the post by id) when the conversation isn't cached locally, so a fresh device never dead-ends; `ConversationPanel` consumes the stash param by bumping its existing `openReplySignal` when the id belongs to its reply scope (the collapsed resting affordance mounts no composer, so the panel itself must open the form); `useDraftSummary` counts board drafts, fixing the quick-link count and the Drafts link folding away at zero.

**Branch-tail + sub-topic auto-open (commit 4, after Kris's second dogfood pass).** Those two composers mount only while their gesture is open, so commit 3 left their explorer rows navigate-only. Now `useInlineBranchComposer` (shared by board card and panel) consumes the `?stash=` param via a new `useStashParamDraftRow` (a Dexie point query on the one id — re-fires only on that row, cheap per card): a `branch-reply` stash whose thread this surface renders opens that branch's tail; a `subtopic` stash whose fork message is a member here opens the new-sub-topic form; the mounted form's own `useStashComposer` restores. Ownership and the explorer's deep-link targets are **structural** — a branch's parent is its anchor thread's `parentMessageId` → the conversation holding it — because sub-topic conversations carry no `parentConversationId` (verified against the live DB; the first cut wrongly assumed the field is populated, and only the live run caught it). Also fixed live: a reply typed into a still-*pending* branch tail was draft-keyed by the branch's synthetic draft-panel id, which dies at promotion, orphaning the draft — it now keys by the stable sub-topic scope (fork message), whose send path converges on the same child.

**In-situ draft visibility (commit 5, Kris's third dogfood pass: "hiding stuff is the opposite of discoverability").** The resting affordances now *show* the draft instead of a generic label, using the mobile composer's collapsed-preview presentation (`getPreviewText` bar in `message-composer.tsx` is the reference): the card/panel bottom reply button renders the draft's first line + pencil; a branch tail swaps its quiet "Reply" link for the same preview pill; and a fork message whose closed sub-topic gesture holds a draft shows branch-arrow + pencil + preview inline (`SubtopicDraftIndicator`). Backed by `useScopeDraftPreview` (checked-out row first, else newest — the roamed shape) on the `[workspaceId+scope]` index and `useBoardSubtopicDraftIndex` (sub-topic drafts keyed by fork message, one prefix range query per surface). Clicking an affordance that advertised a not-checked-out row passes `restoreStashedIdOnMount` to `InlineComposerForm`, which checks the row out once mounted — the click always surfaces exactly what the button showed, including roamed drafts on a fresh device.

**Thread-composer semantics for the panel (commit 6, Kris's composer ruling).** The conversation panel's composer behaves like a thread's: always open on desktop (only the open state — send/Escape/blur leave it mounted, like the timeline), collapsed⇄focused on mobile. `BoardReplyComposer` gains `desktopAlwaysOpen` (the panel passes it): in that mode the form mounts permanently with a no-op `onClose`, `autoFocus` off, and "open the reply composer" requests (`openReplySignal`, incl. the `?stash=` bump) become focus requests via a new `focusSignal` prop on `InlineComposerForm`; the drafts-explorer restore is consumed by the always-mounted form's own URL effect. The deliberate exceptions, per the ruling: board cards (composers aren't kept mounted per card) and the inline sub-conversation affordances keep the collapsed resting state.

**Sub-topic drafts merge into their branch (commit 7, Kris's screenshots: indicator + branch + tail draft stacking).** A draft to *create* a sub-conversation is a reply into a branch that doesn't exist yet; once the branch materializes they are the same target, so `useInlineBranchComposer` migrates `board:subtopic:` drafts onto the branch's scope (`rescopeScopeDrafts` — loaded pointer and stash siblings follow, server-mirrored), skipped while the surface has an open inline composer so live flushes can't race the move (idempotent across surfaces). `renderAfterMessage` additionally never renders the create-indicator next to a materialized branch, closing the one-frame gap before migration lands. The indicator itself now renders the same draft pill as the branch tail, prefixed with the branch arrow — one presentation for a sub-conversation draft in both states.

**`?stash=` auto-restore hardened (caught in self-review, commit 2).** `useStashComposer`'s URL auto-restore called `restoreStashedDraftToComposer` without checking the row belongs to its scope. Multiple hosts already coexist (stream composer + thread panel), and this PR mounts the hook in every open inline form — a foreign host consuming the param would point its own loaded slot at another scope's row, splitting one draft across two composers. The effect now consumes the param only when the id is in its own scope's pile (leaving it for the owning host); the regression test proves the foreign host skips and the owning host restores, and fails with the guard reverted.

### Key design decisions

**1. Declared schedule target, not deferred routing.** The alternative — persisting the call site's routing inputs on the scheduled row and re-running `useReplyToBoardPost` at fire time — would need new schema and a worker-side re-implementation of client routing. The existing `conversation` directive on `ScheduleMessageInput` already does the right thing ("stored on the row and forwarded to the send at fire time"; cross-stream within one root is allowed), at the cost of one divergence from live sends: a scheduled board reply never thread-converts a lone post — it posts flat into the conversation's stream and attaches by id. Same tradeoff `MessageInput` already accepted for armed scheduled replies.

**2. Absent affordance over a disabled one.** New sub-topic and pending branches simply don't render the schedule picker. A disabled trigger would need an explanation surface ("why can't I schedule this?") for a state most users never hit; the picker not existing until the target does is the honest UI.

**3. No `useDecryptedDraftPreviews` pass.** The other hosts run it because their drafts can be sealed (E2E scopes). Inline drafts can't be — `useDraftComposer` is constructed without `e2eStreamId` — and `StashedDraftsPicker` documents the `previewById`-absent fallback as the plaintext-caller path.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-inline-composer.tsx` | Stash pile + pickers wired into the shared props; `scheduleTarget` prop + `handleSchedule` |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Passes `scheduleTarget` (conversation stream + id) |
| `apps/frontend/src/components/board/use-inline-branch-composer.tsx` | Branch tail passes `scheduleTarget`; `?stash=` consumer (auto-opens branch tail / sub-topic form); pending-branch drafts keyed by the stable sub-topic scope |
| `apps/frontend/src/components/board/use-inline-branch-composer.test.tsx` | New: 3 consumer tests (branch auto-open, sub-topic auto-open, foreign scope ignored) |
| `apps/frontend/src/hooks/use-stash-composer.ts` | `?stash=` consumer now scope-owned (see above); new `useStashParamDraftRow` point-query hook |
| `apps/frontend/src/components/board/board-inline-composer.test.tsx` | 4 new tests: wiring, schedule directive + close, failure restore, E2E gate |
| `apps/frontend/src/hooks/use-stash-composer.test.ts` | Regression test for the scope-owned `?stash=` consumer |
| `apps/frontend/src/lib/board/draft-keys.ts` | New: board draft-scope key builders + parser (single source of truth) |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Board scopes in the explorer + summary count; conversation resolution via `db.conversations` |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Consumes the `?stash=` deep link via `openReplySignal` (scope-ownership checked) |
| `apps/frontend/src/hooks/use-all-drafts.test.ts` | 4 new tests: reply/branch/sub-topic resolution, uncached fallback, summary count |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | 2 new tests: stash deep link opens the composer; foreign param ignored |

## Out of scope (deliberate)

- **Scheduling a new sub-topic** (would require schedulable `streamCreation`) — see design decision 2.
- **Auto-restore for a branch draft whose branch conversation isn't cached locally** — the parent is then unresolvable, so the row links to the branch's own panel for manual pickup (`supportsStashRestore: false`). Requires a fresh device plus a board cache missing that branch; rare enough to accept.

## Test plan

- [x] `apps/frontend` vitest: `src/components/board` + `src/components/conversations` — 138 pass (incl. 4 new inline-composer tests)
- [x] `apps/frontend` vitest: `src/components/composer` + `src/hooks` — 810 pass (incl. the new stash-guard regression test)
- [x] Stash-guard regression test confirmed to fail with the guard reverted (git stash round-trip)
- [x] `tsc --noEmit` frontend app + test configs clean (pre-commit runs the full monorepo typecheck)
- [x] Live-verified on `dev:test` via scripted Playwright: pickers present in the board reply composer; type → stash → row in pile → restore back into the editor; schedule "In 1 hour" → form collapses → row shows in the picker (`Scheduled (1 pending)`) and on `/scheduled`; new sub-topic composer has Drafts but no Scheduled trigger. Screenshots checked, incl. a settled-popover pass to rule out a z-index artifact (was mid-animation).
- [x] Commit 3 suites: `src/components/board` + `src/components/conversations` + `src/hooks` — 868 pass (incl. 6 new explorer/panel tests)
- [x] Two-device live verify (two isolated Playwright contexts = separate IndexedDBs, one server): stash a board reply on device A → sidebar shows `Drafts (1)` and `/drafts` lists "Reply in \<topic\>" on A → device B (fresh IDB) sees the roamed row in `/drafts` → click → conversation panel opens, reply composer auto-opens, draft body restored. Screenshots checked.
- [x] Commit 4 suites: board + conversations + hooks — 876 pass (incl. 3 new `useInlineBranchComposer` consumer tests; explorer tests updated to the structural-parent model)
- [x] Commit 4 live verify on `dev:test`: stash in the new-sub-topic composer → `/drafts` shows "New sub-topic in ⟨host⟩" → click auto-opens the gesture with the body restored; after the branch settles on the board, stash in its tail → `/drafts` → click opens the PARENT conversation's panel with the branch-tail composer holding the draft. Screenshots checked.
- [x] Commit 5 suites: board + conversations + hooks — 880 pass (incl. 7 new tests: scope-preview hook, restore-on-mount, sub-topic indicator)
- [x] Commit 5 live verify on `dev:test`: ambient draft shows on the resting button and hydrates on reopen; a stashed row is advertised after a reload and checked back out on click; the fork message shows the inline sub-topic indicator and clicking reopens the gesture with the body. Screenshots checked.
- [x] Commit 6 suites: board + conversations + hooks — 883 pass (incl. 3 new `BoardReplyComposer` variant tests; panel harness stubs the composer by default now that desktop mounts the real form)
- [x] Commit 6 live verify on `dev:test`: desktop panel mounts the composer with no resting button and it stays open across a send; board card keeps the collapsed affordance; mobile panel (390×844 touch context) keeps the collapsed⇄focused pair. Screenshots checked.
- [x] Commit 7: 884 suites pass (new migration test proves the draft lands on the branch scope and the indicator disappears)
- [x] Commit 7 live verify of the exact reported repro on `dev:test`: stash a sub-topic draft → send (branch materializes) → exactly ONE affordance for the old stash (the branch-tail pill; no duplicate indicator) and opening the tail checks it out. Screenshots checked.
- [ ] Mobile floating-pill layout not live-verified (pickers ride the same `MessageComposer` chrome verified in #1305; unit-covered)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786485790&installation_id=129946197&pr_number=1310&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1310&signature=048f1802586b0f4c6231109065ab62c0a04d91517df7ce45766e0dea3e343395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->




