### PR TITLE
feat(personas): knowledge by reference — attach existing chat files as persona knowledge (copy-on-attach)

### DIFF
--- a/apps/backend/evals/suites/brief-correction/suite.ts
+++ b/apps/backend/evals/suites/brief-correction/suite.ts
@@ -224,6 +224,7 @@ async function runBriefCorrectionTask(input: BriefCorrectionInput, ctx: EvalCont
       },
       putObject: async () => {},
       delete: async () => {},
+      copyObject: async () => {},
     }
     const attachmentService = new AttachmentService(
       ctx.pool,

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -405,6 +405,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       },
       putObject: async () => {},
       delete: async () => {},
+      copyObject: async () => {},
     }
 
     // Create PersonaAgent with real dependencies

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -136,6 +136,9 @@ function createMockStorage(images: Map<string, Buffer>): StorageProvider {
     async delete(): Promise<void> {
       // No-op for mock
     },
+    async copyObject(): Promise<void> {
+      // No-op for mock
+    },
   }
 }
 

--- a/apps/backend/evals/suites/persona-style/suite.ts
+++ b/apps/backend/evals/suites/persona-style/suite.ts
@@ -192,6 +192,7 @@ async function runPersonaStyleTask(input: PersonaStyleInput, ctx: EvalContext): 
       },
       putObject: async () => {},
       delete: async () => {},
