### PR TITLE
feat: default companion persona — workspace default + per-user override, resolved at dispatch

### DIFF
--- a/apps/backend/src/features/agents/companion-outbox-handler.test.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.test.ts
@@ -7,7 +7,6 @@ import { StreamRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { CompanionHandler } from "./companion-outbox-handler"
 import { PersonaRepository } from "./persona-repository"
-import * as resolveDefaultPersonaModule from "./resolve-default-persona"
 import { PersonaConfigDraftRepository } from "./persona-config-draft-repository"
 import { AgentSessionRepository } from "./session-repository"
 
@@ -263,7 +262,7 @@ describe("CompanionHandler", () => {
     )
   })
 
-  it("resolves the default persona at dispatch when the scratchpad has no explicit pick", async () => {
+  it("falls back to the built-in default (never the user/workspace default) for a legacy NULL pointer", async () => {
     mockUserMessageEvent("stream_unpinned")
 
     const scratchpad = makeStream({
@@ -276,8 +275,8 @@ describe("CompanionHandler", () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(scratchpad)
     const findById = spyOn(PersonaRepository, "findById")
     spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
-    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona").mockResolvedValue({
-      id: "persona_resolved_default",
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault").mockResolvedValue({
+      id: "persona_system_ariadne",
       status: "active",
     } as any)
 
@@ -285,19 +284,20 @@ describe("CompanionHandler", () => {
     handler.handle()
     await waitForDebounce()
 
-    // Null pointer never hits findById; the resolver runs with the creator's id.
+    // Defaults resolve at CREATE and pin; dispatch never re-resolves them —
+    // a legacy NULL pointer degrades to the built-in only.
     expect(findById).not.toHaveBeenCalled()
-    expect(resolveSpy).toHaveBeenCalledWith({}, "ws_1", "usr_creator")
+    expect(systemDefault).toHaveBeenCalledWith({}, "ws_1")
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       expect.objectContaining({
         streamId: "stream_unpinned",
-        personaId: "persona_resolved_default",
+        personaId: "persona_system_ariadne",
       })
     )
   })
 
-  it("resolves the default with the ROOT scratchpad's creator for an unpinned nested thread", async () => {
+  it("falls back to the built-in default for an unpinned nested thread via its root scratchpad", async () => {
     mockUserMessageEvent("stream_thread_unpinned")
 
     const thread = makeStream({
@@ -323,8 +323,8 @@ describe("CompanionHandler", () => {
       return null
     })
     spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
-    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona").mockResolvedValue({
-      id: "persona_resolved_default",
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault").mockResolvedValue({
+      id: "persona_system_ariadne",
       status: "active",
     } as any)
 
@@ -332,17 +332,17 @@ describe("CompanionHandler", () => {
     handler.handle()
     await waitForDebounce()
 
-    expect(resolveSpy).toHaveBeenCalledWith({}, "ws_1", "usr_root_owner")
+    expect(systemDefault).toHaveBeenCalledWith({}, "ws_1")
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       expect.objectContaining({
         streamId: "stream_thread_unpinned",
-        personaId: "persona_resolved_default",
+        personaId: "persona_system_ariadne",
       })
     )
   })
 
-  it("bypasses the default resolver when the scratchpad has an active explicit pick", async () => {
+  it("uses the pinned persona directly when the scratchpad has an active explicit pick", async () => {
     mockUserMessageEvent("stream_pinned")
 
     const scratchpad = makeStream({
@@ -354,13 +354,13 @@ describe("CompanionHandler", () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(scratchpad)
     spyOn(PersonaRepository, "findById").mockResolvedValue({ id: "persona_pinned", status: "active" } as any)
     spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
-    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona")
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault")
 
     const { handler, jobQueue } = createHandler()
     handler.handle()
     await waitForDebounce()
 
-    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(systemDefault).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       expect.objectContaining({ streamId: "stream_pinned", personaId: "persona_pinned" })

--- a/apps/backend/src/features/agents/companion-outbox-handler.test.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.test.ts
@@ -7,6 +7,7 @@ import { StreamRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { CompanionHandler } from "./companion-outbox-handler"
 import { PersonaRepository } from "./persona-repository"
+import * as resolveDefaultPersonaModule from "./resolve-default-persona"
 import { PersonaConfigDraftRepository } from "./persona-config-draft-repository"
 import { AgentSessionRepository } from "./session-repository"
 
@@ -259,6 +260,110 @@ describe("CompanionHandler", () => {
         personaId: "persona_system_ariadne",
         personaDraftId: "pcd_1",
       })
+    )
+  })
+
+  it("resolves the default persona at dispatch when the scratchpad has no explicit pick", async () => {
+    mockUserMessageEvent("stream_unpinned")
+
+    const scratchpad = makeStream({
+      id: "stream_unpinned",
+      type: StreamTypes.SCRATCHPAD,
+      companionMode: CompanionModes.ON,
+      companionPersonaId: null,
+      createdBy: "usr_creator",
+    })
+    spyOn(StreamRepository, "findById").mockResolvedValue(scratchpad)
+    const findById = spyOn(PersonaRepository, "findById")
+    spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
+    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona").mockResolvedValue({
+      id: "persona_resolved_default",
+      status: "active",
+    } as any)
+
+    const { handler, jobQueue } = createHandler()
+    handler.handle()
+    await waitForDebounce()
+
+    // Null pointer never hits findById; the resolver runs with the creator's id.
+    expect(findById).not.toHaveBeenCalled()
+    expect(resolveSpy).toHaveBeenCalledWith({}, "ws_1", "usr_creator")
+    expect(jobQueue.send).toHaveBeenCalledWith(
+      "persona.agent",
+      expect.objectContaining({
+        streamId: "stream_unpinned",
+        personaId: "persona_resolved_default",
+      })
+    )
+  })
+
+  it("resolves the default with the ROOT scratchpad's creator for an unpinned nested thread", async () => {
+    mockUserMessageEvent("stream_thread_unpinned")
+
+    const thread = makeStream({
+      id: "stream_thread_unpinned",
+      type: StreamTypes.THREAD,
+      parentStreamId: "stream_root_unpinned",
+      parentMessageId: "msg_parent",
+      rootStreamId: "stream_root_unpinned",
+      companionMode: CompanionModes.OFF,
+      companionPersonaId: null,
+      createdBy: "usr_thread_author",
+    })
+    const rootScratchpad = makeStream({
+      id: "stream_root_unpinned",
+      type: StreamTypes.SCRATCHPAD,
+      companionMode: CompanionModes.ON,
+      companionPersonaId: null,
+      createdBy: "usr_root_owner",
+    })
+    spyOn(StreamRepository, "findById").mockImplementation(async (_db: any, id: string) => {
+      if (id === "stream_thread_unpinned") return thread
+      if (id === "stream_root_unpinned") return rootScratchpad
+      return null
+    })
+    spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
+    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona").mockResolvedValue({
+      id: "persona_resolved_default",
+      status: "active",
+    } as any)
+
+    const { handler, jobQueue } = createHandler()
+    handler.handle()
+    await waitForDebounce()
+
+    expect(resolveSpy).toHaveBeenCalledWith({}, "ws_1", "usr_root_owner")
+    expect(jobQueue.send).toHaveBeenCalledWith(
+      "persona.agent",
+      expect.objectContaining({
+        streamId: "stream_thread_unpinned",
+        personaId: "persona_resolved_default",
+      })
+    )
+  })
+
+  it("bypasses the default resolver when the scratchpad has an active explicit pick", async () => {
+    mockUserMessageEvent("stream_pinned")
+
+    const scratchpad = makeStream({
+      id: "stream_pinned",
+      type: StreamTypes.SCRATCHPAD,
+      companionMode: CompanionModes.ON,
+      companionPersonaId: "persona_pinned",
+    })
+    spyOn(StreamRepository, "findById").mockResolvedValue(scratchpad)
+    spyOn(PersonaRepository, "findById").mockResolvedValue({ id: "persona_pinned", status: "active" } as any)
+    spyOn(AgentSessionRepository, "findLatestByStream").mockResolvedValue(null)
+    const resolveSpy = spyOn(resolveDefaultPersonaModule, "resolveDefaultPersona")
+
+    const { handler, jobQueue } = createHandler()
+    handler.handle()
+    await waitForDebounce()
+
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(jobQueue.send).toHaveBeenCalledWith(
+      "persona.agent",
+      expect.objectContaining({ streamId: "stream_pinned", personaId: "persona_pinned" })
     )
   })
 

--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -3,7 +3,6 @@ import { StreamRepository } from "../streams"
 import { resolveDeliveryVerdict, TrustTiers } from "@threa/agent-runtime"
 import { resolveSealingContext } from "../e2e-streams"
 import { PersonaRepository } from "./persona-repository"
-import { resolveDefaultPersona } from "./resolve-default-persona"
 import { PersonaConfigDraftRepository } from "./persona-config-draft-repository"
 import { AgentSessionRepository, SessionStatuses } from "./session-repository"
 import { parseMessagePayload } from "../../lib/outbox"
@@ -102,10 +101,11 @@ export class CompanionHandler extends DebouncedOutboxHandler {
       : null
 
     if (!persona || persona.status !== "active") {
-      // No explicit (or a now-inactive) pick: resolve the default at dispatch —
-      // owning user's preference → workspace setting → Ariadne. The owner is the
-      // companion-source stream's creator (the root scratchpad for threads).
-      persona = await resolveDefaultPersona(this.db, companionSource.workspaceId, companionSource.createdBy)
+      // Legacy NULL pointers (pre-pin-at-create rows) and archived picks fall
+      // back to the built-in default. Deliberately NOT the user/workspace
+      // default resolver — that runs at CREATE time only; re-resolving here
+      // would switch a scratchpad's agent mid-run when a default changes.
+      persona = await PersonaRepository.getSystemDefault(this.db, companionSource.workspaceId)
     }
 
     if (!persona) {

--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -3,6 +3,7 @@ import { StreamRepository } from "../streams"
 import { resolveDeliveryVerdict, TrustTiers } from "@threa/agent-runtime"
 import { resolveSealingContext } from "../e2e-streams"
 import { PersonaRepository } from "./persona-repository"
+import { resolveDefaultPersona } from "./resolve-default-persona"
 import { PersonaConfigDraftRepository } from "./persona-config-draft-repository"
 import { AgentSessionRepository, SessionStatuses } from "./session-repository"
 import { parseMessagePayload } from "../../lib/outbox"
@@ -101,7 +102,10 @@ export class CompanionHandler extends DebouncedOutboxHandler {
       : null
 
     if (!persona || persona.status !== "active") {
-      persona = await PersonaRepository.getSystemDefault(this.db, companionSource.workspaceId)
+      // No explicit (or a now-inactive) pick: resolve the default at dispatch —
+      // owning user's preference → workspace setting → Ariadne. The owner is the
+      // companion-source stream's creator (the root scratchpad for threads).
+      persona = await resolveDefaultPersona(this.db, companionSource.workspaceId, companionSource.createdBy)
     }
 
     if (!persona) {

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -121,6 +121,7 @@ export type { OrphanSessionCleanup } from "./orphan-session-cleanup"
 export { PersonaRepository } from "./persona-repository"
 export type { Persona } from "./persona-repository"
 export { assertAssignablePersona } from "./persona-guards"
+export { resolveDefaultPersona } from "./resolve-default-persona"
 export {
   ARIADNE_AGENT_ID,
   EMPTY_AGENT_ID,

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -120,6 +120,7 @@ export type { OrphanSessionCleanup } from "./orphan-session-cleanup"
 
 export { PersonaRepository } from "./persona-repository"
 export type { Persona } from "./persona-repository"
+export { assertAssignablePersona } from "./persona-guards"
 export {
   ARIADNE_AGENT_ID,
   EMPTY_AGENT_ID,

--- a/apps/backend/src/features/agents/persona-config-service.test.ts
+++ b/apps/backend/src/features/agents/persona-config-service.test.ts
@@ -343,6 +343,7 @@ describe("PersonaConfigService.setOverride", () => {
         kind: "builtin",
         avatarUrl: null,
         isCustomized: true,
+        status: "active",
       },
     })
     // Draft dropped on the same client the override wrote through (the txn).

--- a/apps/backend/src/features/agents/persona-config-service.ts
+++ b/apps/backend/src/features/agents/persona-config-service.ts
@@ -154,6 +154,7 @@ function customRowToListItem(row: Persona): PersonaListItem {
     kind: "custom",
     avatarUrl: row.avatarUrl,
     isCustomized: false,
+    status: row.status,
   }
 }
 
@@ -187,6 +188,9 @@ function toPersonaListItem(config: PersonaResolvedConfig, isCustomized: boolean)
     kind: "builtin",
     avatarUrl: null,
     isCustomized,
+    // Only visible (non-hidden) built-ins reach list surfaces, and a built-in
+    // has no archived state — the broadcast consumer relies on this field.
+    status: "active",
   }
 }
 

--- a/apps/backend/src/features/agents/persona-guards.ts
+++ b/apps/backend/src/features/agents/persona-guards.ts
@@ -1,0 +1,23 @@
+import type { Querier } from "../../db"
+import { HttpError } from "../../lib/errors"
+import { PersonaRepository } from "./persona-repository"
+
+/**
+ * Assert a persona pointer references an active persona visible to this
+ * workspace (a built-in or a workspace custom). `null`/`undefined` skip the
+ * check — callers use them for "clear"/"inherit"/"unchanged". An archived or
+ * foreign persona is a 400 rather than a silent pointer that degrades to
+ * Ariadne at dispatch (INV-11). Call before opening a transaction so no
+ * connection is held during the lookup (INV-41).
+ */
+export async function assertAssignablePersona(
+  db: Querier,
+  personaId: string | null | undefined,
+  workspaceId: string
+): Promise<void> {
+  if (personaId == null) return
+  const persona = await PersonaRepository.findById(db, personaId, workspaceId)
+  if (!persona || persona.status !== "active") {
+    throw new HttpError("Persona not available", { status: 400, code: "PERSONA_NOT_AVAILABLE" })
+  }
+}

--- a/apps/backend/src/features/agents/resolve-default-persona.test.ts
+++ b/apps/backend/src/features/agents/resolve-default-persona.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { UserPreferencesRepository } from "../user-preferences"
+import { WorkspaceSettingsRepository } from "../workspace-settings"
+import { PersonaRepository, type Persona } from "./persona-repository"
+import { resolveDefaultPersona } from "./resolve-default-persona"
+
+const WORKSPACE_ID = "workspace_1"
+const OWNER_ID = "usr_owner"
+const db = {} as any
+
+function persona(id: string, status: Persona["status"] = "active"): Persona {
+  return { id, status } as Persona
+}
+
+/** Point a repo's single-key read at a stored value (or null = no override). */
+function stubUserOverride(value: unknown | null) {
+  return spyOn(UserPreferencesRepository, "findOverride").mockResolvedValue(
+    value === null ? null : { key: "defaultCompanionPersonaId", value }
+  )
+}
+function stubWorkspaceOverride(value: unknown | null) {
+  return spyOn(WorkspaceSettingsRepository, "findOverride").mockResolvedValue(
+    value === null ? null : { key: "defaultCompanionPersonaId", value }
+  )
+}
+
+describe("resolveDefaultPersona", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("prefers the user preference over the workspace setting", async () => {
+    stubUserOverride("persona_user")
+    stubWorkspaceOverride("persona_workspace")
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue(persona("persona_user"))
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault")
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_user"))
+    expect(findById).toHaveBeenCalledWith(db, "persona_user", WORKSPACE_ID)
+    expect(systemDefault).not.toHaveBeenCalled()
+  })
+
+  it("uses the workspace setting when the user preference is absent", async () => {
+    stubUserOverride(null)
+    stubWorkspaceOverride("persona_workspace")
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue(persona("persona_workspace"))
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault")
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_workspace"))
+    expect(findById).toHaveBeenCalledWith(db, "persona_workspace", WORKSPACE_ID)
+    expect(systemDefault).not.toHaveBeenCalled()
+  })
+
+  it("falls to Ariadne when neither the user preference nor the workspace setting is set", async () => {
+    stubUserOverride(null)
+    stubWorkspaceOverride(null)
+    const findById = spyOn(PersonaRepository, "findById")
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault").mockResolvedValue(persona("persona_ariadne"))
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_ariadne"))
+    expect(findById).not.toHaveBeenCalled()
+    expect(systemDefault).toHaveBeenCalledWith(db, WORKSPACE_ID)
+  })
+
+  it("degrades a user preference pointing at an archived persona to the workspace setting", async () => {
+    stubUserOverride("persona_user_archived")
+    stubWorkspaceOverride("persona_workspace")
+    spyOn(PersonaRepository, "findById").mockImplementation(async (_db: any, id: string) =>
+      id === "persona_user_archived" ? persona("persona_user_archived", "archived") : persona("persona_workspace")
+    )
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault")
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_workspace"))
+    expect(systemDefault).not.toHaveBeenCalled()
+  })
+
+  it("degrades an archived workspace setting to Ariadne", async () => {
+    stubUserOverride(null)
+    stubWorkspaceOverride("persona_workspace_archived")
+    spyOn(PersonaRepository, "findById").mockResolvedValue(persona("persona_workspace_archived", "archived"))
+    const systemDefault = spyOn(PersonaRepository, "getSystemDefault").mockResolvedValue(persona("persona_ariadne"))
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_ariadne"))
+    expect(systemDefault).toHaveBeenCalledWith(db, WORKSPACE_ID)
+  })
+
+  it("degrades a user preference pointing at a no-longer-resolving persona to the workspace setting", async () => {
+    stubUserOverride("persona_gone")
+    stubWorkspaceOverride("persona_workspace")
+    spyOn(PersonaRepository, "findById").mockImplementation(async (_db: any, id: string) =>
+      id === "persona_gone" ? null : persona("persona_workspace")
+    )
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID, OWNER_ID)
+
+    expect(result).toEqual(persona("persona_workspace"))
+  })
+
+  it("skips the user tier entirely when ownerUserId is omitted", async () => {
+    const userOverride = spyOn(UserPreferencesRepository, "findOverride")
+    stubWorkspaceOverride("persona_workspace")
+    spyOn(PersonaRepository, "findById").mockResolvedValue(persona("persona_workspace"))
+
+    const result = await resolveDefaultPersona(db, WORKSPACE_ID)
+
+    expect(result).toEqual(persona("persona_workspace"))
+    expect(userOverride).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/agents/resolve-default-persona.ts
+++ b/apps/backend/src/features/agents/resolve-default-persona.ts
@@ -1,0 +1,57 @@
+import type { UserPreferences, WorkspaceSettings } from "@threa/types"
+import type { Querier } from "../../db"
+import { UserPreferencesRepository } from "../user-preferences"
+import { WorkspaceSettingsRepository } from "../workspace-settings"
+import { PersonaRepository, type Persona } from "./persona-repository"
+
+/**
+ * The one KV key both the user-preference and workspace-setting stores use for
+ * the default companion persona pointer. `satisfies` ties it to the shared field
+ * name so a rename in either type surfaces here (INV-31/33).
+ */
+const DEFAULT_COMPANION_PERSONA_KEY = "defaultCompanionPersonaId" satisfies keyof UserPreferences &
+  keyof WorkspaceSettings
+
+/**
+ * Resolve the persona a companion turn should run when a scratchpad carries no
+ * explicit pick. Precedence (brief §Settled decision 2): the owning user's
+ * preference → the workspace setting → built-in Ariadne.
+ *
+ * Each tier degrades to the next when its stored pointer is missing, points at a
+ * persona that no longer resolves in this workspace, or resolves to a non-active
+ * (archived/disabled) persona. This resolve-time tolerance is the ONE sanctioned
+ * silent fallback (INV-11): write-time `assertAssignablePersona` already rejects
+ * pointers that aren't active-in-workspace, so a stale pointer here means the
+ * persona was archived *after* it was chosen — degrade rather than abort the turn.
+ *
+ * `ownerUserId` omitted (or the user tier absent) skips straight to the workspace
+ * setting. Returns null only if even Ariadne is unavailable.
+ */
+export async function resolveDefaultPersona(
+  db: Querier,
+  workspaceId: string,
+  ownerUserId?: string
+): Promise<Persona | null> {
+  if (ownerUserId) {
+    const userOverride = await UserPreferencesRepository.findOverride(db, ownerUserId, DEFAULT_COMPANION_PERSONA_KEY)
+    const userPersona = await resolvePointer(db, userOverride?.value, workspaceId)
+    if (userPersona) return userPersona
+  }
+
+  const workspaceOverride = await WorkspaceSettingsRepository.findOverride(
+    db,
+    workspaceId,
+    DEFAULT_COMPANION_PERSONA_KEY
+  )
+  const workspacePersona = await resolvePointer(db, workspaceOverride?.value, workspaceId)
+  if (workspacePersona) return workspacePersona
+
+  return PersonaRepository.getSystemDefault(db, workspaceId)
+}
+
+/** A stored pointer resolves only when it is a string id for an active persona in the workspace. */
+async function resolvePointer(db: Querier, value: unknown, workspaceId: string): Promise<Persona | null> {
+  if (typeof value !== "string" || value.length === 0) return null
+  const persona = await PersonaRepository.findById(db, value, workspaceId)
+  return persona?.status === "active" ? persona : null
+}

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, mock } from "bun:test"
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { LinkPreviewSummary } from "@threa/types"
 import type { Request, Response } from "express"
 import type { StreamEvent } from "./event-repository"
 import { applyLinkPreviewStateToEvents, createStreamHandlers } from "./handlers"
 import type { StreamService } from "./service"
+import * as agentsBarrel from "../agents"
 
 function createMessageEvent(messageId: string): StreamEvent {
   return {
@@ -275,12 +276,22 @@ describe("createStreamHandlers.create — allowedToolCategories", () => {
   }
 
   function makeHandlers(streamService: Partial<StreamService>) {
-    return createStreamHandlers({ streamService } as unknown as Parameters<typeof createStreamHandlers>[0])
+    return createStreamHandlers({ streamService, pool: {} } as unknown as Parameters<typeof createStreamHandlers>[0])
   }
 
   function makeCreateReq(body: unknown): Request {
     return { user: { id: "user_owner" }, workspaceId: "ws_1", params: {}, body } as unknown as Request
   }
+
+  let resolveSpy: ReturnType<typeof spyOn<typeof agentsBarrel, "resolveDefaultPersona">>
+
+  beforeEach(() => {
+    // A persona-less scratchpad create resolves the default and pins it. The
+    // spy is shared across tests (bun returns the same instance) — clear it.
+    resolveSpy = spyOn(agentsBarrel, "resolveDefaultPersona")
+    resolveSpy.mockClear()
+    resolveSpy.mockResolvedValue({ id: "persona_system_ariadne", status: "active" } as never)
+  })
 
   it("threads allowedToolCategories to the service when creating a scratchpad", async () => {
     const create = mock(async (_params: { allowedToolCategories?: unknown }) => ({ id: "stream_sp" }))
@@ -303,5 +314,41 @@ describe("createStreamHandlers.create — allowedToolCategories", () => {
       handlers.create(makeCreateReq({ type: "channel", slug: "general", allowedToolCategories: ["web"] }), res)
     ).rejects.toMatchObject({ status: 400 })
     expect(create).not.toHaveBeenCalled()
+  })
+
+  it("pins the resolved default persona when a scratchpad is created with no explicit pick", async () => {
+    const create = mock(async (_params: { companionPersonaId?: string }) => ({ id: "stream_sp" }))
+    resolveSpy.mockResolvedValue({ id: "persona_pinned_default", status: "active" } as never)
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res } = makeRes()
+
+    await handlers.create(makeCreateReq({ type: "scratchpad" }), res)
+
+    // The default is resolved ONCE at create (creator's pref → workspace → Ariadne)
+    // and the concrete id is pinned — later default changes never touch this stream.
+    expect(resolveSpy).toHaveBeenCalledWith({}, "ws_1", "user_owner")
+    expect(create.mock.calls[0]![0].companionPersonaId).toBe("persona_pinned_default")
+  })
+
+  it("keeps an explicit pick verbatim (no default resolution)", async () => {
+    const create = mock(async (_params: { companionPersonaId?: string }) => ({ id: "stream_sp" }))
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res } = makeRes()
+
+    await handlers.create(makeCreateReq({ type: "scratchpad", companionPersonaId: "persona_explicit" }), res)
+
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(create.mock.calls[0]![0].companionPersonaId).toBe("persona_explicit")
+  })
+
+  it("does not resolve a default for non-scratchpad creates", async () => {
+    const create = mock(async (_params: { companionPersonaId?: string }) => ({ id: "stream_ch" }))
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res } = makeRes()
+
+    await handlers.create(makeCreateReq({ type: "channel", slug: "general" }), res)
+
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(create.mock.calls[0]![0].companionPersonaId).toBeUndefined()
   })
 })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -30,7 +30,7 @@ import {
   STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH,
 } from "@threa/types"
 import type { Pool } from "pg"
-import { PersonaRepository, assertRefAccess, fetchStreamBag, contextBagSchema } from "../agents"
+import { PersonaRepository, assertRefAccess, fetchStreamBag, contextBagSchema, resolveDefaultPersona } from "../agents"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
 import { HttpError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
@@ -606,6 +606,15 @@ export function createStreamHandlers({
         }
         resolvedCompanionMode = CompanionModes.ON
         resolvedPersonaId = ariadne.id
+      }
+      if (type === StreamTypes.SCRATCHPAD && !e2eEnabled && !resolvedPersonaId) {
+        // No explicit pick: resolve the creator's default (user pref → workspace
+        // setting → Ariadne) NOW and pin the concrete id. Scratchpads are locked
+        // to the persona they were created with — a later default change must
+        // never switch an existing scratchpad's agent mid-run; dispatch reads
+        // the pointer and never re-resolves.
+        const defaultPersona = await resolveDefaultPersona(pool, workspaceId, userId)
+        resolvedPersonaId = defaultPersona?.id
       }
 
       const stream = await streamService.create({

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -51,7 +51,7 @@ import {
   type AuthorType,
   type DescriptionSetEventPayload,
 } from "@threa/types"
-import { ContextBagRepository, PersonaRepository } from "../agents"
+import { ContextBagRepository, PersonaRepository, assertAssignablePersona } from "../agents"
 import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepository } from "../e2e-streams"
 import type { E2eStream, StreamE2eKeyWrap } from "../e2e-streams"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
@@ -735,17 +735,7 @@ export class StreamService {
     companionMode: CompanionMode,
     companionPersonaId?: string | null
   ): Promise<Stream> {
-    // Setting a companion persona must resolve to an active persona visible to
-    // this workspace (a built-in or a workspace custom). `null` clears it and
-    // `undefined` leaves it unchanged — both skip validation. An archived/foreign
-    // persona is a 400 rather than a silent pointer to a persona that degrades to
-    // Ariadne at dispatch.
-    if (companionPersonaId != null) {
-      const persona = await PersonaRepository.findById(this.pool, companionPersonaId, workspaceId)
-      if (!persona || persona.status !== "active") {
-        throw new HttpError("Persona not available", { status: 400, code: "PERSONA_NOT_AVAILABLE" })
-      }
-    }
+    await assertAssignablePersona(this.pool, companionPersonaId, workspaceId)
     return withTransaction(this.pool, async (client) => {
       const stream = await StreamRepository.update(client, streamId, {
         companionMode,

--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -87,6 +87,30 @@ describe("updatePreferencesSchema boardDefaultViewId", () => {
   })
 })
 
+describe("updatePreferencesSchema defaultCompanionPersonaId", () => {
+  it("accepts a persona id", () => {
+    expect(updatePreferencesSchema.parse({ defaultCompanionPersonaId: "persona_1" }).defaultCompanionPersonaId).toBe(
+      "persona_1"
+    )
+  })
+
+  it("accepts null to inherit the workspace default", () => {
+    expect(updatePreferencesSchema.parse({ defaultCompanionPersonaId: null }).defaultCompanionPersonaId).toBeNull()
+  })
+
+  it("rejects an empty id", () => {
+    expect(updatePreferencesSchema.safeParse({ defaultCompanionPersonaId: "" }).success).toBe(false)
+  })
+
+  it("rejects an over-long id", () => {
+    expect(updatePreferencesSchema.safeParse({ defaultCompanionPersonaId: "x".repeat(65) }).success).toBe(false)
+  })
+
+  it("treats the field as optional", () => {
+    expect(updatePreferencesSchema.parse({}).defaultCompanionPersonaId).toBeUndefined()
+  })
+})
+
 describe("updatePreferencesSchema board card collapse settings", () => {
   it("accepts valid board card collapse settings", () => {
     const parsed = updatePreferencesSchema.parse({

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -120,6 +120,9 @@ const updatePreferencesSchema = z.object({
     .optional(),
   // null clears the personal override (revert to the workspace default).
   workSchedule: workScheduleSchema.nullable().optional(),
+  // Personal default companion persona id; null clears back to the workspace
+  // default. Semantic validation (active persona in this workspace) runs in the service.
+  defaultCompanionPersonaId: z.string().min(1).max(64).nullable().optional(),
   // Per-user custom status presets, additive to the workspace/system defaults.
   statusPresets: statusPresetsSchema.optional(),
   gettingStartedDismissed: z.boolean().optional(),

--- a/apps/backend/src/features/user-preferences/repository.ts
+++ b/apps/backend/src/features/user-preferences/repository.ts
@@ -26,6 +26,22 @@ export const UserPreferencesRepository = {
     }))
   },
 
+  /**
+   * Read a single override by key, or null when the user has no override for it
+   * (i.e. inherits the default). Cheaper than merging the whole preference object
+   * when a caller needs one key (INV-27).
+   */
+  async findOverride(db: Querier, userId: string, key: string): Promise<PreferenceOverrideRecord | null> {
+    const result = await db.query<PreferenceOverrideRow>(sql`
+      SELECT key, value
+      FROM user_preference_overrides
+      WHERE user_id = ${userId}
+        AND key = ${key}
+    `)
+    const row = result.rows[0]
+    return row ? { key: row.key, value: row.value } : null
+  },
+
   async setOverride(db: Querier, userId: string, key: string, value: unknown): Promise<void> {
     await db.query(sql`
       INSERT INTO user_preference_overrides (user_id, key, value)

--- a/apps/backend/src/features/user-preferences/service.test.ts
+++ b/apps/backend/src/features/user-preferences/service.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { PoolClient } from "pg"
+import { UserPreferencesService } from "./service"
+import { UserPreferencesRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
+import { PersonaRepository } from "../agents"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const USER_ID = "usr_1"
+
+function setupTransaction() {
+  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+}
+
+describe("UserPreferencesService.updatePreferences defaultCompanionPersonaId", () => {
+  afterEach(() => mock.restore())
+
+  it("stores an active persona id as an override", async () => {
+    setupTransaction()
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "active" } as any)
+    const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
+    const bulkDelete = spyOn(UserPreferencesRepository, "bulkDeleteOverrides").mockResolvedValue(undefined as any)
+    spyOn(UserPreferencesRepository, "findOverrides").mockResolvedValue([
+      { key: "defaultCompanionPersonaId", value: "persona_x" },
+    ])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new UserPreferencesService({} as any)
+
+    const prefs = await service.updatePreferences(WORKSPACE_ID, USER_ID, { defaultCompanionPersonaId: "persona_x" })
+
+    expect(findById).toHaveBeenCalledWith({}, "persona_x", WORKSPACE_ID)
+    expect(bulkSet).toHaveBeenCalledWith({}, USER_ID, [{ key: "defaultCompanionPersonaId", value: "persona_x" }])
+    expect(bulkDelete).not.toHaveBeenCalled()
+    expect(prefs.defaultCompanionPersonaId).toBe("persona_x")
+  })
+
+  it("rejects an archived persona id with a 400", async () => {
+    spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "archived" } as any)
+    const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
+    const service = new UserPreferencesService({} as any)
+
+    await expect(
+      service.updatePreferences(WORKSPACE_ID, USER_ID, { defaultCompanionPersonaId: "persona_x" })
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_AVAILABLE" })
+    expect(bulkSet).not.toHaveBeenCalled()
+  })
+
+  it("rejects an id not resolvable in this workspace with a 400", async () => {
+    spyOn(PersonaRepository, "findById").mockResolvedValue(null)
+    const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
+    const service = new UserPreferencesService({} as any)
+
+    await expect(
+      service.updatePreferences(WORKSPACE_ID, USER_ID, { defaultCompanionPersonaId: "persona_other_ws" })
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_AVAILABLE" })
+    expect(bulkSet).not.toHaveBeenCalled()
+  })
+
+  it("clears the override on null without a persona lookup", async () => {
+    setupTransaction()
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "active" } as any)
+    const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
+    const bulkDelete = spyOn(UserPreferencesRepository, "bulkDeleteOverrides").mockResolvedValue(undefined as any)
+    spyOn(UserPreferencesRepository, "findOverrides").mockResolvedValue([])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new UserPreferencesService({} as any)
+
+    await service.updatePreferences(WORKSPACE_ID, USER_ID, { defaultCompanionPersonaId: null })
+
+    // null equals the default, so it is a delete, not a store — and no lookup runs.
+    expect(findById).not.toHaveBeenCalled()
+    expect(bulkDelete).toHaveBeenCalledWith({}, USER_ID, ["defaultCompanionPersonaId"])
+    expect(bulkSet).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -2,6 +2,7 @@ import { Pool } from "pg"
 import { withTransaction } from "../../db"
 import { UserPreferencesRepository } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
+import { assertAssignablePersona } from "../agents"
 import {
   type UserPreferences,
   type UpdateUserPreferencesInput,
@@ -88,6 +89,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "voicePolishLevel",
     "voiceSteeringWords",
     "workSchedule",
+    "defaultCompanionPersonaId",
     "statusPresets",
     "gettingStartedDismissed",
   ] as const
@@ -135,6 +137,7 @@ export class UserPreferencesService {
     userId: string,
     updates: UpdateUserPreferencesInput
   ): Promise<UserPreferences> {
+    await assertAssignablePersona(this.pool, updates.defaultCompanionPersonaId, workspaceId)
     return withTransaction(this.pool, async (client) => {
       const currentOverrides =
         updates.keyboardShortcuts !== undefined ? await UserPreferencesRepository.findOverrides(client, userId) : null

--- a/apps/backend/src/features/workspace-settings/handlers.test.ts
+++ b/apps/backend/src/features/workspace-settings/handlers.test.ts
@@ -23,3 +23,26 @@ describe("updateWorkspaceSettingsSchema voiceSteeringWords", () => {
     expect(updateWorkspaceSettingsSchema.parse({}).voiceSteeringWords).toBeUndefined()
   })
 })
+
+describe("updateWorkspaceSettingsSchema defaultCompanionPersonaId", () => {
+  it("accepts a persona id", () => {
+    expect(
+      updateWorkspaceSettingsSchema.parse({ defaultCompanionPersonaId: "persona_1" }).defaultCompanionPersonaId
+    ).toBe("persona_1")
+  })
+
+  it("accepts null to clear back to Ariadne", () => {
+    expect(
+      updateWorkspaceSettingsSchema.parse({ defaultCompanionPersonaId: null }).defaultCompanionPersonaId
+    ).toBeNull()
+  })
+
+  it("rejects an empty or over-long id", () => {
+    expect(updateWorkspaceSettingsSchema.safeParse({ defaultCompanionPersonaId: "" }).success).toBe(false)
+    expect(updateWorkspaceSettingsSchema.safeParse({ defaultCompanionPersonaId: "x".repeat(65) }).success).toBe(false)
+  })
+
+  it("treats the field as optional", () => {
+    expect(updateWorkspaceSettingsSchema.parse({}).defaultCompanionPersonaId).toBeUndefined()
+  })
+})

--- a/apps/backend/src/features/workspace-settings/handlers.ts
+++ b/apps/backend/src/features/workspace-settings/handlers.ts
@@ -23,6 +23,9 @@ const updateWorkspaceSettingsSchema = z.object({
     .optional(),
   // Per-stream pending follow-up cap the assistant self-regulates against (roadmap 1.4).
   maxPendingFollowUps: z.number().int().min(MAX_PENDING_FOLLOW_UPS_MIN).max(MAX_PENDING_FOLLOW_UPS_MAX).optional(),
+  // Workspace default companion persona id; null clears back to built-in Ariadne.
+  // Semantic validation (active persona in this workspace) runs in the service.
+  defaultCompanionPersonaId: z.string().min(1).max(64).nullable().optional(),
 })
 
 export { updateWorkspaceSettingsSchema }

--- a/apps/backend/src/features/workspace-settings/repository.ts
+++ b/apps/backend/src/features/workspace-settings/repository.ts
@@ -21,6 +21,22 @@ export const WorkspaceSettingsRepository = {
   },
 
   /**
+   * Read a single setting override by key, or null when unset (i.e. the code
+   * default applies). Cheaper than merging the whole settings object when a
+   * caller needs one key (INV-27).
+   */
+  async findOverride(db: Querier, workspaceId: string, key: string): Promise<WorkspaceSettingOverrideRecord | null> {
+    const result = await db.query<WorkspaceSettingOverrideRow>(sql`
+      SELECT key, value
+      FROM workspace_setting_overrides
+      WHERE workspace_id = ${workspaceId}
+        AND key = ${key}
+    `)
+    const row = result.rows[0]
+    return row ? { key: row.key, value: row.value } : null
+  },
+
+  /**
    * Upsert a single setting override. Race-safe via ON CONFLICT so concurrent
    * admins don't clobber with a check-then-act (INV-20).
    */

--- a/apps/backend/src/features/workspace-settings/service.test.ts
+++ b/apps/backend/src/features/workspace-settings/service.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_WORK_SCHEDULE, DEFAULT_MAX_PENDING_FOLLOW_UPS, type WorkSchedul
 import { WorkspaceSettingsService } from "./service"
 import { WorkspaceSettingsRepository } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
+import { PersonaRepository } from "../agents"
 import * as dbModule from "../../db"
 
 const WORKSPACE_ID = "ws_1"
@@ -111,6 +112,66 @@ describe("WorkspaceSettingsService.updateSettings", () => {
     await service.updateSettings(WORKSPACE_ID, { maxPendingFollowUps: DEFAULT_MAX_PENDING_FOLLOW_UPS })
 
     expect(deleteOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "maxPendingFollowUps")
+    expect(setOverride).not.toHaveBeenCalled()
+  })
+})
+
+describe("WorkspaceSettingsService.updateSettings defaultCompanionPersonaId", () => {
+  afterEach(() => mock.restore())
+
+  it("stores an active persona id as an override", async () => {
+    setupTransaction()
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "active" } as any)
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([
+      { key: "defaultCompanionPersonaId", value: "persona_x" },
+    ])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new WorkspaceSettingsService({} as any)
+
+    const settings = await service.updateSettings(WORKSPACE_ID, { defaultCompanionPersonaId: "persona_x" })
+
+    expect(findById).toHaveBeenCalledWith({}, "persona_x", WORKSPACE_ID)
+    expect(setOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "defaultCompanionPersonaId", "persona_x")
+    expect(settings.defaultCompanionPersonaId).toBe("persona_x")
+  })
+
+  it("rejects an archived persona id with a 400", async () => {
+    spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "archived" } as any)
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    const service = new WorkspaceSettingsService({} as any)
+
+    await expect(
+      service.updateSettings(WORKSPACE_ID, { defaultCompanionPersonaId: "persona_x" })
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_AVAILABLE" })
+    expect(setOverride).not.toHaveBeenCalled()
+  })
+
+  it("rejects an id not resolvable in this workspace with a 400", async () => {
+    spyOn(PersonaRepository, "findById").mockResolvedValue(null)
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    const service = new WorkspaceSettingsService({} as any)
+
+    await expect(
+      service.updateSettings(WORKSPACE_ID, { defaultCompanionPersonaId: "persona_other_ws" })
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_AVAILABLE" })
+    expect(setOverride).not.toHaveBeenCalled()
+  })
+
+  it("clears the override on null without a persona lookup", async () => {
+    setupTransaction()
+    const findById = spyOn(PersonaRepository, "findById").mockResolvedValue({ status: "active" } as any)
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    const deleteOverride = spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new WorkspaceSettingsService({} as any)
+
+    await service.updateSettings(WORKSPACE_ID, { defaultCompanionPersonaId: null })
+
+    expect(findById).not.toHaveBeenCalled()
+    expect(deleteOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "defaultCompanionPersonaId")
     expect(setOverride).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/workspace-settings/service.ts
+++ b/apps/backend/src/features/workspace-settings/service.ts
@@ -2,6 +2,7 @@ import { Pool } from "pg"
 import { withTransaction } from "../../db"
 import { WorkspaceSettingsRepository } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
+import { assertAssignablePersona } from "../agents"
 import { type WorkspaceSettings, type UpdateWorkspaceSettingsInput, DEFAULT_WORKSPACE_SETTINGS } from "@threa/types"
 
 /** Merge sparse overrides onto code defaults to produce full settings. */
@@ -34,6 +35,7 @@ function flattenUpdates(updates: UpdateWorkspaceSettingsInput): Array<{ key: str
     "memoLanguage",
     "voiceSteeringWords",
     "maxPendingFollowUps",
+    "defaultCompanionPersonaId",
   ] as const
   for (const key of simpleKeys) {
     if (updates[key] !== undefined) {
@@ -58,6 +60,7 @@ export class WorkspaceSettingsService {
    * setting a value back to the default clears the override.
    */
   async updateSettings(workspaceId: string, updates: UpdateWorkspaceSettingsInput): Promise<WorkspaceSettings> {
+    await assertAssignablePersona(this.pool, updates.defaultCompanionPersonaId, workspaceId)
     return withTransaction(this.pool, async (client) => {
       for (const { key, value } of flattenUpdates(updates)) {
         if (matchesDefault(key, value)) {

--- a/apps/backend/tests/integration/user-preferences.test.ts
+++ b/apps/backend/tests/integration/user-preferences.test.ts
@@ -4,6 +4,7 @@ import { UserPreferencesService, UserPreferencesRepository } from "../../src/fea
 import { workspaceId, userId } from "../../src/lib/id"
 import { setupTestDatabase } from "./setup"
 import { DEFAULT_USER_PREFERENCES } from "@threa/types"
+import { ARIADNE_AGENT_ID } from "../../src/features/agents"
 
 describe("User Preferences - Sparse Override Pattern", () => {
   let pool: Pool
@@ -158,6 +159,40 @@ describe("User Preferences - Sparse Override Pattern", () => {
       const overrides = await UserPreferencesRepository.findOverrides(pool, testUserId)
 
       expect(overrides).toEqual([{ key: "scratchpadCustomPrompt", value: "Be terse in scratchpads." }])
+    })
+
+    test("should store a non-null default companion persona override (active persona passes validation)", async () => {
+      // Ariadne (a built-in) is always an active persona in every workspace, so it
+      // passes write-time validation; the stored id differs from the null default.
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        defaultCompanionPersonaId: ARIADNE_AGENT_ID,
+      })
+
+      const overrides = await UserPreferencesRepository.findOverrides(pool, testUserId)
+      expect(overrides).toEqual([{ key: "defaultCompanionPersonaId", value: ARIADNE_AGENT_ID }])
+    })
+
+    test("should delete the default companion persona override when reverted to null", async () => {
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        defaultCompanionPersonaId: ARIADNE_AGENT_ID,
+      })
+      expect(await UserPreferencesRepository.findOverrides(pool, testUserId)).toHaveLength(1)
+
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        defaultCompanionPersonaId: null,
+      })
+      expect(await UserPreferencesRepository.findOverrides(pool, testUserId)).toHaveLength(0)
+    })
+
+    test("should reject a default companion persona id that is not an active workspace persona", async () => {
+      await expect(
+        service.updatePreferences(testWorkspaceId, testUserId, {
+          defaultCompanionPersonaId: "persona_does_not_exist",
+        })
+      ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_AVAILABLE" })
+
+      // Nothing was stored on the rejected write.
+      expect(await UserPreferencesRepository.findOverrides(pool, testUserId)).toHaveLength(0)
     })
   })
 

--- a/apps/frontend/src/components/settings/ai-settings.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.tsx
@@ -11,7 +11,8 @@ import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import {
   CompanionAgentSelect,
-  COMPANION_DEFAULT_OPTION_VALUE,
+  companionPickerValue,
+  companionPointerFromPickerValue,
 } from "@/components/stream-settings/companion-agent-select"
 import { type JSONContent } from "@threa/types"
 
@@ -25,17 +26,16 @@ const MODIFIER_LABEL =
  * workspace default. Mirrors `BoardHomeSection`'s sentinel-value technique.
  */
 export function PersonalDefaultCompanionSection({ workspaceId }: { workspaceId: string }) {
-  const { preferences, updatePreference } = usePreferences()
+  const { preferences, updatePreference, isLoading } = usePreferences()
   const { data: personas } = usePersonas(workspaceId)
   const { workspaceDefault } = useDefaultCompanionPersona(workspaceId)
 
-  const storedId = preferences?.defaultCompanionPersonaId ?? null
-  // Degrade an override that no longer resolves (archived persona) to the
+  // An override that no longer resolves (archived persona) degrades to the
   // synthetic "workspace default" rather than showing an empty trigger.
-  const value = storedId && personas?.some((p) => p.id === storedId) ? storedId : COMPANION_DEFAULT_OPTION_VALUE
+  const value = companionPickerValue(personas, preferences?.defaultCompanionPersonaId)
 
   const onChange = (next: string) => {
-    void updatePreference("defaultCompanionPersonaId", next === COMPANION_DEFAULT_OPTION_VALUE ? null : next)
+    void updatePreference("defaultCompanionPersonaId", companionPointerFromPickerValue(next))
   }
 
   if (!personas || personas.length === 0) return null
@@ -55,6 +55,7 @@ export function PersonalDefaultCompanionSection({ workspaceId }: { workspaceId: 
         value={value}
         onChange={onChange}
         defaultOption={{ label: `Workspace default (${workspaceDefault?.name ?? "Ariadne"})` }}
+        disabled={isLoading}
         triggerClassName="w-full sm:w-72"
       />
     </section>

--- a/apps/frontend/src/components/settings/ai-settings.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useParams } from "react-router-dom"
 import { serializeToMarkdown, parsePromptMarkdown } from "@/components/editor/editor-markdown"
 import { EditorActionBar, RichEditor, type RichEditorHandle } from "@/components/editor"
 import { EncryptedScratchpadsSection } from "@/components/encryption"
@@ -6,13 +7,63 @@ import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { usePersonas } from "@/hooks/use-personas"
+import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
+import {
+  CompanionAgentSelect,
+  COMPANION_DEFAULT_OPTION_VALUE,
+} from "@/components/stream-settings/companion-agent-select"
 import { type JSONContent } from "@threa/types"
 
 const MODIFIER_LABEL =
   typeof navigator !== "undefined" && navigator.platform?.toLowerCase().includes("mac") ? "Cmd" : "Ctrl"
 
+/**
+ * The viewer's personal default companion for scratchpads with no explicit pick.
+ * A leading "Workspace default (<name>)" option round-trips as null (inherit the
+ * workspace tier); any persona pick stores that concrete id, which wins over the
+ * workspace default. Mirrors `BoardHomeSection`'s sentinel-value technique.
+ */
+export function PersonalDefaultCompanionSection({ workspaceId }: { workspaceId: string }) {
+  const { preferences, updatePreference } = usePreferences()
+  const { data: personas } = usePersonas(workspaceId)
+  const { workspaceDefault } = useDefaultCompanionPersona(workspaceId)
+
+  const storedId = preferences?.defaultCompanionPersonaId ?? null
+  // Degrade an override that no longer resolves (archived persona) to the
+  // synthetic "workspace default" rather than showing an empty trigger.
+  const value = storedId && personas?.some((p) => p.id === storedId) ? storedId : COMPANION_DEFAULT_OPTION_VALUE
+
+  const onChange = (next: string) => {
+    void updatePreference("defaultCompanionPersonaId", next === COMPANION_DEFAULT_OPTION_VALUE ? null : next)
+  }
+
+  if (!personas || personas.length === 0) return null
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="text-sm font-medium">Default companion</h3>
+        <p className="text-sm text-muted-foreground">
+          The agent that answers in your scratchpads unless a scratchpad has its own pick. Choose Workspace default to
+          follow whatever your workspace sets.
+        </p>
+      </div>
+      <CompanionAgentSelect
+        workspaceId={workspaceId}
+        personas={personas}
+        value={value}
+        onChange={onChange}
+        defaultOption={{ label: `Workspace default (${workspaceDefault?.name ?? "Ariadne"})` }}
+        triggerClassName="w-full sm:w-72"
+      />
+    </section>
+  )
+}
+
 export function AISettings() {
   const { preferences, updatePreference, isLoading } = usePreferences()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
   // Selection toolbar is a hover/mouse affordance — suppress it only when a
   // finger is the active input, so a mouse on a touchscreen laptop keeps it.
   const disableSelectionToolbar = useInputMode() === "touch"
@@ -116,6 +167,13 @@ export function AISettings() {
           <span>{MODIFIER_LABEL}+Enter to save</span>
         </div>
       </section>
+
+      {workspaceId && (
+        <>
+          <Separator />
+          <PersonalDefaultCompanionSection workspaceId={workspaceId} />
+        </>
+      )}
 
       <Separator />
 

--- a/apps/frontend/src/components/settings/ai-settings.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.tsx
@@ -7,8 +7,8 @@ import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
 import { useInputMode } from "@/hooks/use-input-mode"
-import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
+import { useCompanionRoster } from "@/hooks/use-companion-roster"
 import {
   CompanionAgentSelect,
   companionPickerValue,
@@ -27,7 +27,7 @@ const MODIFIER_LABEL =
  */
 export function PersonalDefaultCompanionSection({ workspaceId }: { workspaceId: string }) {
   const { preferences, updatePreference, isLoading } = usePreferences()
-  const { data: personas } = usePersonas(workspaceId)
+  const personas = useCompanionRoster(workspaceId)
   const { workspaceDefault } = useDefaultCompanionPersona(workspaceId)
 
   // An override that no longer resolves (archived persona) degrades to the
@@ -38,7 +38,7 @@ export function PersonalDefaultCompanionSection({ workspaceId }: { workspaceId: 
     void updatePreference("defaultCompanionPersonaId", companionPointerFromPickerValue(next))
   }
 
-  if (!personas || personas.length === 0) return null
+  if (personas.length === 0) return null
 
   return (
     <section className="space-y-3">

--- a/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
+++ b/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
@@ -77,6 +77,14 @@ describe("PersonalDefaultCompanionSection", () => {
     expect(updatePreference).toHaveBeenCalledWith("defaultCompanionPersonaId", "persona_coach")
   })
 
+  it("degrades an archived (off-roster) override to the workspace-default option", () => {
+    mockPreferences("persona_archived")
+    renderSection()
+    expect(screen.getByRole("combobox", { name: /companion agent/i })).toHaveTextContent(
+      /Workspace default \(Ariadne\)/i
+    )
+  })
+
   it("stores null when the workspace-default option is chosen", async () => {
     mockPreferences("persona_coach")
     const user = userEvent.setup()

--- a/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
+++ b/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import type { PersonaListItem } from "@threa/types"
 import * as contextsModule from "@/contexts"
-import * as personasHooks from "@/hooks/use-personas"
+import * as rosterHooks from "@/hooks/use-companion-roster"
 import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import { PersonalDefaultCompanionSection } from "./ai-settings"
@@ -18,6 +18,7 @@ function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id
     kind: "custom",
     avatarUrl: null,
     isCustomized: false,
+    status: "active",
     ...overrides,
   }
 }
@@ -46,9 +47,7 @@ describe("PersonalDefaultCompanionSection", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     updatePreference.mockClear()
-    vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-      data: [ARIADNE, COACH],
-    } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+    vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([ARIADNE, COACH])
     vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
       effectiveDefault: ARIADNE,
       workspaceDefault: ARIADNE,

--- a/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
+++ b/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import type { PersonaListItem } from "@threa/types"
+import * as contextsModule from "@/contexts"
+import * as personasHooks from "@/hooks/use-personas"
+import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
+import * as emojiHooks from "@/hooks/use-workspace-emoji"
+import { PersonalDefaultCompanionSection } from "./ai-settings"
+
+function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id" | "slug" | "name">): PersonaListItem {
+  return {
+    description: null,
+    avatarEmoji: null,
+    model: "openrouter:anthropic/claude-haiku-4.5",
+    kind: "custom",
+    avatarUrl: null,
+    isCustomized: false,
+    ...overrides,
+  }
+}
+
+const ARIADNE = persona({ id: "persona_ariadne", slug: "ariadne", name: "Ariadne", kind: "builtin" })
+const COACH = persona({ id: "persona_coach", slug: "coach", name: "Coach", avatarEmoji: "🏋️" })
+
+const updatePreference = vi.fn().mockResolvedValue(undefined)
+
+function mockPreferences(defaultCompanionPersonaId: string | null) {
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { defaultCompanionPersonaId },
+    updatePreference,
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+}
+
+function renderSection() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+  return render(<PersonalDefaultCompanionSection workspaceId="ws_1" />, { wrapper: Wrapper })
+}
+
+describe("PersonalDefaultCompanionSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    updatePreference.mockClear()
+    vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
+      data: [ARIADNE, COACH],
+    } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+    vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
+      effectiveDefault: ARIADNE,
+      workspaceDefault: ARIADNE,
+    })
+    vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
+      toEmoji: (shortcode: string) => shortcode,
+    } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)
+  })
+
+  it("shows the workspace-default synthetic option when no personal override is set", () => {
+    mockPreferences(null)
+    renderSection()
+    expect(screen.getByRole("combobox", { name: /companion agent/i })).toHaveTextContent(
+      /Workspace default \(Ariadne\)/i
+    )
+  })
+
+  it("stores the picked persona id as the personal override", async () => {
+    mockPreferences(null)
+    const user = userEvent.setup()
+    renderSection()
+
+    await user.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await user.click(await screen.findByRole("option", { name: /Coach/i }))
+
+    expect(updatePreference).toHaveBeenCalledWith("defaultCompanionPersonaId", "persona_coach")
+  })
+
+  it("stores null when the workspace-default option is chosen", async () => {
+    mockPreferences("persona_coach")
+    const user = userEvent.setup()
+    renderSection()
+
+    await user.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await user.click(await screen.findByRole("option", { name: /Workspace default/i }))
+
+    expect(updatePreference).toHaveBeenCalledWith("defaultCompanionPersonaId", null)
+  })
+})

--- a/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
+++ b/apps/frontend/src/components/settings/personal-default-companion-section.test.tsx
@@ -51,6 +51,7 @@ describe("PersonalDefaultCompanionSection", () => {
     vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
       effectiveDefault: ARIADNE,
       workspaceDefault: ARIADNE,
+      personalDefault: undefined,
     })
     vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
       toEmoji: (shortcode: string) => shortcode,

--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label"
 import type { ActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { ToolPolicyControl } from "./tool-policy-picker"
 import { ExternalAgentIndicator } from "./external-agent-indicator"
-import { CompanionAgentSelect, type CompanionPersona } from "./companion-agent-select"
+import { CompanionAgentSelect, type CompanionDefaultBadges, type CompanionPersona } from "./companion-agent-select"
 
 export interface AgentToolPolicyBinding {
   value: ToolPrivacyPolicy
@@ -25,9 +25,11 @@ export interface AgentPersonaBinding {
    *  `companionPickerValue`). */
   selectedPersonaId: string | undefined
   onChange: (personaId: string) => void
-  /** The synthetic leading "Default (X)" row; the caller maps its sentinel
-   *  value back to null (inherit). */
+  /** The synthetic leading "Default (X)" row (creation-time surfaces only);
+   *  the caller maps its sentinel value back to unset. */
   defaultOption?: { label: string }
+  /** Row indicators marking the workspace/personal default personas. */
+  defaultBadges?: CompanionDefaultBadges
   busy?: boolean
 }
 
@@ -91,6 +93,7 @@ export function AgentSettingsPanel({
             value={personaPicker.selectedPersonaId}
             onChange={personaPicker.onChange}
             defaultOption={personaPicker.defaultOption}
+            defaultBadges={personaPicker.defaultBadges}
             disabled={personaPicker.busy}
             triggerClassName="w-full"
           />

--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -1,18 +1,12 @@
 import type { ComponentType } from "react"
 import { Moon, Sparkles } from "lucide-react"
-import {
-  CompanionModes,
-  type CompanionMode,
-  type PersonaListItem,
-  type ToolPrivacyCategory,
-  type ToolPrivacyPolicy,
-} from "@threa/types"
+import { CompanionModes, type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
 import type { ActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { ToolPolicyControl } from "./tool-policy-picker"
 import { ExternalAgentIndicator } from "./external-agent-indicator"
-import { CompanionAgentSelect } from "./companion-agent-select"
+import { CompanionAgentSelect, type CompanionPersona } from "./companion-agent-select"
 
 export interface AgentToolPolicyBinding {
   value: ToolPrivacyPolicy
@@ -26,7 +20,7 @@ export interface AgentToolPolicyBinding {
 export interface AgentPersonaBinding {
   workspaceId: string
   /** Roster to offer (built-ins + active customs). */
-  personas: PersonaListItem[]
+  personas: CompanionPersona[]
   /** Select value: an explicit persona id, or the inherit sentinel (see
    *  `companionPickerValue`). */
   selectedPersonaId: string | undefined

--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -27,8 +27,13 @@ export interface AgentPersonaBinding {
   workspaceId: string
   /** Roster to offer (built-ins + active customs). */
   personas: PersonaListItem[]
+  /** Select value: an explicit persona id, or the inherit sentinel (see
+   *  `companionPickerValue`). */
   selectedPersonaId: string | undefined
   onChange: (personaId: string) => void
+  /** The synthetic leading "Default (X)" row; the caller maps its sentinel
+   *  value back to null (inherit). */
+  defaultOption?: { label: string }
   busy?: boolean
 }
 
@@ -91,6 +96,7 @@ export function AgentSettingsPanel({
             personas={personaPicker.personas}
             value={personaPicker.selectedPersonaId}
             onChange={personaPicker.onChange}
+            defaultOption={personaPicker.defaultOption}
             disabled={personaPicker.busy}
             triggerClassName="w-full"
           />

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
@@ -21,38 +21,50 @@ const ROSTER = [ARIADNE, COACH, SCRIBE]
 
 describe("resolveCompanionSelection", () => {
   it("uses the supplied default for a null pointer instead of Ariadne", () => {
-    const result = resolveCompanionSelection(ROSTER, null, COACH)
-    expect(result.selectedPersonaId).toBe("persona_coach")
-    expect(result.companionName).toBe("Coach")
+    expect(resolveCompanionSelection(ROSTER, null, COACH)).toEqual({
+      selectedPersonaId: "persona_coach",
+      selectedPersona: COACH,
+      companionName: "Coach",
+    })
   })
 
   it("prefers an explicit pointer over the supplied default", () => {
-    const result = resolveCompanionSelection(ROSTER, "persona_scribe", COACH)
-    expect(result.selectedPersonaId).toBe("persona_scribe")
-    expect(result.companionName).toBe("Scribe")
+    expect(resolveCompanionSelection(ROSTER, "persona_scribe", COACH)).toEqual({
+      selectedPersonaId: "persona_scribe",
+      selectedPersona: SCRIBE,
+      companionName: "Scribe",
+    })
   })
 
   it("degrades an off-roster pointer to the supplied default", () => {
-    const result = resolveCompanionSelection(ROSTER, "persona_archived", COACH)
-    expect(result.selectedPersonaId).toBe("persona_coach")
-    expect(result.companionName).toBe("Coach")
+    expect(resolveCompanionSelection(ROSTER, "persona_archived", COACH)).toEqual({
+      selectedPersonaId: "persona_coach",
+      selectedPersona: COACH,
+      companionName: "Coach",
+    })
   })
 
   it("falls back to the Ariadne-slug lookup when no default is supplied (unchanged legacy behavior)", () => {
-    const result = resolveCompanionSelection(ROSTER, null)
-    expect(result.selectedPersonaId).toBe("persona_ariadne")
-    expect(result.companionName).toBe("Ariadne")
+    expect(resolveCompanionSelection(ROSTER, null)).toEqual({
+      selectedPersonaId: "persona_ariadne",
+      selectedPersona: ARIADNE,
+      companionName: "Ariadne",
+    })
   })
 
   it("degrades to Ariadne by slug when the supplied default is undefined and the pointer is off-roster", () => {
-    const result = resolveCompanionSelection(ROSTER, "persona_archived", undefined)
-    expect(result.selectedPersonaId).toBe("persona_ariadne")
-    expect(result.companionName).toBe("Ariadne")
+    expect(resolveCompanionSelection(ROSTER, "persona_archived", undefined)).toEqual({
+      selectedPersonaId: "persona_ariadne",
+      selectedPersona: ARIADNE,
+      companionName: "Ariadne",
+    })
   })
 
   it("returns the 'Ariadne' name literal when the roster is empty and no default is supplied", () => {
-    const result = resolveCompanionSelection(undefined, null)
-    expect(result.selectedPersonaId).toBeUndefined()
-    expect(result.companionName).toBe("Ariadne")
+    expect(resolveCompanionSelection(undefined, null)).toEqual({
+      selectedPersonaId: undefined,
+      selectedPersona: undefined,
+      companionName: "Ariadne",
+    })
   })
 })

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
@@ -10,6 +10,7 @@ function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id
     kind: "custom",
     avatarUrl: null,
     isCustomized: false,
+    status: "active",
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import type { PersonaListItem } from "@threa/types"
+import { resolveCompanionSelection } from "./companion-agent-select"
+
+function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id" | "slug" | "name">): PersonaListItem {
+  return {
+    description: null,
+    avatarEmoji: null,
+    model: "openrouter:anthropic/claude-haiku-4.5",
+    kind: "custom",
+    avatarUrl: null,
+    isCustomized: false,
+    ...overrides,
+  }
+}
+
+const ARIADNE = persona({ id: "persona_ariadne", slug: "ariadne", name: "Ariadne", kind: "builtin" })
+const COACH = persona({ id: "persona_coach", slug: "coach", name: "Coach" })
+const SCRIBE = persona({ id: "persona_scribe", slug: "scribe", name: "Scribe" })
+const ROSTER = [ARIADNE, COACH, SCRIBE]
+
+describe("resolveCompanionSelection", () => {
+  it("uses the supplied default for a null pointer instead of Ariadne", () => {
+    const result = resolveCompanionSelection(ROSTER, null, COACH)
+    expect(result.selectedPersonaId).toBe("persona_coach")
+    expect(result.companionName).toBe("Coach")
+  })
+
+  it("prefers an explicit pointer over the supplied default", () => {
+    const result = resolveCompanionSelection(ROSTER, "persona_scribe", COACH)
+    expect(result.selectedPersonaId).toBe("persona_scribe")
+    expect(result.companionName).toBe("Scribe")
+  })
+
+  it("degrades an off-roster pointer to the supplied default", () => {
+    const result = resolveCompanionSelection(ROSTER, "persona_archived", COACH)
+    expect(result.selectedPersonaId).toBe("persona_coach")
+    expect(result.companionName).toBe("Coach")
+  })
+
+  it("falls back to the Ariadne-slug lookup when no default is supplied (unchanged legacy behavior)", () => {
+    const result = resolveCompanionSelection(ROSTER, null)
+    expect(result.selectedPersonaId).toBe("persona_ariadne")
+    expect(result.companionName).toBe("Ariadne")
+  })
+
+  it("degrades to Ariadne by slug when the supplied default is undefined and the pointer is off-roster", () => {
+    const result = resolveCompanionSelection(ROSTER, "persona_archived", undefined)
+    expect(result.selectedPersonaId).toBe("persona_ariadne")
+    expect(result.companionName).toBe("Ariadne")
+  })
+
+  it("returns the 'Ariadne' name literal when the roster is empty and no default is supplied", () => {
+    const result = resolveCompanionSelection(undefined, null)
+    expect(result.selectedPersonaId).toBeUndefined()
+    expect(result.companionName).toBe("Ariadne")
+  })
+})

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -9,9 +9,30 @@ export interface CompanionSelection {
   companionName: string
 }
 
-/** Sentinel Select value for the "Workspace default" synthetic option (user
- *  settings): distinct from any `persona_…` id, round-trips as null at the caller. */
+/** Sentinel Select value for the synthetic "default" option: distinct from any
+ *  `persona_…` id, round-trips as null (streams) / null-pref (user settings). */
 export const COMPANION_DEFAULT_OPTION_VALUE = "__workspace_default__"
+
+/**
+ * Select value for a stream surface's picker: an explicit on-roster pointer
+ * selects its persona row; anything else — null (inherit) or an off-roster
+ * (archived) pointer that dispatch would degrade anyway — selects the synthetic
+ * default row. Inherit is legible and picking a concrete persona always pins.
+ */
+export function companionPickerValue(
+  personas: PersonaListItem[] | undefined,
+  companionPersonaId: string | null | undefined
+): string {
+  return companionPersonaId && personas?.some((p) => p.id === companionPersonaId)
+    ? companionPersonaId
+    : COMPANION_DEFAULT_OPTION_VALUE
+}
+
+/** Label for the stream pickers' synthetic inherit row, naming the persona the
+ *  default currently resolves to. */
+export function companionDefaultOptionLabel(defaultPersona: PersonaListItem | undefined): string {
+  return `Default (${defaultPersona?.name ?? "Ariadne"})`
+}
 
 /**
  * Resolve a stream's companion-persona pointer against the roster. A null

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -34,6 +34,12 @@ export function companionDefaultOptionLabel(defaultPersona: PersonaListItem | un
   return `Default (${defaultPersona?.name ?? "Ariadne"})`
 }
 
+/** Map a picker value back to the stored pointer: the synthetic inherit row
+ *  round-trips as null; any other value is a concrete persona id (a pin). */
+export function companionPointerFromPickerValue(value: string): string | null {
+  return value === COMPANION_DEFAULT_OPTION_VALUE ? null : value
+}
+
 /**
  * Resolve a stream's companion-persona pointer against the roster. A null
  * pointer resolves to the effective default (user → workspace → Ariadne) at

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -9,21 +9,30 @@ export interface CompanionSelection {
   companionName: string
 }
 
+/** Sentinel Select value for the "Workspace default" synthetic option (user
+ *  settings): distinct from any `persona_…` id, round-trips as null at the caller. */
+export const COMPANION_DEFAULT_OPTION_VALUE = "__workspace_default__"
+
 /**
  * Resolve a stream's companion-persona pointer against the roster. A null
- * pointer resolves to the built-in default (Ariadne) at dispatch, so the picker
- * pre-selects that persona and mode copy names it. A pointer to a persona
- * missing from the roster (archived) degrades to the default too — the returned
- * id is the RESOLVED persona's, never the raw off-roster pointer, so the Select
- * trigger and the mode copy always agree.
+ * pointer resolves to the effective default (user → workspace → Ariadne) at
+ * dispatch, so the picker pre-selects that persona and mode copy names it. A
+ * pointer to a persona missing from the roster (archived) degrades to the default
+ * too — the returned id is the RESOLVED persona's, never the raw off-roster
+ * pointer, so the Select trigger and the mode copy always agree.
+ *
+ * `defaultPersona` is the resolved default from `useDefaultCompanionPersona`; when
+ * a caller can't supply one (roster-less states, tests), the Ariadne-slug lookup
+ * inside stays the final fallback so behavior is byte-identical to before.
  */
 export function resolveCompanionSelection(
   personas: PersonaListItem[] | undefined,
-  companionPersonaId: string | null | undefined
+  companionPersonaId: string | null | undefined,
+  defaultPersona?: PersonaListItem
 ): CompanionSelection {
-  const defaultPersona = personas?.find((p) => p.slug === ARIADNE_PERSONA_SLUG)
+  const fallback = defaultPersona ?? personas?.find((p) => p.slug === ARIADNE_PERSONA_SLUG)
   const pointed = companionPersonaId ? personas?.find((p) => p.id === companionPersonaId) : undefined
-  const selectedPersona = pointed ?? defaultPersona
+  const selectedPersona = pointed ?? fallback
   return { selectedPersonaId: selectedPersona?.id, selectedPersona, companionName: selectedPersona?.name ?? "Ariadne" }
 }
 
@@ -34,6 +43,10 @@ interface CompanionAgentSelectProps {
   onChange: (personaId: string) => void
   disabled?: boolean
   triggerClassName?: string
+  /** A leading synthetic option (e.g. "Workspace default (Ariadne)") rendered
+   *  before the persona rows; it carries {@link COMPANION_DEFAULT_OPTION_VALUE},
+   *  which the caller maps back to null. */
+  defaultOption?: { label: string }
 }
 
 /** The companion-agent dropdown (avatar + name rows) shared by every surface
@@ -45,6 +58,7 @@ export function CompanionAgentSelect({
   onChange,
   disabled,
   triggerClassName,
+  defaultOption,
 }: CompanionAgentSelectProps) {
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
@@ -52,6 +66,11 @@ export function CompanionAgentSelect({
         <SelectValue placeholder="Select an agent" />
       </SelectTrigger>
       <SelectContent>
+        {defaultOption && (
+          <SelectItem value={COMPANION_DEFAULT_OPTION_VALUE}>
+            <span className="truncate">{defaultOption.label}</span>
+          </SelectItem>
+        )}
         {personas.map((persona) => (
           <SelectItem key={persona.id} value={persona.id}>
             <span className="flex items-center gap-2">

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -70,6 +70,21 @@ export function resolveCompanionSelection(
   return { selectedPersonaId: selectedPersona?.id, selectedPersona, companionName: selectedPersona?.name ?? "Ariadne" }
 }
 
+/** Which persona rows get a default indicator: the workspace tier's resolution
+ *  and the viewer's explicit personal default (when set). */
+export interface CompanionDefaultBadges {
+  workspaceDefaultId?: string
+  personalDefaultId?: string
+}
+
+function defaultBadgeLabel(personaId: string, badges: CompanionDefaultBadges | undefined): string | null {
+  if (!badges) return null
+  // "Your default" is the more specific tier — it wins when both land on one row.
+  if (badges.personalDefaultId === personaId) return "Your default"
+  if (badges.workspaceDefaultId === personaId) return "Workspace default"
+  return null
+}
+
 interface CompanionAgentSelectProps {
   workspaceId: string
   personas: CompanionPersona[]
@@ -77,10 +92,13 @@ interface CompanionAgentSelectProps {
   onChange: (personaId: string) => void
   disabled?: boolean
   triggerClassName?: string
-  /** A leading synthetic option (e.g. "Workspace default (Ariadne)") rendered
-   *  before the persona rows; it carries {@link COMPANION_DEFAULT_OPTION_VALUE},
-   *  which the caller maps back to null. */
+  /** A leading synthetic option (e.g. "Default (Ariadne)") rendered before the
+   *  persona rows; it carries {@link COMPANION_DEFAULT_OPTION_VALUE}, which the
+   *  caller maps back to null/unset. Creation-time surfaces only — a created
+   *  scratchpad is pinned to one persona and offers no inherit row. */
   defaultOption?: { label: string }
+  /** Row indicators marking the workspace/personal default personas. */
+  defaultBadges?: CompanionDefaultBadges
 }
 
 /** The companion-agent dropdown (avatar + name rows) shared by every surface
@@ -93,6 +111,7 @@ export function CompanionAgentSelect({
   disabled,
   triggerClassName,
   defaultOption,
+  defaultBadges,
 }: CompanionAgentSelectProps) {
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
@@ -105,14 +124,18 @@ export function CompanionAgentSelect({
             <span className="truncate">{defaultOption.label}</span>
           </SelectItem>
         )}
-        {personas.map((persona) => (
-          <SelectItem key={persona.id} value={persona.id}>
-            <span className="flex items-center gap-2">
-              <PersonaListAvatar workspaceId={workspaceId} persona={persona} size="xs" />
-              <span className="truncate">{persona.name}</span>
-            </span>
-          </SelectItem>
-        ))}
+        {personas.map((persona) => {
+          const badge = defaultBadgeLabel(persona.id, defaultBadges)
+          return (
+            <SelectItem key={persona.id} value={persona.id}>
+              <span className="flex items-center gap-2">
+                <PersonaListAvatar workspaceId={workspaceId} persona={persona} size="xs" />
+                <span className="truncate">{persona.name}</span>
+                {badge && <span className="shrink-0 text-[10px] text-muted-foreground">{badge}</span>}
+              </span>
+            </SelectItem>
+          )
+        })}
       </SelectContent>
     </Select>
   )

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -2,9 +2,16 @@ import { ARIADNE_PERSONA_SLUG, type PersonaListItem } from "@threa/types"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { PersonaListAvatar } from "@/components/persona-avatar"
 
+/**
+ * The fields the companion pickers render/resolve. Both the API roster's
+ * `PersonaListItem` (settings surfaces) and the bootstrap-backed store rows
+ * (`useCompanionRoster`) satisfy it, so every surface shares one picker.
+ */
+export type CompanionPersona = Pick<PersonaListItem, "id" | "slug" | "name" | "avatarEmoji" | "avatarUrl">
+
 export interface CompanionSelection {
   selectedPersonaId: string | undefined
-  selectedPersona: PersonaListItem | undefined
+  selectedPersona: CompanionPersona | undefined
   /** Display name for copy ("… reads new messages and replies"). */
   companionName: string
 }
@@ -20,7 +27,7 @@ export const COMPANION_DEFAULT_OPTION_VALUE = "__workspace_default__"
  * default row. Inherit is legible and picking a concrete persona always pins.
  */
 export function companionPickerValue(
-  personas: PersonaListItem[] | undefined,
+  personas: CompanionPersona[] | undefined,
   companionPersonaId: string | null | undefined
 ): string {
   return companionPersonaId && personas?.some((p) => p.id === companionPersonaId)
@@ -30,7 +37,7 @@ export function companionPickerValue(
 
 /** Label for the stream pickers' synthetic inherit row, naming the persona the
  *  default currently resolves to. */
-export function companionDefaultOptionLabel(defaultPersona: PersonaListItem | undefined): string {
+export function companionDefaultOptionLabel(defaultPersona: CompanionPersona | undefined): string {
   return `Default (${defaultPersona?.name ?? "Ariadne"})`
 }
 
@@ -53,9 +60,9 @@ export function companionPointerFromPickerValue(value: string): string | null {
  * inside stays the final fallback so behavior is byte-identical to before.
  */
 export function resolveCompanionSelection(
-  personas: PersonaListItem[] | undefined,
+  personas: CompanionPersona[] | undefined,
   companionPersonaId: string | null | undefined,
-  defaultPersona?: PersonaListItem
+  defaultPersona?: CompanionPersona
 ): CompanionSelection {
   const fallback = defaultPersona ?? personas?.find((p) => p.slug === ARIADNE_PERSONA_SLUG)
   const pointed = companionPersonaId ? personas?.find((p) => p.id === companionPersonaId) : undefined
@@ -65,7 +72,7 @@ export function resolveCompanionSelection(
 
 interface CompanionAgentSelectProps {
   workspaceId: string
-  personas: PersonaListItem[]
+  personas: CompanionPersona[]
   value: string | undefined
   onChange: (personaId: string) => void
   disabled?: boolean

--- a/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import type { PersonaListItem, Stream } from "@threa/types"
 import * as streamsHooks from "@/hooks/use-streams"
 import * as personasHooks from "@/hooks/use-personas"
+import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import * as botPresenceHooks from "@/hooks/use-active-bot-presence"
 import * as briefHooks from "@/hooks/use-stream-brief"
@@ -38,6 +39,10 @@ beforeEach(() => {
   vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
     data: [ARIADNE, COACH],
   } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
+    effectiveDefault: ARIADNE,
+    workspaceDefault: ARIADNE,
+  } as unknown as ReturnType<typeof defaultCompanionHooks.useDefaultCompanionPersona>)
   vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
     toEmoji: (shortcode: string) => shortcode,
   } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)
@@ -103,6 +108,17 @@ describe("CompanionTab persona picker", () => {
   it("names the pointed-at persona in the mode copy", () => {
     renderTab({ companionPersonaId: "persona_coach" })
 
+    expect(screen.getByText(/Coach reads new messages and replies in the thread/i)).toBeInTheDocument()
+  })
+
+  it("shows the configured workspace default on an unpinned stream", () => {
+    vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
+      effectiveDefault: COACH,
+      workspaceDefault: COACH,
+    })
+    renderTab({ companionPersonaId: null })
+
+    // A null pointer now resolves to the configured default, not the hardcoded Ariadne.
     expect(screen.getByText(/Coach reads new messages and replies in the thread/i)).toBeInTheDocument()
   })
 

--- a/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
@@ -92,7 +92,11 @@ describe("CompanionTab persona picker", () => {
     expect(screen.getByText(/Ariadne reads new messages and replies in the thread/i)).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    expect(await screen.findByRole("option", { name: /Ariadne/i })).toBeInTheDocument()
+    // Leading synthetic inherit row, then the roster.
+    expect(await screen.findByRole("option", { name: /Default \(Ariadne\)/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: (name) => name.includes("Ariadne") && !name.includes("Default") })
+    ).toBeInTheDocument()
     expect(screen.getByRole("option", { name: /Coach/i })).toBeInTheDocument()
   })
 

--- a/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type { PersonaListItem, Stream } from "@threa/types"
 import * as streamsHooks from "@/hooks/use-streams"
-import * as personasHooks from "@/hooks/use-personas"
+import * as rosterHooks from "@/hooks/use-companion-roster"
 import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import * as botPresenceHooks from "@/hooks/use-active-bot-presence"
@@ -23,6 +23,7 @@ function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id
     kind: "custom",
     avatarUrl: null,
     isCustomized: false,
+    status: "active",
     ...overrides,
   }
 }
@@ -36,9 +37,7 @@ beforeEach(() => {
     mutateAsync: companionMutate,
     isPending: false,
   } as unknown as ReturnType<typeof streamsHooks.useUpdateCompanionMode>)
-  vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-    data: [ARIADNE, COACH],
-  } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([ARIADNE, COACH])
   vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
     effectiveDefault: ARIADNE,
     workspaceDefault: ARIADNE,

--- a/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
@@ -41,6 +41,7 @@ beforeEach(() => {
   vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
     effectiveDefault: ARIADNE,
     workspaceDefault: ARIADNE,
+    personalDefault: undefined,
   } as unknown as ReturnType<typeof defaultCompanionHooks.useDefaultCompanionPersona>)
   vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
     toEmoji: (shortcode: string) => shortcode,
@@ -91,11 +92,9 @@ describe("CompanionTab persona picker", () => {
     expect(screen.getByText(/Ariadne reads new messages and replies in the thread/i)).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    // Leading synthetic inherit row, then the roster.
-    expect(await screen.findByRole("option", { name: /Default \(Ariadne\)/i })).toBeInTheDocument()
-    expect(
-      screen.getByRole("option", { name: (name) => name.includes("Ariadne") && !name.includes("Default") })
-    ).toBeInTheDocument()
+    // No inherit row on a created stream — it's pinned; rows carry default badges.
+    expect(screen.queryByRole("option", { name: /Default \(/i })).not.toBeInTheDocument()
+    expect(await screen.findByRole("option", { name: /Ariadne.*Workspace default/i })).toBeInTheDocument()
     expect(screen.getByRole("option", { name: /Coach/i })).toBeInTheDocument()
   })
 
@@ -114,15 +113,17 @@ describe("CompanionTab persona picker", () => {
     expect(screen.getByText(/Coach reads new messages and replies in the thread/i)).toBeInTheDocument()
   })
 
-  it("shows the configured workspace default on an unpinned stream", () => {
+  it("does NOT retroactively apply a changed default to a stream with a null pointer", () => {
     vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
       effectiveDefault: COACH,
       workspaceDefault: COACH,
+      personalDefault: undefined,
     })
     renderTab({ companionPersonaId: null })
 
-    // A null pointer now resolves to the configured default, not the hardcoded Ariadne.
-    expect(screen.getByText(/Coach reads new messages and replies in the thread/i)).toBeInTheDocument()
+    // Defaults pin at CREATE; a legacy null pointer displays (and dispatches
+    // as) the built-in default, never the currently-configured one.
+    expect(screen.getByText(/Ariadne reads new messages and replies in the thread/i)).toBeInTheDocument()
   })
 
   it("hides the persona picker on encrypted streams (enclave is Ariadne-only)", () => {

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -3,8 +3,8 @@ import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
-import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
+import { useCompanionRoster } from "@/hooks/use-companion-roster"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import {
   CompanionModes,
@@ -51,20 +51,22 @@ export function CompanionTab({
   const isE2e = stream.e2eEnabled === true
   const disabled = isPending
 
-  // The picker (and its roster fetch) is plaintext-only — an encrypted
-  // scratchpad always runs the built-in Ariadne, so don't fire /personas there.
-  const { data: personas } = usePersonas(workspaceId, { enabled: !isE2e })
-  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId, { enabled: !isE2e })
+  // Bootstrap-backed store read (no fetch) — instant on open, offline-capable.
+  // The picker itself stays hidden on encrypted scratchpads (enclave is
+  // Ariadne-only).
+  const personas = useCompanionRoster(workspaceId)
+  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
 
   const { companionName: resolvedName } = resolveCompanionSelection(
     personas,
     stream.companionPersonaId,
     effectiveDefault
   )
-  // Until the roster resolves, the real default is unknown — say "your companion"
-  // rather than flash a name that may be wrong. E2E streams never load the roster
-  // and genuinely always run Ariadne, so the resolved name is correct there.
-  const rosterReady = isE2e || personas !== undefined
+  // Until the store hydrates ([] before the bootstrap/IDB seed lands), the real
+  // default is unknown — say "your companion" rather than flash a name that may
+  // be wrong. E2E scratchpads genuinely always run Ariadne, so the resolved name
+  // is correct there regardless.
+  const rosterReady = isE2e || personas.length > 0
   const companionName = rosterReady ? resolvedName : "your companion"
   const pickerValue = companionPickerValue(personas, stream.companionPersonaId)
 
@@ -134,7 +136,7 @@ export function CompanionTab({
 
       {/* Encrypted scratchpads always run the built-in Ariadne in the enclave
           regardless of the pointer, so the persona picker is plaintext-only. */}
-      {!isE2e && personas && personas.length > 0 && (
+      {!isE2e && personas.length > 0 && (
         <div className="space-y-2">
           <div className="space-y-1">
             <Label className="text-sm font-medium">Companion agent</Label>

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -13,7 +13,13 @@ import {
   type ToolPrivacyCategory,
   type ToolPrivacyPolicy,
 } from "@threa/types"
-import { CompanionAgentSelect, resolveCompanionSelection } from "./companion-agent-select"
+import {
+  COMPANION_DEFAULT_OPTION_VALUE,
+  CompanionAgentSelect,
+  companionDefaultOptionLabel,
+  companionPickerValue,
+  resolveCompanionSelection,
+} from "./companion-agent-select"
 import { ToolPolicyPicker } from "./tool-policy-picker"
 import { ExternalAgentIndicator } from "./external-agent-indicator"
 import { BriefSection } from "./brief-section"
@@ -50,11 +56,17 @@ export function CompanionTab({
   const { data: personas } = usePersonas(workspaceId, { enabled: !isE2e })
   const { effectiveDefault } = useDefaultCompanionPersona(workspaceId, { enabled: !isE2e })
 
-  const { selectedPersonaId, companionName } = resolveCompanionSelection(
+  const { companionName: resolvedName } = resolveCompanionSelection(
     personas,
     stream.companionPersonaId,
     effectiveDefault
   )
+  // Until the roster resolves, the real default is unknown — say "your companion"
+  // rather than flash a name that may be wrong. E2E streams never load the roster
+  // and genuinely always run Ariadne, so the resolved name is correct there.
+  const rosterReady = isE2e || personas !== undefined
+  const companionName = rosterReady ? resolvedName : "your companion"
+  const pickerValue = companionPickerValue(personas, stream.companionPersonaId)
 
   const handleChange = async (next: CompanionMode) => {
     if (next === stream.companionMode) return
@@ -67,9 +79,12 @@ export function CompanionTab({
   }
 
   const handlePersonaChange = async (personaId: string) => {
-    if (personaId === selectedPersonaId) return
+    if (personaId === pickerValue) return
     try {
-      await updateCompanionMode({ companionMode: stream.companionMode, companionPersonaId: personaId })
+      await updateCompanionMode({
+        companionMode: stream.companionMode,
+        companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? null : personaId,
+      })
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to update companion agent"
       toast.error(message)
@@ -99,7 +114,11 @@ export function CompanionTab({
             onSelect={() => handleChange(CompanionModes.ON)}
             icon={Sparkles}
             label="Companion"
-            hint={`${companionName} reads new messages and replies in the thread`}
+            hint={
+              rosterReady
+                ? `${companionName} reads new messages and replies in the thread`
+                : "Your companion reads new messages and replies in the thread"
+            }
             disabled={disabled}
           />
           <CompanionOption
@@ -127,8 +146,9 @@ export function CompanionTab({
           <CompanionAgentSelect
             workspaceId={workspaceId}
             personas={personas}
-            value={selectedPersonaId}
+            value={pickerValue}
             onChange={handlePersonaChange}
+            defaultOption={{ label: companionDefaultOptionLabel(effectiveDefault) }}
             disabled={disabled}
             triggerClassName="w-full sm:w-72"
           />

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -13,13 +13,7 @@ import {
   type ToolPrivacyCategory,
   type ToolPrivacyPolicy,
 } from "@threa/types"
-import {
-  CompanionAgentSelect,
-  companionDefaultOptionLabel,
-  companionPickerValue,
-  companionPointerFromPickerValue,
-  resolveCompanionSelection,
-} from "./companion-agent-select"
+import { CompanionAgentSelect, resolveCompanionSelection } from "./companion-agent-select"
 import { ToolPolicyPicker } from "./tool-policy-picker"
 import { ExternalAgentIndicator } from "./external-agent-indicator"
 import { BriefSection } from "./brief-section"
@@ -55,12 +49,14 @@ export function CompanionTab({
   // The picker itself stays hidden on encrypted scratchpads (enclave is
   // Ariadne-only).
   const personas = useCompanionRoster(workspaceId)
-  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
+  const { workspaceDefault, personalDefault } = useDefaultCompanionPersona(workspaceId)
 
-  const { companionName: resolvedName } = resolveCompanionSelection(
+  // A created scratchpad is pinned to one persona; a legacy NULL pointer
+  // displays (and dispatches as) the built-in default. Only an explicit pick
+  // changes the agent — defaults apply at create, never retroactively.
+  const { selectedPersonaId, companionName: resolvedName } = resolveCompanionSelection(
     personas,
-    stream.companionPersonaId,
-    effectiveDefault
+    stream.companionPersonaId
   )
   // Until the store hydrates ([] before the bootstrap/IDB seed lands), the real
   // default is unknown — say "your companion" rather than flash a name that may
@@ -68,7 +64,6 @@ export function CompanionTab({
   // is correct there regardless.
   const rosterReady = isE2e || personas.length > 0
   const companionName = rosterReady ? resolvedName : "your companion"
-  const pickerValue = companionPickerValue(personas, stream.companionPersonaId)
 
   const handleChange = async (next: CompanionMode) => {
     if (next === stream.companionMode) return
@@ -81,12 +76,9 @@ export function CompanionTab({
   }
 
   const handlePersonaChange = async (personaId: string) => {
-    if (personaId === pickerValue) return
+    if (personaId === selectedPersonaId) return
     try {
-      await updateCompanionMode({
-        companionMode: stream.companionMode,
-        companionPersonaId: companionPointerFromPickerValue(personaId),
-      })
+      await updateCompanionMode({ companionMode: stream.companionMode, companionPersonaId: personaId })
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to update companion agent"
       toast.error(message)
@@ -148,9 +140,9 @@ export function CompanionTab({
           <CompanionAgentSelect
             workspaceId={workspaceId}
             personas={personas}
-            value={pickerValue}
+            value={selectedPersonaId}
             onChange={handlePersonaChange}
-            defaultOption={{ label: companionDefaultOptionLabel(effectiveDefault) }}
+            defaultBadges={{ workspaceDefaultId: workspaceDefault?.id, personalDefaultId: personalDefault?.id }}
             disabled={disabled}
             triggerClassName="w-full sm:w-72"
           />

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -14,10 +14,10 @@ import {
   type ToolPrivacyPolicy,
 } from "@threa/types"
 import {
-  COMPANION_DEFAULT_OPTION_VALUE,
   CompanionAgentSelect,
   companionDefaultOptionLabel,
   companionPickerValue,
+  companionPointerFromPickerValue,
   resolveCompanionSelection,
 } from "./companion-agent-select"
 import { ToolPolicyPicker } from "./tool-policy-picker"
@@ -83,7 +83,7 @@ export function CompanionTab({
     try {
       await updateCompanionMode({
         companionMode: stream.companionMode,
-        companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? null : personaId,
+        companionPersonaId: companionPointerFromPickerValue(personaId),
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to update companion agent"

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -4,6 +4,7 @@ import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
 import { usePersonas } from "@/hooks/use-personas"
+import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import {
   CompanionModes,
@@ -47,8 +48,13 @@ export function CompanionTab({
   // The picker (and its roster fetch) is plaintext-only — an encrypted
   // scratchpad always runs the built-in Ariadne, so don't fire /personas there.
   const { data: personas } = usePersonas(workspaceId, { enabled: !isE2e })
+  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId, { enabled: !isE2e })
 
-  const { selectedPersonaId, companionName } = resolveCompanionSelection(personas, stream.companionPersonaId)
+  const { selectedPersonaId, companionName } = resolveCompanionSelection(
+    personas,
+    stream.companionPersonaId,
+    effectiveDefault
+  )
 
   const handleChange = async (next: CompanionMode) => {
     if (next === stream.companionMode) return

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import * as draftHook from "@/hooks/use-draft-scratchpads"
-import * as personasHooks from "@/hooks/use-personas"
+import * as rosterHooks from "@/hooks/use-companion-roster"
 import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import { DraftAgentSettings } from "./draft-agent-settings"
@@ -45,9 +45,9 @@ beforeEach(() => {
     deleteScratchpad: vi.fn(),
     getScratchpad: vi.fn(),
   } as unknown as ReturnType<typeof draftHook.useDraftScratchpads>)
-  vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-    data: ROSTER,
-  } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue(
+    ROSTER as unknown as ReturnType<typeof rosterHooks.useCompanionRoster>
+  )
   vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
     effectiveDefault: ROSTER[0],
     workspaceDefault: ROSTER[0],
@@ -109,10 +109,8 @@ describe("DraftAgentSettings", () => {
     expect(updateScratchpad).toHaveBeenCalledWith("draft_1", { companionPersonaId: "persona_coach" })
   })
 
-  it("hides the picker while the roster is still loading", () => {
-    vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-      data: undefined,
-    } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  it("hides the picker while the store is still hydrating (empty roster)", () => {
+    vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([])
 
     renderSettings({})
 

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import * as draftHook from "@/hooks/use-draft-scratchpads"
 import * as personasHooks from "@/hooks/use-personas"
+import * as defaultCompanionHooks from "@/hooks/use-default-companion-persona"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import { DraftAgentSettings } from "./draft-agent-settings"
 
@@ -47,6 +48,10 @@ beforeEach(() => {
   vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
     data: ROSTER,
   } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  vi.spyOn(defaultCompanionHooks, "useDefaultCompanionPersona").mockReturnValue({
+    effectiveDefault: ROSTER[0],
+    workspaceDefault: ROSTER[0],
+  } as unknown as ReturnType<typeof defaultCompanionHooks.useDefaultCompanionPersona>)
   vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
     toEmoji: (shortcode: string) => shortcode,
   } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -4,9 +4,9 @@ import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import { AgentSettingsPanel } from "./agent-settings-panel"
 import {
-  COMPANION_DEFAULT_OPTION_VALUE,
   companionDefaultOptionLabel,
   companionPickerValue,
+  companionPointerFromPickerValue,
 } from "./companion-agent-select"
 
 interface DraftAgentSettingsProps {
@@ -51,7 +51,7 @@ export function DraftAgentSettings({
               onChange: (personaId) =>
                 updateScratchpad(draftId, {
                   // Dexie removes a key set to undefined — inherit means no stored pointer.
-                  companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? undefined : personaId,
+                  companionPersonaId: companionPointerFromPickerValue(personaId) ?? undefined,
                 }),
               defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
             }

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -34,7 +34,7 @@ export function DraftAgentSettings({
 }: DraftAgentSettingsProps) {
   const { getScratchpad, updateScratchpad } = useDraftScratchpads(workspaceId)
   const personas = useCompanionRoster(workspaceId)
-  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
+  const { effectiveDefault, workspaceDefault, personalDefault } = useDefaultCompanionPersona(workspaceId)
 
   const pickerValue = companionPickerValue(personas, getScratchpad(draftId)?.companionPersonaId)
 
@@ -54,6 +54,7 @@ export function DraftAgentSettings({
                   companionPersonaId: companionPointerFromPickerValue(personaId) ?? undefined,
                 }),
               defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
+              defaultBadges: { workspaceDefaultId: workspaceDefault?.id, personalDefaultId: personalDefault?.id },
             }
           : undefined
       }

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -1,6 +1,7 @@
 import { type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
 import { useDraftScratchpads } from "@/hooks/use-draft-scratchpads"
 import { usePersonas } from "@/hooks/use-personas"
+import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import { AgentSettingsPanel } from "./agent-settings-panel"
 import { resolveCompanionSelection } from "./companion-agent-select"
 
@@ -29,8 +30,13 @@ export function DraftAgentSettings({
 }: DraftAgentSettingsProps) {
   const { getScratchpad, updateScratchpad } = useDraftScratchpads(workspaceId)
   const { data: personas } = usePersonas(workspaceId)
+  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
 
-  const { selectedPersonaId } = resolveCompanionSelection(personas, getScratchpad(draftId)?.companionPersonaId)
+  const { selectedPersonaId } = resolveCompanionSelection(
+    personas,
+    getScratchpad(draftId)?.companionPersonaId,
+    effectiveDefault
+  )
 
   return (
     <AgentSettingsPanel

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -1,7 +1,7 @@
 import { type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
 import { useDraftScratchpads } from "@/hooks/use-draft-scratchpads"
-import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
+import { useCompanionRoster } from "@/hooks/use-companion-roster"
 import { AgentSettingsPanel } from "./agent-settings-panel"
 import {
   companionDefaultOptionLabel,
@@ -33,7 +33,7 @@ export function DraftAgentSettings({
   configuredCategories,
 }: DraftAgentSettingsProps) {
   const { getScratchpad, updateScratchpad } = useDraftScratchpads(workspaceId)
-  const { data: personas } = usePersonas(workspaceId)
+  const personas = useCompanionRoster(workspaceId)
   const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
 
   const pickerValue = companionPickerValue(personas, getScratchpad(draftId)?.companionPersonaId)
@@ -43,7 +43,7 @@ export function DraftAgentSettings({
       companionMode={companionMode}
       onCompanionModeChange={(mode) => updateScratchpad(draftId, { companionMode: mode })}
       personaPicker={
-        personas
+        personas.length > 0
           ? {
               workspaceId,
               personas,

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -3,7 +3,11 @@ import { useDraftScratchpads } from "@/hooks/use-draft-scratchpads"
 import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import { AgentSettingsPanel } from "./agent-settings-panel"
-import { resolveCompanionSelection } from "./companion-agent-select"
+import {
+  COMPANION_DEFAULT_OPTION_VALUE,
+  companionDefaultOptionLabel,
+  companionPickerValue,
+} from "./companion-agent-select"
 
 interface DraftAgentSettingsProps {
   workspaceId: string
@@ -32,11 +36,7 @@ export function DraftAgentSettings({
   const { data: personas } = usePersonas(workspaceId)
   const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
 
-  const { selectedPersonaId } = resolveCompanionSelection(
-    personas,
-    getScratchpad(draftId)?.companionPersonaId,
-    effectiveDefault
-  )
+  const pickerValue = companionPickerValue(personas, getScratchpad(draftId)?.companionPersonaId)
 
   return (
     <AgentSettingsPanel
@@ -47,8 +47,13 @@ export function DraftAgentSettings({
           ? {
               workspaceId,
               personas,
-              selectedPersonaId,
-              onChange: (personaId) => updateScratchpad(draftId, { companionPersonaId: personaId }),
+              selectedPersonaId: pickerValue,
+              onChange: (personaId) =>
+                updateScratchpad(draftId, {
+                  // Dexie removes a key set to undefined — inherit means no stored pointer.
+                  companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? undefined : personaId,
+                }),
+              defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
             }
           : undefined
       }

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -7,7 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import { streamKeys } from "@/hooks"
 import * as streamsHooks from "@/hooks/use-streams"
-import * as personasHooks from "@/hooks/use-personas"
+import * as rosterHooks from "@/hooks/use-companion-roster"
 import * as emojiHooks from "@/hooks/use-workspace-emoji"
 import * as workspacesHooks from "@/hooks/use-workspaces"
 import * as workspaceStore from "@/stores/workspace-store"
@@ -33,9 +33,7 @@ beforeEach(() => {
     id: "user_owner",
   } as unknown as ReturnType<typeof workspacesHooks.useCurrentWorkspaceUser>)
   vi.spyOn(workspaceStore, "useWorkspaceBots").mockReturnValue([])
-  vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-    data: undefined,
-  } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+  vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([])
   vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
     toEmoji: (shortcode: string) => shortcode,
   } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)
@@ -81,9 +79,9 @@ function seedAndRender(opts: {
     vi.spyOn(workspaceStore, "useWorkspaceBots").mockReturnValue(opts.bots)
   }
   if (opts.personas) {
-    vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
-      data: opts.personas,
-    } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+    vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue(
+      opts.personas as unknown as ReturnType<typeof rosterHooks.useCompanionRoster>
+    )
   }
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_sp"), {

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -164,13 +164,33 @@ describe("LiveAgentSettings", () => {
     expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: "persona_coach" })
   })
 
-  it("treats picking the already-selected agent (the null-pointer default) as a no-op", async () => {
+  it("treats re-picking the inherit row on an unpinned stream as a no-op", async () => {
     seedAndRender({ personas: ROSTER, companionPersonaId: null })
 
     await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    await userEvent.click(screen.getByRole("option", { name: /ariadne/i }))
+    await userEvent.click(screen.getByRole("option", { name: /Default \(/i }))
 
     expect(companionMutate).not.toHaveBeenCalled()
+  })
+
+  it("pins the stream when the resolved default is picked explicitly", async () => {
+    seedAndRender({ personas: ROSTER, companionPersonaId: null })
+
+    await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await userEvent.click(
+      screen.getByRole("option", { name: (name) => name.includes("Ariadne") && !name.includes("Default") })
+    )
+
+    expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: "persona_ariadne" })
+  })
+
+  it("clears the pin back to inherit via the synthetic default row", async () => {
+    seedAndRender({ personas: ROSTER, companionPersonaId: "persona_coach" })
+
+    await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await userEvent.click(screen.getByRole("option", { name: /Default \(/i }))
+
+    expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: null })
   })
 
   it("hides the picker on encrypted scratchpads (enclave runs the built-in Ariadne)", () => {

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -162,33 +162,24 @@ describe("LiveAgentSettings", () => {
     expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: "persona_coach" })
   })
 
-  it("treats re-picking the inherit row on an unpinned stream as a no-op", async () => {
-    seedAndRender({ personas: ROSTER, companionPersonaId: null })
-
-    await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    await userEvent.click(screen.getByRole("option", { name: /Default \(/i }))
-
-    expect(companionMutate).not.toHaveBeenCalled()
-  })
-
-  it("pins the stream when the resolved default is picked explicitly", async () => {
-    seedAndRender({ personas: ROSTER, companionPersonaId: null })
-
-    await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    await userEvent.click(
-      screen.getByRole("option", { name: (name) => name.includes("Ariadne") && !name.includes("Default") })
-    )
-
-    expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: "persona_ariadne" })
-  })
-
-  it("clears the pin back to inherit via the synthetic default row", async () => {
+  it("offers no inherit row — a created stream is pinned; rows carry default badges", async () => {
     seedAndRender({ personas: ROSTER, companionPersonaId: "persona_coach" })
 
     await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
-    await userEvent.click(screen.getByRole("option", { name: /Default \(/i }))
 
-    expect(companionMutate).toHaveBeenCalledWith({ companionMode: "on", companionPersonaId: null })
+    expect(screen.queryByRole("option", { name: /Default \(/i })).not.toBeInTheDocument()
+    // No workspace/personal default configured → the built-in tier (Ariadne) is
+    // the workspace default and gets the badge.
+    expect(screen.getByRole("option", { name: /Ariadne.*Workspace default/i })).toBeInTheDocument()
+  })
+
+  it("treats re-picking the pinned persona as a no-op", async () => {
+    seedAndRender({ personas: ROSTER, companionPersonaId: "persona_coach" })
+
+    await userEvent.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await userEvent.click(screen.getByRole("option", { name: /coach/i }))
+
+    expect(companionMutate).not.toHaveBeenCalled()
   })
 
   it("hides the picker on encrypted scratchpads (enclave runs the built-in Ariadne)", () => {

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -9,9 +9,9 @@ import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
 import {
-  COMPANION_DEFAULT_OPTION_VALUE,
   companionDefaultOptionLabel,
   companionPickerValue,
+  companionPointerFromPickerValue,
 } from "./companion-agent-select"
 
 interface LiveAgentSettingsProps {
@@ -65,7 +65,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
     try {
       await updateCompanionMode({
         companionMode,
-        companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? null : personaId,
+        companionPersonaId: companionPointerFromPickerValue(personaId),
       })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update companion agent")

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -3,8 +3,8 @@ import { toast } from "sonner"
 import type { CompanionMode, StreamBootstrap, ToolPrivacyPolicy } from "@threa/types"
 import { streamKeys } from "@/hooks"
 import { useUpdateCompanionMode, useUpdateToolPolicy } from "@/hooks/use-streams"
-import { usePersonas } from "@/hooks/use-personas"
 import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
+import { useCompanionRoster } from "@/hooks/use-companion-roster"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
@@ -34,10 +34,10 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
   const { mutateAsync: updateToolPolicy, isPending: toolBusy } = useUpdateToolPolicy(workspaceId, streamId)
   const currentUser = useCurrentWorkspaceUser(workspaceId)
   const externalAgent = useActiveBotPresence(workspaceId, streamId)
-  // Encrypted scratchpads always run the enclave's built-in Ariadne, so the
-  // picker (and its roster fetch) is plaintext-only.
-  const { data: personas } = usePersonas(workspaceId, { enabled: !e2e })
-  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId, { enabled: !e2e })
+  // Bootstrap-backed store read (no fetch); the picker stays hidden on
+  // encrypted scratchpads (enclave always runs the built-in Ariadne).
+  const personas = useCompanionRoster(workspaceId)
+  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
 
   // Cache-only observer: re-renders when a mutation patches the bootstrap.
   const { data: bootstrap } = useQuery({
@@ -87,7 +87,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
       companionBusy={companionBusy}
       externalAgent={externalAgent}
       personaPicker={
-        !e2e && personas
+        !e2e && personas.length > 0
           ? {
               workspaceId,
               personas,

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -4,6 +4,7 @@ import type { CompanionMode, StreamBootstrap, ToolPrivacyPolicy } from "@threa/t
 import { streamKeys } from "@/hooks"
 import { useUpdateCompanionMode, useUpdateToolPolicy } from "@/hooks/use-streams"
 import { usePersonas } from "@/hooks/use-personas"
+import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-persona"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
@@ -32,6 +33,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
   // Encrypted scratchpads always run the enclave's built-in Ariadne, so the
   // picker (and its roster fetch) is plaintext-only.
   const { data: personas } = usePersonas(workspaceId, { enabled: !e2e })
+  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId, { enabled: !e2e })
 
   // Cache-only observer: re-renders when a mutation patches the bootstrap.
   const { data: bootstrap } = useQuery({
@@ -52,7 +54,11 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
     }
   }
 
-  const { selectedPersonaId } = resolveCompanionSelection(personas, bootstrap?.stream?.companionPersonaId)
+  const { selectedPersonaId } = resolveCompanionSelection(
+    personas,
+    bootstrap?.stream?.companionPersonaId,
+    effectiveDefault
+  )
 
   const handlePersona = async (personaId: string) => {
     if (personaId === selectedPersonaId) return

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -8,11 +8,7 @@ import { useCompanionRoster } from "@/hooks/use-companion-roster"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
-import {
-  companionDefaultOptionLabel,
-  companionPickerValue,
-  companionPointerFromPickerValue,
-} from "./companion-agent-select"
+import { resolveCompanionSelection } from "./companion-agent-select"
 
 interface LiveAgentSettingsProps {
   workspaceId: string
@@ -37,7 +33,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
   // Bootstrap-backed store read (no fetch); the picker stays hidden on
   // encrypted scratchpads (enclave always runs the built-in Ariadne).
   const personas = useCompanionRoster(workspaceId)
-  const { effectiveDefault } = useDefaultCompanionPersona(workspaceId)
+  const { workspaceDefault, personalDefault } = useDefaultCompanionPersona(workspaceId)
 
   // Cache-only observer: re-renders when a mutation patches the bootstrap.
   const { data: bootstrap } = useQuery({
@@ -58,15 +54,15 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
     }
   }
 
-  const pickerValue = companionPickerValue(personas, bootstrap?.stream?.companionPersonaId)
+  // A created scratchpad is pinned to one persona; a legacy NULL pointer
+  // displays (and dispatches as) the built-in default. No inherit row here —
+  // only an explicit pick changes the agent.
+  const { selectedPersonaId } = resolveCompanionSelection(personas, bootstrap?.stream?.companionPersonaId)
 
   const handlePersona = async (personaId: string) => {
-    if (personaId === pickerValue) return
+    if (personaId === selectedPersonaId) return
     try {
-      await updateCompanionMode({
-        companionMode,
-        companionPersonaId: companionPointerFromPickerValue(personaId),
-      })
+      await updateCompanionMode({ companionMode, companionPersonaId: personaId })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update companion agent")
     }
@@ -91,9 +87,9 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
           ? {
               workspaceId,
               personas,
-              selectedPersonaId: pickerValue,
+              selectedPersonaId,
               onChange: handlePersona,
-              defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
+              defaultBadges: { workspaceDefaultId: workspaceDefault?.id, personalDefaultId: personalDefault?.id },
               busy: companionBusy,
             }
           : undefined

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -8,7 +8,11 @@ import { useDefaultCompanionPersona } from "@/hooks/use-default-companion-person
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
 import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
-import { resolveCompanionSelection } from "./companion-agent-select"
+import {
+  COMPANION_DEFAULT_OPTION_VALUE,
+  companionDefaultOptionLabel,
+  companionPickerValue,
+} from "./companion-agent-select"
 
 interface LiveAgentSettingsProps {
   workspaceId: string
@@ -54,16 +58,15 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
     }
   }
 
-  const { selectedPersonaId } = resolveCompanionSelection(
-    personas,
-    bootstrap?.stream?.companionPersonaId,
-    effectiveDefault
-  )
+  const pickerValue = companionPickerValue(personas, bootstrap?.stream?.companionPersonaId)
 
   const handlePersona = async (personaId: string) => {
-    if (personaId === selectedPersonaId) return
+    if (personaId === pickerValue) return
     try {
-      await updateCompanionMode({ companionMode, companionPersonaId: personaId })
+      await updateCompanionMode({
+        companionMode,
+        companionPersonaId: personaId === COMPANION_DEFAULT_OPTION_VALUE ? null : personaId,
+      })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update companion agent")
     }
@@ -85,7 +88,14 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
       externalAgent={externalAgent}
       personaPicker={
         !e2e && personas
-          ? { workspaceId, personas, selectedPersonaId, onChange: handlePersona, busy: companionBusy }
+          ? {
+              workspaceId,
+              personas,
+              selectedPersonaId: pickerValue,
+              onChange: handlePersona,
+              defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
+              busy: companionBusy,
+            }
           : undefined
       }
       toolPolicy={

--- a/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  WORKSPACE_PERMISSION_SCOPES,
+  type PersonaListItem,
+  type WorkspaceBootstrap,
+  type WorkspaceSettings,
+  type WorkspacePermissionSlug,
+} from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { workspaceSettingsApi } from "@/api"
+import * as personasHooks from "@/hooks/use-personas"
+import * as emojiHooks from "@/hooks/use-workspace-emoji"
+import { DefaultCompanionSection } from "./default-companion-section"
+
+function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id" | "slug" | "name">): PersonaListItem {
+  return {
+    description: null,
+    avatarEmoji: null,
+    model: "openrouter:anthropic/claude-haiku-4.5",
+    kind: "custom",
+    avatarUrl: null,
+    isCustomized: false,
+    ...overrides,
+  }
+}
+
+const ARIADNE = persona({ id: "persona_ariadne", slug: "ariadne", name: "Ariadne", kind: "builtin" })
+const COACH = persona({ id: "persona_coach", slug: "coach", name: "Coach", avatarEmoji: "🏋️" })
+
+function seedBootstrap(
+  queryClient: QueryClient,
+  viewerPermissions: WorkspacePermissionSlug[],
+  defaultCompanionPersonaId: string | null
+) {
+  queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+    viewerPermissions,
+    workspaceSettings: { defaultCompanionPersonaId } as WorkspaceSettings,
+  } as unknown as WorkspaceBootstrap)
+}
+
+function renderSection(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DefaultCompanionSection workspaceId="ws_1" />
+    </QueryClientProvider>
+  )
+}
+
+describe("DefaultCompanionSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(personasHooks, "usePersonas").mockReturnValue({
+      data: [ARIADNE, COACH],
+    } as unknown as ReturnType<typeof personasHooks.usePersonas>)
+    vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
+      toEmoji: (shortcode: string) => shortcode,
+    } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)
+  })
+
+  it("shows Ariadne for a null setting and saves the picked persona id", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN], null)
+    const update = vi
+      .spyOn(workspaceSettingsApi, "update")
+      .mockResolvedValue({ defaultCompanionPersonaId: "persona_coach" } as WorkspaceSettings)
+    const user = userEvent.setup()
+
+    renderSection(queryClient)
+    const combobox = screen.getByRole("combobox", { name: /companion agent/i })
+    expect(combobox).toHaveTextContent("Ariadne")
+
+    await user.click(combobox)
+    await user.click(await screen.findByRole("option", { name: /Coach/i }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", { defaultCompanionPersonaId: "persona_coach" }))
+  })
+
+  it("shows the resolved default read-only to a non-admin", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    seedBootstrap(queryClient, [], "persona_coach")
+
+    renderSection(queryClient)
+
+    expect(screen.queryByRole("combobox", { name: /companion agent/i })).not.toBeInTheDocument()
+    expect(screen.getByText("Coach")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
@@ -24,6 +24,7 @@ function persona(overrides: Partial<PersonaListItem> & Pick<PersonaListItem, "id
     kind: "custom",
     avatarUrl: null,
     isCustomized: false,
+    status: "active",
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/default-companion-section.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { toast } from "sonner"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   WORKSPACE_PERMISSION_SCOPES,
@@ -76,6 +77,22 @@ describe("DefaultCompanionSection", () => {
     await user.click(await screen.findByRole("option", { name: /Coach/i }))
 
     await waitFor(() => expect(update).toHaveBeenCalledWith("ws_1", { defaultCompanionPersonaId: "persona_coach" }))
+  })
+
+  it("rolls the optimistic cache patch back and toasts on a rejected save", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN], null)
+    vi.spyOn(workspaceSettingsApi, "update").mockRejectedValue(new Error("Persona not available"))
+    const toastError = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+    const user = userEvent.setup()
+
+    renderSection(queryClient)
+    await user.click(screen.getByRole("combobox", { name: /companion agent/i }))
+    await user.click(await screen.findByRole("option", { name: /Coach/i }))
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Failed to save the default companion"))
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.workspaceSettings?.defaultCompanionPersonaId).toBeNull()
   })
 
   it("shows the resolved default read-only to a non-admin", () => {

--- a/apps/frontend/src/components/workspace-settings/default-companion-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/default-companion-section.tsx
@@ -1,0 +1,83 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { WORKSPACE_PERMISSION_SCOPES, type WorkspaceBootstrap, type WorkspaceSettings } from "@threa/types"
+import { workspaceSettingsApi } from "@/api"
+import { workspaceKeys, useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { usePersonas } from "@/hooks/use-personas"
+import { hasPermission } from "@/lib/permissions"
+import { Label } from "@/components/ui/label"
+import { CompanionAgentSelect, resolveCompanionSelection } from "@/components/stream-settings/companion-agent-select"
+
+interface DefaultCompanionSectionProps {
+  workspaceId: string
+}
+
+/**
+ * Workspace default companion persona: which agent unpinned scratchpads run when
+ * neither the user nor the stream has picked one. Editing is admin-gated; others
+ * see the resolved name read-only. Applied at dispatch, so a change takes effect
+ * on every unpinned scratchpad going forward. Mirrors `FollowUpLimitSection`'s
+ * optimistic bootstrap-cache plumbing.
+ */
+export function DefaultCompanionSection({ workspaceId }: DefaultCompanionSectionProps) {
+  const queryClient = useQueryClient()
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId)
+  const canManage = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN)
+  const settings = bootstrap?.workspaceSettings ?? null
+  const { data: personas } = usePersonas(workspaceId)
+
+  // Resolve the stored id (null = Ariadne) against the roster so the trigger and
+  // the read-only fallback both name the persona that actually runs.
+  const { selectedPersonaId, companionName } = resolveCompanionSelection(personas, settings?.defaultCompanionPersonaId)
+
+  const mutation = useMutation({
+    mutationFn: (defaultCompanionPersonaId: string) =>
+      workspaceSettingsApi.update(workspaceId, { defaultCompanionPersonaId }),
+    onMutate: async (defaultCompanionPersonaId) => {
+      await queryClient.cancelQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) })
+      let previousSettings: WorkspaceSettings | null = null
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+        previousSettings = old?.workspaceSettings ?? null
+        return old?.workspaceSettings
+          ? { ...old, workspaceSettings: { ...old.workspaceSettings, defaultCompanionPersonaId } }
+          : old
+      })
+      return { previousSettings }
+    },
+    onError: (_err, _next, context) => {
+      if (context?.previousSettings) {
+        const restored = context.previousSettings
+        queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
+          old ? { ...old, workspaceSettings: restored } : old
+        )
+      }
+      toast.error("Failed to save the default companion")
+    },
+    onSuccess: (saved) => {
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
+        old ? { ...old, workspaceSettings: saved } : old
+      )
+    },
+  })
+
+  return (
+    <div>
+      <Label className="text-sm font-medium">Default companion</Label>
+      <p className="text-xs text-muted-foreground mt-0.5">
+        The agent that answers in scratchpads where neither the scratchpad nor the member has picked one.
+      </p>
+      {canManage && personas && personas.length > 0 ? (
+        <CompanionAgentSelect
+          workspaceId={workspaceId}
+          personas={personas}
+          value={selectedPersonaId}
+          onChange={(personaId) => mutation.mutate(personaId)}
+          disabled={settings == null || mutation.isPending}
+          triggerClassName="mt-2 w-full sm:w-72"
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground mt-2">{companionName}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/persona-fork-dialog.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/persona-fork-dialog.test.tsx
@@ -20,6 +20,7 @@ const sources: PersonaListItem[] = [
     kind: "builtin",
     avatarUrl: null,
     isCustomized: false,
+    status: "active",
   },
 ]
 

--- a/apps/frontend/src/components/workspace-settings/personas-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/personas-tab.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 import { PersonaListAvatar } from "@/components/persona-avatar"
 import { useArchivedPersonas, usePersonas, useUnarchivePersona } from "@/hooks/use-personas"
 import { FollowUpLimitSection } from "./follow-up-limit-section"
+import { DefaultCompanionSection } from "./default-companion-section"
 import { PersonaForkDialog } from "./persona-fork-dialog"
 
 interface PersonasTabProps {
@@ -136,6 +137,7 @@ export function PersonasTab({ workspaceId }: PersonasTabProps) {
             Workspace-wide limits on what the assistants may do on their own.
           </p>
         </div>
+        <DefaultCompanionSection workspaceId={workspaceId} />
         <FollowUpLimitSection workspaceId={workspaceId} />
       </div>
     </div>

--- a/apps/frontend/src/hooks/use-companion-roster.ts
+++ b/apps/frontend/src/hooks/use-companion-roster.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react"
+import type { CompanionPersona } from "@/components/stream-settings/companion-agent-select"
+import { useWorkspacePersonas } from "@/stores/workspace-store"
+
+/**
+ * Active personas for the companion pickers, read from the bootstrap-backed
+ * workspace store (IndexedDB + `agent_config:updated` broadcasts) — instant on
+ * open and offline-capable, no per-surface fetch. The bootstrap ships active
+ * rows with built-in overrides already resolved; the broadcast flips `status`
+ * on archive/unarchive, so filtering here keeps mid-session archives out.
+ * Ordering mirrors the API roster: built-ins first, then customs by name.
+ */
+export function useCompanionRoster(workspaceId: string | undefined): CompanionPersona[] {
+  const personas = useWorkspacePersonas(workspaceId)
+  return useMemo(
+    () =>
+      personas
+        .filter((p) => p.status === "active")
+        .sort((a, b) => {
+          if (a.managedBy !== b.managedBy) return a.managedBy === "system" ? -1 : 1
+          return a.name.localeCompare(b.name)
+        }),
+    [personas]
+  )
+}

--- a/apps/frontend/src/hooks/use-default-companion-persona.ts
+++ b/apps/frontend/src/hooks/use-default-companion-persona.ts
@@ -1,0 +1,64 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { ARIADNE_PERSONA_SLUG, type PersonaListItem, type WorkspaceBootstrap } from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { usePreferencesOptional } from "@/contexts"
+import { usePersonas } from "@/hooks/use-personas"
+
+export interface DefaultCompanionResolution {
+  /** The default that applies to the viewer: user pref → workspace setting → Ariadne. */
+  effectiveDefault: PersonaListItem | undefined
+  /** The workspace-tier default alone (workspace setting → Ariadne), for the
+   *  user-settings picker's "what would I inherit" synthetic option. */
+  workspaceDefault: PersonaListItem | undefined
+}
+
+/**
+ * Resolve the companion default a null stream pointer displays as. Precedence is
+ * user preference → workspace setting → built-in Ariadne, degrading a tier when
+ * its stored id is absent from the roster — the roster carries only active
+ * personas, so an off-roster id is archived/inactive and falls through (the same
+ * resolve-time tolerance the dispatch resolver applies, INV-11's one sanctioned
+ * fallback). `workspaceDefault` is exposed separately so the user picker can name
+ * the tier it would inherit independent of the viewer's own override.
+ */
+export function useDefaultCompanionPersona(
+  workspaceId: string,
+  opts?: { enabled?: boolean }
+): DefaultCompanionResolution {
+  const userDefaultId = usePreferencesOptional()?.preferences?.defaultCompanionPersonaId ?? null
+  const workspaceDefaultId = useWorkspaceDefaultCompanionPersonaId(workspaceId)
+  const { data: personas } = usePersonas(workspaceId, { enabled: opts?.enabled ?? true })
+  return resolveDefaultCompanionPersona(personas, userDefaultId, workspaceDefaultId)
+}
+
+/** Pure precedence resolver (roster + stored ids → resolved rows). */
+export function resolveDefaultCompanionPersona(
+  personas: PersonaListItem[] | undefined,
+  userDefaultId: string | null,
+  workspaceDefaultId: string | null
+): DefaultCompanionResolution {
+  const ariadne = personas?.find((p) => p.slug === ARIADNE_PERSONA_SLUG)
+  const workspacePersona = workspaceDefaultId ? personas?.find((p) => p.id === workspaceDefaultId) : undefined
+  const workspaceDefault = workspacePersona ?? ariadne
+  const userPersona = userDefaultId ? personas?.find((p) => p.id === userDefaultId) : undefined
+  const effectiveDefault = userPersona ?? workspaceDefault
+  return { effectiveDefault, workspaceDefault }
+}
+
+/**
+ * The workspace-wide default companion persona id (read from the bootstrap cache
+ * via the cache-only observer pattern). Rides `WorkspaceBootstrap.workspaceSettings`,
+ * so a `workspace_settings:updated` broadcast re-renders callers with no extra
+ * fetch. Mirrors `useWorkspaceDefaultWorkSchedule`.
+ */
+function useWorkspaceDefaultCompanionPersonaId(workspaceId: string): string | null {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap) => bootstrap?.workspaceSettings?.defaultCompanionPersonaId ?? null,
+  })
+  return data ?? null
+}

--- a/apps/frontend/src/hooks/use-default-companion-persona.ts
+++ b/apps/frontend/src/hooks/use-default-companion-persona.ts
@@ -1,15 +1,16 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { ARIADNE_PERSONA_SLUG, type PersonaListItem, type WorkspaceBootstrap } from "@threa/types"
+import { ARIADNE_PERSONA_SLUG, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { usePreferencesOptional } from "@/contexts"
-import { usePersonas } from "@/hooks/use-personas"
+import { useCompanionRoster } from "@/hooks/use-companion-roster"
+import type { CompanionPersona } from "@/components/stream-settings/companion-agent-select"
 
 export interface DefaultCompanionResolution {
   /** The default that applies to the viewer: user pref → workspace setting → Ariadne. */
-  effectiveDefault: PersonaListItem | undefined
+  effectiveDefault: CompanionPersona | undefined
   /** The workspace-tier default alone (workspace setting → Ariadne), for the
    *  user-settings picker's "what would I inherit" synthetic option. */
-  workspaceDefault: PersonaListItem | undefined
+  workspaceDefault: CompanionPersona | undefined
 }
 
 /**
@@ -19,21 +20,19 @@ export interface DefaultCompanionResolution {
  * personas, so an off-roster id is archived/inactive and falls through (the same
  * resolve-time tolerance the dispatch resolver applies, INV-11's one sanctioned
  * fallback). `workspaceDefault` is exposed separately so the user picker can name
- * the tier it would inherit independent of the viewer's own override.
+ * the tier it would inherit independent of the viewer's own override. Reads the
+ * bootstrap-backed store — no fetch.
  */
-export function useDefaultCompanionPersona(
-  workspaceId: string,
-  opts?: { enabled?: boolean }
-): DefaultCompanionResolution {
+export function useDefaultCompanionPersona(workspaceId: string): DefaultCompanionResolution {
   const userDefaultId = usePreferencesOptional()?.preferences?.defaultCompanionPersonaId ?? null
   const workspaceDefaultId = useWorkspaceDefaultCompanionPersonaId(workspaceId)
-  const { data: personas } = usePersonas(workspaceId, { enabled: opts?.enabled ?? true })
+  const personas = useCompanionRoster(workspaceId)
   return resolveDefaultCompanionPersona(personas, userDefaultId, workspaceDefaultId)
 }
 
 /** Pure precedence resolver (roster + stored ids → resolved rows). */
 export function resolveDefaultCompanionPersona(
-  personas: PersonaListItem[] | undefined,
+  personas: CompanionPersona[] | undefined,
   userDefaultId: string | null,
   workspaceDefaultId: string | null
 ): DefaultCompanionResolution {

--- a/apps/frontend/src/hooks/use-default-companion-persona.ts
+++ b/apps/frontend/src/hooks/use-default-companion-persona.ts
@@ -11,10 +11,14 @@ export interface DefaultCompanionResolution {
   /** The workspace-tier default alone (workspace setting → Ariadne), for the
    *  user-settings picker's "what would I inherit" synthetic option. */
   workspaceDefault: CompanionPersona | undefined
+  /** The viewer's explicit personal default, or undefined when inheriting the
+   *  workspace tier — drives the "Your default" row indicator in the pickers. */
+  personalDefault: CompanionPersona | undefined
 }
 
 /**
- * Resolve the companion default a null stream pointer displays as. Precedence is
+ * Resolve the companion default a new scratchpad is pinned to at create (and
+ * the pickers' "Default (X)" sentinel/indicators display). Precedence is
  * user preference → workspace setting → built-in Ariadne, degrading a tier when
  * its stored id is absent from the roster — the roster carries only active
  * personas, so an off-roster id is archived/inactive and falls through (the same
@@ -41,7 +45,7 @@ export function resolveDefaultCompanionPersona(
   const workspaceDefault = workspacePersona ?? ariadne
   const userPersona = userDefaultId ? personas?.find((p) => p.id === userDefaultId) : undefined
   const effectiveDefault = userPersona ?? workspaceDefault
-  return { effectiveDefault, workspaceDefault }
+  return { effectiveDefault, workspaceDefault, personalDefault: userPersona }
 }
 
 /**

--- a/apps/frontend/src/hooks/use-personas.ts
+++ b/apps/frontend/src/hooks/use-personas.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import type {
   PersonaConfigPatch,
@@ -119,40 +118,14 @@ function removeFromList(queryClient: QueryClient, key: readonly unknown[], perso
   queryClient.setQueryData<PersonaListItem[]>(key, (old) => old?.filter((p) => p.id !== personaId))
 }
 
-const PERSONA_LIST_STALE_TIME = 30_000
-/** Session-long retention: the roster is tiny, every companion picker needs it
- *  instantly on open, and mutation reconciles keep the cached rows fresh — so
- *  don't let the default 5-min gc evict it between picker opens. */
-const PERSONA_LIST_GC_TIME = 60 * 60_000
-
 /** Member-visible persona list (no systemPrompt). Powers the settings tab. */
 export function usePersonas(workspaceId: string, opts?: { enabled?: boolean }) {
   return useQuery({
     queryKey: personaKeys.list(workspaceId),
     queryFn: () => personasApi.list(workspaceId),
     enabled: !!workspaceId && (opts?.enabled ?? true),
-    staleTime: PERSONA_LIST_STALE_TIME,
-    gcTime: PERSONA_LIST_GC_TIME,
+    staleTime: 30_000,
   })
-}
-
-/**
- * Warm the roster cache at workspace mount so the companion pickers (stream
- * popover/sheet, draft settings, settings tabs) render their options on first
- * open instead of popping in after a fetch — the pop-in is user-visible on
- * mobile latency.
- */
-export function usePrefetchPersonas(workspaceId: string | undefined) {
-  const queryClient = useQueryClient()
-  useEffect(() => {
-    if (!workspaceId) return
-    void queryClient.prefetchQuery({
-      queryKey: personaKeys.list(workspaceId),
-      queryFn: () => personasApi.list(workspaceId),
-      staleTime: PERSONA_LIST_STALE_TIME,
-      gcTime: PERSONA_LIST_GC_TIME,
-    })
-  }, [queryClient, workspaceId])
 }
 
 /**

--- a/apps/frontend/src/hooks/use-personas.ts
+++ b/apps/frontend/src/hooks/use-personas.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import type {
   PersonaConfigPatch,
@@ -118,14 +119,40 @@ function removeFromList(queryClient: QueryClient, key: readonly unknown[], perso
   queryClient.setQueryData<PersonaListItem[]>(key, (old) => old?.filter((p) => p.id !== personaId))
 }
 
+const PERSONA_LIST_STALE_TIME = 30_000
+/** Session-long retention: the roster is tiny, every companion picker needs it
+ *  instantly on open, and mutation reconciles keep the cached rows fresh — so
+ *  don't let the default 5-min gc evict it between picker opens. */
+const PERSONA_LIST_GC_TIME = 60 * 60_000
+
 /** Member-visible persona list (no systemPrompt). Powers the settings tab. */
 export function usePersonas(workspaceId: string, opts?: { enabled?: boolean }) {
   return useQuery({
     queryKey: personaKeys.list(workspaceId),
     queryFn: () => personasApi.list(workspaceId),
     enabled: !!workspaceId && (opts?.enabled ?? true),
-    staleTime: 30_000,
+    staleTime: PERSONA_LIST_STALE_TIME,
+    gcTime: PERSONA_LIST_GC_TIME,
   })
+}
+
+/**
+ * Warm the roster cache at workspace mount so the companion pickers (stream
+ * popover/sheet, draft settings, settings tabs) render their options on first
+ * open instead of popping in after a fetch — the pop-in is user-visible on
+ * mobile latency.
+ */
+export function usePrefetchPersonas(workspaceId: string | undefined) {
+  const queryClient = useQueryClient()
+  useEffect(() => {
+    if (!workspaceId) return
+    void queryClient.prefetchQuery({
+      queryKey: personaKeys.list(workspaceId),
+      queryFn: () => personasApi.list(workspaceId),
+      staleTime: PERSONA_LIST_STALE_TIME,
+      gcTime: PERSONA_LIST_GC_TIME,
+    })
+  }, [queryClient, workspaceId])
 }
 
 /**

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -97,6 +97,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       voiceSteeringWords: [],
       statusPresets: [],
       workSchedule: null,
+      defaultCompanionPersonaId: null,
       gettingStartedDismissed: false,
       accessibility: {
         fontSize: "medium",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -106,6 +106,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       voiceSteeringWords: [],
       statusPresets: [],
       workSchedule: null,
+      defaultCompanionPersonaId: null,
       gettingStartedDismissed: false,
       accessibility: {
         fontSize: "medium",

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/hooks"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
 import { usePageResume } from "@/hooks/use-page-resume"
+import { usePrefetchPersonas } from "@/hooks/use-personas"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
@@ -423,6 +424,9 @@ export function WorkspaceLayout() {
   const streams = useWorkspaceStreams(workspaceId ?? "")
 
   usePersistLastLocation(workspaceId)
+  // Warm the persona roster so companion pickers open with options already
+  // cached instead of popping in after a fetch (mobile-visible latency).
+  usePrefetchPersonas(workspaceId)
 
   // Remember the workspace the user is in so the `/` entry route can redirect
   // straight here on a returning launch (renders from IndexedDB) instead of

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -58,7 +58,6 @@ import {
 } from "@/hooks"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
 import { usePageResume } from "@/hooks/use-page-resume"
-import { usePrefetchPersonas } from "@/hooks/use-personas"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
@@ -424,9 +423,6 @@ export function WorkspaceLayout() {
   const streams = useWorkspaceStreams(workspaceId ?? "")
 
   usePersistLastLocation(workspaceId)
-  // Warm the persona roster so companion pickers open with options already
-  // cached instead of popping in after a fetch (mobile-visible latency).
-  usePrefetchPersonas(workspaceId)
 
   // Remember the workspace the user is in so the `/` entry route can redirect
   // straight here on a returning launch (renders from IndexedDB) instead of

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1434,8 +1434,10 @@ export function registerWorkspaceSocketHandlers(
   const handleAgentConfigUpdated = (payload: { workspaceId: string; agentId: string; persona: PersonaListItem }) => {
     if (payload.workspaceId !== workspaceId) return
 
-    const { id, slug, name, description, avatarEmoji, avatarUrl, model, kind } = payload.persona
-    const patch = { slug, name, description, avatarEmoji, avatarUrl, model }
+    const { id, slug, name, description, avatarEmoji, avatarUrl, model, kind, status } = payload.persona
+    // status rides along so an archive/unarchive flips the cached row — the
+    // store-backed companion roster filters on it without a refetch.
+    const patch = { slug, name, description, avatarEmoji, avatarUrl, model, status }
     // A fork broadcasts a NEW custom that no existing row covers — upsert it so the
     // roster and actor rendering reflect it live (the list payload lacks the full
     // row, so synthesize the non-display fields; a bootstrap resync fills them in).
@@ -1454,7 +1456,7 @@ export function registerWorkspaceSocketHandlers(
       maxTokens: null,
       enabledTools: null,
       managedBy: kind === "custom" ? "workspace" : "system",
-      status: "active",
+      status,
       createdAt: nowIso,
       updatedAt: nowIso,
     }

--- a/packages/types/src/persona-config.ts
+++ b/packages/types/src/persona-config.ts
@@ -7,7 +7,7 @@
 // `availableModels`; built-in defaults stay legal even if the registry lacks them.
 
 import { z } from "zod"
-import { AGENT_TOOL_NAMES, TONE_PRESETS, BREVITY_PRESETS } from "./constants"
+import { AGENT_TOOL_NAMES, TONE_PRESETS, BREVITY_PRESETS, type PersonaStatus } from "./constants"
 
 /**
  * One selectable chat model for the persona editor's model / escalation-model
@@ -206,6 +206,13 @@ export interface PersonaListItem {
    * always false there.
    */
   isCustomized: boolean
+  /**
+   * Lifecycle status. The visible list returns `active` rows only, but the
+   * `agent_config:updated` broadcast reuses this shape for archive/unarchive —
+   * the field lets store-backed consumers flip their cached row without a
+   * refetch.
+   */
+  status: PersonaStatus
 }
 
 /**

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -347,6 +347,16 @@ export interface UserPreferences {
    */
   workSchedule: WorkSchedule | null
   /**
+   * The user's personal default companion persona for scratchpads with no
+   * explicit persona pick. `null` means "inherit the workspace default" — only a
+   * user who deliberately diverges from the workspace stores an override. Resolve
+   * the effective default with
+   * user.defaultCompanionPersonaId ?? workspaceSettings.defaultCompanionPersonaId
+   * ?? built-in Ariadne; each tier degrades to the next when its id is missing,
+   * archived, or not active in the workspace.
+   */
+  defaultCompanionPersonaId: string | null
+  /**
    * The user's personal status presets, additive to the workspace/system
    * defaults shown in the status picker. Empty by default.
    */
@@ -397,6 +407,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   keyboardShortcuts: {},
   accessibility: DEFAULT_ACCESSIBILITY,
   workSchedule: null,
+  defaultCompanionPersonaId: null,
   statusPresets: [],
   gettingStartedDismissed: false,
 }
@@ -436,6 +447,7 @@ export interface UpdateUserPreferencesInput {
   keyboardShortcuts?: KeyboardShortcuts
   accessibility?: Partial<AccessibilityPreferences>
   workSchedule?: WorkSchedule | null
+  defaultCompanionPersonaId?: string | null
   statusPresets?: StatusPreset[]
   gettingStartedDismissed?: boolean
 }

--- a/packages/types/src/workspace-settings.ts
+++ b/packages/types/src/workspace-settings.ts
@@ -54,6 +54,15 @@ export interface WorkspaceSettings {
    * in the follow-up service; a per-stream column is deferred until asked for.
    */
   maxPendingFollowUps: number
+  /**
+   * The workspace-wide default companion persona a scratchpad runs when it has no
+   * explicit persona pick. Resolution order is user preference
+   * (`UserPreferences.defaultCompanionPersonaId`) → this workspace setting →
+   * built-in Ariadne. `null` means Ariadne. A stored id that is missing, archived,
+   * or not active in the workspace degrades to the next tier at dispatch time;
+   * write-time validation rejects an id that isn't an active persona here.
+   */
+  defaultCompanionPersonaId: string | null
   createdAt: string
   updatedAt: string
 }
@@ -65,6 +74,7 @@ export const DEFAULT_WORKSPACE_SETTINGS: Omit<WorkspaceSettings, "workspaceId" |
   memoLanguage: null,
   voiceSteeringWords: [],
   maxPendingFollowUps: DEFAULT_MAX_PENDING_FOLLOW_UPS,
+  defaultCompanionPersonaId: null,
 }
 
 /** Partial update — only provided fields are changed. */
@@ -74,6 +84,7 @@ export interface UpdateWorkspaceSettingsInput {
   memoLanguage?: string | null
   voiceSteeringWords?: string[]
   maxPendingFollowUps?: number
+  defaultCompanionPersonaId?: string | null
 }
 
 /** Valid top-level settings keys that can be overridden. */

--- a/tests/browser/persona-customization.spec.ts
+++ b/tests/browser/persona-customization.spec.ts
@@ -31,7 +31,7 @@ test.describe("Persona roster + editors", () => {
 
     await page.goto(`/w/${workspaceId}?ws-settings=ai-agents`)
     const dialog = page.getByRole("dialog")
-    await expect(dialog.getByText("Ariadne", { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(dialog.getByRole("listitem").filter({ hasText: "Ariadne" })).toBeVisible({ timeout: 10000 })
     // Fresh workspace — Ariadne has no override yet.
     await expect(dialog.getByText("Customized")).toHaveCount(0)
 
@@ -89,7 +89,7 @@ test.describe("Persona roster + editors", () => {
 
     await page.goto(`/w/${workspaceId}?ws-settings=ai-agents`)
     const settingsDialog = page.getByRole("dialog")
-    await expect(settingsDialog.getByText("Ariadne", { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(settingsDialog.getByRole("listitem").filter({ hasText: "Ariadne" })).toBeVisible({ timeout: 10000 })
 
     await settingsDialog.getByRole("button", { name: "New agent" }).click()
     const forkDialog = page.getByRole("dialog").filter({ hasText: "Fork an existing agent" })
@@ -168,7 +168,7 @@ test.describe("Persona roster + editors", () => {
     // Lands back on the AI Agents tab; the agent left the active roster.
     await expect(page).toHaveURL(/ws-settings=ai-agents/)
     const dialog = page.getByRole("dialog")
-    await expect(dialog.getByText("Ariadne", { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(dialog.getByRole("listitem").filter({ hasText: "Ariadne" })).toBeVisible({ timeout: 10000 })
 
     // ──── It sits behind the Archived disclosure; unarchive returns it ────
 
@@ -182,5 +182,74 @@ test.describe("Persona roster + editors", () => {
     await expect(
       dialog.getByRole("listitem").filter({ hasText: agentName }).getByRole("link", { name: "Edit" })
     ).toBeVisible({ timeout: 10000 })
+  })
+
+  test("default companion resolves through workspace setting then a personal override, with no explicit stream pick", async ({
+    page,
+  }) => {
+    test.setTimeout(60000)
+
+    const { testId } = await loginAndCreateWorkspace(page, "persona-default")
+    const workspaceId = page.url().match(/\/w\/(ws_[^/]+)/)![1]
+    const wsAgentName = `Workspace pick ${testId}`
+    const userAgentName = `Personal pick ${testId}`
+
+    // Two custom personas (forked via API for speed) give the workspace tier and
+    // the personal tier distinct, assertable names.
+    for (const name of [wsAgentName, userAgentName]) {
+      const forkRes = await page.request.post(`/api/workspaces/${workspaceId}/personas`, {
+        data: { sourcePersonaId: "persona_system_ariadne", name },
+      })
+      await expectApiOk(forkRes, `Persona fork (${name})`)
+    }
+
+    // ──── Admin sets the workspace default via the Personas tab combobox ────
+
+    await page.goto(`/w/${workspaceId}?ws-settings=ai-agents`)
+    const settingsDialog = page.getByRole("dialog")
+    const wsDefaultPicker = settingsDialog.getByRole("combobox", { name: "Companion agent" })
+    await expect(wsDefaultPicker).toBeEnabled({ timeout: 10000 })
+    const wsSettingsSaved = page.waitForResponse(
+      (r) => r.url().includes("/workspace-settings") && r.request().method() === "PATCH" && r.ok()
+    )
+    await wsDefaultPicker.click()
+    await page.getByRole("option", { name: wsAgentName }).click()
+    await expect(wsDefaultPicker).toContainText(wsAgentName)
+    await wsSettingsSaved
+
+    // ──── A fresh scratchpad with NO explicit pick shows the workspace default ────
+
+    const createRes = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad", displayName: `pad-${testId}` },
+    })
+    await expectApiOk(createRes, "Scratchpad creation")
+    const streamId = ((await createRes.json()) as { stream: { id: string } }).stream.id
+
+    const companionUrl = `/w/${workspaceId}/s/${streamId}?stream-settings=companion&sid=${streamId}`
+    await page.goto(companionUrl)
+    const streamPicker = page.getByRole("combobox", { name: "Companion agent" })
+    // The stream keeps a null pointer (resolution is at dispatch); the picker
+    // displays the resolved workspace default with no manual selection.
+    await expect(streamPicker).toContainText(wsAgentName, { timeout: 10000 })
+
+    // ──── A personal default overrides the workspace tier for this viewer ────
+
+    await page.goto(`/w/${workspaceId}?settings=ai`)
+    const userDefaultPicker = page.getByRole("combobox", { name: "Companion agent" })
+    // The synthetic leading option names the tier it would inherit (the workspace pick).
+    await expect(userDefaultPicker).toContainText(wsAgentName, { timeout: 10000 })
+    const preferenceSaved = page.waitForResponse(
+      (r) => r.url().includes("/preferences") && r.request().method() === "PATCH" && r.ok()
+    )
+    await userDefaultPicker.click()
+    await page.getByRole("option", { name: userAgentName }).click()
+    await expect(userDefaultPicker).toContainText(userAgentName)
+    await preferenceSaved
+
+    // Same scratchpad, still no explicit pick — the personal override now wins.
+    await page.goto(companionUrl)
+    await expect(page.getByRole("combobox", { name: "Companion agent" })).toContainText(userAgentName, {
+      timeout: 10000,
+    })
   })
 })

--- a/tests/browser/persona-customization.spec.ts
+++ b/tests/browser/persona-customization.spec.ts
@@ -184,7 +184,7 @@ test.describe("Persona roster + editors", () => {
     ).toBeVisible({ timeout: 10000 })
   })
 
-  test("default companion resolves through workspace setting then a personal override, with no explicit stream pick", async ({
+  test("defaults pin at create: a later default change never switches an existing scratchpad's agent", async ({
     page,
   }) => {
     test.setTimeout(60000)
@@ -217,22 +217,24 @@ test.describe("Persona roster + editors", () => {
     await expect(wsDefaultPicker).toContainText(wsAgentName)
     await wsSettingsSaved
 
-    // ──── A fresh scratchpad with NO explicit pick shows the workspace default ────
+    // ──── A scratchpad created with NO explicit pick PINS the workspace default ────
 
     const createRes = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
       data: { type: "scratchpad", displayName: `pad-${testId}` },
     })
     await expectApiOk(createRes, "Scratchpad creation")
     const streamId = ((await createRes.json()) as { stream: { id: string } }).stream.id
+    const created = ((await createRes.json()) as { stream: { companionPersonaId: string | null } }).stream
+    // The default resolves at create and the concrete id is written — never a
+    // null pointer to be re-resolved later.
+    expect(created.companionPersonaId).not.toBeNull()
 
     const companionUrl = `/w/${workspaceId}/s/${streamId}?stream-settings=companion&sid=${streamId}`
     await page.goto(companionUrl)
     const streamPicker = page.getByRole("combobox", { name: "Companion agent" })
-    // The stream keeps a null pointer (resolution is at dispatch); the picker
-    // displays the resolved workspace default with no manual selection.
     await expect(streamPicker).toContainText(wsAgentName, { timeout: 10000 })
 
-    // ──── A personal default overrides the workspace tier for this viewer ────
+    // ──── Changing defaults later must NOT touch the existing scratchpad ────
 
     await page.goto(`/w/${workspaceId}?settings=ai`)
     const userDefaultPicker = page.getByRole("combobox", { name: "Companion agent" })
@@ -246,8 +248,21 @@ test.describe("Persona roster + editors", () => {
     await expect(userDefaultPicker).toContainText(userAgentName)
     await preferenceSaved
 
-    // Same scratchpad, still no explicit pick — the personal override now wins.
+    // The existing scratchpad stays on the persona it was created with — a
+    // default change never switches an agent mid-scratchpad.
     await page.goto(companionUrl)
+    await expect(page.getByRole("combobox", { name: "Companion agent" })).toContainText(wsAgentName, {
+      timeout: 10000,
+    })
+
+    // ──── A NEW scratchpad pins the current default (the personal pick) ────
+
+    const createRes2 = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad", displayName: `pad2-${testId}` },
+    })
+    await expectApiOk(createRes2, "Second scratchpad creation")
+    const streamId2 = ((await createRes2.json()) as { stream: { id: string } }).stream.id
+    await page.goto(`/w/${workspaceId}/s/${streamId2}?stream-settings=companion&sid=${streamId2}`)
     await expect(page.getByRole("combobox", { name: "Companion agent" })).toContainText(userAgentName, {
       timeout: 10000,
     })


### PR DESCRIPTION
## Problem

Every scratchpad without an explicit persona pick runs Ariadne — the fallback is hardcoded in `PersonaRepository.getSystemDefault` (backend dispatch) and in `resolveCompanionSelection`'s Ariadne-slug lookup (every picker surface). With custom personas shipped in #1299 there is no way for a workspace to say "our default agent is X" nor for a member to say "mine is Y" — each new scratchpad requires re-picking by hand.

## Solution

An org-level default with a personal override, mirroring the existing `defaultWorkSchedule` shape: admin-set `WorkspaceSettings.defaultCompanionPersonaId` + per-user `UserPreferences.defaultCompanionPersonaId` (null = inherit), **resolved once at scratchpad creation and pinned** — a created scratchpad is locked to a concrete persona; changing a default later never touches existing scratchpads.

### How it works

1. **Storage** — both keys live in the existing sparse KV override stores (`workspace_setting_overrides`, `user_preference_overrides`), so there is **no migration**. One zod line + one `simpleKeys` entry per store; the workspace PATCH route already carries the `WORKSPACE_ADMIN` gate.
2. **Write-time validation** — a non-null id must be an active persona in the workspace or the PATCH 400s (`PERSONA_NOT_AVAILABLE`). The guard was extracted to `assertAssignablePersona` (`features/agents/persona-guards.ts`) and now also backs `streams.updateCompanionMode` — one guard, three call sites.
3. **Pin at create** — `resolveDefaultPersona(db, workspaceId, ownerUserId)` (`features/agents/resolve-default-persona.ts`): creator's preference → workspace setting → `getSystemDefault` (Ariadne), each tier degrading when its pointer no longer resolves to an active workspace persona. It runs **once, in the stream-create handler** (`streams/handlers.ts`), when a plaintext scratchpad is created with no explicit pick — the resolved concrete id is written to `companion_persona_id`. Dispatch (`companion-outbox-handler.ts`) reads the pointer and never re-resolves; its fallback stays the pre-existing `getSystemDefault`, reachable only by legacy NULL rows (none in production) and archived picks.
4. **Roster is local-first** — the pickers read the bootstrap-backed workspace store (`useCompanionRoster` over `useWorkspacePersonas`: IndexedDB + `agent_config:updated` broadcasts) instead of fetching `GET /personas` per surface — instant on open, offline-capable. `PersonaListItem` gained `status` and the sync handler merges it, so an archive broadcast flips the cached row (previously masked by API refetches). The settings roster tab keeps its API query (`isCustomized` + archived list are admin-surface data).
5. **Settings UI** — `DefaultCompanionSection` in workspace settings → Personas → "Assistant behavior" (mirrors `FollowUpLimitSection`: optimistic bootstrap patch + rollback, error toast only per INV-63). `PersonalDefaultCompanionSection` in Settings → AI with a leading synthetic "Workspace default (X)" option that round-trips as `null`. Both ride existing outbox events for live propagation.
6. **Picker UI** — live stream pickers offer **no inherit row**: a created scratchpad is locked to one agent and only an explicit pick changes it. The **draft** picker (the one creation-time surface) keeps the leading "Default (X)" sentinel row — leave it selected and the create pins whatever the default resolves to at that moment. All picker rows carry small "Workspace default" / "Your default" indicators (`defaultBadges` on the shared `CompanionAgentSelect`; the personal badge wins when both land on one row).

### Key design decisions

**1. Pin at create, never re-resolve.** The first iteration resolved defaults at dispatch (NULL pointer = "inherit"), which meant changing the workspace default from Ariadne to Stefan switched every unpinned scratchpad's agent mid-run — caught in staging and rejected (Kris: "scratchpads should be pinned to the version they were created with"). Now the default is a creation-time sentinel: streams always carry a concrete persona, dispatch does zero lookups, and the only way a scratchpad's agent changes is the user changing it. Simpler and correct.

**2. Whose preference applies at create: the creator's.** The create handler resolves with the caller's id; all creation entry points that go through the HTTP create (drafts, sidebar, quick switcher, share target) get the pin for free.

**3. Deliberate pins stay pinned.** Enclave/E2E (always built-in Ariadne) and the "Discuss with Ariadne" contextBag path are untouched — both are hard pins that precede the default resolution branch in the handler.

**4. No `isWorkspaceDefault` flag on `PersonaListItem`.** The settings field is the single source of truth; the badges resolve client-side from the same bootstrap-backed values.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/resolve-default-persona.ts` | Create-time precedence resolver (user pref → workspace setting → Ariadne) |
| `apps/backend/src/features/agents/persona-guards.ts` | `assertAssignablePersona` write-time guard (extracted from 3 inline copies) |
| `apps/frontend/src/hooks/use-companion-roster.ts` | Store-backed active-persona roster for the pickers (no fetch) |
| `apps/frontend/src/hooks/use-default-companion-persona.ts` | Client-side default resolution (`{effectiveDefault, workspaceDefault, personalDefault}`) |
| `apps/frontend/src/components/workspace-settings/default-companion-section.tsx` | Admin workspace-default picker (Personas tab) |
| + test files | resolver, guard sites, both sections, picker, roster |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/{workspace-settings,preferences}.ts` | `defaultCompanionPersonaId: string \| null` on both stores + defaults + update inputs |
| `packages/types/src/persona-config.ts` | `PersonaListItem.status` (archive broadcasts flip the cached store row) |
| `apps/backend/src/features/{workspace-settings,user-preferences}/{handlers,service,repository}.ts` | zod line, `simpleKeys` entry, write-time guard, composable `findOverride` single-key read |
| `apps/backend/src/features/streams/handlers.ts` | Scratchpad create with no pick resolves the creator's default and pins the concrete id |
| `apps/backend/src/features/agents/companion-outbox-handler.ts` | Fallback stays `getSystemDefault` (legacy NULL/archived only) — never the user/workspace default |
| `apps/backend/src/features/streams/service.ts` | `updateCompanionMode` inline check → shared `assertAssignablePersona` |
| `apps/frontend/src/components/stream-settings/companion-agent-select.tsx` | `CompanionPersona` picker contract, `defaultOption` sentinel row (drafts), `defaultBadges` row indicators |
| `apps/frontend/src/components/stream-settings/{live-agent-settings,companion-tab}.tsx` | Pinned-value semantics, no inherit row, badges; store-backed roster |
| `apps/frontend/src/components/stream-settings/draft-agent-settings.tsx` | Sentinel "Default (X)" row + badges; unset draft = pin-at-create |
| `apps/frontend/src/components/settings/ai-settings.tsx` | `PersonalDefaultCompanionSection` (personal default + inherit option) |
| `apps/frontend/src/components/workspace-settings/personas-tab.tsx` | Render `DefaultCompanionSection` in "Assistant behavior" |
| `apps/frontend/src/sync/workspace-sync.ts` | `agent_config:updated` merge carries `status` |
| `tests/browser/persona-customization.spec.ts` | E2E rewritten to the pin-at-create contract (below) |

## Out of scope (deliberate)

- **User-scoped personas** (members defining their own personas) — queued follow-up; nothing here precludes it.
- **Persona context attachments** — queued follow-up.
- Legacy NULL-pointer rows: staging-only (production predates none); staging DB reset via `/staging reset db` rather than a backfill.

## Test plan

- [x] Backend: agents + streams suites — resolver precedence/degradation (7), create-handler pin-at-create (3: pins resolved default, keeps explicit pick verbatim, non-scratchpads skip), dispatch fallback = built-in only (3), write-time validation, zod cases; 775 pass
- [x] Integration (live PG): sparse-override store/revert/reject round-trip — 15 pass
- [x] Frontend: 1182 pass across stream-settings/settings/workspace-settings/hooks/sync
- [x] Browser E2E (4 pass): **the key case** — admin sets workspace default → scratchpad created with no pick has a concrete pointer and shows it → personal default changed afterwards → **existing scratchpad stays on its original persona** → a new scratchpad pins the new default
- [x] `bun run typecheck` — 0 errors, all packages/apps
- [x] Screenshot QA at 1440px/390px (settings pickers, scratchpad popover)
- [x] Per-step adversarial review (4 steps × 2 Opus lenses, zero fix rounds) + full 4-lens Opus review (6/7, both UX findings fixed) + 6 CodeRabbit findings fixed
- [x] Design revision after staging dogfood: resolve-at-dispatch → pin-at-create (`669baba8`), all suites re-run green

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** workspace default companion persona (admin-set) + per-user override, applied where a scratchpad is created without an explicit pick.

**What was built:**
1. Storage keys on both sparse KV stores + write-time validation (`assertAssignablePersona`).
2. `resolveDefaultPersona` precedence resolver; composable `findOverride` reads.
3. Frontend: store-backed `useCompanionRoster`, `useDefaultCompanionPersona`, `DefaultCompanionSection` (workspace) + `PersonalDefaultCompanionSection` (user, synthetic inherit option), default badges on picker rows.
4. Browser E2E + screenshot QA.

**Design evolution:** v1 resolved defaults at dispatch (NULL = inherit, live pickers had an inherit row). Staging dogfood surfaced the failure mode — changing a default switched existing scratchpads' agents mid-run. Reworked in `669baba8` to pin-at-create: the resolver runs once in the create handler, streams always carry a concrete persona, dispatch never re-resolves, live pickers lose the inherit row (the draft picker keeps the creation-time sentinel), rows carry default badges. Also `29ddae67`: pickers read the bootstrap-backed store instead of lazy `GET /personas` (local-first; `PersonaListItem.status` added so archive broadcasts flip cached rows).

**Not included:** user-scoped personas, persona context attachments (queued follow-ups).

**Status:** complete; all suites green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
