### PR TITLE
fix(frontend): board first paint includes branch bodies + draft pills — no post-reveal layout shift

### DIFF
--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -60,6 +60,7 @@ export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } 
 export {
   useScopeDraftPreview,
   useBoardSubtopicDraftIndex,
+  useBoardDraftsReady,
   type ScopeDraftPreview,
   type SubtopicDraftEntry,
 } from "./use-scope-draft-preview"

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
-import { useScopeDraftPreview, useBoardSubtopicDraftIndex } from "./use-scope-draft-preview"
+import {
+  useScopeDraftPreview,
+  useBoardSubtopicDraftIndex,
+  useBoardDraftsReady,
+  __clearBoardDraftsRegistry,
+} from "./use-scope-draft-preview"
 
 const workspaceId = "ws_1"
 const scope = "board:reply:conv_1"
@@ -17,6 +22,7 @@ async function seed(id: string, draftScope: string, text: string, clientUpdatedA
 }
 
 beforeEach(async () => {
+  __clearBoardDraftsRegistry()
   await db.drafts.clear()
   await db.composerLoaded.clear()
 })
@@ -48,6 +54,24 @@ describe("useScopeDraftPreview", () => {
     await waitFor(() =>
       expect(result.current).toMatchObject({ draftId: "draft_new", preview: "newest roamed body", isCheckedOut: false })
     )
+  })
+
+  it("throws on a non-board scope — the shared snapshot only covers board:* rows", () => {
+    expect(() => renderHook(() => useScopeDraftPreview(workspaceId, "stream:stream_1"))).toThrow(/board draft scopes/)
+  })
+})
+
+describe("useBoardDraftsReady", () => {
+  it("is false until the shared snapshot's first read lands, then true — and the settled snapshot serves scope reads synchronously", async () => {
+    await seed("draft_1", scope, "body", 1000)
+    const ready = renderHook(() => useBoardDraftsReady(workspaceId))
+    expect(ready.result.current).toBe(false)
+    await waitFor(() => expect(ready.result.current).toBe(true))
+
+    // A hook mounting AFTER the snapshot resolved (a card painting post-reveal)
+    // reads its preview in its very first render — no post-mount pop-in.
+    const preview = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    expect(preview.result.current).toMatchObject({ draftId: "draft_1", preview: "body" })
   })
 })
 

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -1,8 +1,9 @@
-import { useLiveQuery } from "dexie-react-hooks"
+import { useCallback, useSyncExternalStore } from "react"
+import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedDraft } from "@/db"
 import { draftInlineText } from "@/lib/drafts/decryption"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
-import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+import { parseBoardDraftKey, BOARD_DRAFT_SCOPE_PREFIX } from "@/lib/board/draft-keys"
 
 export interface ScopeDraftPreview {
   draftId: string
@@ -16,6 +17,12 @@ export interface ScopeDraftPreview {
    * opener must restore the row explicitly for the advertised draft to appear.
    */
   isCheckedOut: boolean
+}
+
+export interface SubtopicDraftEntry extends ScopeDraftPreview {
+  scope: string
+  streamId: string
+  messageId: string
 }
 
 function hasPayload(draft: CachedDraft): boolean {
@@ -42,78 +49,167 @@ function bestRow(rows: CachedDraft[], loadedDraftId: string | null): CachedDraft
   )
 }
 
