### PR TITLE
feat: include link previews in AI context

### DIFF
--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -17,6 +17,7 @@ import {
   type StreamBrief,
 } from "../../streams"
 import { awaitAttachmentProcessing } from "../../attachments"
+import { awaitLinkPreviewProcessing } from "../../link-previews"
 import { buildStreamContext, type StreamContext } from "../context-builder"
 import type { ContextWindowPolicy } from "../context-window-policy"
 import type { ConversationSummaryService } from "../conversation-summary-service"
@@ -145,6 +146,10 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     ])
   }
 
+  const linkPreviewProcessing = triggerMessage
+    ? awaitLinkPreviewProcessing(db, workspaceId, [triggerMessage])
+    : Promise.resolve()
+
   // Await attachment processing for trigger message so agent can access extracted content
   if (triggerMessage) {
     const triggerAttachments = await AttachmentRepository.findByMessageId(db, messageId)
@@ -166,6 +171,11 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     }
   }
 
+  // Link-preview extraction is an independent outbox peer, so its junction row
+  // may not exist yet when the companion job starts. Bound the wait; timeout
+  // still gives the agent the original URL and any previews that did finish.
+  await linkPreviewProcessing
+
   // Compute accessible streams once, here — used by both quote-reply resolution
   // below and by the workspace-tool deps wiring in persona-agent.ts. Bot turns
   // (no invoking user) get `null`; downstream consumers decide how to treat it.
@@ -186,6 +196,7 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     maxChars: policy.maxChars,
     triggerMessageId: messageId,
     includeAttachments: true,
+    includeLinkPreviews: true,
   })
 
   const streamScopedMessages = streamContext.conversationHistory.filter((m) => m.streamId === stream.id)

--- a/apps/backend/src/features/agents/context-bag/render.ts
+++ b/apps/backend/src/features/agents/context-bag/render.ts
@@ -1,5 +1,6 @@
 import type { LastRenderedSnapshot, RenderableMessage, SummaryInput } from "./types"
 import type { DiffResult } from "./diff"
