### PR TITLE
fix(frontend): backfill member streams the board declares — fresh devices get branch bodies

### DIFF
--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -966,8 +966,83 @@ describe("SyncEngine.setBoardStreamIds", () => {
 
     engine.setBoardStreamIds(["stream_open"])
 
-    // Give any errant async sync a chance to fire before asserting it didn't.
-    await Promise.resolve()
+    // Give any errant async sync a chance to fire before asserting it didn't —
+    // the persisted-window probe is an IDB read, so a microtask isn't enough.
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(deps.streamService.bootstrap).not.toHaveBeenCalled()
+  })
+
+  it("backfills a member stream whose room was joined at bootstrap but whose history was never synced (fresh device)", async () => {
+    const deps = makeDeps()
+    const now = new Date().toISOString()
+    deps.workspaceService.bootstrap.mockResolvedValue({
+      ...makeWorkspaceBootstrap(),
+      streamMemberships: [
+        {
+          streamId: "stream_member",
+          memberId: "user_1",
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: now,
+        },
+      ],
+    })
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    // Bootstrap joined the member room but fetched no history for it — the
+    // fresh-device state where the board card's rail would stay empty.
+    expect(deps.streamService.bootstrap).not.toHaveBeenCalledWith("ws_1", "stream_member", undefined)
+
+    engine.setBoardStreamIds(["stream_member"])
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_member", undefined)
+    })
+  })
+
+  it("skips a subscribed member stream whose window is already local — an IDB probe, no fetch", async () => {
+    const deps = makeDeps()
+    const now = new Date().toISOString()
+    deps.workspaceService.bootstrap.mockResolvedValue({
+      ...makeWorkspaceBootstrap(),
+      streamMemberships: [
+        {
+          streamId: "stream_member",
+          memberId: "user_1",
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: now,
+        },
+      ],
+    })
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    await db.events.put({
+      id: "evt_member_1",
+      workspaceId: "ws_1",
+      streamId: "stream_member",
+      sequence: "1",
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_member_1",
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: now,
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+    deps.streamService.bootstrap.mockClear()
+
+    engine.setBoardStreamIds(["stream_member"])
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
     expect(deps.streamService.bootstrap).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -233,17 +233,18 @@ export class SyncEngine {
    *
    * It is additive and must NEVER route through setVisibleStreamIds — that set is
    * the sidebar's and is replaced wholesale (clobbering it would drop the
-   * sidebar's reconnect catch-up). Newly-declared streams not already subscribed
-   * are caught up + bootstrapped here, concurrency-capped so opening the board
-   * doesn't fire a fetch burst across dozens of unsynced streams. Board streams
-   * join the reconnect / connectivity-resume re-sync set (getVisibleServerStreamIds)
-   * so they stay live across drops while the board is open.
+   * sidebar's reconnect catch-up). Newly-declared streams are caught up +
+   * bootstrapped here unless their history is already local (syncBoardStreams'
+   * persisted-window skip), concurrency-capped so opening the board doesn't fire
+   * a fetch burst across dozens of unsynced streams. Board streams join the
+   * reconnect / connectivity-resume re-sync set (getVisibleServerStreamIds) so
+   * they stay live across drops while the board is open.
    *
    * Subscriptions are NOT torn down per card: clearing on unmount only shrinks the
    * reconnect set (so a closed board doesn't re-fetch on reconnect), while the
-   * already-subscribed skip below means reopening the board re-syncs nothing. We
-   * never unsubscribe a board stream — that would race a card click that navigates
-   * into the very stream being torn down.
+   * persisted-window skip means reopening the board costs one IDB probe per
+   * stream and no network. We never unsubscribe a board stream — that would race
+   * a card click that navigates into the very stream being torn down.
    */
   setBoardStreamIds(ids: string[]): void {
     const next = new Set(ids)
@@ -251,10 +252,12 @@ export class SyncEngine {
     for (const streamId of next) {
       if (this.boardStreamIds.has(streamId)) continue
       if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
-      if (this.subscribedStreams.has(streamId)) continue
       toSync.push(streamId)
     }
     this.boardStreamIds = next
+    // Newly-declared streams INCLUDING already-subscribed ones: a bootstrap room
+    // join is not history, so `syncBoardStreams` decides per stream whether a
+    // fetch is actually needed (see its persisted-window skip).
     if (toSync.length > 0) void this.syncBoardStreams(toSync)
   }
 
@@ -271,7 +274,6 @@ export class SyncEngine {
     for (const streamId of next) {
       if (this.panelStreamIds.has(streamId)) continue
       if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
-      if (this.subscribedStreams.has(streamId)) continue
       toSync.push(streamId)
     }
     this.panelStreamIds = next
@@ -347,8 +349,12 @@ export class SyncEngine {
     // the fresh bootstrap didn't join — otherwise their cards wouldn't go live
     // until the next reconnect.
     if (!isReconnect && (this.boardStreamIds.size > 0 || this.panelStreamIds.size > 0)) {
+      // Subscribed streams stay in the set: bootstrap just joined every member
+      // stream's room (subscribeMemberStreams), but a fresh device has no
+      // history for them — syncBoardStreams' persisted-window skip separates
+      // the two, so warm streams cost one IDB probe and cold ones backfill.
       const pending = [...this.boardStreamIds, ...this.panelStreamIds].filter(
-        (id) => !this.subscribedStreams.has(id) && !id.startsWith("draft_") && !id.startsWith("draft:")
+        (id) => !id.startsWith("draft_") && !id.startsWith("draft:")
       )
       if (pending.length > 0) void this.syncBoardStreams([...new Set(pending)])
     }
@@ -960,6 +966,17 @@ export class SyncEngine {
     const worker = async (): Promise<void> => {
       while (cursor < streamIds.length && !this.isDestroyed) {
         const streamId = streamIds[cursor++]
+        // "Subscribed" means the room is joined, not that history is local:
+        // subscribeMemberStreams joins every member stream at bootstrap, so on
+        // a fresh device a member stream is subscribed with an EMPTY events
+        // store — skipping it here left board branch groups bodiless ("N more
+        // replies") until the stream was opened. Skip only when a persisted
+        // window exists; the room join plus the workspace catch-up cursor keep
+        // that window current, so re-fetching it would be redundant network.
+        // Reading the sequence as an emptiness probe is safe outside
+        // joinStreamForCatchUp's cursor-before-join rule: nothing is ordered
+        // against a join, and the refresh below re-derives its own cursor.
+        if (this.subscribedStreams.has(streamId) && (await getLatestPersistedSequence(streamId)) !== null) continue
         await this.refreshStreamAfterNavigation(streamId)
       }
     }


### PR DESCRIPTION
## Problem

Found during #1330's verification: on a **fresh device** (empty IDB), a board card's nested branch groups render "N more replies" with no bodies — indefinitely, until the viewer happens to open each stream. Reproduced with an API-only seed: the account's `events` store stayed literally empty after 20s on the open board.

Root cause is a conflation in the sync engine: `setBoardStreamIds` / `setPanelStreamIds` skip any stream in `subscribedStreams` (`sync-engine.ts`), but that set means *the socket room is joined* — `subscribeMemberStreams` joins every member stream's room at bootstrap without fetching any history. So the board's declaration backfills only streams the viewer is **not** a member of (never-joined public channels, threads), while member streams — the common case — skip with empty rails. Board card bodies survive via the server projection on the conversation row; branch bodies have no projection (they resolve only through the `db.events` rail), so they're the visible casualty.

## Solution

Move the skip decision from "room joined?" to "history local?", owned by `syncBoardStreams`.

### How it works

1. `setBoardStreamIds` / `setPanelStreamIds` no longer filter on `subscribedStreams`; newly-declared ids (the existing diff guard is unchanged) all flow to `syncBoardStreams`.
2. `syncBoardStreams`' worker skips a stream only when it is subscribed **and** `getLatestPersistedSequence(streamId) !== null` — a per-stream IDB point read. A joined-but-empty member stream falls through to `refreshStreamAfterNavigation`, the same cursor-owned catch-up + bootstrap path opening a stream runs (in-flight-deduped, full window when no cached bootstrap, `BOARD_SYNC_CONCURRENCY`-capped).
3. The post-first-connect declaration sweep in `onConnect` (deep-link / warm-but-offline board that comes online) drops its `!subscribedStreams.has(id)` filter for the same reason — it runs after `runBootstrap` has already joined member rooms, so the filter excluded exactly the streams that needed backfill.

Reading `getLatestPersistedSequence` as an emptiness probe sits outside `joinStreamForCatchUp`'s cursor-before-join rule (documented at the probe): nothing is ordered against a join, and the refresh re-derives its own cursor; a live event landing between probe and refresh is dedup-safe.

### Cost on warm devices

Unchanged network. A warm device's declared member streams now cost one IDB point read each (previously skipped for free); subscribed streams with a window still never refetch, and reopening the board still fetches nothing. The only new fetches are for joined streams with **no** persisted window — the fresh-device case, which previously got nothing forever. A genuinely empty member stream (zero events) re-probes null and refetches its empty bootstrap once per board mount; harmless, and memoizing it would be speculative (INV-36).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | Skip decision moved into `syncBoardStreams` (subscribed + persisted-window probe); both setters and the `onConnect` sweep stop filtering on `subscribedStreams`; doc comments updated |
| `apps/frontend/src/sync/sync-engine.test.ts` | Two new tests (member stream with no history backfills; member stream with a local window skips with no fetch); the existing already-subscribed skip test's wait widened (the probe is an IDB read, one microtask wasn't a real negative) |

## Out of scope (deliberate)

- **Paint order for the backfilled bodies**: on a fresh device the branch fills in after the network fetch lands — that's genuinely new data arriving (the timeline's cold-open equivalent), not the warm-device pop-in #1330 fixed. Holding the board's reveal on network would break offline-first.
- The sidebar's `visibleStreamIds` path is untouched — it has its own reconnect semantics.

## Test plan

- [x] `bun run test src/sync` — 354 pass (68 in `sync-engine.test.ts`, incl. the 2 new cases)
- [x] Frontend `tsc --noEmit` clean; full monorepo lint+typecheck via pre-commit
- [x] Live verify on dev:test: API-only seed (viewer is a member of channel + thread, no stream ever opened in a browser), fresh browser context, board open → branch body appears. **Fix stashed**: the same wait times out at 20s — the exact failure state found during #1330's verification (empty `events` store, "1 more reply" forever). Stash round-trip proves the check detects the regression.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786563819&installation_id=129946197&pr_number=1331&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1331&signature=d0cece156cf68d40bca6b0bd8ce5c056ffb02b8cb44963302e1cb9e55fbd2d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->