+      copyObject: async () => {},
     }
     const attachmentService = new AttachmentService(
       ctx.pool,

--- a/apps/backend/src/features/agents/persona-config-handlers.test.ts
+++ b/apps/backend/src/features/agents/persona-config-handlers.test.ts
@@ -513,6 +513,39 @@ describe("persona config avatar handlers", () => {
     expect(bindAttachment).toHaveBeenCalledWith("workspace_1", CUSTOM_ID, CALLER, "attach_1")
   })
 
+  it("POST attachments/from-existing 400s when the body has no sourceAttachmentId (INV-55)", async () => {
+    const attachFromExisting = mock(async () => ({}) as never)
+    const handlers = makeHandlers({ attachFromExisting } as unknown as Partial<PersonaConfigService>)
+
+    await expect(
+      handlers.attachFromExisting(fakeReq({ params: { personaId: CUSTOM_ID }, body: {} }), fakeRes())
+    ).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" })
+    expect(attachFromExisting).not.toHaveBeenCalled()
+  })
+
+  it("POST attachments/from-existing copies the source id and returns 201", async () => {
+    const item = {
+      id: "attach_copy_1",
+      filename: "runbook.md",
+      mimeType: "text/markdown",
+      sizeBytes: 512,
+      processingStatus: "ready",
+      contextMode: "full",
+      position: 0,
+      createdAt: "2026-07-13T00:00:00.000Z",
+    }
+    const attachFromExisting = mock(async () => item)
+    const handlers = makeHandlers({ attachFromExisting } as unknown as Partial<PersonaConfigService>)
+    const req = fakeReq({ params: { personaId: CUSTOM_ID }, body: { sourceAttachmentId: "attach_source_1" } })
+    const res = fakeRes()
+
+    await handlers.attachFromExisting(req, res)
+
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toEqual({ attachment: item })
+    expect(attachFromExisting).toHaveBeenCalledWith("workspace_1", CUSTOM_ID, CALLER, "attach_source_1")
+  })
+
   it("DELETE attachment authorizes via the service and 204s", async () => {
     const removeAttachment = mock(async () => undefined)
     const handlers = makeHandlers({ removeAttachment } as unknown as Partial<PersonaConfigService>)

--- a/apps/backend/src/features/agents/persona-config-handlers.ts
+++ b/apps/backend/src/features/agents/persona-config-handlers.ts
@@ -73,6 +73,10 @@ const bindAttachmentSchema = z.object({
   attachmentId: z.string().min(1),
 })
 
+const attachFromExistingSchema = z.object({
+  sourceAttachmentId: z.string().min(1),
+})
+
 function personaNotFound(): HttpError {
   return new HttpError("Persona not found", { status: 404, code: "PERSONA_NOT_FOUND" })
 }
@@ -304,6 +308,31 @@ export function createPersonaConfigHandlers({ personaConfigService, avatarServic
         personaId,
         resolveCaller(req),
         attachmentId
+      )
+      res.status(201).json({ attachment })
+    },
+
+    /**
+     * POST /api/workspaces/:workspaceId/personas/:personaId/attachments/from-existing
+     *
+     * Attach an EXISTING workspace file to a persona as context knowledge by
+     * COPYING it (knowledge-by-reference). JSON `{ sourceAttachmentId }` — the
+     * caller picks a file they can already read; the service copies its bytes +
+     * extraction into a fresh persona-owned row (copy-on-attach). Custom/personal
+     * personas only. The service authorizes and returns structured errors
+     * (404 unreadable/missing source, 400 ineligible source, 400 cap reached).
+     */
+    async attachFromExisting(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const personaId = req.params.personaId!
+
+      const { sourceAttachmentId } = validateRequest(attachFromExistingSchema, req.body)
+
+      const attachment = await personaConfigService.attachFromExisting(
+        workspaceId,
+        personaId,
+        resolveCaller(req),
+        sourceAttachmentId
       )
       res.status(201).json({ attachment })
     },

--- a/apps/backend/src/features/agents/persona-config-service.test.ts
+++ b/apps/backend/src/features/agents/persona-config-service.test.ts
@@ -19,6 +19,8 @@ import { PERSONA_ATTACHMENT_INLINE_FULLTEXT_MAX_CHARS } from "./config"
 import { COMPANION_MODEL_ID, TONE_PRESET_FRAGMENTS, BREVITY_PRESET_FRAGMENTS } from "./companion/config"
 import { OutboxRepository } from "../../lib/outbox"
 import { ARIADNE_AGENT_ID, EMPTY_AGENT_ID, getVisibleBuiltInAgentConfig } from "./built-in-agents"
+import { AttachmentReferenceRepository } from "../attachments"
+import { SharedMessageRepository } from "../messaging"
 import * as dbModule from "../../db"
 
 const WORKSPACE_ID = "workspace_1"
@@ -1859,6 +1861,378 @@ describe("PersonaConfigService.bindAttachment — cap and conflicts", () => {
       makeService(undefined, deps).bindAttachment(WORKSPACE_ID, "persona_custom_1", ADMIN, ATTACHMENT_ID)
     ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_LIMIT" })
     expect(del).toHaveBeenCalledWith(ATTACHMENT_ID)
+  })
+})
+
+// A CLEAN, message-bound source the caller can read — the normal copy-on-attach case.
+function sourceAttachment(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "attach_source_1",
+    workspaceId: WORKSPACE_ID,
+    uploadedBy: ADMIN.userId,
+    streamId: "stream_src",
+    messageId: "msg_src",
+    filename: "runbook.md",
+    mimeType: "text/markdown",
+    sizeBytes: 512,
+    storagePath: `${WORKSPACE_ID}/attach_source_1/runbook.md`,
+    processingStatus: "completed",
+    safetyStatus: "clean",
+    e2eOnly: false,
+    thumbnailStoragePath: null,
+    width: null,
+    height: null,
+    ...overrides,
+  }
+}
+
+/** A persona knowledge list row for the post-bind re-read (contextMode derivation). */
+function personaListRow(attachmentId: string, opts: { hasExtraction: boolean; processingStatus?: string }) {
+  return {
+    attachmentId,
+    filename: "runbook.md",
+    mimeType: "text/markdown",
+    sizeBytes: 512,
+    position: 0,
+    createdAt: new Date("2026-07-13T00:00:00Z"),
+    processingStatus: (opts.processingStatus ?? "completed") as any,
+    hasExtraction: opts.hasExtraction,
+    fullTextChars: opts.hasExtraction ? 40 : null,
+    summaryChars: opts.hasExtraction ? 20 : null,
+  }
+}
+
+/**
+ * Attachment-service seam for the copy-on-attach path: `getById` returns the
+ * SOURCE, `copyForPersona` records the generated new id and returns the copy row,
+ * `deleteIfUnbound` is the cap-loss / error cleanup. A `streamService` with
+ * `tryAccess` grants source readability for the bound-source cases.
+ */
+function makeAttachDeps(
+  overrides: {
+    getById?: any
+    copyForPersona?: any
+    deleteIfUnbound?: any
+  } = {}
+): { attachmentService: any; capturedNewId: () => string } {
+  let captured = ""
+  const copyForPersona =
+    overrides.copyForPersona ??
+    mock(async (p: any) => {
+      captured = p.newId
+      return { ...sourceAttachment(), id: p.newId }
+    })
+  const attachmentService = {
+    getById: overrides.getById ?? mock(async () => sourceAttachment()),
+    copyForPersona,
+    deleteIfUnbound: overrides.deleteIfUnbound ?? mock(async () => ({ deleted: true })),
+  }
+  return { attachmentService, capturedNewId: () => captured }
+}
+
+function grantingStreamService() {
+  return { tryAccess: mock(async () => ({ id: "stream_src", archivedAt: null })) }
+}
+
+describe("PersonaConfigService.attachFromExisting — authorization matrix", () => {
+  afterEach(() => mock.restore())
+
+  it("workspace persona: an admin may copy a readable source; returns a ready item with a real contextMode", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(binding())
+    const { attachmentService, capturedNewId } = makeAttachDeps()
+    spyOn(PersonaAttachmentRepository, "listForPersona").mockImplementation(async () => [
+      personaListRow(capturedNewId(), { hasExtraction: true }),
+    ])
+
+    const item = await makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+      WORKSPACE_ID,
+      "persona_custom_1",
+      ADMIN,
+      "attach_source_1"
+    )
+
+    expect(item).toMatchObject({
+      filename: "runbook.md",
+      mimeType: "text/markdown",
+      processingStatus: "ready",
+      contextMode: "full",
+    })
+    expect(attachmentService.copyForPersona).toHaveBeenCalledTimes(1)
+    expect(attachmentService.copyForPersona.mock.calls[0]![0]).toMatchObject({ uploadedBy: ADMIN.userId })
+  })
+
+  it("workspace persona: a non-admin member is 403'd and no copy is performed", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps()
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        MEMBER,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 403, code: "FORBIDDEN" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+    expect(attachmentService.getById).not.toHaveBeenCalled()
+  })
+
+  it("personal persona: the owner may copy", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: personalPersona() })
+    spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(
+      binding({ personaId: "persona_personal_1", createdBy: OWNER.userId })
+    )
+    const { attachmentService, capturedNewId } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ uploadedBy: OWNER.userId, streamId: null, messageId: null })),
+    })
+    spyOn(PersonaAttachmentRepository, "listForPersona").mockImplementation(async () => [
+      personaListRow(capturedNewId(), { hasExtraction: true }),
+    ])
+
+    const item = await makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+      WORKSPACE_ID,
+      "persona_personal_1",
+      OWNER,
+      "attach_source_1"
+    )
+    expect(item.processingStatus).toBe("ready")
+  })
+
+  it("personal persona: a non-owner (admin included) 404s (invisible means invisible)", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue(null)
+    const { attachmentService } = makeAttachDeps()
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_personal_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 404, code: "PERSONA_NOT_FOUND" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("a built-in persona 400s PERSONA_NOT_CUSTOM", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({
+      kind: "builtin",
+      base: getVisibleBuiltInAgentConfig(ARIADNE_AGENT_ID)!,
+    })
+    const { attachmentService } = makeAttachDeps()
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        ARIADNE_AGENT_ID,
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_NOT_CUSTOM" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+})
+
+describe("PersonaConfigService.attachFromExisting — source gates", () => {
+  afterEach(() => mock.restore())
+
+  it("404s a missing source and never copies", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({ getById: mock(async () => null) })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 404, code: "PERSONA_ATTACHMENT_SOURCE_NOT_FOUND" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("404s a cross-workspace source", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ workspaceId: "workspace_other" })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 404, code: "PERSONA_ATTACHMENT_SOURCE_NOT_FOUND" })
+  })
+
+  it("404s when the caller cannot read the source stream and performs NO copy", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    // Bound source, but tryAccess denies and the share/reference fallback also denies.
+    spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+    spyOn(AttachmentReferenceRepository, "hasViewerAccessByReference").mockResolvedValue(false)
+    const streamService = { tryAccess: mock(async () => null) }
+    const { attachmentService } = makeAttachDeps()
+
+    await expect(
+      makeService(streamService, { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 404, code: "PERSONA_ATTACHMENT_SOURCE_NOT_FOUND" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("404s an UNBOUND source uploaded by someone else (uploader-only), no copy", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ streamId: null, messageId: null, uploadedBy: "usr_someone_else" })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 404, code: "PERSONA_ATTACHMENT_SOURCE_NOT_FOUND" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("400s a non-CLEAN source (e2e_unscanned / pending scan / quarantined)", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ safetyStatus: "e2e_unscanned" })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_SOURCE_NOT_CLEAN" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("400s an e2e_only source even if flagged clean", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ e2eOnly: true })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_SOURCE_NOT_CLEAN" })
+  })
+
+  it("400s a disallowed mime type", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ mimeType: "image/png", filename: "logo.png" })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_INVALID_TYPE" })
+    expect(attachmentService.copyForPersona).not.toHaveBeenCalled()
+  })
+
+  it("400s an oversized source", async () => {
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const { attachmentService } = makeAttachDeps({
+      getById: mock(async () => sourceAttachment({ sizeBytes: 21 * 1024 * 1024 })),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_TOO_LARGE" })
+  })
+})
+
+describe("PersonaConfigService.attachFromExisting — copy, cap, and cleanup", () => {
+  afterEach(() => mock.restore())
+
+  it("a copy that kicked the pipeline (no extraction) is `processing` with a null contextMode", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(binding())
+    const { attachmentService, capturedNewId } = makeAttachDeps()
+    spyOn(PersonaAttachmentRepository, "listForPersona").mockImplementation(async () => [
+      personaListRow(capturedNewId(), { hasExtraction: false, processingStatus: "pending" }),
+    ])
+
+    const item = await makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+      WORKSPACE_ID,
+      "persona_custom_1",
+      ADMIN,
+      "attach_source_1"
+    )
+    expect(item.processingStatus).toBe("processing")
+    expect(item.contextMode).toBeNull()
+  })
+
+  it("lost cap race (insertBinding null) hard-deletes the just-created copy and 400s", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    spyOn(PersonaAttachmentRepository, "insertBinding").mockResolvedValue(null)
+    const del = mock(async () => ({ deleted: true }))
+    const { attachmentService, capturedNewId } = makeAttachDeps({ deleteIfUnbound: del })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toMatchObject({ status: 400, code: "PERSONA_ATTACHMENT_LIMIT" })
+    // The copy is the freshly-generated id, not the source — cleanup targets it.
+    expect(del).toHaveBeenCalledWith(capturedNewId())
+    expect(capturedNewId()).not.toBe("attach_source_1")
+  })
+
+  it("propagates a copy failure without binding (the copy's own S3 cleanup runs in the attachment layer)", async () => {
+    setupTransaction()
+    spyOn(PersonaRepository, "resolveEditable").mockResolvedValue({ kind: "custom", row: customPersona() })
+    const insert = spyOn(PersonaAttachmentRepository, "insertBinding")
+    const { attachmentService } = makeAttachDeps({
+      copyForPersona: mock(async () => {
+        throw new Error("s3 copy boom")
+      }),
+    })
+
+    await expect(
+      makeService(grantingStreamService(), { attachmentService }).attachFromExisting(
+        WORKSPACE_ID,
+        "persona_custom_1",
+        ADMIN,
+        "attach_source_1"
+      )
+    ).rejects.toThrow("s3 copy boom")
+    expect(insert).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/agents/persona-config-service.ts
+++ b/apps/backend/src/features/agents/persona-config-service.ts
@@ -2,6 +2,7 @@ import type { Pool } from "pg"
 import { generateSlug } from "@threa/backend-common"
 import type { ModelRegistry } from "@threa/agent-runtime"
 import {
+  AttachmentSafetyStatuses,
   personaConfigPatchSchema,
   personaCustomConfigSchema,
   SYSTEM_PERSONA_EDITABLE_FIELDS,
@@ -29,7 +30,13 @@ import { withTransaction } from "../../db"
 import { HttpError } from "../../lib/errors"
 import { logger } from "../../lib/logger"
 import { OutboxRepository } from "../../lib/outbox"
-import type { AttachmentService } from "../attachments"
+import { attachmentId as generateAttachmentId } from "../../lib/id"
+import {
+  isAttachmentReadableViaShareOrReference,
+  unboundAttachmentBlockedForCaller,
+  type Attachment,
+  type AttachmentService,
+} from "../attachments"
 import {
   personaAttachmentExtractionFailed,
   PersonaAttachmentRepository,
@@ -122,6 +129,18 @@ function personaAttachmentLimitReached(): HttpError {
 
 function personaAttachmentNotFound(): HttpError {
   return new HttpError("Persona attachment not found", { status: 404, code: "PERSONA_ATTACHMENT_NOT_FOUND" })
+}
+
+/**
+ * The copy-on-attach source is missing, cross-workspace, or one the caller may
+ * not read. A single 404 for all three so a private file's existence never leaks
+ * (matching the download gate's non-leak posture) — the copy is never performed.
+ */
+function personaAttachmentSourceNotFound(): HttpError {
+  return new HttpError("Source attachment not found", {
+    status: 404,
+    code: "PERSONA_ATTACHMENT_SOURCE_NOT_FOUND",
+  })
 }
 
 /** Derive the structured wire status (INV-46) from the extraction/pipeline state. */
@@ -1151,18 +1170,7 @@ export class PersonaConfigService {
     }
     // The generic reserve path allows 100MB / any mime; the persona rules apply
     // here at bind, against the stored row's real metadata (INV-11 — loud).
-    if (!isPersonaAttachmentMimeAllowed(attachment.mimeType)) {
-      throw new HttpError(
-        `File type "${attachment.mimeType}" is not allowed. Allowed: text/*, ${PERSONA_ATTACHMENT_ALLOWED_MIME_TYPES.join(", ")}`,
-        { status: 400, code: "PERSONA_ATTACHMENT_INVALID_TYPE" }
-      )
-    }
-    if (attachment.sizeBytes > PERSONA_ATTACHMENT_MAX_SIZE_BYTES) {
-      throw new HttpError(`File exceeds the ${PERSONA_ATTACHMENT_MAX_SIZE_BYTES}-byte limit`, {
-        status: 400,
-        code: "PERSONA_ATTACHMENT_TOO_LARGE",
-      })
-    }
+    this.assertPersonaMimeAndSizeEligible(attachment)
 
     let binding
     try {
@@ -1213,6 +1221,143 @@ export class PersonaConfigService {
       sizeBytes: attachment.sizeBytes,
       // Extraction runs off the upload's settle event; it may still be in flight,
       // so no content mode can be planned yet. The config refetch reconciles.
+      processingStatus: "processing",
+      contextMode: null,
+      position: binding.position,
+      createdAt: binding.createdAt.toISOString(),
+    }
+  }
+
+  /** The persona mime allowlist + per-file size cap, applied against a stored row (INV-11 — loud). */
+  private assertPersonaMimeAndSizeEligible(attachment: Pick<Attachment, "mimeType" | "sizeBytes">): void {
+    if (!isPersonaAttachmentMimeAllowed(attachment.mimeType)) {
+      throw new HttpError(
+        `File type "${attachment.mimeType}" is not allowed. Allowed: text/*, ${PERSONA_ATTACHMENT_ALLOWED_MIME_TYPES.join(", ")}`,
+        { status: 400, code: "PERSONA_ATTACHMENT_INVALID_TYPE" }
+      )
+    }
+    if (attachment.sizeBytes > PERSONA_ATTACHMENT_MAX_SIZE_BYTES) {
+      throw new HttpError(`File exceeds the ${PERSONA_ATTACHMENT_MAX_SIZE_BYTES}-byte limit`, {
+        status: 400,
+        code: "PERSONA_ATTACHMENT_TOO_LARGE",
+      })
+    }
+  }
+
+  /**
+   * The exact readability chain the download/content handlers use (INV-35), not a
+   * reimplementation: a bound source resolves through direct stream access with
+   * the share-grant / inline-reference fallback; an unbound source (someone's
+   * pending upload) is private to its uploader. Throws a non-leaking 404 when the
+   * caller may not read it — so the copy is never performed for a file the caller
+   * can't already see.
+   */
+  private async assertCallerCanReadSource(source: Attachment, workspaceId: string, userId: string): Promise<void> {
+    if (source.streamId) {
+      const accessible = await this.streamService.tryAccess(source.streamId, workspaceId, userId)
+      if (accessible) return
+      const granted = await isAttachmentReadableViaShareOrReference(this.pool, source, workspaceId, userId)
+      if (granted) return
+      throw personaAttachmentSourceNotFound()
+    }
+    if (unboundAttachmentBlockedForCaller(source, userId)) throw personaAttachmentSourceNotFound()
+  }
+
+  /**
+   * Attach an EXISTING workspace file to a custom/personal persona as context
+   * knowledge by COPYING it (knowledge-by-reference). Attachments are immutable,
+   * so an independent copy IS reference semantics from the user's view and keeps
+   * every ownership rule intact: the persona owns its copy outright (message/
+   * stream NULL forever, uploader-only, hard-delete safe, cap-guarded), and the
+   * source message's file can never be mutated or deleted out from under the
+   * persona. `attachment_references` (row-sharing) is deliberately NOT used.
+   *
+   * Flow: the persona edit gate (as bind); load the source workspace-scoped
+   * (404 if missing/cross-workspace); the caller must be able to READ the source
+   * ({@link assertCallerCanReadSource} — the download handlers' exact chain);
+   * eligibility (CLEAN only, not e2e, persona mime + size against the SOURCE);
+   * server-side copy + extraction copy / pipeline kick
+   * ({@link AttachmentService.copyForPersona}); then the existing cap-guarded
+   * {@link PersonaAttachmentRepository.insertBinding} with the existing cap-loss
+   * cleanup ({@link AttachmentService.deleteIfUnbound}). A copy with a copied
+   * extraction is `ready` immediately with a real contextMode; a copy that kicked
+   * the pipeline shows `processing`.
+   */
+  async attachFromExisting(
+    workspaceId: string,
+    personaId: string,
+    caller: PersonaCaller,
+    sourceAttachmentId: string
+  ): Promise<PersonaAttachmentItem> {
+    const editable = await this.authorizeEditableOr404(workspaceId, personaId, caller)
+    if (editable.kind !== "custom") throw customsOnly()
+
+    const source = await this.attachmentService.getById(sourceAttachmentId)
+    if (!source || source.workspaceId !== workspaceId) throw personaAttachmentSourceNotFound()
+
+    await this.assertCallerCanReadSource(source, workspaceId, caller.userId)
+
+    // Eligibility against the SOURCE row (INV-11 — loud, structured). CLEAN only:
+    // rejects e2e_unscanned / pending scan / quarantined; the explicit e2e_only
+    // guard is belt-and-suspenders (an e2e file is never CLEAN anyway).
+    if (source.safetyStatus !== AttachmentSafetyStatuses.CLEAN || source.e2eOnly) {
+      throw new HttpError("This file cannot be attached as persona knowledge (not a scanned-clean file)", {
+        status: 400,
+        code: "PERSONA_ATTACHMENT_SOURCE_NOT_CLEAN",
+      })
+    }
+    this.assertPersonaMimeAndSizeEligible(source)
+
+    const newId = generateAttachmentId()
+    const copy = await this.attachmentService.copyForPersona({
+      source,
+      newId,
+      uploadedBy: caller.userId,
+    })
+
+    let binding
+    try {
+      binding = await withTransaction(this.pool, async (client) =>
+        PersonaAttachmentRepository.insertBinding(client, {
+          attachmentId: newId,
+          workspaceId,
+          personaId,
+          createdBy: caller.userId,
+          maxCount: PERSONA_ATTACHMENT_MAX_COUNT,
+        })
+      )
+    } catch (error) {
+      // The copy is a brand-new id, so a unique-PK collision cannot be a real
+      // "already bound" case — clean up the just-created copy and rethrow.
+      await this.attachmentService.deleteIfUnbound(newId).catch((err) => {
+        logger.error({ err, attachmentId: newId }, "failed to clean up persona copy after bind error")
+      })
+      throw error
+    }
+    if (!binding) {
+      // Cap reached. The copy is unbound, so hard-delete it cleanly (its bytes +
+      // extraction go with it) — race-safe so a message that somehow claimed it
+      // keeps its bytes (INV-20; mirrors bind's cap-loss cleanup).
+      await this.attachmentService.deleteIfUnbound(newId).catch((err) => {
+        logger.error({ err, attachmentId: newId }, "failed to clean up persona copy after cap race")
+      })
+      throw personaAttachmentLimitReached()
+    }
+
+    // Return the item exactly as the config GET would render it — re-read through
+    // the same budget planner so the contextMode can't drift (decision 2g): a
+    // copied extraction yields a real mode now; a kicked pipeline is `processing`.
+    const items = await this.listAttachments(workspaceId, personaId)
+    const created = items.find((item) => item.id === newId)
+    if (created) return created
+
+    // Unreachable in practice (we just bound it); construct a safe fallback
+    // rather than throw after a committed copy+bind (the operation succeeded).
+    return {
+      id: newId,
+      filename: copy.filename,
+      mimeType: copy.mimeType,
+      sizeBytes: copy.sizeBytes,
       processingStatus: "processing",
       contextMode: null,
       position: binding.position,

--- a/apps/backend/src/features/attachments/access.ts
+++ b/apps/backend/src/features/attachments/access.ts
@@ -37,13 +37,15 @@ export async function isAttachmentReadableViaShareOrReference(
  * An UNBOUND attachment (no `stream_id`) is private to its uploader: no stream
  * gates it, so only the uploader may read it. Returns `true` when the caller
  * must be BLOCKED — a foreign user reading someone else's pending/persona-owned
- * upload. Bound attachments (stream set) are gated by stream access upstream and
- * never reach this check. Shared by the download/content handlers and the
- * persona copy-on-attach readability gate (one definition, INV-35).
+ * upload. A legacy row with no `uploaded_by` (predates the column) has no owner
+ * to match, so it is blocked for everyone rather than readable by anyone —
+ * fail-closed. Bound attachments (stream set) are gated by stream access
+ * upstream and never reach this check. Shared by the download/content handlers
+ * and the persona copy-on-attach readability gate (one definition, INV-35).
  */
 export function unboundAttachmentBlockedForCaller(
   attachment: Pick<Attachment, "streamId" | "uploadedBy">,
   userId: string
 ): boolean {
-  return !attachment.streamId && !!attachment.uploadedBy && attachment.uploadedBy !== userId
+  return !attachment.streamId && attachment.uploadedBy !== userId
 }

--- a/apps/backend/src/features/attachments/access.ts
+++ b/apps/backend/src/features/attachments/access.ts
@@ -32,3 +32,18 @@ export async function isAttachmentReadableViaShareOrReference(
   }
   return AttachmentReferenceRepository.hasViewerAccessByReference(db, workspaceId, userId, attachment.id)
 }
+
+/**
+ * An UNBOUND attachment (no `stream_id`) is private to its uploader: no stream
+ * gates it, so only the uploader may read it. Returns `true` when the caller
+ * must be BLOCKED — a foreign user reading someone else's pending/persona-owned
+ * upload. Bound attachments (stream set) are gated by stream access upstream and
+ * never reach this check. Shared by the download/content handlers and the
+ * persona copy-on-attach readability gate (one definition, INV-35).
+ */
+export function unboundAttachmentBlockedForCaller(
+  attachment: Pick<Attachment, "streamId" | "uploadedBy">,
+  userId: string
+): boolean {
+  return !attachment.streamId && !!attachment.uploadedBy && attachment.uploadedBy !== userId
+}

--- a/apps/backend/src/features/attachments/extraction-repository.ts
+++ b/apps/backend/src/features/attachments/extraction-repository.ts
@@ -139,6 +139,36 @@ export const AttachmentExtractionRepository = {
     return mapRowToExtraction(result.rows[0])
   },
 
+  /**
+   * Copy an existing extraction to a NEW attachment id in one `INSERT ... SELECT`
+   * (persona knowledge-by-reference copy-on-attach): the copied file has identical
+   * content, so its `summary_embedding` carries over natively — no re-embed job.
+   * `search_vector` is GENERATED and never copied. Workspace-scoped on the source
+   * read (INV-8). Returns `true` when a source row existed and was copied; `false`
+   * when the source has no extraction yet (the caller kicks the pipeline instead).
+   */
+  async copyForAttachment(
+    client: Querier,
+    params: { id: string; sourceAttachmentId: string; attachmentId: string; workspaceId: string }
+  ): Promise<boolean> {
+    const result = await client.query(sql`
+      INSERT INTO attachment_extractions (
+        id, attachment_id, workspace_id,
+        content_type, summary, full_text, structured_data,
+        source_type, pdf_metadata, text_metadata, word_metadata, excel_metadata,
+        summary_embedding
+      )
+      SELECT
+        ${params.id}, ${params.attachmentId}, ${params.workspaceId},
+        content_type, summary, full_text, structured_data,
+        source_type, pdf_metadata, text_metadata, word_metadata, excel_metadata,
+        summary_embedding
+      FROM attachment_extractions
+      WHERE attachment_id = ${params.sourceAttachmentId} AND workspace_id = ${params.workspaceId}
+    `)
+    return (result.rowCount ?? 0) > 0
+  },
+
   async findByAttachmentId(client: Querier, attachmentId: string): Promise<AttachmentExtraction | null> {
     const result = await client.query<AttachmentExtractionRow>(
       sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM attachment_extractions WHERE attachment_id = ${attachmentId}`

--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, Response } from "express"
 import { z } from "zod"
 import type { Pool } from "pg"
 import { buildContentDisposition, buildUploadParams, parseE2eUploadFlag, type AttachmentService } from "./service"
-import { isAttachmentReadableViaShareOrReference } from "./access"
+import { isAttachmentReadableViaShareOrReference, unboundAttachmentBlockedForCaller } from "./access"
 import {
   AttachmentRepository,
   type Attachment,
@@ -32,20 +32,6 @@ interface Dependencies {
   streamService: StreamService
   storage: StorageProvider
   pool: Pool
-}
-
-/**
- * An attachment not yet bound to a message (null stream) has no stream ACL to
- * gate the generic serving path on, so only its uploader may read it. This
- * closes the persona-context-attachments leak: a persona file keeps `stream_id`
- * NULL forever, so without this any workspace member holding the (ULID) id could
- * fetch another user's private persona knowledge or its extracted text. Bound
- * attachments (stream set) are gated by stream access upstream and never reach
- * this check. Composer previews still work — the uploader reads their own
- * pending upload.
- */
-function unboundAttachmentBlockedForCaller(attachment: Attachment, userId: string): boolean {
-  return !attachment.streamId && !!attachment.uploadedBy && attachment.uploadedBy !== userId
 }
 
 const reserveAttachmentSchema = z.object({

--- a/apps/backend/src/features/attachments/index.ts
+++ b/apps/backend/src/features/attachments/index.ts
@@ -12,7 +12,7 @@ export { createAttachmentUploadSweepWorker } from "./upload-sweep-worker"
 // Fallback access helper — `getDownloadUrl` and create-message validation
 // both walk share-grant + inline-reference after their stream-access fast
 // path fails. See `access.ts`.
-export { isAttachmentReadableViaShareOrReference } from "./access"
+export { isAttachmentReadableViaShareOrReference, unboundAttachmentBlockedForCaller } from "./access"
 
 export { toAttachmentSummary, fetchUploadStatuses, hydrateAttachmentSummaries } from "./summary"
 

--- a/apps/backend/src/features/attachments/service.test.ts
+++ b/apps/backend/src/features/attachments/service.test.ts
@@ -42,6 +42,7 @@ function createService() {
   const storage = {
     getObjectSize: mock(async () => 0),
     getSignedDownloadUrl: mock(async () => "https://example.com/file"),
+    copyObject: mock(async () => {}),
     delete: mock(async () => {}),
   } as any
 
@@ -555,5 +556,127 @@ describe("parseE2eUploadFlag", () => {
     expect(parseE2eUploadFlag({ e2e: "false" })).toBe(false)
     expect(parseE2eUploadFlag({})).toBe(false)
     expect(parseE2eUploadFlag(undefined)).toBe(false)
+  })
+})
+
+describe("AttachmentService.copyForPersona", () => {
+  afterEach(() => mock.restore())
+
+  function setupCopyTransaction() {
+    spyOn(db, "withTransaction").mockImplementation((async (_db: unknown, fn: (client: any) => Promise<any>) =>
+      fn({})) as any)
+  }
+
+  const SOURCE = makeAttachment({
+    id: "attach_src",
+    workspaceId: "ws_1",
+    streamId: "stream_origin",
+    messageId: "msg_origin",
+    filename: "runbook.md",
+    mimeType: "text/markdown",
+    sizeBytes: 512,
+    storagePath: "ws_1/attach_src/runbook.md",
+    processingStatus: "completed",
+    thumbnailStoragePath: null,
+    width: null,
+    height: null,
+  })
+
+  it("server-side copies the object to the new key and inserts an unbound CLEAN row with copied processing status", async () => {
+    setupCopyTransaction()
+    const { service, storage } = createService()
+    const insert = spyOn(AttachmentRepository, "insert").mockResolvedValue(
+      makeAttachment({ id: "attach_copy", storagePath: "ws_1/attach_copy/runbook.md" })
+    )
+    spyOn(AttachmentExtractionRepository, "copyForAttachment").mockResolvedValue(true)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.copyForPersona({ source: SOURCE, newId: "attach_copy", uploadedBy: "usr_caller" })
+
+    expect(storage.copyObject).toHaveBeenCalledWith("ws_1/attach_src/runbook.md", "ws_1/attach_copy/runbook.md")
+    expect(insert.mock.calls[0]![1]).toMatchObject({
+      id: "attach_copy",
+      workspaceId: "ws_1",
+      uploadedBy: "usr_caller",
+      filename: "runbook.md",
+      mimeType: "text/markdown",
+      sizeBytes: 512,
+      storagePath: "ws_1/attach_copy/runbook.md",
+      safetyStatus: AttachmentSafetyStatuses.CLEAN,
+      processingStatus: "completed",
+    })
+    // stream/message are never set on a persona copy (owned outright).
+    expect(insert.mock.calls[0]![1].streamId).toBeUndefined()
+    // Extraction was copied → the normal pipeline is NOT kicked (no re-embed).
+    expect(outbox).not.toHaveBeenCalled()
+  })
+
+  it("carries the extraction via copyForAttachment (embedding rides the INSERT…SELECT) and emits no event", async () => {
+    setupCopyTransaction()
+    const { service } = createService()
+    spyOn(AttachmentRepository, "insert").mockResolvedValue(makeAttachment({ id: "attach_copy" }))
+    const copyExtraction = spyOn(AttachmentExtractionRepository, "copyForAttachment").mockResolvedValue(true)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.copyForPersona({ source: SOURCE, newId: "attach_copy", uploadedBy: "usr_caller" })
+
+    expect(copyExtraction.mock.calls[0]![1]).toMatchObject({
+      sourceAttachmentId: "attach_src",
+      attachmentId: "attach_copy",
+      workspaceId: "ws_1",
+    })
+    expect(outbox).not.toHaveBeenCalled()
+  })
+
+  it("kicks the pipeline exactly once when the source has no extraction (in the copy transaction)", async () => {
+    setupCopyTransaction()
+    const { service } = createService()
+    spyOn(AttachmentRepository, "insert").mockResolvedValue(makeAttachment({ id: "attach_copy" }))
+    spyOn(AttachmentExtractionRepository, "copyForAttachment").mockResolvedValue(false)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.copyForPersona({ source: SOURCE, newId: "attach_copy", uploadedBy: "usr_caller" })
+
+    const uploadedEvents = outbox.mock.calls.filter((call) => call[1] === "attachment:uploaded")
+    expect(uploadedEvents).toHaveLength(1)
+    expect(uploadedEvents[0]![2]).toMatchObject({ workspaceId: "ws_1", attachmentId: "attach_copy" })
+  })
+
+  it("copies the thumbnail object + variant metadata when the source carries one", async () => {
+    setupCopyTransaction()
+    const { service, storage } = createService()
+    spyOn(AttachmentRepository, "insert").mockResolvedValue(makeAttachment({ id: "attach_copy" }))
+    const updateVariant = spyOn(AttachmentRepository, "updateImageVariant").mockResolvedValue(true)
+    spyOn(AttachmentExtractionRepository, "copyForAttachment").mockResolvedValue(true)
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const withThumb = makeAttachment({
+      ...SOURCE,
+      thumbnailStoragePath: "ws_1/attach_src/thumbnail.webp",
+      width: 800,
+      height: 600,
+    })
+    await service.copyForPersona({ source: withThumb, newId: "attach_copy", uploadedBy: "usr_caller" })
+
+    expect(storage.copyObject).toHaveBeenCalledWith("ws_1/attach_src/thumbnail.webp", "ws_1/attach_copy/thumbnail.webp")
+    expect(updateVariant.mock.calls[0]![2]).toMatchObject({
+      thumbnailStoragePath: "ws_1/attach_copy/thumbnail.webp",
+      width: 800,
+      height: 600,
+    })
+  })
+
+  it("best-effort deletes the copied object when the insert transaction throws (never orphan the bytes)", async () => {
+    setupCopyTransaction()
+    const { service, storage } = createService()
+    spyOn(AttachmentRepository, "insert").mockRejectedValue(new Error("insert boom"))
+
+    await expect(
+      service.copyForPersona({ source: SOURCE, newId: "attach_copy", uploadedBy: "usr_caller" })
+    ).rejects.toThrow("insert boom")
+
+    // The S3 copy already ran, so the object must be cleaned up.
+    expect(storage.copyObject).toHaveBeenCalledWith("ws_1/attach_src/runbook.md", "ws_1/attach_copy/runbook.md")
+    expect(storage.delete).toHaveBeenCalledWith("ws_1/attach_copy/runbook.md")
   })
 })

--- a/apps/backend/src/features/attachments/service.ts
+++ b/apps/backend/src/features/attachments/service.ts
@@ -15,7 +15,7 @@ import {
   type AttachmentUploadStatus,
 } from "@threa/types"
 import { isAttachmentSafeForSharing, safetyStatusBlockReason, type MalwareScanner } from "./upload-safety-policy"
-import { attachmentUploadId } from "../../lib/id"
+import { attachmentUploadId, extractionId } from "../../lib/id"
 import { logger } from "../../lib/logger"
 
 /**
@@ -655,6 +655,100 @@ export class AttachmentService {
     }
 
     return { status: "blocked", reason: blockReason }
+  }
+
+  /**
+   * Copy an existing CLEAN attachment's bytes + extraction into a fresh
+   * uploader-owned, message-unbound row (persona knowledge-by-reference,
+   * copy-on-attach). The result is an INDEPENDENT copy the persona owns
+   * outright: a server-side S3 copy of the object (and its thumbnail when
+   * present — persona-eligible mimes never carry one, but honour it), an
+   * `attachments` row with `stream_id`/`message_id` NULL and `safety_status`
+   * CLEAN, and either a copied `attachment_extractions` row — carrying
+   * `summary_embedding` natively, no re-embed — or, when the source has no
+   * extraction yet (still processing / failed), an `attachment:uploaded` outbox
+   * event so the normal pipeline extracts the copy (INV-4, same transaction).
+   *
+   * `pdf_page_extractions` are deliberately NOT copied: the persona knowledge
+   * path reads only `attachment_extractions`, and `read_attachment` (the only
+   * per-page reader) is message-scoped, so a persona copy can never surface a
+   * per-page read.
+   *
+   * The S3 copy runs BEFORE the row insert so an `attachments` row never points
+   * at bytes that failed to land; a best-effort object cleanup runs if the
+   * insert transaction throws so a copied object is never orphaned. Eligibility
+   * (CLEAN / not e2e / mime / size) is the caller's gate — this assumes a
+   * validated source.
+   */
+  async copyForPersona(params: { source: Attachment; newId: string; uploadedBy: string }): Promise<Attachment> {
+    const { source, newId, uploadedBy } = params
+    const newStoragePath = `${source.workspaceId}/${newId}/${source.filename}`
+    await this.storage.copyObject(source.storagePath, newStoragePath)
+
+    let newThumbnailStoragePath: string | null = null
+    if (source.thumbnailStoragePath) {
+      newThumbnailStoragePath = `${source.workspaceId}/${newId}/thumbnail.webp`
+      await this.storage.copyObject(source.thumbnailStoragePath, newThumbnailStoragePath)
+    }
+
+    try {
+      return await withTransaction(this.pool, async (client) => {
+        const attachment = await AttachmentRepository.insert(client, {
+          id: newId,
+          workspaceId: source.workspaceId,
+          uploadedBy,
+          filename: source.filename,
+          mimeType: source.mimeType,
+          sizeBytes: source.sizeBytes,
+          storagePath: newStoragePath,
+          safetyStatus: AttachmentSafetyStatuses.CLEAN,
+          processingStatus: source.processingStatus,
+        })
+        if (newThumbnailStoragePath && source.width != null && source.height != null) {
+          await AttachmentRepository.updateImageVariant(client, newId, {
+            thumbnailStoragePath: newThumbnailStoragePath,
+            width: source.width,
+            height: source.height,
+          })
+        }
+
+        const extractionCopied = await AttachmentExtractionRepository.copyForAttachment(client, {
+          id: extractionId(),
+          sourceAttachmentId: source.id,
+          attachmentId: newId,
+          workspaceId: source.workspaceId,
+        })
+        if (!extractionCopied) {
+          // No extraction on the source yet — kick the normal pipeline for the
+          // copy in the same transaction (INV-4), mirroring create()'s emit.
+          await OutboxRepository.insert(client, "attachment:uploaded", {
+            workspaceId: source.workspaceId,
+            attachmentId: newId,
+            filename: source.filename,
+            mimeType: source.mimeType,
+            sizeBytes: source.sizeBytes,
+            storagePath: newStoragePath,
+          })
+        }
+
+        return attachment
+      })
+    } catch (err) {
+      // Never leave a copied object without its row. Best-effort — the caller
+      // surfaces the original error.
+      await this.storage.delete(newStoragePath).catch((cleanupErr) => {
+        logger.error({ cleanupErr, storagePath: newStoragePath }, "Failed to clean up persona copy object after error")
+      })
+      if (newThumbnailStoragePath) {
+        await this.storage.delete(newThumbnailStoragePath).catch((cleanupErr) => {
+          logger.error(
+            { cleanupErr, storagePath: newThumbnailStoragePath },
+            "Failed to clean up persona copy thumbnail after error"
+          )
+        })
+      }
+      throw err
+    }
   }
 
   getSharingBlockReason(attachment: Attachment): string | null {

--- a/apps/backend/src/features/attachments/service.ts
+++ b/apps/backend/src/features/attachments/service.ts
@@ -683,15 +683,18 @@ export class AttachmentService {
   async copyForPersona(params: { source: Attachment; newId: string; uploadedBy: string }): Promise<Attachment> {
     const { source, newId, uploadedBy } = params
     const newStoragePath = `${source.workspaceId}/${newId}/${source.filename}`
-    await this.storage.copyObject(source.storagePath, newStoragePath)
-
     let newThumbnailStoragePath: string | null = null
-    if (source.thumbnailStoragePath) {
-      newThumbnailStoragePath = `${source.workspaceId}/${newId}/thumbnail.webp`
-      await this.storage.copyObject(source.thumbnailStoragePath, newThumbnailStoragePath)
-    }
 
+    // The cleanup guard starts BEFORE the first copy: a thumbnail copy that
+    // rejects after the primary landed must still reap the primary object.
     try {
+      await this.storage.copyObject(source.storagePath, newStoragePath)
+
+      if (source.thumbnailStoragePath) {
+        newThumbnailStoragePath = `${source.workspaceId}/${newId}/thumbnail.webp`
+        await this.storage.copyObject(source.thumbnailStoragePath, newThumbnailStoragePath)
+      }
+
       return await withTransaction(this.pool, async (client) => {
         const attachment = await AttachmentRepository.insert(client, {
           id: newId,

--- a/apps/backend/src/lib/storage/s3-client.ts
+++ b/apps/backend/src/lib/storage/s3-client.ts
@@ -5,6 +5,7 @@ import {
   DeleteObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
+  CopyObjectCommand,
 } from "@aws-sdk/client-s3"
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 import type { S3Config } from "../env"
@@ -38,6 +39,14 @@ export interface StorageProvider {
   /** Stream an object with the metadata needed to proxy it over HTTP (optionally a Range slice). */
   getObjectContent(key: string, options?: { range?: string }): Promise<ObjectContent>
   putObject(key: string, body: Buffer, contentType: string): Promise<void>
+  /**
+   * Server-side copy of an existing object to a new key (no bytes transit the
+   * app). Used by persona knowledge-by-reference: attaching an existing file to
+   * a persona copies its bytes to a fresh key so the persona owns an independent
+   * copy (copy-on-attach). `srcKey` is URL-encoded into `CopySource` so keys with
+   * spaces/unicode filenames round-trip.
+   */
+  copyObject(srcKey: string, destKey: string): Promise<void>
   delete(key: string): Promise<void>
 }
 
@@ -181,6 +190,16 @@ export function createS3Storage(config: S3Config): StorageProvider {
           Key: key,
           Body: body,
           ContentType: contentType,
+        })
+      )
+    },
+
+    async copyObject(srcKey: string, destKey: string): Promise<void> {
+      await client.send(
+        new CopyObjectCommand({
+          Bucket: config.bucket,
+          Key: destKey,
+          CopySource: `${config.bucket}/${encodeURIComponent(srcKey)}`,
         })
       )
     },

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -491,6 +491,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // so there is one frontend upload path (INV-35/37). The list rides the config
   // GET — no separate GET route.
   app.post("/api/workspaces/:workspaceId/personas/:personaId/attachments", ...authed, persona.bindAttachment)
+  // Knowledge-by-reference: copy an existing readable workspace file into a fresh
+  // persona-owned attachment (copy-on-attach). The service authorizes + copies.
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/attachments/from-existing",
+    ...authed,
+    persona.attachFromExisting
+  )
   app.delete(
     "/api/workspaces/:workspaceId/personas/:personaId/attachments/:attachmentId",
     ...authed,

--- a/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
+++ b/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import type { Pool } from "pg"
-import { PERSONA_ATTACHMENT_MAX_COUNT, StreamTypes } from "@threa/types"
+import { AttachmentSafetyStatuses, PERSONA_ATTACHMENT_MAX_COUNT, StreamTypes } from "@threa/types"
 import { sql } from "../../src/db"
 import { attachmentId, extractionId, personaId, workspaceId as newWorkspaceId, userId } from "../../src/lib/id"
 import { PersonaAttachmentRepository } from "../../src/features/agents/persona-attachment-repository"
+import { PersonaConfigService } from "../../src/features/agents/persona-config-service"
+import { PersonaRepository } from "../../src/features/agents/persona-repository"
+import { AttachmentService, AttachmentExtractionRepository } from "../../src/features/attachments"
 import { buildSystemPrompt } from "../../src/features/agents/companion/prompt/system-prompt"
 import type { Persona } from "../../src/features/agents/persona-repository"
 import type { StreamContext } from "../../src/features/agents/context-builder"
@@ -371,5 +374,189 @@ describe("persona_attachments binding invariants (integration)", () => {
       const remaining = await PersonaAttachmentRepository.listForPersona(client, workspaceId, personaRowId)
       expect(remaining.map((row) => row.attachmentId)).toEqual([attId])
     })
+  })
+})
+
+/**
+ * End-to-end proof for F1 (knowledge-by-reference copy-on-attach) against the
+ * real database: seed a CLEAN source attachment WITH an extraction row (and a
+ * summary embedding), run the REAL `PersonaConfigService.attachFromExisting`
+ * service path (only the S3 StorageProvider is an in-memory fake that records
+ * `copyObject`), then compose the REAL system prompt and assert the persona now
+ * carries the COPIED content. Proves the copy is independent: deleting the SOURCE
+ * row leaves the persona's copy + its extraction (and embedding) intact.
+ *
+ * Uses committed data (the service opens its own transactions on the pool), so it
+ * cleans up explicitly in `finally`.
+ */
+describe("PersonaConfigService.attachFromExisting → copy-on-attach (integration)", () => {
+  function inMemoryStorage() {
+    const copied: Array<{ src: string; dest: string }> = []
+    const deleted: string[] = []
+    const storage = {
+      copyObject: async (src: string, dest: string) => {
+        copied.push({ src, dest })
+      },
+      delete: async (key: string) => {
+        deleted.push(key)
+      },
+      getObjectSize: async () => 0,
+      getObjectStat: async () => ({ sizeBytes: 0, etag: "stub" }),
+      getSignedDownloadUrl: async () => "https://example.test/x",
+      getObject: async () => Buffer.from(""),
+      getObjectRange: async () => Buffer.from(""),
+      getObjectStream: async () => Buffer.from("") as never,
+      getObjectContent: async () => ({ stream: Buffer.from("") as never }),
+      putObject: async () => {},
+    } as never
+    return { storage, copied, deleted }
+  }
+
+  function makeService(pool: Pool, storage: never) {
+    const attachmentService = new AttachmentService(pool, storage, {
+      scan: async () => ({ status: AttachmentSafetyStatuses.CLEAN }),
+    } as never)
+    const service = new PersonaConfigService({
+      pool,
+      // Unbound source owned by the caller resolves via the uploader-only gate,
+      // so `tryAccess` is never reached (this stub is defensive, not exercised).
+      streamService: { tryAccess: async () => null } as never,
+      modelRegistry: {} as never,
+      attachmentService,
+    })
+    return { service, attachmentService }
+  }
+
+  test("copies bytes + extraction under the persona; the copy is independent of the source", async () => {
+    const workspaceId = newWorkspaceId()
+    const caller = userId()
+    const sourceId = attachmentId()
+    const sourceText = "RUNBOOK: 1) rotate key 2) redeploy 3) verify health"
+    const embeddingLiteral = `[${Array(1536).fill(0.0123).join(",")}]`
+
+    const { storage, copied } = inMemoryStorage()
+    const { service, attachmentService } = makeService(pool, storage)
+
+    try {
+      // A workspace custom persona to attach to (real row via the repo layer).
+      const personaRow = await withTransaction(pool, (client) =>
+        PersonaRepository.insertWorkspacePersona(client, {
+          workspaceId,
+          slug: `helper-${sourceId.slice(-6)}`,
+          config: {
+            name: "Helper",
+            description: null,
+            avatarEmoji: null,
+            systemPrompt: "Base system prompt",
+            model: "openai/gpt-5.4",
+            escalationModel: null,
+            temperature: null,
+            maxTokens: null,
+            enabledTools: [],
+            tonePrompt: null,
+            brevityPrompt: null,
+          },
+        })
+      )
+
+      // Seed the SOURCE: a CLEAN, unbound (uploader-readable), caller-owned file
+      // with fake bytes recorded in the DB, plus its extraction + a real embedding.
+      await pool.query(sql`
+        INSERT INTO attachments (
+          id, workspace_id, stream_id, message_id, filename, mime_type, size_bytes,
+          storage_provider, storage_path, processing_status, safety_status, uploaded_by
+        ) VALUES (
+          ${sourceId}, ${workspaceId}, NULL, NULL, 'runbook.md', 'text/markdown', 512,
+          's3', ${`${workspaceId}/${sourceId}/runbook.md`}, 'completed', 'clean', ${caller}
+        )
+      `)
+      await pool.query(sql`
+        INSERT INTO attachment_extractions (
+          id, attachment_id, workspace_id, content_type, summary, full_text, summary_embedding
+        ) VALUES (
+          ${extractionId()}, ${sourceId}, ${workspaceId}, 'document', 'A short runbook.', ${sourceText},
+          ${embeddingLiteral}::vector
+        )
+      `)
+
+      const item = await service.attachFromExisting(
+        workspaceId,
+        personaRow.id,
+        { userId: caller, isAdmin: true },
+        sourceId
+      )
+
+      // A ready copy with a real context mode (extraction was copied, not kicked).
+      expect(item.processingStatus).toBe("ready")
+      expect(item.contextMode).toBe("full")
+      expect(item.id).not.toBe(sourceId)
+      const copyId = item.id
+
+      // The S3 object was server-side copied source → the new key.
+      expect(copied).toHaveLength(1)
+      expect(copied[0]!.src).toBe(`${workspaceId}/${sourceId}/runbook.md`)
+      expect(copied[0]!.dest).toBe(`${workspaceId}/${copyId}/runbook.md`)
+
+      // The copy row: uploader = caller, unbound (stream/message NULL), CLEAN.
+      const copyRow = await pool.query<{
+        uploaded_by: string
+        stream_id: string | null
+        message_id: string | null
+        safety_status: string
+      }>(sql`SELECT uploaded_by, stream_id, message_id, safety_status FROM attachments WHERE id = ${copyId}`)
+      expect(copyRow.rows[0]).toMatchObject({
+        uploaded_by: caller,
+        stream_id: null,
+        message_id: null,
+        safety_status: "clean",
+      })
+
+      // The copied extraction carries the content AND the embedding (no re-embed).
+      const copyExtraction = await AttachmentExtractionRepository.findByAttachmentId(pool, copyId)
+      expect(copyExtraction?.fullText).toBe(sourceText)
+      expect(copyExtraction?.hasSummaryEmbedding).toBe(true)
+
+      // The REAL prompt path carries the copied content under the persona.
+      const knowledge = await PersonaAttachmentRepository.listForPersonaWithContent(pool, workspaceId, personaRow.id)
+      const prompt = buildSystemPrompt(
+        { ...persona, id: personaRow.id, workspaceId, systemPrompt: "Base system prompt" },
+        scratchpadContext,
+        null,
+        undefined,
+        undefined,
+        null,
+        [],
+        null,
+        null,
+        null,
+        null,
+        null,
+        undefined,
+        knowledge
+      )
+      expect(prompt).toContain("## Knowledge")
+      expect(prompt).toContain("### runbook.md")
+      expect(prompt).toContain(sourceText)
+
+      // INDEPENDENCE: delete the SOURCE row + its extraction; the copy survives.
+      const sourceDeleted = await attachmentService.delete(sourceId)
+      expect(sourceDeleted).toBe(true)
+      const sourceGone = await pool.query(sql`SELECT 1 FROM attachments WHERE id = ${sourceId}`)
+      expect(sourceGone.rows).toHaveLength(0)
+
+      const survivingExtraction = await AttachmentExtractionRepository.findByAttachmentId(pool, copyId)
+      expect(survivingExtraction?.fullText).toBe(sourceText)
+      const survivingKnowledge = await PersonaAttachmentRepository.listForPersonaWithContent(
+        pool,
+        workspaceId,
+        personaRow.id
+      )
+      expect(survivingKnowledge.map((k) => k.fullText)).toEqual([sourceText])
+    } finally {
+      await pool.query(sql`DELETE FROM persona_attachments WHERE workspace_id = ${workspaceId}`)
+      await pool.query(sql`DELETE FROM attachment_extractions WHERE workspace_id = ${workspaceId}`)
+      await pool.query(sql`DELETE FROM attachments WHERE workspace_id = ${workspaceId}`)
+      await pool.query(sql`DELETE FROM personas WHERE workspace_id = ${workspaceId}`)
+    }
   })
 })

--- a/apps/frontend/src/api/personas.ts
+++ b/apps/frontend/src/api/personas.ts
@@ -133,6 +133,29 @@ export const personasApi = {
     return attachment
   },
 
+  /**
+   * Attach an EXISTING workspace file to a custom/personal persona by COPYING it
+   * (knowledge-by-reference). The caller picks a file they can already read; the
+   * server copies its bytes + extraction into a fresh persona-owned row and binds
+   * it (copy-on-attach). Returns the created {@link PersonaAttachmentItem} —
+   * `processingStatus` is `ready` immediately when the source's extraction was
+   * copied, else `processing` until the pipeline runs on the copy. An
+   * unreadable/missing source is a 404; an ineligible source (not clean / e2e /
+   * mime / size) or a full cap throws an `ApiError` whose message names the
+   * constraint (INV-11).
+   */
+  async attachFromExisting(
+    workspaceId: string,
+    personaId: string,
+    sourceAttachmentId: string
+  ): Promise<PersonaAttachmentItem> {
+    const { attachment } = await api.post<{ attachment: PersonaAttachmentItem }>(
+      `/api/workspaces/${workspaceId}/personas/${personaId}/attachments/from-existing`,
+      { sourceAttachmentId }
+    )
+    return attachment
+  },
+
   /** Remove a persona context attachment (hard delete — the file is unbound to any message). */
   deleteAttachment(workspaceId: string, personaId: string, attachmentId: string): Promise<void> {
     return api.delete<void>(`/api/workspaces/${workspaceId}/personas/${personaId}/attachments/${attachmentId}`)

--- a/apps/frontend/src/components/attachment-explorer/explorer-list.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-list.tsx
@@ -16,6 +16,8 @@ interface ExplorerListProps {
   fetchNextPage: () => void
   selectedId: string | null
   onSelect: (id: string) => void
+  /** Picker override forwarded to each {@link ExplorerRow}; see its prop doc. */
+  onSelectAttachment?: (item: AttachmentSearchItem) => void
   onClearFilters?: () => void
   onWidenScope?: () => void
   hasFilters: boolean
@@ -65,6 +67,7 @@ export function ExplorerList({
   fetchNextPage,
   selectedId,
   onSelect,
+  onSelectAttachment,
   onClearFilters,
   onWidenScope,
   hasFilters,
@@ -130,6 +133,7 @@ export function ExplorerList({
                   item={item}
                   isSelected={selectedId === item.id}
                   onSelect={onSelect}
+                  onSelectAttachment={onSelectAttachment}
                 />
               </div>
             ))}

--- a/apps/frontend/src/components/attachment-explorer/explorer-row.onselect.test.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-row.onselect.test.tsx
@@ -1,0 +1,84 @@
+import { MemoryRouter } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, userEvent } from "@/test"
+import * as preferencesModule from "@/contexts/preferences-context"
+import type { AttachmentSearchItem } from "@/api/attachments"
+import { ExplorerRow } from "./explorer-row"
+
+function makeItem(overrides: Partial<AttachmentSearchItem> = {}): AttachmentSearchItem {
+  return {
+    id: "attach_a",
+    workspaceId: "ws_1",
+    streamId: "str_design",
+    messageId: "msg_1",
+    uploadedBy: "usr_1",
+    filename: "handbook.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 1024,
+    storageProvider: "s3",
+    storagePath: "ws_1/attach_a/handbook.pdf",
+    processingStatus: "completed",
+    safetyStatus: "clean",
+    createdAt: new Date("2026-05-01T10:00:00.000Z").toISOString() as unknown as Date,
+    extraction: null,
+    streamSlug: "design",
+    streamName: "Design",
+    streamType: "channel",
+    uploaderSlug: "mira",
+    uploaderName: "Mira",
+    referenceCount: 0,
+    ...overrides,
+  } as AttachmentSearchItem
+}
+
+function renderRow(props: Partial<React.ComponentProps<typeof ExplorerRow>> = {}) {
+  const item = props.item ?? makeItem()
+  return render(
+    <MemoryRouter>
+      <ExplorerRow
+        workspaceId="ws_1"
+        item={item}
+        isSelected={false}
+        onSelect={props.onSelect ?? (() => undefined)}
+        onSelectAttachment={props.onSelectAttachment}
+      />
+    </MemoryRouter>
+  )
+}
+
+describe("ExplorerRow onSelectAttachment", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(preferencesModule, "usePreferences").mockReturnValue({
+      preferences: { dateFormat: "YYYY-MM-DD", timeFormat: "24h", timezone: "UTC" } as never,
+    } as unknown as ReturnType<typeof preferencesModule.usePreferences>)
+  })
+
+  it("hands back the whole attachment and skips the URL-state onSelect when set", async () => {
+    const onSelect = vi.fn()
+    const onSelectAttachment = vi.fn()
+    const item = makeItem()
+    const user = userEvent.setup()
+    renderRow({ item, onSelect, onSelectAttachment })
+
+    await user.click(screen.getByRole("button", { name: /handbook\.pdf/i }))
+
+    expect(onSelectAttachment).toHaveBeenCalledWith(item)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the URL-state onSelect(id) when no picker override is given", async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    renderRow({ onSelect })
+
+    await user.click(screen.getByRole("button", { name: /handbook\.pdf/i }))
+
+    expect(onSelect).toHaveBeenCalledWith("attach_a")
+  })
+
+  it("hides the open-in-stream link in picker mode so the row is a single pick action", () => {
+    renderRow({ onSelectAttachment: vi.fn() })
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/attachment-explorer/explorer-row.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-row.tsx
@@ -13,9 +13,16 @@ interface ExplorerRowProps {
   item: AttachmentSearchItem
   isSelected: boolean
   onSelect: (id: string) => void
+  /**
+   * Picker override: when set, a row click hands back the whole attachment
+   * instead of driving the explorer's URL-state selection (`onSelect`). Lets a
+   * host (the persona Attach-existing dialog) reuse the row rendering as a
+   * one-shot chooser without forking it (INV-35/37).
+   */
+  onSelectAttachment?: (item: AttachmentSearchItem) => void
 }
 
-export function ExplorerRow({ workspaceId, item, isSelected, onSelect }: ExplorerRowProps) {
+export function ExplorerRow({ workspaceId, item, isSelected, onSelect, onSelectAttachment }: ExplorerRowProps) {
   const { formatTime, formatRelative } = useFormattedDate()
   const category = categoryFromMime(item.mimeType)
   const meta = CATEGORY_META[category]
@@ -45,7 +52,7 @@ export function ExplorerRow({ workspaceId, item, isSelected, onSelect }: Explore
   return (
     <button
       type="button"
-      onClick={() => onSelect(item.id)}
+      onClick={() => (onSelectAttachment ? onSelectAttachment(item) : onSelect(item.id))}
       className={cn(
         "group/row reveal-host flex w-full items-center gap-3 rounded-item px-3 py-2 text-left transition-colors",
         "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -88,7 +95,7 @@ export function ExplorerRow({ workspaceId, item, isSelected, onSelect }: Explore
           <span className="flex-none">{formatFileSize(item.sizeBytes)}</span>
         </div>
       </div>
-      {sourceUrl ? (
+      {sourceUrl && !onSelectAttachment ? (
         <Link
           to={sourceUrl}
           onClick={(e) => e.stopPropagation()}

--- a/apps/frontend/src/components/attachment-explorer/index.ts
+++ b/apps/frontend/src/components/attachment-explorer/index.ts
@@ -1,2 +1,4 @@
 export { AttachmentExplorer } from "./attachment-explorer"
+export { ExplorerList } from "./explorer-list"
+export { useAttachmentSearch } from "./use-attachment-search"
 export { EXPLORER_PARAM, useExplorerUrlState, type ExplorerFilters } from "./use-explorer-url-state"

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.test.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.test.tsx
@@ -1,0 +1,139 @@
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { toast } from "sonner"
+import { render, screen, userEvent, waitFor } from "@/test"
+import * as attachmentsApiModule from "@/api/attachments"
+import * as preferencesModule from "@/contexts/preferences-context"
+import { personasApi } from "@/api"
+import { ApiError } from "@/api/client"
+import { AttachExistingDialog } from "./attach-existing-dialog"
+
+function makeItem(
+  overrides: Partial<attachmentsApiModule.AttachmentSearchItem> = {}
+): attachmentsApiModule.AttachmentSearchItem {
+  return {
+    id: "attach_a",
+    workspaceId: "ws_1",
+    streamId: "str_design",
+    messageId: "msg_1",
+    uploadedBy: "usr_1",
+    filename: "handbook.md",
+    mimeType: "text/markdown",
+    sizeBytes: 1024,
+    storageProvider: "s3",
+    storagePath: "ws_1/attach_a/handbook.md",
+    processingStatus: "completed",
+    safetyStatus: "clean",
+    createdAt: new Date("2026-05-01T10:00:00.000Z").toISOString() as unknown as Date,
+    extraction: null,
+    streamSlug: "design",
+    streamName: "Design",
+    streamType: "channel",
+    uploaderSlug: "mira",
+    uploaderName: "Mira",
+    referenceCount: 0,
+    ...overrides,
+  } as attachmentsApiModule.AttachmentSearchItem
+}
+
+function personaAttachment(
+  overrides: Partial<import("@threa/types").PersonaAttachmentItem> = {}
+): import("@threa/types").PersonaAttachmentItem {
+  return {
+    id: "att_copy",
+    filename: "handbook.md",
+    mimeType: "text/markdown",
+    sizeBytes: 1024,
+    processingStatus: "ready",
+    contextMode: "full",
+    position: 0,
+    createdAt: "2026-07-13T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AttachExistingDialog workspaceId="ws_1" personaId="persona_c1" open onOpenChange={onOpenChange} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return { ...result, onOpenChange }
+}
+
+describe("AttachExistingDialog", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(attachmentsApiModule.attachmentsApi, "getDownloadUrl").mockResolvedValue("https://example.test/blob")
+    vi.spyOn(preferencesModule, "usePreferences").mockReturnValue({
+      preferences: { dateFormat: "YYYY-MM-DD", timeFormat: "24h", timezone: "UTC" } as never,
+    } as unknown as ReturnType<typeof preferencesModule.usePreferences>)
+  })
+
+  it("issues a persona-eligible-category search and renders the results", async () => {
+    const searchSpy = vi
+      .spyOn(attachmentsApiModule.attachmentsApi, "search")
+      .mockResolvedValue({ items: [makeItem()], nextCursor: null })
+
+    renderDialog()
+
+    expect(await screen.findByText("handbook.md")).toBeInTheDocument()
+    await waitFor(() => expect(searchSpy).toHaveBeenCalled())
+    const body = searchSpy.mock.calls[0]![1]
+    expect(body.categories).toEqual(expect.arrayContaining(["pdf", "doc", "sheet", "code"]))
+    expect(body.categories).not.toContain("image")
+  })
+
+  it("drops server results whose mime is not persona-eligible (client-side belt-and-braces)", async () => {
+    vi.spyOn(attachmentsApiModule.attachmentsApi, "search").mockResolvedValue({
+      items: [makeItem(), makeItem({ id: "attach_xls", filename: "legacy.xls", mimeType: "application/vnd.ms-excel" })],
+      nextCursor: null,
+    })
+
+    renderDialog()
+
+    expect(await screen.findByText("handbook.md")).toBeInTheDocument()
+    expect(screen.queryByText("legacy.xls")).not.toBeInTheDocument()
+  })
+
+  it("copies the picked file and closes on success (no success toast, INV-63)", async () => {
+    vi.spyOn(attachmentsApiModule.attachmentsApi, "search").mockResolvedValue({
+      items: [makeItem()],
+      nextCursor: null,
+    })
+    const attachSpy = vi.spyOn(personasApi, "attachFromExisting").mockResolvedValue(personaAttachment())
+    const successToast = vi.spyOn(toast, "success")
+    const { onOpenChange } = renderDialog()
+
+    await screen.findByText("handbook.md")
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("button", { name: /handbook\.md/i }))
+
+    await waitFor(() => expect(attachSpy).toHaveBeenCalledWith("ws_1", "persona_c1", "attach_a"))
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(successToast).not.toHaveBeenCalled()
+  })
+
+  it("toasts the server's message and stays open when the copy is rejected (INV-11)", async () => {
+    vi.spyOn(attachmentsApiModule.attachmentsApi, "search").mockResolvedValue({
+      items: [makeItem()],
+      nextCursor: null,
+    })
+    vi.spyOn(personasApi, "attachFromExisting").mockRejectedValue(
+      new ApiError(400, "PERSONA_ATTACHMENT_SOURCE_NOT_CLEAN", "This file hasn’t finished a safety scan yet.")
+    )
+    const errorToast = vi.spyOn(toast, "error")
+    const { onOpenChange } = renderDialog()
+
+    await screen.findByText("handbook.md")
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("button", { name: /handbook\.md/i }))
+
+    await waitFor(() => expect(errorToast).toHaveBeenCalledWith("This file hasn’t finished a safety scan yet."))
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.test.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.test.tsx
@@ -136,4 +136,26 @@ describe("AttachExistingDialog", () => {
     await waitFor(() => expect(errorToast).toHaveBeenCalledWith("This file hasn’t finished a safety scan yet."))
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
+
+  it("shows the pending overlay while the copy runs and ignores further picks", async () => {
+    vi.spyOn(attachmentsApiModule.attachmentsApi, "search").mockResolvedValue({
+      items: [makeItem(), makeItem({ id: "attach_b", filename: "notes.md" })],
+      nextCursor: null,
+    })
+    // A copy that never settles pins the mutation in `isPending`.
+    const attachSpy = vi.spyOn(personasApi, "attachFromExisting").mockReturnValue(new Promise(() => undefined))
+    const { onOpenChange } = renderDialog()
+
+    await screen.findByText("handbook.md")
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("button", { name: /handbook\.md/i }))
+
+    const overlay = await screen.findByTestId("attach-existing-pending")
+    expect(overlay).toHaveTextContent("Attaching…")
+
+    // A second pick while pending is a no-op — one copy in flight at a time.
+    await user.click(screen.getByRole("button", { name: /notes\.md/i }))
+    expect(attachSpy).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
 })

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useState } from "react"
+import { Search } from "lucide-react"
+import { toast } from "sonner"
+import {
+  categoryFromMime,
+  isPersonaAttachmentMimeAllowed,
+  PERSONA_ATTACHMENT_ALLOWED_MIME_TYPES,
+  type AttachmentCategory,
+} from "@threa/types"
+import type { AttachmentSearchItem } from "@/api/attachments"
+import { ExplorerList, useAttachmentSearch, type ExplorerFilters } from "@/components/attachment-explorer"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { Input } from "@/components/ui/input"
+import { useAttachPersonaAttachmentFromExisting } from "@/hooks/use-personas"
+
+/**
+ * Attachment categories that can cover a persona-eligible file, derived from the
+ * mime allowlist so it can't drift: the exact allowed types map to pdf/doc/sheet/
+ * code, and every `text/*` subtype fans out to doc (plain), code (markdown/yaml/…)
+ * or sheet (csv/tsv). This narrows the server search; it CANNOT express the
+ * allowlist exactly (the categories also admit e.g. `.doc`/`.xls`/`.xml`, which
+ * are not on the persona allowlist), so the results are additionally filtered
+ * client-side by {@link isPersonaAttachmentMimeAllowed}, and the server re-checks
+ * eligibility on the actual pick. The narrowing also UNDER-includes: the backend
+ * matches categories on exact mime strings, so an uncommon `text/*` subtype the
+ * allowlist would accept (e.g. `text/x-log`) never surfaces here — a completeness
+ * gap, never a wrong attach. Dropping the category filter would fix it at the
+ * cost of noisier results.
+ */
+const PERSONA_ELIGIBLE_CATEGORIES: AttachmentCategory[] = Array.from(
+  new Set<AttachmentCategory>([...PERSONA_ATTACHMENT_ALLOWED_MIME_TYPES.map(categoryFromMime), "doc", "code", "sheet"])
+)
+
+const QUERY_DEBOUNCE_MS = 200
+
+interface AttachExistingDialogProps {
+  workspaceId: string
+  personaId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Search-and-pick dialog that attaches an existing workspace file to a persona's
+ * Knowledge by copy (knowledge-by-reference). Reuses the explorer's list/row
+ * rendering via `ExplorerList` + its `onSelectAttachment` prop (INV-35/37) rather
+ * than forking it; server search already scopes to message-bound CLEAN files the
+ * caller can read, so the results are correct for free. A pick fires the copy
+ * mutation and closes on success (single-pick v1); the new Knowledge row is the
+ * signal (INV-63 — no success toast). A server-side eligibility rejection surfaces
+ * its structured message via `toast.error` (INV-11) and leaves the dialog open.
+ */
+export function AttachExistingDialog({ workspaceId, personaId, open, onOpenChange }: AttachExistingDialogProps) {
+  const [query, setQuery] = useState("")
+  const [debouncedQuery, setDebouncedQuery] = useState("")
+  const attach = useAttachPersonaAttachmentFromExisting(workspaceId, personaId)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), QUERY_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [query])
+
+  // Reset the search each time the dialog opens so a fresh pick starts clean.
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setDebouncedQuery("")
+    }
+  }, [open])
+
+  const filters: ExplorerFilters = useMemo(
+    () => ({
+      streamIds: [],
+      queryText: debouncedQuery,
+      categories: PERSONA_ELIGIBLE_CATEGORIES,
+      uploadedBy: null,
+      nameSubstring: null,
+      before: null,
+      after: null,
+      view: "list",
+      selectedAttachmentId: null,
+    }),
+    [debouncedQuery]
+  )
+
+  const search = useAttachmentSearch(workspaceId, filters, { enabled: open })
+  const items = useMemo(
+    () => search.items.filter((item) => isPersonaAttachmentMimeAllowed(item.mimeType)),
+    [search.items]
+  )
+
+  const handlePick = (item: AttachmentSearchItem) => {
+    if (attach.isPending) return
+    attach.mutate(item.id, {
+      onSuccess: () => onOpenChange(false),
+      onError: (error) => toast.error(error instanceof Error ? error.message : "Couldn't attach that file"),
+    })
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent
+        desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[12%] sm:!translate-y-0 sm:!flex sm:!flex-col sm:max-w-[560px] sm:rounded-2xl sm:!h-[70vh]"
+        drawerClassName="overflow-hidden p-0 h-[85dvh]"
+        hideCloseButton
+      >
+        <div className="flex h-full flex-col" data-testid="attach-existing-dialog">
+          <ResponsiveDialogTitle className="border-b px-4 py-3 text-sm font-semibold">
+            Attach existing file
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            Search files you can read and attach one to this persona’s knowledge.
+          </ResponsiveDialogDescription>
+          <div className="flex items-center gap-2 border-b px-3 py-2">
+            <Search className="h-4 w-4 flex-none text-muted-foreground" aria-hidden />
+            <Input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search files by name or content"
+              className="h-8 border-none px-1 shadow-none focus-visible:ring-0"
+              aria-label="Search files"
+            />
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <ExplorerList
+              workspaceId={workspaceId}
+              items={items}
+              isLoading={search.isLoading}
+              isError={search.isError}
+              hasNextPage={search.hasNextPage}
+              isFetchingNextPage={search.isFetchingNextPage}
+              fetchNextPage={search.fetchNextPage}
+              selectedId={null}
+              onSelect={() => undefined}
+              onSelectAttachment={handlePick}
+              hasFilters={debouncedQuery.trim().length > 0}
+              onClearFilters={() => setQuery("")}
+            />
+          </div>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
@@ -128,20 +128,43 @@ export function AttachExistingDialog({ workspaceId, personaId, open, onOpenChang
             />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
-            <ExplorerList
-              workspaceId={workspaceId}
-              items={items}
-              isLoading={search.isLoading}
-              isError={search.isError}
-              hasNextPage={search.hasNextPage}
-              isFetchingNextPage={search.isFetchingNextPage}
-              fetchNextPage={search.fetchNextPage}
-              selectedId={null}
-              onSelect={() => undefined}
-              onSelectAttachment={handlePick}
-              hasFilters={debouncedQuery.trim().length > 0}
-              onClearFilters={() => setQuery("")}
-            />
+            {/* Own empty copy: the explorer's inherited strings ("No files yet…",
+                "widen the search") describe a surface this dialog is not — the
+                picker's scope (files posted in chats you can read, knowledge
+                types only) must be stated or an empty result reads as broken. */}
+            {!search.isLoading && !search.isError && items.length === 0 ? (
+              <div className="px-6 py-10 text-center text-sm text-muted-foreground">
+                {debouncedQuery.trim().length > 0 ? (
+                  <>
+                    <p className="font-medium text-foreground">No files match &ldquo;{debouncedQuery.trim()}&rdquo;</p>
+                    <p className="mt-1">Try a different name or keyword.</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="font-medium text-foreground">Search files from your chats</p>
+                    <p className="mt-1">
+                      This finds text, PDF, Word, Excel, and JSON files already shared in streams you can read. To add
+                      something from your device, use Add file instead.
+                    </p>
+                  </>
+                )}
+              </div>
+            ) : (
+              <ExplorerList
+                workspaceId={workspaceId}
+                items={items}
+                isLoading={search.isLoading}
+                isError={search.isError}
+                hasNextPage={search.hasNextPage}
+                isFetchingNextPage={search.isFetchingNextPage}
+                fetchNextPage={search.fetchNextPage}
+                selectedId={null}
+                onSelect={() => undefined}
+                onSelectAttachment={handlePick}
+                hasFilters={debouncedQuery.trim().length > 0}
+                onClearFilters={() => setQuery("")}
+              />
+            )}
           </div>
         </div>
       </ResponsiveDialogContent>

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { Search } from "lucide-react"
+import { Loader2, Search } from "lucide-react"
 import { toast } from "sonner"
 import {
   categoryFromMime,
@@ -103,7 +103,9 @@ export function AttachExistingDialog({ workspaceId, personaId, open, onOpenChang
   }
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+    // disableSnapPoints: this dialog opens with a focused text input, and the
+    // snap-point drawer slides its header off-screen when the keyboard opens.
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
       <ResponsiveDialogContent
         desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[12%] sm:!translate-y-0 sm:!flex sm:!flex-col sm:max-w-[560px] sm:rounded-2xl sm:!h-[70vh]"
         drawerClassName="overflow-hidden p-0 h-[85dvh]"
@@ -127,7 +129,18 @@ export function AttachExistingDialog({ workspaceId, personaId, open, onOpenChang
               aria-label="Search files"
             />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="relative min-h-0 flex-1 overflow-y-auto">
+            {/* The pick is a server-side copy (S3 CopyObject + insert) — block
+                further picks and say so while it runs, without shifting layout. */}
+            {attach.isPending && (
+              <div
+                className="absolute inset-0 z-10 flex items-center justify-center gap-2 bg-background/60 text-sm text-muted-foreground"
+                data-testid="attach-existing-pending"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Attaching…
+              </div>
+            )}
             {/* Own empty copy: the explorer's inherited strings ("No files yet…",
                 "widen the search") describe a surface this dialog is not — the
                 picker's scope (files posted in chats you can read, knowledge

--- a/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
+++ b/apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx
@@ -134,6 +134,7 @@ export function AttachExistingDialog({ workspaceId, personaId, open, onOpenChang
                 further picks and say so while it runs, without shifting layout. */}
             {attach.isPending && (
               <div
+                role="status"
                 className="absolute inset-0 z-10 flex items-center justify-center gap-2 bg-background/60 text-sm text-muted-foreground"
                 data-testid="attach-existing-pending"
               >

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.test.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@threa/types"
 import { personasApi } from "@/api"
 import { ApiError } from "@/api/client"
+import * as attachmentsApiModule from "@/api/attachments"
 import { spyOnExport } from "@/test/spy"
 import * as editorModule from "@/components/editor"
 import * as uploadManager from "@/lib/uploads/upload-manager"
@@ -475,9 +476,21 @@ describe("CustomPersonaEditor", () => {
       renderEditor(config({ attachments }))
 
       expect(screen.getByRole("button", { name: /Add file/ })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Attach existing" })).toBeDisabled()
       expect(
         screen.getByText(`${PERSONA_ATTACHMENT_MAX_COUNT} of ${PERSONA_ATTACHMENT_MAX_COUNT} files`)
       ).toBeInTheDocument()
+    })
+
+    it("opens the Attach existing picker from the Knowledge section", async () => {
+      vi.spyOn(attachmentsApiModule.attachmentsApi, "search").mockResolvedValue({ items: [], nextCursor: null })
+      const user = userEvent.setup()
+      renderEditor()
+
+      expect(screen.queryByText("Attach existing file")).not.toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Attach existing" }))
+
+      expect(await screen.findByText("Attach existing file")).toBeInTheDocument()
     })
   })
 })

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.test.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event"
 import { toast } from "sonner"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import {
   PERSONA_ATTACHMENT_MAX_COUNT,
   type PersonaAttachmentItem,
@@ -206,15 +207,17 @@ function renderEditor(cfg: PersonaConfigResponse = config()) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const tree = (next: PersonaConfigResponse) => (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/w/ws_1/settings/personas/persona_c1"]}>
-        <Routes>
-          <Route
-            path="/w/:workspaceId/settings/personas/:personaId"
-            element={<CustomPersonaEditor workspaceId="ws_1" personaId="persona_c1" config={next} />}
-          />
-          <Route path="/w/:workspaceId" element={<div>Workspace home</div>} />
-        </Routes>
-      </MemoryRouter>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/w/ws_1/settings/personas/persona_c1"]}>
+          <Routes>
+            <Route
+              path="/w/:workspaceId/settings/personas/:personaId"
+              element={<CustomPersonaEditor workspaceId="ws_1" personaId="persona_c1" config={next} />}
+            />
+            <Route path="/w/:workspaceId" element={<div>Workspace home</div>} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   )
   const result = render(tree(cfg))

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { FileText, Upload, X } from "lucide-react"
+import { FileText, Paperclip, Upload, X } from "lucide-react"
 import {
   getPersonaAvatarUrl,
   isPersonaAttachmentMimeAllowed,
@@ -53,6 +53,7 @@ import {
   useUpdatePersonaCustom,
   useUploadPersonaAvatar,
 } from "@/hooks/use-personas"
+import { AttachExistingDialog } from "./attach-existing-dialog"
 import { buildModelOptions, toCustomConfig, CUSTOM_EDITABLE_FIELDS } from "./persona-form"
 import type { SyncState } from "./persona-form"
 import { usePersonaDraftEditor } from "./use-persona-draft-editor"
@@ -122,6 +123,7 @@ export function CustomPersonaEditor({
   const disableSelectionToolbar = useInputMode() === "touch"
   const promptEditorRef = useRef<RichEditorHandle>(null)
   const [promptFormatOpen, setPromptFormatOpen] = useState(false)
+  const [attachExistingOpen, setAttachExistingOpen] = useState(false)
 
   const resolved = config.resolved
   const editor = usePersonaDraftEditor({
@@ -521,6 +523,16 @@ export function CustomPersonaEditor({
             <Upload className="mr-1 h-3.5 w-3.5" />
             Add file
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setAttachExistingOpen(true)}
+            disabled={atAttachmentCap}
+          >
+            <Paperclip className="mr-1 h-3.5 w-3.5" />
+            Attach existing
+          </Button>
           <span className="text-xs text-muted-foreground">
             {attachmentCount} of {PERSONA_ATTACHMENT_MAX_COUNT} files
           </span>
@@ -532,6 +544,12 @@ export function CustomPersonaEditor({
           accept={PERSONA_ATTACHMENT_ACCEPT}
           className="hidden"
           onChange={handleAttachmentFile}
+        />
+        <AttachExistingDialog
+          workspaceId={workspaceId}
+          personaId={personaId}
+          open={attachExistingOpen}
+          onOpenChange={setAttachExistingOpen}
         />
       </div>
 

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
@@ -71,6 +71,15 @@ const CONTEXT_MODE_LABEL: Record<PersonaAttachmentContextMode, string> = {
   name_only: "Name only",
 }
 
+/** Hover explanation for each context label: the budget is invisible otherwise,
+ *  and "Summary only" reads as a silent downgrade without the why. */
+const CONTEXT_MODE_HINT: Record<PersonaAttachmentContextMode, string> = {
+  full: "The file's full text is in the persona's context.",
+  summary:
+    "Too large to include in full, so the persona gets a short summary. Smaller or fewer files are included in full.",
+  name_only: "The persona's knowledge budget is used up, so only the filename is included.",
+}
+
 /** The file input's `accept` — the persona-attachment mime allowlist (INV-33 source). */
 const PERSONA_ATTACHMENT_ACCEPT = [
   ...PERSONA_ATTACHMENT_ALLOWED_MIME_PREFIXES.map((prefix) => `${prefix}*`),
@@ -438,7 +447,8 @@ export function CustomPersonaEditor({
       <div className="space-y-2">
         <Label>Knowledge</Label>
         <p className="text-xs text-muted-foreground">
-          Files the persona always carries in its context. Text, PDF, Word, Excel, or JSON.
+          Files the persona always carries in its context. Text, PDF, Word, Excel, or JSON. Large files are carried as
+          short summaries so everything fits the persona&apos;s knowledge budget.
         </p>
         {(config.attachments.length > 0 || knowledge.rows.length > 0) && (
           <ul className="space-y-1.5">
@@ -453,11 +463,16 @@ export function CustomPersonaEditor({
                   <p className="text-xs text-muted-foreground">
                     {formatFileSize(attachment.sizeBytes)}
                     {attachment.processingStatus === "processing" && " · Processing…"}
-                    {attachment.processingStatus === "ready" &&
-                      attachment.contextMode &&
-                      ` · ${CONTEXT_MODE_LABEL[attachment.contextMode]}`}
+                    {attachment.processingStatus === "ready" && attachment.contextMode && (
+                      <span title={CONTEXT_MODE_HINT[attachment.contextMode]}>
+                        {` · ${CONTEXT_MODE_LABEL[attachment.contextMode]}`}
+                      </span>
+                    )}
                     {attachment.processingStatus === "failed" && (
-                      <span className="text-destructive"> · Couldn&apos;t read this file</span>
+                      <span className="text-destructive">
+                        {" "}
+                        · Couldn&apos;t read this file. Remove it and try a different format.
+                      </span>
                     )}
                   </p>
                 </div>

--- a/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
+++ b/apps/frontend/src/components/persona-editor/custom-persona-editor.tsx
@@ -33,6 +33,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
@@ -464,9 +465,19 @@ export function CustomPersonaEditor({
                     {formatFileSize(attachment.sizeBytes)}
                     {attachment.processingStatus === "processing" && " · Processing…"}
                     {attachment.processingStatus === "ready" && attachment.contextMode && (
-                      <span title={CONTEXT_MODE_HINT[attachment.contextMode]}>
-                        {` · ${CONTEXT_MODE_LABEL[attachment.contextMode]}`}
-                      </span>
+                      <Tooltip>
+                        {/* A real focusable trigger: native `title` never fires on
+                            touch and a bare span can't take keyboard focus, which
+                            hid the budget explanation from two input modalities. */}
+                        <TooltipTrigger asChild>
+                          <button type="button" className="cursor-default">
+                            {` · ${CONTEXT_MODE_LABEL[attachment.contextMode]}`}
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-64">
+                          {CONTEXT_MODE_HINT[attachment.contextMode]}
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                     {attachment.processingStatus === "failed" && (
                       <span className="text-destructive">

--- a/apps/frontend/src/hooks/use-personas.ts
+++ b/apps/frontend/src/hooks/use-personas.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import type {
+  PersonaAttachmentItem,
   PersonaConfigPatch,
   PersonaConfigResponse,
   PersonaCustomConfig,
@@ -394,24 +395,53 @@ export function useRemovePersonaAvatar(workspaceId: string, personaId: string) {
 }
 
 /**
+ * The single "a new persona attachment landed" cache reconcile shared by bind
+ * (upload path) and attach-from-existing (copy path): append the returned row so
+ * it renders immediately (INV-63 — the row appearing IS the signal, no toast),
+ * then invalidate the config query so the server-authoritative position/ordering
+ * reconciles and the gated 3s `refetchInterval` takes over polling while a
+ * `processing` copy's extraction runs. One home so the two writers can't drift.
+ */
+function appendPersonaAttachment(
+  queryClient: QueryClient,
+  workspaceId: string,
+  personaId: string,
+  attachment: PersonaAttachmentItem
+) {
+  queryClient.setQueryData<PersonaConfigResponse>(personaKeys.config(workspaceId, personaId), (old) =>
+    old ? { ...old, attachments: [...old.attachments, attachment] } : old
+  )
+  void queryClient.invalidateQueries({ queryKey: personaKeys.config(workspaceId, personaId) })
+}
+
+/**
  * Bind an already-uploaded workspace attachment to a custom/personal persona as
  * context knowledge — the persona-ness step after the shared upload transport
- * settled the bytes (INV-35/37). The returned row is appended to the config cache
- * so it renders immediately (INV-63 — the row appearing IS the signal, no toast);
- * the config query is then invalidated so the server-authoritative position/
- * ordering reconciles, and its gated refetchInterval takes over polling while
- * extraction runs.
+ * settled the bytes (INV-35/37). Shares {@link appendPersonaAttachment} with the
+ * attach-from-existing path.
  */
 export function useBindPersonaAttachment(workspaceId: string, personaId: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (attachmentId: string) => personasApi.bindAttachment(workspaceId, personaId, attachmentId),
-    onSuccess: (attachment) => {
-      queryClient.setQueryData<PersonaConfigResponse>(personaKeys.config(workspaceId, personaId), (old) =>
-        old ? { ...old, attachments: [...old.attachments, attachment] } : old
-      )
-      void queryClient.invalidateQueries({ queryKey: personaKeys.config(workspaceId, personaId) })
-    },
+    onSuccess: (attachment) => appendPersonaAttachment(queryClient, workspaceId, personaId, attachment),
+  })
+}
+
+/**
+ * Attach an EXISTING workspace file to a custom/personal persona by copying it
+ * (knowledge-by-reference). Mirrors {@link useBindPersonaAttachment} — the
+ * server-created copy row is appended to the config cache so it renders
+ * immediately (INV-63 no success toast) and the gated refetch resolves a copy
+ * whose extraction is still `processing`. The caller toasts the server's
+ * structured message (INV-11) on an ineligible/unreadable source or a full cap.
+ */
+export function useAttachPersonaAttachmentFromExisting(workspaceId: string, personaId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (sourceAttachmentId: string) =>
+      personasApi.attachFromExisting(workspaceId, personaId, sourceAttachmentId),
+    onSuccess: (attachment) => appendPersonaAttachment(queryClient, workspaceId, personaId, attachment),
   })
 }
 

--- a/docs/features/public/custom-personas.md
+++ b/docs/features/public/custom-personas.md
@@ -68,10 +68,16 @@ and Brevity choices; the prompt is read-only and the identity is fixed.
 A persona can carry attached knowledge: files whose extracted content rides as
 standing context in every reply the persona gives (companion turns, mentions, and
 test drives alike). The persona does not have to be asked to fetch anything; the
-content is simply present. Today knowledge is attached by uploading files, through
-the same upload machinery as sending a file in chat (per-file progress, retry,
-several files at once) and the same extraction pipeline (PDF, Word, Excel, CSV,
-JSON, Markdown, plain text).
+content is simply present. Knowledge is attached two ways. You can upload files,
+through the same upload machinery as sending a file in chat (per-file progress,
+retry, several files at once) and the same extraction pipeline (PDF, Word, Excel,
+CSV, JSON, Markdown, plain text). Or you can attach an existing file: "Attach
+existing" opens a search over the files already posted in streams you can read,
+and picking one gives the persona its own independent copy. The picker only offers
+message-bound files that finished scanning clean, of the same text-bearing types
+uploads accept; it never lists a file you cannot already open. The copy is
+independent from the moment it is made: deleting the original message or file never
+affects the persona, and the persona's copy is never shared back to the source.
 
 Because context is bounded, each file lands in one of three forms, decided by a
 single budget walk over the list in order, and each row in the editor shows which
@@ -100,9 +106,11 @@ persona's knowledge follows the same permissions as editing it.
   and prompt.
 - There is no promotion path from a personal persona to a workspace one, and no
   sharing of one persona (or its files) between members or workspaces.
-- Knowledge is attach-by-upload only today; referencing an existing workspace
-  file by link is not built. There is also no on-demand deep read: a file larger
-  than the inline cap is represented by its summary.
+- Knowledge is attached by upload or by attaching an existing workspace file;
+  either way the persona holds an independent copy (attaching an existing file
+  copies it rather than linking, since deleting the source must never change what
+  the persona carries). There is no on-demand deep read: a file larger than the
+  inline cap is represented by its summary.
 - When a member leaves, their personal personas simply stop being visible or
   dispatchable; nothing cleans them up.
 - If a scratchpad pinned to someone's personal persona is later shared, other

--- a/tests/browser/persona-customization.spec.ts
+++ b/tests/browser/persona-customization.spec.ts
@@ -558,6 +558,140 @@ test.describe("Persona roster + editors", () => {
     await expect(page.getByText(fileNameB)).toBeVisible()
     await expect(page.getByText("1 of 50 files")).toBeVisible({ timeout: 10000 })
   })
+
+  /**
+   * Knowledge by reference (copy-on-attach), end to end. A .md posted in a
+   * scratchpad becomes a message-bound CLEAN file the workspace can search; a
+   * forked persona's editor attaches it through the Attach-existing picker (search
+   * → pick a row), and the copy lands as an ordinary Knowledge row — filename, an
+   * "In full" context label (the extraction is copied, so the row is ready at once,
+   * no processing badge), and the cap hint moves to 1 of 50.
+   *
+   * The copy is INDEPENDENT by design: deleting the source message never touches
+   * the persona's copy. The message delete drives the real hover menu (reveal the
+   * row's "Message actions", confirm the dialog); the disappearance is asserted
+   * only over the main timeline rows (`main .message-item`), because the
+   * sidebar last-message preview carries the same text. Reloading the editor proves
+   * the copy survived a fresh fetch, not just an optimistic cache entry.
+   */
+  test("Knowledge by reference: attach an existing chat file to a persona, copy survives source deletion", async ({
+    page,
+  }) => {
+    test.setTimeout(90000)
+
+    const { testId } = await loginAndCreateWorkspace(page, "persona-attach-existing")
+    const workspaceId = page.url().match(/\/w\/(ws_[^/]+)/)![1]
+    // The picker's search is FTS. A filename indexes as a single lexeme, so the
+    // exact full filename is the reliable query term (it matches the filename
+    // search_vector directly, independent of the extraction text — which is a stub
+    // placeholder under the test AI). A separate clean token marks the message body
+    // so the source row is locatable for deletion.
+    const token = `kref${testId}`
+    const fileName = `runbook-${testId}.md`
+
+    // ──── Post the .md in a scratchpad and let it settle into a searchable file ────
+
+    const padRes = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad", displayName: `src-pad-${testId}` },
+    })
+    await expectApiOk(padRes, "Scratchpad creation")
+    const streamId = ((await padRes.json()) as { stream: { id: string } }).stream.id
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    const mainEditor = page.locator("[data-editor-zone='main'] [contenteditable='true']").last()
+    await expect(mainEditor).toBeVisible({ timeout: 15000 })
+    await mainEditor.click()
+    await page.keyboard.type(token)
+
+    // Paste the .md as a composer attachment (mirrors inline-file-upload.spec):
+    // the bytes stream through the upload manager and the reference chip appears.
+    await mainEditor.evaluate(
+      (el, { content, name }) => {
+        const blob = new Blob([content], { type: "text/markdown" })
+        const file = new File([blob], name, { type: "text/markdown" })
+        const dataTransfer = new DataTransfer()
+        dataTransfer.items.add(file)
+        el.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: dataTransfer }))
+      },
+      { content: `# Deploy runbook\n\n${token}\n\nStep 1: rotate the key.\nStep 2: redeploy.\n`, name: fileName }
+    )
+    await expect(mainEditor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 15000 })
+
+    // Send via the button, not Enter — Enter races the async paste insertion.
+    await page.getByRole("button", { name: "Send", exact: true }).first().click()
+    await expect(mainEditor.locator("span[data-type='attachment-reference']")).toHaveCount(0, { timeout: 15000 })
+
+    // The file is searchable once it is message-bound AND scanned CLEAN — the exact
+    // gate the picker's search enforces. Poll the same endpoint the picker uses so
+    // the UI step below is deterministic rather than racing the scan.
+    await expect
+      .poll(
+        async () => {
+          const res = await page.request.post(`/api/workspaces/${workspaceId}/attachments/search`, {
+            data: { queryText: fileName },
+          })
+          if (!res.ok()) return 0
+          const body = (await res.json()) as { items: Array<{ filename: string }> }
+          return body.items.filter((i) => i.filename === fileName).length
+        },
+        { timeout: 40000, intervals: [500, 1000, 2000] }
+      )
+      .toBeGreaterThan(0)
+
+    // ──── Fork a persona and open its editor at an empty Knowledge section ────
+
+    const forkRes = await page.request.post(`/api/workspaces/${workspaceId}/personas`, {
+      data: { sourcePersonaId: "persona_system_ariadne", name: `Attach agent ${testId}` },
+    })
+    await expectApiOk(forkRes, "Persona fork")
+    const personaId = ((await forkRes.json()) as { persona: { id: string } }).persona.id
+
+    const editorUrl = `/w/${workspaceId}/settings/personas/${personaId}`
+    await page.goto(editorUrl)
+    await expect(page.getByRole("heading", { name: `Edit Attach agent ${testId}` })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("0 of 50 files")).toBeVisible()
+
+    // ──── Attach existing → search → pick the row ────
+
+    await page.getByRole("button", { name: "Attach existing" }).click()
+    const pickerDialog = page.getByTestId("attach-existing-dialog")
+    await expect(pickerDialog).toBeVisible({ timeout: 10000 })
+    await pickerDialog.getByRole("textbox", { name: "Search files" }).fill(fileName)
+
+    // Rows are buttons named by their filename; picking one copies the file onto the
+    // persona and closes the dialog (single-pick v1, INV-63 — the row is the signal).
+    await pickerDialog.getByRole("button", { name: fileName }).click({ timeout: 15000 })
+    await expect(pickerDialog).toHaveCount(0, { timeout: 10000 })
+
+    // The copy appears as an ordinary bound Knowledge row: filename + "In full"
+    // (extraction copied, so ready immediately), and the cap hint increments.
+    const knowledgeRow = page.getByRole("listitem").filter({ hasText: fileName })
+    await expect(knowledgeRow).toBeVisible({ timeout: 10000 })
+    await expect(knowledgeRow).toContainText("In full", { timeout: 10000 })
+    await expect(page.getByText("1 of 50 files")).toBeVisible({ timeout: 10000 })
+
+    // ──── Delete the source message; the persona's copy is independent ────
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    const sourceRow = page.locator("main .message-item").filter({ hasText: token })
+    await expect(sourceRow).toBeVisible({ timeout: 15000 })
+    await sourceRow.hover()
+    await sourceRow.getByRole("button", { name: "Message actions" }).click({ force: true })
+    await page.getByRole("menuitem", { name: "Delete message" }).click()
+    await page.getByRole("alertdialog").getByRole("button", { name: "Delete", exact: true }).click()
+    // Scope the disappearance to the main timeline — the sidebar preview matches the
+    // same text, so an unscoped assertion would never reach zero.
+    await expect(page.locator("main .message-item").filter({ hasText: token })).toHaveCount(0, { timeout: 15000 })
+
+    // ──── Reload the editor: the copy survives a fresh fetch (real independence) ────
+
+    await page.goto(editorUrl)
+    await expect(page.getByRole("heading", { name: `Edit Attach agent ${testId}` })).toBeVisible({ timeout: 10000 })
+    const survivingRow = page.getByRole("listitem").filter({ hasText: fileName })
+    await expect(survivingRow).toBeVisible({ timeout: 10000 })
+    await expect(survivingRow).toContainText("In full")
+    await expect(page.getByText("1 of 50 files")).toBeVisible()
+  })
 })
 
 /** Focus the main composer and type an @-mention trigger, opening the suggestion popup. */


### PR DESCRIPTION
## Problem

A persona's Knowledge could only be filled by re-uploading files from disk. Kris: "maybe in the future we want to make this reference existing files or something by a link." The obvious sources — files already posted in chat — were unreachable: the bind endpoint deliberately rejects message-bound attachments (an attachment belongs to exactly one place), so there was no path from "that runbook someone posted in #ops" to "my persona knows it."

## Solution

**Attach existing = copy-on-attach.** Attachments are immutable in Threa, so a copy IS reference semantics from the user's view, and it keeps every ownership rule from #1324/#1332 intact: the persona owns its copy outright (unbound forever, uploader-only generic access, hard-delete safe, cap applies), and deleting the source message or file never touches what the persona carries. Row-sharing via `attachment_references` (the resend precedent) was considered and rejected: it would let stream-access revocation and message deletion silently mutate a persona's knowledge later.

### How it works

1. **`POST /personas/:id/attachments/from-existing {sourceAttachmentId}`** — persona edit gate (#1318 semantics: personal persona non-owners, admins included, 404), then source readability via the exact access chain the download endpoints use (`streamService.tryAccess` + share/reference fallback + the now-shared `unboundAttachmentBlockedForCaller`), then eligibility: `safety_status = CLEAN` only, no `e2e_only`, persona mime allowlist + 20MB against the source.
2. **The copy:** new attachment id, S3 server-side `CopyObject` (object + thumbnail; `copyObject` added to `StorageProvider`), unbound CLEAN row owned by the caller. The extraction row is copied in one `INSERT … SELECT` including `summary_embedding` — identical content, so no re-embed AI call; a source with no extraction instead emits `attachment:uploaded` in the same transaction (INV-4) so the normal pipeline extracts the copy. `pdf_page_extractions` are deliberately not copied: the Knowledge prompt path reads only `attachment_extractions`, and `read_attachment` is message-scoped so per-page reads can never target a persona file.
3. **Bind** reuses the existing cap-guarded `insertBinding`; a cap-race loss or bind error cleans the copy via the race-safe `deleteIfUnbound` (a settled-unbound row is invisible to the sweep — nothing else would reap it).
4. **The picker:** an "Attach existing" button beside "Add file" opens a dialog reusing the file explorer's search/list/rows via a new `onSelectAttachment` prop path (no fork, INV-35/37). The server search already scopes to message-bound, scanned-clean files in streams the caller can read; results are additionally narrowed to knowledge-eligible types (category pre-filter + client-side allowlist; the server re-checks on pick). Picking fires the copy, the returned row seeds the config cache (INV-63 — the row is the signal), and the context label derives from the same budget planner as everything else.

### Key design decisions

**1. Copy, not reference** — see Solution. The independence is proven live and in the browser spec: delete the source message, reload the editor, the persona's row survives.

**2. The access model is "attach what you could already read."** The picker never lists a file you cannot open (server-side stream-access CTE), and the endpoint re-verifies with the download handlers' chain — a private channel's file cannot be exfiltrated into a persona by id.

**3. Adversarial UX round (Kris's requested finale) drove a fix commit.** An Opus reviewer exercised the live product against the "simple, understandable, not restrictive" lens. Its three before-merge findings are fixed in `5f2f2d00`: the picker had inherited the explorer's empty-state strings ("No files yet…", "widen the search"), which described controls the dialog doesn't have and made an empty result read as broken — it now states its real scope and points at Add file; the context labels ("Summary only") read as a silent downgrade with no visible cause — the section help now states the budget and each label carries a hover explanation; the failed-extraction row was a dead end — it now says what to do. Deferred with eyes open: multi-pick per dialog open, extraction preview ("what text did the persona actually get"), at-cap explanation, and the picker not surfacing uncommon `text/*` subtypes (documented under-inclusion; nothing ineligible can ever be attached).

**4. End-to-end verification was enforced, not assumed.** Per Kris's ruling, every feature step's verification had to exercise the real product. When F2's workflow verifiers settled for unit suites, the commit was held and a dedicated live verifier booted the full stack (real backend/control-plane/router/frontend, real Postgres + MinIO, real Chromium) and walked the whole flow — including the source-deletion independence check and the negative 404 — before F2 landed.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/persona-editor/attach-existing-dialog.tsx` | The picker: explorer search/list reuse, scope-honest empty states, single-pick |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/storage/s3-client.ts` | `StorageProvider.copyObject` via `CopyObjectCommand` (+ eval-suite fakes) |
| `apps/backend/src/features/attachments/extraction-repository.ts` | `copyForAttachment` — one `INSERT … SELECT` incl. embedding, never the generated `search_vector` |
| `apps/backend/src/features/attachments/service.ts` | `copyForPersona` (S3 copy → row insert → extraction copy or in-txn pipeline kick → cleanup on throw) |
| `apps/backend/src/features/attachments/access.ts`, `handlers.ts`, `index.ts` | `unboundAttachmentBlockedForCaller` moved to access.ts and shared |
| `apps/backend/src/features/agents/persona-config-service.ts` | `attachFromExisting` (flow above); shared mime/size gate extracted and reused by bind |
| `apps/backend/src/features/agents/persona-config-handlers.ts`, `routes.ts` | Endpoint + Zod schema |
| `apps/frontend/src/components/attachment-explorer/{explorer-row,explorer-list,index}.tsx` | Optional `onSelectAttachment` pick path + exports |
| `apps/frontend/src/components/persona-editor/custom-persona-editor.tsx` | Attach existing button, budget sentence in the help text, label hints, actionable failure row |
| `apps/frontend/src/api/personas.ts`, `hooks/use-personas.ts` | `attachFromExisting` client + hook; shared `appendPersonaAttachment` reconcile so the two writers can't drift |
| `docs/features/public/custom-personas.md` | Attached knowledge describes both paths; by-link boundary rewritten to the copy rationale |
| `tests/browser/persona-customization.spec.ts` | Knowledge-by-reference spec incl. copy-independence |

## Out of scope (deliberate)

- Memos as knowledge (different entity; own pass).
- Multi-pick per dialog open; extraction preview; at-cap explanation; picker coverage of uncommon `text/*` subtypes (all named in the UX review, deferred).
- No changes to `attachment_references`, the share flow, or `read_attachment`.

## Test plan

- [x] Backend `bun test src/` — 3023 pass, 0 fail
- [x] Integration (real DB) — 6 pass, incl. the F1 proof: real `attachFromExisting`, copied content in the real composed prompt, copy survives source-row deletion
- [x] Frontend `bunx vitest run` full — 4310 pass; only the 4 known pre-existing `dates.test.ts` TZ reds
- [x] Browser `persona-customization.spec.ts` — 7 passed (33.1s) incl. the new by-reference spec; Knowledge specs re-run green after the UX commit
- [x] Live end-to-end (dedicated verifier, real stack + Chromium): full flow incl. `84 B · In full` label, cap hint, source-deletion independence, negative 404 — with screenshots
- [x] Adversarial UX review (live product): 3 before-merge findings fixed, 4 deferred and named
- [x] `bun run typecheck` repo root — 0 errors
- [x] Per-step 2-lens Opus verify: 3 steps, zero unresolved findings, zero fix rounds

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786573547&installation_id=129946197&pr_number=1338&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1338&signature=286c7d3455358969289bf7f7f064b98de3aa592a2ac58df9c81e97a8bd990d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->