### PR TITLE
fix(frontend): hide drafts for archived streams (incl. nested threads)

### DIFF
--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -60,6 +60,34 @@ async function pendingDeleteIds(): Promise<string[]> {
   return ops.map((op) => op.payload.draftId as string)
 }
 
+function seedStream(overrides: { id: string } & Partial<Record<string, unknown>>): Promise<unknown> {
+  return db.streams.put({
+    workspaceId,
+    type: "channel",
+    visibility: "private",
+    rootStreamId: null,
+    parentMessageId: null,
+    archivedAt: null,
+    ...overrides,
+  } as never)
+}
+
+function seedMessageEvent(messageId: string, streamId: string, seq: number): Promise<unknown> {
+  return db.events.put({
+    id: `evt_${messageId}`,
+    workspaceId,
+    streamId,
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType: "message_created",
+    payload: { messageId, contentMarkdown: "x", reactions: {} },
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt: new Date(seq).toISOString(),
+    _cachedAt: seq,
+  } as never)
+}
+
 beforeEach(async () => {
   vi.restoreAllMocks()
   resetDraftStoreCache()
@@ -69,6 +97,7 @@ beforeEach(async () => {
   await db.draftScratchpads.clear()
   await db.conversations.clear()
   await db.streams.clear()
+  await db.events.clear()
   // The drafts explorer now decrypts E2E previews via the shared cache, which
   // reads the viewer id + session; default them to "no viewer / locked" so these
   // plaintext-draft tests run without an AuthProvider (INV-48 namespace spyOn).
@@ -313,6 +342,93 @@ describe("useAllDrafts E2E drafts", () => {
 
     await waitFor(() => expect(result.current.drafts.some((d) => d.id === "draft_locked")).toBe(true))
     expect(result.current.drafts.find((d) => d.id === "draft_locked")!.preview).toBe("Encrypted draft")
+  })
+})
+
+describe("useAllDrafts archived streams", () => {
+  it("hides a draft whose stream is archived and keeps one whose stream is active", async () => {
+    await seedStream({ id: "stream_active" })
+    await seedStream({ id: "stream_archived", archivedAt: "2026-01-01T00:00:00Z" })
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_active", scope: "stream:stream_active", contentJson: makeDoc("keep me") }),
+      syncedDraft({ id: "draft_archived", scope: "stream:stream_archived", contentJson: makeDoc("hide me") }),
+    ])
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_active"]))
+  })
+
+  it("hides a thread-reply draft whose root stream is archived, at any nesting depth", async () => {
+    // root (archived) -> mid thread -> deep thread. The reply draft targets a
+    // message inside the deepest thread; archival is marked only on the root.
+    await seedStream({ id: "stream_root", archivedAt: "2026-01-01T00:00:00Z" })
+    await seedStream({ id: "stream_mid", type: "thread", rootStreamId: "stream_root" })
+    await seedStream({ id: "stream_deep", type: "thread", rootStreamId: "stream_root" })
+    await seedMessageEvent("msg_deep", "stream_deep", 1)
+    await db.drafts.add(syncedDraft({ id: "draft_thread", scope: "thread:msg_deep", contentJson: makeDoc("reply") }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    // The gated events query resolves the reply's parent stream; once it does,
+    // the thread draft is hidden because its root (`stream_root`) is archived.
+    await waitFor(() => expect(result.current.drafts).toHaveLength(0))
+  })
+
+  it("keeps a thread-reply draft whose root stream is active", async () => {
+    await seedStream({ id: "stream_root_active" })
+    await seedStream({ id: "stream_thread", type: "thread", rootStreamId: "stream_root_active" })
+    await seedMessageEvent("msg_active", "stream_thread", 1)
+    await db.drafts.add(
+      syncedDraft({ id: "draft_thread_ok", scope: "thread:msg_active", contentJson: makeDoc("reply") })
+    )
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_thread_ok"]))
+  })
+
+  it("keeps the summary badge count in step with the hidden list for channel/DM drafts", async () => {
+    await seedStream({ id: "stream_keep" })
+    await seedStream({ id: "stream_gone", archivedAt: "2026-01-01T00:00:00Z" })
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_keep", scope: "stream:stream_keep", contentJson: makeDoc("keep") }),
+      syncedDraft({ id: "draft_gone", scope: "stream:stream_gone", contentJson: makeDoc("gone") }),
+    ])
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.all.drafts.length).toBe(1))
+    expect(result.current.summary.draftCount).toBe(1)
+    expect(result.current.summary.draftCount).toBe(result.current.all.drafts.length)
+  })
+
+  it("badge still counts a thread draft under an archived root (deliberate: no events scan in the sidebar)", async () => {
+    // The explorer resolves the thread's stream via a db.events scan and hides
+    // the draft; the summary skips that scan to keep the always-mounted sidebar
+    // off a query that churns on every message, so it over-counts this rare case.
+    await seedStream({ id: "stream_root_arch", archivedAt: "2026-01-01T00:00:00Z" })
+    await seedStream({ id: "stream_thr", type: "thread", rootStreamId: "stream_root_arch" })
+    await seedMessageEvent("msg_x", "stream_thr", 1)
+    await db.drafts.add(syncedDraft({ id: "draft_thr", scope: "thread:msg_x", contentJson: makeDoc("reply") }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
+
+    // Steady state: the explorer hides it while the badge still counts it.
+    // Asserted together so we read the settled state, not a co-mount transient.
+    await waitFor(() => {
+      expect(result.current.all.drafts).toHaveLength(0)
+      expect(result.current.summary.draftCount).toBe(1)
+    })
   })
 })
 

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -132,6 +132,28 @@ function resolveRootStreamId(
   return streamMap.get(parsed.id)?.rootStreamId ?? parsed.id
 }
 