+import { renderLinkPreviewContext } from "../../link-previews"
 
 export interface StableRenderInput {
   preamble: string
@@ -73,7 +74,9 @@ function formatInlineMessage(item: RenderableMessage, options?: { focal?: boolea
   // attachment tools, keeping the stable region small.
   const attachments =
     item.attachments && item.attachments.length > 0 ? `\n  ${formatAttachments(item.attachments)}` : ""
-  return `${bullet} [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}${attachments}`
+  const previewContext = renderLinkPreviewContext(item.linkPreviews ?? [])
+  const linkPreviews = previewContext ? `\n  ${previewContext.replaceAll("\n", "\n  ")}` : ""
+  return `${bullet} [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}${attachments}${linkPreviews}`
 }
 
 function formatAttachments(attachments: NonNullable<RenderableMessage["attachments"]>): string {

--- a/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.test.ts
@@ -3,6 +3,7 @@ import { ContextRefKinds, Visibilities } from "@threa/types"
 import { ConversationResolver } from "./conversation-resolver"
 import { AttachmentRepository } from "../../../attachments"
 import { MessageRepository } from "../../../messaging"
+import { LinkPreviewRepository } from "../../../link-previews"
 import { ConversationRepository } from "../../../conversations"
 import { StreamRepository, StreamMemberRepository } from "../../../streams"
 import { UserRepository } from "../../../workspaces"
@@ -10,6 +11,7 @@ import { PersonaRepository } from "../../persona-repository"
 
 beforeEach(() => {
   spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+  spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
   spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
 })

--- a/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.ts
@@ -1,5 +1,5 @@
 import type { Querier } from "../../../../db"
-import { ContextRefKinds, type AttachmentSummary, type ConversationContextRef } from "@threa/types"
+import { ContextRefKinds, LinkPreviewStatuses, type AttachmentSummary, type ConversationContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import { AttachmentRepository } from "../../../attachments"
 import { LinkPreviewRepository, renderLinkPreviewContext } from "../../../link-previews"
@@ -119,7 +119,9 @@ export const ConversationResolver: Resolver<ConversationContextRef> = {
                 sizeBytes: a.sizeBytes,
               }))
           : undefined
-      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter((preview) => preview.status === "completed")
+      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter(
+        (preview) => preview.status === LinkPreviewStatuses.COMPLETED
+      )
       return {
         messageId: m.id,
         authorId: m.authorId,

--- a/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/conversation-resolver.ts
@@ -2,6 +2,7 @@ import type { Querier } from "../../../../db"
 import { ContextRefKinds, type AttachmentSummary, type ConversationContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import { AttachmentRepository } from "../../../attachments"
+import { LinkPreviewRepository, renderLinkPreviewContext } from "../../../link-previews"
 import { MessageRepository } from "../../../messaging"
 import { ConversationRepository } from "../../../conversations"
 import { checkStreamAccess } from "../../../streams"
@@ -96,9 +97,10 @@ export const ConversationResolver: Resolver<ConversationContextRef> = {
 
     const authorIds = new Set(windowed.map((m) => m.authorId))
     const messageIds = windowed.map((m) => m.id)
-    const [authorNames, attachmentsByMessage] = await Promise.all([
+    const [authorNames, attachmentsByMessage, linkPreviewsByMessage] = await Promise.all([
       resolveActorNames(db, conversation.workspaceId, authorIds),
       AttachmentRepository.findByMessageIds(db, messageIds),
+      LinkPreviewRepository.findByMessageIds(db, conversation.workspaceId, messageIds),
     ])
 
     const items: RenderableMessage[] = windowed.map((m) => {
@@ -117,6 +119,7 @@ export const ConversationResolver: Resolver<ConversationContextRef> = {
                 sizeBytes: a.sizeBytes,
               }))
           : undefined
+      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter((preview) => preview.status === "completed")
       return {
         messageId: m.id,
         authorId: m.authorId,
@@ -126,12 +129,13 @@ export const ConversationResolver: Resolver<ConversationContextRef> = {
         editedAt: m.editedAt?.toISOString() ?? null,
         sequence: m.sequence,
         ...(attachments && { attachments }),
+        ...(linkPreviews.length > 0 && { linkPreviews }),
       }
     })
 
     const inputs: SummaryInput[] = items.map((item) => ({
       messageId: item.messageId,
-      contentFingerprint: fingerprintContent(item.contentMarkdown),
+      contentFingerprint: fingerprintContent(item.contentMarkdown + renderLinkPreviewContext(item.linkPreviews ?? [])),
       editedAt: item.editedAt,
       deleted: false,
     }))

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -3,6 +3,7 @@ import { ContextIntents, ContextRefKinds, Visibilities } from "@threa/types"
 import { ThreadResolver } from "./thread-resolver"
 import { AttachmentRepository, type Attachment } from "../../../attachments"
 import { MessageRepository } from "../../../messaging"
+import { LinkPreviewRepository } from "../../../link-previews"
 import { StreamRepository, StreamMemberRepository } from "../../../streams"
 import { UserRepository } from "../../../workspaces"
 import { PersonaRepository } from "../../persona-repository"
@@ -11,6 +12,7 @@ import { PersonaRepository } from "../../persona-repository"
 // tests that care about attachment rendering override locally.
 beforeEach(() => {
   spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+  spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
 })
 
 function makeStream(overrides: Record<string, any> = {}): any {

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -1,5 +1,11 @@
 import type { Querier } from "../../../../db"
-import { ContextIntents, ContextRefKinds, type AttachmentSummary, type ContextRef } from "@threa/types"
+import {
+  ContextIntents,
+  ContextRefKinds,
+  LinkPreviewStatuses,
+  type AttachmentSummary,
+  type ContextRef,
+} from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import { AttachmentRepository } from "../../../attachments"
 import { LinkPreviewRepository, renderLinkPreviewContext } from "../../../link-previews"
@@ -122,7 +128,9 @@ export const ThreadResolver: Resolver<ThreadRef> = {
                 sizeBytes: a.sizeBytes,
               }))
           : undefined
-      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter((preview) => preview.status === "completed")
+      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter(
+        (preview) => preview.status === LinkPreviewStatuses.COMPLETED
+      )
       return {
         messageId: m.id,
         authorId: m.authorId,

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -2,6 +2,7 @@ import type { Querier } from "../../../../db"
 import { ContextIntents, ContextRefKinds, type AttachmentSummary, type ContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import { AttachmentRepository } from "../../../attachments"
+import { LinkPreviewRepository, renderLinkPreviewContext } from "../../../link-previews"
 import type { Message } from "../../../messaging"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, checkStreamAccess } from "../../../streams"
@@ -93,7 +94,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
 
     const authorIds = new Set(withRoot.map((m) => m.authorId))
     const messageIds = withRoot.map((m) => m.id)
-    const [authorNames, attachmentsByMessage] = await Promise.all([
+    const [authorNames, attachmentsByMessage, linkPreviewsByMessage] = await Promise.all([
       resolveActorNames(db, stream.workspaceId, authorIds),
       // Without this the focal message in a "Discuss with Ariadne" window
       // loses its attachments — the trace shows only the text and the model
@@ -101,6 +102,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
       // inline below; full extraction content stays behind the existing
       // attachment tools so we don't duplicate the heavy enrichment path.
       AttachmentRepository.findByMessageIds(db, messageIds),
+      LinkPreviewRepository.findByMessageIds(db, stream.workspaceId, messageIds),
     ])
 
     const items: RenderableMessage[] = withRoot.map((m) => {
@@ -120,6 +122,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
                 sizeBytes: a.sizeBytes,
               }))
           : undefined
+      const linkPreviews = (linkPreviewsByMessage.get(m.id) ?? []).filter((preview) => preview.status === "completed")
       return {
         messageId: m.id,
         authorId: m.authorId,
@@ -129,6 +132,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
         editedAt: m.editedAt?.toISOString() ?? null,
         sequence: m.sequence,
         ...(attachments && { attachments }),
+        ...(linkPreviews.length > 0 && { linkPreviews }),
       }
     })
 
@@ -140,7 +144,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
     // fingerprint stays put — the cache would silently serve a stale summary.
     const inputs: SummaryInput[] = items.map((item) => ({
       messageId: item.messageId,
-      contentFingerprint: fingerprintContent(item.contentMarkdown),
+      contentFingerprint: fingerprintContent(item.contentMarkdown + renderLinkPreviewContext(item.linkPreviews ?? [])),
       editedAt: item.editedAt,
       deleted: false,
     }))

--- a/apps/backend/src/features/agents/context-bag/types.ts
+++ b/apps/backend/src/features/agents/context-bag/types.ts
@@ -1,5 +1,6 @@
 import type { AttachmentSummary, ContextBag, ContextIntent, ContextRef, ContextRefKind } from "@threa/types"
 import type { Querier } from "../../../db"
+import type { LinkPreview } from "../../link-previews"
 import type { AI, CostContext } from "@threa/agent-runtime"
 
 /**
@@ -57,6 +58,8 @@ export interface RenderableMessage {
   sequence: bigint
   /** Attachments on this source message, if any. Omitted when the message has none. */
   attachments?: AttachmentSummary[]
+  /** Completed preview-card metadata on this source message. */
+  linkPreviews?: LinkPreview[]
 }
 
 /**

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -23,6 +23,7 @@ import { MessageRepository, type Message } from "../messaging"
 import { UserRepository } from "../workspaces"
 import { AttachmentRepository } from "../attachments"
 import { AttachmentExtractionRepository, type PdfMetadata, type PdfSection } from "../attachments"
+import { enrichMessagesWithLinkPreviews } from "../link-previews"
 import { getUtcOffset, type TemporalContext, type ParticipantTemporal } from "../../lib/temporal"
 import { DEFAULT_CONTEXT_WINDOW_MESSAGES } from "./context-window-policy"
 
@@ -167,6 +168,8 @@ export interface BuildStreamContextOptions {
   triggerMessageId?: string
   /** Whether to include attachment context */
   includeAttachments?: boolean
+  /** Whether to append completed link-preview card metadata to each message. */
+  includeLinkPreviews?: boolean
   /**
    * Storage provider for loading image data.
    * Required when loadImages is true.
@@ -282,6 +285,13 @@ export async function buildStreamContext(
       storage: options.storage,
       loadImages: options.loadImages,
     })
+  }
+  if (options?.includeLinkPreviews) {
+    context.conversationHistory = await enrichMessagesWithLinkPreviews(
+      db,
+      stream.workspaceId,
+      context.conversationHistory
+    )
   }
 
   return context

--- a/apps/backend/src/features/agents/conversation-summary-service.test.ts
+++ b/apps/backend/src/features/agents/conversation-summary-service.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:t
 import type { AI } from "@threa/agent-runtime"
 import type { Message } from "../messaging"
 import { MessageRepository } from "../messaging"
+import { LinkPreviewRepository } from "../link-previews"
 import { ConversationSummaryRepository } from "./conversation-summary-repository"
 import { ConversationSummaryService } from "./conversation-summary-service"
 
@@ -59,6 +60,7 @@ describe("ConversationSummaryService", () => {
   const upsertSummarySpy = spyOn(ConversationSummaryRepository, "upsert")
   const listMessagesSpy = spyOn(MessageRepository, "list")
   const listByRangeSpy = spyOn(MessageRepository, "listBySequenceRange")
+  const linkPreviewsSpy = spyOn(LinkPreviewRepository, "findByMessageIds")
 
   beforeEach(() => {
     mockGenerateText.mockClear()
@@ -66,6 +68,8 @@ describe("ConversationSummaryService", () => {
     upsertSummarySpy.mockClear()
     listMessagesSpy.mockClear()
     listByRangeSpy.mockClear()
+    linkPreviewsSpy.mockClear()
+    linkPreviewsSpy.mockResolvedValue(new Map())
     findSummarySpy.mockResolvedValue(null)
     upsertSummarySpy.mockResolvedValue({
       id: "agsum_1",

--- a/apps/backend/src/features/agents/conversation-summary-service.ts
+++ b/apps/backend/src/features/agents/conversation-summary-service.ts
@@ -1,5 +1,6 @@
 import type { Querier } from "../../db"
 import { MessageRepository, type Message } from "../messaging"
+import { enrichMessagesWithLinkPreviews } from "../link-previews"
 import { agentConversationSummaryId } from "../../lib/id"
 import type { AI } from "@threa/agent-runtime"
 import {
@@ -83,6 +84,7 @@ export class ConversationSummaryService {
       })
       if (batch.length === 0) break
 
+      const enrichedBatch = await enrichMessagesWithLinkPreviews(db, workspaceId, batch)
       try {
         currentSummary = await foldRollingSummary({
           ai: this.deps.ai,
@@ -90,7 +92,7 @@ export class ConversationSummaryService {
           modelString: this.deps.modelId,
           temperature: this.deps.temperature,
           existingSummary: currentSummary,
-          newMessages: batch.map(toSummaryMessage),
+          newMessages: enrichedBatch.map(toSummaryMessage),
           telemetry: { functionId: "summary-update" },
           context: { workspaceId, origin: "system" },
         })

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -23,7 +23,7 @@ import { addStalenessFields } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
 import { emitAssignmentEvents } from "./assignment-events"
 import { conversationId } from "../../lib/id"
-import { AuthorTypes, ConversationStatuses, StreamTypes } from "@threa/types"
+import { AuthorTypes, ConversationStatuses, LinkPreviewStatuses, StreamTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
 
 const MESSAGES_BEFORE = 5
@@ -303,7 +303,7 @@ export class BoundaryExtractionService {
       const linkPreviewsByMessageId = new Map(
         [...previewRowsByMessage].map(([targetMessageId, previews]) => [
           targetMessageId,
-          previews.filter((preview) => preview.status === "completed"),
+          previews.filter((preview) => preview.status === LinkPreviewStatuses.COMPLETED),
         ])
       )
 

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -5,6 +5,7 @@ import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository, type Stream } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
 import { AttachmentRepository, awaitAttachmentProcessing, type AttachmentWithExtraction } from "../attachments"
+import { awaitLinkPreviewProcessing, LinkPreviewRepository } from "../link-previews"
 import type {
   AttachmentExtractContext,
   BoundaryExtractor,
@@ -272,6 +273,7 @@ export class BoundaryExtractionService {
     // connection held (INV-41), then fetch extractions on the pool (INV-30).
     let extractionContext: ExtractionContext | null = null
     if (extractionContextBase && attachmentTargetIds) {
+      const linkPreviewProcessing = awaitLinkPreviewProcessing(this.pool, workspaceId, [message])
       if (newMessageAttachmentIds && newMessageAttachmentIds.length > 0) {
         logger.debug(
           { messageId, attachmentCount: newMessageAttachmentIds.length },
@@ -291,13 +293,21 @@ export class BoundaryExtractionService {
         }
       }
 
-      const attachmentsByMessage = await AttachmentRepository.findByMessageIdsWithExtractions(
-        this.pool,
-        attachmentTargetIds
-      )
-      const attachmentsByMessageId = buildAttachmentContextMap(attachmentsByMessage, message.id)
+      await linkPreviewProcessing
 
-      extractionContext = { ...extractionContextBase, attachmentsByMessageId }
+      const [attachmentsByMessage, previewRowsByMessage] = await Promise.all([
+        AttachmentRepository.findByMessageIdsWithExtractions(this.pool, attachmentTargetIds),
+        LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, attachmentTargetIds),
+      ])
+      const attachmentsByMessageId = buildAttachmentContextMap(attachmentsByMessage, message.id)
+      const linkPreviewsByMessageId = new Map(
+        [...previewRowsByMessage].map(([targetMessageId, previews]) => [
+          targetMessageId,
+          previews.filter((preview) => preview.status === "completed"),
+        ])
+      )
+
+      extractionContext = { ...extractionContextBase, attachmentsByMessageId, linkPreviewsByMessageId }
     }
 
     // Phase 2: determine conversation (AI call only for channels/threads).

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -709,6 +709,47 @@ describe("LLMBoundaryExtractor", () => {
     })
   })
 
+  describe("link preview context", () => {
+    test("includes completed card metadata in the classification prompt", async () => {
+      const newMessage = createMockMessage({ id: "msg_link", contentMarkdown: "https://x.com/example/status/123" })
+      const existingConv = createMockConversation({ id: "conv_existing" })
+      const context = createMockContext({
+        streamType: "channel",
+        newMessage,
+        recentMessages: [newMessage],
+        activeConversations: [existingConv],
+        linkPreviewsByMessageId: new Map([
+          [
+            newMessage.id,
+            [
+              {
+                url: "https://x.com/example/status/123",
+                title: "Pierre on agent context",
+                description: "Agents should receive the subject of linked posts.",
+                siteName: "X",
+                status: "completed",
+              } as never,
+            ],
+          ],
+        ]),
+      })
+      mockGenerateObject.mockResolvedValueOnce({
+        value: { assignments: [{ conversationId: "conv_existing", isPrimary: true }], confidence: 0.9 },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const prompt = calls[0]?.[0].messages.find((message) => message.role === "user")?.content ?? ""
+      expect(prompt).toContain('title="Pierre on agent context"')
+      expect(prompt).toContain("Agents should receive the subject of linked posts.")
+    })
+  })
+
   describe("temporal context in prompt", () => {
     test("renders message ages and conversation last-activity relative to the new message", async () => {
       const now = new Date("2026-07-01T12:00:00Z")

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -14,6 +14,7 @@ import type {
   SplitGroup,
 } from "./types"
 import type { Message } from "../../messaging"
+import { renderLinkPreviewContext } from "../../link-previews"
 import { logger } from "../../../lib/logger"
 import { StreamTypes } from "@threa/types"
 import {
@@ -289,19 +290,23 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
         : "No active conversations in this stream yet."
 
     const attachmentsByMessageId = context.attachmentsByMessageId ?? new Map()
+    const linkPreviewsByMessageId = context.linkPreviewsByMessageId ?? new Map()
 
     const recentSection = context.recentMessages
       .map((m) => {
         const head = `[${m.id}] (${formatRelativeAge(m.createdAt, now)}) ${m.authorType}:${m.authorId.slice(-8)}: ${m.contentMarkdown.slice(0, 200)}${m.contentMarkdown.length > 200 ? "..." : ""}`
         const atts = attachmentsByMessageId.get(m.id)
         const attBlock = atts && atts.length > 0 ? `\n${this.renderAttachments(atts, RECENT_ATTACHMENT_CHARS)}` : ""
-        return head + attBlock
+        const previewBlock = renderLinkPreviewContext(linkPreviewsByMessageId.get(m.id) ?? [])
+        return head + attBlock + (previewBlock ? `\n${previewBlock}` : "")
       })
       .join("\n")
 
     const newMessageAtts = attachmentsByMessageId.get(context.newMessage.id) ?? []
     const newMessageAttachmentSection =
       newMessageAtts.length > 0 ? `\n${this.renderAttachments(newMessageAtts, NEW_MESSAGE_ATTACHMENT_CHARS)}` : ""
+    const newMessagePreviewBlock = renderLinkPreviewContext(linkPreviewsByMessageId.get(context.newMessage.id) ?? [])
+    const newMessagePreviewSection = newMessagePreviewBlock ? `\n${newMessagePreviewBlock}` : ""
 
     const replyTargets = context.replyTargets ?? []
     const replySection =
@@ -317,7 +322,10 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
     return BOUNDARY_EXTRACTION_PROMPT.replace("{{CONVERSATIONS}}", convSection)
       .replace("{{RECENT_MESSAGES}}", recentSection || "No recent messages.")
       .replace("{{AUTHOR}}", `${context.newMessage.authorType}:${context.newMessage.authorId.slice(-8)}`)
-      .replace("{{CONTENT}}", context.newMessage.contentMarkdown + newMessageAttachmentSection)
+      .replace(
+        "{{CONTENT}}",
+        context.newMessage.contentMarkdown + newMessageAttachmentSection + newMessagePreviewSection
+      )
       .replace("{{REPLY_CONTEXT}}", replySection)
   }
 

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import { CONVERSATION_STATUSES } from "@threa/types"
 import type { Message } from "../../messaging"
+import type { LinkPreview } from "../../link-previews"
 
 /**
  * Internal Zod schemas for boundary extraction output shapes.
@@ -154,6 +155,8 @@ export interface ExtractionContext {
    * relevant attachments exist.
    */
   attachmentsByMessageId?: Map<string, AttachmentExtractContext[]>
+  /** Completed link-preview card metadata, keyed by source message id. */
+  linkPreviewsByMessageId?: Map<string, LinkPreview[]>
   /** Workspace ID for cost tracking - required for cost attribution */
   workspaceId: string
 }

--- a/apps/backend/src/features/link-previews/ai-context.test.ts
+++ b/apps/backend/src/features/link-previews/ai-context.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, spyOn } from "bun:test"
+import { awaitLinkPreviewProcessing, renderLinkPreviewContext } from "./ai-context"
+import { LinkPreviewRepository, type LinkPreview } from "./repository"
+
+function preview(overrides: Partial<LinkPreview> = {}): LinkPreview {
+  return {
+    id: "lp_1",
+    workspaceId: "ws_1",
+    url: "https://x.com/example/status/123",
+    normalizedUrl: "https://x.com/example/status/123",
+    title: "Example",
+    description: "The actual subject of the linked post.",
+    imageUrl: "https://example.com/image.jpg",
+    faviconUrl: null,
+    siteName: "X",
+    contentType: "website",
+    status: "completed",
+    previewType: null,
+    previewData: null,
+    targetWorkspaceId: null,
+    targetStreamId: null,
+    targetMessageId: null,
+    targetMemoId: null,
+    targetConversationId: null,
+    fetchedAt: new Date(),
+    expiresAt: null,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe("renderLinkPreviewContext", () => {
+  it("renders the same textual metadata used by a link-preview card", () => {
+    expect(renderLinkPreviewContext([preview()])).toBe(
+      '<link-preview url="https://x.com/example/status/123" site="X" title="Example">\nThe actual subject of the linked post.\n</link-preview>'
+    )
+  })
+
+  it("escapes metadata and omits empty cards", () => {
+    expect(
+      renderLinkPreviewContext([
+        preview({
+          url: "https://example.com/?a=1&b=2",
+          title: 'A <title> "quoted"',
+          description: "x & y",
+          siteName: null,
+        }),
+        preview({ id: "lp_2", title: null, description: null, siteName: null }),
+      ])
+    ).toBe(
+      '<link-preview url="https://example.com/?a=1&amp;b=2" title="A &lt;title&gt; &quot;quoted&quot;">\nx &amp; y\n</link-preview>'
+    )
+  })
+})
+
+describe("awaitLinkPreviewProcessing", () => {
+  it("waits for the extraction peer to create a row before treating it as complete", async () => {
+    const completed = preview()
+    const find = spyOn(LinkPreviewRepository, "findByMessageIds")
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(new Map([["msg_1", [completed]]]))
+
+    const result = await awaitLinkPreviewProcessing(
+      {} as never,
+      "ws_1",
+      [
+        {
+          id: "msg_1",
+          contentMarkdown: "https://x.com/example/status/123",
+          contentJson: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "https://x.com/example/status/123" }],
+              },
+            ],
+          },
+        },
+      ],
+      500
+    )
+
+    expect(result).toEqual({
+      allCompleted: true,
+      completedUrls: ["https://x.com/example/status/123"],
+      failedOrTimedOutUrls: [],
+    })
+    expect(find).toHaveBeenCalledTimes(2)
+    find.mockRestore()
+  })
+})

