### PR TITLE
fix(personas): honor the knowledge budget end-to-end + attachment delete guards

### DIFF
--- a/apps/backend/src/features/agents/companion/context.test.ts
+++ b/apps/backend/src/features/agents/companion/context.test.ts
@@ -145,8 +145,24 @@ describe("buildAgentContext persona knowledge (context attachments, decision 7)"
 
   it("injects the persona's attachments in position order, resolving them by the persona id", async () => {
     const listWithContent = spyOn(PersonaAttachmentRepository, "listForPersonaWithContent").mockResolvedValue([
-      { attachmentId: "att_1", filename: "guide.md", position: 0, fullText: "GUIDE CONTENT", summary: null },
-      { attachmentId: "att_2", filename: "spec.txt", position: 1, fullText: null, summary: "SPEC SUMMARY" },
+      {
+        attachmentId: "att_1",
+        filename: "guide.md",
+        position: 0,
+        fullText: "GUIDE CONTENT",
+        summary: null,
+        processingStatus: "completed",
+        hasExtraction: true,
+      },
+      {
+        attachmentId: "att_2",
+        filename: "spec.txt",
+        position: 1,
+        fullText: null,
+        summary: "SPEC SUMMARY",
+        processingStatus: "completed",
+        hasExtraction: true,
+      },
     ])
 
     const customPersona: Persona = { ...persona, id: "persona_custom", managedBy: "workspace", workspaceId: "ws_1" }

--- a/apps/backend/src/features/agents/companion/prompt/persona-knowledge-plan.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/persona-knowledge-plan.test.ts
@@ -2,12 +2,44 @@ import { describe, expect, test } from "bun:test"
 import { PERSONA_ATTACHMENT_BLOCK_MAX_CHARS, PERSONA_ATTACHMENT_INLINE_FULLTEXT_MAX_CHARS } from "../../config"
 import {
   planPersonaKnowledge,
+  PERSONA_KNOWLEDGE_FAILURE_NOTE,
   PERSONA_KNOWLEDGE_PROCESSING_NOTE,
   type PersonaKnowledgeLengths,
+  type PersonaKnowledgePlan,
 } from "./persona-knowledge-plan"
 
 function lengths(overrides: Partial<PersonaKnowledgeLengths> = {}): PersonaKnowledgeLengths {
   return { fullTextChars: null, summaryChars: null, ...overrides }
+}
+
+/** The whole-body length one plan's source renders (0 for a marker-only row). */
+function wholeBodyLen(item: PersonaKnowledgeLengths, plan: PersonaKnowledgePlan): number {
+  switch (plan.source) {
+    case "fullText":
+      return item.fullTextChars ?? 0
+    case "summary":
+      return item.summaryChars ?? 0
+    case "processingNote":
+      return PERSONA_KNOWLEDGE_PROCESSING_NOTE.length
+    case "failureNote":
+      return PERSONA_KNOWLEDGE_FAILURE_NOTE.length
+    case "marker":
+      return 0
+  }
+}
+
+/**
+ * The content chars the plans spend against the block budget: a whole body's
+ * length, a truncated body's slice (`truncateAt`), and 0 for marker-only rows.
+ * Excludes the `…[truncated]` suffix and the marker sentinel — those are fixed
+ * structural chrome, like the `### filename` headings, not budgeted content.
+ */
+function spentChars(plans: PersonaKnowledgePlan[], items: PersonaKnowledgeLengths[]): number {
+  return plans.reduce((total, plan, index) => {
+    if (plan.source === "marker") return total
+    if (plan.truncated) return total + (plan.truncateAt ?? 0)
+    return total + wholeBodyLen(items[index]!, plan)
+  }, 0)
 }
 
 describe("planPersonaKnowledge — per-file selection (decision 6)", () => {
@@ -60,14 +92,35 @@ describe("planPersonaKnowledge — cumulative block budget walk", () => {
     })
   })
 
-  test("files after the crossing file degrade to summary-only (full text dropped), untruncated", () => {
+  test("budget-aware degradation: a full text that won't fit the remaining budget degrades to a WHOLE summary", () => {
+    // The first file's whole summary fits and leaves only 100 chars. The second
+    // file's full text (4000) overruns that remainder, but its summary (60) fits —
+    // a complete summary beats a truncated full text, so it degrades, untruncated.
+    const first = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - 100
     const plans = planPersonaKnowledge([
-      lengths({ summaryChars: PERSONA_ATTACHMENT_BLOCK_MAX_CHARS + 100 }),
+      lengths({ summaryChars: first }),
       lengths({ fullTextChars: 4000, summaryChars: 60 }),
     ])
-    expect(plans[0]!.truncated).toBe(true)
-    // The later file would have inlined its full text pre-budget, but now shows summary only.
+    expect(plans[0]).toEqual({ mode: "summary", truncated: false, source: "summary", truncateAt: null })
     expect(plans[1]).toEqual({ mode: "summary", truncated: false, source: "summary", truncateAt: null })
+  })
+
+  test("continuous walk: a summary tail renders only while budget remains, then markers — total within cap", () => {
+    // A near-limit first file leaves ~200 chars; the next 300-char summary can't
+    // fit whole, so it is the sole truncation and the remaining tail is markers.
+    const near = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - 200
+    const items = [
+      lengths({ summaryChars: near }),
+      lengths({ summaryChars: 300 }),
+      lengths({ summaryChars: 300 }),
+      lengths({ summaryChars: 300 }),
+    ]
+    const plans = planPersonaKnowledge(items)
+    expect(plans[0]).toEqual({ mode: "summary", truncated: false, source: "summary", truncateAt: null })
+    expect(plans[1]).toEqual({ mode: "summary", truncated: true, source: "summary", truncateAt: 200 })
+    expect(plans[2]).toEqual({ mode: "name_only", truncated: false, source: "marker", truncateAt: null })
+    expect(plans[3]).toEqual({ mode: "name_only", truncated: false, source: "marker", truncateAt: null })
+    expect(spentChars(plans, items)).toBeLessThanOrEqual(PERSONA_ATTACHMENT_BLOCK_MAX_CHARS)
   })
 
   test("a post-budget file with no summary renders the marker (name_only), never dropped", () => {
@@ -112,3 +165,58 @@ describe("planPersonaKnowledge — cumulative block budget walk", () => {
     expect(planPersonaKnowledge([])).toEqual([])
   })
 })
+
+describe("planPersonaKnowledge — failure note (T3)", () => {
+  test("content-less file with extractionFailed → the failure note (name_only), budget-accounted", () => {
+    const [plan] = planPersonaKnowledge([lengths({ extractionFailed: true })])
+    expect(plan).toEqual({ mode: "name_only", truncated: false, source: "failureNote", truncateAt: null })
+  })
+
+  test("content-less file still processing (no failure flag) → the processing note", () => {
+    const [plan] = planPersonaKnowledge([lengths({ extractionFailed: false })])
+    expect(plan).toEqual({ mode: "name_only", truncated: false, source: "processingNote", truncateAt: null })
+  })
+
+  test("extractionFailed is ignored once real content exists → the content wins", () => {
+    const [plan] = planPersonaKnowledge([lengths({ summaryChars: 40, extractionFailed: true })])
+    expect(plan).toEqual({ mode: "summary", truncated: false, source: "summary", truncateAt: null })
+  })
+
+  test("a failure note that can't fit the remaining budget is itself truncated like the processing note", () => {
+    const first = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - 4
+    const plans = planPersonaKnowledge([lengths({ summaryChars: first }), lengths({ extractionFailed: true })])
+    expect(PERSONA_KNOWLEDGE_FAILURE_NOTE.length).toBeGreaterThan(4)
+    expect(plans[1]).toEqual({ mode: "name_only", truncated: true, source: "failureNote", truncateAt: 4 })
+  })
+})
+
+describe("planPersonaKnowledge — budget invariant (T1)", () => {
+  test("for ANY input the spent content never exceeds the block budget and at most one file is truncated", () => {
+    const rng = mulberry32(0x5eed)
+    for (let iteration = 0; iteration < 500; iteration++) {
+      const count = Math.floor(rng() * 6) // 0..5, the real cap
+      const items: PersonaKnowledgeLengths[] = Array.from({ length: count }, () => ({
+        // Draw across the whole range: absent, tiny, near-cap, and over-cap bodies.
+        fullTextChars: rng() < 0.35 ? null : Math.floor(rng() * (PERSONA_ATTACHMENT_BLOCK_MAX_CHARS * 1.5)),
+        summaryChars: rng() < 0.35 ? null : Math.floor(rng() * (PERSONA_ATTACHMENT_BLOCK_MAX_CHARS * 1.5)),
+        extractionFailed: rng() < 0.5,
+      }))
+      const plans = planPersonaKnowledge(items)
+      expect(plans).toHaveLength(count)
+      expect(spentChars(plans, items)).toBeLessThanOrEqual(PERSONA_ATTACHMENT_BLOCK_MAX_CHARS)
+      expect(plans.filter((p) => p.truncated).length).toBeLessThanOrEqual(1)
+    }
+  })
+})
+
+/** Tiny deterministic PRNG so the property sweep is reproducible (no test flake). */
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}

--- a/apps/backend/src/features/agents/companion/prompt/persona-knowledge-plan.ts
+++ b/apps/backend/src/features/agents/companion/prompt/persona-knowledge-plan.ts
@@ -3,9 +3,16 @@ import { PERSONA_ATTACHMENT_BLOCK_MAX_CHARS, PERSONA_ATTACHMENT_INLINE_FULLTEXT_
 
 /**
  * The literal body rendered when a file has no usable extracted content yet
- * (extraction pending or produced nothing) and the block budget is still open.
+ * (extraction still in flight) and the block budget is still open.
  */
 export const PERSONA_KNOWLEDGE_PROCESSING_NOTE = "(processing — content not yet available)"
+
+/**
+ * The literal body rendered when a file's extraction pipeline gave up
+ * (terminal failed/skipped, no extraction row) — the persona is told the file
+ * exists but its content is unavailable, never silently dropped (INV-11).
+ */
+export const PERSONA_KNOWLEDGE_FAILURE_NOTE = "(extraction failed — content unavailable)"
 
 /** Marks a body cut short by the block budget — a file is degraded, never silently dropped. */
 export const PERSONA_KNOWLEDGE_TRUNCATION_MARKER = "…[truncated]"
@@ -16,14 +23,17 @@ export const PERSONA_KNOWLEDGE_TRUNCATION_MARKER = "…[truncated]"
  * extraction hasn't produced. This is the ONLY input to the planner: it never
  * sees the text itself, so the same logic drives the prompt renderer (which has
  * the content) and the config payload (which must not carry it — decision 6/7).
+ * `extractionFailed` distinguishes a content-less file whose pipeline gave up
+ * (renders the failure note) from one still processing (the processing note).
  */
 export interface PersonaKnowledgeLengths {
   fullTextChars: number | null
   summaryChars: number | null
+  extractionFailed?: boolean
 }
 
 /** Which extracted source the renderer should draw a file's body from. */
-export type PersonaKnowledgeSource = "fullText" | "summary" | "processingNote" | "marker"
+export type PersonaKnowledgeSource = "fullText" | "summary" | "processingNote" | "failureNote" | "marker"
 
 /**
  * The plan for rendering one attachment's body. `mode` is the user-facing context
@@ -43,6 +53,7 @@ const MODE_BY_SOURCE: Record<Exclude<PersonaKnowledgeSource, "marker">, PersonaA
   fullText: "full",
   summary: "summary",
   processingNote: "name_only",
+  failureNote: "name_only",
 }
 
 /** A column counts as present only when it has at least one character (an empty extraction is "absent"). */
@@ -50,62 +61,85 @@ function hasContent(chars: number | null): boolean {
   return chars != null && chars > 0
 }
 
+interface Candidate {
+  source: Exclude<PersonaKnowledgeSource, "marker">
+  len: number
+}
+
+/**
+ * The body sources one file could render, in descending priority: the inline
+ * full text (only when present and within the per-file cap), then the short
+ * summary, then — only when there is no extracted content at all — a one-line
+ * note (the failure note when the pipeline gave up, else the processing note).
+ */
+function candidatesFor(item: PersonaKnowledgeLengths): Candidate[] {
+  const candidates: Candidate[] = []
+  if (hasContent(item.fullTextChars) && item.fullTextChars! <= PERSONA_ATTACHMENT_INLINE_FULLTEXT_MAX_CHARS) {
+    candidates.push({ source: "fullText", len: item.fullTextChars! })
+  }
+  if (hasContent(item.summaryChars)) {
+    candidates.push({ source: "summary", len: item.summaryChars! })
+  }
+  if (candidates.length === 0) {
+    candidates.push(
+      item.extractionFailed
+        ? { source: "failureNote", len: PERSONA_KNOWLEDGE_FAILURE_NOTE.length }
+        : { source: "processingNote", len: PERSONA_KNOWLEDGE_PROCESSING_NOTE.length }
+    )
+  }
+  return candidates
+}
+
 /**
  * The single source of truth for how a persona's context attachments map to
- * prompt bodies (INV-29/43): the selection rules (decision 6) and the cumulative
- * block-budget walk, expressed over content LENGTHS only. Both callers feed it
- * lengths — the prompt renderer from the content it is about to render, the
- * config service from `LENGTH(...)` columns — so the mode label the editor shows
- * is derived by the exact logic that builds the prompt and cannot drift from it.
+ * prompt bodies (INV-29/43): the selection rules (decision 6) and the block
+ * budget, expressed over content LENGTHS only. Both callers feed it lengths —
+ * the prompt renderer from the content it is about to render, the config service
+ * from `LENGTH(...)` columns — so the mode label the editor shows is derived by
+ * the exact logic that builds the prompt and cannot drift from it.
  *
- * Per file, in `position` (array) order:
- * - Full extracted text when present and within
- *   {@link PERSONA_ATTACHMENT_INLINE_FULLTEXT_MAX_CHARS}; else the short summary;
- *   else a processing note.
- * - The chosen body spends the cumulative {@link PERSONA_ATTACHMENT_BLOCK_MAX_CHARS}
- *   budget. The file that crosses it is truncated with an explicit marker, and
- *   every later file degrades to its summary-only (or the marker when it has none)
- *   — a file is never silently dropped.
+ * ONE continuous budget walk over the files in `position` (array) order. The
+ * chosen body of each file spends the cumulative
+ * {@link PERSONA_ATTACHMENT_BLOCK_MAX_CHARS} budget:
+ * - Emit the highest-priority candidate that fits the remaining budget WHOLE and
+ *   spend its length. A too-big full text degrades to a whole summary rather than
+ *   being truncated — a complete gist beats a cut-off body.
+ * - If no candidate fits whole (but budget remains), truncate the SMALLEST
+ *   candidate to what's left with an explicit marker and spend the rest of the
+ *   budget.
+ * - Once the budget is exhausted, later files render a marker-only row (their
+ *   heading still appears) — a file is never silently dropped, and the total
+ *   rendered content stays within the cap (only one file is ever truncated).
  */
 export function planPersonaKnowledge(items: PersonaKnowledgeLengths[]): PersonaKnowledgePlan[] {
   const plans: PersonaKnowledgePlan[] = []
   let usedChars = 0
-  let budgetCrossed = false
 
   for (const item of items) {
-    if (budgetCrossed) {
-      // Budget already spent by an earlier file: degrade to the short summary so
-      // this file's gist still lands; the marker stands in when it has none.
-      if (hasContent(item.summaryChars)) {
-        plans.push({ mode: "summary", truncated: false, source: "summary", truncateAt: null })
-      } else {
-        plans.push({ mode: "name_only", truncated: false, source: "marker", truncateAt: null })
-      }
+    const remaining = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - usedChars
+    if (remaining <= 0) {
+      plans.push({ mode: "name_only", truncated: false, source: "marker", truncateAt: null })
       continue
     }
 
-    let source: Exclude<PersonaKnowledgeSource, "marker">
-    let bodyLen: number
-    if (hasContent(item.fullTextChars) && item.fullTextChars! <= PERSONA_ATTACHMENT_INLINE_FULLTEXT_MAX_CHARS) {
-      source = "fullText"
-      bodyLen = item.fullTextChars!
-    } else if (hasContent(item.summaryChars)) {
-      source = "summary"
-      bodyLen = item.summaryChars!
-    } else {
-      source = "processingNote"
-      bodyLen = PERSONA_KNOWLEDGE_PROCESSING_NOTE.length
+    const candidates = candidatesFor(item)
+    const whole = candidates.find((candidate) => candidate.len <= remaining)
+    if (whole) {
+      usedChars += whole.len
+      plans.push({ mode: MODE_BY_SOURCE[whole.source], truncated: false, source: whole.source, truncateAt: null })
+      continue
     }
 
-    const remaining = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - usedChars
-    const mode = MODE_BY_SOURCE[source]
-    if (bodyLen > remaining) {
-      budgetCrossed = true
-      plans.push({ mode, truncated: true, source, truncateAt: remaining })
-    } else {
-      usedChars += bodyLen
-      plans.push({ mode, truncated: false, source, truncateAt: null })
-    }
+    // Nothing fits whole: truncate the smallest candidate to what's left and
+    // spend the rest of the budget (every later file becomes marker-only).
+    const smallest = candidates.reduce((a, b) => (b.len < a.len ? b : a))
+    usedChars = PERSONA_ATTACHMENT_BLOCK_MAX_CHARS
+    plans.push({
+      mode: MODE_BY_SOURCE[smallest.source],
+      truncated: true,
+      source: smallest.source,
+      truncateAt: remaining,
+    })
   }
 
   return plans

--- a/apps/backend/src/features/agents/companion/prompt/persona-knowledge.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/persona-knowledge.test.ts
@@ -10,6 +10,8 @@ function item(overrides: Partial<PersonaAttachmentContentItem>): PersonaAttachme
     position: 0,
     fullText: null,
     summary: null,
+    processingStatus: "processing",
+    hasExtraction: false,
     ...overrides,
   }
 }
@@ -63,13 +65,13 @@ describe("buildPersonaKnowledgeSection", () => {
     expect(block).not.toContain(summary)
   })
 
-  test("files after the budget-crossing file degrade to summary-only (full text dropped)", () => {
-    // The first file's summary alone overruns the block budget, so it is the
-    // one that gets truncated; the second file then degrades to summary-only.
-    const crossingSummary = "C".repeat(PERSONA_ATTACHMENT_BLOCK_MAX_CHARS + 100)
-    const laterFullText = "LATER_FULL_TEXT_SHOULD_NOT_APPEAR"
+  test("budget-aware degradation: a file whose full text won't fit shows its whole summary instead", () => {
+    // The first file's whole summary fits but leaves only a small remainder; the
+    // second file's full text overruns it, so it degrades to its whole summary.
+    const firstSummary = "C".repeat(PERSONA_ATTACHMENT_BLOCK_MAX_CHARS - 100)
+    const laterFullText = "LATER_FULL_TEXT_SHOULD_NOT_APPEAR_".repeat(20)
     const block = buildPersonaKnowledgeSection([
-      item({ attachmentId: "att_1", filename: "first.txt", fullText: null, summary: crossingSummary }),
+      item({ attachmentId: "att_1", filename: "first.txt", fullText: null, summary: firstSummary }),
       item({
         attachmentId: "att_2",
         filename: "second.txt",
@@ -78,11 +80,36 @@ describe("buildPersonaKnowledgeSection", () => {
       }),
     ])
 
-    // Second file is still present (never silently dropped) but shows its short
-    // summary, not its full text.
+    // First file renders whole (untruncated); the second shows its short summary,
+    // not its full text — never silently dropped.
+    expect(block).not.toContain("…[truncated]")
     expect(block).toContain("### second.txt")
     expect(block).toContain("SECOND SUMMARY GIST")
     expect(block).not.toContain(laterFullText)
+  })
+
+  test("processing vs failed extractions render distinct notes (T3)", () => {
+    const block = buildPersonaKnowledgeSection([
+      item({
+        attachmentId: "att_1",
+        filename: "pending.pdf",
+        fullText: null,
+        summary: null,
+        processingStatus: "processing",
+        hasExtraction: false,
+      }),
+      item({
+        attachmentId: "att_2",
+        filename: "broken.pdf",
+        fullText: null,
+        summary: null,
+        processingStatus: "failed",
+        hasExtraction: false,
+      }),
+    ])
+
+    expect(block).toContain("### pending.pdf\n\n(processing — content not yet available)")
+    expect(block).toContain("### broken.pdf\n\n(extraction failed — content unavailable)")
   })
 
   test("a post-budget file with no summary renders the marker so it is never silently dropped", () => {

--- a/apps/backend/src/features/agents/companion/prompt/persona-knowledge.ts
+++ b/apps/backend/src/features/agents/companion/prompt/persona-knowledge.ts
@@ -1,6 +1,10 @@
-import type { PersonaAttachmentContentItem } from "../../persona-attachment-repository"
+import {
+  personaAttachmentExtractionFailed,
+  type PersonaAttachmentContentItem,
+} from "../../persona-attachment-repository"
 import {
   planPersonaKnowledge,
+  PERSONA_KNOWLEDGE_FAILURE_NOTE,
   PERSONA_KNOWLEDGE_PROCESSING_NOTE,
   PERSONA_KNOWLEDGE_TRUNCATION_MARKER,
   type PersonaKnowledgePlan,
@@ -32,6 +36,10 @@ function renderBody(item: PersonaAttachmentContentItem, plan: PersonaKnowledgePl
       return plan.truncateAt == null
         ? PERSONA_KNOWLEDGE_PROCESSING_NOTE
         : truncateWithMarker(PERSONA_KNOWLEDGE_PROCESSING_NOTE, plan.truncateAt)
+    case "failureNote":
+      return plan.truncateAt == null
+        ? PERSONA_KNOWLEDGE_FAILURE_NOTE
+        : truncateWithMarker(PERSONA_KNOWLEDGE_FAILURE_NOTE, plan.truncateAt)
     case "marker":
       return PERSONA_KNOWLEDGE_TRUNCATION_MARKER
   }
@@ -55,6 +63,7 @@ export function buildPersonaKnowledgeSection(items: PersonaAttachmentContentItem
     items.map((item) => ({
       fullTextChars: item.fullText?.length ?? null,
       summaryChars: item.summary?.length ?? null,
+      extractionFailed: personaAttachmentExtractionFailed(item),
     }))
   )
 

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -342,8 +342,24 @@ describe("buildSystemPrompt", () => {
   })
 
   const knowledge = [
-    { attachmentId: "att_1", filename: "runbook.md", position: 0, fullText: "RUNBOOK CONTENT", summary: null },
-    { attachmentId: "att_2", filename: "faq.txt", position: 1, fullText: null, summary: "FAQ SUMMARY" },
+    {
+      attachmentId: "att_1",
+      filename: "runbook.md",
+      position: 0,
+      fullText: "RUNBOOK CONTENT",
+      summary: null,
+      processingStatus: "completed" as const,
+      hasExtraction: true,
+    },
+    {
+      attachmentId: "att_2",
+      filename: "faq.txt",
+      position: 1,
+      fullText: null,
+      summary: "FAQ SUMMARY",
+      processingStatus: "completed" as const,
+      hasExtraction: true,
+    },
   ]
 
   test("injects the persona ## Knowledge block after the persona prompt and before the stream context", () => {

--- a/apps/backend/src/features/agents/persona-attachment-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-attachment-repository.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { PersonaAttachmentRepository } from "./persona-attachment-repository"
+import { personaAttachmentExtractionFailed, PersonaAttachmentRepository } from "./persona-attachment-repository"
 
 interface CapturedQuery {
   text: string
@@ -118,6 +118,53 @@ describe("PersonaAttachmentRepository.listForPersona", () => {
       fullTextChars: 1200,
       summaryChars: 80,
     })
+  })
+})
+
+describe("PersonaAttachmentRepository.listForPersonaWithContent", () => {
+  test("returns extraction content plus processing_status + has_extraction for the prompt/failure path", async () => {
+    const db = createDb([
+      [
+        {
+          attachment_id: "att_1",
+          filename: "runbook.md",
+          position: 0,
+          full_text: "STEP 1",
+          summary: "",
+          processing_status: "failed",
+          has_extraction: false,
+        },
+      ],
+    ])
+
+    const items = await PersonaAttachmentRepository.listForPersonaWithContent(db, "workspace_1", "persona_1")
+
+    const text = db.queries[0]!.text
+    expect(text).toContain("a.processing_status")
+    expect(text).toContain("(e.attachment_id IS NOT NULL) AS has_extraction")
+    expect(text).toContain("ORDER BY pa.position ASC")
+    expect(items[0]).toEqual({
+      attachmentId: "att_1",
+      filename: "runbook.md",
+      position: 0,
+      fullText: "STEP 1",
+      // '' summary normalizes to null so "has a summary" is a plain null-check.
+      summary: null,
+      processingStatus: "failed",
+      hasExtraction: false,
+    })
+  })
+})
+
+describe("personaAttachmentExtractionFailed", () => {
+  test("true only when there is no extraction AND a terminal (failed/skipped) status", () => {
+    expect(personaAttachmentExtractionFailed({ hasExtraction: false, processingStatus: "failed" })).toBe(true)
+    expect(personaAttachmentExtractionFailed({ hasExtraction: false, processingStatus: "skipped" })).toBe(true)
+    // An extraction that landed is never "failed", whatever the pipeline status.
+    expect(personaAttachmentExtractionFailed({ hasExtraction: true, processingStatus: "failed" })).toBe(false)
+    // Non-terminal statuses are still processing, not failed.
+    expect(personaAttachmentExtractionFailed({ hasExtraction: false, processingStatus: "processing" })).toBe(false)
+    expect(personaAttachmentExtractionFailed({ hasExtraction: false, processingStatus: "pending" })).toBe(false)
   })
 })
 

--- a/apps/backend/src/features/agents/persona-attachment-repository.ts
+++ b/apps/backend/src/features/agents/persona-attachment-repository.ts
@@ -1,5 +1,22 @@
 import { sql, type Querier } from "../../db"
-import type { ProcessingStatus } from "@threa/types"
+import { ProcessingStatuses, type ProcessingStatus } from "@threa/types"
+
+/**
+ * A persona file whose extraction pipeline gave up: no extraction landed and the
+ * attachment reached a terminal state (failed scan/extraction, or an unsupported
+ * type skipped). The single predicate behind BOTH the config wire status
+ * (`failed`) and the prompt's failure note, so the editor label and the prompt
+ * body can never disagree about which files are unrecoverable.
+ */
+export function personaAttachmentExtractionFailed(item: {
+  hasExtraction: boolean
+  processingStatus: ProcessingStatus
+}): boolean {
+  return (
+    !item.hasExtraction &&
+    (item.processingStatus === ProcessingStatuses.FAILED || item.processingStatus === ProcessingStatuses.SKIPPED)
+  )
+}
 
 interface PersonaAttachmentBindingRow {
   attachment_id: string
@@ -87,6 +104,8 @@ interface PersonaAttachmentContentRow {
   position: number
   full_text: string | null
   summary: string | null
+  processing_status: string
+  has_extraction: boolean
 }
 
 /**
@@ -102,6 +121,8 @@ export interface PersonaAttachmentContentItem {
   position: number
   fullText: string | null
   summary: string | null
+  processingStatus: ProcessingStatus
+  hasExtraction: boolean
 }
 
 function mapContentRow(row: PersonaAttachmentContentRow): PersonaAttachmentContentItem {
@@ -114,6 +135,8 @@ function mapContentRow(row: PersonaAttachmentContentRow): PersonaAttachmentConte
     // empty string to null so the block's "has a summary" test is a plain
     // null-check.
     summary: row.summary && row.summary.length > 0 ? row.summary : null,
+    processingStatus: row.processing_status as ProcessingStatus,
+    hasExtraction: row.has_extraction,
   }
 }
 
@@ -202,7 +225,9 @@ export const PersonaAttachmentRepository = {
         a.filename,
         pa.position,
         e.full_text,
-        e.summary
+        e.summary,
+        a.processing_status,
+        (e.attachment_id IS NOT NULL) AS has_extraction
       FROM persona_attachments pa
       JOIN attachments a ON a.id = pa.attachment_id AND a.workspace_id = pa.workspace_id
       LEFT JOIN attachment_extractions e ON e.attachment_id = pa.attachment_id

--- a/apps/backend/src/features/agents/persona-config-service.test.ts
+++ b/apps/backend/src/features/agents/persona-config-service.test.ts
@@ -1612,16 +1612,18 @@ function settledAttachment(overrides: Partial<Record<string, unknown>> = {}) {
 /**
  * Attachment-service seam for the bind path: `getById` returns the row to bind,
  * `getSharingBlockReason` is the settled-and-safe predicate (null = safe), and
- * `delete` is the cap-race cleanup. No S3 / createForUpload — the bytes already
- * landed through the shared upload transport (INV-35/37).
+ * `deleteIfUnbound` is the race-safe cap-race / remove cleanup (`{ deleted }`;
+ * `false` = a message claimed the file, so its bytes were left intact — INV-20).
+ * No S3 / createForUpload — the bytes already landed through the shared upload
+ * transport (INV-35/37).
  */
-function makeBindDeps(overrides: { getById?: any; getSharingBlockReason?: any; delete?: any } = {}): {
+function makeBindDeps(overrides: { getById?: any; getSharingBlockReason?: any; deleteIfUnbound?: any } = {}): {
   attachmentService: any
 } {
   const attachmentService = {
     getById: overrides.getById ?? mock(async () => settledAttachment()),
     getSharingBlockReason: overrides.getSharingBlockReason ?? mock(() => null),
-    delete: overrides.delete ?? mock(async () => true),
+    deleteIfUnbound: overrides.deleteIfUnbound ?? mock(async () => ({ deleted: true })),
   }
   return { attachmentService }
 }
@@ -1820,8 +1822,8 @@ describe("PersonaConfigService.bindAttachment — cap and conflicts", () => {
     setupTransaction()
     spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
     spyOn(PersonaAttachmentRepository, "insertBinding").mockRejectedValue({ code: "23505" })
-    const del = mock(async () => true)
-    const deps = makeBindDeps({ delete: del })
+    const del = mock(async () => ({ deleted: true }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
 
     await expect(
       makeService(undefined, deps).bindAttachment(WORKSPACE_ID, "persona_custom_1", ADMIN, ATTACHMENT_ID)
@@ -1834,14 +1836,28 @@ describe("PersonaConfigService.bindAttachment — cap and conflicts", () => {
     setupTransaction()
     spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
     spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(null)
-    const del = mock(async () => true)
-    const deps = makeBindDeps({ delete: del })
+    const del = mock(async () => ({ deleted: true }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
 
     await expect(
       makeService(undefined, deps).bindAttachment(WORKSPACE_ID, "persona_custom_1", ADMIN, ATTACHMENT_ID)
     ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_LIMIT" })
     // The sweep never reaps a settled-but-unbound attachment (its tracking row is
-    // gone), so bind must delete it to avoid a permanent orphan.
+    // gone), so bind must delete it to avoid a permanent orphan — race-safely, so
+    // a file a message claimed in the meantime keeps its bytes (INV-20).
+    expect(del).toHaveBeenCalledWith(ATTACHMENT_ID)
+  })
+
+  it("lost cap race where a message claimed the file: cleanup no-ops but still 400s", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(null)
+    const del = mock(async () => ({ deleted: false }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
+
+    await expect(
+      makeService(undefined, deps).bindAttachment(WORKSPACE_ID, "persona_custom_1", ADMIN, ATTACHMENT_ID)
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_LIMIT" })
     expect(del).toHaveBeenCalledWith(ATTACHMENT_ID)
   })
 })
@@ -1849,22 +1865,36 @@ describe("PersonaConfigService.bindAttachment — cap and conflicts", () => {
 describe("PersonaConfigService.removeAttachment", () => {
   afterEach(() => mock.restore())
 
-  it("deletes the binding then hard-deletes the attachment row + S3 object", async () => {
+  it("deletes the binding then hard-deletes the attachment row + S3 object (only while unbound)", async () => {
     spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
     spyOn(PersonaAttachmentRepository, "deleteBinding").mockResolvedValue(true)
-    const del = mock(async () => true)
-    const deps = makeBindDeps({ delete: del })
+    const del = mock(async () => ({ deleted: true }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
 
     await makeService(undefined, deps).removeAttachment(WORKSPACE_ID, "persona_custom_1", "att_1", ADMIN)
 
     expect(del).toHaveBeenCalledWith("att_1")
   })
 
+  it("still succeeds when a message claimed the file first (binding gone, bytes left intact)", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const unbind = spyOn(PersonaAttachmentRepository, "deleteBinding").mockResolvedValue(true)
+    const del = mock(async () => ({ deleted: false }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
+
+    // No throw: the user-visible action (unbind) happened; the file's bytes are a
+    // message's now and were intentionally not destroyed.
+    await makeService(undefined, deps).removeAttachment(WORKSPACE_ID, "persona_custom_1", "att_1", ADMIN)
+
+    expect(unbind).toHaveBeenCalled()
+    expect(del).toHaveBeenCalledWith("att_1")
+  })
+
   it("404s when the binding does not exist (and never touches the attachment)", async () => {
     spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
     spyOn(PersonaAttachmentRepository, "deleteBinding").mockResolvedValue(false)
-    const del = mock(async () => true)
-    const deps = makeBindDeps({ delete: del })
+    const del = mock(async () => ({ deleted: true }))
+    const deps = makeBindDeps({ deleteIfUnbound: del })
 
     await expect(
       makeService(undefined, deps).removeAttachment(WORKSPACE_ID, "persona_custom_1", "missing", ADMIN)

--- a/apps/backend/src/features/agents/persona-config-service.ts
+++ b/apps/backend/src/features/agents/persona-config-service.ts
@@ -10,7 +10,6 @@ import {
   CompanionModes,
   MemoryModes,
   StreamPurposes,
-  ProcessingStatuses,
   PERSONA_ATTACHMENT_MAX_COUNT,
   PERSONA_ATTACHMENT_MAX_SIZE_BYTES,
   PERSONA_ATTACHMENT_ALLOWED_MIME_TYPES,
@@ -31,7 +30,11 @@ import { HttpError } from "../../lib/errors"
 import { logger } from "../../lib/logger"
 import { OutboxRepository } from "../../lib/outbox"
 import type { AttachmentService } from "../attachments"
-import { PersonaAttachmentRepository, type PersonaAttachmentListItem } from "./persona-attachment-repository"
+import {
+  personaAttachmentExtractionFailed,
+  PersonaAttachmentRepository,
+  type PersonaAttachmentListItem,
+} from "./persona-attachment-repository"
 import { planPersonaKnowledge, type PersonaKnowledgePlan } from "./companion/prompt/persona-knowledge-plan"
 import type { StreamService } from "../streams"
 import { AgentConfigOverrideRepository, type AgentConfigOverrideDetail } from "./agent-config-override-repository"
@@ -124,9 +127,7 @@ function personaAttachmentNotFound(): HttpError {
 /** Derive the structured wire status (INV-46) from the extraction/pipeline state. */
 function personaAttachmentProcessingStatus(item: PersonaAttachmentListItem): PersonaAttachmentProcessingStatus {
   if (item.hasExtraction) return "ready"
-  if (item.processingStatus === ProcessingStatuses.FAILED || item.processingStatus === ProcessingStatuses.SKIPPED) {
-    return "failed"
-  }
+  if (personaAttachmentExtractionFailed(item)) return "failed"
   return "processing"
 }
 
@@ -544,7 +545,11 @@ export class PersonaConfigService {
     // prompt uses, fed the extraction lengths in position order (INV-29/43) — the
     // label the editor shows can't drift from what the prompt actually carries.
     const plans = planPersonaKnowledge(
-      rows.map((row) => ({ fullTextChars: row.fullTextChars, summaryChars: row.summaryChars }))
+      rows.map((row) => ({
+        fullTextChars: row.fullTextChars,
+        summaryChars: row.summaryChars,
+        extractionFailed: personaAttachmentExtractionFailed(row),
+      }))
     )
     return rows.map((row, index) => toPersonaAttachmentItem(row, plans[index]!))
   }
@@ -1186,10 +1191,18 @@ export class PersonaConfigService {
       // Cap reached. A settled-but-unbound attachment is NEVER reaped by the
       // upload sweep — its `attachment_uploads` tracking row is deleted at settle,
       // and the sweep only reaps rows that still have one — so hard-delete it here
-      // to avoid a permanent orphan, matching the old cap-race cleanup.
-      await this.attachmentService.delete(attachmentId).catch((err) => {
-        logger.error({ err, attachmentId }, "failed to clean up persona attachment after cap race")
-      })
+      // to avoid a permanent orphan. `deleteIfUnbound` so a message that claimed
+      // the file between the cap check and now keeps its bytes (INV-20).
+      await this.attachmentService
+        .deleteIfUnbound(attachmentId)
+        .then((result) => {
+          if (!result.deleted) {
+            logger.info({ attachmentId }, "persona cap-race cleanup skipped — file was claimed by a message")
+          }
+        })
+        .catch((err) => {
+          logger.error({ err, attachmentId }, "failed to clean up persona attachment after cap race")
+        })
       throw personaAttachmentLimitReached()
     }
 
@@ -1210,10 +1223,10 @@ export class PersonaConfigService {
   /**
    * Remove a persona context attachment: verify the binding under the persona
    * edit gate, delete it, then hard-delete the attachment row + extraction + S3
-   * object ({@link AttachmentService.delete}). Persona files are never bound to a
-   * message, so a hard delete is safe. The binding delete runs first so a failure
-   * mid-way leaves at worst an unbound (invisible) attachment row, never a
-   * binding pointing at deleted bytes.
+   * object — but only while it is still unbound ({@link AttachmentService.deleteIfUnbound}),
+   * so a file a message claimed in the meantime keeps its bytes (INV-20). The
+   * binding delete runs first so a failure mid-way leaves at worst an unbound
+   * (invisible) attachment row, never a binding pointing at deleted bytes.
    */
   async removeAttachment(
     workspaceId: string,
@@ -1227,6 +1240,15 @@ export class PersonaConfigService {
     const deleted = await PersonaAttachmentRepository.deleteBinding(this.pool, workspaceId, personaId, attachmentId)
     if (!deleted) throw personaAttachmentNotFound()
 
-    await this.attachmentService.delete(attachmentId)
+    // The binding is gone — the user-visible action succeeded. Hard-delete the
+    // file only while it is still unbound: a message that claimed it between the
+    // binding delete and now keeps its bytes (INV-20), we just log the skip.
+    const result = await this.attachmentService.deleteIfUnbound(attachmentId)
+    if (!result.deleted) {
+      logger.info(
+        { workspaceId, personaId, attachmentId },
+        "persona attachment unbound but file left intact — claimed by a message"
+      )
+    }
   }
 }

--- a/apps/backend/src/features/attachments/repository.ts
+++ b/apps/backend/src/features/attachments/repository.ts
@@ -263,6 +263,36 @@ export const AttachmentRepository = {
   },
 
   /**
+   * Delete the row ONLY while it is still free-floating (bound to neither a
+   * message nor a stream), returning its storage path when it ran so the caller
+   * can drop the S3 object — and `null` when it did not, because a concurrent
+   * `attachToMessage` claimed it between the caller's checks (INV-20: the
+   * predicate is in the DELETE, not a check-then-act re-fetch). A `null` return
+   * means the file now has real message provenance and its bytes must be left
+   * intact.
+   */
+  async deleteIfUnbound(client: Querier, id: string): Promise<string | null> {
+    const result = await client.query<{ storage_path: string }>(sql`
+      DELETE FROM attachments
+      WHERE id = ${id} AND message_id IS NULL AND stream_id IS NULL
+      RETURNING storage_path
+    `)
+    return result.rows[0]?.storage_path ?? null
+  },
+
+  /**
+   * Cascade an attachment delete to its persona context-attachment binding
+   * (agents domain). No FKs (INV-1), so the attachments deleter owns the cascade;
+   * without it a hard-deleted persona file leaves a dangling `persona_attachments`
+   * row that silently eats a persona's attachment-cap slot forever. The
+   * cross-feature table name is deliberate — attachments must not import agents
+   * code — and stays scoped to this single chokepoint.
+   */
+  async deletePersonaBindings(client: Querier, id: string): Promise<void> {
+    await client.query(sql`DELETE FROM persona_attachments WHERE attachment_id = ${id}`)
+  },
+
+  /**
    * Batch-delete rows that never bound to a message (abandoned-reservation
    * sweep). The `message_id IS NULL` guard makes a race with a concurrent
    * send lose cleanly: a just-bound row is skipped, not deleted.

--- a/apps/backend/src/features/attachments/service.test.ts
+++ b/apps/backend/src/features/attachments/service.test.ts
@@ -95,6 +95,9 @@ describe("AttachmentService", () => {
     spyOn(AttachmentUploadRepository, "deleteByAttachmentId").mockImplementation(async () => {
       steps.push("upload:delete")
     })
+    spyOn(AttachmentRepository, "deletePersonaBindings").mockImplementation(async () => {
+      steps.push("persona:unbind")
+    })
     spyOn(AttachmentRepository, "delete").mockImplementation(async () => {
       steps.push("attachment:delete")
       return true
@@ -113,10 +116,67 @@ describe("AttachmentService", () => {
       "attachment:lock",
       "extraction:delete",
       "upload:delete",
+      "persona:unbind",
       "attachment:delete",
       "transaction:end",
       "storage:delete",
     ])
+  })
+
+  it("cascades a delete to the file's persona context-attachment binding (INV-1, no FKs)", async () => {
+    spyOn(db, "withTransaction").mockImplementation((async (_db: unknown, callback: (client: any) => Promise<any>) =>
+      callback({})) as any)
+    spyOn(AttachmentRepository, "findByIdForUpdate").mockResolvedValue(
+      makeAttachment({ streamId: null, messageId: null })
+    )
+    spyOn(AttachmentExtractionRepository, "deleteByAttachmentId").mockResolvedValue(true)
+    spyOn(AttachmentUploadRepository, "deleteByAttachmentId").mockResolvedValue(undefined as never)
+    const unbind = spyOn(AttachmentRepository, "deletePersonaBindings").mockResolvedValue(undefined as never)
+    spyOn(AttachmentRepository, "delete").mockResolvedValue(true)
+
+    const { service } = createService()
+    const deleted = await service.delete("attach_1")
+
+    expect(deleted).toBe(true)
+    expect(unbind).toHaveBeenCalledWith(expect.anything(), "attach_1")
+  })
+
+  describe("deleteIfUnbound", () => {
+    it("deletes the file (and its extraction/upload/persona rows + S3 object) when still unbound", async () => {
+      spyOn(db, "withTransaction").mockImplementation((async (_db: unknown, callback: (client: any) => Promise<any>) =>
+        callback({})) as any)
+      const conditionalDelete = spyOn(AttachmentRepository, "deleteIfUnbound").mockResolvedValue("ws_1/attach_1/f")
+      const extraction = spyOn(AttachmentExtractionRepository, "deleteByAttachmentId").mockResolvedValue(true)
+      const upload = spyOn(AttachmentUploadRepository, "deleteByAttachmentId").mockResolvedValue(undefined as never)
+      const unbind = spyOn(AttachmentRepository, "deletePersonaBindings").mockResolvedValue(undefined as never)
+
+      const { service, storage } = createService()
+      const result = await service.deleteIfUnbound("attach_1")
+
+      expect(result).toEqual({ deleted: true })
+      expect(conditionalDelete).toHaveBeenCalledWith(expect.anything(), "attach_1")
+      expect(extraction).toHaveBeenCalled()
+      expect(upload).toHaveBeenCalled()
+      expect(unbind).toHaveBeenCalled()
+      expect(storage.delete).toHaveBeenCalledWith("ws_1/attach_1/f")
+    })
+
+    it("leaves the bytes and rows intact when a message claimed the file (conditional delete no-ops)", async () => {
+      spyOn(db, "withTransaction").mockImplementation((async (_db: unknown, callback: (client: any) => Promise<any>) =>
+        callback({})) as any)
+      // The race-safe DELETE matched no row: message_id/stream_id got set first.
+      spyOn(AttachmentRepository, "deleteIfUnbound").mockResolvedValue(null)
+      const extraction = spyOn(AttachmentExtractionRepository, "deleteByAttachmentId").mockResolvedValue(true)
+      const unbind = spyOn(AttachmentRepository, "deletePersonaBindings").mockResolvedValue(undefined as never)
+
+      const { service, storage } = createService()
+      const result = await service.deleteIfUnbound("attach_1")
+
+      expect(result).toEqual({ deleted: false })
+      expect(extraction).not.toHaveBeenCalled()
+      expect(unbind).not.toHaveBeenCalled()
+      expect(storage.delete).not.toHaveBeenCalled()
+    })
   })
 
   it("returns false when attachment does not exist", async () => {

--- a/apps/backend/src/features/attachments/service.ts
+++ b/apps/backend/src/features/attachments/service.ts
@@ -719,6 +719,19 @@ export class AttachmentService {
     return this.storage.getSignedDownloadUrl(attachment.storagePath, { responseContentDisposition })
   }
 
+  /**
+   * No FKs (INV-1): whoever deletes the attachments row owns the cascade to its
+   * child rows — extraction, upload tracking, and any persona context-attachment
+   * binding (else a dangling row eats a persona cap slot forever). One helper for
+   * every row-delete path so a new child table can't get cascaded in one deleter
+   * but not the other.
+   */
+  private async cascadeChildRows(client: PoolClient, id: string): Promise<void> {
+    await AttachmentExtractionRepository.deleteByAttachmentId(client, id)
+    await AttachmentUploadRepository.deleteByAttachmentId(client, id)
+    await AttachmentRepository.deletePersonaBindings(client, id)
+  }
+
   async delete(id: string): Promise<boolean> {
     const storagePath = await withTransaction(this.pool, async (client) => {
       const attachment = await AttachmentRepository.findByIdForUpdate(client, id)
@@ -726,8 +739,7 @@ export class AttachmentService {
         return null
       }
 
-      await AttachmentExtractionRepository.deleteByAttachmentId(client, id)
-      await AttachmentUploadRepository.deleteByAttachmentId(client, id)
+      await this.cascadeChildRows(client, id)
       const deleted = await AttachmentRepository.delete(client, id)
       if (!deleted) {
         throw new Error(`Attachment ${id} could not be deleted after row lock`)
@@ -742,6 +754,32 @@ export class AttachmentService {
 
     await this.storage.delete(storagePath)
     return true
+  }
+
+  /**
+   * Hard-delete an attachment ONLY while it is still free-floating (unbound to a
+   * message and a stream), race-safe against a concurrent `attachToMessage`
+   * (INV-20 — the predicate rides the DELETE). Used by the persona
+   * context-attachment paths, where the file must never be destroyed once a
+   * message has claimed it. Returns `{ deleted }`: `false` (extraction/upload
+   * rows and the S3 object left intact) when the row was already claimed or gone.
+   */
+  async deleteIfUnbound(id: string): Promise<{ deleted: boolean }> {
+    const storagePath = await withTransaction(this.pool, async (client) => {
+      const path = await AttachmentRepository.deleteIfUnbound(client, id)
+      if (path == null) {
+        return null
+      }
+      await this.cascadeChildRows(client, id)
+      return path
+    })
+
+    if (storagePath == null) {
+      return { deleted: false }
+    }
+
+    await this.storage.delete(storagePath)
+    return { deleted: true }
   }
 
   async recoverStalePendingScans(options?: { staleThresholdMs?: number; batchSize?: number }): Promise<number> {

--- a/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
+++ b/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
@@ -7,7 +7,7 @@ import { PersonaAttachmentRepository } from "../../src/features/agents/persona-a
 import { buildSystemPrompt } from "../../src/features/agents/companion/prompt/system-prompt"
 import type { Persona } from "../../src/features/agents/persona-repository"
 import type { StreamContext } from "../../src/features/agents/context-builder"
-import { setupTestDatabase, withTestTransaction } from "./setup"
+import { setupTestDatabase, withTestTransaction, withTransaction } from "./setup"
 
 /**
  * End-to-end proof of the persona-context-attachments prompt path against a real
@@ -200,6 +200,176 @@ describe("persona context attachments → dispatch prompt (integration)", () => 
       )
       expect(withForeign).toBe(base)
       expect(base).not.toContain("## Knowledge")
+    })
+  })
+})
+
+/**
+ * Behavior proofs for the persona_attachments binding against the REAL database —
+ * the SQL-string unit tests can pass while the DB semantics are broken, so these
+ * exercise the actual concurrency, workspace scoping, and no-op paths.
+ */
+async function insertAttachmentRow(
+  db: Parameters<typeof PersonaAttachmentRepository.insertBinding>[0],
+  params: { id: string; workspaceId: string; personaId: string; uploadedBy: string; filename?: string }
+): Promise<void> {
+  await db.query(sql`
+    INSERT INTO attachments (
+      id, workspace_id, stream_id, message_id, filename, mime_type, size_bytes,
+      storage_provider, storage_path, processing_status, uploaded_by
+    ) VALUES (
+      ${params.id}, ${params.workspaceId}, NULL, NULL, ${params.filename ?? "file.md"}, 'text/markdown', 128,
+      's3', ${`personas/${params.personaId}/${params.id}`}, 'completed', ${params.uploadedBy}
+    )
+  `)
+}
+
+describe("persona_attachments binding invariants (integration)", () => {
+  test("concurrency: two adds at the cap boundary → exactly one binds, positions stay unique/dense", async () => {
+    // maxCount 2, one slot already taken → the two concurrent adds contend for the
+    // last slot. Committed data (advisory xact lock spans real transactions), so
+    // clean up explicitly afterwards.
+    const workspaceId = newWorkspaceId()
+    const personaRowId = personaId()
+    const creator = userId()
+    const seededId = attachmentId()
+    const contenderA = attachmentId()
+    const contenderB = attachmentId()
+
+    try {
+      await withTransaction(pool, async (client) => {
+        await PersonaAttachmentRepository.insertBinding(client, {
+          attachmentId: seededId,
+          workspaceId,
+          personaId: personaRowId,
+          createdBy: creator,
+          maxCount: 2,
+        })
+      })
+
+      const [a, b] = await Promise.all([
+        withTransaction(pool, (client) =>
+          PersonaAttachmentRepository.insertBinding(client, {
+            attachmentId: contenderA,
+            workspaceId,
+            personaId: personaRowId,
+            createdBy: creator,
+            maxCount: 2,
+          })
+        ),
+        withTransaction(pool, (client) =>
+          PersonaAttachmentRepository.insertBinding(client, {
+            attachmentId: contenderB,
+            workspaceId,
+            personaId: personaRowId,
+            createdBy: creator,
+            maxCount: 2,
+          })
+        ),
+      ])
+
+      // Exactly one of the two contenders won the last slot.
+      const winners = [a, b].filter((binding) => binding !== null)
+      expect(winners).toHaveLength(1)
+
+      const rows = await pool.query<{ position: number }>(sql`
+        SELECT position FROM persona_attachments
+        WHERE workspace_id = ${workspaceId} AND persona_id = ${personaRowId}
+        ORDER BY position ASC
+      `)
+      // Dense, unique positions: the seed at 0 and the single winner at 1.
+      expect(rows.rows.map((row) => row.position)).toEqual([0, 1])
+    } finally {
+      await pool.query(sql`DELETE FROM persona_attachments WHERE workspace_id = ${workspaceId}`)
+    }
+  })
+
+  test("cross-workspace isolation: identical persona id in two workspaces reads only its own rows", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const wsA = newWorkspaceId()
+      const wsB = newWorkspaceId()
+      const sharedPersonaId = personaId()
+      const creator = userId()
+      const attA = attachmentId()
+      const attB = attachmentId()
+
+      for (const [ws, att, filename] of [
+        [wsA, attA, "a.md"],
+        [wsB, attB, "b.md"],
+      ] as const) {
+        await insertAttachmentRow(client, {
+          id: att,
+          workspaceId: ws,
+          personaId: sharedPersonaId,
+          uploadedBy: creator,
+          filename,
+        })
+        await PersonaAttachmentRepository.insertBinding(client, {
+          attachmentId: att,
+          workspaceId: ws,
+          personaId: sharedPersonaId,
+          createdBy: creator,
+          maxCount: PERSONA_ATTACHMENT_MAX_COUNT,
+        })
+        await client.query(sql`
+          INSERT INTO attachment_extractions (id, attachment_id, workspace_id, content_type, summary, full_text)
+          VALUES (${extractionId()}, ${att}, ${ws}, 'document', 'S', 'FULL')
+        `)
+      }
+
+      const listA = await PersonaAttachmentRepository.listForPersona(client, wsA, sharedPersonaId)
+      const listB = await PersonaAttachmentRepository.listForPersona(client, wsB, sharedPersonaId)
+      expect(listA.map((row) => row.attachmentId)).toEqual([attA])
+      expect(listB.map((row) => row.attachmentId)).toEqual([attB])
+
+      const contentA = await PersonaAttachmentRepository.listForPersonaWithContent(client, wsA, sharedPersonaId)
+      expect(contentA.map((row) => row.filename)).toEqual(["a.md"])
+    })
+  })
+
+  test("deleteBinding with a foreign persona id is a no-op (leaves the real binding intact)", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const workspaceId = newWorkspaceId()
+      const personaRowId = personaId()
+      const otherPersonaId = personaId()
+      const creator = userId()
+      const attId = attachmentId()
+
+      await insertAttachmentRow(client, {
+        id: attId,
+        workspaceId,
+        personaId: personaRowId,
+        uploadedBy: creator,
+      })
+      await PersonaAttachmentRepository.insertBinding(client, {
+        attachmentId: attId,
+        workspaceId,
+        personaId: personaRowId,
+        createdBy: creator,
+        maxCount: PERSONA_ATTACHMENT_MAX_COUNT,
+      })
+
+      // Wrong persona id → no row matched.
+      const removedForeignPersona = await PersonaAttachmentRepository.deleteBinding(
+        client,
+        workspaceId,
+        otherPersonaId,
+        attId
+      )
+      expect(removedForeignPersona).toBe(false)
+
+      // Wrong attachment id → no row matched.
+      const removedForeignAttachment = await PersonaAttachmentRepository.deleteBinding(
+        client,
+        workspaceId,
+        personaRowId,
+        attachmentId()
+      )
+      expect(removedForeignAttachment).toBe(false)
+
+      // The real binding survives both no-ops.
+      const remaining = await PersonaAttachmentRepository.listForPersona(client, workspaceId, personaRowId)
+      expect(remaining.map((row) => row.attachmentId)).toEqual([attId])
     })
   })
 })

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
@@ -268,7 +268,8 @@ export function CustomPersonaEditor({
     const rejected: string[] = []
     for (const file of picked) {
       if (!isPersonaAttachmentMimeAllowed(file.type)) rejected.push(`${file.name} (unsupported type)`)
-      else if (file.size > PERSONA_ATTACHMENT_MAX_SIZE_BYTES) rejected.push(`${file.name} (over 20MB)`)
+      else if (file.size > PERSONA_ATTACHMENT_MAX_SIZE_BYTES)
+        rejected.push(`${file.name} (over ${formatFileSize(PERSONA_ATTACHMENT_MAX_SIZE_BYTES)})`)
       else valid.push(file)
     }
     if (rejected.length > 0) toast.error(`Can't add ${rejected.join(", ")}`)


### PR DESCRIPTION
## Problem

CodeRabbit's final pass on #1324 landed after merge; its six findings were triaged and the real ones are fixed here. The headline: **the `## Knowledge` block's documented 24k-char budget was violable** — `planPersonaKnowledge` stopped accounting once the budget was crossed, so every later file's summary rendered unbudgeted (40 tail files × 400-char summaries = +16k over the cap). Also: a failed extraction rendered "(processing — content not yet available)" in the prompt forever; the persona hard-delete paths could destroy a file a message had just claimed; and a generic attachment delete could leave a dangling `persona_attachments` row silently eating a cap slot.

## Solution

**1. Continuous budget walk (T1).** One walk, no phases: per file, emit the highest-priority candidate (fullText ≤8k → summary → note) that fits the remaining budget *whole* — a full text that won't fit degrades to a whole summary rather than truncating (a complete summary beats a cut-off text). When nothing fits, the smallest candidate is truncated to the exact remainder (at most one truncated file ever), and after that every file is a name+marker row. A 500-iteration seeded property test pins the invariant: spent content ≤ `PERSONA_ATTACHMENT_BLOCK_MAX_CHARS`, ≤1 truncation. The planner stays the single source for both the prompt and the editor's `contextMode` labels.

**2. Failed ≠ processing (T3).** `listForPersonaWithContent` now carries `processing_status`/`has_extraction`; one shared predicate (`personaAttachmentExtractionFailed`) drives both the config status and a new prompt body `(extraction failed — content unavailable)` — a persona no longer implies a broken file might still arrive.

**3. Race-safe hard deletes (T5).** `attachToMessage` only checks `message_id IS NULL`, so a persona file could be claimed by a message between check and delete. New `AttachmentService.deleteIfUnbound` puts the predicate on the DELETE itself (INV-20); `removeAttachment` and the bind cap-loss cleanup route through it — the unbind still succeeds, the claimed file survives, the skip is logged.

**4. Cascade at the chokepoint (T4, accepted part).** Both attachments row-deleters share one `cascadeChildRows` helper (extraction + upload tracking + persona binding, INV-1: the deleter owns the cascade) — the uploader's own generic DELETE, sweep quarantine, and blocked-cleanup can no longer orphan a binding. The thread's broader cross-table lock protocol is disputed on-thread: the PK already prevents double-persona-binds, and with the guarded deletes the remaining interleaving (same owner racing their own upload into both a message and a persona) converges to a benign both-bound state.

**5. Behavior-level proofs (T2).** The real-DB integration suite now exercises what SQL-string assertions can't: two concurrent `insertBinding` calls at the cap boundary (exactly one wins, positions stay dense), cross-workspace isolation on both list queries, and foreign-persona `deleteBinding` no-ops. The fast unit guards stay.

**6.** Editor size-reject message derives from `formatFileSize(PERSONA_ATTACHMENT_MAX_SIZE_BYTES)` (T6).

## Files changed

| File | Change |
| ---- | ------ |
| `companion/prompt/persona-knowledge-plan.ts` | Continuous budget walk, `failureNote` source, `PERSONA_KNOWLEDGE_FAILURE_NOTE` |
| `companion/prompt/persona-knowledge.ts` | Renders `failureNote`; feeds `extractionFailed` into the planner |
| `persona-attachment-repository.ts` | Content query carries `processing_status`/`has_extraction`; shared `personaAttachmentExtractionFailed` |
| `persona-config-service.ts` | Status mapping via the shared predicate; deletes via `deleteIfUnbound` |
| `attachments/repository.ts` | `deleteIfUnbound` (conditional DELETE), `deletePersonaBindings` |
| `attachments/service.ts` | `deleteIfUnbound`, shared `cascadeChildRows` on both row-deleters |
| `custom-persona-editor.tsx` | Size message from the constant |
| tests | Planner property test + failureNote group, prompt failed-vs-processing, service cascade + deleteIfUnbound, bind/remove claimed-file cases, 3 real-DB integration proofs |

## Test plan

- [x] Backend `bun test src/features/agents src/features/attachments` — 912 pass
- [x] Integration (real DB) `persona-attachment-knowledge.test.ts` — 5 pass (incl. concurrent cap race)
- [x] Frontend persona-editor + toast guard — 42 pass
- [x] `bun run typecheck` repo root — 0 errors
- [x] Per-step adversarial review (2-lens Opus verify) — zero unresolved findings

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786563915&installation_id=129946197&pr_number=1332&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1332&signature=280f162ff76c1cfb8032b0569c16b8ae99634a75a9ff5eb188162f7320835f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->