### PR TITLE
fix(frontend): catch up reopened thread panels

### DIFF
--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -6,6 +6,7 @@ import { isApplyWindowOpen, resetApplyWindow, subscribeApplyWindow } from "@/sto
 import { SyncStatusStore } from "./sync-status"
 import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import { streamKeys } from "@/hooks/use-streams"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
@@ -769,7 +770,7 @@ describe("SyncEngine reconnect catch-up cursor (INV-53 gap safety)", () => {
     await primeConnectedEngine(engine, socket)
 
     deps.streamService.bootstrap.mockClear()
-    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "thread_1"], makeStreamBootstrap("thread_1", "1"))
+    deps.queryClient.setQueryData(streamKeys.bootstrap("ws_1", "thread_1"), makeStreamBootstrap("thread_1", "1"))
     await seedEvent("thread_1", 1)
 
     engine.setVisibleStreamIds(["thread_1"])
@@ -2225,23 +2226,22 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
     engine.destroy()
   })
 
-  it("still fetches per-stream data for visible streams on a slim reconnect (per-stream cursor mechanism kept)", async () => {
+  it("refreshes real visible streams but excludes synthetic IDs on a slim reconnect", async () => {
     const deps = makeReconnectDeps()
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
 
     await engine.onConnect(asSocket(socket))
-    // Mark a stream visible after the first connect; the slim reconnect must
-    // still heal its timeline (a per-stream sequence, not the workspace
-    // sync-log), so the per-stream bootstrap fetch fires for it.
-    engine.setVisibleStreamIds(["stream_v"])
+    engine.setVisibleStreamIds(["stream_v", "draft_local", "draft:stream_parent:msg_1", "conv:conversation_1"])
+    await vi.waitFor(() =>
+      expect(deps.streamService.bootstrap.mock.calls.some((call) => call[1] === "stream_v")).toBe(true)
+    )
     deps.streamService.bootstrap.mockClear()
 
     await engine.onConnect(asSocket(socket))
 
-    await vi.waitFor(() =>
-      expect(deps.streamService.bootstrap.mock.calls.some((call) => call[1] === "stream_v")).toBe(true)
-    )
+    await vi.waitFor(() => expect(deps.streamService.bootstrap).toHaveBeenCalled())
+    expect(deps.streamService.bootstrap.mock.calls.map((call) => call[1])).toEqual(["stream_v"])
     engine.destroy()
   })
 

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -761,6 +761,26 @@ describe("SyncEngine reconnect catch-up cursor (INV-53 gap safety)", () => {
       expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
     })
   })
