### PR TITLE
feat: resume active harness agents after reboot

### DIFF
--- a/extensions/harness-daemon/package.json
+++ b/extensions/harness-daemon/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "bun src/index.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/extensions/harness-daemon/src/boot.ts
+++ b/extensions/harness-daemon/src/boot.ts
@@ -10,7 +10,9 @@ export function installBootResume(tmux: string): void {
       "install-boot-resume currently supports macOS LaunchAgents only; run boot-resume from your Linux startup service"
     )
   }
-  const entrypoint = resolve(process.argv[1] ?? "")
+  const entrypointArg = process.argv[1]
+  if (!entrypointArg) throw new Error("install-boot-resume: could not determine entrypoint path")
+  const entrypoint = resolve(entrypointArg)
   const bun = process.execPath
   const logDir = join(homedir(), ".threa", "harnessd", "log")
   const plist = join(homedir(), "Library", "LaunchAgents", `${LABEL}.plist`)

--- a/extensions/harness-daemon/src/boot.ts
+++ b/extensions/harness-daemon/src/boot.ts
@@ -1,0 +1,60 @@
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join, resolve } from "node:path"
+
+const LABEL = "io.threa.harnessd.resume-active"
+
+export function installBootResume(tmux: string): void {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "install-boot-resume currently supports macOS LaunchAgents only; run boot-resume from your Linux startup service"
+    )
+  }
+  const entrypoint = resolve(process.argv[1] ?? "")
+  const bun = process.execPath
+  const logDir = join(homedir(), ".threa", "harnessd", "log")
+  const plist = join(homedir(), "Library", "LaunchAgents", `${LABEL}.plist`)
+  mkdirSync(logDir, { recursive: true })
+  mkdirSync(join(homedir(), "Library", "LaunchAgents"), { recursive: true })
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([key, value]) => key.startsWith("THREA_") && Boolean(value))
+  ) as Record<string, string>
+  writeFileSync(plist, launchAgentPlist({ bun, entrypoint, tmux, logDir, path: process.env.PATH ?? "", environment }))
+  chmodSync(plist, 0o600)
+
+  console.log(`harnessd: installed ${LABEL}; it will resume agents in tmux session '${tmux}' at the next login`)
+}
+
+export function launchAgentPlist(params: {
+  bun: string
+  entrypoint: string
+  tmux: string
+  logDir: string
+  path: string
+  environment: Record<string, string>
+}): string {
+  const command = `sleep 15; exec ${shellQuote(params.bun)} ${shellQuote(params.entrypoint)} boot-resume --tmux ${shellQuote(params.tmux)}`
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>${LABEL}</string>
+<key>ProgramArguments</key><array><string>/bin/bash</string><string>-c</string><string>${xmlEscape(command)}</string></array>
+<key>RunAtLoad</key><true/>
+<key>EnvironmentVariables</key><dict><key>PATH</key><string>${xmlEscape(params.path)}</string>${Object.entries(
+    params.environment
+  )
+    .map(([key, value]) => `<key>${xmlEscape(key)}</key><string>${xmlEscape(value)}</string>`)
+    .join("")}</dict>
+<key>StandardOutPath</key><string>${xmlEscape(join(params.logDir, "resume-active.log"))}</string>
+<key>StandardErrorPath</key><string>${xmlEscape(join(params.logDir, "resume-active.error.log"))}</string>
+</dict></plist>
+`
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function xmlEscape(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -9,6 +9,9 @@ Usage:
   threa-harnessd spawn <pi|claude> --name <name> [--branch <ref>] [--repo <path>] [--tmux <session>] [--skip-setup]
   threa-harnessd do <natural language command>
   threa-harnessd list
+  threa-harnessd resume-active [--tmux <session>] [--dry-run] [--force]
+  threa-harnessd boot-resume [--tmux <session>] [--dry-run] [--force]
+  threa-harnessd install-boot-resume [--tmux <session>]
   threa-harnessd stop <agent-id-or-name>
   threa-harnessd interrupt <agent-id-or-name>
   threa-harnessd steer <agent-id-or-name> [follow-up text]
@@ -19,6 +22,8 @@ Usage:
 Examples:
   threa-harnessd spawn pi --name explore-long-chat-perf --branch explore/long-chat-perf
   threa-harnessd spawn claude --name fix-sidebar --branch fix/sidebar
+  threa-harnessd resume-active --dry-run
+  threa-harnessd install-boot-resume
   threa-harnessd do spawn a pi agent for long chat performance
   threa-harnessd interrupt fix-sidebar
   threa-harnessd steer fix-sidebar "also update the tests"
@@ -81,6 +86,15 @@ export function inferBranch(name: string, text?: string): string {
   if (lower.includes("fix")) return `fix/${name.replace(/^fix-/, "")}`
   if (lower.includes("refactor")) return `refactor/${name.replace(/^refactor-/, "")}`
   return `explore/${name.replace(/^explore-/, "")}`
+}
+
+export function parseResume(args: string[]): { tmux?: string; dryRun?: boolean; force?: boolean } {
+  const flags = parseFlags(args)
+  return {
+    tmux: stringFlag(flags, "tmux"),
+    dryRun: boolFlag(flags, "dry-run"),
+    force: boolFlag(flags, "force"),
+  }
 }
 
 export function parseSpawn(args: string[]): SpawnOptions {

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path"
 import { die } from "./errors"
-import type { RuntimeKind, SpawnOptions } from "./types"
+import type { ResumeOptions, RuntimeKind, SpawnOptions } from "./types"
 
 export function usage(): never {
   console.log(`threa-harnessd
@@ -88,7 +88,7 @@ export function inferBranch(name: string, text?: string): string {
   return `explore/${name.replace(/^explore-/, "")}`
 }
 
-export function parseResume(args: string[]): { tmux?: string; dryRun?: boolean; force?: boolean } {
+export function parseResume(args: string[]): ResumeOptions {
   const flags = parseFlags(args)
   return {
     tmux: stringFlag(flags, "tmux"),

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -1,11 +1,16 @@
 import { randomUUID } from "node:crypto"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { installBootResume } from "./boot"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
 import { die } from "./errors"
 import { findAgent, inventoryPath, readInventory, upsertAgent } from "./inventory"
 import { commandExists, commandPath, output } from "./shell"
-import { ClaudeRuntimeSpawner, PiRuntimeSpawner } from "./spawners"
-import { attachedTmuxSession, sendKeys } from "./tmux"
-import type { ManagedAgent, SpawnOptions } from "./types"
+import { ClaudeRuntimeSpawner, PiRuntimeSpawner, readThreaChannelConfig } from "./spawners"
+import { latestAgents, parseScratchpadUrl } from "./resume"
+import { agentWindowExists, attachedTmuxSession, ensureTmuxSession, sendKeys } from "./tmux"
+import type { ManagedAgent, ResumeOptions, SpawnOptions } from "./types"
 
 function spawnCommand(options: SpawnOptions): string[] {
   const command = ["threa-harnessd", "spawn", options.runtime, "--name", options.name]
@@ -58,6 +63,154 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
   } catch (error) {
     upsertAgent({ ...agent, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })
     throw error
+  }
+}
+
+export async function bootResume(options: ResumeOptions): Promise<void> {
+  const session = options.tmux ?? "threa-agents"
+  ensureTmuxSession(session, true)
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const retryable = await resumeActive({ ...options, tmux: session })
+    if (!retryable || options.dryRun) return
+    if (attempt < 3) {
+      console.warn(`harnessd: Threa API unavailable; retrying boot resume (${attempt}/3) in 10 seconds`)
+      await Bun.sleep(10_000)
+    }
+  }
+}
+
+export function installBootResumeAgent(options: ResumeOptions): void {
+  installBootResume(options.tmux ?? "threa-agents")
+}
+
+export async function resumeActive(options: ResumeOptions): Promise<boolean> {
+  output(["tmux", "wait-for", "-L", "harnessd-resume-active"])
+  try {
+    return await resumeActiveUnlocked(options)
+  } finally {
+    output(["tmux", "wait-for", "-U", "harnessd-resume-active"], { allowFailure: true })
+  }
+}
+
+async function resumeActiveUnlocked(options: ResumeOptions): Promise<boolean> {
+  const config = readThreaChannelConfig()
+  const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+  const apiKey = process.env.THREA_API_KEY || config.apiKey
+  const agents = latestAgents(readInventory())
+  if (agents.length === 0) {
+    console.log("No managed agents.")
+    return false
+  }
+  let retryable = false
+
+  for (const agent of agents) {
+    const skip = (reason: string) => console.log(`skip\t${agent.name}\t${reason}`)
+    if (agentWindowExists(agent)) {
+      skip("already running")
+      continue
+    }
+    if (agent.status === "stopped") {
+      skip("stopped")
+      continue
+    }
+    if (agent.runtime === "pi") {
+      skip("Pi session reattachment is not supported")
+      continue
+    }
+    if (!agent.scratchpadUrl) {
+      skip("no scratchpad URL")
+      continue
+    }
+    if (!agent.worktree || !existsSync(agent.worktree)) {
+      skip("missing worktree dir")
+      continue
+    }
+    const mcpConfig = join(homedir(), ".threa", "harnessd", "mcp", `${agent.name}.json`)
+    if (!existsSync(mcpConfig)) {
+      skip("missing MCP config")
+      continue
+    }
+    const scratchpad = parseScratchpadUrl(agent.scratchpadUrl)
+    if (!scratchpad) {
+      skip("invalid scratchpad URL")
+      continue
+    }
+    const configuredBaseUrl = (process.env.THREA_BASE_URL || config.baseUrl || "https://app.threa.io").replace(
+      /\/$/,
+      ""
+    )
+    if (scratchpad.baseUrl !== configuredBaseUrl) {
+      skip("scratchpad URL origin does not match configured Threa base URL")
+      continue
+    }
+    if (workspaceId && scratchpad.workspaceId && workspaceId !== scratchpad.workspaceId) {
+      skip("scratchpad workspace does not match configured workspace")
+      continue
+    }
+    const scratchpadWorkspaceId = scratchpad.workspaceId || workspaceId
+    if (!scratchpadWorkspaceId || !apiKey) {
+      if (!options.force) {
+        skip("missing Threa credentials")
+        continue
+      }
+    } else {
+      const result = await scratchpadStatus({
+        baseUrl: configuredBaseUrl,
+        workspaceId: scratchpadWorkspaceId,
+        apiKey,
+        streamId: scratchpad.streamId,
+      })
+      if (result === "unavailable") retryable = true
+      if (result !== "active" && !options.force) {
+        skip(result)
+        continue
+      }
+      if (result !== "active") console.log(`force\t${agent.name}\t${result}`)
+    }
+    if (options.dryRun) {
+      console.log(`restore\t${agent.name}\t${agent.scratchpadUrl}`)
+      continue
+    }
+
+    try {
+      const result = await new ClaudeRuntimeSpawner().resume(agent, options)
+      upsertAgent({
+        ...agent,
+        tmuxSession: result.tmuxSession,
+        tmuxWindow: result.tmuxWindow,
+        tmuxWindowId: result.tmuxWindowId,
+        status: "online",
+        updatedAt: now(),
+        lastOutput: result.output.slice(-4000),
+      })
+      const bypass = agent.command.includes("--no-yolo") ? "disabled" : "enabled"
+      console.log(`restored\t${agent.name}\tbypass ${bypass}`)
+    } catch (error) {
+      upsertAgent({ ...agent, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })
+      skip(`launch failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+  return retryable
+}
+
+async function scratchpadStatus(params: {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+  streamId: string
+}): Promise<"active" | "archived" | "inaccessible" | "unavailable"> {
+  try {
+    const response = await fetch(
+      `${params.baseUrl.replace(/\/$/, "")}/api/v1/workspaces/${params.workspaceId}/streams/${params.streamId}`,
+      { headers: { authorization: `Bearer ${params.apiKey}` }, signal: AbortSignal.timeout(10_000) }
+    )
+    if (response.status === 403 || response.status === 404) return "inaccessible"
+    if (!response.ok) return response.status === 429 || response.status >= 500 ? "unavailable" : "inaccessible"
+    const json = (await response.json()) as { data?: { archivedAt?: string | null } }
+    if (!json.data || !("archivedAt" in json.data)) return "inaccessible"
+    return json.data.archivedAt ? "archived" : "active"
+  } catch {
+    return "unavailable"
   }
 }
 

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -1,14 +1,18 @@
 import { randomUUID } from "node:crypto"
 import { existsSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import { installBootResume } from "./boot"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
 import { die } from "./errors"
 import { findAgent, inventoryPath, readInventory, upsertAgent } from "./inventory"
 import { commandExists, commandPath, output } from "./shell"
-import { ClaudeRuntimeSpawner, PiRuntimeSpawner, readThreaChannelConfig } from "./spawners"
-import { latestAgents, parseScratchpadUrl } from "./resume"
+import {
+  ClaudeRuntimeSpawner,
+  PiRuntimeSpawner,
+  configuredThreaBaseUrl,
+  mcpConfigPath,
+  readThreaChannelConfig,
+} from "./spawners"
+import { latestAgents, parseScratchpadUrl, recordedNoYolo } from "./resume"
 import { agentWindowExists, attachedTmuxSession, ensureTmuxSession, sendKeys } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions } from "./types"
 
@@ -77,6 +81,7 @@ export async function bootResume(options: ResumeOptions): Promise<void> {
       await Bun.sleep(10_000)
     }
   }
+  console.error("harnessd: gave up resuming agents after 3 attempts; Threa API is still unavailable")
 }
 
 export function installBootResumeAgent(options: ResumeOptions): void {
@@ -125,7 +130,7 @@ async function resumeActiveUnlocked(options: ResumeOptions): Promise<boolean> {
       skip("missing worktree dir")
       continue
     }
-    const mcpConfig = join(homedir(), ".threa", "harnessd", "mcp", `${agent.name}.json`)
+    const mcpConfig = mcpConfigPath(agent.name)
     if (!existsSync(mcpConfig)) {
       skip("missing MCP config")
       continue
@@ -135,10 +140,7 @@ async function resumeActiveUnlocked(options: ResumeOptions): Promise<boolean> {
       skip("invalid scratchpad URL")
       continue
     }
-    const configuredBaseUrl = (process.env.THREA_BASE_URL || config.baseUrl || "https://app.threa.io").replace(
-      /\/$/,
-      ""
-    )
+    const configuredBaseUrl = configuredThreaBaseUrl(config)
     if (scratchpad.baseUrl !== configuredBaseUrl) {
       skip("scratchpad URL origin does not match configured Threa base URL")
       continue
@@ -183,7 +185,7 @@ async function resumeActiveUnlocked(options: ResumeOptions): Promise<boolean> {
         updatedAt: now(),
         lastOutput: result.output.slice(-4000),
       })
-      const bypass = agent.command.includes("--no-yolo") ? "disabled" : "enabled"
+      const bypass = recordedNoYolo(agent) ? "disabled" : "enabled"
       console.log(`restored\t${agent.name}\tbypass ${bypass}`)
     } catch (error) {
       upsertAgent({ ...agent, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env bun
 
-import { parseSpawn, usage } from "./cli"
+import { parseResume, parseSpawn, usage } from "./cli"
 import {
   attachAgent,
+  bootResume,
   doctor,
   inferAndRun,
+  installBootResumeAgent,
   interruptAgent,
   listAgents,
+  resumeActive,
   sendKeysToAgent,
   spawnAgent,
   steerAgent,
@@ -19,6 +22,12 @@ async function main(): Promise<void> {
   if (!command || command === "help" || command === "--help" || command === "-h") usage()
   if (command === "spawn") return spawnAgent(parseSpawn(args))
   if (command === "list") return listAgents()
+  if (command === "resume-active" || command === "restore-active") {
+    await resumeActive(parseResume(args))
+    return
+  }
+  if (command === "boot-resume") return bootResume(parseResume(args))
+  if (command === "install-boot-resume") return installBootResumeAgent(parseResume(args))
   if (command === "stop") return stopAgent(args[0] ?? die("stop requires an agent id or name"))
   if (command === "interrupt") return interruptAgent(args[0] ?? die("interrupt requires an agent id or name"))
   if (command === "steer")

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { latestAgents, parseScratchpadUrl, recordedNoYolo } from "./resume"
+import { launchAgentPlist } from "./boot"
+import { claudeLaunchArgs } from "./spawners"
+import type { ManagedAgent } from "./types"
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "repair",
+    runtime: "claude",
+    status: "online",
+    command: ["threa-harnessd", "spawn", "claude"],
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+test("parses a stream id from a scratchpad URL", () => {
+  expect(parseScratchpadUrl("https://app.threa.io/w/ws_01WORKSPACE/s/stream_01ABCDEF?view=chat")).toEqual({
+    baseUrl: "https://app.threa.io",
+    workspaceId: "ws_01WORKSPACE",
+    streamId: "stream_01ABCDEF",
+  })
+  expect(parseScratchpadUrl("not-a-url")).toBeUndefined()
+})
+
+test("selects only the latest inventory row for an agent name", () => {
+  const newest = agent({ id: "claude-2", updatedAt: "2026-07-02T00:00:00.000Z" })
+  expect(latestAgents([agent(), newest, agent({ name: "other" })])).toEqual([agent({ name: "other" }), newest])
+})
+
+test("preserves an explicitly non-yolo launch", () => {
+  expect(recordedNoYolo(agent())).toBeFalse()
+  expect(recordedNoYolo(agent({ command: ["threa-harnessd", "spawn", "claude", "--no-yolo"] }))).toBeTrue()
+})
+
+test("writes a login LaunchAgent that runs boot-resume in a dedicated tmux session", () => {
+  const plist = launchAgentPlist({
+    bun: "/Users/me/.bun/bin/bun",
+    entrypoint: "/repo/extensions/harness-daemon/src/index.ts",
+    tmux: "threa-agents",
+    logDir: "/Users/me/.threa/harnessd/log",
+    path: "/Users/me/.bun/bin:/usr/bin:/bin",
+    environment: { THREA_API_KEY: "secret" },
+  })
+  expect(plist).toContain("<key>RunAtLoad</key><true/>")
+  expect(plist).toContain("boot-resume --tmux 'threa-agents'")
+  expect(plist).toContain("resume-active.error.log")
+  expect(plist).toContain("<key>PATH</key><string>/Users/me/.bun/bin:/usr/bin:/bin</string>")
+  expect(plist).toContain("<key>THREA_API_KEY</key><string>secret</string>")
+})
+
+test("reconstructs the Claude channel launch with the recorded permission mode", () => {
+  const args = claudeLaunchArgs({
+    claudeBin: "claude",
+    name: "repair",
+    channel: "threa",
+    mcpConfig: "/tmp/repair.json",
+  })
+  expect(args).toEqual([
+    "claude",
+    "--name",
+    "threa.repair",
+    "--mcp-config",
+    "/tmp/repair.json",
+    "--dangerously-load-development-channels",
+    "server:threa",
+    "--dangerously-skip-permissions",
+  ])
+  expect(claudeLaunchArgs({ claudeBin: "claude", name: "repair", channel: "threa", noYolo: true })).not.toContain(
+    "--dangerously-skip-permissions"
+  )
+})

--- a/extensions/harness-daemon/src/resume.ts
+++ b/extensions/harness-daemon/src/resume.ts
@@ -1,0 +1,36 @@
+import type { ManagedAgent } from "./types"
+
+export interface ScratchpadRef {
+  baseUrl: string
+  workspaceId?: string
+  streamId: string
+}
+
+export function parseScratchpadUrl(value: string): ScratchpadRef | undefined {
+  try {
+    const url = new URL(value)
+    const streamId = url.pathname.match(/\/(?:streams|s)\/(stream_[A-Za-z0-9]+)(?:\/|$)/)?.[1]
+    if (!streamId) return undefined
+    return {
+      baseUrl: url.origin,
+      workspaceId: url.pathname.match(/\/w\/(ws_[A-Za-z0-9]+)(?:\/|$)/)?.[1],
+      streamId,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/** An inventory row is immutable per launch, so resume only the newest launch for each name. */
+export function latestAgents(agents: ManagedAgent[]): ManagedAgent[] {
+  const byName = new Map<string, ManagedAgent>()
+  for (const agent of agents) {
+    const existing = byName.get(agent.name)
+    if (!existing || agent.updatedAt > existing.updatedAt) byName.set(agent.name, agent)
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function recordedNoYolo(agent: ManagedAgent): boolean {
+  return agent.command.includes("--no-yolo")
+}

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -5,8 +5,34 @@ import { basename, join } from "node:path"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
 import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
-import type { SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
+import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
 import { ensureWorktree } from "./worktree"
+
+export function claudeLaunchArgs(params: {
+  claudeBin: string
+  name: string
+  channel: string
+  mcpConfig?: string
+  noYolo?: boolean
+}): string[] {
+  const args = [params.claudeBin, "--name", `threa.${params.name}`]
+  if (params.mcpConfig) {
+    args.push("--mcp-config", params.mcpConfig, "--dangerously-load-development-channels", `server:${params.channel}`)
+  }
+  if (!params.noYolo) args.push("--dangerously-skip-permissions")
+  return args
+}
+
+function mcpChannel(path: string): string {
+  try {
+    const mcpServers = JSON.parse(readFileSync(path, "utf8")).mcpServers
+    const channels = mcpServers && typeof mcpServers === "object" ? Object.keys(mcpServers) : []
+    if (channels.length === 1 && channels[0]) return channels[0]
+  } catch {
+    // The caller reports the same actionable MCP-config error for malformed JSON.
+  }
+  die(`MCP config must contain exactly one channel server: ${path}`)
+}
 
 function firstScratchpadUrl(text: string): string | undefined {
   return text.match(/https:\/\/app\.threa\.io\/[^\s)]+/)?.[0]
@@ -92,16 +118,13 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     const scratchpadUrl = await this.prelinkScratchpad(worktree)
     if (scratchpadUrl) console.log(`harnessd: scratchpad: ${scratchpadUrl}`)
 
-    const args = [claudeBin, "--name", `threa.${options.name}`]
-    if (!options.noRegister) {
-      args.push(
-        "--mcp-config",
-        this.writeMcpConfig(options.name, channel, channelEntry),
-        "--dangerously-load-development-channels",
-        `server:${channel}`
-      )
-    }
-    if (!options.noYolo) args.push("--dangerously-skip-permissions")
+    const args = claudeLaunchArgs({
+      claudeBin,
+      name: options.name,
+      channel,
+      mcpConfig: options.noRegister ? undefined : this.writeMcpConfig(options.name, channel, channelEntry),
+      noYolo: options.noYolo,
+    })
 
     const window = pickTmuxWindow(session, options.name)
     const windowId = createWindow(session, window, worktree, args.map(shellQuote).join(" "))
@@ -118,6 +141,48 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
       tmuxWindowId: windowId,
       scratchpadUrl: scratchpadUrl ?? firstScratchpadUrl(outputText),
       output: outputText,
+    }
+  }
+
+  async resume(agent: ManagedAgent, options: ResumeOptions): Promise<SpawnResult> {
+    if (!agent.worktree || !existsSync(agent.worktree)) die(`worktree dir missing: ${agent.worktree ?? "<none>"}`)
+    if (!commandExists("tmux")) die("tmux not found")
+    const claudeBin = process.env.THREA_HARNESSD_CLAUDE_BIN || commandPath("claude")
+    if (!claudeBin) die("claude binary not found; set THREA_HARNESSD_CLAUDE_BIN or put claude on PATH")
+
+    const mcpConfig = join(homedir(), ".threa", "harnessd", "mcp", `${agent.name}.json`)
+    if (!existsSync(mcpConfig)) die(`MCP config missing: ${mcpConfig}`)
+    const channel = mcpChannel(mcpConfig)
+    const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "claude", name: agent.name })
+    ensureTmuxSession(session, true)
+    const noYolo = agent.command.includes("--no-yolo")
+    const window = pickTmuxWindow(session, agent.name)
+    const windowId = createWindow(
+      session,
+      window,
+      agent.worktree,
+      claudeLaunchArgs({ claudeBin, name: agent.name, channel, mcpConfig, noYolo }).map(shellQuote).join(" ")
+    )
+    console.log(`harnessd: resumed Claude Code in tmux ${session}:${window} (${windowId})`)
+    try {
+      await this.acceptBootPrompts(windowId)
+      sendKeys(windowId, ["/remote-control", "Enter"])
+      await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_REMOTE_WAIT_MS ?? 2000))
+      sendKeys(windowId, ["/rc", "Enter"])
+      await Bun.sleep(500)
+      const output = capturePane(windowId)
+      return {
+        worktree: agent.worktree,
+        branch: agent.branch ?? agent.name,
+        tmuxSession: session,
+        tmuxWindow: window,
+        tmuxWindowId: windowId,
+        scratchpadUrl: agent.scratchpadUrl,
+        output,
+      }
+    } catch (error) {
+      run(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+      throw error
     }
   }
 
@@ -219,7 +284,7 @@ function ensurePiDefaultLabel(): void {
   }
 }
 
-function readThreaChannelConfig(): ThreaChannelConfig {
+export function readThreaChannelConfig(): ThreaChannelConfig {
   const path = join(homedir(), ".claude", "threa-channel", "config.json")
   if (!existsSync(path)) return {}
   try {

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -1,12 +1,21 @@
 import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
-import { basename, join } from "node:path"
+import { basename, dirname, join } from "node:path"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
 import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
+import { recordedNoYolo } from "./resume"
 import { ensureWorktree } from "./worktree"
+
+export function mcpConfigPath(name: string): string {
+  return join(homedir(), ".threa", "harnessd", "mcp", `${name}.json`)
+}
+
+export function configuredThreaBaseUrl(config: ThreaChannelConfig): string {
+  return (process.env.THREA_BASE_URL || config.baseUrl || "https://app.threa.io").replace(/\/$/, "")
+}
 
 export function claudeLaunchArgs(params: {
   claudeBin: string
@@ -150,12 +159,12 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     const claudeBin = process.env.THREA_HARNESSD_CLAUDE_BIN || commandPath("claude")
     if (!claudeBin) die("claude binary not found; set THREA_HARNESSD_CLAUDE_BIN or put claude on PATH")
 
-    const mcpConfig = join(homedir(), ".threa", "harnessd", "mcp", `${agent.name}.json`)
+    const mcpConfig = mcpConfigPath(agent.name)
     if (!existsSync(mcpConfig)) die(`MCP config missing: ${mcpConfig}`)
     const channel = mcpChannel(mcpConfig)
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "claude", name: agent.name })
     ensureTmuxSession(session, true)
-    const noYolo = agent.command.includes("--no-yolo")
+    const noYolo = recordedNoYolo(agent)
     const window = pickTmuxWindow(session, agent.name)
     const windowId = createWindow(
       session,
@@ -196,9 +205,8 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
    * and leaves global config untouched.
    */
   private writeMcpConfig(name: string, channel: string, channelEntry: string): string {
-    const dir = join(homedir(), ".threa", "harnessd", "mcp")
-    mkdirSync(dir, { recursive: true })
-    const path = join(dir, `${name}.json`)
+    const path = mcpConfigPath(name)
+    mkdirSync(dirname(path), { recursive: true })
     writeFileSync(
       path,
       JSON.stringify({ mcpServers: { [channel]: { type: "stdio", command: "bun", args: [channelEntry] } } }, null, 2)
@@ -230,7 +238,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
 
   private async prelinkScratchpad(worktree: string): Promise<string | undefined> {
     const config = readThreaChannelConfig()
-    const baseUrl = (process.env.THREA_BASE_URL || config.baseUrl || "https://app.threa.io").replace(/\/$/, "")
+    const baseUrl = configuredThreaBaseUrl(config)
     const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
     const apiKey = process.env.THREA_API_KEY || config.apiKey
     if (!workspaceId || !apiKey) {

--- a/extensions/harness-daemon/src/tmux.ts
+++ b/extensions/harness-daemon/src/tmux.ts
@@ -1,6 +1,6 @@
 import { die } from "./errors"
 import { output, run } from "./shell"
-import type { SpawnOptions } from "./types"
+import type { ManagedAgent, SpawnOptions } from "./types"
 
 /**
  * The tmux session the user is actually looking at: the enclosing session when
@@ -28,9 +28,26 @@ export function tmuxSession(options: SpawnOptions): string {
   return options.tmux ?? attachedTmuxSession() ?? "0"
 }
 
-export function ensureTmuxSession(session: string): void {
+export function ensureTmuxSession(session: string, create = false): void {
   const result = output(["tmux", "has-session", "-t", session], { allowFailure: true })
-  if (result.exitCode !== 0) die(`tmux session '${session}' not found`)
+  if (result.exitCode === 0) return
+  if (!create) die(`tmux session '${session}' not found`)
+  run(["tmux", "new-session", "-d", "-s", session, "-n", "harnessd"])
+}
+
+/** A surviving tmux window means a LaunchAgent reload must not start a duplicate agent. */
+export function agentWindowExists(agent: ManagedAgent): boolean {
+  if (agent.tmuxWindowId) {
+    const result = output(["tmux", "display-message", "-p", "-t", agent.tmuxWindowId, "#{session_name}"], {
+      allowFailure: true,
+    })
+    if (result.exitCode === 0 && (!agent.tmuxSession || result.stdout.trim() === agent.tmuxSession)) return true
+  }
+  const window = agent.tmuxWindow ?? agent.name
+  const target = agent.tmuxSession ? ["-t", agent.tmuxSession] : ["-a"]
+  return output(["tmux", "list-windows", ...target, "-F", "#{window_name}"], { allowFailure: true })
+    .stdout.split("\n")
+    .includes(window)
 }
 
 export function pickTmuxWindow(session: string, name: string): string {

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -33,6 +33,12 @@ export interface SpawnOptions {
   noYolo?: boolean
 }
 
+export interface ResumeOptions {
+  tmux?: string
+  dryRun?: boolean
+  force?: boolean
+}
+
 export interface SpawnResult {
   worktree: string
   branch: string


### PR DESCRIPTION
## Problem

A reboot removes tmux sessions while inventory still lists agents as online. Manual recovery relaunched archived Claude scratchpads, unlinked Pi panes, and Claude sessions without their channel or permission-bypass flags.

## Solution

Add inventory-backed Claude recovery plus an opt-in macOS login LaunchAgent.

### How it works

1. `resume-active` selects the latest row per agent name, skips stopped/Pi/missing-worktree/missing-MCP entries, validates the scratchpad URL against configured Threa origin and workspace, then checks `GET /api/v1/workspaces/:workspaceId/streams/:streamId`.
2. `ClaudeRuntimeSpawner.resume` uses the recorded worktree and MCP file, derives the channel name from that MCP file, preserves `--no-yolo`, accepts boot dialogs, then sends `/remote-control` and `/rc`.
3. Tmux `wait-for` serializes resume attempts. Existing windows must match the recorded id *and* name; failed post-launch setup kills its new window.
4. `boot-resume` creates the dedicated `threa-agents` session, retries transient Threa API failures three times at ten-second intervals, and leaves archived/inaccessible streams skipped.
5. `install-boot-resume` writes a per-user LaunchAgent for the next login. It preserves the invoking PATH and any env-supplied Threa API credentials.

### Key design decisions

**Validate before launch** — recovery only launches HTTP-200, unarchived streams. `--force` remains the explicit escape hatch requested for inaccessible records.

**Skip Pi recovery** — Pi session linkage is not durable enough in inventory to prove reattachment to the existing scratchpad. Launching a fresh Pi risks `Threa remote: not linked` panes.

**Use the persisted MCP config** — the MCP file is the session-specific channel source of truth; environment changes cannot silently select a different channel at recovery.

## New files

| File | Purpose |
| --- | --- |
| `extensions/harness-daemon/src/resume.ts` | Scratchpad parsing and latest-record selection. |
| `extensions/harness-daemon/src/boot.ts` | macOS LaunchAgent generation. |
| `extensions/harness-daemon/src/resume.test.ts` | Recovery and launch configuration tests. |

## Modified files

| File | Change |
| --- | --- |
| `extensions/harness-daemon/src/commands.ts` | Recovery filtering, API validation, locking, retries, and reporting. |
| `extensions/harness-daemon/src/spawners.ts` | Claude resume path and shared launch arguments. |
| `extensions/harness-daemon/src/tmux.ts` | Session creation and duplicate-window detection. |
| `extensions/harness-daemon/src/{cli,index,types}.ts` | Recovery command wiring and options. |
| `extensions/harness-daemon/package.json` | Bun test script. |

## Out of scope

Pi restoration remains disabled until inventory can prove that a new Pi process reattaches to its existing stream. Linux startup-service installation is not included.

## Test plan

- [x] `bun test extensions/harness-daemon/src/resume.test.ts` — 5 pass
- [x] `tsc --noEmit -p extensions/harness-daemon/tsconfig.json`
- [x] Pre-commit lint, monorepo typecheck, Dockerfile workspace check, migration check, and OpenAPI check
- [x] Luna pre-PR review — fixed lifecycle, credential, origin/workspace validation, and transient-API findings; retained `--force` as the explicit user-required override.

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Reconstruct only active, scratchpad-backed harness agents after a reboot and make that recovery available at macOS login.

## What Was Built

### Inventory recovery

`resume-active` reads `~/.threa/harnessd/inventory.sqlite`, takes the latest record for each agent name, validates its stream with the configured workspace bot key, and reports every skip reason. Claude recovery reuses its worktree and MCP config. Pi records are skipped.

**Files:**
- `extensions/harness-daemon/src/commands.ts`
- `extensions/harness-daemon/src/resume.ts`
- `extensions/harness-daemon/src/spawners.ts`
- `extensions/harness-daemon/src/tmux.ts`

### Login recovery

`boot-resume` creates a detached `threa-agents` tmux session and retries transient API failures. `install-boot-resume` emits a user LaunchAgent that starts it after login.

**Files:**
- `extensions/harness-daemon/src/boot.ts`
- `extensions/harness-daemon/src/{cli,index,types}.ts`

## Design Decisions

**Chose:** validate the inventory URL origin and workspace against configured credentials before calling the API.
**Why:** prevents sending the bot key to a tampered inventory URL or validating a stream in the wrong environment.
**Alternatives considered:** trusting the inventory URL as the API origin; rejected because inventory is local mutable state.

## Design Evolution

- Added serialization, retry behavior, persisted-MCP channel selection, window cleanup, and LaunchAgent environment preservation after Luna review found recovery lifecycle gaps.

## Schema Changes

None.

## What's NOT Included

- Pi reattachment.
- Linux service installation.
- Automatic LaunchAgent installation; users opt in with `install-boot-resume`.

## Status

- [x] Inventory filtering and stream validation
- [x] Claude reconstruction and remote-control boot flow
- [x] Login recovery command and LaunchAgent installer
- [x] Unit tests and Luna review

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786487110&installation_id=129946197&pr_number=1311&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1311&signature=7dbd729cf89626a0e8bc186bdc89bc7327c1700c60ab6c1149b719d8b6c8cd0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->