### PR TITLE
fix(staging): DROP DATABASE WITH (FORCE) in the PR reset script

### DIFF
--- a/scripts/staging-pr.ts
+++ b/scripts/staging-pr.ts
@@ -238,10 +238,11 @@ async function dropDatabase(dbName: string): Promise<void> {
     return
   }
   console.log(`Dropping database '${dbName}'...`)
-  await runPsqlOnDefault(
-    `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${dbName}' AND pid <> pg_backend_pid()`
-  )
-  await runPsqlOnDefault(`DROP DATABASE "${dbName}"`)
+  // WITH (FORCE) terminates remaining sessions atomically with the drop. A
+  // separate pg_terminate_backend loses the race against the live PR backend's
+  // pools, whose reconnect loops re-attach in the gap and fail the DROP with
+  // "is being accessed by other users" (seen twice on #1318).
+  await runPsqlOnDefault(`DROP DATABASE "${dbName}" WITH (FORCE)`)
   console.log(`Dropped '${dbName}'`)
 }
 


### PR DESCRIPTION
## Problem

`/staging reset db` failed twice on #1318 with `ERROR: database "pr_1318" is being accessed by other users` ([run 1](https://github.com/threahq/threa/actions/runs/29244431818), [run 2](https://github.com/threahq/threa/actions/runs/29244610006)). `dropDatabase` in `scripts/staging-pr.ts` runs `pg_terminate_backend` and `DROP DATABASE` as two separate psql calls; the live PR backend's pools (30 main + 12 listen connections, both with reconnect loops) re-attach in the gap, and the error is not in `isTransientPsqlError`, so no retry.

## Solution

One line: `DROP DATABASE "x" WITH (FORCE)` (Postgres 13+) terminates remaining sessions atomically with the drop — no window to lose. The separate terminate call is removed as redundant.

## Test plan

- [ ] Merge, then re-fire `/staging reset db` on #1318 — the failing case is the live verification (the script only runs in the slash-command workflow, which checks out main)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786532521&installation_id=129946197&pr_number=1320&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1320&signature=982c491d84fb6108c7a0be1ff2a601eb9bf0e1b029a7196c35576eeafcd8f365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->