+/**
+ * Whether a stream is archived — directly, or because it descends from an
+ * archived root. Archiving marks only the root row (a thread stays "active" and
+ * inherits archival via `rootStreamId`), so a thread at any depth under an
+ * archived root resolves as archived here; this mirrors the sidebar's
+ * `isSidebarStreamVisible` archived rule. Callers pass a draft's resolved host
+ * stream id (channel/DM/thread-parent/board-anchor). An unresolved id (`null`,
+ * or a stream not in cache) is treated as not-archived, so a draft is never
+ * hidden on missing data.
+ */
+function isStreamArchived(
+  streamId: string | null,
+  streamMap: Map<string, CachedStream>,
+  archivedStreamIds: ReadonlySet<string>
+): boolean {
+  if (!streamId) return false
+  const stream = streamMap.get(streamId)
+  if (!stream) return false
+  if (stream.archivedAt) return true
+  return stream.rootStreamId != null && archivedStreamIds.has(stream.rootStreamId)
+}
+
 interface ResolvedDraftLocation {
   draftType: DraftType
   streamId: string | null
@@ -363,6 +385,14 @@ export function useAllDrafts(workspaceId: string) {
     return map
   }, [cachedStreams])
 
+  // Ids of directly-archived streams; a thread inherits archival via its root
+  // (see `isStreamArchived`). Drives the archived-draft filter in the loop below.
+  const archivedStreamIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const stream of cachedStreams ?? []) if (stream.archivedAt) ids.add(stream.id)
+    return ids
+  }, [cachedStreams])
+
   // Conversations referenced by board-scoped drafts (`board:reply:` /
   // `board:branch-reply:`), for location resolution. Keyed on the id set (not
   // the drafts array) so a body keystroke doesn't re-fire the query.
