### PR TITLE
feat(board): board GA — retire the board-view flag + symmetric first-class sidebar rows

### DIFF
--- a/apps/backend/src/features/board-views/handlers.test.ts
+++ b/apps/backend/src/features/board-views/handlers.test.ts
@@ -26,11 +26,9 @@ describe("Board view handlers", () => {
   const mockCreate = mock(() => Promise.resolve({ id: "boardview_1" } as Record<string, unknown>))
   const mockUpdate = mock(() => Promise.resolve({ id: "boardview_1" } as Record<string, unknown>))
   const mockDelete = mock(() => Promise.resolve())
-  const mockGetFlag = mock(() => Promise.resolve("on" as string))
 
   const handlers = createBoardViewHandlers({
     boardViewService: { list: mockList, create: mockCreate, update: mockUpdate, delete: mockDelete } as never,
-    featureFlagService: { getFlag: mockGetFlag } as never,
   })
 
   beforeEach(() => {
@@ -38,11 +36,9 @@ describe("Board view handlers", () => {
     mockCreate.mockReset()
     mockUpdate.mockReset()
     mockDelete.mockReset()
-    mockGetFlag.mockReset()
     mockList.mockResolvedValue([])
     mockCreate.mockResolvedValue({ id: "boardview_1", name: "My view" })
     mockUpdate.mockResolvedValue({ id: "boardview_1", name: "Renamed" })
-    mockGetFlag.mockResolvedValue("on")
   })
 
   test("list returns the viewer's saved views", async () => {
@@ -143,15 +139,5 @@ describe("Board view handlers", () => {
     await handlers.remove(mockReq({ params: { boardViewId: "boardview_1" } }), res)
     expect(mockDelete).toHaveBeenCalledWith("ws_1", "usr_1", "boardview_1")
     expect((res as unknown as { body: unknown }).body).toEqual({ ok: true })
-  })
-
-  test("every endpoint 404s without the board-view flag before touching the service", async () => {
-    mockGetFlag.mockResolvedValue("off")
-    await expect(handlers.list(mockReq(), mockRes())).rejects.toMatchObject({ status: 404 })
-    await expect(handlers.create(mockReq({ body: { name: "x", baseLens: "all" } }), mockRes())).rejects.toMatchObject({
-      status: 404,
-    })
-    expect(mockList).not.toHaveBeenCalled()
-    expect(mockCreate).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/board-views/handlers.ts
+++ b/apps/backend/src/features/board-views/handlers.ts
@@ -2,8 +2,6 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { BoardViewService } from "./service"
 import { validateRequest } from "../../lib/validation"
-import { HttpError } from "../../lib/errors"
-import type { FeatureFlagService } from "../feature-flags"
 import {
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
@@ -45,32 +43,22 @@ const updateBoardViewSchema = z
 
 interface Dependencies {
   boardViewService: BoardViewService
-  featureFlagService: FeatureFlagService
 }
 
 /**
- * User-saved board lenses (board-view-design.md § "Lenses"). All board-flag-gated
- * (404 without `board-view`, like the feed). No stream-access check: a saved view
- * is just filter state (names of streams the viewer already sees), and the feed it
- * expands to is itself access-filtered (INV-62) — a muted/inaccessible stream in a
- * saved scope simply returns nothing.
+ * User-saved board lenses (board-view-design.md § "Lenses"). No stream-access
+ * check: a saved view is just filter state (names of streams the viewer already
+ * sees), and the feed it expands to is itself access-filtered (INV-62) — a
+ * muted/inaccessible stream in a saved scope simply returns nothing.
  */
-export function createBoardViewHandlers({ boardViewService, featureFlagService }: Dependencies) {
-  async function requireBoardFlag(req: Request): Promise<void> {
-    if ((await featureFlagService.getFlag(req.workspaceId!, req.user!.id, "board-view")) !== "on") {
-      throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-    }
-  }
-
+export function createBoardViewHandlers({ boardViewService }: Dependencies) {
   return {
     async list(req: Request, res: Response) {
-      await requireBoardFlag(req)
       const boardViews = await boardViewService.list(req.workspaceId!, req.user!.id)
       res.json({ boardViews })
     },
 
     async create(req: Request, res: Response) {
-      await requireBoardFlag(req)
       const body = validateRequest(createBoardViewSchema, req.body)
       const boardView = await boardViewService.create({
         workspaceId: req.workspaceId!,
@@ -81,7 +69,6 @@ export function createBoardViewHandlers({ boardViewService, featureFlagService }
     },
 
     async update(req: Request, res: Response) {
-      await requireBoardFlag(req)
       const { boardViewId } = validateRequest(boardViewParamsSchema, req.params)
       const body = validateRequest(updateBoardViewSchema, req.body)
       const boardView = await boardViewService.update(req.workspaceId!, req.user!.id, boardViewId, body)
@@ -89,7 +76,6 @@ export function createBoardViewHandlers({ boardViewService, featureFlagService }
     },
 
     async remove(req: Request, res: Response) {
-      await requireBoardFlag(req)
       const { boardViewId } = validateRequest(boardViewParamsSchema, req.params)
       await boardViewService.delete(req.workspaceId!, req.user!.id, boardViewId)
       res.json({ ok: true })

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -48,7 +48,6 @@ describe("Conversation Handlers", () => {
       mutedStreamIds: [] as string[],
     })
   )
-  const mockGetFlag = mock(() => Promise.resolve("on" as string))
   const mockSplitThread = mock(() =>
     Promise.resolve({ conversation: { id: "conv_new" }, sourceConversation: { id: "conv_1" } })
   )
@@ -78,9 +77,6 @@ describe("Conversation Handlers", () => {
     streamService: {
       validateStreamAccess: mockValidateStreamAccess,
     } as never,
-    featureFlagService: {
-      getFlag: mockGetFlag,
-    } as never,
   })
 
   beforeEach(() => {
@@ -96,7 +92,6 @@ describe("Conversation Handlers", () => {
     mockMuteStream.mockReset()
     mockUnmuteStream.mockReset()
     mockGetExclusions.mockReset()
-    mockGetFlag.mockReset()
     mockUpdateConversation.mockResolvedValue({
       conversation: { id: "conv_1", topicSummary: "Renamed", status: "active" },
     })
@@ -108,7 +103,6 @@ describe("Conversation Handlers", () => {
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
     mockListByWorkspace.mockResolvedValue({ posts: [], nextCursor: null })
-    mockGetFlag.mockResolvedValue("on")
     mockGetById.mockResolvedValue({
       id: "conv_1",
       streamId: "stream_1",
@@ -144,17 +138,6 @@ describe("Conversation Handlers", () => {
   })
 
   describe("listByWorkspace", () => {
-    test("404s when the board-view feature flag is not 'on'", async () => {
-      mockGetFlag.mockResolvedValue("off")
-      await expect(handlers.listByWorkspace(mockReq({ query: {} }), mockRes())).rejects.toMatchObject({ status: 404 })
-      expect(mockListByWorkspace).not.toHaveBeenCalled()
-    })
-
-    test("checks the board-view flag for the viewer", async () => {
-      await handlers.listByWorkspace(mockReq({ query: {} }), mockRes())
-      expect(mockGetFlag).toHaveBeenCalledWith("ws_1", "usr_1", "board-view")
-    })
-
     test("passes workspaceId, userId and validated query (incl. decoded cursor) to the service", async () => {
       const res = mockRes()
       await handlers.listByWorkspace(
@@ -386,14 +369,6 @@ describe("Conversation Handlers", () => {
   })
 
   describe("getBoardPost", () => {
-    test("404s when the board-view feature flag is not 'on'", async () => {
-      mockGetFlag.mockResolvedValue("off")
-      await expect(
-        handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
-      ).rejects.toMatchObject({ status: 404 })
-      expect(mockGetBoardPostById).not.toHaveBeenCalled()
-    })
-
     test("gates on the conversation's single root via validateStreamAccess (INV-62)", async () => {
       await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
       expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
@@ -487,10 +462,9 @@ describe("Conversation Handlers", () => {
   })
 
   describe("board exclusions", () => {
-    test("hideConversation gates on the board flag, checks access, then delegates", async () => {
+    test("hideConversation checks access, then delegates", async () => {
       const res = mockRes()
       await handlers.hideConversation(mockReq({ params: { conversationId: "conv_1" } }), res)
-      expect(mockGetFlag).toHaveBeenCalledWith("ws_1", "usr_1", "board-view")
       expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
       expect(mockHideConversation).toHaveBeenCalledWith({
         workspaceId: "ws_1",
@@ -498,14 +472,6 @@ describe("Conversation Handlers", () => {
         userId: "usr_1",
       })
       expect((res as unknown as { body: unknown }).body).toEqual({ hiddenAt: "2026-07-05T00:00:00.000Z" })
-    })
-
-    test("hideConversation 404s without the board-view flag before writing", async () => {
-      mockGetFlag.mockResolvedValue("off")
-      await expect(
-        handlers.hideConversation(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
-      ).rejects.toMatchObject({ status: 404 })
-      expect(mockHideConversation).not.toHaveBeenCalled()
     })
 
     test("muteStream validates the target stream then delegates", async () => {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -4,7 +4,6 @@ import type { ConversationService } from "./service"
 import type { BoundaryExtractionService } from "./boundary-extraction-service"
 import type { BoardExclusionService } from "./board-exclusion-service"
 import type { StreamService } from "../streams"
-import type { FeatureFlagService } from "../feature-flags"
 import {
   CONVERSATION_STATUSES,
   ConversationStatuses,
@@ -165,7 +164,6 @@ interface Dependencies {
   boundaryExtractionService: BoundaryExtractionService
   boardExclusionService: BoardExclusionService
   streamService: StreamService
-  featureFlagService: FeatureFlagService
 }
 
 export function createConversationHandlers({
@@ -173,23 +171,15 @@ export function createConversationHandlers({
   boundaryExtractionService,
   boardExclusionService,
   streamService,
-  featureFlagService,
 }: Dependencies) {
   return {
     /**
      * Cross-stream board feed. Access is enforced inside the query (INV-62), so
      * there's no single stream to validate here — unlike {@link listByStream}.
-     * Gated behind the `board-view` feature flag: a viewer without it gets a 404,
-     * so the board isn't reachable even by hitting the endpoint directly.
      */
     async listByWorkspace(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-
-      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
-      if (boardFlag !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
 
       const query = validateRequest(listWorkspaceConversationsSchema, req.query)
 
@@ -259,18 +249,12 @@ export function createConversationHandlers({
     /**
      * The board card's "N more" expand: the full conversation as enriched board
      * post messages (attachments + link previews), so revealed middle messages
-     * read like the rest of the post. Board-gated (404 without the flag), same
-     * as the workspace feed.
+     * read like the rest of the post.
      */
     async getBoardMessages(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { conversationId } = req.params
-
-      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
-      if (boardFlag !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
 
       const conversation = await conversationService.getById(conversationId)
       if (!conversation || conversation.workspaceId !== workspaceId) {
@@ -288,18 +272,13 @@ export function createConversationHandlers({
      * The board post for a single conversation — backs the conversation side
      * panel (Mechanism B, board-view-design.md), which renders the same projection
      * a board card does but reachable by id (a board-card expand or an /s/:id
-     * deep-link, where the board feed never seeded the post). Board-gated (404
-     * without the flag), same access as {@link getBoardMessages}.
+     * deep-link, where the board feed never seeded the post). Same access as
+     * {@link getBoardMessages}.
      */
     async getBoardPost(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { conversationId } = req.params
-
-      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
-      if (boardFlag !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
 
       const conversation = await conversationService.getById(conversationId)
       if (!conversation || conversation.workspaceId !== workspaceId) {
@@ -482,17 +461,13 @@ export function createConversationHandlers({
     },
 
     /**
-     * Per-viewer board exclusions (board-view-design.md § "Hide & mute"). All are
-     * board-flag-gated (404 without `board-view`, like the feed). Hide/unhide gate
-     * on the conversation's root-stream access (INV-62); mute/unmute on the target
-     * stream.
+     * Per-viewer board exclusions (board-view-design.md § "Hide & mute").
+     * Hide/unhide gate on the conversation's root-stream access (INV-62);
+     * mute/unmute on the target stream.
      */
     async hideConversation(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
       const { conversationId } = validateRequest(hideConversationParamsSchema, req.params)
       const conversation = await conversationService.getById(conversationId)
       if (!conversation || conversation.workspaceId !== workspaceId) {
@@ -506,9 +481,6 @@ export function createConversationHandlers({
     async unhideConversation(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
       const { conversationId } = validateRequest(hideConversationParamsSchema, req.params)
       const conversation = await conversationService.getById(conversationId)
       if (!conversation || conversation.workspaceId !== workspaceId) {
@@ -522,9 +494,6 @@ export function createConversationHandlers({
     async muteStream(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
       const { streamId } = validateRequest(muteStreamParamsSchema, req.params)
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
       await boardExclusionService.muteStream({ workspaceId, streamId, userId })
@@ -534,9 +503,6 @@ export function createConversationHandlers({
     async unmuteStream(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
       const { streamId } = validateRequest(muteStreamParamsSchema, req.params)
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
       await boardExclusionService.unmuteStream({ workspaceId, streamId, userId })
@@ -546,9 +512,6 @@ export function createConversationHandlers({
     async getBoardExclusions(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
-      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
-        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
-      }
       res.json(await boardExclusionService.getExclusions(workspaceId, userId))
     },
 

--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -6,7 +6,6 @@ import {
   SIDEBAR_SECTION_KEYS,
   SIDEBAR_TYPE_SECTIONS,
   SIDEBAR_BASE_PRESETS,
-  SIDEBAR_QUICK_LINKS,
   SIDEBAR_QUICK_LINK_VISIBILITIES,
   MAX_CUSTOM_SECTION_NAME_LENGTH,
   MAX_CUSTOM_SECTION_STREAM_IDS,
@@ -39,8 +38,13 @@ const sidebarSectionSchema = z.object({
 // `visibility` is the current tri-state; `enabled` is the pre-v2 boolean an
 // older client may still send. Both are optional so either shape validates; the
 // service's normalizeSidebarConfig collapses them to a canonical visibility.
+//
+// `key` is a bounded raw string, not an enum of the current keys: a stale client
+// may still send a retired key (e.g. the removed "board" link), and rejecting the
+// whole PATCH would strand its layout. normalizeSidebarConfig drops unknown keys
+// on write, so the retired link disappears without a 400.
 const sidebarQuickLinkSchema = z.object({
-  key: z.enum(SIDEBAR_QUICK_LINKS),
+  key: z.string().min(1).max(64),
   visibility: z.enum(SIDEBAR_QUICK_LINK_VISIBILITIES).optional(),
   enabled: z.boolean().optional(),
 })
@@ -53,7 +57,9 @@ const updateSidebarConfigSchema = z.object({
   version: z.number().int().optional(),
   basePreset: z.enum(SIDEBAR_BASE_PRESETS),
   sections: z.array(sidebarSectionSchema).max(50),
-  quickLinks: z.array(sidebarQuickLinkSchema).max(SIDEBAR_QUICK_LINKS.length).optional().default([]),
+  // Cap only guards payload size; the array may carry a few retired keys from a
+  // stale client that normalizeSidebarConfig then drops.
+  quickLinks: z.array(sidebarQuickLinkSchema).max(32).optional().default([]),
 })
 
 export { updateSidebarConfigSchema }

--- a/apps/backend/src/features/sidebar-config/service.test.ts
+++ b/apps/backend/src/features/sidebar-config/service.test.ts
@@ -152,6 +152,20 @@ describe("updateSidebarConfigSchema", () => {
     ])
   })
 
+  it("tolerates a retired quick-link key instead of 400ing the PATCH", () => {
+    // A stale client still sends the removed "board" link; the schema accepts it
+    // (normalizeSidebarConfig drops unknown keys on write) rather than rejecting.
+    const result = updateSidebarConfigSchema.safeParse({
+      basePreset: "smart",
+      sections: [{ id: QUICK_LINKS_SECTION_ID, spec: { kind: "quicklinks" } }],
+      quickLinks: [
+        { key: "board", visibility: "show" },
+        { key: "drafts", visibility: "show" },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
   it("accepts the quicklinks section spec", () => {
     const parsed = updateSidebarConfigSchema.parse({
       basePreset: "smart",

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -305,13 +305,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     boundaryExtractionService,
     boardExclusionService,
     streamService,
-    featureFlagService,
   })
   const command = createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService })
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
   const workspaceSettings = createWorkspaceSettingsHandlers({ workspaceSettingsService })
   const sidebarConfig = createSidebarConfigHandlers({ sidebarConfigService })
-  const boardView = createBoardViewHandlers({ boardViewService, featureFlagService })
+  const boardView = createBoardViewHandlers({ boardViewService })
   const userE2eKeys = createUserE2eKeysHandlers({ userE2eKeysService })
   const aiUsage = createAIUsageHandlers({ pool })
   const debug = createDebugHandlers({ pool, poolMonitor })

--- a/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom"
+import { ArrowRight, LayoutGrid } from "lucide-react"
+import { useSidebar } from "@/contexts"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { buildBoardHref, getLastLocation } from "@/lib/last-location"
+
+interface BoardLinkRowProps {
+  workspaceId: string
+  /** The viewer's auth id — keys the last-location record for the board target. */
+  userId: string | null
+}
+
+/**
+ * Chats-mode counterpart to BoardModeBlock's "← Chats" row: a first-class link
+ * to the board, restoring the viewer's last board state. Same row styling as
+ * "← Chats", and the href mirrors that block's `chatsHref` derivation.
+ */
+export function BoardLinkRow({ workspaceId, userId }: BoardLinkRowProps) {
+  const { collapseOnMobile } = useSidebar()
+  const streams = useWorkspaceStreams(workspaceId)
+
+  const record = userId ? getLastLocation(userId, workspaceId) : null
+  const boardHref = record?.board
+    ? buildBoardHref(
+        workspaceId,
+        record.board,
+        streams.map((s) => s.id)
+      )
+    : `/w/${workspaceId}/board`
+
+  return (
+    <div className="mb-2 space-y-1">
+      <Link
+        to={boardHref}
+        onClick={collapseOnMobile}
+        className="flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors text-muted-foreground hover:bg-muted/50"
+      >
+        <LayoutGrid className="h-4 w-4" />
+        Board
+        <ArrowRight className="ml-auto h-4 w-4" />
+      </Link>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
@@ -39,7 +39,6 @@ function renderQuickLinks(props: Partial<Parameters<typeof SidebarQuickLinks>[0]
         isScheduledPage={false}
         scheduledCount={0}
         isActivityPage={false}
-        isBoardPage={false}
         isMemoryPage={false}
         isFilesPage={false}
         isLabelsPage={false}
@@ -109,7 +108,6 @@ describe("SidebarQuickLinks", () => {
           isScheduledPage={false}
           scheduledCount={0}
           isActivityPage={false}
-          isBoardPage={false}
           isMemoryPage={false}
           isFilesPage={false}
           isLabelsPage={false}

--- a/apps/frontend/src/components/layout/sidebar/quick-links.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.tsx
@@ -1,14 +1,4 @@
-import {
-  Bell,
-  Bookmark,
-  Brain,
-  CalendarClock,
-  FileEdit,
-  LayoutGrid,
-  Paperclip,
-  Tag,
-  type LucideIcon,
-} from "lucide-react"
+import { Bell, Bookmark, Brain, CalendarClock, FileEdit, Paperclip, Tag, type LucideIcon } from "lucide-react"
 import type { ReactNode } from "react"
 import { Link } from "react-router-dom"
 import type { SidebarQuickLink, SidebarQuickLinkKey } from "@threa/types"
@@ -24,7 +14,6 @@ import { MoreDivider, SectionHeader } from "./sections"
  * show-hide), so the two never drift.
  */
 export const QUICK_LINK_META: Record<SidebarQuickLinkKey, { label: string; icon: LucideIcon }> = {
-  board: { label: "Board", icon: LayoutGrid },
   drafts: { label: "Drafts", icon: FileEdit },
   saved: { label: "Saved", icon: Bookmark },
   files: { label: "Files", icon: Paperclip },
@@ -45,7 +34,6 @@ interface SidebarQuickLinksProps {
   isScheduledPage: boolean
   scheduledCount: number
   isActivityPage: boolean
-  isBoardPage: boolean
   isMemoryPage: boolean
   isFilesPage: boolean
   isLabelsPage: boolean
@@ -84,7 +72,6 @@ export function SidebarQuickLinks({
   isScheduledPage,
   scheduledCount,
   isActivityPage,
-  isBoardPage,
   isMemoryPage,
   isFilesPage,
   isLabelsPage,
@@ -97,7 +84,6 @@ export function SidebarQuickLinks({
   // The route/count signal data per key; presentation (label/icon) comes from
   // QUICK_LINK_META so the editor and the list stay in sync.
   const itemByKey: Record<SidebarQuickLinkKey, QuickLinkItem> = {
-    board: { to: `/w/${workspaceId}/board`, isActive: isBoardPage, unreadCount: 0, signalSlot: null },
     drafts: {
       to: `/w/${workspaceId}/drafts`,
       isActive: isDraftsPage,

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -201,7 +201,6 @@ describe("moveQuickLink", () => {
     // Move "activity" (last) to the front (over "drafts").
     const moved = moveQuickLink(SMART_SIDEBAR_CONFIG, "activity", "drafts")
     expect(moved.quickLinks.map((l) => l.key)).toEqual([
-      "board",
       "activity",
       "drafts",
       "saved",

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
@@ -65,7 +65,6 @@ describe("SidebarEditorDialog", () => {
       // inside its row (so they appear in the DOM right after it), then the
       // sibling stream sections follow.
       "Reorder Quick Links",
-      "Reorder Board",
       "Reorder Drafts",
       "Reorder Saved",
       "Reorder Files",

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -76,9 +76,6 @@ interface SidebarEditorDialogProps {
   workspaceId: string
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** Quick-link keys to hide from the reorder list (e.g. a flag-gated link the
-   * viewer doesn't have). Display-only — the stored config is left untouched. */
-  hiddenQuickLinkKeys?: readonly string[]
 }
 
 /**
@@ -91,18 +88,8 @@ interface SidebarEditorDialogProps {
  * cross-device sync) — there is no save step, so the live sidebar reflects each
  * change as it's made.
  */
-export function SidebarEditorDialog({
-  workspaceId,
-  open,
-  onOpenChange,
-  hiddenQuickLinkKeys,
-}: SidebarEditorDialogProps) {
+export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: SidebarEditorDialogProps) {
   const { config, setConfig, setBasePreset } = useSidebarConfig(workspaceId)
-  // Display-only filter: hide flag-gated links the viewer can't use, without
-  // mutating the stored config (so it returns intact if the flag flips on).
-  const visibleQuickLinks = hiddenQuickLinkKeys?.length
-    ? config.quickLinks.filter((link) => !hiddenQuickLinkKeys.includes(link.key))
-    : config.quickLinks
   const { preferences } = usePreferences()
   // dnd-kit applies its reorder transition via an inline style, which the global
   // `.reduced-motion` stylesheet rule can't reach — so gate it here.
@@ -221,7 +208,7 @@ export function SidebarEditorDialog({
                 sections={config.sections}
                 sectionIds={sectionIds}
                 labelsById={labelsById}
-                quickLinks={visibleQuickLinks}
+                quickLinks={config.quickLinks}
                 reduceMotion={reduceMotion}
                 onRemoveSection={(id) => setConfig(removeSection(config, id))}
                 onRenameCustomSection={(sectionId, name) => setConfig(renameCustomSection(config, sectionId, name))}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -31,7 +31,6 @@ import {
   useWorkspaceLabelAssignments,
 } from "@/stores/workspace-store"
 import { useCoordinatedLoading, useSidebar, usePreferencesOptional } from "@/contexts"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useCreateChannel } from "@/components/create-channel"
 import { Button } from "@/components/ui/button"
 import { SidebarShell } from "./sidebar-shell"
@@ -74,10 +73,7 @@ import {
 } from "@/components/board/board-filter-params"
 import { isBoardPath, type SidebarBoardMode } from "./board-sidebar-mode"
 import { useBoardSidebarStats, ZERO_BOARD_STREAM_STATS } from "@/hooks/use-board-sidebar-stats"
-import { StreamTypes, LabelableResourceTypes, type SidebarQuickLinkKey } from "@threa/types"
-
-/** The flag-gated Board quick-link key — one constant for the filter + the editor. */
-const BOARD_QUICK_LINK_KEY: SidebarQuickLinkKey = "board"
+import { StreamTypes, LabelableResourceTypes } from "@threa/types"
 
 /** Stable empty set for layouts with no Unread section (avoids a new ref each render). */
 const EMPTY_UNREAD_IDS: ReadonlySet<string> = new Set()
@@ -144,13 +140,6 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // Reactive pathname (useLocation), and a real matcher: /board carries an
   // optional lens segment, so a suffix check misses /board/active.
   const isBoardPage = isBoardPath(location.pathname)
-  // The Board is gated behind the board-view flag — hide its quick link (and its
-  // editor row) for users without it, matching the route + endpoint gates.
-  const boardEnabled = useFeatureFlag(workspaceId, "board-view") === "on"
-  const boardQuickLinks = boardEnabled
-    ? sidebarConfig.quickLinks
-    : sidebarConfig.quickLinks.filter((link) => link.key !== BOARD_QUICK_LINK_KEY)
-  const isBoardMode = isBoardPage && boardEnabled
   const boardMutedStreamIds = useBoardMutedStreamIds(workspaceId)
   const muteStream = useMuteStream(workspaceId)
   const unmuteStream = useUnmuteStream(workspaceId)
@@ -247,13 +236,13 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const virtualDmStreams = useMemo(
     () =>
       buildVirtualDmDrafts({
-        isBoardMode,
+        isBoardMode: isBoardPage,
         workspaceId,
         currentUserId: currentUser?.id ?? null,
         workspaceUsers,
         dmPeerUserIds: idbDmPeers.map((peer) => peer.userId),
       }),
-    [workspaceUsers, idbDmPeers, currentUser, workspaceId, isBoardMode]
+    [workspaceUsers, idbDmPeers, currentUser, workspaceId, isBoardPage]
   )
 
   const hasUserStreams = hasUserStreamsFromStreams || virtualDmStreams.length > 0
@@ -339,9 +328,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // The single reactive topic-stats pass — one subscription for the whole board
   // sidebar (rows + Lenses counts), gated on board mode so chats mode subscribes
   // to nothing (perf contract in the exploration doc).
-  const boardSidebarStats = useBoardSidebarStats(workspaceId, isBoardMode)
+  const boardSidebarStats = useBoardSidebarStats(workspaceId, isBoardPage)
   const boardMode = useMemo<SidebarBoardMode | null>(() => {
-    if (!isBoardMode) return null
+    if (!isBoardPage) return null
     return {
       workspaceId,
       includedStreamIds: boardIncludedStreamIds,
@@ -360,7 +349,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       lensTotals: boardSidebarStats?.lensTotals ?? null,
     }
   }, [
-    isBoardMode,
+    isBoardPage,
     workspaceId,
     boardIncludedStreamIds,
     boardExcludedStreamIds,
@@ -377,35 +366,30 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // removing the section from the editor takes it out of both the normal list
   // (resolved as a positioned section) and the empty-streams state.
   const hasQuickLinksSection = sidebarConfig.sections.some((s) => s.spec.kind === "quicklinks")
-  // On `/board` (flag on) the board block replaces the quick-links block in place;
-  // every other surface keeps the unchanged quick links.
+  // On `/board` the board block replaces the quick-links block in place; every
+  // other surface keeps the unchanged quick links.
   let quickLinksSlot: ReactNode
   if (hasQuickLinksSection) {
-    quickLinksSlot =
-      isBoardPage && boardEnabled ? (
-        <BoardModeBlock
-          workspaceId={workspaceId}
-          userId={user?.id ?? null}
-          lensTotals={boardMode?.lensTotals ?? null}
-        />
-      ) : (
-        <SidebarQuickLinks
-          workspaceId={workspaceId}
-          quickLinks={boardQuickLinks}
-          isDraftsPage={isDraftsPage}
-          draftCount={draftCount}
-          isSavedPage={isSavedPage}
-          savedCount={savedCount}
-          isScheduledPage={isScheduledPage}
-          scheduledCount={scheduledCount}
-          isActivityPage={isActivityPage}
-          isBoardPage={isBoardPage}
-          isMemoryPage={isMemoryPage}
-          isFilesPage={isFilesPage}
-          isLabelsPage={isLabelsPage}
-          unreadActivityCount={unreadActivityCount}
-        />
-      )
+    quickLinksSlot = isBoardPage ? (
+      <BoardModeBlock workspaceId={workspaceId} userId={user?.id ?? null} lensTotals={boardMode?.lensTotals ?? null} />
+    ) : (
+      <SidebarQuickLinks
+        workspaceId={workspaceId}
+        quickLinks={sidebarConfig.quickLinks}
+        isDraftsPage={isDraftsPage}
+        draftCount={draftCount}
+        isSavedPage={isSavedPage}
+        savedCount={savedCount}
+        isScheduledPage={isScheduledPage}
+        scheduledCount={scheduledCount}
+        isActivityPage={isActivityPage}
+        isBoardPage={isBoardPage}
+        isMemoryPage={isMemoryPage}
+        isFilesPage={isFilesPage}
+        isLabelsPage={isLabelsPage}
+        unreadActivityCount={unreadActivityCount}
+      />
+    )
   }
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -699,12 +683,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           </>
         }
       />
-      <SidebarEditorDialog
-        workspaceId={workspaceId}
-        open={isEditorOpen}
-        onOpenChange={setIsEditorOpen}
-        hiddenQuickLinkKeys={boardEnabled ? undefined : [BOARD_QUICK_LINK_KEY]}
-      />
+      <SidebarEditorDialog workspaceId={workspaceId} open={isEditorOpen} onOpenChange={setIsEditorOpen} />
       {labelRemovePrompt && (
         <RemoveLabelDialog
           open

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -38,6 +38,7 @@ import { SidebarSearchPanel, useSearchPanel } from "@/components/search"
 import { SidebarHeader } from "./sidebar-header"
 import { SidebarQuickLinks } from "./quick-links"
 import { BoardModeBlock } from "./board-mode-block"
+import { BoardLinkRow } from "./board-link-row"
 import { SidebarStreamList } from "./sidebar-stream-list"
 import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skeletons"
 import { SidebarFooter } from "./sidebar-footer"
@@ -373,22 +374,24 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     quickLinksSlot = isBoardPage ? (
       <BoardModeBlock workspaceId={workspaceId} userId={user?.id ?? null} lensTotals={boardMode?.lensTotals ?? null} />
     ) : (
-      <SidebarQuickLinks
-        workspaceId={workspaceId}
-        quickLinks={sidebarConfig.quickLinks}
-        isDraftsPage={isDraftsPage}
-        draftCount={draftCount}
-        isSavedPage={isSavedPage}
-        savedCount={savedCount}
-        isScheduledPage={isScheduledPage}
-        scheduledCount={scheduledCount}
-        isActivityPage={isActivityPage}
-        isBoardPage={isBoardPage}
-        isMemoryPage={isMemoryPage}
-        isFilesPage={isFilesPage}
-        isLabelsPage={isLabelsPage}
-        unreadActivityCount={unreadActivityCount}
-      />
+      <>
+        <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
+        <SidebarQuickLinks
+          workspaceId={workspaceId}
+          quickLinks={sidebarConfig.quickLinks}
+          isDraftsPage={isDraftsPage}
+          draftCount={draftCount}
+          isSavedPage={isSavedPage}
+          savedCount={savedCount}
+          isScheduledPage={isScheduledPage}
+          scheduledCount={scheduledCount}
+          isActivityPage={isActivityPage}
+          isMemoryPage={isMemoryPage}
+          isFilesPage={isFilesPage}
+          isLabelsPage={isLabelsPage}
+          unreadActivityCount={unreadActivityCount}
+        />
+      </>
     )
   }
 

--- a/apps/frontend/src/components/quick-switcher/commands.test.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.test.ts
@@ -106,7 +106,6 @@ describe("commands", () => {
 
     /** The palette destination each sidebar quick link must be reachable through. */
     const reachability: Record<SidebarQuickLinkKey, (ctx: ReturnType<typeof makeContext>) => void> = {
-      board: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/board`),
       drafts: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/drafts`),
       saved: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/saved`),
       files: ({ openExplorer }) => expect(openExplorer).toHaveBeenCalled(),

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -563,14 +563,11 @@ describe("QuickSwitcher Integration Tests", () => {
       // Switch to command mode
       await user.type(screen.getByLabelText("Quick switcher input"), ">")
 
-      // First command should be selected after mode switch
+      // selectedIndex resets to 0 on the mode switch — the first command row
+      // (data-index 0) carries the highlight regardless of which command it is.
       await waitFor(() => {
-        // Look for command items (they're rendered as divs since commands don't have href)
-        const commandItems = screen.getAllByText(/new scratchpad|new channel|toggle theme/i)
-        if (commandItems.length > 0) {
-          const firstCommandItem = commandItems[0].closest("div[data-index]")
-          expect(firstCommandItem?.classList.contains("bg-muted")).toBe(true)
-        }
+        const firstCommandItem = document.querySelector('[data-index="0"]')
+        expect(firstCommandItem?.classList.contains("bg-muted")).toBe(true)
       })
     })
   })

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -1,16 +1,12 @@
 import { useMemo } from "react"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { isDraftId } from "@/hooks"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { hasPermission } from "@/lib/permissions"
 import { rankMatches } from "@/lib/match-score"
 import { commands, type Command, type CommandContext } from "./commands"
 import { draftStreamCommands, streamCommands } from "./stream-commands"
 import type { ModeResult, QuickSwitcherItem } from "./types"
-
-// Commands only shown when the board-view flag is on (route + sidebar gated too).
-const BOARD_GATED_COMMAND_IDS = new Set(["view-board", "new-post"])
 
 interface UseCommandItemsParams {
   query: string
@@ -32,9 +28,6 @@ export function rankCommands(candidates: Command[], query: string): Command[] {
 }
 
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {
-  // The board commands ("View Board", "New Post") are gated behind the board-view
-  // flag, matching the route + sidebar gates.
-  const boardEnabled = useFeatureFlag(commandContext.workspaceId, "board-view") === "on"
   // AI Agents settings is admin-only (the tab itself is admin-gated), so the
   // command hides for non-admins rather than opening settings to a fallback tab.
   const bootstrap = useCachedWorkspaceBootstrap(commandContext.workspaceId)
@@ -65,13 +58,11 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
     // cross-group ordering is the section order, not match quality.
     const contextualItems = rankCommands(contextualCommands, query).map((c) => toItem(c, contextualGroup))
 
-    const globalCommands = commands.filter(
-      (c) => (!BOARD_GATED_COMMAND_IDS.has(c.id) || boardEnabled) && (c.id !== "open-ai-agents" || isAdmin)
-    )
+    const globalCommands = commands.filter((c) => c.id !== "open-ai-agents" || isAdmin)
     const globalItems = rankCommands(globalCommands, query).map((c) => toItem(c, "Commands"))
 
     return [...contextualItems, ...globalItems]
-  }, [query, commandContext, boardEnabled, isAdmin])
+  }, [query, commandContext, isAdmin])
 
   return {
     items,

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -4,7 +4,6 @@ import { renderHook } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
-import * as featureFlagsModule from "@/hooks/use-feature-flags"
 import { useLastLocation, usePersistLastLocation } from "./use-last-location"
 import { setLastLocation, getLastLocation } from "@/lib/last-location"
 import type { CachedStream } from "@/db"
@@ -16,12 +15,11 @@ function stream(id: string, updatedAt = "2026-01-01T00:00:00.000Z"): CachedStrea
   return { id, updatedAt } as unknown as CachedStream
 }
 
-function setup({ streams = [], flag = null }: { streams?: CachedStream[]; flag?: "on" | "off" | null }) {
+function setup({ streams = [] }: { streams?: CachedStream[] }) {
   vi.spyOn(authModule, "useAuth").mockReturnValue({ user: { id: USER } } as unknown as ReturnType<
     typeof authModule.useAuth
   >)
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(streams)
-  vi.spyOn(featureFlagsModule, "useFeatureFlagWhenKnown").mockReturnValue(flag as never)
 }
 
 beforeEach(() => {
@@ -34,7 +32,7 @@ describe("useLastLocation — stream arm", () => {
     setup({ streams: [stream("stream_a")] })
     setLastLocation(USER, WS, { surface: "stream", streamId: "stream_a", board: null })
     const { result } = renderHook(() => useLastLocation(WS))
-    expect(result.current).toMatchObject({ redirectStreamId: "stream_a", boardHref: null, pendingBoardFlag: false })
+    expect(result.current).toMatchObject({ redirectStreamId: "stream_a", boardHref: null })
   })
 
   it("falls back to the most-recent stream and evicts a stale record", () => {
@@ -55,19 +53,8 @@ describe("useLastLocation — stream arm", () => {
 })
 
 describe("useLastLocation — board arm", () => {
-  it("renders nothing while the flag is unknown", () => {
-    setup({ streams: [stream("stream_a")], flag: null })
-    setLastLocation(USER, WS, {
-      surface: "board",
-      streamId: "stream_a",
-      board: { lens: "active", search: "?in=stream_a" },
-    })
-    const { result } = renderHook(() => useLastLocation(WS))
-    expect(result.current).toMatchObject({ pendingBoardFlag: true, boardHref: null, redirectStreamId: null })
-  })
-
-  it("builds the board href when the flag is on, sweeping stale scope", () => {
-    setup({ streams: [stream("stream_a")], flag: "on" })
+  it("builds the board href from a stored board record, sweeping stale scope", () => {
+    setup({ streams: [stream("stream_a")] })
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: "stream_a",
@@ -76,19 +63,8 @@ describe("useLastLocation — board arm", () => {
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({
       boardHref: "/w/ws_1/board/active?in=stream_a",
-      pendingBoardFlag: false,
+      redirectStreamId: null,
     })
-  })
-
-  it("falls through to the retained stream when the flag is off", () => {
-    setup({ streams: [stream("stream_a")], flag: "off" })
-    setLastLocation(USER, WS, {
-      surface: "board",
-      streamId: "stream_a",
-      board: { lens: "active", search: "?in=stream_a" },
-    })
-    const { result } = renderHook(() => useLastLocation(WS))
-    expect(result.current).toMatchObject({ redirectStreamId: "stream_a", boardHref: null, pendingBoardFlag: false })
   })
 })
 

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -2,7 +2,6 @@ import { useEffect, useMemo } from "react"
 import { useLocation, useMatch } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
-import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import {
   buildBoardHref,
   getLastLocation,
@@ -19,18 +18,14 @@ interface UseLastLocationResult {
   boardHref: string | null
   /** True when bootstrap is loaded and the workspace has zero streams. */
   shouldOpenSidebar: boolean
-  /** Board surface chosen but the `board-view` flag isn't known yet — render nothing. */
-  pendingBoardFlag: boolean
 }
 
 /**
  * Resolves where the workspace index route should land, restoring the last
  * surface (stream or board) the viewer was on.
  *
- * Board arm: requires the `board-view` flag to be known and `"on"` (render
- * nothing while unknown, mirroring the board page's own gate; flag off falls
- * through to the stream arm using the retained last stream). The lens is
- * validated and stale scope ids swept inside {@link buildBoardHref}.
+ * Board arm: a stored board record resolves straight to the board URL, with the
+ * lens validated and stale scope ids swept inside {@link buildBoardHref}.
  *
  * Stream arm (unchanged): stored stream validated against bootstrap, most-
  * recently-active fallback, and `shouldOpenSidebar` only once bootstrap has
@@ -39,35 +34,21 @@ interface UseLastLocationResult {
 export function useLastLocation(workspaceId: string): UseLastLocationResult {
   const { user } = useAuth()
   const streams = useWorkspaceStreams(workspaceId)
-  const boardFlag = useFeatureFlagWhenKnown(workspaceId, "board-view")
 
   const result = useMemo(() => {
     const record = user ? getLastLocation(user.id, workspaceId) : null
 
     if (record?.surface === "board" && record.board) {
-      if (boardFlag === null) {
-        return {
-          redirectStreamId: null,
-          boardHref: null,
-          shouldOpenSidebar: false,
-          pendingBoardFlag: true,
-          staleStoredId: false,
-        }
+      return {
+        redirectStreamId: null,
+        boardHref: buildBoardHref(
+          workspaceId,
+          record.board,
+          streams.map((s) => s.id)
+        ),
+        shouldOpenSidebar: false,
+        staleStoredId: false,
       }
-      if (boardFlag === "on") {
-        return {
-          redirectStreamId: null,
-          boardHref: buildBoardHref(
-            workspaceId,
-            record.board,
-            streams.map((s) => s.id)
-          ),
-          shouldOpenSidebar: false,
-          pendingBoardFlag: false,
-          staleStoredId: false,
-        }
-      }
-      // Flag off: fall through to the stream arm using the retained stream id.
     }
 
     const storedId = record?.streamId ?? null
@@ -78,7 +59,6 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
           redirectStreamId: storedId,
           boardHref: null,
           shouldOpenSidebar: false,
-          pendingBoardFlag: false,
           staleStoredId: false,
         }
       }
@@ -86,7 +66,6 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
         redirectStreamId: streams.length > 0 ? getMostRecentStreamId(streams) : null,
         boardHref: null,
         shouldOpenSidebar: streams.length === 0,
-        pendingBoardFlag: false,
         staleStoredId: true,
       }
     }
@@ -96,7 +75,6 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
         redirectStreamId: getMostRecentStreamId(streams),
         boardHref: null,
         shouldOpenSidebar: false,
-        pendingBoardFlag: false,
         staleStoredId: false,
       }
     }
@@ -105,10 +83,9 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
       redirectStreamId: null,
       boardHref: null,
       shouldOpenSidebar: true,
-      pendingBoardFlag: false,
       staleStoredId: false,
     }
-  }, [user, workspaceId, streams, boardFlag])
+  }, [user, workspaceId, streams])
 
   useEffect(() => {
     if (result.staleStoredId && user) {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { Fragment, createElement } from "react"
 import * as boardFeedListModule from "@/components/board/board-feed-list"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
@@ -116,8 +116,6 @@ function mountBoard(
   opts: {
     nextCursor?: string | null
     fail?: boolean
-    /** "unknown" leaves the flag absent from the bootstrap (still-resolving state). */
-    boardFlag?: "on" | "off" | "unknown"
     failMessages?: boolean
     /** URL to mount at — set `/w/<ws>/board/<lens>` to exercise a lens segment. */
     entry?: string
@@ -125,14 +123,7 @@ function mountBoard(
     boardViews?: BoardView[]
   } = {}
 ) {
-  const {
-    nextCursor = null,
-    fail = false,
-    boardFlag = "on",
-    failMessages = false,
-    entry = `/w/${WORKSPACE_ID}/board`,
-    boardViews,
-  } = opts
+  const { nextCursor = null, fail = false, failMessages = false, entry = `/w/${WORKSPACE_ID}/board`, boardViews } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
     return { posts, nextCursor }
@@ -147,10 +138,8 @@ function mountBoard(
   // pagination/loading/error, so `listByWorkspace` is exercised as before.
   vi.spyOn(boardStoreModule, "useBoardPosts").mockReturnValue(posts as never)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  // The board is gated behind the board-view flag, read from the bootstrap cache;
   // `boardViews` seeds the saved-view list `useBoardViews` reads from bootstrap.
   queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), {
-    featureFlags: boardFlag === "unknown" ? {} : { "board-view": boardFlag },
     boardViews: boardViews ?? [],
   })
   const tree = (
@@ -275,29 +264,6 @@ describe("BoardPage", () => {
     mountBoard([], { boardViews: [makeBoardView()] })
     const probe = await screen.findByTestId("location")
     await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board/active?is=channel`))
-  })
-
-  it("does not bounce to the saved-view home while the board-view flag is unknown", async () => {
-    // The redirect is gated behind the resolved flag (like the rest of the board),
-    // so a still-loading flag never bounces through the saved-view URL first.
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    mountBoard([], { boardFlag: "unknown", boardViews: [makeBoardView()] })
-    const probe = await screen.findByTestId("location")
-    // Stays put on bare `/board`; never navigates to the view URL.
-    expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board`)
-  })
-
-  it("does not bounce to the saved-view home when the board-view flag is off", async () => {
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    mountBoard([], { boardFlag: "off", boardViews: [makeBoardView()] })
-    const probe = await screen.findByTestId("location")
-    // Flag-off leaves the board route (to the workspace), never through the view URL.
-    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}`))
-    expect(probe.textContent).not.toContain("is=channel")
   })
 
   it("hides 'Show everything' on an empty saved-view home landing", async () => {
@@ -511,16 +477,6 @@ describe("BoardPage", () => {
     // Load more is driven by the query's async `hasNextPage` (the feed itself
     // renders synchronously from the store), so wait for it to resolve.
     expect(await screen.findByRole("button", { name: "Load more" })).toBeTruthy()
-  })
-
-  it("does not render the board when the board-view flag is off", async () => {
-    const { listByWorkspace } = mountBoard([makePost()], { boardFlag: "off" })
-    // Gate redirects away — board content never appears and the feed isn't fetched.
-    // Flush effects so a (hypothetical) deferred mount would have its chance to fire.
-    await act(async () => {})
-    expect(screen.queryByText("Opening message body.")).toBeNull()
-    expect(screen.queryByText("Board")).toBeNull()
-    expect(listByWorkspace).not.toHaveBeenCalled()
   })
 
   it("permalinks each message to itself in its stream timeline (no conversations pane)", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -9,7 +9,6 @@ import { PanelHost } from "@/components/layout/panel-host"
 import { SidebarToggle } from "@/components/layout/sidebar-toggle"
 import { usePanel, usePreferencesOptional, useSidebar } from "@/contexts"
 import { usePanelLayout } from "@/hooks"
-import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
 import { localStartOfDayMs } from "@/lib/dates"
 import {
@@ -198,11 +197,10 @@ export function BoardPage() {
   const bareBoard = lensParam === undefined && location.search === ""
   // Bare `/board` is a "resolve where home is" route: hold (render nothing) until
   // the home is knowable, rather than paint the plain-lens board and then bounce
-  // to a saved-view home a frame later (mirrors the flag gate below).
+  // to a saved-view home a frame later.
   if (bareBoard && !savedViewReady) return null
   // The bounce target for a bare `/board` arrival with a saved-view home. Resolved
-  // here but NAVIGATED inside BoardPageGate — only once the board-view flag is on
-  // and at most once per navigation — so it never fires ahead of the flag gate and
+  // here but NAVIGATED inside BoardPageGate — at most once per navigation — so
   // pinning a view as home while sitting on `/board` (a same-URL preference change)
   // can't yank the user off the page.
   const savedViewTarget =
@@ -230,11 +228,10 @@ export function BoardPage() {
 }
 
 /**
- * The board is gated behind the `board-view` feature flag. While the bootstrap
- * (and thus the flag) is still unknown, render nothing rather than redirect —
- * redirecting on the default would bounce a flagged user who deep-links or
- * refreshes on /board before the bootstrap cache is populated. The backend
- * endpoint 404s without the flag too, so this is the UX half of the gate.
+ * Handles the bare `/board` → saved-view-home redirect as a post-commit effect.
+ * It lives in this child (not BoardPage) because a hook can't sit after
+ * BoardPage's early returns. The redirect fires at most once per navigation; a
+ * later same-URL re-render from pinning a view as home must not re-trigger it.
  */
 function BoardPageGate({
   workspaceId,
@@ -249,29 +246,26 @@ function BoardPageGate({
   savedViewTarget: string | null
   savedViewReady: boolean
 }) {
-  const boardFlag = useFeatureFlagWhenKnown(workspaceId, "board-view")
   const navigate = useNavigate()
   const location = useLocation()
-  // Bounce a bare `/board` arrival to the saved-view home, but only once the flag
-  // is on and at most once per navigation (`location.key`): a later same-URL
-  // re-render from pinning a view as home must not re-trigger it, so the redirect
-  // follows navigation, not the live preference.
+  // Bounce a bare `/board` arrival to the saved-view home at most once per
+  // navigation (`location.key`): a later same-URL re-render from pinning a view
+  // as home must not re-trigger it, so the redirect follows navigation, not the
+  // live preference.
   const handledKeyRef = useRef<string | null>(null)
   useEffect(() => {
-    if (boardFlag !== "on" || !savedViewReady) return
+    if (!savedViewReady) return
     if (handledKeyRef.current === location.key) return
     handledKeyRef.current = location.key
     if (savedViewTarget) navigate(savedViewTarget, { replace: true })
-  }, [boardFlag, savedViewReady, savedViewTarget, location.key, navigate])
-  if (boardFlag === null) return null
-  if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
+  }, [savedViewReady, savedViewTarget, location.key, navigate])
   // A saved-view home is about to redirect (the effect above fires post-commit) —
-  // render nothing rather than paint one frame of the wrong lens board first,
-  // mirroring the flag gate's "render nothing rather than redirect". Gate this on
-  // the SAME "not yet handled this navigation" condition the effect uses: when the
-  // target only appears because the viewer pinned a view as home while sitting on
-  // `/board` (same `location.key`, already handled), the effect deliberately won't
-  // navigate — so blanking here would strand the board. Render it instead.
+  // render nothing rather than paint one frame of the wrong lens board first. Gate
+  // this on the SAME "not yet handled this navigation" condition the effect uses:
+  // when the target only appears because the viewer pinned a view as home while
+  // sitting on `/board` (same `location.key`, already handled), the effect
+  // deliberately won't navigate — so blanking here would strand the board. Render
+  // it instead.
   if (savedViewTarget && handledKeyRef.current !== location.key) return null
   return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
 }

--- a/apps/frontend/src/routes/index.test.tsx
+++ b/apps/frontend/src/routes/index.test.tsx
@@ -69,7 +69,6 @@ describe("WorkspaceHome", () => {
       redirectStreamId: "stream_123",
       boardHref: null,
       shouldOpenSidebar: false,
-      pendingBoardFlag: false,
     })
   })
 
@@ -91,7 +90,6 @@ describe("WorkspaceHome", () => {
       redirectStreamId: null,
       boardHref: "/w/ws_123/board/active?in=stream_x",
       shouldOpenSidebar: false,
-      pendingBoardFlag: false,
     })
     render(
       <MemoryRouter initialEntries={["/w/ws_123"]}>
@@ -103,27 +101,6 @@ describe("WorkspaceHome", () => {
     )
 
     expect(await screen.findByTestId("path")).toHaveTextContent("/w/ws_123/board/active")
-  })
-
-  it("renders nothing while the board flag is still unknown", () => {
-    mockUseLastLocation.mockReturnValue({
-      redirectStreamId: null,
-      boardHref: null,
-      shouldOpenSidebar: false,
-      pendingBoardFlag: true,
-    })
-    render(
-      <MemoryRouter initialEntries={["/w/ws_123"]}>
-        <Routes>
-          <Route path="/w/:workspaceId" element={<WorkspaceHome />} />
-          <Route path="/w/:workspaceId/s/:streamId" element={<SearchEcho />} />
-        </Routes>
-      </MemoryRouter>
-    )
-
-    expect(screen.queryByText("Select a stream from the sidebar")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("search")).not.toBeInTheDocument()
-    expect(mockTogglePinned).not.toHaveBeenCalled()
   })
 
   it("redirects legacy memo routes into the memory explorer", async () => {

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -179,7 +179,7 @@ export function WorkspaceHome() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const location = useLocation()
   const { state, togglePinned } = useSidebar()
-  const { redirectStreamId, boardHref, shouldOpenSidebar, pendingBoardFlag } = useLastLocation(workspaceId ?? "")
+  const { redirectStreamId, boardHref, shouldOpenSidebar } = useLastLocation(workspaceId ?? "")
   const sidebarOpenedRef = useRef(false)
 
   useEffect(() => {
@@ -188,10 +188,6 @@ export function WorkspaceHome() {
       togglePinned()
     }
   }, [shouldOpenSidebar, state, togglePinned])
-
-  if (pendingBoardFlag) {
-    return null
-  }
 
   if (boardHref && workspaceId) {
     return <Navigate to={boardHref} replace />

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -16,13 +16,8 @@
  * Every live feature flag, mapping key → allowed values. The first value is
  * the default. Add a flag while rolling a feature out; delete it the moment
  * the rollout is done. A flag that survives long here is a smell.
- *
- * - `board-view`: gates the workspace Board (a cross-stream view of
- *   conversations). Off by default; flip to `on` per user from the backoffice.
  */
-export const FEATURE_FLAGS = {
-  "board-view": ["off", "on"],
-} as const satisfies Record<string, readonly [string, ...string[]]>
+export const FEATURE_FLAGS = {} as const satisfies Record<string, readonly [string, ...string[]]>
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -897,6 +897,7 @@ export {
   SIDEBAR_QUICK_LINKS_WITH_ACTIVE_STATE,
   type SidebarActiveQuickLinkKey,
   quickLinkHasActiveState,
+  isKnownQuickLinkKey,
   SIDEBAR_QUICK_LINK_VISIBILITIES,
   type SidebarQuickLinkVisibility,
   type SidebarQuickLink,

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test"
 import {
   normalizeSidebarConfig,
   SIDEBAR_CONFIG_VERSION,
+  SIDEBAR_QUICK_LINKS,
   QUICK_LINKS_SECTION_ID,
   MAX_CUSTOM_SECTION_STREAM_IDS,
   type RawSidebarConfig,
@@ -162,5 +163,29 @@ describe("normalizeSidebarConfig section sanitization", () => {
     const spec = result.sections[0].spec
     if (spec.kind !== "custom") throw new Error("expected a custom section")
     expect(spec.streamIds).toHaveLength(MAX_CUSTOM_SECTION_STREAM_IDS)
+  })
+})
+
+describe("normalizeSidebarConfig quick-link sanitization", () => {
+  test("drops a retired quick-link key (board) while keeping the rest and appending missing keys", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [],
+      // A stale client persisted the removed "board" link ahead of the others.
+      quickLinks: [
+        { key: "board", visibility: "show" },
+        { key: "drafts", visibility: "hidden" },
+      ],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+    const keys = result.quickLinks.map((l) => l.key)
+
+    expect(keys).not.toContain("board")
+    // The known key it carried keeps its stored visibility and leading position;
+    // every other current key is appended (shown) in canonical order.
+    expect(keys).toEqual(["drafts", ...SIDEBAR_QUICK_LINKS.filter((k) => k !== "drafts")])
+    expect(result.quickLinks.find((l) => l.key === "drafts")?.visibility).toBe("hidden")
   })
 })

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -80,17 +80,13 @@ export type SidebarBasePreset = (typeof SIDEBAR_BASE_PRESETS)[number]
  * reorder them and set each one's visibility; the set itself is fixed (these are
  * the workspace's standing views).
  */
-export const SIDEBAR_QUICK_LINKS = [
-  "board",
-  "drafts",
-  "saved",
-  "files",
-  "scheduled",
-  "memory",
-  "labels",
-  "activity",
-] as const
+export const SIDEBAR_QUICK_LINKS = ["drafts", "saved", "files", "scheduled", "memory", "labels", "activity"] as const
 export type SidebarQuickLinkKey = (typeof SIDEBAR_QUICK_LINKS)[number]
+
+/** Whether a stored/wire key is one of the current quick links. */
+export function isKnownQuickLinkKey(key: string): key is SidebarQuickLinkKey {
+  return (SIDEBAR_QUICK_LINKS as readonly string[]).includes(key)
+}
 
 /** Stable section id for the Quick Links block — doubles as its collapse-state key. */
 export const QUICK_LINKS_SECTION_ID = "quick-links"
@@ -147,9 +143,14 @@ export interface SidebarConfig {
   quickLinks: SidebarQuickLink[]
 }
 
-/** The legacy ({ enabled }) and current ({ visibility }) shapes a stored link can take. */
+/**
+ * The legacy ({ enabled }) and current ({ visibility }) shapes a stored link can
+ * take. `key` is a raw string, not {@link SidebarQuickLinkKey}: a persisted row or
+ * a stale client can carry a retired key (e.g. the removed "board" link), which
+ * {@link normalizeSidebarConfig} drops on read.
+ */
 export type StoredQuickLink = {
-  key: SidebarQuickLinkKey
+  key: string
   visibility?: SidebarQuickLinkVisibility
   /** Pre-v2 boolean flag, migrated to {@link SidebarQuickLink.visibility}. */
   enabled?: boolean
@@ -229,11 +230,11 @@ function sanitizeCustomStreamIds(streamIds: unknown, claimed: Set<string>): stri
 }
 
 /** Resolve a stored link's visibility, migrating the pre-v2 boolean and coercing invalid `active`. */
-function normalizeQuickLinkVisibility(link: StoredQuickLink): SidebarQuickLinkVisibility {
+function normalizeQuickLinkVisibility(link: StoredQuickLink, key: SidebarQuickLinkKey): SidebarQuickLinkVisibility {
   const stored = link.visibility
   if (stored === "show" || stored === "active" || stored === "hidden") {
     // "active" only makes sense for links with a live signal.
-    return stored === "active" && !quickLinkHasActiveState(link.key) ? "show" : stored
+    return stored === "active" && !quickLinkHasActiveState(key) ? "show" : stored
   }
   // Pre-v2 documents carried a boolean `enabled` instead of a visibility.
   if (typeof link.enabled === "boolean") return link.enabled ? "show" : "hidden"
@@ -259,9 +260,10 @@ export function normalizeSidebarConfig(config: RawSidebarConfig): SidebarConfig 
   const seen = new Set<SidebarQuickLinkKey>()
   const quickLinks: SidebarQuickLink[] = []
   for (const link of storedLinks) {
-    if (SIDEBAR_QUICK_LINKS.includes(link.key) && !seen.has(link.key)) {
-      seen.add(link.key)
-      quickLinks.push({ key: link.key, visibility: normalizeQuickLinkVisibility(link) })
+    const key = link.key
+    if (isKnownQuickLinkKey(key) && !seen.has(key)) {
+      seen.add(key)
+      quickLinks.push({ key, visibility: normalizeQuickLinkVisibility(link, key) })
     }
   }
   for (const key of SIDEBAR_QUICK_LINKS) {


### PR DESCRIPTION
## Problem

Two leftovers from the board's incubation, both raised while dogfooding #1302:

1. **The `board-view` flag has done its job.** The board shipped through #1188 → #1302 → #1305 behind a per-user flag; it's now the daily surface and the gate is pure friction — nine backend 404 guards, a `BoardPageGate` flag arm, a `pendingBoardFlag` hold in the landing redirect, and a flag-known wait before last-location can restore the board.
2. **The sidebar cross-links are asymmetric.** Board mode leads with a first-class "← Chats" row, but chats mode buries "Board" inside the collapsible Quick Links section. Kris's ruling (handover stream sketch): both surfaces should give the other one first-class row.

## Solution

Delete the flag end to end and make the cross-links mirror each other: chats mode gets a standalone "Board →" row above the Quick Links block, and `board` stops being a quick link.

### How it works

- **Registry** — `"board-view"` removed from `FEATURE_FLAGS` (`packages/types/src/feature-flags.ts`). The registry filters stored overrides at read time, so lingering `user_feature_flags` rows go inert with no migration. The flag *infrastructure* (hooks, `FeatureFlagService`, control-plane feature, backoffice page) stays for the next rollout; with an empty registry `FeatureFlagKey` is `never`, which is exactly what forces every call site in this diff to be gone.
- **Backend** — the nine `getFlag(...) !== "on" → 404` guards in `conversations/handlers.ts` (feed, board messages, board post, hide/unhide, mute/unmute, exclusions) and `board-views/handlers.ts` (`requireBoardFlag`) are deleted; `featureFlagService` is unwired from both factories in `routes.ts`. Access still resolves per-row through the feed queries (INV-62) — the flag was reachability, not access.
- **Frontend** — `BoardPageGate` keeps only the bare-`/board` → saved-view-home redirect; its once-per-navigation `location.key` latch and the pin-while-on-`/board` no-yank guard are byte-for-byte preserved. `useLastLocation`'s board arm resolves unconditionally (`pendingBoardFlag` removed from the result and from `WorkspaceHome`), the sidebar drops `boardEnabled`/quick-link filtering, and the quick-switcher board commands are ungated.
- **Symmetric rows** — new `board-link-row.tsx` (~44 lines) renders `LayoutGrid · Board · →` with the same row classes as `BoardModeBlock`'s "← Chats", linking to the viewer's last board state via the same `getLastLocation` + `buildBoardHref` pair that block uses for `chatsHref` (falls back to bare `/board`). It renders above `SidebarQuickLinks` inside the same `quickLinksSlot`, so a user who removed the Quick Links block gets neither cross-link — symmetric with board mode.
- **Quick-link retirement** — `"board"` removed from `SIDEBAR_QUICK_LINKS`; `normalizeSidebarConfig` already drops unknown stored keys on read, so persisted configs self-heal. New `isKnownQuickLinkKey` guard narrows the loop now that `StoredQuickLink.key` is honestly `string` (wire input can carry a retired key).

### Key design decisions

**1. Landing stays per-device, no new preference.** Kris's call: "the app simply remembering where you were last time on this device" — which is exactly #1302's last-location restore. This PR only deletes its flag-wait arm; an explicit "what counts as main" control is deferred.

**2. Write path tolerates retired keys instead of 400ing.** `sidebar-config/handlers.ts` had `key: z.enum(SIDEBAR_QUICK_LINKS)` with the array capped at the enum length. A stale client PATCHing its full 8-key set (including `board`) would have failed the whole layout write. Now the key is a bounded string (`min(1).max(64)`, array `.max(32)` as a plain size guard) and `normalizeSidebarConfig` drops the retired key — the same read-time registry-filtering philosophy the feature-flag system uses.

**3. `BoardPageGate` survives as a component.** Collapsing it into `BoardPage` would put a hook after early returns (rules-of-hooks), so it stays — renamed in purpose only: it now exists solely to own the saved-view-home redirect effect.

**4. First-class row placement.** `LayoutGrid` icon left, trailing `ArrowRight` — the closest mirror of "← Chats" inferable from the sketch. Flagged as a judgment call; trivially restyled if the sketch differs.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/layout/sidebar/board-link-row.tsx` | Chats-mode "Board →" first-class row; mirrors `BoardModeBlock`'s "← Chats" styling and href derivation |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/feature-flags.ts` | `board-view` key deleted; registry now empty, helpers unchanged |
| `packages/types/src/sidebar.ts` | `board` out of `SIDEBAR_QUICK_LINKS`; `isKnownQuickLinkKey` guard; `StoredQuickLink.key` widened to `string` (wire honesty) |
| `apps/backend/src/features/conversations/handlers.ts` | 8 flag gates removed; `featureFlagService` dep dropped; gate comments rewritten (INV-25) |
| `apps/backend/src/features/board-views/handlers.ts` | `requireBoardFlag` + 4 call sites removed; dep dropped |
| `apps/backend/src/features/sidebar-config/handlers.ts` | Quick-link key schema: enum → bounded string; array cap decoupled from registry length |
| `apps/backend/src/routes.ts` | Flag service unwired from the two factories |
| `apps/frontend/src/pages/board.tsx` | `BoardPageGate` flag arms removed; saved-view-home redirect semantics preserved |
| `apps/frontend/src/hooks/use-last-location.ts` | Board arm unconditional; `pendingBoardFlag` removed |
| `apps/frontend/src/routes/index.tsx` | `WorkspaceHome` drops the flag hold |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | `boardEnabled`/filtering gone; `BoardLinkRow` above quick links in chats mode |
| `apps/frontend/src/components/layout/sidebar/quick-links.tsx` | `board` entry + `isBoardPage` prop removed |
| `apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx` | `hiddenQuickLinkKeys` prop deleted (board was its only caller) |
| `apps/frontend/src/components/quick-switcher/use-command-items.ts` | `BOARD_GATED_COMMAND_IDS` gating removed |
| Tests (9 files) | Flag-arm cases deleted; stored-`board`-key drop + schema-tolerance cases added; quick-switcher `selectedIndex` test re-anchored to `[data-index="0"]` (its old anchor depended on the board command being filtered out) |

## Out of scope (deliberate)

- **Landing preference / "choose your main surface"** — deferred per Kris; last-location per-device restore is the behavior.
- **Board unread counts + board-mode browser-E2E specs** — open follow-ups from #1302, untouched.
- **`apps/frontend/src/lib/dates.test.ts`** — 4 `formatFutureTime` failures reproduce identically on untouched `main` (assertions expect UTC rendering; fail on any non-UTC machine). Pre-existing, isolated as a follow-up per CLAUDE.md.

## Test plan

- [x] Backend `test:unit` full — 2764 pass, 0 fail
- [x] Frontend `vitest run` full — 4186 pass; only the 4 pre-existing TZ-dependent `dates.test.ts` failures (identical on main, see Out of scope)
- [x] `packages/types` — 109+ pass incl. new stored-`board`-key normalization case
- [x] Full monorepo typecheck + lint green (pre-commit hook, all 14 workspaces)
- [x] Live `dev:test` + scripted Playwright, 14/14 checks: Board row above Quick Links (exactly one Board link in the sidebar), board mode ← Chats + Lenses, lens click → `/board/active`, `/w/:id` reload restores board **with lens**, ← Chats returns to the stream, stream restore after revisit, mobile 390px drawer shows the row and opens the board; screenshots reviewed at 1440px + 390px
- [x] Per-step review: each of the 3 steps implemented by an Opus worker and checked by 2 Opus verifiers (correctness+invariants, reusability+design) — all converged with 0 fix rounds
- [ ] Board browser-E2E specs — still the standing follow-up from #1302; this PR's live verification is scripted-Playwright, not a committed spec

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Board GA (retire the `board-view` flag) + symmetric first-class sidebar cross-links, per Kris's dogfood feedback on #1302.

**What was built:**
1. Step 1 — registry key deleted, nine backend gates removed, `featureFlagService` unwired, flag-only tests deleted.
2. Step 2 — frontend gates removed: `BoardPageGate` (saved-view redirect preserved), `useLastLocation` (`pendingBoardFlag` gone), sidebar, quick-switcher; tests updated.
3. Step 3 — `board` retired from the quick-link registry (read-side self-heal, write-side tolerance), new `BoardLinkRow` in chats mode mirroring "← Chats".

**Design decisions:** per-device landing only (no preference); retired-key-tolerant write path (bounded string key + normalization drop, not enum 400); `BoardPageGate` kept as a component (rules-of-hooks); row visual = `LayoutGrid · Board · →` (judgment call from the sketch description).

**What's NOT included:** landing preference, board unread counts, committed board E2E specs, the pre-existing TZ-dependent `dates.test.ts` failures.

**Status:** complete; verified live via `dev:test` + Playwright at both breakpoints.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_019a75zNDV15tjKe8VNxMsJo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786487293&installation_id=129946197&pr_number=1312&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1312&signature=51e8642572cbb8b5128478a1f1d26259647f4b5a2e6d3140706aed7a75b35d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->