### PR TITLE
fix: prefer canonical links in stream context

### DIFF
--- a/apps/frontend/src/lib/stream-context/derive.test.ts
+++ b/apps/frontend/src/lib/stream-context/derive.test.ts
@@ -120,6 +120,38 @@ describe("deriveStreamContext", () => {
     expect(bare?.badge).toBeNull()
   })
 
+  it("uses the canonical document URL when a stale rich preview has trailing punctuation", () => {
+    const canonicalUrl = "https://github.com/acme/repo/pull/42"
+    const events = [
+      messageEvent("2026-06-23T10:00:00.000Z", {
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: `${canonicalUrl}.` }] }],
+        },
+        linkPreviews: [
+          {
+            id: "lp_stale",
+            url: `${canonicalUrl}.`,
+            title: "Stale preview",
+            description: null,
+            imageUrl: null,
+            faviconUrl: "https://github.com/favicon.ico",
+            siteName: "GitHub",
+            contentType: "website",
+            previewType: "github_pr",
+            position: 0,
+          },
+        ],
+      }),
+    ]
+
+    const links = deriveStreamContext(events).items.filter((i): i is LinkContextItem => i.category === "link")
+    expect(links).toHaveLength(1)
+    expect(links[0].url).toBe(canonicalUrl)
+    expect(links[0].title).toBeNull()
+    expect(links[0].badge).toBeNull()
+  })
+
   it("reads links from contentJson, so a bold link keeps a clean URL (no trailing ** leak)", () => {
     const events = [
       messageEvent("2026-06-23T10:00:00.000Z", {

--- a/apps/frontend/src/lib/stream-context/derive.ts
+++ b/apps/frontend/src/lib/stream-context/derive.ts
@@ -137,41 +137,19 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
     const messageId = payload.messageId
     const snippet = firstLine(payload.contentMarkdown)
 
-    // ── Links: rich previews first, then any bare markdown URLs not covered.
-    const seenInMessage = new Set<string>()
+    // ── Links: the structured document owns the href; server previews only
+    // enrich an exact normalized match. This keeps a stale/malformed preview
+    // row from replacing the URL the message actually contains.
+    const previewsByUrl = new Map<string, LinkPreviewSummary>()
     for (const preview of payload.linkPreviews ?? []) {
-      // In-app links (message / stream / memo) point at other workspace
-      // resources, not the web — they belong to "related", not the external-links list.
-      if (isInAppLinkContentType(preview.contentType)) continue
-      // The href renders into an <a> (React does not sanitize href), and unlike
-      // the bare/markdown passes this URL never went through an http(s) regex —
-      // gate the scheme so a non-http preview url can't reach the anchor.
+      // Preview hrefs render into <a> elements, so never admit a custom scheme.
       if (!/^https?:\/\//i.test(preview.url)) continue
       const norm = normalizeUrl(preview.url)
-      seenInMessage.add(norm)
-      const existing = links.get(norm)
-      if (existing) {
-        existing.refCount += 1
-        continue
-      }
-      const { previewKind, badge } = linkBadge(preview.previewType)
-      links.set(norm, {
-        key: `link:${norm}`,
-        category: "link",
-        createdAt,
-        sourceMessageId: messageId,
-        snippet,
-        url: preview.url,
-        title: preview.title,
-        siteName: preview.siteName,
-        faviconUrl: preview.faviconUrl,
-        imageUrl: preview.imageUrl,
-        previewKind,
-        badge,
-        refCount: 1,
-      })
+      if (!previewsByUrl.has(norm)) previewsByUrl.set(norm, preview)
     }
-    const addBareLink = (url: string) => {
+
+    const seenInMessage = new Set<string>()
+    const addLink = (url: string, preview?: LinkPreviewSummary) => {
       const norm = normalizeUrl(url)
       if (seenInMessage.has(norm)) return
       seenInMessage.add(norm)
@@ -180,6 +158,7 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
         existing.refCount += 1
         return
       }
+      const { previewKind, badge } = linkBadge(preview?.previewType)
       links.set(norm, {
         key: `link:${norm}`,
         category: "link",
@@ -187,22 +166,32 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
         sourceMessageId: messageId,
         snippet,
         url,
-        title: null,
-        siteName: null,
-        faviconUrl: null,
-        imageUrl: null,
-        previewKind: "generic",
-        badge: null,
+        title: preview?.title ?? null,
+        siteName: preview?.siteName ?? null,
+        faviconUrl: preview?.faviconUrl ?? null,
+        imageUrl: preview?.imageUrl ?? null,
+        previewKind,
+        badge,
         refCount: 1,
       })
     }
-    // Body links + inline media read from the structured document (INV-58),
-    // never the serialized markdown — a regex over `**[x](url)**` leaks the
-    // bold markers into the URL. E2E messages whose content isn't decrypted
-    // carry a placeholder doc and simply contribute nothing here.
+
+    // Body links read from the structured document (INV-58), never serialized
+    // markdown. A regex over `**[x](url)**` can leak bold markers into the URL.
+    // Events without a document retain the legacy preview-only fallback.
     const contentJson = payload.contentJson
     if (contentJson) {
-      for (const url of collectLinkUrls(contentJson)) addBareLink(url)
+      for (const url of collectLinkUrls(contentJson)) {
+        const preview = previewsByUrl.get(normalizeUrl(url))
+        // In-app resources belong to "related", not the external-links list.
+        if (preview && isInAppLinkContentType(preview.contentType)) continue
+        addLink(url, preview)
+      }
+    } else {
+      for (const preview of previewsByUrl.values()) {
+        if (isInAppLinkContentType(preview.contentType)) continue
+        addLink(preview.url, preview)
+      }
     }
 
     // ── Attachments → media (image/gif/video) or files (everything else).


### PR DESCRIPTION
## Problem

The frontend-only “In this stream” panel derived links from cached timeline events, but processed server-generated `linkPreviews` before the message’s structured document. A stale preview row such as `https://github.com/threahq/threa/pull/1318.` therefore became the row href even when `contentJson` canonically extracted `https://github.com/threahq/threa/pull/1318`. The mismatch could also produce a duplicate row.

## Solution

Make `contentJson` authoritative for link hrefs in `deriveStreamContext`. Server previews now enrich only an exact normalized document URL with title, favicon, image, site, and provider badge metadata.

Events without `contentJson` retain the preview-only fallback. In-app preview types remain excluded, and preview URLs are still restricted to HTTP(S).

## Files changed

| File | Change |
| --- | --- |
| `apps/frontend/src/lib/stream-context/derive.ts` | Derive hrefs from `collectLinkUrls(contentJson)` and join preview metadata by normalized URL. |
| `apps/frontend/src/lib/stream-context/derive.test.ts` | Cover a stale punctuated preview alongside a canonical plaintext URL. |

## Test plan

- [x] Frontend stream-context unit tests — 12 pass
- [x] Frontend typecheck
- [x] Monorepo pre-commit lint and typecheck
- [x] `git diff --check`

## Base

Branched from and rebased onto freshly fetched `origin/main` at `d7168d6b` before push.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786548449&installation_id=129946197&pr_number=1323&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1323&signature=21624ccb7fadbdd76616cb18216d44a9d0d488432f15e12cb0ba3a332af164ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->