### PR TITLE
fix(public-site): scroll wide dev-docs tables instead of overflowing the page

### DIFF
--- a/apps/public-site/src/pages/developers/authentication.astro
+++ b/apps/public-site/src/pages/developers/authentication.astro
@@ -102,6 +102,7 @@ const scopes = [
 
   <h2>Scopes</h2>
   <p>These are the scopes a key can carry. Workspace-admin powers (managing members, creating shared bots, owning the workspace) are deliberately not grantable to API keys.</p>
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Scope</th><th>Grants</th></tr></thead>
     <tbody>
@@ -110,6 +111,7 @@ const scopes = [
       ))}
     </tbody>
   </table>
+  </div>
 
   <div class="note">
     <strong>How keys are stored</strong>

--- a/apps/public-site/src/pages/developers/markdown.astro
+++ b/apps/public-site/src/pages/developers/markdown.astro
@@ -52,6 +52,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   <p>
     Common GitHub-flavored markdown renders as you'd expect. Supported:
   </p>
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Element</th><th>Syntax</th></tr></thead>
     <tbody>
@@ -64,6 +65,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
       <tr><td>Links</td><td><code>[text](https://…)</code></td></tr>
     </tbody>
   </table>
+  </div>
   <div class="note">
     <strong>Reserved schemes</strong>
     A link whose target starts with one of the schemes below (for example
@@ -137,6 +139,7 @@ curl -X POST {{baseUrl}}/api/v1/workspaces/{{workspaceId}}/streams/STREAM_ID/mes
     label as readable text. The ones you'll write are the first group; the rest
     you'll mostly encounter on reads.
   </p>
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Scheme</th><th>Reference</th><th>Example</th></tr></thead>
     <tbody>
@@ -151,6 +154,7 @@ curl -X POST {{baseUrl}}/api/v1/workspaces/{{workspaceId}}/streams/STREAM_ID/mes
       <tr><td><code>shared-message:</code></td><td>cross-stream share (read)</td><td><code>[Alice](shared-message:stream_…/msg_…)</code></td></tr>
     </tbody>
   </table>
+  </div>
 
   <h2 id="structure">Why the schemes exist</h2>
   <p>

--- a/apps/public-site/src/pages/developers/operations.astro
+++ b/apps/public-site/src/pages/developers/operations.astro
@@ -36,6 +36,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   }
 }`}
   />
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Status</th><th>Means</th></tr></thead>
     <tbody>
@@ -47,6 +48,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
       <tr><td><code>429</code></td><td>Rate limited. See below.</td></tr>
     </tbody>
   </table>
+  </div>
 
   <h2 id="pagination">Pagination</h2>
   <p>
@@ -110,6 +112,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
     clear all of them, so the tightest one that applies is what you actually feel.
     These are the current defaults and may be tuned.
   </p>
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Limit</th><th>Window</th><th>Scope</th><th>Applies to</th></tr></thead>
     <tbody>
@@ -119,6 +122,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
       <tr><td><strong>20 requests</strong></td><td>60s</td><td>per caller</td><td>attachment uploads</td></tr>
     </tbody>
   </table>
+  </div>
   <p>
     For a single key on a single host, the <strong>60/min per key</strong> limit is
     the one you'll hit first. The per-IP baseline matters when many keys share one

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -165,6 +165,7 @@ if (data.apiVersion.resolved !== data.apiVersion.current) {
     field's type or meaning, tightens request validation, changes a default, or
     changes an error code or status. This is the same split Stripe uses.
   </p>
+  <div class="docs-table-wrap">
   <table class="docs-table">
     <thead><tr><th>Change</th><th>New version?</th></tr></thead>
     <tbody>
@@ -179,6 +180,7 @@ if (data.apiVersion.resolved !== data.apiVersion.current) {
       <tr><td>Changing an error code or status</td><td>Yes</td></tr>
     </tbody>
   </table>
+  </div>
 
   <h2 id="support-window">Support window</h2>
   <p>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -775,11 +775,36 @@ a {
 }
 
 /* parameter / scope tables */
+/* Cells hold unbreakable code strings, so a table wider than its column would
+   push the page past the viewport. The wrapper clips that to a horizontal
+   scroll; the scrollbar is thin and overlay-style so it isn't always visible. */
+.docs-table-wrap {
+  max-width: 100%;
+  margin: 18px 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--line)) transparent;
+}
+.docs-table-wrap::-webkit-scrollbar {
+  height: 6px;
+}
+.docs-table-wrap::-webkit-scrollbar-thumb {
+  background: hsl(var(--line));
+  border-radius: 3px;
+}
+.docs-table-wrap::-webkit-scrollbar-track {
+  background: transparent;
+}
 .docs-table {
   width: 100%;
   border-collapse: collapse;
   margin: 18px 0;
   font-size: 14px;
+}
+/* Margins live on the wrapper when present; avoid double vertical spacing. */
+.docs-table-wrap > .docs-table {
+  margin: 0;
 }
 .docs-table th {
   text-align: left;


### PR DESCRIPTION
## Summary

Dev-docs pages (`/developers/*`) overflowed horizontally on mobile — the page could be zoomed out and content bled past the viewport. Root cause: the `.docs-table` tables are `width:100%` but hold **unbreakable code strings** (e.g. `[Alice](quote:stream_…/msg_…/usr_…/user)`). `width:100%` is only a *minimum*, so a table whose content is wider than its column grows past it and pushes the whole page wider than the viewport. At a 390px mobile viewport the layout viewport widened to **501px**.

## Fix

Wrap all six dev-docs tables in a `.docs-table-wrap` scroll container:

```css
.docs-table-wrap {
  max-width: 100%;
  overflow-x: auto;      /* wide table scrolls inside, page stays put */
  overflow-y: hidden;
  scrollbar-width: thin; /* + transparent track → overlay/auto-hiding */
}
```

Wide tables now scroll horizontally within their own box; the scrollbar is thin and overlay-style (auto-hiding on mobile/macOS), not a permanent bar.

## Files

- `apps/public-site/src/styles/docs.css` — `.docs-table-wrap` rules + thin webkit scrollbar; strip the table's own vertical margin when wrapped
- `pages/developers/markdown.astro` (2 tables), `operations.astro` (2), `authentication.astro` (1), `versioning.astro` (1) — wrapped each `<table class="docs-table">`

The API reference page uses the endpoint layout, not tables, and its code panels already scroll/wrap.

## Verification

Headless Chromium at a 390px mobile viewport:

| | page scrollWidth | table wrapper |
|---|---|---|
| **Before** | **501px** (overflows) | not scrollable |
| **After** | **390px** (contained) | `scrollW 481 > clientW 350` → scrolls |

Local pre-commit gate green: eslint, monorepo typecheck, `astro check` (0 errors), migration + dockerfile checks, OpenAPI docs up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW4BNjrhusd9FDZ1ZXueXq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555328&installation_id=129946197&pr_number=1325&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1325&signature=f41be40b21fb86e4b34ad417a6dd06f9ead412c0601dace1b086a83d71f54247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->