@@ -569,6 +599,12 @@ export function useAllDrafts(workspaceId: string) {
       const resolved = parsed
         ? resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
         : boardResolved!
+
+      // Hide drafts whose host stream is archived — a channel/DM directly, a
+      // thread or board reply via its resolved parent/anchor stream, and any
+      // nested thread through the root check inside `isStreamArchived`.
+      if (isStreamArchived(resolved.streamId, streamMap, archivedStreamIds)) continue
+
       const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
 
       // A stashed row deep-links via `?stash=<draftId>` so the composer host
@@ -608,6 +644,7 @@ export function useAllDrafts(workspaceId: string) {
     draftsById,
     loadedByScope,
     streamMap,
+    archivedStreamIds,
     messageToStreamMap,
     boardPostMap,
     subtopicHostByMessageId,
@@ -670,12 +707,18 @@ export interface DraftSummary {
  * NO preview building, sealed-body decryption, location resolution, or sort, so
  * a keystroke's debounced draft save doesn't rebuild the full {@link useAllDrafts}
  * explorer model (which it does on every change) just to read two values off it.
- * Shares {@link draftHasPayload} with the explorer so the count never drifts.
+ * Shares {@link draftHasPayload} and {@link isStreamArchived} with the explorer,
+ * so archived channel/DM drafts are hidden from the badge and the list alike.
+ * Thread and board drafts resolve their host stream only in the explorer (via a
+ * `db.events` / conversation lookup that would be too heavy for the always-
+ * mounted sidebar), so the badge can over-count one whose root is archived —
+ * rare, and the explorer still hides it.
  */
 export function useDraftSummary(workspaceId: string): DraftSummary {
   const draftScratchpads = useDraftScratchpadsFromStore(workspaceId)
   const allDrafts = useDraftsFromStore(workspaceId)
   const composerLoaded = useComposerLoadedFromStore(workspaceId)
+  const cachedStreams = useWorkspaceStreams(workspaceId)
 
   const loadedByScope = useMemo(() => {
     const map = new Map<string, string | null>()
@@ -688,6 +731,21 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     for (const draft of allDrafts) map.set(draft.id, draft)
     return map
   }, [allDrafts])
+
+  // Stream map + archived-id set from the already-loaded workspace streams
+  // (cheap; no events/conversation queries), so the badge filters archived
+  // channel/DM drafts in step with the explorer.
+  const streamMap = useMemo(() => {
+    const map = new Map<string, CachedStream>()
+    for (const stream of cachedStreams ?? []) map.set(stream.id, stream)
+    return map
+  }, [cachedStreams])
+
+  const archivedStreamIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const stream of cachedStreams ?? []) if (stream.archivedAt) ids.add(stream.id)
+    return ids
+  }, [cachedStreams])
 
   return useMemo(() => {
     let draftCount = 0
@@ -712,6 +770,10 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
       // Scratchpad-scoped rows are counted above; skip them and their siblings.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
       if (!draftHasPayload(draft)) continue
+      // Hide archived channel/DM drafts (`parsed.id` is the stream). Thread
+      // drafts aren't resolved here (no events scan), so one under an archived
+      // root stays counted — the explorer still hides it.
+      if (parsed.type === "stream" && isStreamArchived(parsed.id, streamMap, archivedStreamIds)) continue
       draftCount++
       // A non-thread stream draft that is the loaded (not stashed) one for its
       // scope surfaces as the per-row "unsent draft" hint — mirrors
@@ -722,5 +784,5 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     }
 
     return { draftCount, loadedDraftStreamIdSignature: [...loadedDraftStreamIds].sort().join(",") }
-  }, [draftScratchpads, allDrafts, loadedByScope, draftsById])
+  }, [draftScratchpads, allDrafts, loadedByScope, draftsById, streamMap, archivedStreamIds])
 }


### PR DESCRIPTION
## Problem

The drafts explorer (`/w/:id/drafts`) and the sidebar "Drafts" badge listed and counted unsent drafts for **archived** streams. Archiving marks only the root row (`streams.archived_at`) — a thread inherits archival through `rootStreamId` and stays `active` — so thread-reply drafts nested any number of levels under an archived scratchpad/channel leaked through too. The sidebar already hides archived streams (and their nested threads) via `isSidebarStreamVisible`; the drafts surfaces didn't apply the same rule.

## Solution

