### PR TITLE
fix(public-site): wrap code-block header so Copy/Run stay reachable on mobile

### DIFF
--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -570,10 +570,15 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 6px 12px;
   padding: 7px 12px;
   border-bottom: 1px solid hsl(var(--line));
   background: hsl(var(--paper-warm));
   border-radius: 6px 6px 0 0;
+  /* The label carries the full "VERB /path" on the reference side rail; without
+     wrap it refuses to shrink and shoves the Copy/Run buttons off the block's
+     right edge (no scroll — the buttons become untappable on narrow phones). */
+  flex-wrap: wrap;
 }
 .pg-lang {
   font-family: var(--font-mono);
@@ -581,6 +586,8 @@ a {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: hsl(var(--muted));
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .pg-actions {
   display: flex;


### PR DESCRIPTION
## Summary

Found by a mobile-overflow audit of the public-site. On the API reference page, `.pg-block-head` (the code-block header: language label + Run/Copy buttons) is a `space-between` flex row with **no `flex-wrap`**. On the narrow `.api-op-side` rail its `.pg-lang` label carries the full `VERB /path` (fed by `ApiEndpoint.astro`), refuses to shrink, and shoves `.pg-actions` past the block's right edge. `.pg-block` is `overflow:visible`, so there's no scroll — the buttons go off-canvas and become **untappable**.

Measured overflow: **45px on 12 endpoints at 320px, 5px at 360px** (e.g. `POST /delegations/{delegationId}/heartbeat`).

## Fix

- `.pg-block-head`: add `flex-wrap:wrap` + row-gap, matching the existing `.ep-head`/`.api-op-head`/`.api-scopes` convention in the same file. A long label now drops to its own line above the actions.
- `.pg-lang`: add `min-width:0` + `overflow-wrap:anywhere` so a single long path wraps within its line instead of overflowing.

Short labels ("BASH", "JSON") on the marketing/other docs pages are unaffected.

## Verification

Headless Chromium: reference page clean at 320/360/375px (was 45px over at 320); full sweep of **all 10 public-site routes at 320/375/390px → zero overflow**. Local pre-commit gate green (eslint, monorepo typecheck, `astro check` 0 errors, migrations/dockerfiles, OpenAPI up to date).

## Audit note

Two Sonnet agents + an empirical Playwright sweep audited the whole public-site for this bug class. This `.pg-block-head` overflow was the **only** remaining real issue (both agents converged on it, confidence 95). Everything else — every `.docs-table` (wrapped), the footer (now a list), all `.pg-pre` code blocks, marketing hero/grids, the `.byo-agents` carousel — verified clean at phone widths. One low-priority non-bug noted: `.docs-article code` in prose has no `overflow-wrap` fallback; every current inline code string is short enough to be fine, but a future long one could reproduce this class. Left untouched (INV-36, no speculative change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW4BNjrhusd9FDZ1ZXueXq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786557437&installation_id=129946197&pr_number=1327&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1327&signature=6532ab1d17159272f9274dc38da8dce6a2054c93c2528c5588330e7ded3777dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->