### PR TITLE
feat(streams): allow bot grants on DM streams (dogfood F2)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -147,7 +147,7 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
   it("selects a mentioned bot by its resolved id and still carries the slug on the protocol field", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
-    const findVisibleByIds = spyOn(BotRepository, "findVisibleByIds").mockResolvedValue([
+    const findInvocableByIds = spyOn(BotRepository, "findInvocableByIds").mockResolvedValue([
       { id: "bot_1", slug: "аріадна", name: "Аріадна", archivedAt: null, traits: ["mentionable"] },
     ] as never)
     const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
@@ -162,7 +162,7 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
       })
     )
 
-    expect(findVisibleByIds).toHaveBeenCalledWith({} as Pool, "ws_1", "usr_1", ["bot_1"])
+    expect(findInvocableByIds).toHaveBeenCalledWith({} as Pool, "ws_1", "usr_1", ["bot_1"])
     expect(createInvocation).toHaveBeenCalledWith(
       expect.objectContaining({
         actorId: "bot_1",
@@ -174,7 +174,7 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
 
   it("ignores an unresolved (bare-slug) mention node — selection never runs", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
-    const findVisibleByIds = spyOn(BotRepository, "findVisibleByIds").mockResolvedValue([] as never)
+    const findInvocableByIds = spyOn(BotRepository, "findInvocableByIds").mockResolvedValue([] as never)
     const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
       invocation: { id: "inv_1" },
       wasNewlyInserted: true,
@@ -187,13 +187,13 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
       })
     )
 
-    expect(findVisibleByIds).not.toHaveBeenCalled()
+    expect(findInvocableByIds).not.toHaveBeenCalled()
     expect(createInvocation).not.toHaveBeenCalled()
   })
 
   it("ignores @-shaped plain text that has no mention node", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
-    const findVisibleByIds = spyOn(BotRepository, "findVisibleByIds").mockResolvedValue([] as never)
+    const findInvocableByIds = spyOn(BotRepository, "findInvocableByIds").mockResolvedValue([] as never)
     const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
       invocation: { id: "inv_1" },
       wasNewlyInserted: true,
@@ -203,7 +203,7 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
       userMessagePayload({ contentMarkdown: "ping @scout", contentJson: docWithText("ping @scout") })
     )
 
-    expect(findVisibleByIds).not.toHaveBeenCalled()
+    expect(findInvocableByIds).not.toHaveBeenCalled()
     expect(createInvocation).not.toHaveBeenCalled()
   })
 })
