### PR TITLE
fix(public-site): stop docs header overlap on mobile

### DIFF
--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -1287,6 +1287,19 @@ a {
   .docs-nav-links {
     display: none;
   }
+  /* The top bar collapses to hamburger + brand + toggle + Credentials here.
+     The fixed-width theme toggle doesn't shrink, so on narrow phones the
+     brand's "Developers" tag would overflow into it — drop the tag and
+     tighten the gaps so the row fits down to ~320px. */
+  .docs-nav {
+    gap: 12px;
+  }
+  .docs-nav-right {
+    gap: 12px;
+  }
+  .docs-nav .brand .tag {
+    display: none;
+  }
 
   /* Side nav becomes an off-canvas drawer that slides in below the sticky
      top bar (which stays above it, so the hamburger keeps toggling it). */


### PR DESCRIPTION
## Summary

The developer docs top bar overlapped "Developers" with the theme-toggle (moon) icon on mobile — reported from a real device screenshot (~360px wide).

The theme toggle is a fixed 30px `flex-shrink:0` box. On mobile the horizontal nav-links hide but the toggle stays, and the brand box (`min-width:0`) shrinks below its content, so the "Developers" tag overflowed right into the toggle.

## Change

`apps/public-site/src/styles/docs.css`, inside the existing `@media (max-width: 880px)` block:
- Hide `.docs-nav .brand .tag` ("Developers") on mobile.
- Tighten `.docs-nav` and `.docs-nav-right` gaps to 12px.

The row now fits cleanly down to ~320px-wide phones.

## Verification

Headless Chromium against the docs page:
- **Before** @360px: tag right edge 205px overran the toggle left 163px — a 42px collision (reproduces the reported screenshot).
- **After** @360px: 38px gap, no overlap.
- **After** @320px: 12px gap, still clear.

Pre-commit passed: monorepo lint, full typecheck, `astro check` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786517848&installation_id=129946197&pr_number=1314&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1314&signature=1ac5c018fb5abfb268414d587864ccb66023a380fd2611a7641c8ee34a6db63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->