### PR TITLE
fix(public-site): stack docs footer into a wrapping link list on mobile

### DIFF
--- a/apps/public-site/src/layouts/DocsLayout.astro
+++ b/apps/public-site/src/layouts/DocsLayout.astro
@@ -230,20 +230,15 @@ const schema: Record<string, unknown>[] = [
         </article>
 
         <footer class="docs-foot">
-          <span>Threa · Developers</span>
-          <span>
+          <span class="docs-foot-brand">Threa · Developers</span>
+          <ul class="docs-foot-links">
             {markdownHref && (
-              <>
-                <a href={markdownHref}>View as Markdown</a>
-                &nbsp;·&nbsp;
-              </>
+              <li><a href={markdownHref}>View as Markdown</a></li>
             )}
-            <a href="/llms.txt">llms.txt</a>
-            &nbsp;·&nbsp;
-            <a href="/developers/feature-requests">Request a feature</a>
-            &nbsp;·&nbsp;
-            <a href="/">threa.io</a>
-          </span>
+            <li><a href="/llms.txt">llms.txt</a></li>
+            <li><a href="/developers/feature-requests">Request a feature</a></li>
+            <li><a href="/">threa.io</a></li>
+          </ul>
         </footer>
       </main>
     </div>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -1290,6 +1290,30 @@ a {
   text-transform: uppercase;
   color: hsl(var(--muted));
 }
+.docs-foot-brand {
+  flex-shrink: 0;
+}
+/* Links as a real list: flex-wrap keeps whole items together (no wrapping
+   mid-separator), and the "·" is a pseudo-element between items rather than a
+   non-breaking-space glyph that could strand a lone dot on its own line. */
+.docs-foot-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+}
+.docs-foot-links li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.docs-foot-links li + li::before {
+  content: "·";
+  color: hsl(var(--line));
+}
 .docs-foot a {
   color: hsl(var(--muted));
   text-decoration: none;
@@ -1401,6 +1425,15 @@ a {
   }
   .keytype-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Stack the footer: brand over links, both left-aligned. space-between +
+     mono-uppercase links crammed to the right wrapped mid-separator on narrow
+     phones. */
+  .docs-foot {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary

The docs footer (`.docs-foot`) was a flex `space-between` row: brand on the left, links on the right joined by `&nbsp;·&nbsp;`. On narrow phones the mono-uppercase links wrapped **mid-separator**, stranding lone `·` dots and reading as garbled text.

## Fix

- Links become a real `<ul class="docs-foot-links">`. `flex-wrap` keeps whole items together (never wraps mid-separator); the `·` is a `li + li::before` pseudo-element, not a wrappable `&nbsp;` glyph.
- On `<=880px` the footer stacks: brand over links, both left-aligned.

## Files

- `apps/public-site/src/layouts/DocsLayout.astro` — footer markup → semantic list
- `apps/public-site/src/styles/docs.css` — `.docs-foot-links` list styling + mobile stack rule

## Verification

Headless Chromium at 390px: footer renders brand-over-links, items wrap cleanly with `·` between them, page stays at 390px (no overflow). Empirically swept all 10 public-site routes at 320/375/390px — clean at 375/390.

Local pre-commit gate green (eslint, monorepo typecheck, `astro check` 0 errors, migrations/dockerfiles, OpenAPI docs up to date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW4BNjrhusd9FDZ1ZXueXq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786556945&installation_id=129946197&pr_number=1326&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1326&signature=5c1ba04be1c30355d408c90ff4ba49b98c4bdca60464da167fd405f1a77c37d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->