### PR TITLE
feat(frontend): board lens as ?lens= query state — clear filters can never bounce

### DIFF
--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -4,6 +4,7 @@ import { Archive, Ban, Bell, BellOff, Check, ChevronDown, CircleDot, Hash, Layer
 import {
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
+  DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   type BoardLens,
@@ -24,16 +25,10 @@ import {
 } from "@/stores/workspace-store"
 import type { CachedLabel } from "@/hooks/use-labels"
 import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
-import {
-  BoardSavedViews,
-  isBoardAtHome,
-  isViewActive,
-  lensHref,
-  savedViewHref,
-  type BoardViewSelection,
-} from "@/components/board/board-saved-views"
+import { BoardSavedViews, isViewActive, lensHref, type BoardViewSelection } from "@/components/board/board-saved-views"
 import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
-import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
+import { clearFiltersSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
+import { isBoardFiltered } from "@/lib/board/filter-state"
 import { usePreferences } from "@/contexts"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { BOARD_STREAM_TYPE_LABELS as TYPE_LABELS } from "@/lib/board/stream-type-labels"
@@ -52,9 +47,6 @@ type FilterIcon = ComponentType<{ className?: string }>
 interface BoardFilterBarProps {
   workspaceId: string
   lens: BoardLens
-  /** The viewer's home lens (bare `/board`) — decides which lens is segment-less
-   *  and where "Clear filters" returns (the All surfacing baseline). */
-  homeLens: BoardLens
   /** Included scope stream ids (root streams), in URL order. */
   scopeStreamIds: string[]
   /** Excluded stream ids (anchor-or-root veto), in URL order. */
@@ -92,9 +84,8 @@ interface BoardFilterBarProps {
  * optional narrowings over the always-available All home. Deliberately a
  * filter control — not a tab strip — so the lenses read as suggestions you can
  * reach for (like the search page's stream-type filter), not as the prescribed
- * ways to use the board. Every filter lives in the URL (lens as a route
- * segment, the rest as query params), so refresh/back/share reproduce the view
- * (INV-59).
+ * ways to use the board. Every filter lives in the URL as query params — the
+ * lens included (`?lens=`) — so refresh/back/share reproduce the view (INV-59).
  *
  * Each picker row is tri-state: the row toggles INCLUDE (checkbox), the ban
  * button on its right toggles EXCLUDE — include narrows, exclude vetoes, and
@@ -109,7 +100,6 @@ interface BoardFilterBarProps {
 export function BoardFilterBar({
   workspaceId,
   lens,
-  homeLens,
   scopeStreamIds,
   excludeStreamIds,
   onStreamFilterChange,
@@ -138,20 +128,15 @@ export function BoardFilterBar({
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
   const labelById = useMemo(() => new Map(myLabels.map((l) => [l.id, l])), [myLabels])
 
-  // The viewer's home baseline is NOT "filtered" — otherwise the home shows a
-  // permanent "Clear filters" affordance on its own untouched landing. The home
-  // is the plain home lens, or (when set) the saved view they home on, so resting
-  // on that view must also read as unfiltered even though it carries scope.
-  const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
+  // The baseline is absolute — the unfiltered All lens — so any narrowing offers
+  // "Clear filters", including the viewer's own saved-view or non-All home (its
+  // filters must be clearable too; the home-relative baseline made them not be).
   // `unreadOnly` narrows the feed like every other axis (unlike `showArchived`,
-  // which broadens it), so it must count toward "filtered" too — otherwise
-  // toggling Unread with nothing else selected hides "Clear filters" and the
-  // empty-state "Show everything" CTA even though the board is narrowed.
-  // `BoardViewSelection` itself stays unread-unaware (matching `showArchived`'s
-  // precedent): unread state churns on every read receipt, so it isn't
-  // meaningful to capture in a saved view.
+  // which broadens it), so it counts toward "filtered"; `BoardViewSelection`
+  // itself stays unread-unaware (matching `showArchived`'s precedent): unread
+  // state churns on every read receipt, so it isn't meaningful in a saved view.
   const isFiltered =
-    !isBoardAtHome(homeLens, homeView, {
+    isBoardFiltered({
       lens,
       scopeStreamIds,
       scopeStreamTypes,
@@ -160,20 +145,14 @@ export function BoardFilterBar({
       excludeStreamTypes,
       excludeLabelIds,
     }) || unreadOnly
-  const clearedSearch = useMemo(() => boardHomeSearch(location.search), [location.search])
-  // "Clear filters" returns to the viewer's home: the saved-view home when one
-  // resolves (straight to its URL — no bare `/board` detour that would blank-flash
-  // through the redirect), else the plain home lens (explicit segment while a home
-  // view is configured-but-still-loading, so it stays reachable). Either way the
-  // surviving non-filter query — an open `?panel=` — rides along, per the
-  // `boardHomeSearch` contract, so clearing filters never drops the open thread.
-  const clearFiltersTo = useMemo(() => {
-    if (!homeView) return lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeViewId !== null)
-    const href = savedViewHref(workspaceId, homeView, homeLens)
-    const extra = clearedSearch.replace(/^\?/, "")
-    if (!extra) return href
-    return href.includes("?") ? `${href}&${extra}` : `${href}?${extra}`
-  }, [homeView, homeViewId, workspaceId, homeLens, clearedSearch])
+  // "Clear filters" shows everything: explicit `?lens=all` with no filter axes —
+  // never the bare `/board` entry alias, which would bounce to the viewer's home.
+  // The surviving non-filter query — an open `?panel=` — rides along, per the
+  // `clearFiltersSearch` contract, so clearing filters never drops the open thread.
+  const clearFiltersTo = useMemo(
+    () => `/w/${workspaceId}/board${clearFiltersSearch(location.search)}`,
+    [workspaceId, location.search]
+  )
 
   const labelFor = (streamId: string) =>
     resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
@@ -193,7 +172,6 @@ export function BoardFilterBar({
       <BoardLensMenu
         workspaceId={workspaceId}
         lens={lens}
-        homeLens={homeLens}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         scopeStreamTypes={scopeStreamTypes}
@@ -467,7 +445,6 @@ function ExcludeToggle({ excluded, onToggle, subject }: { excluded: boolean; onT
 function BoardLensMenu({
   workspaceId,
   lens,
-  homeLens,
   scopeStreamIds,
   excludeStreamIds,
   scopeStreamTypes,
@@ -477,7 +454,6 @@ function BoardLensMenu({
 }: {
   workspaceId: string
   lens: BoardLens
-  homeLens: BoardLens
   scopeStreamIds: string[]
   excludeStreamIds: string[]
   scopeStreamTypes: BoardScopeStreamType[]
@@ -506,14 +482,10 @@ function BoardLensMenu({
   }
   const activeViewId = views?.find((view) => isViewActive(view, selection))?.id ?? null
 
-  // Two distinct signals: whether a saved-view home is CONFIGURED (known from the
-  // preference before the list loads) drives the lens links — the home lens must
-  // keep its explicit segment as soon as a view is set, or a click during the load
-  // window emits bare `/board` and gets bounced to the saved view (unreachable
-  // fallback lens). Whether it RESOLVES drives the pin fill: no lens reads as home
-  // while a real saved-view home exists.
-  const { view: homeMenuView, configuredId: homeMenuViewId } = useBoardHome(workspaceId)
-  const hasConfiguredHomeView = homeMenuViewId !== null
+  // The pin fill: the home lens preference marks a lens row, but no lens reads
+  // as home while a saved-view home resolves (the view's pin is the home then).
+  const homeLens = usePreferences().preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const { view: homeMenuView } = useBoardHome(workspaceId)
   const homeViewActive = homeMenuView != null
 
   const content = (
@@ -533,7 +505,7 @@ function BoardLensMenu({
               )}
             >
               <Link
-                to={lensHref(workspaceId, value, search, homeLens, hasConfiguredHomeView)}
+                to={lensHref(workspaceId, value, search)}
                 onClick={() => setOpen(false)}
                 aria-current={selected ? "true" : undefined}
                 className="flex min-w-0 flex-1 items-start gap-2.5 rounded-item px-2.5 py-2"
@@ -568,7 +540,6 @@ function BoardLensMenu({
       <BoardSavedViews
         workspaceId={workspaceId}
         lens={lens}
-        homeLens={homeLens}
         activeViewId={activeViewId}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
@@ -583,7 +554,7 @@ function BoardLensMenu({
 
   const trigger = (
     <Button
-      variant={lens === homeLens ? "outline" : "secondary"}
+      variant={lens === DEFAULT_BOARD_LENS ? "outline" : "secondary"}
       size="sm"
       className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
       aria-label={`Board lens: ${current.label}`}

--- a/apps/frontend/src/components/board/board-filter-params.test.ts
+++ b/apps/frontend/src/components/board/board-filter-params.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { MAX_BOARD_SCOPE_STREAMS } from "@threa/types"
 import {
-  boardHomeSearch,
+  clearFiltersSearch,
   focusScopeSearch,
   isSoleInclude,
   labelFocusSearch,
@@ -15,14 +15,17 @@ import {
   toggleIncludeSearch,
 } from "./board-filter-params"
 
-describe("boardHomeSearch", () => {
-  it("strips every filter param and keeps unrelated URL state", () => {
-    const search = "?in=a,b&not-in=c&is=dm&not-is=system&label=l1&not-label=l2&panel=conv_1"
-    expect(boardHomeSearch(search)).toBe("?panel=conv_1")
+describe("clearFiltersSearch", () => {
+  it("strips every filter param, resets the lens to all, and keeps unrelated URL state", () => {
+    const search = "?lens=active&in=a,b&not-in=c&is=dm&not-is=system&label=l1&not-label=l2&panel=conv_1"
+    expect(clearFiltersSearch(search)).toBe("?lens=all&panel=conv_1")
   })
 
-  it("returns an empty string when nothing survives", () => {
-    expect(boardHomeSearch("?in=a")).toBe("")
+  it("is never the bare (query-less) URL — the explicit lens survives", () => {
+    // Bare `/board` is the home-redirect entry alias; emitting it from a clear
+    // affordance is the filters-bounce this scheme exists to prevent.
+    expect(clearFiltersSearch("?in=a")).toBe("?lens=all")
+    expect(clearFiltersSearch("")).toBe("?lens=all")
   })
 })
 

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -1,15 +1,30 @@
-import { BOARD_SCOPE_STREAM_TYPES, MAX_BOARD_SCOPE_STREAMS, type BoardScopeStreamType } from "@threa/types"
+import {
+  BOARD_LENSES,
+  BOARD_SCOPE_STREAM_TYPES,
+  DEFAULT_BOARD_LENS,
+  MAX_BOARD_SCOPE_STREAMS,
+  type BoardLens,
+  type BoardScopeStreamType,
+} from "@threa/types"
 
 /**
  * The board's URL filter vocabulary — one source of truth (INV-33) for every
  * writer/reader of the board's query params: the page (parse), the filter bar
  * (toggles), and saved views (expand a bookmark back into a URL).
  *
- * Six params, three dimensions × include/exclude. `in`/`is` follow the search
- * syntax's vocabulary; the `not-` prefix is the negation. Include narrows,
- * exclude vetoes; when both name the same id the veto wins (the backend ANDs
- * the two conditions).
+ * The lens plus six filter params, three dimensions × include/exclude. `in`/`is`
+ * follow the search syntax's vocabulary; the `not-` prefix is the negation.
+ * Include narrows, exclude vetoes; when both name the same id the veto wins
+ * (the backend ANDs the two conditions).
  */
+
+/** The lens (`?lens=all,active,…`). The whole board view is query state: every
+ *  rendered board URL carries an explicit `?lens=`, and the bare query-less
+ *  `/board` is only an entry alias that redirects to the viewer's home — so no
+ *  URL a filter affordance produces can re-trigger the home resolution (the old
+ *  path-segment scheme made bare `/board` double as the "cleared" URL, which
+ *  bounced Clear filters straight back into a saved-view home's filters). */
+export const BOARD_LENS_PARAM = "lens"
 
 /** Stream scope (`?in=<id>,<id>` — root-stream ids). */
 export const BOARD_SCOPE_PARAM = "in"
@@ -61,19 +76,28 @@ export const BOARD_FILTER_PARAMS = [
   BOARD_UNREAD_PARAM,
 ] as const
 
+/** Parse `?lens=`: a valid lens, anything else (absent, unknown) degrades to
+ *  the default `all` — a hand-built URL renders the widest view rather than
+ *  erroring. */
+export function parseLensParam(value: string | null): BoardLens {
+  return value && (BOARD_LENSES as readonly string[]).includes(value) ? (value as BoardLens) : DEFAULT_BOARD_LENS
+}
+
 /**
- * The search string for a link back to the unfiltered board home: the current
- * query minus the filter params. Every "clear the filters" affordance (the
- * bar's Clear filters, the empty state's Show everything, the
- * post-from-filtered-view navigation) must route through this so clearing
- * filters never has the side effect of dropping unrelated URL state — an open
- * `?panel=` must survive.
+ * The search string for "show everything, unfiltered": the current query minus
+ * every filter param, with the lens reset to the default `all` — explicitly, so
+ * the result is never the bare query-less `/board` (which is the home-redirect
+ * entry alias; emitting it here is exactly the clear-filters bounce this scheme
+ * exists to prevent). Every "clear the filters" affordance (the bar's Clear
+ * filters, the empty state's Show everything, the post-from-filtered-view
+ * navigation, the sidebar chips' Clear) routes through this, and unrelated URL
+ * state — an open `?panel=` — survives.
  */
-export function boardHomeSearch(search: string): string {
+export function clearFiltersSearch(search: string): string {
   const params = new URLSearchParams(search)
   for (const param of BOARD_FILTER_PARAMS) params.delete(param)
-  const query = params.toString()
-  return query ? `?${query}` : ""
+  params.set(BOARD_LENS_PARAM, DEFAULT_BOARD_LENS)
+  return `?${params.toString()}`
 }
 
 /** Parse a comma-separated id list param: trimmed, deduped, order-preserving. */

--- a/apps/frontend/src/components/board/board-home-redirect.test.ts
+++ b/apps/frontend/src/components/board/board-home-redirect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { BoardView } from "@threa/types"
-import { boardHomeRedirectHref } from "@/components/board/board-saved-views"
+import { boardHomeHref } from "@/components/board/board-saved-views"
 
 const WS = "ws_1"
 
@@ -20,32 +20,23 @@ function view(overrides: Partial<BoardView> = {}): BoardView {
   }
 }
 
-describe("boardHomeRedirectHref", () => {
-  it("expands the default view to its canonical filtered URL", () => {
-    expect(boardHomeRedirectHref(WS, "bview_1", [view()], "all")).toBe(`/w/${WS}/board/active?is=channel`)
+describe("boardHomeHref", () => {
+  it("expands the default view to its canonical query URL", () => {
+    expect(boardHomeHref(WS, "bview_1", [view()], "all")).toBe(`/w/${WS}/board?lens=active&is=channel`)
   })
 
-  it("uses the segment-less base for a view whose lens is the viewer's home", () => {
-    const v = view({ id: "bview_2", baseLens: "all", scopeStreamTypes: ["dm"] })
-    expect(boardHomeRedirectHref(WS, "bview_2", [v], "all")).toBe(`/w/${WS}/board?is=dm`)
+  it("targets the home lens when no default view is set", () => {
+    expect(boardHomeHref(WS, null, [view()], "mine")).toBe(`/w/${WS}/board?lens=mine`)
   })
 
-  it("returns null when no default view is set", () => {
-    expect(boardHomeRedirectHref(WS, null, [view()], "all")).toBeNull()
+  it("falls back to the home lens when the default id no longer resolves", () => {
+    expect(boardHomeHref(WS, "bview_gone", [view()], "all")).toBe(`/w/${WS}/board?lens=all`)
   })
 
-  it("returns null while views are still loading", () => {
-    expect(boardHomeRedirectHref(WS, "bview_1", undefined, "all")).toBeNull()
-  })
-
-  it("falls back to the lens (null) when the default id no longer resolves", () => {
-    expect(boardHomeRedirectHref(WS, "bview_gone", [view()], "all")).toBeNull()
-  })
-
-  it("returns null when the view expands to the bare home URL (no redirect loop)", () => {
-    // A view on the home lens with no filters would address `/board` itself —
-    // redirecting there from bare `/board` would loop, so the helper declines.
+  it("never emits the bare entry alias, even for an unfiltered all-lens view", () => {
+    // Bare `/board` IS the redirecting entry — targeting it would loop. The
+    // explicit `?lens=` guarantees the redirect terminates in one hop.
     const bare = view({ id: "bview_bare", baseLens: "all", scopeStreamTypes: [] })
-    expect(boardHomeRedirectHref(WS, "bview_bare", [bare], "all")).toBeNull()
+    expect(boardHomeHref(WS, "bview_bare", [bare], "all")).toBe(`/w/${WS}/board?lens=all`)
   })
 })

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -5,13 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardView } from "@threa/types"
 import { ServicesProvider } from "@/contexts"
-import {
-  BoardSavedViews,
-  savedViewHref,
-  isViewActive,
-  isBoardAtHome,
-  type BoardViewSelection,
-} from "./board-saved-views"
+import { BoardSavedViews, savedViewHref, isViewActive, type BoardViewSelection } from "./board-saved-views"
 
 const view = (over: Partial<BoardView> = {}): BoardView => ({
   id: "boardview_1",
@@ -36,7 +30,6 @@ function mount(boardViews: Record<string, unknown>, props: Partial<Parameters<ty
           <BoardSavedViews
             workspaceId="ws_1"
             lens="mine"
-            homeLens="all"
             activeViewId={null}
             scopeStreamIds={["stream_1"]}
             scopeStreamTypes={[]}
@@ -81,57 +74,19 @@ describe("isViewActive", () => {
   })
 })
 
-describe("isBoardAtHome", () => {
-  const selection = (over: Partial<BoardViewSelection> = {}): BoardViewSelection => ({
-    lens: "all",
-    scopeStreamIds: [],
-    scopeStreamTypes: [],
-    scopeLabelIds: [],
-    excludeStreamIds: [],
-    excludeStreamTypes: [],
-    excludeLabelIds: [],
-    ...over,
-  })
-
-  it("is home on the plain home lens with no narrowing", () => {
-    expect(isBoardAtHome("all", null, selection())).toBe(true)
-  })
-
-  it("is home when the selection exactly matches the saved-view home (though filtered)", () => {
-    const homeView = view({ baseLens: "mine", scopeStreamIds: ["stream_1"] })
-    expect(isBoardAtHome("all", homeView, selection({ lens: "mine", scopeStreamIds: ["stream_1"] }))).toBe(true)
-  })
-
-  it("is not home when narrowed off the saved-view home", () => {
-    const homeView = view({ baseLens: "mine", scopeStreamIds: ["stream_1"] })
-    expect(isBoardAtHome("all", homeView, selection({ lens: "mine", scopeStreamIds: ["stream_2"] }))).toBe(false)
-  })
-
-  it("is not home when narrowed off the plain home lens with no saved-view home", () => {
-    expect(isBoardAtHome("all", null, selection({ lens: "active" }))).toBe(false)
-  })
-})
-
 describe("savedViewHref", () => {
-  it("expands a saved view into its canonical board URL", () => {
-    const href = savedViewHref("ws_1", view({ scopeStreamIds: ["s1", "s2"], scopeStreamTypes: ["channel"] }), "all")
+  it("expands a saved view into its canonical query URL, lens included", () => {
+    const href = savedViewHref("ws_1", view({ scopeStreamIds: ["s1", "s2"], scopeStreamTypes: ["channel"] }))
     const url = new URL(href, "http://x")
-    expect(url.pathname).toBe("/w/ws_1/board/mine")
+    expect(url.pathname).toBe("/w/ws_1/board")
+    expect(url.searchParams.get("lens")).toBe("mine")
     expect(url.searchParams.get("in")).toBe("s1,s2")
     expect(url.searchParams.get("is")).toBe("channel")
   })
 
-  it("uses the bare board path for the home lens with no scope", () => {
-    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }), "all")).toBe(
-      "/w/ws_1/board"
-    )
-  })
-
-  it("segments the All lens when the viewer's home lens is something else", () => {
-    // Home is Active, so bare `/board` is Active; a saved All view must address
-    // its own `/board/all` segment to reproduce, not collapse to the home.
-    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }), "active")).toBe(
-      "/w/ws_1/board/all"
+  it("never emits the bare entry alias, even for an unfiltered all-lens view", () => {
+    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }))).toBe(
+      "/w/ws_1/board?lens=all"
     )
   })
 
@@ -145,11 +100,11 @@ describe("savedViewHref", () => {
         excludeStreamIds: ["s9"],
         excludeStreamTypes: ["system"],
         excludeLabelIds: ["label_b"],
-      }),
-      "all"
+      })
     )
     const url = new URL(href, "http://x")
     expect(url.pathname).toBe("/w/ws_1/board")
+    expect(url.searchParams.get("lens")).toBe("all")
     expect(url.searchParams.get("label")).toBe("label_a")
     expect(url.searchParams.get("not-in")).toBe("s9")
     expect(url.searchParams.get("not-is")).toBe("system")
@@ -168,7 +123,7 @@ describe("BoardSavedViews", () => {
   it("lists saved views linking to their expanded URL", async () => {
     mount({ ...base })
     const link = await screen.findByRole("link", { name: /Design work/ })
-    expect(link.getAttribute("href")).toContain("/w/ws_1/board/mine")
+    expect(link.getAttribute("href")).toContain("/w/ws_1/board?lens=mine")
   })
 
   it("saves the current filter state as a named view", async () => {

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -28,6 +28,7 @@ import {
   useDeleteBoardView,
 } from "@/hooks/use-board-views"
 import {
+  BOARD_LENS_PARAM,
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
   BOARD_LABEL_PARAM,
@@ -39,39 +40,28 @@ import { isBoardFiltered, type BoardViewSelection } from "@/lib/board/filter-sta
 
 export type { BoardViewSelection }
 
-/** Expand a saved view into the canonical board URL it bookmarks (INV-59). The
- *  viewer's home lens is the segment-less one, so a saved All view addresses
- *  `/board/all` for anyone whose home is another lens. */
-export function savedViewHref(workspaceId: string, view: BoardView, homeLens: BoardLens): string {
-  const base = view.baseLens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${view.baseLens}`
+/** Expand a saved view into the canonical board URL it bookmarks (INV-59): the
+ *  explicit `?lens=` plus its filter axes. */
+export function savedViewHref(workspaceId: string, view: BoardView): string {
   const params = new URLSearchParams()
+  params.set(BOARD_LENS_PARAM, view.baseLens)
   if (view.scopeStreamIds.length > 0) params.set(BOARD_SCOPE_PARAM, view.scopeStreamIds.join(","))
   if (view.scopeStreamTypes.length > 0) params.set(BOARD_TYPE_PARAM, view.scopeStreamTypes.join(","))
   if (view.scopeLabelIds.length > 0) params.set(BOARD_LABEL_PARAM, view.scopeLabelIds.join(","))
   if (view.excludeStreamIds.length > 0) params.set(BOARD_EXCLUDE_SCOPE_PARAM, view.excludeStreamIds.join(","))
   if (view.excludeStreamTypes.length > 0) params.set(BOARD_EXCLUDE_TYPE_PARAM, view.excludeStreamTypes.join(","))
   if (view.excludeLabelIds.length > 0) params.set(BOARD_EXCLUDE_LABEL_PARAM, view.excludeLabelIds.join(","))
-  const qs = params.toString()
-  return qs ? `${base}?${qs}` : base
+  return `/w/${workspaceId}/board?${params.toString()}`
 }
 
-/** The lens's URL (INV-59): the viewer's home lens rests at the bare `/board`,
- *  every other lens takes a segment (so `all` gets `/board/all` when it isn't
- *  home). `search` rides along so switching lens keeps the scope (and an open
- *  panel). When a saved view is the home, the bare `/board` bounces to that view,
- *  so the home lens must keep its explicit segment or it'd be unreachable — omit
- *  the segment only when no saved-view home is active. Sibling of
+/** The lens's URL (INV-59): `?lens=` rewritten in the current search so the
+ *  filter axes (and an open `?panel=`) ride along a lens switch. Sibling of
  *  {@link savedViewHref}; shared by the filter bar's lens menu and the board-mode
  *  sidebar block so the two can't drift (INV-35). */
-export function lensHref(
-  workspaceId: string,
-  lens: BoardLens,
-  search: string,
-  homeLens: BoardLens,
-  hasSavedViewHome: boolean
-): string {
-  const base = !hasSavedViewHome && lens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${lens}`
-  return `${base}${search}`
+export function lensHref(workspaceId: string, lens: BoardLens, search: string): string {
+  const params = new URLSearchParams(search)
+  params.set(BOARD_LENS_PARAM, lens)
+  return `/w/${workspaceId}/board?${params.toString()}`
 }
 
 /** Order-independent membership equality — URL params carry no stable order, so
@@ -96,52 +86,26 @@ export function isViewActive(view: BoardView, selection: BoardViewSelection): bo
   )
 }
 
-/**
- * Whether the live selection is a baseline state where "Clear filters" / "Save
- * current view" / "Show everything" would be no-ops and should stay hidden. Two
- * such states, and the branch order is load-bearing:
- *   1. The plain unfiltered home lens (nothing narrowed → nothing to clear, save,
- *      or show-more), even when a saved view is the configured home. This lens is
- *      reachable explicitly (bare `/board` redirects to the view, but `/board/all`
- *      does not), and on it those three affordances are all meaningless.
- *   2. Exactly the saved-view home — itself a filtered selection, so
- *      `isBoardFiltered` alone would wrongly read it as narrowed and offer a
- *      "Clear filters" that just bounces back to the same view.
- * Checking the unfiltered case first is intentional: flipping to "resolve the
- * view first" would report the plain All lens as narrowed and wrongly surface
- * "Show everything" (on the everything lens) and "Save current view" (on an
- * unfiltered selection). Any genuinely narrowed selection makes `isBoardFiltered`
- * true and falls through to `isViewActive`, which is where the real work happens.
- */
-export function isBoardAtHome(homeLens: BoardLens, homeView: BoardView | null, selection: BoardViewSelection): boolean {
-  if (!isBoardFiltered(homeLens, selection)) return true
-  return homeView != null && isViewActive(homeView, selection)
-}
-
 /** Count phrase: `3 streams`, `1 label`. */
 function countOf(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? "" : "s"}`
 }
 
 /**
- * The URL the bare `/board` should bounce to for a viewer whose board home is a
- * saved view (`boardDefaultViewId`) rather than a plain lens. `null` when there's
- * nothing to redirect to: no default view, views not yet loaded, the id no longer
- * resolves (deleted view — degrade to the home lens), or the view expands to the
- * bare home URL anyway (guards against a redirect loop). Pure so the landing
- * decision is unit-testable without mounting the page.
+ * The explicit URL the bare query-less `/board` entry alias redirects to: the
+ * saved-view home when the configured `boardDefaultViewId` resolves, else the
+ * home lens. Always a `?lens=`-carrying URL, never the bare path — the redirect
+ * cannot loop. A stale/deleted view id degrades to the home lens. Pure so the
+ * landing decision is unit-testable without mounting the page.
  */
-export function boardHomeRedirectHref(
+export function boardHomeHref(
   workspaceId: string,
   defaultViewId: string | null,
   views: BoardView[] | undefined,
   homeLens: BoardLens
-): string | null {
-  if (!defaultViewId || !views) return null
-  const view = views.find((v) => v.id === defaultViewId)
-  if (!view) return null
-  const href = savedViewHref(workspaceId, view, homeLens)
-  return href === `/w/${workspaceId}/board` ? null : href
+): string {
+  const view = defaultViewId ? views?.find((v) => v.id === defaultViewId) : undefined
+  return view ? savedViewHref(workspaceId, view) : lensHref(workspaceId, homeLens, "")
 }
 
 /** A one-line summary of what a view filters to, under its name. */
@@ -163,8 +127,6 @@ interface BoardSavedViewsProps {
   workspaceId: string
   /** The board's live filter state — captured when saving "the current view". */
   lens: BoardLens
-  /** The viewer's home lens — the segment-less one when addressing a saved view. */
-  homeLens: BoardLens
   /** The saved view whose lens + filters match the live board, or `null`. Owned by
    *  the lens menu so the lens list and this list never both mark a row. */
   activeViewId: string | null
@@ -188,7 +150,6 @@ interface BoardSavedViewsProps {
 export function BoardSavedViews({
   workspaceId,
   lens,
-  homeLens,
   activeViewId,
   scopeStreamIds,
   scopeStreamTypes,
@@ -208,18 +169,20 @@ export function BoardSavedViews({
   // `null` closed; `{ id: null }` = save-current; `{ id }` = rename that view.
   const [editing, setEditing] = useState<{ id: string | null; name: string } | null>(null)
 
-  // Only offer "save current view" when there's actually a narrowing to bookmark
-  // — the viewer's home baseline (the plain home lens, or the saved view that is
-  // their home) is nothing worth saving.
-  const isFiltered = !isBoardAtHome(homeLens, homeView, {
-    lens,
-    scopeStreamIds,
-    scopeStreamTypes,
-    scopeLabelIds,
-    excludeStreamIds,
-    excludeStreamTypes,
-    excludeLabelIds,
-  })
+  // Only offer "save current view" when there's a narrowing to bookmark that
+  // isn't already bookmarked — the unfiltered baseline has nothing to save, and
+  // a selection that matches an existing view (activeViewId) IS that view.
+  const isFiltered =
+    activeViewId === null &&
+    isBoardFiltered({
+      lens,
+      scopeStreamIds,
+      scopeStreamTypes,
+      scopeLabelIds,
+      excludeStreamIds,
+      excludeStreamTypes,
+      excludeLabelIds,
+    })
 
   const submit = (name: string) => {
     if (editing?.id) update.mutate({ id: editing.id, input: { name } })
@@ -255,7 +218,7 @@ export function BoardSavedViews({
                 )}
               >
                 <Link
-                  to={savedViewHref(workspaceId, view, homeLens)}
+                  to={savedViewHref(workspaceId, view)}
                   onClick={onNavigate}
                   aria-current={active ? "true" : undefined}
                   className="flex min-w-0 flex-1 items-start gap-2.5"

--- a/apps/frontend/src/components/layout/sidebar/board-filter-chips.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-filter-chips.test.tsx
@@ -55,11 +55,13 @@ describe("BoardFilterChips", () => {
     expect(loc()).toBe(`/w/${WS}/board?label=label_a`)
   })
 
-  it("Clear returns to the lens base, dropping every filter param", () => {
+  it("Clear shows everything: every filter param dropped, lens reset to all explicitly", () => {
     stubStores()
-    mountAt(`/w/${WS}/board/active?in=stream_1&label=label_a`)
+    mountAt(`/w/${WS}/board?lens=active&in=stream_1&label=label_a`)
     fireEvent.click(screen.getByRole("link", { name: "Clear" }))
-    expect(loc()).toBe(`/w/${WS}/board/active`)
+    // Never the bare query-less /board — that's the home-redirect entry alias,
+    // and targeting it is the clear-filters bounce this URL scheme prevents.
+    expect(loc()).toBe(`/w/${WS}/board?lens=all`)
   })
 
   it("Save view opens the save-view dialog", () => {

--- a/apps/frontend/src/components/layout/sidebar/board-filter-chips.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-filter-chips.tsx
@@ -19,7 +19,7 @@ import {
   BOARD_EXCLUDE_TYPE_PARAM,
   BOARD_LABEL_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
-  boardHomeSearch,
+  clearFiltersSearch,
   removeAxisValueSearch,
 } from "@/components/board/board-filter-params"
 
@@ -31,7 +31,7 @@ interface BoardFilterChipsProps {
  * The board-mode "Filtering the board" block (board-centered-sidebar-exploration.md
  * § V1). One chip per active include/exclude across the stream, type, and label
  * axes; each chip's X removes just that entry through the URL-vocabulary SSOT.
- * "Clear" returns to the lens base and "Save view" bookmarks the live selection
+ * "Clear" shows everything (`?lens=all`, no axes) and "Save view" bookmarks the live selection
  * via the shared save dialog. The whole block only mounts when something is
  * filtered (the sidebar gates it), so success is silent (INV-63) — the chips are
  * the feedback.
@@ -125,7 +125,7 @@ export function BoardFilterChips({ workspaceId }: BoardFilterChipsProps) {
       </div>
       <div className="mt-1.5 flex items-center gap-3 px-1">
         <Link
-          to={`${location.pathname}${boardHomeSearch(location.search)}`}
+          to={`${location.pathname}${clearFiltersSearch(location.search)}`}
           className="text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -32,7 +32,6 @@ function stub(
   opts: {
     views?: BoardView[]
     homeView?: BoardView | null
-    configuredId?: string | null
     boardDefaultLens?: string | null
   } = {}
 ) {
@@ -51,7 +50,6 @@ function stub(
   } as unknown as ReturnType<typeof BoardViewsHooks.useBoardViews>)
   vi.spyOn(BoardViewsHooks, "useBoardHome").mockReturnValue({
     view: opts.homeView ?? null,
-    configuredId: opts.configuredId ?? null,
   })
 }
 
@@ -93,7 +91,7 @@ describe("BoardModeBlock", () => {
 
   it("points ← Chats at the retained last stream", () => {
     stub()
-    setLastLocation(USER, WS, { surface: "board", streamId: "stream_9", board: { lens: null, search: "" } })
+    setLastLocation(USER, WS, { surface: "board", streamId: "stream_9", board: { search: "" } })
     mountAt(`/w/${WS}/board`)
     expect(hrefOf("Chats")).toBe(`/w/${WS}/s/stream_9`)
   })
@@ -106,38 +104,33 @@ describe("BoardModeBlock", () => {
 
   it("carries the current filters across every lens link", () => {
     stub()
-    mountAt(`/w/${WS}/board/active?in=stream_1&label=label_a`)
+    mountAt(`/w/${WS}/board?lens=active&in=stream_1&label=label_a`)
 
     const all = new URL(hrefOf("All"), "http://x")
+    expect(all.searchParams.get("lens")).toBe("all")
     expect(all.searchParams.get("in")).toBe("stream_1")
     expect(all.searchParams.get("label")).toBe("label_a")
 
     const decisions = new URL(hrefOf("Decisions"), "http://x")
-    expect(decisions.pathname).toBe(`/w/${WS}/board/decisions`)
+    expect(decisions.pathname).toBe(`/w/${WS}/board`)
+    expect(decisions.searchParams.get("lens")).toBe("decisions")
     expect(decisions.searchParams.get("in")).toBe("stream_1")
   })
 
-  it("canonicalizes the home lens to bare /board and segments the others", () => {
-    // Default home lens is All.
+  it("every lens link carries an explicit ?lens=, never the bare entry alias", () => {
     stub()
-    mountAt(`/w/${WS}/board`)
+    mountAt(`/w/${WS}/board?lens=all`)
 
-    expect(new URL(hrefOf("All"), "http://x").pathname).toBe(`/w/${WS}/board`)
-    expect(new URL(hrefOf("Active"), "http://x").pathname).toBe(`/w/${WS}/board/active`)
-  })
-
-  it("segments the All lens when the viewer homes on a different lens", () => {
-    stub({ boardDefaultLens: "active" })
-    mountAt(`/w/${WS}/board/active`)
-
-    expect(new URL(hrefOf("All"), "http://x").pathname).toBe(`/w/${WS}/board/all`)
-    // The home lens (Active) collapses to bare /board.
-    expect(new URL(hrefOf("Active"), "http://x").pathname).toBe(`/w/${WS}/board`)
+    const all = new URL(hrefOf("All"), "http://x")
+    expect(all.pathname).toBe(`/w/${WS}/board`)
+    expect(all.searchParams.get("lens")).toBe("all")
+    const active = new URL(hrefOf("Active"), "http://x")
+    expect(active.searchParams.get("lens")).toBe("active")
   })
 
   it("marks the current lens active", () => {
     stub()
-    mountAt(`/w/${WS}/board/active`)
+    mountAt(`/w/${WS}/board?lens=active`)
 
     expect(screen.getByRole("link", { name: "Active" })).toHaveAttribute("aria-current", "true")
     expect(screen.getByRole("link", { name: "All" })).not.toHaveAttribute("aria-current")
@@ -155,13 +148,13 @@ describe("BoardModeBlock", () => {
       .map((l) => l.textContent)
       .filter((t) => t === "First" || t === "Second")
     expect(rendered).toEqual(["First", "Second"])
-    expect(hrefOf("First")).toContain(`/w/${WS}/board/mine`)
+    expect(hrefOf("First")).toContain(`/w/${WS}/board?lens=mine`)
   })
 
   it("marks the matching saved view active and no lens active", () => {
     const v = view({ baseLens: "mine", scopeStreamIds: ["stream_1"] })
     stub({ views: [v] })
-    mountAt(`/w/${WS}/board/mine?in=stream_1`)
+    mountAt(`/w/${WS}/board?lens=mine&in=stream_1`)
 
     expect(screen.getByRole("link", { name: /Design work/ })).toHaveAttribute("aria-current", "true")
     // The view is the selection, so the underlying Mine lens is NOT marked active.
@@ -170,7 +163,7 @@ describe("BoardModeBlock", () => {
 
   it("shows the board-home indicator on the pinned view", () => {
     const v = view()
-    stub({ views: [v], homeView: v, configuredId: v.id })
+    stub({ views: [v], homeView: v })
     mountAt(`/w/${WS}/board`)
 
     expect(screen.getByLabelText("Board home")).toBeInTheDocument()

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -38,11 +38,10 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
   const location = useLocation()
 
   // One shared URL derivation (INV-35) — the chips block reads the same hook.
-  const { homeLens, currentLens, selection } = useBoardSelection()
+  const { currentLens, selection } = useBoardSelection()
 
   const { data: views } = useBoardViews(workspaceId)
-  const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
-  const hasSavedViewHome = homeViewId !== null
+  const { view: homeView } = useBoardHome(workspaceId)
 
   // A saved view IS the selection when the live lens + every axis match it, so it
   // — not its base lens — reads as active; a lens is active only when no view is.
@@ -86,7 +85,7 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
             return (
               <Link
                 key={view.id}
-                to={savedViewHref(workspaceId, view, homeLens)}
+                to={savedViewHref(workspaceId, view)}
                 onClick={collapseOnMobile}
                 aria-current={active ? "true" : undefined}
                 className={cn(ROW_CLASS, active ? "bg-primary/10" : "hover:bg-muted/50 text-muted-foreground")}
@@ -113,7 +112,7 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
           return (
             <Link
               key={value}
-              to={lensHref(workspaceId, value, location.search, homeLens, hasSavedViewHome)}
+              to={lensHref(workspaceId, value, location.search)}
               onClick={collapseOnMobile}
               aria-current={active ? "true" : undefined}
               className={cn(ROW_CLASS, active ? "bg-primary/10" : "hover:bg-muted/50 text-muted-foreground")}

--- a/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, it } from "vitest"
 import { isBoardPath } from "./board-sidebar-mode"
 
 describe("isBoardPath", () => {
-  it("matches the bare board and lens-segmented board URLs", () => {
+  it("matches the board pathname (the whole view is query state)", () => {
     expect(isBoardPath("/w/ws_1/board")).toBe(true)
-    expect(isBoardPath("/w/ws_1/board/active")).toBe(true)
-    expect(isBoardPath("/w/ws_1/board/needs-resolution")).toBe(true)
   })
 
   it("rejects non-board surfaces", () => {
@@ -13,7 +11,7 @@ describe("isBoardPath", () => {
     expect(isBoardPath("/w/ws_1")).toBe(false)
     expect(isBoardPath("/w/ws_1/saved")).toBe(false)
     expect(isBoardPath("/w/ws_1/boardroom")).toBe(false)
-    expect(isBoardPath("/w/ws_1/board/active/extra")).toBe(false)
+    expect(isBoardPath("/w/ws_1/board/active")).toBe(false)
     expect(isBoardPath("/workspaces")).toBe(false)
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
+++ b/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
@@ -12,13 +12,12 @@ export function boardScopeStreamId(stream: { type: StreamType; id: string; rootS
 }
 
 /**
- * Whether a workspace-relative location is the board surface — bare `/board` OR
- * a lens segment (`/board/active`). A suffix `endsWith("/board")` check misses
- * the lens form, which turned the sidebar back to chats mode the moment a lens
- * was active (caught live; no full-Sidebar mount harness covers the swap).
+ * Whether a workspace-relative location is the board surface. The whole board
+ * view is query state (`?lens=` + filter axes), so the pathname is exactly
+ * `/w/:workspaceId/board` — no lens segment exists anymore.
  */
 export function isBoardPath(pathname: string): boolean {
-  return /^\/w\/[^/]+\/board(\/[^/]*)?$/.test(pathname)
+  return /^\/w\/[^/]+\/board$/.test(pathname)
 }
 
 /**

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -138,8 +138,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const isSavedPage = splat === "saved" || window.location.pathname.endsWith("/saved")
   const isScheduledPage = splat === "scheduled" || window.location.pathname.includes("/scheduled")
   const isActivityPage = splat === "activity" || window.location.pathname.endsWith("/activity")
-  // Reactive pathname (useLocation), and a real matcher: /board carries an
-  // optional lens segment, so a suffix check misses /board/active.
+  // Reactive pathname (useLocation), matched by the shared board predicate.
   const isBoardPage = isBoardPath(location.pathname)
   const boardMutedStreamIds = useBoardMutedStreamIds(workspaceId)
   const muteStream = useMuteStream(workspaceId)

--- a/apps/frontend/src/hooks/use-board-selection.ts
+++ b/apps/frontend/src/hooks/use-board-selection.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react"
-import { useLocation, useMatch } from "react-router-dom"
-import { DEFAULT_BOARD_LENS, type BoardLens } from "@threa/types"
-import { usePreferencesOptional } from "@/contexts"
+import { useLocation } from "react-router-dom"
+import type { BoardLens } from "@threa/types"
 import type { BoardViewSelection } from "@/components/board/board-saved-views"
 import {
+  BOARD_LENS_PARAM,
   BOARD_SCOPE_PARAM,
   BOARD_EXCLUDE_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
@@ -11,13 +11,12 @@ import {
   BOARD_LABEL_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
   parseIdListParam,
+  parseLensParam,
   parseTypeListParam,
 } from "@/components/board/board-filter-params"
 
 export interface BoardSelectionState {
-  /** The viewer's home lens (the one the bare `/board` URL resolves to). */
-  homeLens: BoardLens
-  /** The lens the current URL is on (route segment, falling back to home). */
+  /** The lens the current URL is on (`?lens=`, degrading to the default). */
   currentLens: BoardLens
   /** The live six-axis filter selection parsed off the URL. */
   selection: BoardViewSelection
@@ -31,9 +30,7 @@ export interface BoardSelectionState {
  */
 export function useBoardSelection(): BoardSelectionState {
   const location = useLocation()
-  const lensMatch = useMatch("/w/:workspaceId/board/:lens?")
-  const homeLens: BoardLens = usePreferencesOptional()?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
-  const currentLens: BoardLens = (lensMatch?.params.lens as BoardLens | undefined) ?? homeLens
+  const currentLens = parseLensParam(new URLSearchParams(location.search).get(BOARD_LENS_PARAM))
 
   const selection = useMemo<BoardViewSelection>(() => {
     const params = new URLSearchParams(location.search)
@@ -48,5 +45,5 @@ export function useBoardSelection(): BoardSelectionState {
     }
   }, [location.search, currentLens])
 
-  return { homeLens, currentLens, selection }
+  return { currentLens, selection }
 }

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -41,23 +41,16 @@ export function useBoardViews(workspaceId: string) {
 
 export interface BoardHome {
   /** The RESOLVED saved view the viewer homes on — `null` when the home is a plain
-   *  lens, the id no longer resolves, or the list is still loading. Use for the
-   *  "is this the home baseline" checks (isBoardAtHome), the pin fill, the settings
-   *  radio, and the direct "return to the saved-view home" navigation. */
+   *  lens, the id no longer resolves, or the list is still loading. Drives the pin
+   *  fill and the settings radio. */
   view: BoardView | null
-  /** The CONFIGURED `boardDefaultViewId` — `null` only when the home is a plain
-   *  lens. Known from the preference BEFORE the list loads, so URL-building can keep
-   *  explicit lens segments during the load window (a bare `/board` would bounce to
-   *  the view once the list resolves, making the target unreachable). */
-  configuredId: string | null
 }
 
 /**
- * The viewer's board home — the resolved saved view and the raw configured id. One
- * resolver for every surface that needs it (the filter bar, the empty-state CTA,
- * the saved-views pin, the settings radio, the "escape to everything" links) so
- * they can't drift. `usePreferencesOptional` so it's safe in surfaces mounted
- * without the provider (e.g. the saved-views menu in isolation). The bare-`/board`
+ * The viewer's board home — the resolved saved view. One resolver for every
+ * surface that needs it (the saved-views pin, the lens menu, the settings radio)
+ * so they can't drift. `usePreferencesOptional` so it's safe in surfaces mounted
+ * without the provider (e.g. the saved-views menu in isolation). The entry-alias
  * redirect in `board.tsx` deliberately keeps its own raw `boardDefaultViewId` +
  * list access — it must tell "still loading" from "unset" to gate the redirect,
  * a distinction the resolved `view` collapses to `null`.
@@ -67,7 +60,7 @@ export function useBoardHome(workspaceId: string): BoardHome {
   const { data: views } = useBoardViews(workspaceId)
   const configuredId = preferences?.boardDefaultViewId ?? null
   const view = views?.find((v) => v.id === configuredId) ?? null
-  return { view, configuredId }
+  return { view }
 }
 
 /**

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -58,11 +58,11 @@ describe("useLastLocation — board arm", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: "stream_a",
-      board: { lens: "active", search: "?in=stream_a,stream_gone" },
+      board: { search: "?lens=active&in=stream_a,stream_gone" },
     })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({
-      boardHref: "/w/ws_1/board/active?in=stream_a",
+      boardHref: "/w/ws_1/board?lens=active&in=stream_a",
       redirectStreamId: null,
     })
   })
@@ -82,12 +82,12 @@ describe("usePersistLastLocation", () => {
   it("retains the prior stream id when writing a board surface", () => {
     setLastLocation(USER, WS, { surface: "stream", streamId: "stream_prior", board: null })
     renderHook(() => usePersistLastLocation(WS), {
-      wrapper: routerAt("/w/ws_1/board/active?in=stream_x&panel=stream_z"),
+      wrapper: routerAt("/w/ws_1/board?lens=active&in=stream_x&panel=stream_z"),
     })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "board",
       streamId: "stream_prior",
-      board: { lens: "active", search: "?in=stream_x" },
+      board: { search: "?lens=active&in=stream_x" },
     })
   })
 
@@ -95,13 +95,13 @@ describe("usePersistLastLocation", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: null,
-      board: { lens: "active", search: "?in=stream_a" },
+      board: { search: "?lens=active&in=stream_a" },
     })
     renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_new") })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "stream",
       streamId: "stream_new",
-      board: { lens: "active", search: "?in=stream_a" },
+      board: { search: "?lens=active&in=stream_a" },
     })
   })
 })

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -25,7 +25,7 @@ interface UseLastLocationResult {
  * surface (stream or board) the viewer was on.
  *
  * Board arm: a stored board record resolves straight to the board URL, with the
- * lens validated and stale scope ids swept inside {@link buildBoardHref}.
+ * query sanitized and stale scope ids swept inside {@link buildBoardHref}.
  *
  * Stream arm (unchanged): stored stream validated against bootstrap, most-
  * recently-active fallback, and `shouldOpenSidebar` only once bootstrap has
@@ -105,11 +105,10 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
 export function usePersistLastLocation(workspaceId: string | undefined) {
   const { user } = useAuth()
   const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
-  const boardMatch = useMatch("/w/:workspaceId/board/:lens?")
+  const boardMatch = useMatch("/w/:workspaceId/board")
   const search = useLocation().search
 
   const streamId = streamMatch?.params.streamId
-  const lens = boardMatch?.params.lens ?? null
   const onBoard = boardMatch !== null
 
   useEffect(() => {
@@ -119,7 +118,7 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
       setLastLocation(user.id, workspaceId, {
         surface: "board",
         streamId: existing?.streamId ?? null,
-        board: { lens, search: sanitizeBoardSearch(search) },
+        board: { search: sanitizeBoardSearch(search) },
       })
       return
     }
@@ -131,7 +130,7 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
         board: existing?.board ?? null,
       })
     }
-  }, [user, workspaceId, streamId, lens, search, onBoard])
+  }, [user, workspaceId, streamId, search, onBoard])
 }
 
 function getMostRecentStreamId(streams: CachedStream[]): string {

--- a/apps/frontend/src/lib/board/filter-state.ts
+++ b/apps/frontend/src/lib/board/filter-state.ts
@@ -1,8 +1,8 @@
-import type { BoardLens, BoardScopeStreamType } from "@threa/types"
+import { DEFAULT_BOARD_LENS, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 
 /** The board's live view — lens plus every filter axis — matched against a saved
- *  view to mark which one you're currently looking at, and against the viewer's
- *  home lens to decide whether the board is narrowed. */
+ *  view to mark which one you're currently looking at, and against the unfiltered
+ *  baseline to decide whether the board is narrowed. */
 export interface BoardViewSelection {
   lens: BoardLens
   scopeStreamIds: string[]
@@ -13,15 +13,16 @@ export interface BoardViewSelection {
   excludeLabelIds: string[]
 }
 
-/** Is the board showing something narrower than the viewer's home? True when the
- *  live lens differs from home or any include/exclude axis is populated. The home
- *  lens is the baseline, so resting on it with no scope is NOT filtered — this
- *  gates the "Clear filters" chrome, the "Save current view" affordance, and the
- *  empty-state "Show everything" CTA, all of which must stay hidden on the plain
- *  landing view of a non-All home. */
-export function isBoardFiltered(homeLens: BoardLens, selection: BoardViewSelection): boolean {
+/** Is the board showing something narrower than everything? True when the lens
+ *  isn't the default `all` or any include/exclude axis is populated. The baseline
+ *  is absolute — the unfiltered All lens — NOT the viewer's home: a saved-view or
+ *  non-All home is itself a narrowing, and treating it as the baseline is what
+ *  made its filters unclearable (no Clear affordance, and clearing bounced back).
+ *  Gates the "Clear filters" chrome, the "Save current view" affordance, and the
+ *  empty-state "Show everything" CTA. */
+export function isBoardFiltered(selection: BoardViewSelection): boolean {
   return (
-    selection.lens !== homeLens ||
+    selection.lens !== DEFAULT_BOARD_LENS ||
     selection.scopeStreamIds.length > 0 ||
     selection.scopeStreamTypes.length > 0 ||
     selection.scopeLabelIds.length > 0 ||

--- a/apps/frontend/src/lib/last-location.test.ts
+++ b/apps/frontend/src/lib/last-location.test.ts
@@ -16,14 +16,15 @@ const legacyKey = `threa-last-stream:${USER}:${WS}`
 beforeEach(() => localStorage.clear())
 
 describe("sanitizeBoardSearch", () => {
-  it("keeps only the board filter axes and archived", () => {
+  it("keeps the lens, the board filter axes, and archived", () => {
     // Comma-separated id lists round-trip through URLSearchParams (which
     // percent-encodes the comma, matching savedViewHref's own output), so
     // compare by parsed params rather than raw string.
     const search =
-      "?in=stream_a,stream_b&not-in=stream_c&is=dm&not-is=channel&label=lbl_1&not-label=lbl_2&archived=true"
+      "?lens=active&in=stream_a,stream_b&not-in=stream_c&is=dm&not-is=channel&label=lbl_1&not-label=lbl_2&archived=true"
     const out = new URLSearchParams(sanitizeBoardSearch(search))
     expect(Object.fromEntries(out)).toEqual({
+      lens: "active",
       in: "stream_a,stream_b",
       "not-in": "stream_c",
       is: "dm",
@@ -32,6 +33,10 @@ describe("sanitizeBoardSearch", () => {
       "not-label": "lbl_2",
       archived: "true",
     })
+  })
+
+  it("degrades an unknown lens value to the default", () => {
+    expect(sanitizeBoardSearch("?lens=bogus&in=stream_a")).toBe("?lens=all&in=stream_a")
   })
 
   it("strips panel, m, and unrelated params", () => {
@@ -45,40 +50,37 @@ describe("sanitizeBoardSearch", () => {
 })
 
 describe("buildBoardHref", () => {
-  it("uses a known lens segment", () => {
-    expect(buildBoardHref(WS, { lens: "active", search: "" }, [])).toBe("/w/ws_1/board/active")
+  it("carries the lens in the query", () => {
+    expect(buildBoardHref(WS, { search: "?lens=active" }, [])).toBe("/w/ws_1/board?lens=active")
   })
 
-  it("degrades an unknown lens to the bare board", () => {
-    expect(buildBoardHref(WS, { lens: "bogus", search: "" }, [])).toBe("/w/ws_1/board")
-    expect(buildBoardHref(WS, { lens: null, search: "?in=stream_a" }, ["stream_a"])).toBe("/w/ws_1/board?in=stream_a")
+  it("restores the bare entry alias for a record captured there", () => {
+    expect(buildBoardHref(WS, { search: "" }, [])).toBe("/w/ws_1/board")
   })
 
   it("sweeps stale ids out of the in axis against known streams", () => {
-    const href = buildBoardHref(WS, { lens: "all", search: "?in=stream_a,stream_gone&is=dm" }, ["stream_a", "stream_b"])
-    expect(href).toBe("/w/ws_1/board/all?in=stream_a&is=dm")
+    const href = buildBoardHref(WS, { search: "?lens=all&in=stream_a,stream_gone&is=dm" }, ["stream_a", "stream_b"])
+    expect(href).toBe("/w/ws_1/board?lens=all&in=stream_a&is=dm")
   })
 
   it("preserves an unknown not-in id (thread anchors are lazily hydrated)", () => {
-    const href = buildBoardHref(WS, { lens: "all", search: "?in=stream_a&not-in=stream_thread_gone&is=dm" }, [
-      "stream_a",
-    ])
-    expect(href).toBe("/w/ws_1/board/all?in=stream_a&not-in=stream_thread_gone&is=dm")
+    const href = buildBoardHref(WS, { search: "?lens=all&in=stream_a&not-in=stream_thread_gone&is=dm" }, ["stream_a"])
+    expect(href).toBe("/w/ws_1/board?lens=all&in=stream_a&not-in=stream_thread_gone&is=dm")
   })
 
   it("drops a scope param that becomes empty after the sweep", () => {
-    const href = buildBoardHref(WS, { lens: "all", search: "?in=stream_gone&label=lbl_1" }, ["stream_a"])
-    expect(href).toBe("/w/ws_1/board/all?label=lbl_1")
+    const href = buildBoardHref(WS, { search: "?lens=all&in=stream_gone&label=lbl_1" }, ["stream_a"])
+    expect(href).toBe("/w/ws_1/board?lens=all&label=lbl_1")
   })
 
   it("skips the sweep when no known ids are available", () => {
-    const href = buildBoardHref(WS, { lens: "all", search: "?in=stream_gone" }, [])
-    expect(href).toBe("/w/ws_1/board/all?in=stream_gone")
+    const href = buildBoardHref(WS, { search: "?lens=all&in=stream_gone" }, [])
+    expect(href).toBe("/w/ws_1/board?lens=all&in=stream_gone")
   })
 
   it("sanitizes the search before building the href", () => {
-    const href = buildBoardHref(WS, { lens: "all", search: "?in=stream_a&panel=stream_z" }, ["stream_a"])
-    expect(href).toBe("/w/ws_1/board/all?in=stream_a")
+    const href = buildBoardHref(WS, { search: "?lens=all&in=stream_a&panel=stream_z" }, ["stream_a"])
+    expect(href).toBe("/w/ws_1/board?lens=all&in=stream_a")
   })
 })
 
@@ -93,12 +95,12 @@ describe("getLastLocation / setLastLocation round-trip", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: "stream_a",
-      board: { lens: "active", search: "?in=stream_a&panel=stream_z" },
+      board: { search: "?lens=active&in=stream_a&panel=stream_z" },
     })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "board",
       streamId: "stream_a",
-      board: { lens: "active", search: "?in=stream_a" },
+      board: { search: "?lens=active&in=stream_a" },
     })
   })
 

--- a/apps/frontend/src/lib/last-location.ts
+++ b/apps/frontend/src/lib/last-location.ts
@@ -1,5 +1,10 @@
-import { BOARD_LENSES } from "@threa/types"
-import { BOARD_FILTER_PARAMS, BOARD_SCOPE_PARAM, parseIdListParam } from "@/components/board/board-filter-params"
+import {
+  BOARD_FILTER_PARAMS,
+  BOARD_LENS_PARAM,
+  BOARD_SCOPE_PARAM,
+  parseIdListParam,
+  parseLensParam,
+} from "@/components/board/board-filter-params"
 
 const STORAGE_PREFIX = "threa-last-location"
 const LEGACY_STREAM_PREFIX = "threa-last-stream"
@@ -7,7 +12,6 @@ const LEGACY_STREAM_PREFIX = "threa-last-stream"
 export type LastLocationSurface = "stream" | "board"
 
 export interface LastLocationBoard {
-  lens: string | null
   search: string
 }
 
@@ -27,13 +31,17 @@ function legacyKey(userId: string, workspaceId: string): string {
 
 /**
  * Keep only the board's own URL vocabulary in a persisted search string: the
- * six filter axes + `archived` ({@link BOARD_FILTER_PARAMS}). `?panel=` and
- * `?m=` are deliberately dropped — a cold start into a months-old panel is a
- * worse default than the filtered feed. Returns a leading-`?` string (or "").
+ * lens plus the filter axes + `archived` ({@link BOARD_FILTER_PARAMS}). `?panel=`
+ * and `?m=` are deliberately dropped — a cold start into a months-old panel is a
+ * worse default than the filtered feed. Returns a leading-`?` string (or "" for
+ * a record captured on the bare entry alias — restoring that resolves the
+ * viewer's home again, which is what landing there meant).
  */
 export function sanitizeBoardSearch(search: string): string {
   const src = new URLSearchParams(search)
   const out = new URLSearchParams()
+  const lens = src.get(BOARD_LENS_PARAM)
+  if (lens !== null) out.set(BOARD_LENS_PARAM, parseLensParam(lens))
   for (const param of BOARD_FILTER_PARAMS) {
     for (const value of src.getAll(param)) out.append(param, value)
   }
@@ -57,9 +65,8 @@ function parseRecord(raw: string): LastLocation | null {
   if (record.board !== null && record.board !== undefined) {
     if (typeof record.board !== "object") return null
     const b = record.board as Record<string, unknown>
-    if (b.lens !== null && typeof b.lens !== "string") return null
     if (typeof b.search !== "string") return null
-    board = { lens: (b.lens as string | null) ?? null, search: b.search }
+    board = { search: b.search }
   }
 
   return {
@@ -93,7 +100,7 @@ export function setLastLocation(userId: string, workspaceId: string, location: L
     const record: LastLocation = {
       surface: location.surface,
       streamId: location.streamId,
-      board: location.board ? { lens: location.board.lens, search: sanitizeBoardSearch(location.board.search) } : null,
+      board: location.board ? { search: sanitizeBoardSearch(location.board.search) } : null,
     }
     localStorage.setItem(key(userId, workspaceId), JSON.stringify(record))
     localStorage.removeItem(legacyKey(userId, workspaceId))
@@ -137,18 +144,16 @@ function sweepStaleStreamScope(search: string, knownStreamIds: readonly string[]
 }
 
 /**
- * Build the explicit board URL to restore from a persisted board state.
- * An unknown lens degrades to the bare `/board` (the home lens resolves there),
- * and stale stream ids are swept from the `in` axis. Writing the explicit URL
- * lets the board's own home-redirect run cleanly for a bare-board record.
+ * Build the board URL to restore from a persisted board state: `/board` plus the
+ * sanitized query (lens + filter axes), with stale stream ids swept from the
+ * `in` axis. An empty stored search restores the bare entry alias, which
+ * re-resolves the viewer's home — the meaning of having been there.
  */
 export function buildBoardHref(
   workspaceId: string,
   board: LastLocationBoard,
   knownStreamIds: readonly string[]
 ): string {
-  const lens = board.lens && (BOARD_LENSES as readonly string[]).includes(board.lens) ? board.lens : null
-  const pathname = lens ? `/w/${workspaceId}/board/${lens}` : `/w/${workspaceId}/board`
   const search = sweepStaleStreamScope(sanitizeBoardSearch(board.search), knownStreamIds)
-  return `${pathname}${search}`
+  return `/w/${workspaceId}/board${search}`
 }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -117,7 +117,7 @@ function mountBoard(
     nextCursor?: string | null
     fail?: boolean
     failMessages?: boolean
-    /** URL to mount at — set `/w/<ws>/board/<lens>` to exercise a lens segment. */
+    /** URL to mount at — set `/w/<ws>/board?lens=<lens>` to exercise a lens. */
     entry?: string
     /** Seeds the saved-view list into the bootstrap cache (what `useBoardViews` reads). */
     boardViews?: BoardView[]
@@ -151,7 +151,7 @@ function mountBoard(
               <PanelProvider>
                 <LocationProbe />
                 <Routes>
-                  <Route path="/w/:workspaceId/board/:lens?" element={<BoardPage />} />
+                  <Route path="/w/:workspaceId/board" element={<BoardPage />} />
                 </Routes>
               </PanelProvider>
             </MemoryRouter>
@@ -208,8 +208,8 @@ beforeEach(() => {
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: { timezone: "UTC", locale: "en-US" },
   } as unknown as ReturnType<typeof contextsModule.usePreferences>)
-  // BoardPage resolves the home lens (bare `/board`) from the preferences
-  // context; default to All so existing cases keep their unsegmented meaning.
+  // BoardPage resolves the home (bare `/board` entry alias) from the
+  // preferences context; default to All.
   vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
     preferences: { boardDefaultLens: "all" },
   } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
@@ -231,19 +231,19 @@ describe("BoardPage", () => {
   it("shows only the viewer's own conversations on the Mine lens", async () => {
     // Server precomputes `isMine`; the Mine lens is wired into the same
     // client filter (`matchesBoardLens`) the other lenses ride, keyed off the
-    // `/board/mine` URL segment.
+    // `?lens=mine` query param.
     const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
     const notMine = { ...makePost({ id: "conv_other" }, { contentMarkdown: "Someone else's topic." }), isMine: false }
-    mountBoard([mine, notMine], { entry: `/w/${WORKSPACE_ID}/board/mine` })
+    mountBoard([mine, notMine], { entry: `/w/${WORKSPACE_ID}/board?lens=mine` })
 
     expect(await screen.findByText("My own topic.")).toBeTruthy()
     expect(screen.queryByText("Someone else's topic.")).toBeNull()
   })
 
-  it("lands the bare `/board` on the viewer's home-lens preference", async () => {
-    // boardDefaultLens picks which lens bare `/board` resolves to; here Mine, so
-    // the unsegmented URL filters down to the viewer's own conversations without
-    // a `/board/mine` segment.
+  it("lands the bare `/board` entry alias on the viewer's home-lens preference", async () => {
+    // boardDefaultLens picks where the query-less entry redirects; here Mine, so
+    // the entry resolves to `?lens=mine` and filters down to the viewer's own
+    // conversations.
     vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
       preferences: { boardDefaultLens: "mine" },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
@@ -263,13 +263,13 @@ describe("BoardPage", () => {
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     mountBoard([], { boardViews: [makeBoardView()] })
     const probe = await screen.findByTestId("location")
-    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board/active?is=channel`))
+    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board?lens=active&is=channel`))
   })
 
-  it("hides 'Show everything' on an empty saved-view home landing", async () => {
-    // The viewer homes on a saved view; sitting on that view's own (empty) URL is
-    // their baseline, so no "Show everything" CTA — the empty-state resolves the
-    // baseline through isBoardAtHome, not raw isBoardFiltered.
+  it("offers 'Show everything' on the viewer's own empty saved-view home (its filters are clearable)", async () => {
+    // The saved-view home is itself a narrowing. The old home-relative baseline
+    // treated it as unfiltered — which made its filters unclearable (the bounce
+    // Kris hit). Absolute baseline: the CTA shows, targeting explicit ?lens=all.
     vi.mocked(contextsModule.usePreferences).mockReturnValue({
       preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
     } as unknown as ReturnType<typeof contextsModule.usePreferences>)
@@ -277,57 +277,47 @@ describe("BoardPage", () => {
       preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     // The saved view's own URL (`makeBoardView` → active + `?is=channel`).
-    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board/active?is=channel` })
+    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board?lens=active&is=channel` })
     expect(await screen.findByText("Nothing here right now")).toBeTruthy()
-    expect(screen.queryByText("Show everything")).toBeNull()
-  })
-
-  it("points 'Show everything' at the explicit All lens for a saved-view-home viewer", async () => {
-    // With a saved-view home, bare `/board` bounces to the view — so the escape to
-    // "everything" must use the explicit `/board/all` segment, not bare `/board`.
-    vi.mocked(contextsModule.usePreferences).mockReturnValue({
-      preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    // A narrowed, empty lens (not the saved-view home) → "Show everything" offered.
-    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board/decisions` })
     const cta = await screen.findByRole("link", { name: "Show everything" })
-    expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board/all`)
+    expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board?lens=all`)
   })
 
-  it("preserves an open panel when clearing filters back to a saved-view home", async () => {
-    // Clearing filters returns to the saved-view home directly (no bare detour),
-    // and the surviving non-filter query — an open `?panel=` thread — rides along.
+  it("clears everything — including the saved-view home's own scope — keeping an open panel", async () => {
+    // "Clear filters" means everything (?lens=all), not "back to the home": the
+    // home's own filters must clear too, and the target is never the bare entry
+    // alias (which would bounce straight back). The open `?panel=` rides along.
     vi.mocked(contextsModule.usePreferences).mockReturnValue({
       preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
     } as unknown as ReturnType<typeof contextsModule.usePreferences>)
     vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
       preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    // Narrowed off the saved-view home (extra `in=`), with an open panel.
     mountBoard([], {
       boardViews: [makeBoardView()],
-      entry: `/w/${WORKSPACE_ID}/board/active?is=channel&in=stream_x&panel=conv%3Aabc`,
+      entry: `/w/${WORKSPACE_ID}/board?lens=active&is=channel&in=stream_x&panel=conv%3Aabc`,
     })
     const clear = await screen.findByRole("link", { name: "Clear filters" })
-    const href = clear.getAttribute("href") ?? ""
-    expect(href).toContain("is=channel") // the saved view's own scope
-    expect(href).toContain("panel=conv") // the open thread survives
-    expect(href).not.toContain("in=stream_x") // the extra narrowing is cleared
+    const url = new URL(clear.getAttribute("href") ?? "", "http://x")
+    expect(url.pathname).toBe(`/w/${WORKSPACE_ID}/board`)
+    expect(url.searchParams.get("lens")).toBe("all") // explicit — never the bare alias
+    expect(url.searchParams.get("panel")).toBe("conv:abc") // the open thread survives
+    expect(url.searchParams.get("is")).toBeNull() // the home view's own scope clears
+    expect(url.searchParams.get("in")).toBeNull() // the extra narrowing clears
   })
 
-  it("keeps the board rendered when a saved view is pinned as home while resting on bare `/board`", async () => {
-    // Regression: pinning a view as home is a same-URL preference change. The
-    // redirect effect (once per `location.key`) correctly declines to navigate, so
-    // the render must keep the board visible rather than blank it waiting for a
-    // redirect that never comes.
+  it("stays put when a saved view is pinned as home while on an explicit board URL", async () => {
+    // Pinning a view as home is a preference change, not a navigation. Rendered
+    // board URLs always carry `?lens=`, so the entry-alias redirect (which only
+    // fires on the query-less path) can never yank the viewer off the page.
     vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
       preferences: { boardDefaultLens: "all", boardDefaultViewId: null },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     const post = makePost({ id: "conv_x" }, { contentMarkdown: "Board still here." })
-    const { tree, rerender } = mountBoard([post], { boardViews: [makeBoardView()] })
+    const { tree, rerender } = mountBoard([post], {
+      boardViews: [makeBoardView()],
+      entry: `/w/${WORKSPACE_ID}/board?lens=all`,
+    })
     expect(await screen.findByText("Board still here.")).toBeTruthy()
 
     // Pin a saved view as home — same URL, no navigation.
@@ -336,54 +326,38 @@ describe("BoardPage", () => {
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     rerender(tree)
 
-    // Still on bare `/board`, board still rendered — not blanked, not navigated.
-    expect(screen.getByTestId("location").textContent).toBe(`/w/${WORKSPACE_ID}/board`)
+    expect(screen.getByTestId("location").textContent).toBe(`/w/${WORKSPACE_ID}/board?lens=all`)
     expect(screen.getByText("Board still here.")).toBeTruthy()
   })
 
-  it("shows no 'Clear filters' on the plain home lens (home is the baseline)", async () => {
-    // With a Mine home, the plain `/board` (lens=mine, no scope filters) is the
-    // viewer's untouched baseline — no filtered-state affordance.
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "mine" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
-    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board` })
-    await screen.findByText("My own topic.")
+  it("shows no 'Clear filters' on the unfiltered All lens (the absolute baseline)", async () => {
+    const post = makePost({ id: "conv_x" }, { contentMarkdown: "A topic." })
+    mountBoard([post], { entry: `/w/${WORKSPACE_ID}/board?lens=all` })
+    await screen.findByText("A topic.")
     expect(screen.queryByText("Clear filters")).toBeNull()
   })
 
-  it("shows 'Clear filters' once the lens is narrowed off the home lens", async () => {
-    // Home is Mine; `/board/all` is a different lens, i.e. a narrowing away from
-    // the baseline, so the clear-to-home affordance reappears.
+  it("shows 'Clear filters' on a non-All lens — even the viewer's own home lens", async () => {
+    // A Mine home landing is still a narrowing of everything; its lens must be
+    // clearable (the home-relative baseline hid the affordance here).
     vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
       preferences: { boardDefaultLens: "mine" },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
-    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board/all` })
+    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board?lens=mine` })
     await screen.findByText("My own topic.")
     expect(screen.getByText("Clear filters")).toBeTruthy()
   })
 
-  it("shows the empty state without a 'Show everything' CTA on the plain home lens", async () => {
-    // Empty `/board` with a Mine home is the baseline coming up empty, not a
-    // filtered view — the lens empty copy shows, but the "Show everything" CTA
-    // (which reads as "you've narrowed something") must not.
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "mine" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board` })
-    expect(await screen.findByText("Nothing here for you yet")).toBeTruthy()
+  it("shows the empty state without a 'Show everything' CTA on the unfiltered All lens", async () => {
+    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board?lens=all` })
+    expect(await screen.findByText("Nothing on the board yet")).toBeTruthy()
     expect(screen.queryByText("Show everything")).toBeNull()
   })
 
-  it("shows 'Show everything' on an empty view narrowed off the home lens", async () => {
-    // Home is Mine; empty `/board/all` is a narrowing away from baseline, so the
-    // empty state offers the one-tap way back home.
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "mine" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board/all` })
+  it("shows 'Show everything' on an empty non-All lens", async () => {
+    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board?lens=mine` })
+    expect(await screen.findByText("Nothing here for you yet")).toBeTruthy()
     expect(await screen.findByText("Show everything")).toBeTruthy()
   })
 

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -45,9 +45,11 @@ import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { openCompose, registerComposeOnPosted } from "@/stores/compose-overlay-store"
 import { setBoardFlash } from "@/stores/board-flash-store"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
-import { boardHomeRedirectHref, isBoardAtHome } from "@/components/board/board-saved-views"
-import { useBoardViews, useBoardHome } from "@/hooks/use-board-views"
+import { boardHomeHref } from "@/components/board/board-saved-views"
+import { useBoardViews } from "@/hooks/use-board-views"
+import { isBoardFiltered } from "@/lib/board/filter-state"
 import {
+  BOARD_LENS_PARAM,
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
   BOARD_LABEL_PARAM,
@@ -58,13 +60,13 @@ import {
   BOARD_ARCHIVED_ON,
   BOARD_UNREAD_PARAM,
   BOARD_UNREAD_ON,
-  boardHomeSearch,
+  clearFiltersSearch,
   parseIdListParam,
+  parseLensParam,
   parseTypeListParam,
 } from "@/components/board/board-filter-params"
 import { cn } from "@/lib/utils"
 import {
-  BOARD_LENSES,
   DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
@@ -72,8 +74,6 @@ import {
   type BoardScopeStreamType,
   type ConversationWithStaleness,
 } from "@threa/types"
-
-const VALID_LENSES = new Set<string>(BOARD_LENSES)
 
 /** Lenses that always contain the viewer's own fresh post: `all` (everything)
  *  and `mine` (a self-authored conversation is `isMine`). The status/memo lenses
@@ -163,128 +163,47 @@ function groupByRecency(posts: BoardViewPost[], activityById: Map<string, number
  * The board: a cross-stream feed of posts (each conversation surfaced as a
  * message-led post) ordered by recent activity, grouped into recency sections.
  *
- * Route is `/w/:workspaceId/board/:lens?`. Bare `/board` rests on the viewer's
- * **home lens** — the `boardDefaultLens` preference, `all` for everyone who
- * hasn't changed it (everything, newest activity first, nothing hidden). The
- * other lenses (`/board/active`, `/board/needs-resolution`, `/board/decisions`,
- * `/board/mine`) are optional narrowings picked from the filter bar
- * (board-view-design.md § "Lenses"); the stream scope rides `?in=`. Refreshes,
- * back/forward, and shared links land on the same view (INV-59). Whichever lens
- * is home canonicalises to the unsegmented URL (keeping the query string) so
- * there aren't two URLs for it — so `all` takes the `/board/all` segment for a
- * viewer whose home is some other lens. An unknown segment redirects to home.
+ * Route is `/w/:workspaceId/board`; the whole view is query state (INV-59). The
+ * lens rides `?lens=` (`all`, `active`, `needs-resolution`, `decisions`, `mine`
+ * — board-view-design.md § "Lenses"; absent or unknown degrades to `all`), the
+ * stream scope rides `?in=`, and every rendered board URL carries an explicit
+ * `?lens=`. The bare query-less `/board` is only an entry alias: it redirects
+ * once to the viewer's home — the pinned saved view (`boardDefaultViewId`) or
+ * the home lens (`boardDefaultLens`) — expanded to its explicit URL. Because no
+ * rendered URL is ever the bare path, no filter affordance can re-trigger the
+ * home resolution: "Clear filters" targets `?lens=all` and sticks.
  */
 export function BoardPage() {
-  const { workspaceId, lens: lensParam } = useParams<{ workspaceId: string; lens?: string }>()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
   const location = useLocation()
   const preferences = usePreferencesOptional()
   const homeLens = preferences?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
   const defaultViewId = preferences?.preferences?.boardDefaultViewId ?? null
   // Already mounted deeper (the lens menu), so this adds no fetch — it just lets
-  // the landing resolve a saved-view home.
+  // the entry alias resolve a saved-view home.
   const { data: boardViews, isError: boardViewsFailed } = useBoardViews(workspaceId ?? "")
   if (!workspaceId) return null
-  // A saved view is the board home iff its id still resolves; a stale/deleted id
-  // falls back to the plain home lens. When a view is home, `/board/<homeLens>` is
-  // a real destination reachable from the lens menu, NOT the canonical bare URL —
-  // so the home lens is not collapsed to bare here (which would just bounce back
-  // to the saved view). `savedViewReady` gates every home-resolution decision on
-  // the sources it needs: `usePreferencesOptional()` returns its context object as
-  // soon as the provider mounts, so read `.preferences` (the IDB data, null until
-  // it hydrates) — otherwise a cold load misreads a saved-view home as unset and
-  // never redirects. The saved-view LIST is only needed when a default view id is
-  // actually set, so a plain-lens landing (no `boardDefaultViewId`) doesn't block
-  // on the board-views query. A FAILED list also counts as "ready": the id can't
-  // resolve, so fall back to the lens and render rather than hold `/board` blank
-  // forever on a network blip.
-  const savedViewReady =
-    preferences?.preferences != null && (defaultViewId === null || boardViews !== undefined || boardViewsFailed)
-  const homeViewActive = !!defaultViewId && !!boardViews?.some((view) => view.id === defaultViewId)
-  const bareBoard = lensParam === undefined && location.search === ""
-  // Bare `/board` is a "resolve where home is" route: hold (render nothing) until
-  // the home is knowable, rather than paint the plain-lens board and then bounce
-  // to a saved-view home a frame later.
-  if (bareBoard && !savedViewReady) return null
-  // The bounce target for a bare `/board` arrival with a saved-view home. Resolved
-  // here but NAVIGATED inside BoardPageGate — at most once per navigation — so
-  // pinning a view as home while sitting on `/board` (a same-URL preference change)
-  // can't yank the user off the page.
-  const savedViewTarget =
-    bareBoard && savedViewReady ? boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens) : null
-  // Collapse `/board/<homeLens>` to bare only once we know it isn't a saved-view
-  // home (else the home lens, a legitimate destination, would bounce to the view).
-  // Gate on `savedViewReady` so a stale `homeViewActive: false` during load can't
-  // fire the bounce prematurely.
-  if (
-    (savedViewReady && !homeViewActive && lensParam === homeLens) ||
-    (lensParam !== undefined && !VALID_LENSES.has(lensParam))
-  ) {
-    return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
+  if (location.search === "") {
+    // The entry alias: resolve where home is, then redirect to its explicit URL.
+    // Hold (render nothing) until home is knowable rather than paint the default
+    // board and bounce a frame later. `usePreferencesOptional()` returns its
+    // context object as soon as the provider mounts, so read `.preferences` (the
+    // IDB data, null until it hydrates) — otherwise a cold load misreads a
+    // saved-view home as unset and lands on the wrong lens. The saved-view LIST
+    // is only needed when a default view id is actually set, so a plain-lens
+    // home doesn't block on the board-views query; a FAILED list also counts as
+    // "ready" (the id can't resolve — degrade to the home lens and render rather
+    // than hold `/board` blank forever on a network blip).
+    const homeReady =
+      preferences?.preferences != null && (defaultViewId === null || boardViews !== undefined || boardViewsFailed)
+    if (!homeReady) return null
+    return <Navigate to={boardHomeHref(workspaceId, defaultViewId, boardViews, homeLens)} replace />
   }
-  const lens: BoardLens = (lensParam as BoardLens | undefined) ?? homeLens
-  return (
-    <BoardPageGate
-      workspaceId={workspaceId}
-      lens={lens}
-      homeLens={homeLens}
-      savedViewTarget={savedViewTarget}
-      savedViewReady={savedViewReady}
-    />
-  )
+  const lens = parseLensParam(new URLSearchParams(location.search).get(BOARD_LENS_PARAM))
+  return <BoardPageInner workspaceId={workspaceId} lens={lens} />
 }
 
-/**
- * Handles the bare `/board` → saved-view-home redirect as a post-commit effect.
- * It lives in this child (not BoardPage) because a hook can't sit after
- * BoardPage's early returns. The redirect fires at most once per navigation; a
- * later same-URL re-render from pinning a view as home must not re-trigger it.
- */
-function BoardPageGate({
-  workspaceId,
-  lens,
-  homeLens,
-  savedViewTarget,
-  savedViewReady,
-}: {
-  workspaceId: string
-  lens: BoardLens
-  homeLens: BoardLens
-  savedViewTarget: string | null
-  savedViewReady: boolean
-}) {
-  const navigate = useNavigate()
-  const location = useLocation()
-  // Bounce a bare `/board` arrival to the saved-view home at most once per
-  // navigation (`location.key`): a later same-URL re-render from pinning a view
-  // as home must not re-trigger it, so the redirect follows navigation, not the
-  // live preference.
-  const handledKeyRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (!savedViewReady) return
-    if (handledKeyRef.current === location.key) return
-    handledKeyRef.current = location.key
-    if (savedViewTarget) navigate(savedViewTarget, { replace: true })
-  }, [savedViewReady, savedViewTarget, location.key, navigate])
-  // A saved-view home is about to redirect (the effect above fires post-commit) —
-  // render nothing rather than paint one frame of the wrong lens board first. Gate
-  // this on the SAME "not yet handled this navigation" condition the effect uses:
-  // when the target only appears because the viewer pinned a view as home while
-  // sitting on `/board` (same `location.key`, already handled), the effect
-  // deliberately won't navigate — so blanking here would strand the board. Render
-  // it instead.
-  if (savedViewTarget && handledKeyRef.current !== location.key) return null
-  return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
-}
-
-function BoardPageInner({
-  workspaceId,
-  lens,
-  homeLens,
-}: {
-  workspaceId: string
-  lens: BoardLens
-  homeLens: BoardLens
-}) {
+function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: BoardLens }) {
   const { isMobile } = useSidebar()
   const { isPanelOpen, closePanel } = usePanel()
   // The board's filters live in the URL (INV-59) — six params, three dimensions
@@ -588,25 +507,15 @@ function BoardPageInner({
   }
 
   const navigate = useNavigate()
-  // The surfacing baseline is **All**, not the home lens: a fresh post is no
-  // Decision (and needn't be Active), so only the widest lens guarantees the
-  // author's own card appears (design § "your own action always surfaces"). All
-  // rests at bare `/board` unless the viewer's home is another lens, in which
-  // case All takes the `/board/all` segment. The non-filter query state (an open
-  // `?panel=`) rides along so it survives clearing filters.
-  // The viewer's home baseline (plain home lens, or the saved view they home on)
-  // reads as unfiltered, so an empty home landing doesn't offer "Show everything".
-  const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
-  // "Show everything" / the own-post-must-surface bounce target the truly
-  // unfiltered All lens. When a saved-view home is CONFIGURED, bare `/board` bounces
-  // to that view once the list resolves, so All must take its explicit `/board/all`
-  // segment (keyed on the configured id, not the resolved view, so the escape is
-  // reachable even during the load window) or these land back on the saved view.
-  const allPathname =
-    homeLens === DEFAULT_BOARD_LENS && homeViewId === null
-      ? `/w/${workspaceId}/board`
-      : `/w/${workspaceId}/board/${DEFAULT_BOARD_LENS}`
-  const boardHome = { pathname: allPathname, search: boardHomeSearch(searchParams.toString()) }
+  // "Show everything" / the own-post-must-surface baseline is **All**, not the
+  // viewer's home: a fresh post is no Decision (and needn't be Active), so only
+  // the widest lens guarantees the author's own card appears (design § "your own
+  // action always surfaces"). Explicit `?lens=all` — never the bare entry alias —
+  // with the non-filter query state (an open `?panel=`) riding along.
+  const boardEverything = {
+    pathname: `/w/${workspaceId}/board`,
+    search: clearFiltersSearch(searchParams.toString()),
+  }
   const hasFilterParams =
     scopeStreamIds.length > 0 ||
     scopeStreamTypes.length > 0 ||
@@ -643,7 +552,7 @@ function BoardPageInner({
     if (currentViewSurfacesOwnPost) {
       if (scrollerRef.current) scrollerRef.current.scrollTop = 0
     } else {
-      navigate(boardHome)
+      navigate(boardEverything)
     }
     if (conversationId) {
       setBoardFlash(conversationId)
@@ -805,19 +714,19 @@ function BoardPageInner({
     } else {
       // A filtered-empty view is the FILTERS coming up empty, never the board
       // hiding things — so it always offers the one-tap way back to everything.
-      // Filtered is measured against the viewer's home lens, so a non-All home's
-      // own empty landing view shows the empty copy without a "Show everything"
-      // CTA (it's already at baseline).
+      // Filtered is absolute (narrower than the unfiltered All lens), so even a
+      // saved-view or non-All home's own empty landing offers the escape.
       const scoped = hasFilterParams
-      const isFiltered = !isBoardAtHome(homeLens, homeView, {
-        lens,
-        scopeStreamIds,
-        scopeStreamTypes,
-        scopeLabelIds,
-        excludeStreamIds,
-        excludeStreamTypes,
-        excludeLabelIds,
-      })
+      const isFiltered =
+        isBoardFiltered({
+          lens,
+          scopeStreamIds,
+          scopeStreamTypes,
+          scopeLabelIds,
+          excludeStreamIds,
+          excludeStreamTypes,
+          excludeLabelIds,
+        }) || unreadOnly
       const copy = scoped ? SCOPED_EMPTY_COPY : LENS_EMPTY_COPY[lens]
       stateContent = (
         <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
@@ -831,7 +740,7 @@ function BoardPageInner({
           <p className="text-sm font-medium">{copy.title}</p>
           <p className="max-w-sm text-sm text-muted-foreground">{copy.body}</p>
           {isFiltered && (
-            <Link to={boardHome} className={cn(buttonVariants({ variant: "outline" }), "mt-1 min-h-11")}>
+            <Link to={boardEverything} className={cn(buttonVariants({ variant: "outline" }), "mt-1 min-h-11")}>
               Show everything
             </Link>
           )}
@@ -862,7 +771,6 @@ function BoardPageInner({
       <BoardFilterBar
         workspaceId={workspaceId}
         lens={lens}
-        homeLens={homeLens}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         onStreamFilterChange={setStreamFilter}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -92,7 +92,7 @@ export const router = createBrowserRouter([
             lazy: async () => ({ Component: (await import("@/pages/scheduled")).ScheduledPage }),
           },
           {
-            path: "board/:lens?",
+            path: "board",
             HydrateFallback: FallbackLoader,
             lazy: async () => ({ Component: (await import("@/pages/board")).BoardPage }),
           },

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -176,12 +176,14 @@ right, so split the dials in two:
 
 **Structural lenses (same signal for everyone):**
 
-> **Per-user home lens (shipped):** which lens the bare `/board` opens on is the
-> `boardDefaultLens` preference — **All** for everyone who hasn't changed it. It
-> only moves the landing: every lens keeps its own URL (the home lens is the
-> segment-less one, so **All** takes `/board/all` for a viewer who homes
-> elsewhere), and the home lens is the viewer's baseline for filtered-state chrome
-> (no "Clear filters" on the plain home; "Clear filters" returns to it). The
+> **Per-user home lens (shipped):** where the bare query-less `/board` entry
+> redirects is the `boardDefaultLens` preference (or a pinned saved view via
+> `boardDefaultViewId`) — **All** for everyone who hasn't changed it. It only
+> moves the landing: the whole board view is query state (`?lens=all`,
+> `?lens=active&in=…`), every rendered board URL carries an explicit `?lens=`,
+> and the bare path is never rested on. Filtered-state chrome measures against
+> the absolute unfiltered All baseline, so even the viewer's own home is
+> clearable ("Clear filters" targets `?lens=all`). The
 > surfacing rule ("your own action always surfaces") still routes a fresh post to
 > **All** — the only lens that always contains it — _unless_ the current view
 > already does: an unfiltered `all` or `mine` (a self-authored post is `isMine`).


### PR DESCRIPTION
## Problem

With a saved view pinned as board home, clearing filters is structurally impossible. Reproduced with a scripted browser on main: board opens at `?in=<stream>` (the pinned view), click the sidebar chips' **Clear** → URL becomes bare `/board` → the home-redirect fires → straight back to `?in=<stream>`. Kris's report verbatim: "resolving a bare path like /board to the default makes it impossible to clear filters … I'm bounced back immediately to the default view, which has some filters."

Root cause: bare `/board` meant two contradictory things — "take me to my default" (the `boardDefaultViewId`/`boardDefaultLens` resolution in `BoardPage`) and "no filters" (`boardHomeSearch` stripped the filter params and left the bare path). Every clear affordance emitted exactly the URL that re-triggers the default resolution. The old scheme also *hid* "Clear filters" on the home itself (`isBoardAtHome` treated the saved-view home as the unfiltered baseline), so the home's own filters had no escape at all.

## Solution

The lens moves into the query and the bare path becomes an entry-only alias (Kris's ruling: "make the different views or the different lenses part of the query … don't care about backwards compatibility whatsoever").

### How it works

1. **One route.** `routes/index.tsx` drops `board/:lens?` for `board`. The lens rides `?lens=` (`BOARD_LENS_PARAM` in `board-filter-params.ts`); `parseLensParam` degrades absent/unknown values to `all`.
2. **Every rendered board URL carries an explicit `?lens=`.** `savedViewHref` emits `?lens=<baseLens>&<axes>`; `lensHref(workspaceId, lens, search)` rewrites `?lens=` in the current search so filters (and an open `?panel=`) ride along a lens switch; `boardHomeHref` (replacing `boardHomeRedirectHref`) always returns a `?lens=`-carrying URL, so the entry redirect terminates in one hop by construction — the old redirect-loop guard is gone because loops are impossible.
3. **Bare query-less `/board` only redirects.** `BoardPage` holds render until the home is knowable (same preferences/board-views readiness gating as before, including the failed-list escape), then `<Navigate replace>` to the home's explicit URL. Since nothing ever rests on the bare path, `BoardPageGate` — the post-commit redirect effect with its once-per-`location.key` bookkeeping for "pinned a view while sitting on `/board`" — is deleted; pinning while on `?lens=…` is just a preference change on a non-redirecting URL.
4. **Clear filters targets `?lens=all`, explicitly.** `clearFiltersSearch` (replacing `boardHomeSearch`) strips the filter axes, sets `lens=all`, and keeps unrelated state (`?panel=`), so its result is never the bare alias. Wired into the filter bar's "Clear filters", the sidebar chips' "Clear", the empty-state "Show everything", and the own-post-must-surface navigation in `handlePosted`.
5. **The filtered baseline is absolute.** `isBoardFiltered(selection)` (homeLens parameter dropped) measures against `all` + empty axes. `isBoardAtHome` is deleted: the saved-view home now *offers* Clear filters — that's the point — and "Save current view" is gated on `isBoardFiltered && activeViewId === null` instead (a selection matching an existing view is that view, nothing to save).
6. **Last-location records store the sanitized query, lens included.** `LastLocationBoard` drops its `lens` field; `sanitizeBoardSearch` keeps `?lens=` (normalized through `parseLensParam`) alongside the filter axes; `buildBoardHref` is `/board` + sanitized-swept search. A record captured on the entry alias restores the alias, which re-resolves the home — the meaning of having been there.

### Key design decisions

**Clear = everything, not "keep the lens".** A lens is a narrowing in Kris's framing ("the default view, which has some filters"), so one click lands on genuinely-everything; per-axis chips and the lens menu remain for finer control. One consistent verb across all four affordances.

**Bare path redirects even for a plain-all home.** `/board` → `/board?lens=all` costs one replace-hop but keeps the invariant binary: query-less = resolve home, anything else = exactly what the URL says. No rendered state is special-cased onto the bare path.

**`BoardHome.configuredId` deleted (INV-38).** Its only consumers were the load-window URL gymnastics ("keep the explicit segment while the home view list loads") that the explicit-`?lens=` scheme makes unnecessary.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-filter-params.ts` | `BOARD_LENS_PARAM`, `parseLensParam`, `clearFiltersSearch` (replaces `boardHomeSearch`) |
| `apps/frontend/src/components/board/board-saved-views.tsx` | `savedViewHref`/`lensHref` emit query-lens URLs (homeLens args dropped); `boardHomeHref` replaces `boardHomeRedirectHref`; `isBoardAtHome` deleted; save-current gated on `activeViewId` |
| `apps/frontend/src/pages/board.tsx` | Entry-alias redirect in render; `BoardPageGate` deleted; lens parsed from `?lens=`; `boardEverything` target for Show-everything/post-surfacing; empty-state uses absolute `isBoardFiltered` (incl. `unreadOnly`) |
| `apps/frontend/src/components/board/board-filter-bar.tsx` | Absolute `isFiltered`; `clearFiltersTo` = `clearFiltersSearch`; lens menu links/pins read preferences directly; homeLens prop dropped |
| `apps/frontend/src/lib/board/filter-state.ts` | `isBoardFiltered(selection)` — absolute baseline |
| `apps/frontend/src/hooks/use-board-selection.ts` | `currentLens` from `?lens=`; `homeLens` export dropped |
| `apps/frontend/src/hooks/use-board-views.ts` | `BoardHome.configuredId` deleted |
| `apps/frontend/src/components/layout/sidebar/board-mode-block.tsx`, `board-filter-chips.tsx` | New helper signatures; chips "Clear" → `clearFiltersSearch` |
| `apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts` | `isBoardPath` matches the exact pathname (no segment) |
| `apps/frontend/src/lib/last-location.ts`, `hooks/use-last-location.ts` | Board records store sanitized query (lens included); `lens` field gone |
| `apps/frontend/src/routes/index.tsx` | `board/:lens?` → `board` |
| `docs/board-view-design.md` | Home-lens paragraph rewritten for the query scheme |
| 8 test files | Updated to the new URLs/semantics (see test plan) |

## Out of scope (deliberate)

- **No backwards compatibility** for old `/board/<lens>` URLs (Kris: "not … whatsoever"). They fall to the app's not-found handling; old persisted last-location records degrade gracefully (their `search` restores, the stored `lens` field is ignored once).
- **Multi-device home-pin lag**: a home pinned on another device applies to the bare-entry redirect only after this device's bootstrap refreshes preferences — same behavior as before this change.

## Test plan

- [x] Live repro on dev:test (scripted Playwright, saved view with stream scope pinned as home): **on main** — Clear → bare `/board` → bounced back to `?in=…` (URL trail captured); **on this branch** — entry redirects once to `?lens=all&in=…`, Clear → `?lens=all` and sticks, reload stays cleared (INV-59), browser back restores the filtered view
- [x] Frontend suites: board + sidebar + hooks + lib 1124 pass; pages/stores/sync/components/hooks 3421 pass; 0 failures
- [x] `tsc --noEmit` clean; full monorepo lint+typecheck via pre-commit
- [ ] `src/lib/dates.test.ts` has 4 pre-existing timezone failures on main (noted since #1312) — untouched by this diff, not re-run green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786569259&installation_id=129946197&pr_number=1335&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1335&signature=bcafc46733e2a0d73c8c0924bd62d939e24bb314afb036118dcf2551445ae354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->