--- a/apps/backend/src/features/link-previews/ai-context.test.ts
+++ b/apps/backend/src/features/link-previews/ai-context.test.ts
@@ -85,6 +85,7 @@ describe("awaitLinkPreviewProcessing", () => {
       allCompleted: true,
       completedUrls: ["https://x.com/example/status/123"],
       failedOrTimedOutUrls: [],
+      previewsByMessage: new Map([["msg_1", [completed]]]),
     })
     expect(find).toHaveBeenCalledTimes(2)
     find.mockRestore()

--- a/apps/backend/src/features/link-previews/ai-context.ts
+++ b/apps/backend/src/features/link-previews/ai-context.ts
@@ -1,5 +1,5 @@
 import type { Pool } from "pg"
-import type { JSONContent } from "@threa/types"
+import { LinkPreviewStatuses, type JSONContent } from "@threa/types"
 import type { Querier } from "../../db"
 import { logger } from "../../lib/logger"
 import { escapeXmlAttr } from "../../lib/xml"
@@ -20,6 +20,7 @@ export interface AwaitLinkPreviewProcessingResult {
   allCompleted: boolean
   completedUrls: string[]
   failedOrTimedOutUrls: string[]
+  previewsByMessage: Map<string, LinkPreview[]>
 }
 
 /**
@@ -42,25 +43,28 @@ export async function awaitLinkPreviewProcessing(
     )
     if (urls.length > 0) expected.set(message.id, new Set(urls.map(normalizeUrl)))
   }
-  if (expected.size === 0) return { allCompleted: true, completedUrls: [], failedOrTimedOutUrls: [] }
+  if (expected.size === 0) {
+    return { allCompleted: true, completedUrls: [], failedOrTimedOutUrls: [], previewsByMessage: new Map() }
+  }
 
   const startedAt = Date.now()
   const completedKeys = new Set<string>()
   const failedKeys = new Set<string>()
+  let previewsByMessage = new Map<string, LinkPreview[]>()
 
   while (Date.now() - startedAt < timeoutMs) {
-    const rowsByMessage = await LinkPreviewRepository.findByMessageIds(pool, workspaceId, [...expected.keys()])
+    previewsByMessage = await LinkPreviewRepository.findByMessageIds(pool, workspaceId, [...expected.keys()])
     let hasPending = false
 
     for (const [messageId, normalizedUrls] of expected) {
-      const rows = rowsByMessage.get(messageId) ?? []
+      const rows = previewsByMessage.get(messageId) ?? []
       for (const normalizedUrl of normalizedUrls) {
         const row = rows.find((candidate) => candidate.normalizedUrl === normalizedUrl)
         if (!row) {
           hasPending = true
-        } else if (row.status === "completed") {
+        } else if (row.status === LinkPreviewStatuses.COMPLETED) {
           completedKeys.add(`${messageId}:${normalizedUrl}`)
-        } else if (row.status === "failed") {
+        } else if (row.status === LinkPreviewStatuses.FAILED) {
           failedKeys.add(`${messageId}:${normalizedUrl}`)
         } else {
           hasPending = true
@@ -93,6 +97,7 @@ export async function awaitLinkPreviewProcessing(
     allCompleted: failedOrTimedOutUrls.length === 0,
     completedUrls,
     failedOrTimedOutUrls,
+    previewsByMessage,
   }
 }
 
@@ -109,9 +114,16 @@ export async function enrichMessagesWithLinkPreviews<T extends LinkPreviewContex
     messages.map((message) => message.id)
   )
 
+  return enrichMessagesWithLinkPreviewMap(messages, previewsByMessage)
+}
+
+export function enrichMessagesWithLinkPreviewMap<T extends LinkPreviewContextMessage>(
+  messages: T[],
+  previewsByMessage: Map<string, LinkPreview[]>
+): T[] {
   return messages.map((message) => {
     const rendered = renderLinkPreviewContext(
-      (previewsByMessage.get(message.id) ?? []).filter((preview) => preview.status === "completed")
+      (previewsByMessage.get(message.id) ?? []).filter((preview) => preview.status === LinkPreviewStatuses.COMPLETED)
     )
     return rendered ? { ...message, contentMarkdown: `${message.contentMarkdown}\n\n${rendered}` } : message
   })

--- a/apps/backend/src/features/link-previews/ai-context.ts
+++ b/apps/backend/src/features/link-previews/ai-context.ts
@@ -1,0 +1,140 @@
+import type { Pool } from "pg"
+import type { JSONContent } from "@threa/types"
+import type { Querier } from "../../db"
+import { logger } from "../../lib/logger"
+import { escapeXmlAttr } from "../../lib/xml"
+import { MAX_PREVIEWS_PER_MESSAGE, getAppOrigins } from "./config"
+import { LinkPreviewRepository, type LinkPreview } from "./repository"
+import { extractUrls, normalizeUrl } from "./url-utils"
+
+export const DEFAULT_LINK_PREVIEW_PROCESSING_TIMEOUT_MS = 5_000
+const POLL_INTERVAL_MS = 100
+
+export interface LinkPreviewContextMessage {
+  id: string
+  contentMarkdown: string
+  contentJson: JSONContent
+}
+
+export interface AwaitLinkPreviewProcessingResult {
+  allCompleted: boolean
+  completedUrls: string[]
+  failedOrTimedOutUrls: string[]
+}
+
+/**
+ * Wait for the preview worker to create and settle every preview implied by the
+ * canonical message content. Rows may not exist on the first poll because URL
+ * extraction and AI consumers are independent outbox peers.
+ */
+export async function awaitLinkPreviewProcessing(
+  pool: Pool,
+  workspaceId: string,
+  messages: LinkPreviewContextMessage[],
+  timeoutMs: number = DEFAULT_LINK_PREVIEW_PROCESSING_TIMEOUT_MS
+): Promise<AwaitLinkPreviewProcessingResult> {
+  const appOrigins = getAppOrigins()
+  const expected = new Map<string, Set<string>>()
+  for (const message of messages) {
+    const urls = extractUrls(message.contentMarkdown, appOrigins, message.contentJson).slice(
+      0,
+      MAX_PREVIEWS_PER_MESSAGE
+    )
+    if (urls.length > 0) expected.set(message.id, new Set(urls.map(normalizeUrl)))
+  }
+  if (expected.size === 0) return { allCompleted: true, completedUrls: [], failedOrTimedOutUrls: [] }
+
+  const startedAt = Date.now()
+  const completedKeys = new Set<string>()
+  const failedKeys = new Set<string>()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const rowsByMessage = await LinkPreviewRepository.findByMessageIds(pool, workspaceId, [...expected.keys()])
+    let hasPending = false
+
+    for (const [messageId, normalizedUrls] of expected) {
+      const rows = rowsByMessage.get(messageId) ?? []
+      for (const normalizedUrl of normalizedUrls) {
+        const row = rows.find((candidate) => candidate.normalizedUrl === normalizedUrl)
+        if (!row) {
+          hasPending = true
+        } else if (row.status === "completed") {
+          completedKeys.add(`${messageId}:${normalizedUrl}`)
+        } else if (row.status === "failed") {
+          failedKeys.add(`${messageId}:${normalizedUrl}`)
+        } else {
+          hasPending = true
+        }
+      }
+    }
+
+    if (!hasPending) break
+    await sleep(POLL_INTERVAL_MS)
+  }
+
+  const timedOutUrls: string[] = []
+  for (const [messageId, normalizedUrls] of expected) {
+    for (const normalizedUrl of normalizedUrls) {
+      const key = `${messageId}:${normalizedUrl}`
+      if (!completedKeys.has(key) && !failedKeys.has(key)) timedOutUrls.push(normalizedUrl)
+    }
+  }
+  if (timedOutUrls.length > 0) {
+    logger.warn(
+      { workspaceId, timedOutCount: timedOutUrls.length, timeoutMs },
+      "Link previews timed out before AI context assembly"
+    )
+  }
+
+  const failedUrls = [...failedKeys].map((key) => key.slice(key.indexOf(":") + 1))
+  const completedUrls = [...completedKeys].map((key) => key.slice(key.indexOf(":") + 1))
+  const failedOrTimedOutUrls = [...failedUrls, ...timedOutUrls]
+  return {
+    allCompleted: failedOrTimedOutUrls.length === 0,
+    completedUrls,
+    failedOrTimedOutUrls,
+  }
+}
+
+/** Append completed card metadata to message text without mutating stored content. */
+export async function enrichMessagesWithLinkPreviews<T extends LinkPreviewContextMessage>(
+  db: Querier,
+  workspaceId: string,
+  messages: T[]
+): Promise<T[]> {
+  if (messages.length === 0) return messages
+  const previewsByMessage = await LinkPreviewRepository.findByMessageIds(
+    db,
+    workspaceId,
+    messages.map((message) => message.id)
+  )
+
+  return messages.map((message) => {
+    const rendered = renderLinkPreviewContext(
+      (previewsByMessage.get(message.id) ?? []).filter((preview) => preview.status === "completed")
+    )
+    return rendered ? { ...message, contentMarkdown: `${message.contentMarkdown}\n\n${rendered}` } : message
+  })
+}
+
+/** Render the textual fields visible on a preview card; image URLs add no semantic context. */
+export function renderLinkPreviewContext(previews: LinkPreview[]): string {
+  return previews
+    .filter((preview) => preview.title || preview.description || preview.siteName)
+    .map((preview) => {
+      const attrs = [`url="${escapeXmlAttr(preview.url)}"`]
+      if (preview.siteName) attrs.push(`site="${escapeXmlAttr(preview.siteName)}"`)
+      if (preview.title) attrs.push(`title="${escapeXmlAttr(preview.title)}"`)
+      const body = preview.description ? `\n${escapeXml(preview.description)}\n` : ""
+      return `<link-preview ${attrs.join(" ")}>${body}</link-preview>`
+    })
+    .join("\n")
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/apps/backend/src/features/link-previews/index.ts
+++ b/apps/backend/src/features/link-previews/index.ts
@@ -18,6 +18,7 @@ export { MAX_PREVIEWS_PER_MESSAGE, getAppOrigins } from "./config"
 export {
   awaitLinkPreviewProcessing,
   enrichMessagesWithLinkPreviews,
+  enrichMessagesWithLinkPreviewMap,
   renderLinkPreviewContext,
   DEFAULT_LINK_PREVIEW_PROCESSING_TIMEOUT_MS,
 } from "./ai-context"

--- a/apps/backend/src/features/link-previews/index.ts
+++ b/apps/backend/src/features/link-previews/index.ts
@@ -14,3 +14,11 @@ export { extractUrls, normalizeUrl, detectContentType, isBlockedUrl, parseInAppL
 export type { InAppLinkRef } from "./url-utils"
 
 export { MAX_PREVIEWS_PER_MESSAGE, getAppOrigins } from "./config"
+
+export {
+  awaitLinkPreviewProcessing,
+  enrichMessagesWithLinkPreviews,
+  renderLinkPreviewContext,
+  DEFAULT_LINK_PREVIEW_PROCESSING_TIMEOUT_MS,
+} from "./ai-context"
+export type { AwaitLinkPreviewProcessingResult, LinkPreviewContextMessage } from "./ai-context"

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -13,6 +13,7 @@ import { StreamEventRepository, StreamStateRepository, StreamRepository, type St
 import type { StreamEvent } from "../streams"
 import { ConversationRepository } from "../conversations"
 import { MessageRepository } from "../messaging"
+import { LinkPreviewRepository } from "../link-previews"
 import { UserRepository } from "../workspaces"
 import { WorkspaceSettingsRepository } from "../workspace-settings"
 import * as dbModule from "../../db"
@@ -122,6 +123,7 @@ function setupService(options: { memoContents: MemoContent[] }) {
   spyOn(MemoRepository, "updateEmbedding").mockResolvedValue(undefined as never)
   spyOn(ConversationRepository, "findById").mockResolvedValue(fakeConversation())
   spyOn(MessageRepository, "findByIds").mockResolvedValue(fakeMessages())
+  spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_1", timezone: "UTC" }] as never)
   spyOn(StreamStateRepository, "markProcessed").mockResolvedValue(undefined as never)
   const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -372,11 +372,18 @@ export class MemoService implements MemoServiceLike {
     // by classification, suggestions, and memorization. Memo accumulation is
     // delayed, so unlike send-time AI consumers it does not need to poll.
     const relativeTo = new Date()
+    const allMessageRows = [...fetchedData.conversationMessages.values()].flatMap((messages) =>
+      [...messages.values()].filter((message): message is Message => message !== null)
+    )
+    const enrichedMessages = await enrichMessagesWithLinkPreviews(this.pool, workspaceId, allMessageRows)
+    const enrichedById = new Map(enrichedMessages.map((message) => [message.id, message]))
+
     for (const [conversationId, messages] of fetchedData.conversationMessages) {
-      const messageRows = [...messages.values()].filter((message): message is Message => message !== null)
+      const messageRows = [...messages.values()]
+        .filter((message): message is Message => message !== null)
+        .map((message) => enrichedById.get(message.id) ?? message)
       if (messageRows.length === 0) continue
-      const enriched = await enrichMessagesWithLinkPreviews(this.pool, workspaceId, messageRows)
-      const formatted = await this.messageFormatter.formatMessages(this.pool, workspaceId, enriched, {
+      const formatted = await this.messageFormatter.formatMessages(this.pool, workspaceId, messageRows, {
         includeIds: true,
         relativeTo,
       })

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -3,6 +3,7 @@ import { withTransaction, withClient, type Querier } from "../../db"
 import { StreamStateRepository, StreamEventRepository, StreamRepository, type Stream } from "../streams"
 import { ConversationRepository } from "../conversations"
 import { MessageRepository, type Message } from "../messaging"
+import { enrichMessagesWithLinkPreviews } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
 import { WorkspaceSettingsRepository } from "../workspace-settings"
@@ -319,26 +320,7 @@ export class MemoService implements MemoServiceLike {
         }
       }
 
-      // Pre-format all messages while we have database access (INV-41)
-      // Formatting requires resolving author names from the database.
-      // includeIds: the memorizer and suggestion collector must cite source
-      // message ids; without ids in the prompt the model can't reference them and
-      // every memo falls back to the whole conversation (mis-attribution).
-      // Anchor relative ages to one "now" for the whole batch so the classifier
-      // and memorizer can weigh durability (live vs. stale content) without
-      // reasoning over absolute timestamps.
-      const now = new Date()
       const formattedConversations = new Map<string, string>()
-      for (const [convId, msgs] of conversationMessages) {
-        const messagesArray = Array.from(msgs.values()).filter((m): m is Message => m !== null)
-        if (messagesArray.length > 0) {
-          const formatted = await this.messageFormatter.formatMessages(client, workspaceId, messagesArray, {
-            includeIds: true,
-            relativeTo: now,
-          })
-          formattedConversations.set(convId, formatted)
-        }
-      }
 
       // Fetch author timezones for date anchoring in memos
       const authorIds = new Set<string>()
@@ -384,6 +366,21 @@ export class MemoService implements MemoServiceLike {
 
     if (!fetchedData) {
       return { processed: 0, memosCreated: 0 }
+    }
+
+    // Format completed preview-card metadata into the same transcript consumed
+    // by classification, suggestions, and memorization. Memo accumulation is
+    // delayed, so unlike send-time AI consumers it does not need to poll.
+    const relativeTo = new Date()
+    for (const [conversationId, messages] of fetchedData.conversationMessages) {
+      const messageRows = [...messages.values()].filter((message): message is Message => message !== null)
+      if (messageRows.length === 0) continue
+      const enriched = await enrichMessagesWithLinkPreviews(this.pool, workspaceId, messageRows)
+      const formatted = await this.messageFormatter.formatMessages(this.pool, workspaceId, enriched, {
+        includeIds: true,
+        relativeTo,
+      })
+      fetchedData.formattedConversations.set(conversationId, formatted)
     }
 
     const memoryContext = fetchedData.existingMemos.map((m) => m.abstract)

--- a/apps/backend/src/features/streams/naming-service.test.ts
+++ b/apps/backend/src/features/streams/naming-service.test.ts
@@ -3,6 +3,7 @@ import { StreamNamingService } from "./naming-service"
 import { MessageFormatter } from "../../lib/ai/message-formatter"
 import { AttachmentRepository } from "../attachments"
 import { MessageRepository } from "../messaging"
+import { LinkPreviewRepository } from "../link-previews"
 import { StreamRepository } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -84,6 +85,7 @@ describe("StreamNamingService", () => {
     spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
     spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
     spyOn(AttachmentRepository, "findByMessageIdsWithExtractions").mockResolvedValue(new Map())
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
 
     service = new StreamNamingService(mockPool, mockAI as AI, mockConfigResolver, mockMessageFormatter)
   })

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -11,6 +11,7 @@ import { needsAutoNaming } from "./display-name"
 import { logger } from "../../lib/logger"
 import { MessageFormatter } from "../../lib/ai/message-formatter"
 import { awaitAttachmentProcessing } from "../attachments"
+import { awaitLinkPreviewProcessing, enrichMessagesWithLinkPreviews } from "../link-previews"
 import { MAX_MESSAGES_FOR_NAMING, MAX_EXISTING_NAMES, buildNamingSystemPrompt } from "./naming-config"
 
 export interface GenerateNameResult {
@@ -129,6 +130,8 @@ export class StreamNamingService {
 
     const { stream, messages, otherStreams, attachmentIds } = fetchedData
 
+    const linkPreviewProcessing = awaitLinkPreviewProcessing(this.pool, stream.workspaceId, messages)
+
     // Await attachment processing (no connection held) so extractions are
     // available before formatting the conversation
     if (attachmentIds.length > 0) {
@@ -147,6 +150,8 @@ export class StreamNamingService {
       )
     }
 
+    await linkPreviewProcessing
+
     // Uses pool directly per INV-30 (single-query path)
     const messageIds = messages.map((m) => m.id)
     let attachmentsByMessageId: Map<string, AttachmentWithExtraction[]>
@@ -156,10 +161,11 @@ export class StreamNamingService {
       attachmentsByMessageId = new Map()
     }
 
+    const messagesWithLinkPreviews = await enrichMessagesWithLinkPreviews(this.pool, stream.workspaceId, messages)
     const conversationText = await this.messageFormatter.formatMessagesWithAttachments(
       this.pool,
       stream.workspaceId,
-      messages,
+      messagesWithLinkPreviews,
       attachmentsByMessageId
     )
 

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -11,7 +11,7 @@ import { needsAutoNaming } from "./display-name"
 import { logger } from "../../lib/logger"
 import { MessageFormatter } from "../../lib/ai/message-formatter"
 import { awaitAttachmentProcessing } from "../attachments"
-import { awaitLinkPreviewProcessing, enrichMessagesWithLinkPreviews } from "../link-previews"
+import { awaitLinkPreviewProcessing, enrichMessagesWithLinkPreviewMap } from "../link-previews"
 import { MAX_MESSAGES_FOR_NAMING, MAX_EXISTING_NAMES, buildNamingSystemPrompt } from "./naming-config"
 
 export interface GenerateNameResult {
@@ -150,7 +150,7 @@ export class StreamNamingService {
       )
     }
 
-    await linkPreviewProcessing
+    const linkPreviewResult = await linkPreviewProcessing
 
     // Uses pool directly per INV-30 (single-query path)
     const messageIds = messages.map((m) => m.id)
@@ -161,7 +161,7 @@ export class StreamNamingService {
       attachmentsByMessageId = new Map()
     }
 
-    const messagesWithLinkPreviews = await enrichMessagesWithLinkPreviews(this.pool, stream.workspaceId, messages)
+    const messagesWithLinkPreviews = enrichMessagesWithLinkPreviewMap(messages, linkPreviewResult.previewsByMessage)
     const conversationText = await this.messageFormatter.formatMessagesWithAttachments(
       this.pool,
       stream.workspaceId,


### PR DESCRIPTION
## Problem

Messages can contain a bare URL whose subject exists only in the generated link-preview metadata. AI consumers currently see the URL but not the preview card's title or description. This produces generic stream/conversation names and removes useful context from companion turns, summaries, and memory extraction.

Link-preview extraction and those AI jobs are independent outbox peers. A send-time AI job can therefore start before `message_link_previews` exists, even though preview fetching normally finishes quickly.

## Solution

Add one AI-context path for completed link previews, then use it anywhere messages become model input.

### How it works

1. `awaitLinkPreviewProcessing` derives expected URLs from canonical `contentJson`/markdown, polls for the junction rows and terminal preview status, and stops after 5 seconds.
2. Send-time consumers—companion context, stream naming, and conversation boundary extraction—start that wait alongside attachment processing. A timeout keeps the original URL and any previews that completed.
3. `renderLinkPreviewContext` emits XML containing the card's URL, site, title, and description. Image URLs are excluded because they add no textual context.
4. Completed previews are added to companion history, Discuss-with-Ariadne context bags, boundary classification, rolling summaries, stream naming, and passive memo extraction.
5. Context-bag fingerprints include preview metadata so pending→completed transitions invalidate cached context.

### Key design decisions

**Bound the send-time wait at 5 seconds.** Waiting indefinitely would put network-fetch latency on agent and naming jobs. Five seconds covers the normal fast path while preserving degraded operation.

**Poll for absent rows, not only `pending` rows.** Link-preview extraction and AI consumers are peer outbox handlers; the first poll can legitimately run before URL extraction creates the junction.

**Reuse preview-card text.** AI context receives the same semantic fields users see instead of fetching page content again or introducing another extraction format.

**Do not await delayed consumers.** Rolling summaries and memo accumulation hydrate completed metadata when they run; their delayed execution makes send-time polling unnecessary.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/link-previews/ai-context.ts` | Bounded waiting, hydration, and model-facing preview rendering |
| `apps/backend/src/features/link-previews/ai-context.test.ts` | Rendering, escaping, and peer-row race coverage |

## Modified areas

| Area | Change |
| ---- | ------ |
| Companion context | Await trigger previews and hydrate conversation history |
| Context bags | Carry/render previews for thread and conversation references; fingerprint them |
| Conversation extraction | Add completed previews to recent/new-message classification context |
| Stream naming | Await previews alongside attachments before formatting |
| Summaries and memos | Hydrate completed previews before rolling-summary and passive-memory model calls |

## Out of scope

- E2E-encrypted messages: the backend cannot inspect ciphertext, and the existing link-preview outbox handler skips those streams.
- Full linked-page content: this change supplies generated preview-card metadata, not a second crawler or `read_url` call.
- Schema changes: existing `link_previews` and `message_link_previews` rows are sufficient.

## Test plan

- [x] Focused backend suites — 131 passed
- [x] Backend unit suite — 2,920 passed
- [x] Backend E2E suite with Postgres + MinIO — 342 passed
- [x] Full monorepo typecheck — clean
- [x] Pre-commit lint, Dockerfile workspace checks, migration checks, and generated OpenAPI check — clean
- [x] Terra review — 3 findings fixed: duplicate naming read, per-conversation memo preview reads, and raw status literals

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make generated link-preview metadata available to AI systems so a linked tweet/article/document contributes its subject—not only its URL—to naming, companion reasoning, summarization, and memory.

## What Was Built

### Shared AI link-preview context

- `apps/backend/src/features/link-previews/ai-context.ts`
  - Derive expected URLs through the production canonical URL extractor.
  - Poll for absent, pending, completed, and failed preview rows without holding a connection during sleeps.
  - Apply a 5-second timeout.
  - Render completed URL/site/title/description metadata as escaped XML.
  - Hydrate cloned messages without changing persisted message content.

### Send-time coordination

- `apps/backend/src/features/agents/companion/context.ts`
- `apps/backend/src/features/streams/naming-service.ts`
- `apps/backend/src/features/conversations/boundary-extraction-service.ts`
  - Start preview waiting outside held DB clients.
  - Run it in parallel with attachment processing.
  - Continue with original URLs when previews fail or time out.

### AI consumers

- Companion history via `buildStreamContext`.
- Discuss-with-Ariadne thread/conversation context bags.
- Boundary classification and generated conversation topics.
- Stream auto-naming.
- Rolling conversation summaries.
- Passive memo classification, suggestions, and memorization.

## Design Decisions

### Use existing preview metadata

**Chose:** URL, site, title, and description from completed preview rows.
**Why:** These are the semantic fields represented by the UI card and already pass through the existing SSRF-safe preview pipeline.
**Alternatives considered:** Refetching linked pages inside each AI consumer would duplicate network work and security policy.

### Await only recent send-time work

**Chose:** Poll in companion, naming, and boundary extraction; hydrate without polling in delayed summary/memo paths.
**Why:** Peer outbox ordering creates a real race immediately after send. Delayed consumers normally run after extraction and should not add latency for old links.

### Keep preview context derived

**Chose:** Clone messages with appended prompt-only metadata.
**Why:** `contentJson`/`contentMarkdown` remain canonical stored user content; preview metadata stays a derived projection.

## Design Evolution

- Expanded from fixing stream naming to a shared renderer used by all identified AI consumers.
- Added absent-row polling after recognizing that AI and preview handlers are outbox peers; checking only existing pending rows would miss the race.
- Included preview metadata in context-bag fingerprints because preview completion changes the stable rendered prompt after message creation.

## Schema Changes

None.

## What's NOT Included

- Server-side previews for E2E ciphertext.
- Image ingestion from preview thumbnails.
- Full-page extraction beyond existing preview metadata.

## Status

- [x] Shared renderer and bounded await helper
- [x] Companion and Discuss-with-Ariadne context
- [x] Stream and conversation naming/classification
- [x] Rolling summaries and passive memory
- [x] Unit, focused, E2E, typecheck, and lint verification

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