Add an archived filter in `apps/frontend/src/hooks/use-all-drafts.ts`, mirroring the sidebar's archived + thread→root rule, in both the explorer list and the badge count.

### How it works

- **`isStreamArchived(streamId, streamMap, archivedStreamIds)`** — returns true when the stream is archived directly (`archivedAt`) **or** descends from an archived root (`stream.rootStreamId ∈ archivedStreamIds`). Archiving marks only the root, so a thread at any depth resolves as archived through the single root check — the backend flattens `rootStreamId` to the true root (`parentStream.rootStreamId ?? parentStream.id` in `streams/service.ts`). An unresolved id (`null`, or a stream not in cache) is treated as not-archived, so a draft is never hidden on missing data.
- **Explorer (`useAllDrafts`)** — filters on each draft's already-resolved host stream: `if (isStreamArchived(resolved.streamId, …)) continue`, placed right after `resolveDraftLocation`/`resolveBoardDraftLocation`. One check covers every draft type — `resolved.streamId` is the stream for a channel/DM draft, the parent stream for a thread reply, and the conversation's anchor stream for a board reply — so nested threads and board replies under an archived root are all hidden.
- **Badge (`useDraftSummary`)** — builds `streamMap` + `archivedStreamIds` from the already-loaded workspace streams (cheap; no events/conversation queries) and filters archived channel/DM drafts by `parsed.id`. Scratchpad rows are exempt (unpromoted, never server-side).

### Key design decisions

**1. The badge stays off `db.events`.** Resolving a thread/board draft's host stream needs the explorer's `db.events` scan / conversation lookup, and `db.events` churns on every incoming message — putting that in the always-mounted sidebar would re-run a workspace-wide query on every message. So the badge resolves only channel/DM drafts (direct `streamMap` lookup). A thread- or board-reply draft under an archived root is left **counted** in the badge while the explorer hides it — a rare over-count vs. a live events subscription in the global chrome.

**2. A post-resolution filter, not a new resolver.** The explorer already resolves every draft to `resolved.streamId`; the filter reuses that instead of re-deriving the stream, so it composes with the board-draft resolution (#1310) added to this hook without duplicating any lookup. The archived rule itself is replicated from `isSidebarStreamVisible` (whose membership/visibility gating drafts don't want), documented as mirroring it.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-all-drafts.ts` | `isStreamArchived` helper + `archivedStreamIds`; post-resolution archived filter in `useAllDrafts`, cheap channel/DM archived filter in `useDraftSummary` |
| `apps/frontend/src/hooks/use-all-drafts.test.ts` | Archived stream/DM draft hidden, nested-archived thread hidden (explorer), active thread kept, badge↔list consistency for channel/DM, and the deliberate explorer-hides / badge-counts thread divergence |

## Out of scope (deliberate)

- **No "N drafts hidden in archived streams" indicator.** Archiving silently removes an unsent draft from the surface billed as "all drafts," with no in-app signal it still exists (it isn't deleted; unarchiving restores it). A hidden-count affordance is a product decision beyond the ask ("no need to show drafts for streams that are archived") — flagged so it's a conscious choice.
- **Badge over-count for thread/board drafts under an archived root** — deliberate; see design decision 1.

## Test plan

- [x] `apps/frontend` `use-all-drafts.test.ts` — 20 pass (main's board-composer cases + 5 new archived cases)
- [x] `drafts.test.tsx` + `quick-links.test.tsx` — 27 pass (no regression)
- [x] `tsc -p apps/frontend/tsconfig.json --noEmit` — clean
- [x] Pre-PR review (3 reviewer agents: spec+design, correctness+data-flow, UX) on the pre-rebase diff: 1 perf finding fixed (kept the badge off `db.events`), correctness clean, 1 UX finding dismissed as intended behavior (documented above)
- [x] Rebased onto `main` after #1310 reworked this hook for board-composer drafts; re-applied as a post-resolution filter fitting the new structure, re-ran all suites green
- [ ] No Playwright run — change is a data-hook filter covered by the hook's unit tests; no new UI surface to drive

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)