### PR TITLE
fix(personas): keep companion-agent picker mounted while the roster hydrates

### DIFF
--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -84,7 +84,7 @@ export function AgentSettingsPanel({
         </div>
       </div>
 
-      {personaPicker && personaPicker.personas.length > 0 && (
+      {personaPicker && (
         <div className="space-y-2">
           <Label className="text-sm font-medium">Companion agent</Label>
           <CompanionAgentSelect

--- a/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-agent-select.tsx
@@ -127,10 +127,17 @@ export function CompanionAgentSelect({
   defaultOption,
   defaultBadges,
 }: CompanionAgentSelectProps) {
+  // An empty roster means the store hasn't hydrated yet (built-ins guarantee a
+  // real roster is never empty), so keep the trigger mounted at full size and
+  // disable it instead of unmounting — a section that pops in after mount
+  // shifts everything below it (INV-21). The value is withheld too: a draft's
+  // synthetic default row would otherwise flash "Default (Ariadne)" before the
+  // configured default resolves.
+  const hydrating = personas.length === 0
   return (
-    <Select value={value} onValueChange={onChange} disabled={disabled}>
+    <Select value={hydrating ? undefined : value} onValueChange={onChange} disabled={disabled || hydrating}>
       <SelectTrigger className={triggerClassName} aria-label="Companion agent">
-        <SelectValue placeholder="Select an agent" />
+        <SelectValue placeholder={hydrating ? "Loading agents…" : "Select an agent"} />
       </SelectTrigger>
       <SelectContent>
         {defaultOption && (

--- a/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.test.tsx
@@ -132,4 +132,16 @@ describe("CompanionTab persona picker", () => {
 
     expect(screen.queryByRole("combobox", { name: /companion agent/i })).not.toBeInTheDocument()
   })
+
+  it("keeps the picker mounted but disabled while the roster is still hydrating (empty store)", () => {
+    vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([])
+
+    renderTab({})
+
+    // No pop-in shove once the roster resolves (INV-21): the section renders
+    // immediately with a full-size disabled trigger.
+    const trigger = screen.getByRole("combobox", { name: /companion agent/i })
+    expect(trigger).toBeDisabled()
+    expect(trigger).toHaveTextContent("Loading agents…")
+  })
 })

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -128,7 +128,7 @@ export function CompanionTab({
 
       {/* Encrypted scratchpads always run the built-in Ariadne in the enclave
           regardless of the pointer, so the persona picker is plaintext-only. */}
-      {!isE2e && personas.length > 0 && (
+      {!isE2e && (
         <div className="space-y-2">
           <div className="space-y-1">
             <Label className="text-sm font-medium">Companion agent</Label>

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
@@ -109,11 +109,16 @@ describe("DraftAgentSettings", () => {
     expect(updateScratchpad).toHaveBeenCalledWith("draft_1", { companionPersonaId: "persona_coach" })
   })
 
-  it("hides the picker while the store is still hydrating (empty roster)", () => {
+  it("keeps the picker mounted but disabled while the store is still hydrating (empty roster)", () => {
     vi.spyOn(rosterHooks, "useCompanionRoster").mockReturnValue([])
 
     renderSettings({})
 
-    expect(screen.queryByRole("combobox", { name: /companion agent/i })).not.toBeInTheDocument()
+    // The section must not pop in and shift the sheet once the roster resolves
+    // (INV-21) — the trigger renders at full size, disabled, with no premature
+    // "Default (Ariadne)" value.
+    const trigger = screen.getByRole("combobox", { name: /companion agent/i })
+    expect(trigger).toBeDisabled()
+    expect(trigger).toHaveTextContent("Loading agents…")
   })
 })

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -42,22 +42,18 @@ export function DraftAgentSettings({
     <AgentSettingsPanel
       companionMode={companionMode}
       onCompanionModeChange={(mode) => updateScratchpad(draftId, { companionMode: mode })}
-      personaPicker={
-        personas.length > 0
-          ? {
-              workspaceId,
-              personas,
-              selectedPersonaId: pickerValue,
-              onChange: (personaId) =>
-                updateScratchpad(draftId, {
-                  // Dexie removes a key set to undefined — inherit means no stored pointer.
-                  companionPersonaId: companionPointerFromPickerValue(personaId) ?? undefined,
-                }),
-              defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
-              defaultBadges: { workspaceDefaultId: workspaceDefault?.id, personalDefaultId: personalDefault?.id },
-            }
-          : undefined
-      }
+      personaPicker={{
+        workspaceId,
+        personas,
+        selectedPersonaId: pickerValue,
+        onChange: (personaId) =>
+          updateScratchpad(draftId, {
+            // Dexie removes a key set to undefined — inherit means no stored pointer.
+            companionPersonaId: companionPointerFromPickerValue(personaId) ?? undefined,
+          }),
+        defaultOption: { label: companionDefaultOptionLabel(effectiveDefault) },
+        defaultBadges: { workspaceDefaultId: workspaceDefault?.id, personalDefaultId: personalDefault?.id },
+      }}
       toolPolicy={{
         value: allowedToolCategories,
         onChange: (next) => updateScratchpad(draftId, { allowedToolCategories: next }),

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -187,4 +187,14 @@ describe("LiveAgentSettings", () => {
 
     expect(screen.queryByRole("combobox", { name: /companion agent/i })).not.toBeInTheDocument()
   })
+
+  it("keeps the picker mounted but disabled while the roster is still hydrating (empty store)", () => {
+    seedAndRender({})
+
+    // No pop-in shove once the roster resolves (INV-21): the section renders
+    // immediately with a full-size disabled trigger.
+    const trigger = screen.getByRole("combobox", { name: /companion agent/i })
+    expect(trigger).toBeDisabled()
+    expect(trigger).toHaveTextContent("Loading agents…")
+  })
 })

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -83,7 +83,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
       companionBusy={companionBusy}
       externalAgent={externalAgent}
       personaPicker={
-        !e2e && personas.length > 0
+        !e2e
           ? {
               workspaceId,
               personas,


### PR DESCRIPTION
## Problem

Opening the stream sheet on mobile (and the draft panel / settings Companion tab) renders without the **Companion agent** section for a beat, then the section pops in and shoves "Restrict tool access" down — caught by Kris on a phone. Cause: `LiveAgentSettings`, `DraftAgentSettings`, and `CompanionTab` all gated the section on `personas.length > 0`, and `useCompanionRoster` reads the bootstrap-backed workspace store, which falls back to an async IndexedDB read when the in-memory cache has not hydrated — so the roster is `[]` for the first render(s). Conditional unmount + late data = INV-21 layout shift.

## Solution

Treat an empty roster as *hydrating*, not *absent* — built-ins guarantee a real roster is never empty. `CompanionAgentSelect` now renders a full-size disabled trigger with a "Loading agents…" placeholder when `personas.length === 0`, and withholds the `value` so a draft cannot flash "Default (Ariadne)" before the configured default resolves (same reasoning as `CompanionTab`'s existing "your companion" name placeholder). The three surfaces keep the section mounted whenever it applies (non-e2e); the e2e gate is unchanged — encrypted scratchpads still hide the picker entirely.

## Files changed

| File | Change |
| ---- | ------ |
| `stream-settings/companion-agent-select.tsx` | Hydrating state: disabled full-size trigger, "Loading agents…" placeholder, value withheld while roster empty |
| `stream-settings/agent-settings-panel.tsx` | Section renders whenever `personaPicker` is provided (dropped `personas.length > 0`) |
| `stream-settings/live-agent-settings.tsx` | Passes `personaPicker` whenever `!e2e` |
| `stream-settings/draft-agent-settings.tsx` | Always passes `personaPicker` (drafts are always plaintext) |
| `stream-settings/companion-tab.tsx` | Section gate `!isE2e && personas.length > 0` → `!isE2e` |
| `*.test.tsx` (live/draft/companion-tab) | Draft "hides while hydrating" test inverted to "mounted but disabled"; same new case added for the live panel and the settings tab |

## Out of scope (deliberate)

The settings-dialog pickers (`ai-settings` default-companion, `default-companion-section`) keep their own empty gates — they live inside dialogs whose content loads as a unit, so there is no mid-view shove to fix.

## Test plan

- [x] `vitest run` stream-settings suites — 34 pass (3 new/updated hydrating cases)
- [x] Full frontend suite — 4250 pass; only the 4 known pre-existing `dates.test.ts` TZ reds (same as #1312)
- [x] `tsc --noEmit` frontend clean; full pre-commit lint/typecheck sweep green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786546729&installation_id=129946197&pr_number=1322&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1322&signature=8058cac5e41f006b08cd44b0e7b31442b8db2240190809ce032ef6d513749000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->