### PR TITLE
fix: follow replaced composer height refs

### DIFF
--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -288,7 +288,6 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
 
   // Measured height of the draft composer pill; consumed by the scroll area
   // below it (padding-bottom) so messages sit offset above the floating pill.
-  const draftComposerRef = useRef<HTMLDivElement>(null)
   const draftScrollRef = useRef<HTMLDivElement | null>(null)
   const handleDraftComposerHeightChange = useCallback((_px: number, opts: { initial: boolean }) => {
     const scroller = draftScrollRef.current
@@ -306,7 +305,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
       requestAnimationFrame(rePin)
     }
   }, [])
-  useComposerHeightPublish(draftComposerRef, {
+  const draftComposerRef = useComposerHeightPublish({
     active: !draftExpanded,
     onHeightChange: handleDraftComposerHeightChange,
   })

--- a/apps/frontend/src/components/timeline/join-channel-bar.tsx
+++ b/apps/frontend/src/components/timeline/join-channel-bar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useState } from "react"
 import { Hash } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { streamsApi } from "@/api"
@@ -21,8 +21,7 @@ export function JoinChannelBar({ workspaceId, streamId, channelName, onJoined, o
   // that variable, and the composer that would otherwise set it is not rendered
   // for non-members. Without this the scroller keeps the stale height a prior
   // composer left behind and the bar can float over messages.
-  const selfRef = useRef<HTMLDivElement | null>(null)
-  useComposerHeightPublish(selfRef, { onHeightChange })
+  const composerHeightRef = useComposerHeightPublish({ onHeightChange })
 
   const handleJoin = async () => {
     setIsJoining(true)
@@ -38,7 +37,7 @@ export function JoinChannelBar({ workspaceId, streamId, channelName, onJoined, o
   }
 
   return (
-    <div ref={selfRef} className="flex flex-col items-center gap-3 border-t bg-background px-4 py-6">
+    <div ref={composerHeightRef} className="flex flex-col items-center gap-3 border-t bg-background px-4 py-6">
       <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
         <span>You're viewing</span>
         <span className="inline-flex items-center gap-0.5 font-medium text-foreground">

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -515,7 +515,10 @@ function MessageInputComponent({
   const connectionState = useConnectionState()
   const isOffline = connectionState === "offline"
 
-  const selfRef = useRef<HTMLDivElement>(null)
+  const composerHeightRef = useComposerHeightPublish({
+    active: !expanded,
+    onHeightChange: onComposerHeightChange,
+  })
 
   // Reset local state on stream change (e.g., draft promotion) without remounting
   useEffect(() => {
@@ -531,12 +534,6 @@ function MessageInputComponent({
 
   const handleExpandClick = useCallback(() => setExpanded(true), [])
   const handleCollapse = useCallback(() => setExpanded(false), [])
-
-  // Publish the floating composer's measured height so the scroll area can dock
-  // above it. Disabled while the overlay is open — the inline composer is hidden
-  // then, so it has no height to publish. `onHeightChange` re-anchors the timeline
-  // to the bottom when the composer settles to a new height.
-  useComposerHeightPublish(selfRef, { active: !expanded, onHeightChange: onComposerHeightChange })
 
   // Stream label for the fullscreen overlay header (the post's destination).
   const overlayStreamName = useStreamName(workspaceId, streamId)
@@ -740,11 +737,11 @@ function MessageInputComponent({
 
   if (disabled && disabledReason) {
     // Use the same floating shell as the live composer so the banner anchors to
-    // the bottom and publishes its height to `--composer-height` (via selfRef).
+    // the bottom and publishes its height to `--composer-height`.
     // A plain in-flow div lands at the top of the absolutely-positioned stream
     // area and overlaps the first messages instead.
     return (
-      <FloatingComposerShell ref={selfRef} data-message-composer-root>
+      <FloatingComposerShell ref={composerHeightRef} data-message-composer-root>
         <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
           <p className="text-sm text-muted-foreground text-center">{disabledReason}</p>
         </div>
@@ -903,7 +900,7 @@ function MessageInputComponent({
 
       {/* Inline composer — hidden while expanded. Mobile inline editing hides the
           composer via the body-level inline-edit presence attribute. */}
-      <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
+      <FloatingComposerShell ref={composerHeightRef} hidden={expanded} data-message-composer-root>
         <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={e2eEnabled} streamId={e2eRootStreamId} />
         {!expanded && conversationReplyStrip}
         {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}

--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { useRef, type CSSProperties } from "react"
+import { type CSSProperties } from "react"
 import { render } from "@testing-library/react"
 import { useComposerHeightPublish } from "./use-composer-height-publish"
 
@@ -7,15 +7,19 @@ type ResizeCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver)
 
 function installManualResizeObserver(): {
   fire: (blockSize: number) => void
+  observed: Element[]
   restore: () => void
 } {
   let lastCallback: ResizeCallback | null = null
+  const observed: Element[] = []
   const original = global.ResizeObserver
   class ManualResizeObserver {
     constructor(cb: ResizeCallback) {
       lastCallback = cb
     }
-    observe() {}
+    observe(target: Element) {
+      observed.push(target)
+    }
     unobserve() {}
     disconnect() {}
   }
@@ -26,6 +30,7 @@ function installManualResizeObserver(): {
         [{ borderBoxSize: [{ blockSize, inlineSize: 0 }] }] as unknown as ResizeObserverEntry[],
         {} as ResizeObserver
       ),
+    observed,
     restore: () => {
       global.ResizeObserver = original
     },
@@ -48,20 +53,22 @@ function Harness({
   onHeightChange,
   active = true,
   zoneHeight,
+  replaceNode = false,
 }: {
   onHeightChange: (px: number) => void
   active?: boolean
   /** Pre-existing `--composer-height` on the zone, simulating the first-paint value. */
   zoneHeight?: string
+  replaceNode?: boolean
 }) {
-  const ref = useRef<HTMLDivElement>(null)
-  useComposerHeightPublish(ref, { active, onHeightChange })
+  const ref = useComposerHeightPublish({ active, onHeightChange })
+  const composer = <div ref={ref}>composer</div>
   return (
     <div
       data-editor-zone="main"
       style={zoneHeight ? ({ "--composer-height": zoneHeight } as CSSProperties) : undefined}
     >
-      <div ref={ref}>composer</div>
+      {replaceNode ? <section>{composer}</section> : composer}
     </div>
   )
 }
@@ -155,6 +162,24 @@ describe("useComposerHeightPublish", () => {
       expect(onHeightChange).toHaveBeenCalledWith(96, { initial: true })
     } finally {
       raf.mockRestore()
+      ro.restore()
+    }
+  })
+
+  it("moves observation when React replaces the ref element without remounting the hook", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      const { container, rerender } = render(<Harness onHeightChange={onHeightChange} />)
+      const firstComposer = container.querySelector<HTMLElement>("[data-editor-zone] > div")!
+      expect(ro.observed).toEqual([firstComposer])
+
+      rerender(<Harness onHeightChange={onHeightChange} replaceNode />)
+      const replacementComposer = container.querySelector<HTMLElement>("[data-editor-zone] section > div")!
+
+      expect(replacementComposer).not.toBe(firstComposer)
+      expect(ro.observed).toEqual([firstComposer, replacementComposer])
+    } finally {
       ro.restore()
     }
   })

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react"
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
 import { persistComposerHeight } from "@/lib/composer-height-storage"
 
 interface UseComposerHeightPublishOptions {
@@ -27,8 +27,10 @@ interface UseComposerHeightPublishOptions {
 }
 
 /**
- * Measures the element referenced by `ref` and publishes its height (in px) as
- * `--composer-height` on the nearest `[data-editor-zone]` ancestor. Scrollable
+ * Returns a callback ref that measures its element and publishes the height (in
+ * px) as `--composer-height` on the nearest `[data-editor-zone]` ancestor. A
+ * callback ref is required because React can replace the composer DOM node while
+ * preserving its parent component and hooks. Scrollable
  * siblings inside the same editor zone can consume the variable (e.g.
  * plain-scroll `padding-bottom`) to reserve space for the floating composer
  * pill.
@@ -46,17 +48,19 @@ interface UseComposerHeightPublishOptions {
  * fallback grew the timeline's footer spacer mid-paint and caused Virtuoso
  * to shift content up on every reload.
  */
-export function useComposerHeightPublish(
-  ref: React.RefObject<HTMLElement | null>,
-  { active = true, onHeightChange }: UseComposerHeightPublishOptions = {}
-): void {
+export function useComposerHeightPublish({
+  active = true,
+  onHeightChange,
+}: UseComposerHeightPublishOptions = {}): React.RefCallback<HTMLElement> {
+  const [el, setEl] = useState<HTMLElement | null>(null)
+  const ref = useCallback((node: HTMLElement | null) => setEl(node), [])
+
   // Held in a ref so a new callback identity each render doesn't tear down and
   // re-create the ResizeObserver (which would re-fire the initial measure).
   const onHeightChangeRef = useRef(onHeightChange)
   onHeightChangeRef.current = onHeightChange
 
   useLayoutEffect(() => {
-    const el = ref.current
     if (!el || !active) return
 
     const zone = el.closest<HTMLElement>("[data-editor-zone]")
@@ -119,5 +123,7 @@ export function useComposerHeightPublish(
       // Intentionally leave --composer-height set so stream navigation
       // starts with a reasonable approximation instead of falling back to 0px.
     }
-  }, [ref, active])
+  }, [el, active])
+
+  return ref
 }


### PR DESCRIPTION
## Problem

`useComposerHeightPublish` observed `ref.current` inside an effect whose dependencies were the stable ref object and `active`. React can replace the composer DOM node while preserving `MessageInputComponent` and its hooks—for example, when its conditional root switches between the disabled banner and live composer. The observer remained attached to the detached node, leaving `--composer-height` at the collapsed/default value. Later composer resizes could not update the timeline footer spacer; a refresh fixed it by remounting the hook.

## Solution

Make `useComposerHeightPublish` own and return a callback ref. The callback records the live DOM node in state, making node replacement reactive; the layout effect disconnects from the old node, measures the replacement, and attaches a new `ResizeObserver`.

All three consumers now attach the returned ref directly:

- `MessageInputComponent`
- `StreamPanel` draft composer
- `JoinChannelBar`

The existing floating composer, footer spacer, persisted-height fallback, and tail-follow behavior remain unchanged.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-composer-height-publish.ts` | Return a reactive callback ref and rebind measurement when its DOM node changes. |
| `apps/frontend/src/hooks/use-composer-height-publish.test.tsx` | Reproduce node replacement without hook remount and assert observation moves to the replacement. |
| `apps/frontend/src/components/timeline/message-input.tsx` | Attach the callback ref to both conditional composer shells. |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Migrate the draft composer to the callback ref. |
| `apps/frontend/src/components/timeline/join-channel-bar.tsx` | Migrate the join bar to the callback ref. |

## Test plan

- [x] Composer-height and join-bar tests — 14 passed
- [x] Frontend TypeScript typecheck
- [x] Full repository lint, monorepo typecheck, migration validation, and OpenAPI validation via commit hooks
- [x] Pre-PR Luna review — no findings

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Keep the timeline's footer spacer connected to the live floating-composer element when React replaces that element without remounting its parent hook.

## What Was Built

- Changed `useComposerHeightPublish` from consuming a stable object ref to returning a callback ref backed by the current DOM node.
- Made the measurement layout effect depend on that node, so replacement disconnects the stale observer and measures/observes the live element.
- Migrated all hook consumers.
- Added regression coverage for ref-element replacement without hook remount.

## Design Decisions

**Chose:** Reactive callback ref.

**Why:** The defect is observer ownership, not unreliable resize delivery. Following the actual node fixes the stale lifecycle without polling, forced re-anchors, or per-keystroke mutation observation.

**Alternatives considered:** A broad `MutationObserver` fallback was implemented first, then removed after review showed it did not establish the root cause, added hot-path layout/storage work, and still missed CSS-only changes.

## Schema Changes

None.

## What's NOT Included

No visual or interaction changes to the floating composer. No changes to timeline follow thresholds or scroll anchoring.

## Status

- [x] Reactive node observation
- [x] All consumers migrated
- [x] Regression test added
- [x] Verification complete

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786542579&installation_id=129946197&pr_number=1321&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1321&signature=cede0d1bb213172498e407de5298abf3b8b230383b290803e90b9560a3a86690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->