### PR TITLE
ci: extension tests + typecheck (extensions/** had zero CI coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,13 @@ jobs:
       # deps (bot-runtime-client → remote-session → claude-code-remote), so
       # installs must run per-package in dependency order. pi-remote is a
       # pi-package with no test/typecheck scripts (deferred per #1153).
+      # The root install is also required: bot-runtime-client's crypto parity
+      # test typechecks against the canonical packages/crypto sources, whose
+      # deps (@hpke/*) resolve from the root node_modules.
       - name: Install extension dependencies
         if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
         run: |
+          bun install
           bun install --cwd extensions/bot-runtime-client
           bun install --cwd extensions/remote-session
           bun install --cwd extensions/claude-code-remote

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/**"
       - "packages/**"
+      - "extensions/**"
       - "tests/**"
       - "scripts/**"
       - "package.json"
@@ -143,6 +144,58 @@ jobs:
 
       - name: Run enclave tests
         run: bun run --cwd apps/enclave test
+
+  extension-tests:
+    name: Extension Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for extension changes
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            extensions:
+              - 'extensions/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Setup Bun
+        if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Extensions live outside the root Bun workspaces (apps/*, packages/*):
+      # each is a standalone package with its own bun.lock, linked by file:
+      # deps (bot-runtime-client → remote-session → claude-code-remote), so
+      # installs must run per-package in dependency order. pi-remote is a
+      # pi-package with no test/typecheck scripts (deferred per #1153).
+      - name: Install extension dependencies
+        if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
+        run: |
+          bun install --cwd extensions/bot-runtime-client
+          bun install --cwd extensions/remote-session
+          bun install --cwd extensions/claude-code-remote
+          bun install --cwd extensions/harness-daemon
+
+      - name: Typecheck extensions
+        if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
+        run: |
+          bun run --cwd extensions/bot-runtime-client typecheck
+          bun run --cwd extensions/remote-session typecheck
+          bun run --cwd extensions/claude-code-remote typecheck
+          bun run --cwd extensions/harness-daemon typecheck
+
+      - name: Run extension tests
+        if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
+        run: |
+          bun run --cwd extensions/bot-runtime-client test
+          bun run --cwd extensions/remote-session test
+          bun run --cwd extensions/claude-code-remote test
+          bun run --cwd extensions/harness-daemon test
 
   workos-permissions:
     name: WorkOS Permissions


### PR DESCRIPTION
Closes the extension CI blind spot found while shipping #1307: `extensions/**` appears in no workflow's `paths:` filter, so an extension-only PR spawns **zero** test workflows — Tests/Typecheck/Lint simply never run, which looks identical to an Actions outage. The four extension packages (`bot-runtime-client`, `remote-session`, `claude-code-remote`, `harness-daemon`) had no CI coverage at all.

## Solution

- Add `extensions/**` to `ci.yml`'s `pull_request.paths` so extension PRs trigger CI.
- New `extension-tests` job. Extensions live outside the root Bun workspaces (`apps/*`, `packages/*`): each is standalone with its own `bun.lock`, linked by `file:` deps, so the job installs per-package in dependency order (`bot-runtime-client → remote-session → claude-code-remote`, then `harness-daemon`), then runs `typecheck` and `bun test` for each.
- The job is gated behind `dorny/paths-filter` (same pattern as the existing `workos-permissions` job), so app-only PRs skip the install/test steps; pushes to main always run it, catching drift from squash merges.
- `pi-remote` is excluded: it's a pi-package with no test/typecheck scripts, deferred per #1153 (its two test files currently fail on module resolution — it has never been installed in CI).
- `browser-tests.yml` deliberately unchanged — the Playwright suite doesn't exercise extensions.

## Files changed

| File | Change |
| ---- | ------ |
| `.github/workflows/ci.yml` | `extensions/**` in paths; new `extension-tests` job (+53 lines) |

## Test plan

- [x] All four suites green locally: bot-runtime-client 50, remote-session 105, claude-code-remote 90, harness-daemon 5 — 250 tests, 0 fail; all four `tsc --noEmit` clean
- [x] YAML validated (`yaml-lint`)
- [x] This PR touches `ci.yml`, which is in the new filter — the `extension-tests` job exercises itself on this PR's checks

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786520499&installation_id=129946197&pr_number=1317&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1317&signature=b5662a6bd51f2be3dd7549eea5c8607fac5d726963f752091d392e9732cf199f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->