+
+  it("catches up a newly visible thread panel even when its bootstrap query is cached", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    deps.streamService.bootstrap.mockClear()
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "thread_1"], makeStreamBootstrap("thread_1", "1"))
+    await seedEvent("thread_1", 1)
+
+    engine.setVisibleStreamIds(["thread_1"])
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "thread_1", { after: "1" })
+    })
+    await vi.waitFor(async () => {
+      expect(await db.events.get("evt_2")).toMatchObject({ streamId: "thread_1", sequence: "2" })
+    })
+  })
 })
 
 describe("SyncEngine HTTP-first warm fetch", () => {

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -87,6 +87,12 @@ const CATCHUP_PAGE_LIMIT = 500
  *  when the board opens onto many unsynced thread/public streams at once. */
 const BOARD_SYNC_CONCURRENCY = 6
 
+const NON_SERVER_STREAM_ID_PREFIXES = ["draft_", "draft:", "conv:"] as const
+
+function isServerStreamId(streamId: string): boolean {
+  return !NON_SERVER_STREAM_ID_PREFIXES.some((prefix) => streamId.startsWith(prefix))
+}
+
 /**
  * Above this many missed entries on the first catch-up page, heal the whole
  * workspace with one atomic snapshot instead of replaying the gap entry by
@@ -230,8 +236,7 @@ export class SyncEngine {
     this.visibleStreamIds = ids
 
     for (const streamId of ids) {
-      if (previous.has(streamId)) continue
-      if (streamId.startsWith("draft_") || streamId.startsWith("draft:") || streamId.startsWith("conv:")) continue
+      if (previous.has(streamId) || !isServerStreamId(streamId)) continue
       void this.refreshStreamAfterNavigation(streamId)
     }
   }
@@ -263,8 +268,7 @@ export class SyncEngine {
     const next = new Set(ids)
     const toSync: string[] = []
     for (const streamId of next) {
-      if (this.boardStreamIds.has(streamId)) continue
-      if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
+      if (this.boardStreamIds.has(streamId) || !isServerStreamId(streamId)) continue
       toSync.push(streamId)
     }
     this.boardStreamIds = next
@@ -285,8 +289,7 @@ export class SyncEngine {
     const next = new Set(ids)
     const toSync: string[] = []
     for (const streamId of next) {
-      if (this.panelStreamIds.has(streamId)) continue
-      if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
+      if (this.panelStreamIds.has(streamId) || !isServerStreamId(streamId)) continue
       toSync.push(streamId)
     }
     this.panelStreamIds = next
@@ -366,9 +369,7 @@ export class SyncEngine {
       // stream's room (subscribeMemberStreams), but a fresh device has no
       // history for them — syncBoardStreams' persisted-window skip separates
       // the two, so warm streams cost one IDB probe and cold ones backfill.
-      const pending = [...this.boardStreamIds, ...this.panelStreamIds].filter(
-        (id) => !id.startsWith("draft_") && !id.startsWith("draft:")
-      )
+      const pending = [...this.boardStreamIds, ...this.panelStreamIds].filter(isServerStreamId)
       if (pending.length > 0) void this.syncBoardStreams([...new Set(pending)])
     }
 
@@ -943,9 +944,7 @@ export class SyncEngine {
       ...this.boardStreamIds,
       ...this.panelStreamIds,
     ]
-    return Array.from(
-      new Set(streamIds.filter((streamId) => !streamId.startsWith("draft_") && !streamId.startsWith("draft:")))
-    )
+    return Array.from(new Set(streamIds.filter(isServerStreamId)))
   }
 
   /**
@@ -1054,7 +1053,7 @@ export class SyncEngine {
   }
 
   private refreshStreamAfterNavigation(streamId: string): Promise<void> {
-    if (this.isDestroyed || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
+    if (this.isDestroyed || !isServerStreamId(streamId)) {
       return Promise.resolve()
     }
 
@@ -1124,7 +1123,7 @@ export class SyncEngine {
    * warm-up, not the sync authority, and must not flash loading chrome.
    */
   private warmStreamOverHttp(streamId: string): Promise<void> {
-    if (this.isDestroyed || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
+    if (this.isDestroyed || !isServerStreamId(streamId)) {
       return Promise.resolve()
     }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -182,9 +182,10 @@ export class SyncEngine {
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
+  /** URL-visible stream surfaces: the route stream plus bare-stream panels. */
   private visibleStreamIds: string[] = []
   /** Streams whose board cards are on screen — declared by the board page, kept
-   *  separate from `visibleStreamIds` (the sidebar's, replaced wholesale). Their
+   *  separate from `visibleStreamIds` (which is replaced wholesale). Their
    *  bodies ride `db.events`, so the board joins + catches them up like any opened
    *  stream and re-asserts them across reconnects (see setBoardStreamIds). */
   private boardStreamIds = new Set<string>()
@@ -219,8 +220,20 @@ export class SyncEngine {
     }
   }
 
+  /**
+   * Refresh newly visible route/panel streams. A cached bootstrap has infinite
+   * stale time, so the query observer alone will not close events missed while
+   * a panel was hidden; the engine-owned delta does (INV-53).
+   */
   setVisibleStreamIds(ids: string[]): void {
+    const previous = new Set(this.visibleStreamIds)
     this.visibleStreamIds = ids
+
+    for (const streamId of ids) {
+      if (previous.has(streamId)) continue
+      if (streamId.startsWith("draft_") || streamId.startsWith("draft:") || streamId.startsWith("conv:")) continue
+      void this.refreshStreamAfterNavigation(streamId)
+    }
   }
 
   /**
@@ -232,8 +245,8 @@ export class SyncEngine {
    * joined (member streams are already subscribed at bootstrap).
    *
    * It is additive and must NEVER route through setVisibleStreamIds — that set is
-   * the sidebar's and is replaced wholesale (clobbering it would drop the
-   * sidebar's reconnect catch-up). Newly-declared streams are caught up +
+   * URL-derived and replaced wholesale (clobbering it would drop the open
+   * route/panel reconnect catch-up). Newly-declared streams are caught up +
    * bootstrapped here unless their history is already local (syncBoardStreams'
    * persisted-window skip), concurrency-capped so opening the board doesn't fire
    * a fetch burst across dozens of unsynced streams. Board streams join the


### PR DESCRIPTION
## Problem

A reopened thread panel could show a stale timeline while its parent card showed the latest reply. `WorkspaceLayout` declares route and panel streams through `SyncEngine.setVisibleStreamIds`, but that method only retained IDs for reconnects. The thread bootstrap query uses infinite stale time, so reopening a cached panel did not fetch events missed while hidden. A full reload cleared the in-memory query cache and masked the gap with a fresh bootstrap.

## Solution

Catch up each newly visible URL-backed stream through the existing sync-engine refresh path.

### How it works

- `SyncEngine.setVisibleStreamIds` compares the new URL-derived stream set with the previous set.
- Newly visible real streams call `refreshStreamAfterNavigation`; draft and conversation projection IDs remain local/projection-only.
- The existing refresh path reads the persisted cursor before joining the room, fetches `bootstrap?after=<cursor>`, and merges the delta into IndexedDB (INV-53).
- Existing active refreshes remain single-flighted, so the main route's `setCurrentStreamId` call does not duplicate network work.

### Key design decision

**Refresh at the visibility boundary, not by changing query staleness.** Bootstrap snapshots retain infinite stale time. The sync engine already owns cursor derivation, room join ordering, reconnects, and delta application; reusing it avoids a second freshness path and closes the hidden-panel gap with overlap-safe subscribe-then-fetch ordering.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | Refresh newly visible route/panel streams through the cursor-owned delta path. |
| `apps/frontend/src/sync/sync-engine.test.ts` | Reproduce a cached thread bootstrap with one persisted event and verify visibility catches up event two. |

## Test plan

- [x] Frontend `sync-engine.test.ts` — 69 pass
- [x] Frontend unit suite with `TZ=UTC` — 4,307 pass
- [x] Root `bun run typecheck` — all workspaces clean
- [x] Pre-commit lint, formatting, migration checks, OpenAPI drift check, and typecheck
- [x] Backend unit suite — 3,000 pass
- [ ] Backend E2E suite — local Postgres/S3 dependencies were not running; 165 files failed setup with `ECONNREFUSED` before test execution

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Ensure every newly visible thread panel converges from its persisted event cursor even when React Query already holds an infinite-stale bootstrap snapshot.

## What Was Built

- Detect additions to `SyncEngine.visibleStreamIds`.
- Run added server stream IDs through `refreshStreamAfterNavigation`.
- Exclude draft IDs and `conv:` projection IDs.
- Add regression coverage for a cached thread bootstrap whose IndexedDB rail is one event behind.

## Design Decisions

**Chose:** Reuse the sync engine's navigation refresh.

**Why:** It already enforces cursor-before-join ordering, single-flight behavior, IndexedDB application, and query-cache merging.

**Alternative considered:** Force React Query refetches when panels mount. This would duplicate sync ownership and weaken the cursor-before-join guarantee.

## Schema Changes

None.

## What's NOT Included

No backend event-routing changes. The parent thread summary and thread message are separate outbox events; this patch fixes the frontend bootstrap gap for the thread stream.

## Status

- [x] Regression reproduced in unit coverage
- [x] Visibility catch-up implemented
- [x] Relevant and full frontend unit suites passed

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786570183&installation_id=129946197&pr_number=1336&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1336&signature=b6ac925d443bcb7b5fdda402ae87287f64d1a91f01f8c85cd6fbe5cf2958dc13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->