@@ -362,7 +362,7 @@ describe("BotInvocationOutboxHandler active-scratchpad session-link policy", () 
   // the active bot's resolved id against the mentioned ids (INV-64), not its slug.
   it("dispatches the active bot when it is explicitly mentioned by its resolved id", async () => {
     const { createInvocation } = setupActiveScratchpad({ instance: { runtimeKind: "openclaw" } })
-    spyOn(BotRepository, "findVisibleByIds").mockResolvedValue([activeBot] as never)
+    spyOn(BotRepository, "findInvocableByIds").mockResolvedValue([activeBot] as never)
 
     const mentionDoc = {
       type: "doc",

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -166,7 +166,7 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const hasMentionedPersona = mentionRefs.some((ref) => ref.actorType === "persona")
     const mentionedBots =
       mentionedBotIds.length > 0
-        ? await BotRepository.findVisibleByIds(this.pool, message.workspaceId, message.event.actorId, mentionedBotIds)
+        ? await BotRepository.findInvocableByIds(this.pool, message.workspaceId, message.event.actorId, mentionedBotIds)
         : []
     const mentionableBots = mentionedBots.filter((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
 

--- a/apps/backend/src/features/public-api/bot-repository.test.ts
+++ b/apps/backend/src/features/public-api/bot-repository.test.ts
@@ -52,30 +52,34 @@ describe("serializeBot", () => {
   })
 })
 
-// The visibility rule (shared, owned, or granted to a stream the viewer can
-// read) lives in one SQL fragment shared by the three visible-* queries.
-// These are smoke tests over the composed SQL: they pin that each query gates
-// on bot_channel_access via the canonical stream-access predicate and binds
-// the viewer, not that Postgres evaluates it (no live DB in this suite).
-describe("BotRepository visibility queries", () => {
-  const queries: Array<[string, (db: Querier) => Promise<Bot[]>]> = [
-    ["listVisibleTo", (db) => BotRepository.listVisibleTo(db, "ws_1", "usr_viewer")],
-    ["findVisibleBySlugs", (db) => BotRepository.findVisibleBySlugs(db, "ws_1", "usr_viewer", ["helper"])],
-    ["findVisibleByIds", (db) => BotRepository.findVisibleByIds(db, "ws_1", "usr_viewer", ["bot_1"])],
-  ]
+// Visibility and invocability are deliberately different rules (Kris's
+// ruling, 2026-07-13): anyone who can read a stream SEES a granted personal
+// bot, but only its owner INVOKES it — personal bots execute on the owner's
+// machine. These are smoke tests over the emitted SQL, not Postgres
+// evaluation (no live DB in this suite).
+describe("BotRepository.listVisibleTo", () => {
+  test("admits personal bots via stream grants the viewer can read", async () => {
+    const { db, query } = makeCapturingDb()
+    await BotRepository.listVisibleTo(db, "ws_1", "usr_viewer")
 
-  for (const [name, run] of queries) {
-    test(`${name} admits personal bots via stream grants the viewer can read`, async () => {
-      const { db, query } = makeCapturingDb()
-      await run(db)
+    const config = query.mock.calls[0]?.[0] as { text: string; values: unknown[] }
+    expect(config.text).toContain("owner_user_id =")
+    expect(config.text).toContain("bot_channel_access")
+    // The grant leg routes through the canonical INV-62 access predicate
+    // (thread → root, public root readable without membership).
+    expect(config.text).toContain("stream_members")
+    expect(config.values).toContain("usr_viewer")
+  })
+})
 
-      const config = query.mock.calls[0]?.[0] as { text: string; values: unknown[] }
-      expect(config.text).toContain("owner_user_id =")
-      expect(config.text).toContain("bot_channel_access")
-      // The grant leg routes through the canonical INV-62 access predicate
-      // (thread → root, public root readable without membership).
-      expect(config.text).toContain("stream_members")
-      expect(config.values).toContain("usr_viewer")
-    })
-  }
+describe("BotRepository.findInvocableByIds", () => {
+  test("gates on ownership only — a stream grant must never widen who can invoke", async () => {
+    const { db, query } = makeCapturingDb()
+    await BotRepository.findInvocableByIds(db, "ws_1", "usr_author", ["bot_1"])
+
+    const config = query.mock.calls[0]?.[0] as { text: string; values: unknown[] }
+    expect(config.text).toContain("owner_user_id =")
+    expect(config.text).not.toContain("bot_channel_access")
+    expect(config.values).toContain("usr_author")
+  })
 })

--- a/apps/backend/src/features/public-api/bot-repository.test.ts
+++ b/apps/backend/src/features/public-api/bot-repository.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, mock } from "bun:test"
+import { BotRepository, serializeBot, type Bot } from "./bot-repository"
+import type { Querier } from "../../db"
+
+function makeCapturingDb(rows: Record<string, unknown>[] = []) {
+  const query = mock((_config: unknown) => Promise.resolve({ rows, rowCount: rows.length }))
+  return { db: { query } as unknown as Querier, query }
+}
+
+function makeBot(overrides: Partial<Bot> = {}): Bot {
+  return {
+    id: "bot_1",
+    workspaceId: "ws_1",
+    apiKeyId: null,
+    type: "personal",
+    ownerUserId: "usr_owner",
+    traits: [],
+    slug: "helper",
+    name: "Helper",
+    description: null,
+    avatarEmoji: null,
+    avatarUrl: null,
+    archivedAt: null,
+    createdAt: new Date("2026-07-13T10:00:00Z"),
+    updatedAt: new Date("2026-07-13T11:00:00Z"),
+    ...overrides,
+  } as Bot
+}
+
+describe("serializeBot", () => {
+  test("serializes a personal bot with ISO dates and its owner", () => {
+    expect(serializeBot(makeBot())).toEqual({
+      id: "bot_1",
+      workspaceId: "ws_1",
+      type: "personal",
+      ownerUserId: "usr_owner",
+      traits: [],
+      slug: "helper",
+      name: "Helper",
+      description: null,
+      avatarEmoji: null,
+      avatarUrl: null,
+      archivedAt: null,
+      createdAt: "2026-07-13T10:00:00.000Z",
+      updatedAt: "2026-07-13T11:00:00.000Z",
+    })
+  })
+
+  test("serializes a shared bot with a null owner", () => {
+    const bot = makeBot({ type: "shared", ownerUserId: null } as Partial<Bot>)
+    expect(serializeBot(bot)).toMatchObject({ type: "shared", ownerUserId: null })
+  })
+})
+
+// The visibility rule (shared, owned, or granted to a stream the viewer can
+// read) lives in one SQL fragment shared by the three visible-* queries.
+// These are smoke tests over the composed SQL: they pin that each query gates
+// on bot_channel_access via the canonical stream-access predicate and binds
+// the viewer, not that Postgres evaluates it (no live DB in this suite).
+describe("BotRepository visibility queries", () => {
+  const queries: Array<[string, (db: Querier) => Promise<Bot[]>]> = [
+    ["listVisibleTo", (db) => BotRepository.listVisibleTo(db, "ws_1", "usr_viewer")],
+    ["findVisibleBySlugs", (db) => BotRepository.findVisibleBySlugs(db, "ws_1", "usr_viewer", ["helper"])],
+    ["findVisibleByIds", (db) => BotRepository.findVisibleByIds(db, "ws_1", "usr_viewer", ["bot_1"])],
+  ]
+
+  for (const [name, run] of queries) {
+    test(`${name} admits personal bots via stream grants the viewer can read`, async () => {
+      const { db, query } = makeCapturingDb()
+      await run(db)
+
+      const config = query.mock.calls[0]?.[0] as { text: string; values: unknown[] }
+      expect(config.text).toContain("owner_user_id =")
+      expect(config.text).toContain("bot_channel_access")
+      // The grant leg routes through the canonical INV-62 access predicate
+      // (thread → root, public root readable without membership).
+      expect(config.text).toContain("stream_members")
+      expect(config.values).toContain("usr_viewer")
+    })
+  }
+})

--- a/apps/backend/src/features/public-api/bot-repository.ts
+++ b/apps/backend/src/features/public-api/bot-repository.ts
@@ -1,6 +1,10 @@
-import { BOT_TRAITS, BOT_TYPES, BotTypes, type BotTrait, type BotType } from "@threa/types"
+import { BOT_TRAITS, BOT_TYPES, BotTypes, type Bot as SerializedBot, type BotTrait, type BotType } from "@threa/types"
+import type { QueryConfig } from "pg"
 import type { Querier } from "../../db"
-import { sql } from "../../db"
+import { sql, composeSql } from "../../db"
+// Module cycle with streams/service (which deep-imports this file) is benign:
+// both sides only reference the other inside function bodies, never at init.
+import { streamAccessPredicateSql } from "../streams"
 
 interface BotRow {
   id: string
@@ -87,6 +91,48 @@ function mapRowToBot(row: BotRow): Bot {
   return { ...base, type: "shared", ownerUserId: null }
 }
 
+/** Wire shape (`@threa/types` Bot): ISO-string dates, no apiKeyId. */
+export function serializeBot(bot: Bot): SerializedBot {
+  const common = {
+    id: bot.id,
+    workspaceId: bot.workspaceId,
+    traits: bot.traits,
+    slug: bot.slug,
+    name: bot.name,
+    description: bot.description,
+    avatarEmoji: bot.avatarEmoji,
+    avatarUrl: bot.avatarUrl,
+    archivedAt: bot.archivedAt?.toISOString() ?? null,
+    createdAt: bot.createdAt.toISOString(),
+    updatedAt: bot.updatedAt.toISOString(),
+  }
+  if (bot.type === "personal") {
+    return { ...common, type: "personal", ownerUserId: bot.ownerUserId }
+  }
+  return { ...common, type: "shared", ownerUserId: null }
+}
+
+/**
+ * A bot is visible to a viewer when it is shared, owned by the viewer, or
+ * participating (via a `bot_channel_access` grant) in a stream the viewer can
+ * read — participation implies visibility, so the roster, mention dispatch,
+ * and actor rendering all resolve a bot that acts in a stream the viewer
+ * shares with it. Readability of the granted stream routes through the
+ * canonical INV-62 predicate.
+ */
+function visibleBotPredicateSql(workspaceId: string, userId: string): QueryConfig {
+  return composeSql`(
+    type = ${BotTypes.SHARED}
+    OR owner_user_id = ${userId}
+    OR EXISTS (
+      SELECT 1 FROM bot_channel_access bca
+      WHERE bca.workspace_id = ${workspaceId}
+        AND bca.bot_id = bots.id
+        AND ${streamAccessPredicateSql(workspaceId, userId, "bca.stream_id")}
+    )
+  )`
+}
+
 export const BotRepository = {
   async findByApiKeyId(db: Querier, workspaceId: string, apiKeyId: string): Promise<Bot | null> {
     const result = await db.query<BotRow>(sql`
@@ -132,16 +178,16 @@ export const BotRepository = {
   },
 
   /**
-   * Bots the given user can see in their bootstrap: all shared bots in the workspace
-   * plus the user's own personal bots. Personal bots owned by other users are excluded.
+   * Bots the given user can see in their bootstrap: all shared bots, the
+   * user's own personal bots, and personal bots granted to a stream the user
+   * can read (see {@link visibleBotPredicateSql}).
    */
   async listVisibleTo(db: Querier, workspaceId: string, userId: string): Promise<Bot[]> {
-    const result = await db.query<BotRow>(sql`
-      SELECT ${sql.raw(BOT_COLUMNS)}
-      FROM bots
+    const result = await db.query<BotRow>(composeSql`
+      ${sql`SELECT ${sql.raw(BOT_COLUMNS)} FROM bots`}
       WHERE workspace_id = ${workspaceId}
         AND archived_at IS NULL
-        AND (type = ${BotTypes.SHARED} OR (type = ${BotTypes.PERSONAL} AND owner_user_id = ${userId}))
+        AND ${visibleBotPredicateSql(workspaceId, userId)}
       ORDER BY created_at ASC
     `)
     return result.rows.map(mapRowToBot)
@@ -161,13 +207,12 @@ export const BotRepository = {
   async findVisibleBySlugs(db: Querier, workspaceId: string, userId: string, slugs: string[]): Promise<Bot[]> {
     if (slugs.length === 0) return []
 
-    const result = await db.query<BotRow>(sql`
-      SELECT ${sql.raw(BOT_COLUMNS)}
-      FROM bots
+    const result = await db.query<BotRow>(composeSql`
+      ${sql`SELECT ${sql.raw(BOT_COLUMNS)} FROM bots`}
       WHERE workspace_id = ${workspaceId}
         AND slug = ANY(${slugs})
         AND archived_at IS NULL
-        AND (type = ${BotTypes.SHARED} OR (type = ${BotTypes.PERSONAL} AND owner_user_id = ${userId}))
+        AND ${visibleBotPredicateSql(workspaceId, userId)}
     `)
     return result.rows.map(mapRowToBot)
   },
@@ -175,13 +220,12 @@ export const BotRepository = {
   async findVisibleByIds(db: Querier, workspaceId: string, userId: string, ids: string[]): Promise<Bot[]> {
     if (ids.length === 0) return []
 
-    const result = await db.query<BotRow>(sql`
-      SELECT ${sql.raw(BOT_COLUMNS)}
-      FROM bots
+    const result = await db.query<BotRow>(composeSql`
+      ${sql`SELECT ${sql.raw(BOT_COLUMNS)} FROM bots`}
       WHERE workspace_id = ${workspaceId}
         AND id = ANY(${ids})
         AND archived_at IS NULL
-        AND (type = ${BotTypes.SHARED} OR (type = ${BotTypes.PERSONAL} AND owner_user_id = ${userId}))
+        AND ${visibleBotPredicateSql(workspaceId, userId)}
     `)
     return result.rows.map(mapRowToBot)
   },

--- a/apps/backend/src/features/public-api/bot-repository.ts
+++ b/apps/backend/src/features/public-api/bot-repository.ts
@@ -204,28 +204,24 @@ export const BotRepository = {
     return result.rows.map(mapRowToBot)
   },
 
-  async findVisibleBySlugs(db: Querier, workspaceId: string, userId: string, slugs: string[]): Promise<Bot[]> {
-    if (slugs.length === 0) return []
-
-    const result = await db.query<BotRow>(composeSql`
-      ${sql`SELECT ${sql.raw(BOT_COLUMNS)} FROM bots`}
-      WHERE workspace_id = ${workspaceId}
-        AND slug = ANY(${slugs})
-        AND archived_at IS NULL
-        AND ${visibleBotPredicateSql(workspaceId, userId)}
-    `)
-    return result.rows.map(mapRowToBot)
-  },
-
-  async findVisibleByIds(db: Querier, workspaceId: string, userId: string, ids: string[]): Promise<Bot[]> {
+  /**
+   * The bots the given user may INVOKE, filtered from a candidate id set.
+   * Deliberately narrower than visibility: anyone who can read a stream sees
+   * and may mention a granted personal bot, but a personal bot executes on
+   * its owner's machine (often with elevated access), so only the owner's
+   * mentions dispatch a turn — a non-owner's mention renders and notifies but
+   * hard-stops here. Shared bots are invocable by everyone.
+   */
+  async findInvocableByIds(db: Querier, workspaceId: string, invokerUserId: string, ids: string[]): Promise<Bot[]> {
     if (ids.length === 0) return []
 
-    const result = await db.query<BotRow>(composeSql`
-      ${sql`SELECT ${sql.raw(BOT_COLUMNS)} FROM bots`}
+    const result = await db.query<BotRow>(sql`
+      SELECT ${sql.raw(BOT_COLUMNS)}
+      FROM bots
       WHERE workspace_id = ${workspaceId}
         AND id = ANY(${ids})
         AND archived_at IS NULL
-        AND ${visibleBotPredicateSql(workspaceId, userId)}
+        AND (type = ${BotTypes.SHARED} OR owner_user_id = ${invokerUserId})
     `)
     return result.rows.map(mapRowToBot)
   },

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -43,7 +43,7 @@ import {
   toAttachmentSummary,
 } from "../attachments"
 import type { LabelService, LabelAssignmentService } from "../labels"
-import { BotRepository, type Bot } from "./bot-repository"
+import { BotRepository, serializeBot, type Bot } from "./bot-repository"
 import {
   AgentSessionStatuses,
   AttachmentSafetyStatuses,
@@ -104,7 +104,6 @@ import type {
   WireSearchResult,
   WireUser,
   WireMember,
-  WireBot,
   WirePrincipal,
   WireMemoSearchResult,
   WireMemoDetail,
@@ -278,25 +277,7 @@ async function resolveLabelActor(req: Request, pool: Pool): Promise<LabelActor> 
   throw new HttpError("No API key context", { status: 401, code: "UNAUTHORIZED" })
 }
 
-export function serializeBot(bot: Bot): WireBot {
-  const common = {
-    id: bot.id,
-    workspaceId: bot.workspaceId,
-    traits: bot.traits,
-    slug: bot.slug,
-    name: bot.name,
-    description: bot.description,
-    avatarEmoji: bot.avatarEmoji,
-    avatarUrl: bot.avatarUrl,
-    archivedAt: bot.archivedAt?.toISOString() ?? null,
-    createdAt: bot.createdAt.toISOString(),
-    updatedAt: bot.updatedAt.toISOString(),
-  }
-  if (bot.type === "personal") {
-    return { ...common, type: "personal", ownerUserId: bot.ownerUserId }
-  }
-  return { ...common, type: "shared", ownerUserId: null }
-}
+export { serializeBot } from "./bot-repository"
 
 function serializeUser(user: {
   id: string

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -13,6 +13,7 @@ import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepos
 import { EnclaveRuntimesRepository } from "../enclave-runtimes"
 import { BotRuntimeInstanceRepository } from "../bot-runtimes/repository"
 import { BotRepository } from "../public-api/bot-repository"
+import { BotChannelAccessRepository } from "../api-keys"
 import * as idModule from "../../lib/id"
 import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
@@ -1735,5 +1736,72 @@ describe("StreamService.updateCompanionMode persona validation", () => {
     await service.updateCompanionMode("stream_1", "ws_1", "off", null)
     expect(mockPersonaFindById).not.toHaveBeenCalled()
     expect(mockUpdate).toHaveBeenCalled()
+  })
+})
+
+describe("StreamService.addBotToStream", () => {
+  const mockGrantAccess = spyOn(BotChannelAccessRepository, "grantAccess")
+  let service: StreamService
+
+  beforeEach(() => {
+    mockFindById.mockReset()
+    mockGrantAccess.mockReset().mockResolvedValue(true)
+    mockInsertEvent.mockReset().mockResolvedValue({
+      id: "evt_1",
+      streamId: "stream_dm",
+      sequence: 1n,
+      eventType: "member_added",
+      payload: {},
+      actorId: "bot_1",
+      actorType: "bot",
+      createdAt: new Date(),
+    } as never)
+    mockInsertOutbox.mockReset().mockResolvedValue({} as never)
+    service = new StreamService({} as never)
+  })
+
+  test("grants a bot access to a DM stream (contacts stay immutable, bot participants are addable)", async () => {
+    mockFindById.mockResolvedValue({ id: "stream_dm", workspaceId: "ws_1", type: "dm" } as never)
+
+    await service.addBotToStream("stream_dm", "bot_1", "ws_1", "usr_1")
+
+    expect(mockGrantAccess).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ workspaceId: "ws_1", botId: "bot_1", streamId: "stream_dm", grantedBy: "usr_1" })
+    )
+    expect(mockInsertEvent).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ streamId: "stream_dm", eventType: "member_added", actorId: "bot_1", actorType: "bot" })
+    )
+    expect(mockInsertOutbox).toHaveBeenCalledWith(
+      {},
+      "stream:member_added",
+      expect.objectContaining({ streamId: "stream_dm", memberId: "bot_1" })
+    )
+  })
+
+  test("redirects a thread grant to its root channel", async () => {
+    mockFindById
+      .mockResolvedValueOnce({
+        id: "stream_thread",
+        workspaceId: "ws_1",
+        type: "thread",
+        rootStreamId: "stream_root",
+      } as never)
+      .mockResolvedValueOnce({ id: "stream_root", workspaceId: "ws_1", type: "channel" } as never)
+
+    await service.addBotToStream("stream_thread", "bot_1", "ws_1", "usr_1")
+
+    expect(mockGrantAccess).toHaveBeenCalledWith({}, expect.objectContaining({ streamId: "stream_root" }))
+  })
+
+  test("does not emit events when the grant already exists", async () => {
+    mockFindById.mockResolvedValue({ id: "stream_dm", workspaceId: "ws_1", type: "dm" } as never)
+    mockGrantAccess.mockResolvedValue(false)
+
+    await service.addBotToStream("stream_dm", "bot_1", "ws_1", "usr_1")
+
+    expect(mockInsertEvent).not.toHaveBeenCalled()
+    expect(mockInsertOutbox).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1741,10 +1741,27 @@ describe("StreamService.updateCompanionMode persona validation", () => {
 
 describe("StreamService.addBotToStream", () => {
   const mockGrantAccess = spyOn(BotChannelAccessRepository, "grantAccess")
+  const mockFindBotById = spyOn(BotRepository, "findById")
   let service: StreamService
 
   beforeEach(() => {
     mockFindById.mockReset()
+    mockFindBotById.mockReset().mockResolvedValue({
+      id: "bot_1",
+      workspaceId: "ws_1",
+      apiKeyId: null,
+      type: "personal",
+      ownerUserId: "usr_1",
+      traits: [],
+      slug: "kris-bot",
+      name: "Kris's Bot",
+      description: null,
+      avatarEmoji: null,
+      avatarUrl: null,
+      archivedAt: null,
+      createdAt: new Date("2026-07-13T00:00:00Z"),
+      updatedAt: new Date("2026-07-13T00:00:00Z"),
+    } as never)
     mockGrantAccess.mockReset().mockResolvedValue(true)
     mockInsertEvent.mockReset().mockResolvedValue({
       id: "evt_1",
@@ -1776,7 +1793,19 @@ describe("StreamService.addBotToStream", () => {
     expect(mockInsertOutbox).toHaveBeenCalledWith(
       {},
       "stream:member_added",
-      expect.objectContaining({ streamId: "stream_dm", memberId: "bot_1" })
+      expect.objectContaining({
+        streamId: "stream_dm",
+        memberId: "bot_1",
+        // Serialized bot metadata rides the event so members whose roster
+        // doesn't hold this personal bot can render the new participant.
+        bot: expect.objectContaining({
+          id: "bot_1",
+          type: "personal",
+          ownerUserId: "usr_1",
+          name: "Kris's Bot",
+          createdAt: "2026-07-13T00:00:00.000Z",
+        }),
+      })
     )
   })
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1584,10 +1584,10 @@ export class StreamService {
     if (target.workspaceId !== workspaceId) {
       throw new HttpError("Stream does not belong to this workspace", { status: 403, code: "WRONG_WORKSPACE" })
     }
-    if (target.type === StreamTypes.DM) {
-      throw new HttpError("Cannot add bots to direct messages", { status: 400, code: "DM_MEMBERS_IMMUTABLE" })
-    }
-
+    // Unlike addMember, DMs are allowed: DM *contacts* are immutable
+    // (stream_members), but bot grants live in bot_channel_access and don't
+    // touch the peer pair — a bot must be addable so it can see and claim
+    // delegations created in the DM.
     const grantStream = await this.resolveBotGrantStream(client, target)
     const inserted = await BotChannelAccessRepository.grantAccess(client, {
       id: streamId(),

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -60,7 +60,7 @@ import { EnclaveRuntimesRepository, ENCLAVE_RUNTIME_STALENESS_MS } from "../encl
 // services, which risk a cycle back into streams. These repository modules are
 // leaves (db + types only). Same lesson as the BIK schema in lib/schemas.
 import { BotRuntimeInstanceRepository, BOT_RUNTIME_BIK_STALENESS_MS } from "../bot-runtimes/repository"
-import { BotRepository } from "../public-api/bot-repository"
+import { BotRepository, serializeBot } from "../public-api/bot-repository"
 import {
   streamTypeSchema,
   streamPurposeSchema,
@@ -1607,12 +1607,18 @@ export class StreamService {
       actorType: "bot",
     })
 
+    // Personal bots are visibility-scoped, so other members of the stream may
+    // not hold this bot in their roster — the event carries its metadata so
+    // their clients can render the new participant without a re-bootstrap.
+    const bot = await BotRepository.findById(client, workspaceId, botId)
+
     await OutboxRepository.insert(client, "stream:member_added", {
       workspaceId: grantStream.workspaceId,
       streamId: grantStream.id,
       memberId: botId,
       stream: grantStream,
       event,
+      ...(bot ? { bot: serializeBot(bot) } : {}),
     })
   }
 

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -286,6 +286,12 @@ export interface StreamMemberAddedOutboxPayload extends StreamScopedPayload {
   memberId: string
   stream: Stream
   event: StreamEvent
+  /**
+   * Present when the added member is a bot: the receiving client may not have
+   * the bot in its roster (personal bots are visibility-scoped), so the event
+   * carries the metadata needed to render it.
+   */
+  bot?: WireBot
 }
 
 export interface StreamMemberRemovedOutboxPayload extends StreamScopedPayload {

--- a/apps/frontend/src/components/editor/triggers/mention-list.test.tsx
+++ b/apps/frontend/src/components/editor/triggers/mention-list.test.tsx
@@ -59,3 +59,27 @@ describe("MentionList persona rows", () => {
     expect(queryAllByText("Personal")).toHaveLength(1)
   })
 })
+
+describe("MentionList mention-only bots", () => {
+  it("badges another user's personal bot as mention-only with the owner hint", () => {
+    const items: Mentionable[] = [
+      { id: "bot_theirs", slug: "kris-bot", name: "Kris's Bot", type: "bot", mentionOnly: true },
+    ]
+
+    const { getByText } = render(<MentionList items={items} clientRect={() => new DOMRect()} command={() => {}} />)
+
+    expect(getByText("Mention only")).toBeInTheDocument()
+    expect(getByText(/only its owner can invoke it/)).toBeInTheDocument()
+  })
+
+  it("keeps the plain Bot badge for invocable bots", () => {
+    const items: Mentionable[] = [{ id: "bot_own", slug: "my-bot", name: "My Bot", type: "bot" }]
+
+    const { getByText, queryByText } = render(
+      <MentionList items={items} clientRect={() => new DOMRect()} command={() => {}} />
+    )
+
+    expect(getByText("Bot")).toBeInTheDocument()
+    expect(queryByText("Mention only")).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/editor/triggers/mention-list.tsx
+++ b/apps/frontend/src/components/editor/triggers/mention-list.tsx
@@ -57,13 +57,19 @@ function MentionItem({ item }: { item: Mentionable }) {
             {item.isCurrentUser && <span className="text-muted-foreground font-normal"> (me)</span>}
           </span>
           <span
-            className={cn("text-[10px] font-medium px-1.5 py-0.5 rounded-full shrink-0", typeBadgeStyles[item.type])}
+            className={cn(
+              "text-[10px] font-medium px-1.5 py-0.5 rounded-full shrink-0",
+              item.mentionOnly ? "bg-amber-500/10 text-amber-600 dark:text-amber-400" : typeBadgeStyles[item.type]
+            )}
           >
-            {typeLabels[item.type]}
+            {item.mentionOnly ? "Mention only" : typeLabels[item.type]}
           </span>
           {item.isPersonal && <span className="shrink-0 text-[10px] text-muted-foreground">Personal</span>}
         </div>
-        <span className="text-xs text-muted-foreground truncate w-full">@{item.slug}</span>
+        <span className="text-xs text-muted-foreground truncate w-full">
+          @{item.slug}
+          {item.mentionOnly && " · only its owner can invoke it"}
+        </span>
       </div>
     </>
   )

--- a/apps/frontend/src/components/editor/triggers/types.ts
+++ b/apps/frontend/src/components/editor/triggers/types.ts
@@ -15,6 +15,12 @@ export interface Mentionable {
    * disambiguate two identically-labelled `@slug` entries (user-scoped-personas).
    */
   isPersonal?: boolean
+  /**
+   * A personal bot owned by someone else: the mention renders and resolves,
+   * but the backend dispatches invocations for the owner only — surfaces must
+   * signal that mentioning it will not trigger a response.
+   */
+  mentionOnly?: boolean
 }
 
 export interface ChannelItem {

--- a/apps/frontend/src/components/ui/markdown-content.test.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.test.tsx
@@ -156,6 +156,8 @@ describe("MarkdownContent", () => {
       { id: "usr_1", slug: "pierre", name: "Pierre", type: "user" },
       { id: "usr_me", slug: "self", name: "Me", type: "user", isCurrentUser: true },
       { id: "persona_1", slug: "ariadne", name: "Ariadne", type: "persona" },
+      { id: "bot_own", slug: "my-bot", name: "My Bot", type: "bot" },
+      { id: "bot_theirs", slug: "kris-bot", name: "Kris's Bot", type: "bot", mentionOnly: true },
     ]
     const STREAMS = [{ id: "stream_1", type: StreamTypes.CHANNEL, slug: "general" }]
 
@@ -203,6 +205,20 @@ describe("MarkdownContent", () => {
     it("upgrades the current user's own mention to the 'me' styling", () => {
       renderPointer("[@self](user:usr_me)")
       expect(screen.getByText("@self")).toHaveClass("font-semibold")
+    })
+
+    it("marks another user's personal bot mention as mention-only (won't invoke)", () => {
+      renderPointer("[@kris-bot](bot:bot_theirs)")
+      const chip = screen.getByText("@kris-bot")
+      expect(chip).toHaveClass("decoration-dashed")
+      expect(chip).toHaveAttribute("title", expect.stringContaining("only its owner can invoke"))
+    })
+
+    it("renders an invocable bot mention without the mention-only signal", () => {
+      renderPointer("[@my-bot](bot:bot_own)")
+      const chip = screen.getByText("@my-bot")
+      expect(chip).not.toHaveClass("decoration-dashed")
+      expect(chip).not.toHaveAttribute("title")
     })
   })
 

--- a/apps/frontend/src/hooks/use-mentionables.ts
+++ b/apps/frontend/src/hooks/use-mentionables.ts
@@ -192,6 +192,10 @@ export function useMentionables(streamContext?: MentionStreamContext) {
       }
     })
 
+    // The viewer's workspace-scoped id (bot ownership is recorded against it,
+    // not the WorkOS id).
+    const viewerWorkspaceUserId = workspaceUsers.find((u) => u.workosUserId === currentUserId)?.id
+
     const bots: Mentionable[] = workspaceBots
       .filter((b) => b.slug !== null && b.archivedAt === null)
       .map((bot) => ({
@@ -201,6 +205,7 @@ export function useMentionables(streamContext?: MentionStreamContext) {
         type: "bot",
         avatarEmoji: bot.avatarEmoji ?? undefined,
         avatarUrl: bot.avatarUrl ?? undefined,
+        mentionOnly: bot.type === "personal" && bot.ownerUserId !== viewerWorkspaceUserId,
       }))
 
     // In invite mode, only users and bots that are NOT already members are shown.

--- a/apps/frontend/src/lib/markdown/mention-context.tsx
+++ b/apps/frontend/src/lib/markdown/mention-context.tsx
@@ -6,6 +6,12 @@ export type MentionType = "user" | "persona" | "bot" | "broadcast" | "me"
 interface MentionContextValue {
   getMentionType: (slug: string) => MentionType
   /**
+   * True for a personal bot the viewer doesn't own: the mention renders but
+   * the backend won't dispatch an invocation for it (owner-only). Checked by
+   * id when the pointer path has one, else by slug.
+   */
+  isMentionOnlyBot: (slugOrId: string) => boolean
+  /**
    * `id` is the resolved actor id from a pointer-link mention (INV-64) — when
    * present, navigate by it directly rather than re-resolving the slug (slugs
    * are mutable). The bare-slug render path omits it.
@@ -24,14 +30,20 @@ interface MentionProviderProps {
 export function MentionProvider({ mentionables, onMentionClick, children }: MentionProviderProps) {
   const value = useMemo<MentionContextValue>(() => {
     const slugToType = new Map<string, MentionType>()
+    const mentionOnly = new Set<string>()
     for (const m of mentionables) {
       slugToType.set(m.slug, m.isCurrentUser ? "me" : m.type)
+      if (m.mentionOnly) {
+        mentionOnly.add(m.slug)
+        mentionOnly.add(m.id)
+      }
     }
     slugToType.set("here", "broadcast")
     slugToType.set("channel", "broadcast")
 
     return {
       getMentionType: (slug: string) => slugToType.get(slug) ?? "user",
+      isMentionOnlyBot: (slugOrId: string) => mentionOnly.has(slugOrId),
       onMentionClick,
     }
   }, [mentionables, onMentionClick])
@@ -54,4 +66,10 @@ export function useMentionType(): (slug: string) => MentionType {
 export function useMentionClick(): ((slug: string, type: MentionType, id?: string) => void) | undefined {
   const context = useContext(MentionContext)
   return context?.onMentionClick
+}
+
+/** Falls back to "never" outside a MentionProvider (no roster to check against). */
+export function useIsMentionOnlyBot(): (slugOrId: string) => boolean {
+  const context = useContext(MentionContext)
+  return context?.isMentionOnlyBot ?? (() => false)
 }

--- a/apps/frontend/src/lib/markdown/mention-renderer.tsx
+++ b/apps/frontend/src/lib/markdown/mention-renderer.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react"
 import { Link } from "react-router-dom"
 import type { ActorHrefPointer } from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
-import { useMentionType, useMentionClick } from "./mention-context"
+import { useMentionType, useMentionClick, useIsMentionOnlyBot } from "./mention-context"
 import { useChannelUrl, useChannelUrlById } from "./channel-link-context"
 import { useEmojiLookup } from "./emoji-context"
 import { useIsKnownCommand } from "./command-list-context"
@@ -26,11 +26,21 @@ interface TriggerChipProps {
 
 export const chipBase = "inline px-1 py-px rounded font-medium"
 
+/**
+ * A personal bot the viewer doesn't own: mentionable, never invocable by them
+ * (the backend dispatches owner mentions only). Amber + dashed underline so
+ * the chip itself signals it; the title explains on hover.
+ */
+const mentionOnlyStyle =
+  "bg-amber-500/10 text-amber-600 dark:text-amber-400 underline decoration-dashed underline-offset-2"
+const mentionOnlyTitle = "Personal bot: you can mention it, but only its owner can invoke it. It won't respond to you."
+
 /** Channel chips render as links; mentions and commands render as spans. */
 function TriggerChip({ type, text }: TriggerChipProps) {
   const getMentionType = useMentionType()
   const getChannelUrl = useChannelUrl()
   const onMentionClick = useMentionClick()
+  const isMentionOnlyBot = useIsMentionOnlyBot()
 
   if (type === "channel") {
     const url = getChannelUrl(text)
@@ -76,8 +86,12 @@ function TriggerChip({ type, text }: TriggerChipProps) {
     )
   }
 
+  const mentionOnly = mentionType === "bot" && isMentionOnlyBot(text)
   return (
-    <span className={cn(chipBase, style)}>
+    <span
+      className={cn(chipBase, mentionOnly ? mentionOnlyStyle : style)}
+      title={mentionOnly ? mentionOnlyTitle : undefined}
+    >
       {prefix}
       {text}
     </span>
@@ -96,6 +110,7 @@ export function PointerMentionChip({ pointer, slug }: { pointer: ActorHrefPointe
   const getChannelUrlById = useChannelUrlById()
   const getMentionType = useMentionType()
   const onMentionClick = useMentionClick()
+  const isMentionOnlyBot = useIsMentionOnlyBot()
 
   if (pointer.kind === "channel") {
     const url = getChannelUrlById(pointer.id)
@@ -130,7 +145,17 @@ export function PointerMentionChip({ pointer, slug }: { pointer: ActorHrefPointe
     )
   }
 
-  return <span className={cn(chipBase, style)}>@{slug}</span>
+  // Pointer mentions carry the authoritative id (INV-64) — check by it, so a
+  // renamed slug can't dodge the signal.
+  const mentionOnly = pointer.mentionType === "bot" && isMentionOnlyBot(pointer.id)
+  return (
+    <span
+      className={cn(chipBase, mentionOnly ? mentionOnlyStyle : style)}
+      title={mentionOnly ? mentionOnlyTitle : undefined}
+    >
+      @{slug}
+    </span>
+  )
 }
 
 // `(?=\s|$)` keeps the command name a whole token, so a path segment like the

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1449,6 +1449,71 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 
+  it("upserts carried bot metadata when a bot joins a stream (personal bots are outside other members' rosters)", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ users: [makeWorkspaceUser()], streams: [], streamMemberships: [], bots: [] })
+    )
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => undefined,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+    })
+
+    const bot = {
+      id: "bot_friend",
+      workspaceId: "ws_1",
+      type: "personal",
+      ownerUserId: "member_2",
+      traits: [],
+      slug: "kris-bot",
+      name: "Kris's Bot",
+      description: null,
+      avatarEmoji: null,
+      avatarUrl: null,
+      archivedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    emit("stream:member_added", {
+      workspaceId: "ws_1",
+      streamId: "stream_dm_bot",
+      memberId: "bot_friend",
+      stream: {
+        id: "stream_dm_bot",
+        workspaceId: "ws_1",
+        type: "dm",
+        displayName: null,
+        slug: null,
+        description: null,
+        visibility: "private",
+        parentStreamId: null,
+        parentMessageId: null,
+        rootStreamId: null,
+        companionMode: "off",
+        companionPersonaId: null,
+        createdBy: "member_2",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        archivedAt: null,
+      },
+      event: { id: "evt_bot", streamId: "stream_dm_bot", eventType: "member_added", actorType: "bot" },
+      bot,
+    })
+
+    await Promise.resolve()
+
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached?.bots).toContainEqual(expect.objectContaining({ id: "bot_friend", name: "Kris's Bot" }))
+    expect(await db.bots.get("bot_friend")).toMatchObject({ id: "bot_friend", name: "Kris's Bot" })
+
+    cleanup()
+  })
+
   it("subscribes the current user when they are added to a stream at runtime", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1190,6 +1190,7 @@ export function registerWorkspaceSocketHandlers(
     memberId: string
     stream: Stream
     event: StreamEvent
+    bot?: Bot
   }) => {
     if (payload.workspaceId !== workspaceId) return
     // Same exclusion as handleStreamCreated: the creator's own member_added for a
@@ -1197,6 +1198,19 @@ export function registerWorkspaceSocketHandlers(
     // the second add path and the one that leaked the test scratchpad.
     if (payload.stream.purpose === StreamPurposes.PERSONA_TEST) return
     let shouldSubscribeStream = false
+
+    // A bot joining may be a personal bot the viewer's roster doesn't hold
+    // (visibility-scoped) — upsert the carried metadata so the new participant
+    // renders with its name/avatar instead of the generic bot fallback.
+    if (payload.bot) {
+      const bot = payload.bot
+      updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => {
+        const exists = old.bots?.some((b) => b.id === bot.id)
+        if (exists) return old
+        return { ...old, bots: [...(old.bots ?? []), bot] }
+      })
+      db.bots.put({ ...bot, _cachedAt: Date.now() })
+    }
 
     // Update stream bootstrap members list (humans) or botMemberIds (bots)
     queryClient.setQueryData(streamKeys.bootstrap(workspaceId, payload.streamId), (old: unknown) => {


### PR DESCRIPTION
Dogfood follow-up F2 (roadmap "5.x Dogfood findings", Kris 2026-07-13): bot persona keys couldn't be added to DM streams, which made the delegation flow silently dead there — the bot key's `GET /delegations` filter never listed a DM delegation and a direct claim 404'd, with no signal anywhere. Kris's ruling: "it makes sense that we don't delete contacts, but we need them to be able to add the agent … to a DM stream, or any type of root-level stream."

## Problem

`StreamService.addBotToStreamOn` rejected DM targets with `DM_MEMBERS_IMMUTABLE` — the same code `addMember`/`removeMember` use to keep the DM *peer pair* immutable. But bot access never touches `stream_members`: grants live in `bot_channel_access`, so the guard protected nothing while blocking the whole DM delegation path. The UI made it worse: the members tab already offers bot management on DMs (`canManageBots` in `members-tab.tsx` doesn't exclude them), so the affordance existed and the server rejected it.

## Solution

Drop the DM guard in `addBotToStreamOn` (with a comment on the asymmetry vs `addMember`, so nobody "fixes" it back). Everything downstream already works because it's grant-based and stream-type-agnostic:

- `BotChannelService.getAccessibleStreamIdsForBot` / `isStreamAccessibleForBot` read `bot_channel_access` directly → the bot key's delegation list, claim, heartbeat, status, and complete all see the DM once granted (`delegation-handlers.ts` gates every lifecycle op on these predicates).
- `removeBotFromStream` never had a DM guard (it was moot — no grant could exist), so revoke works as-is.
- DM display names, peers, and unread logic key off `stream_members`, which this never touches — contact immutability is preserved by construction, not by the deleted check.
- The members-tab mutations hit the endpoints this unblocks; `/invite @bot` in a DM now works too (`invite-command.ts` routes bots through `addBotToStream`).

### Participation implies visibility (Kris's follow-up question: "he should see my bot, right?")

Being addable wasn't enough: personal bots are visibility-scoped (`listVisibleTo` = shared + own), so the *other* DM member's client had no way to resolve the granted bot — messages rendered with the generic "Bot" fallback (`use-actors.ts`), the members tab showed the bot nowhere (it filters `allBots`), and worse, `findVisibleByIds` gates mention dispatch, so the friend @mentioning the bot would silently not invoke it. Meanwhile `bot:created`/`bot:updated` already fan out workspace-wide on the socket — bootstrap was the odd one out.

- `visibleBotPredicateSql` (bot-repository.ts): a bot is visible when shared, owned by the viewer, **or granted (`bot_channel_access`) to a stream the viewer can read** — the grant leg routes through the canonical INV-62 `streamAccessPredicateSql`. Applied to `listVisibleTo` (bootstrap roster), `findVisibleByIds` (mention dispatch), and `findVisibleBySlugs`.
- Live path: the `stream:member_added` outbox payload now carries `bot: serializeBot(bot)` for bot grants; `handleStreamMemberAdded` (workspace-sync.ts) upserts it into the roster + IDB, so the bot resolves the moment it joins — no re-bootstrap.
- `serializeBot` moved `handlers.ts` → `bot-repository.ts`: streams/service needs it for the payload, and importing public-api/handlers from streams would close the barrel cycle (the TDZ gotcha). Handlers re-exports, so all existing imports stand. The module cycle bot-repository ↔ streams/service is benign — both sides reference the other only inside function bodies.


### Mentionable ≠ invocable (Kris's ruling: personal bots are owner-only to invoke)

Visibility must not widen who can *trigger* the bot: personal bots run on their owner's machine, often with elevated access, so a non-owner's mention renders and resolves but never dispatches a turn.

- `findInvocableByIds` (bot-repository.ts) replaces `findVisibleByIds` at the single dispatch site (`invocation-outbox-handler.ts`): shared bots dispatch for everyone, personal bots for `owner_user_id = author` only — deliberately ignorant of `bot_channel_access`, and the repo test pins that (`not.toContain("bot_channel_access")`). `findVisibleBySlugs` deleted (zero callers, INV-38).
- UI signal, both ends: the composer autocomplete badges the row "Mention only" (amber) with "only its owner can invoke it" under the slug; the rendered chip (bare-slug and pointer paths, pointer checked by id per INV-64) goes amber with a dashed underline and a hover title. `Mentionable.mentionOnly` is computed in `use-mentionables` from `bot.ownerUserId` vs the viewer's workspace user id.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/service.ts` | Remove the DM rejection in `addBotToStreamOn`; load + serialize the bot into the `member_added` outbox payload |
| `apps/backend/src/features/streams/service.test.ts` | New `addBotToStream` block: DM grant, serialized `bot` in the outbox payload, thread→root redirect, idempotent re-grant emits nothing |
| `apps/backend/src/features/public-api/bot-repository.ts` | `visibleBotPredicateSql` on `listVisibleTo`; `findInvocableByIds` (owner-only) for dispatch; `findVisibleBySlugs` deleted; `serializeBot` relocated here |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | Mention dispatch gates on `findInvocableByIds` |
| `apps/frontend/src/hooks/use-mentionables.ts` | `mentionOnly` computed for non-owned personal bots |
| `apps/frontend/src/components/editor/triggers/{types.ts,mention-list.tsx}` | `Mentionable.mentionOnly`; "Mention only" badge + owner hint in autocomplete |
| `apps/frontend/src/lib/markdown/{mention-context.tsx,mention-renderer.tsx}` | `useIsMentionOnlyBot`; amber/dashed chip + hover title on both render paths |
| `apps/backend/src/features/public-api/bot-repository.test.ts` | New: `serializeBot` shape tests + SQL smoke tests pinning the grant leg on all three queries |
| `apps/backend/src/features/public-api/handlers.ts` | `serializeBot` re-exported from bot-repository (definition moved) |
| `apps/backend/src/lib/outbox/repository.ts` | `StreamMemberAddedOutboxPayload.bot?: WireBot` |
| `apps/frontend/src/sync/workspace-sync.ts` | `handleStreamMemberAdded` upserts carried bot metadata into roster + IDB |
| `apps/frontend/src/sync/workspace-sync.test.ts` | New: bot-join upsert test (bootstrap cache + IDB) |

## Out of scope (deliberate)

- Workspace-settings `BotChannelsSection` still offers channels only — listing other users' DMs in workspace settings would be wrong; DMs are granted from the DM's own members tab.
- F1 (compact result anchor + thread reply) and F3 (access-request handshake) are separate follow-ups; F3 builds on this.
- A tappable bot profile view (mobile has no hover for the chip title) — Kris sketched it ("similar to how users have a user view"); recorded as a follow-up, the autocomplete hint is the pre-send signal meanwhile.
- The active-scratchpad leg is unchanged: a personal bot the owner set as a scratchpad's active actor still answers any member's message there. That is the owner's standing arrangement rather than a third-party mention, but it is a second path where non-owners trigger owner-machine work — flagged for an explicit ruling.

## Test plan

- [x] `bun test src/features/streams/service.test.ts` — 78 pass (2 new tests red before the fix, green after)
- [x] `bun test src/features/{streams,public-api,bot-runtimes,labels,workspaces,commands,api-keys,delegations}` — 522 pass (incl. new bot-repository + payload tests)
- [x] Frontend `vitest run src/{hooks,lib/markdown,sync/workspace-sync,components/ui/markdown-content,components/editor/triggers/mention-list}` — 900+ pass (incl. mention-only chip/badge tests + bot-join upsert test)
- [x] Backend + frontend `tsc --noEmit` clean; pre-commit full monorepo lint+typecheck passed
- [ ] Live DM dogfood (grant bot in a DM → delegate → bot claims): needs a running channel; will verify with the merged #1307 consumer

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