+interface BoardDraftsSnapshot {
+  previewByScope: Map<string, ScopeDraftPreview>
+  subtopicByMessageId: Map<string, SubtopicDraftEntry>
+}
+
+const EMPTY_SNAPSHOT: BoardDraftsSnapshot = {
+  previewByScope: new Map(),
+  subtopicByMessageId: new Map(),
+}
+
+interface BoardDraftsEntry {
+  snapshot: BoardDraftsSnapshot
+  /** False until the first IDB read emits — the board's reveal gate holds first
+   *  paint on it so draft pills are present from the very first frame. */
+  resolved: boolean
+  listeners: Set<() => void>
+  subscription: Subscription
+  refCount: number
+}
+
+function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | null>): BoardDraftsSnapshot {
+  const byScope = new Map<string, CachedDraft[]>()
+  for (const row of rows) {
+    const list = byScope.get(row.scope)
+    if (list) list.push(row)
+    else byScope.set(row.scope, [row])
+  }
+  const previewByScope = new Map<string, ScopeDraftPreview>()
+  const subtopicByMessageId = new Map<string, SubtopicDraftEntry>()
+  for (const [scope, scopeRows] of byScope) {
+    const loadedDraftId = loadedByScope.get(scope) ?? null
+    const best = bestRow(scopeRows, loadedDraftId)
+    if (!best) continue
+    const preview = toPreview(best, loadedDraftId)
+    previewByScope.set(scope, preview)
+    const parsed = parseBoardDraftKey(scope)
+    if (parsed?.kind === "subtopic") {
+      subtopicByMessageId.set(parsed.messageId, {
+        ...preview,
+        scope,
+        streamId: parsed.streamId,
+        messageId: parsed.messageId,
+      })
+    }
+  }
+  return { previewByScope, subtopicByMessageId }
+}
+
+// INV-9 exception: one shared board-drafts liveQuery per workspace, ref-counted
+// across every resting affordance that advertises a draft (card reply buttons,
+// branch-tail pills, sub-topic indicators). Per-affordance queries can never
+// have data at first paint — Dexie's first emission is always post-mount — so
+// the pills popped in a frame after the board revealed, shifting layout. The
+// registry resolves ONCE per workspace, the board's reveal gate waits on it
+// (`useBoardDraftsReady`), and every hook below reads the settled snapshot
+// synchronously. Mirrors `railRegistry` / `graphRegistry`.
+const boardDraftsRegistry = new Map<string, BoardDraftsEntry>()
+
+function subscribeBoardDrafts(workspaceId: string, listener: () => void): () => void {
+  let entry = boardDraftsRegistry.get(workspaceId)
+  if (!entry) {
+    const created: BoardDraftsEntry = {
+      snapshot: EMPTY_SNAPSHOT,
+      resolved: false,
+      listeners: new Set(),
+      refCount: 0,
+      subscription: { unsubscribe() {} } as Subscription,
+    }
+    // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
+    // the callback re-reads the live entry so a late emission after teardown no-ops.
+    boardDraftsRegistry.set(workspaceId, created)
+    created.subscription = liveQuery(async () => {
+      // The workspace's pointers are read as a whole (workspaceId index) rather
+      // than bulkGet on the scopes with rows, so a pointer-only change (a stash
+      // detaching the loaded pointer) re-fires the query too.
+      const [rows, pointers] = await Promise.all([
+        db.drafts
+          .where("[workspaceId+scope]")
+          .between([workspaceId, BOARD_DRAFT_SCOPE_PREFIX], [workspaceId, BOARD_DRAFT_SCOPE_PREFIX + "\uffff"])
+          .toArray(),
+        db.composerLoaded.where("workspaceId").equals(workspaceId).toArray(),
+      ])
+      return { rows, pointers }
+    }).subscribe(({ rows, pointers }) => {
+      const live = boardDraftsRegistry.get(workspaceId)
+      if (!live) return
+      const loadedByScope = new Map(pointers.map((p) => [p.scope, p.draftId]))
+      live.snapshot = buildSnapshot(rows, loadedByScope)
+      live.resolved = true
+      for (const notify of live.listeners) notify()
+    })
+    entry = created
+  }
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  return () => {
+    const current = boardDraftsRegistry.get(workspaceId)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) {
+      current.subscription.unsubscribe()
+      boardDraftsRegistry.delete(workspaceId)
+    }
+  }
+}
+
+function useBoardDraftsSubscription(workspaceId: string) {
+  return useCallback((onChange: () => void) => subscribeBoardDrafts(workspaceId, onChange), [workspaceId])
+}
+
 /**
  * The draft a collapsed composer affordance for `scope` should advertise —
  * the same "your unsent text, one line" presentation the mobile composer's
- * collapsed bar uses. A Dexie range query on the `[workspaceId+scope]` index
- * (plus the scope's loaded pointer), so it re-fires only on this scope's own
- * rows — cheap enough per board card. Null when the scope holds nothing worth
- * showing.
+ * collapsed bar uses. Read synchronously off the shared workspace snapshot,
+ * so an affordance mounting after the board's reveal has its pill in its very
+ * first frame. Null when the scope holds nothing worth showing.
+ *
+ * Board scopes only (`board:*`) — the registry's query is bounded to that
+ * prefix, so any other scope would silently read null (INV-11: fail loudly).
  */
 export function useScopeDraftPreview(workspaceId: string, scope: string): ScopeDraftPreview | null {
-  const result = useLiveQuery(
-    async () => {
-      const [rows, loaded] = await Promise.all([
-        db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray(),
-        db.composerLoaded.get(scope),
-      ])
-      const best = bestRow(rows, loaded?.draftId ?? null)
-      return best ? toPreview(best, loaded?.draftId ?? null) : null
-    },
-    [workspaceId, scope],
-    null
+  if (!scope.startsWith(BOARD_DRAFT_SCOPE_PREFIX)) {
+    throw new Error(`useScopeDraftPreview only serves board draft scopes (board:*); got "${scope}"`)
+  }
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(
+    () => boardDraftsRegistry.get(workspaceId)?.snapshot.previewByScope.get(scope) ?? null,
+    [workspaceId, scope]
   )
-  return result
-}
-
-export interface SubtopicDraftEntry extends ScopeDraftPreview {
-  scope: string
-  streamId: string
-  messageId: string
+  return useSyncExternalStore(subscribe, getSnapshot)
 }
 
 /**
  * Every new-sub-topic draft in the workspace, keyed by its fork message id —
  * so a conversation surface can mark the message rows that carry an unsent
- * sub-topic draft while the gesture's composer is unmounted. One range query
- * over the `board:subtopic:` scope prefix per surface (the rows are few and
- * only change on draft edits under that prefix).
+ * sub-topic draft while the gesture's composer is unmounted. Same shared
+ * snapshot as {@link useScopeDraftPreview}.
  */
 export function useBoardSubtopicDraftIndex(workspaceId: string): Map<string, SubtopicDraftEntry> {
-  const result = useLiveQuery(
-    async () => {
-      const rows = await db.drafts
-        .where("[workspaceId+scope]")
-        .between([workspaceId, "board:subtopic:"], [workspaceId, "board:subtopic:\uffff"])
-        .toArray()
-      if (rows.length === 0) return new Map<string, SubtopicDraftEntry>()
-
-      const byScope = new Map<string, CachedDraft[]>()
-      for (const row of rows) {
-        const list = byScope.get(row.scope)
-        if (list) list.push(row)
-        else byScope.set(row.scope, [row])
-      }
-      const loadedRows = await db.composerLoaded.bulkGet([...byScope.keys()])
-      const loadedByScope = new Map([...byScope.keys()].map((scope, i) => [scope, loadedRows[i]?.draftId ?? null]))
-
-      const map = new Map<string, SubtopicDraftEntry>()
-      for (const [scope, scopeRows] of byScope) {
-        const parsed = parseBoardDraftKey(scope)
-        if (parsed?.kind !== "subtopic") continue
-        const best = bestRow(scopeRows, loadedByScope.get(scope) ?? null)
-        if (!best) continue
-        map.set(parsed.messageId, {
-          ...toPreview(best, loadedByScope.get(scope) ?? null),
-          scope,
-          streamId: parsed.streamId,
-          messageId: parsed.messageId,
-        })
-      }
-      return map
-    },
-    [workspaceId],
-    undefined
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(
+    () => boardDraftsRegistry.get(workspaceId)?.snapshot.subtopicByMessageId ?? EMPTY_SNAPSHOT.subtopicByMessageId,
+    [workspaceId]
   )
-  return result ?? new Map<string, SubtopicDraftEntry>()
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** Whether the shared board-drafts snapshot's first IDB read has landed. Part
+ *  of the board's coordinated reveal: cards must not take their first paint
+ *  before it, or every draft pill pops in a frame later and shifts the rows
+ *  below it (the timeline's no-shift rule, Kris 2026-07-13). */
+export function useBoardDraftsReady(workspaceId: string): boolean {
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(() => boardDraftsRegistry.get(workspaceId)?.resolved ?? false, [workspaceId])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** Tear down every shared board-drafts subscription — for tests, so a
+ *  module-level registry can't leak a liveQuery (or a snapshot) across cases. */
+export function __clearBoardDraftsRegistry(): void {
+  for (const entry of boardDraftsRegistry.values()) entry.subscription.unsubscribe()
+  boardDraftsRegistry.clear()
 }

--- a/apps/frontend/src/lib/board/draft-keys.ts
+++ b/apps/frontend/src/lib/board/draft-keys.ts
@@ -5,6 +5,10 @@
  * so a key format change can't strand rows.
  */
 
+/** Common prefix of every board draft scope — bounds the shared board-drafts
+ *  registry's IDB range query (use-scope-draft-preview.ts). */
+export const BOARD_DRAFT_SCOPE_PREFIX = "board:"
+
 const REPLY_PREFIX = "board:reply:"
 const BRANCH_REPLY_PREFIX = "board:branch-reply:"
 const SUBTOPIC_PREFIX = "board:subtopic:"

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -30,7 +30,13 @@ import {
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
 import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
-import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
+import {
+  useConversationGraph,
+  useConversationGraphReady,
+  useStreamStructuralIndex,
+  collectBranchThreadStreamIds,
+} from "@/hooks/use-conversation-graph"
+import { useBoardDraftsReady } from "@/hooks/use-scope-draft-preview"
 import { SKELETON_DELAY_MS } from "@/contexts/coordinated-loading-context"
 import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/components/composer"
 import { BoardCard } from "@/components/board/board-card"
@@ -482,19 +488,39 @@ function BoardPageInner({
   // content actually changed — Kris's refresh ruling, 2026-07-05). Warm-device
   // holds are one IDB round-trip; the skeleton appears only past the same delay
   // the timeline uses, so the common path is blank-for-a-beat → complete board.
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
   const prewarmStreamIds = useMemo(() => {
     const set = new Set<string>()
     for (const post of posts.slice(0, REVEAL_PREWARM_CARDS)) {
       set.add(post.conversation.streamId)
       for (const id of post.streamIds ?? []) set.add(id)
+      // The nested branches the card will render, from the graph itself — the
+      // same walk the card does. `post.streamIds` carries a branch's thread
+      // stream only when the branch conversation sits in the same filtered feed
+      // page (the suppression fold); a branch outside the feed window still
+      // renders nested, and without its rail warmed here the branch paints
+      // collapsed ("N more replies") and expands a frame later.
+      for (const id of collectBranchThreadStreamIds({
+        conversationId: post.conversation.id,
+        memberMessageIds: post.conversation.messageIds,
+        index: structuralIndex,
+        graph: conversationGraph,
+      })) {
+        set.add(id)
+      }
     }
     return [...set].sort()
-  }, [posts])
+  }, [posts, structuralIndex, conversationGraph])
   const railsReady = useBoardRailsReady(prewarmStreamIds)
   const graphReady = useConversationGraphReady(workspaceId)
+  // Draft pills (card reply button, branch tails, sub-topic indicators) read the
+  // shared board-drafts snapshot; hold the reveal until its first read lands so
+  // a pill is in the card's first frame, never a later one.
+  const draftsReady = useBoardDraftsReady(workspaceId)
   // Latch the reveal so a newly added conversation's cold rail can't un-paint the
   // whole feed (see `useBoardRevealLatch`); the gate only holds the first paint.
-  const revealReady = useBoardRevealLatch(railsReady && graphReady, workspaceId)
+  const revealReady = useBoardRevealLatch(railsReady && graphReady && draftsReady, workspaceId)
   const holding = posts.length > 0 && !revealReady
   const loading = isLoading || viewLoading || seedPending || holding
   const [skeletonVisible, setSkeletonVisible] = useState(false)


### PR DESCRIPTION
## Problem

Kris's video (2026-07-13, 1310-staging on mobile): the board paints, then ~60ms later every sub-conversation expands from "1 more reply / Reply" into its tail message + draft pill, shoving everything below downward. The rule is the timeline's: the first frame is the final frame — layout never shifts after paint unless genuinely live data lands in the viewport.

The board already has a coordinated reveal (`useBoardRailsReady` + `useConversationGraphReady` + `useBoardRevealLatch` hold the first card paint until the above-fold rails and the conversation graph finish their first IDB read). Two things slipped through it:

1. **Draft pills could never be in the first frame.** `useScopeDraftPreview` / `useBoardSubtopicDraftIndex` (from #1310) were per-affordance Dexie `useLiveQuery`s, and a liveQuery's first emission is always post-mount — so the card reply button's preview, the branch-tail pill, and the ↳ sub-topic indicator all popped in a frame after the reveal, structurally.
2. **Branch rails were only warmed by coincidence.** The reveal prewarms `post.streamIds`, which carries a nested branch's thread stream only when the branch conversation happens to sit in the same filtered feed page (the `projectNestedBoardView` fold adds it). Branches are *rendered* from the conversation graph — which covers every cached conversation — so a branch outside the feed window (paged out, lens/unread-filtered) painted bodiless ("N more replies") and expanded when its rail resolved.

## Solution

Both late loaders become part of the coordinated reveal, using the registry pattern the rails and graph already use.

### How it works

1. **Shared board-drafts registry** (`use-scope-draft-preview.ts`, rewritten): one ref-counted liveQuery per workspace over the `[workspaceId+scope]` range `board:` → `board:￿` plus the workspace's `composerLoaded` pointers, building `{ previewByScope, subtopicByMessageId, resolved }` per emission. `useScopeDraftPreview` and `useBoardSubtopicDraftIndex` keep their exact signatures/return shapes but read the settled snapshot synchronously via `useSyncExternalStore` — an affordance mounting after the reveal has its pill in its very first render. Pointers are read via the `workspaceId` index (not `bulkGet` on scopes with rows) so a pointer-only change — a stash detaching the loaded pointer — re-fires too.
2. **`useBoardDraftsReady(workspaceId)`** joins the reveal gate in `board.tsx`: `railsReady && graphReady && draftsReady`.
3. **Graph-derived prewarm**: `prewarmStreamIds` now also folds in `collectBranchThreadStreamIds(...)` per above-fold post — the exact walk `deriveBranchConversations` renders from, so the gate and the renderer read the same source. Ordering is safe by construction: the graph starts `EMPTY_GRAPH` and `graphReady` is false, so the reveal can't clear before the branch ids join the set; when the graph's first read lands, both flip in the same registry notification and `useBoardRailsReady` holds on the not-yet-resolved branch rails.
4. `BOARD_DRAFT_SCOPE_PREFIX` moves to `lib/board/draft-keys.ts` (INV-33); `useScopeDraftPreview` throws on a non-`board:*` scope rather than silently reading null from a snapshot that never contains it (INV-11) — every production caller uses the board key builders.

### Key design decisions

**1. Registry over gated per-card queries** — the reveal can only wait on state it can observe before cards mount; per-card hooks don't exist yet at gate time. A workspace-level snapshot is observable by the page, resolves once (one indexed range read — board draft rows are few), and makes every per-card read synchronous, which is also what kills the pop-in for cards mounting *later* (scroll, live inserts). Same INV-9-exception shape as `railRegistry` / `graphRegistry`, with the same test escape hatch (`__clearBoardDraftsRegistry`).

**2. Prewarm from the graph, not the fold** — deriving the branch set from `post.streamIds` ties paint-readiness to feed-page membership, which is a filtering artifact. `collectBranchThreadStreamIds` is what the card actually renders from, so gate and renderer can't disagree.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-scope-draft-preview.ts` | Per-hook `useLiveQuery` → shared per-workspace registry; `useBoardDraftsReady`; non-board-scope guard |
| `apps/frontend/src/pages/board.tsx` | Prewarm folds in graph-derived branch thread streams; reveal gate adds `draftsReady` |
| `apps/frontend/src/lib/board/draft-keys.ts` | Export `BOARD_DRAFT_SCOPE_PREFIX` |
| `apps/frontend/src/hooks/index.ts` | Export `useBoardDraftsReady` |
| `apps/frontend/src/hooks/use-scope-draft-preview.test.ts` | Registry reset in `beforeEach`; ready-flag + synchronous-post-resolve test; non-board-scope throw test |

## Out of scope (deliberate)

- **Cold-device branch bodies** (found while verifying): on a *fresh* device, `SyncEngine.setBoardStreamIds` skips streams the viewer is already subscribed to (member streams), and nothing backfills their history into IDB until each stream/panel is opened — so a member's brand-new device shows "N more replies" with no bodies, indefinitely, gate or no gate. The reveal renders that state stably (it *is* the final frame of what's local); making member-stream rails backfill is a sync-engine change, flagged separately.
- **Conversation panel first-paint**: the panel's collapsed composer preview reads the same registry (synchronous once warm, e.g. whenever the board was visited first), but the panel has no coordinated reveal of its own — a panel-first cold navigation can still resolve the pill an emission late. Panel wasn't in the ruling; unchanged.

## Test plan

- [x] `bun run test src/hooks` — 741 pass (includes the rewritten preview tests + new ready-flag/throw tests)
- [x] `bun run test src/components/board src/components/conversations src/pages/board.test.tsx` — 170 pass
- [x] `tsc --noEmit` frontend clean; full monorepo lint+typecheck via pre-commit
- [x] Live verify on dev:test (scripted Playwright, MutationObserver over `[data-board-scroll-viewport]` recording every DOM mutation across a warm-IDB reload): **with fix** — first card-bearing frame already contains branch body + draft pill (16 snapshots, no card-without-content frame); **fix stashed** — same script fails exactly as the video: first card frame has `pill: false`, pill present only in later frames. Stash round-trip proves the check detects the regression.
- [ ] The branch-outside-feed-window prewarm path wasn't exercised live (constructing a feed where the branch is filtered out but the parent isn't needs 50+ seeded posts); covered by construction — the prewarm and the renderer call the same `collectBranchThreadStreamIds` walk, and the gate mechanism holding on those rails is the part the live run proves.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786562258&installation_id=129946197&pr_number=1330&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1330&signature=44718efabbc2495e313d68d87d36ff8ed878e90b7eab0b29f7032e0fce9c9a59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->