### PR TITLE
feat(frontend): quick links render in the board-mode sidebar

### DIFF
--- a/apps/frontend/src/components/board/board-filter-pickers.tsx
+++ b/apps/frontend/src/components/board/board-filter-pickers.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react"
-import { Link, useLocation } from "react-router-dom"
-import { Archive, Ban, Bell, BellOff, Check, ChevronDown, CircleDot, Hash, Layers, Pin, Tag, X } from "lucide-react"
+import { Ban, Bell, BellOff, ChevronDown, Hash, Layers, Tag, X } from "lucide-react"
 import {
-  BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
-  DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
-  type BoardLens,
   type BoardScopeStreamType,
 } from "@threa/types"
 import { Badge } from "@/components/ui/badge"
@@ -17,20 +13,10 @@ import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/
 import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useInputMode } from "@/hooks/use-input-mode"
-import {
-  useWorkspaceDmPeers,
-  useWorkspaceLabels,
-  useWorkspaceStreams,
-  useWorkspaceUsers,
-} from "@/stores/workspace-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
 import type { CachedLabel } from "@/hooks/use-labels"
-import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
-import { BoardSavedViews, isViewActive, lensHref, type BoardViewSelection } from "@/components/board/board-saved-views"
-import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
-import { clearFiltersSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
-import { isBoardFiltered } from "@/lib/board/filter-state"
-import { usePreferences } from "@/contexts"
-import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
+import { STREAM_ICONS } from "@/lib/streams"
+import { toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { BOARD_STREAM_TYPE_LABELS as TYPE_LABELS } from "@/lib/board/stream-type-labels"
 import { cn } from "@/lib/utils"
 
@@ -39,297 +25,15 @@ import { cn } from "@/lib/utils"
 const SCOPE_STREAM_TYPES = new Set<string>(BOARD_SCOPE_STREAM_TYPES)
 
 /** A dimension's include/exclude rewrite: both lists in one URL write. */
-type FilterChange<T> = (include: T[], exclude: T[]) => void
+export type FilterChange<T> = (include: T[], exclude: T[]) => void
 
 /** Chip/row glyph: lucide icons and the `STREAM_ICONS` components both fit. */
-type FilterIcon = ComponentType<{ className?: string }>
-
-interface BoardFilterBarProps {
-  workspaceId: string
-  lens: BoardLens
-  /** Included scope stream ids (root streams), in URL order. */
-  scopeStreamIds: string[]
-  /** Excluded stream ids (anchor-or-root veto), in URL order. */
-  excludeStreamIds: string[]
-  /** Rewrites the stream filter; the page owns the URL write. */
-  onStreamFilterChange: FilterChange<string>
-  /** Included root-stream types, in URL order. */
-  scopeStreamTypes: BoardScopeStreamType[]
-  /** Excluded root-stream types, in URL order. */
-  excludeStreamTypes: BoardScopeStreamType[]
-  /** Rewrites the type filter; the page owns the URL write. */
-  onTypeFilterChange: FilterChange<BoardScopeStreamType>
-  /** Included label ids (the viewer's own labels), in URL order. */
-  scopeLabelIds: string[]
-  /** Excluded label ids, in URL order. */
-  excludeLabelIds: string[]
-  /** Rewrites the label filter; the page owns the URL write. */
-  onLabelFilterChange: FilterChange<string>
-  /** Root streams the viewer muted from the board (board-view-design.md § "Hide & mute"). */
-  mutedStreamIds?: ReadonlySet<string>
-  /** Toggle a stream's board mute; the page owns the write. */
-  onToggleMute?: (streamId: string, mute: boolean) => void
-  /** Whether archived cards are currently included (`?archived=true`). */
-  showArchived: boolean
-  /** Toggle the archived opt-in; the page owns the URL write. */
-  onToggleArchived: (next: boolean) => void
-  /** Whether the board is narrowed to unread conversations (`?unread=true`). */
-  unreadOnly: boolean
-  /** Toggle the unread-only opt-in; the page owns the URL write. */
-  onToggleUnreadOnly: (next: boolean) => void
-}
+export type FilterIcon = ComponentType<{ className?: string }>
 
 /**
- * The board's filter row: a lens picker and stream/type/label pickers, all
- * optional narrowings over the always-available All home. Deliberately a
- * filter control — not a tab strip — so the lenses read as suggestions you can
- * reach for (like the search page's stream-type filter), not as the prescribed
- * ways to use the board. Every filter lives in the URL as query params — the
- * lens included (`?lens=`) — so refresh/back/share reproduce the view (INV-59).
- *
- * Each picker row is tri-state: the row toggles INCLUDE (checkbox), the ban
- * button on its right toggles EXCLUDE — include narrows, exclude vetoes, and
- * the two are mutually exclusive per row. Excluded selections render as "Not:"
- * chips so a veto never reads as a scope.
- *
- * One horizontally-scrollable row on every breakpoint: controls first, then a
- * chip per selection, then a clear-all link once anything narrows. Pickers
- * open as popovers for mouse input and bottom drawers for touch (the
- * `SearchFilterMenu` split).
- */
-export function BoardFilterBar({
-  workspaceId,
-  lens,
-  scopeStreamIds,
-  excludeStreamIds,
-  onStreamFilterChange,
-  scopeStreamTypes,
-  excludeStreamTypes,
-  onTypeFilterChange,
-  scopeLabelIds,
-  excludeLabelIds,
-  onLabelFilterChange,
-  mutedStreamIds,
-  onToggleMute,
-  showArchived,
-  onToggleArchived,
-  unreadOnly,
-  onToggleUnreadOnly,
-}: BoardFilterBarProps) {
-  const location = useLocation()
-  const streams = useWorkspaceStreams(workspaceId)
-  const users = useWorkspaceUsers(workspaceId)
-  const dmPeers = useWorkspaceDmPeers(workspaceId)
-  const allLabels = useWorkspaceLabels(workspaceId)
-  const myLabels = useMemo(
-    () => allLabels.filter((l) => !l.archivedAt).sort((a, b) => a.name.localeCompare(b.name)),
-    [allLabels]
-  )
-  const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
-  const labelById = useMemo(() => new Map(myLabels.map((l) => [l.id, l])), [myLabels])
-
-  // The baseline is absolute — the unfiltered All lens — so any narrowing offers
-  // "Clear filters", including the viewer's own saved-view or non-All home (its
-  // filters must be clearable too; the home-relative baseline made them not be).
-  // `unreadOnly` narrows the feed like every other axis (unlike `showArchived`,
-  // which broadens it), so it counts toward "filtered"; `BoardViewSelection`
-  // itself stays unread-unaware (matching `showArchived`'s precedent): unread
-  // state churns on every read receipt, so it isn't meaningful in a saved view.
-  const isFiltered =
-    isBoardFiltered({
-      lens,
-      scopeStreamIds,
-      scopeStreamTypes,
-      scopeLabelIds,
-      excludeStreamIds,
-      excludeStreamTypes,
-      excludeLabelIds,
-    }) || unreadOnly
-  // "Clear filters" shows everything: explicit `?lens=all` with no filter axes —
-  // never the bare `/board` entry alias, which would bounce to the viewer's home.
-  // The surviving non-filter query — an open `?panel=` — rides along, per the
-  // `clearFiltersSearch` contract, so clearing filters never drops the open thread.
-  const clearFiltersTo = useMemo(
-    () => `/w/${workspaceId}/board${clearFiltersSearch(location.search)}`,
-    [workspaceId, location.search]
-  )
-
-  const labelFor = (streamId: string) =>
-    resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
-  const labelNameFor = (labelId: string) => labelById.get(labelId)?.name ?? "Unknown label"
-
-  // The Labels picker only renders when there's something to pick (or a stale
-  // URL names labels the viewer no longer has — keep it so they can clear it).
-  const showLabelsPicker = myLabels.length > 0 || scopeLabelIds.length > 0 || excludeLabelIds.length > 0
-
-  const streamIconFor = (id: string): FilterIcon => {
-    const type = streamById.get(id)?.type
-    return (type && STREAM_ICONS[type]) || Hash
-  }
-
-  return (
-    <div className="flex min-h-9 items-center gap-1.5 overflow-x-auto border-b px-3 py-1.5 scrollbar-none sm:px-4">
-      <BoardLensMenu
-        workspaceId={workspaceId}
-        lens={lens}
-        scopeStreamIds={scopeStreamIds}
-        excludeStreamIds={excludeStreamIds}
-        scopeStreamTypes={scopeStreamTypes}
-        excludeStreamTypes={excludeStreamTypes}
-        scopeLabelIds={scopeLabelIds}
-        excludeLabelIds={excludeLabelIds}
-      />
-      <BoardScopePicker
-        workspaceId={workspaceId}
-        scopeStreamIds={scopeStreamIds}
-        excludeStreamIds={excludeStreamIds}
-        onStreamFilterChange={onStreamFilterChange}
-        labelFor={labelFor}
-        mutedStreamIds={mutedStreamIds}
-        onToggleMute={onToggleMute}
-      />
-      <BoardTypePicker
-        scopeStreamTypes={scopeStreamTypes}
-        excludeStreamTypes={excludeStreamTypes}
-        onTypeFilterChange={onTypeFilterChange}
-      />
-      {showLabelsPicker && (
-        <BoardLabelPicker
-          myLabels={myLabels}
-          scopeLabelIds={scopeLabelIds}
-          excludeLabelIds={excludeLabelIds}
-          onLabelFilterChange={onLabelFilterChange}
-        />
-      )}
-      <Button
-        type="button"
-        variant={unreadOnly ? "secondary" : "outline"}
-        size="sm"
-        onClick={() => onToggleUnreadOnly(!unreadOnly)}
-        aria-pressed={unreadOnly}
-        className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
-        aria-label={unreadOnly ? "Show every conversation" : "Show only unread conversations"}
-      >
-        <CircleDot className="h-3.5 w-3.5" />
-        Unread
-      </Button>
-      <Button
-        type="button"
-        variant={showArchived ? "secondary" : "outline"}
-        size="sm"
-        onClick={() => onToggleArchived(!showArchived)}
-        aria-pressed={showArchived}
-        className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
-        aria-label={showArchived ? "Hide archived conversations" : "Show archived conversations"}
-      >
-        <Archive className="h-3.5 w-3.5" />
-        Archived
-      </Button>
-      {scopeStreamTypes.map((type) => (
-        <FilterChip
-          key={`is-${type}`}
-          icon={STREAM_ICONS[type] || Layers}
-          label={TYPE_LABELS[type]}
-          onRemove={() =>
-            onTypeFilterChange(
-              scopeStreamTypes.filter((t) => t !== type),
-              excludeStreamTypes
-            )
-          }
-          removeLabel={`Remove ${TYPE_LABELS[type]} from the board scope`}
-        />
-      ))}
-      {excludeStreamTypes.map((type) => (
-        <FilterChip
-          key={`not-is-${type}`}
-          icon={STREAM_ICONS[type] || Layers}
-          label={TYPE_LABELS[type]}
-          excluded
-          onRemove={() =>
-            onTypeFilterChange(
-              scopeStreamTypes,
-              excludeStreamTypes.filter((t) => t !== type)
-            )
-          }
-          removeLabel={`Stop excluding ${TYPE_LABELS[type]} from the board`}
-        />
-      ))}
-      {scopeStreamIds.map((id) => (
-        <FilterChip
-          key={`in-${id}`}
-          icon={streamIconFor(id)}
-          label={labelFor(id)}
-          onRemove={() =>
-            onStreamFilterChange(
-              scopeStreamIds.filter((s) => s !== id),
-              excludeStreamIds
-            )
-          }
-          removeLabel={`Remove ${labelFor(id)} from the board scope`}
-        />
-      ))}
-      {excludeStreamIds.map((id) => (
-        <FilterChip
-          key={`not-in-${id}`}
-          icon={streamIconFor(id)}
-          label={labelFor(id)}
-          excluded
-          onRemove={() =>
-            onStreamFilterChange(
-              scopeStreamIds,
-              excludeStreamIds.filter((s) => s !== id)
-            )
-          }
-          removeLabel={`Stop excluding ${labelFor(id)} from the board`}
-        />
-      ))}
-      {scopeLabelIds.map((id) => (
-        <FilterChip
-          key={`label-${id}`}
-          icon={Tag}
-          label={labelNameFor(id)}
-          swatch={labelById.get(id)?.color}
-          onRemove={() =>
-            onLabelFilterChange(
-              scopeLabelIds.filter((l) => l !== id),
-              excludeLabelIds
-            )
-          }
-          removeLabel={`Remove the ${labelNameFor(id)} label from the board scope`}
-        />
-      ))}
-      {excludeLabelIds.map((id) => (
-        <FilterChip
-          key={`not-label-${id}`}
-          icon={Tag}
-          label={labelNameFor(id)}
-          swatch={labelById.get(id)?.color}
-          excluded
-          onRemove={() =>
-            onLabelFilterChange(
-              scopeLabelIds,
-              excludeLabelIds.filter((l) => l !== id)
-            )
-          }
-          removeLabel={`Stop excluding the ${labelNameFor(id)} label from the board`}
-        />
-      ))}
-      {isFiltered && (
-        <Link
-          to={clearFiltersTo}
-          className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Clear filters
-        </Link>
-      )}
-    </div>
-  )
-}
-
-/**
- * One filter selection in the bar. An `excluded` chip reads as a veto: "Not:"
- * prefix + destructive tint, so a narrowed board and a vetoed stream can't be
- * confused at a glance.
+ * One filter selection rendered as a removable chip. An `excluded` chip reads as
+ * a veto: "Not:" prefix + destructive tint, so a narrowed board and a vetoed
+ * stream can't be confused at a glance.
  */
 export function FilterChip({
   icon: Icon,
@@ -372,11 +76,11 @@ export function FilterChip({
 }
 
 /**
- * Shared container for the bar's pickers: popover for mouse input, bottom
- * drawer when a finger is active (the `SearchFilterMenu` split). One shell so
- * the pickers can't drift as sizing/a11y evolves.
+ * Shared container for the board's filter pickers: popover for mouse input,
+ * bottom drawer when a finger is active (the `SearchFilterMenu` split). One shell
+ * so the pickers can't drift as sizing/a11y evolves.
  */
-function FilterMenuShell({
+export function FilterMenuShell({
   title,
   open,
   onOpenChange,
@@ -437,149 +141,13 @@ function ExcludeToggle({ excluded, onToggle, subject }: { excluded: boolean; onT
 }
 
 /**
- * Lens picker. Each option is a link (lens changes are navigation, INV-40) with
- * a one-line description, so the menu doubles as the explanation of what each
- * lens means. The trigger reflects the active lens and fills in once a
- * non-default lens narrows the board.
- */
-function BoardLensMenu({
-  workspaceId,
-  lens,
-  scopeStreamIds,
-  excludeStreamIds,
-  scopeStreamTypes,
-  excludeStreamTypes,
-  scopeLabelIds,
-  excludeLabelIds,
-}: {
-  workspaceId: string
-  lens: BoardLens
-  scopeStreamIds: string[]
-  excludeStreamIds: string[]
-  scopeStreamTypes: BoardScopeStreamType[]
-  excludeStreamTypes: BoardScopeStreamType[]
-  scopeLabelIds: string[]
-  excludeLabelIds: string[]
-}) {
-  const [open, setOpen] = useState(false)
-  const { search } = useLocation()
-  const { updatePreferences } = usePreferences()
-  const current = BOARD_LENS_DEFS[lens]
-  const CurrentIcon = current.icon
-
-  // A saved view IS the selection when the live lens + every filter axis match
-  // it, so it — not its base lens — is what reads as active. Resolved once here
-  // so the lens list and the saved-view list can't both mark a row.
-  const { data: views } = useBoardViews(workspaceId)
-  const selection: BoardViewSelection = {
-    lens,
-    scopeStreamIds,
-    scopeStreamTypes,
-    scopeLabelIds,
-    excludeStreamIds,
-    excludeStreamTypes,
-    excludeLabelIds,
-  }
-  const activeViewId = views?.find((view) => isViewActive(view, selection))?.id ?? null
-
-  // The pin fill: the home lens preference marks a lens row, but no lens reads
-  // as home while a saved-view home resolves (the view's pin is the home then).
-  const homeLens = usePreferences().preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
-  const { view: homeMenuView } = useBoardHome(workspaceId)
-  const homeViewActive = homeMenuView != null
-
-  const content = (
-    <>
-      <nav aria-label="Board lens" className="py-1">
-        {BOARD_LENSES.map((value) => {
-          const def = BOARD_LENS_DEFS[value]
-          const Icon = def.icon
-          const selected = value === lens && activeViewId === null
-          const isHome = !homeViewActive && value === homeLens
-          return (
-            <div
-              key={value}
-              className={cn(
-                "mx-1 flex items-center rounded-item transition-colors hover:bg-muted",
-                selected && "bg-muted/60"
-              )}
-            >
-              <Link
-                to={lensHref(workspaceId, value, search)}
-                onClick={() => setOpen(false)}
-                aria-current={selected ? "true" : undefined}
-                className="flex min-w-0 flex-1 items-start gap-2.5 rounded-item px-2.5 py-2"
-              >
-                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-medium">{def.label}</span>
-                  <span className="block text-xs text-muted-foreground">{def.description}</span>
-                </span>
-                {selected && <Check className="mt-1 h-4 w-4 shrink-0" />}
-              </Link>
-              {/* Pin this lens as the board home (bare `/board`) — mirrors the
-                  appearance-settings radio, placed where lenses are picked. Also
-                  clears any saved-view home so the landing actually lands here.
-                  Filled when current home; silent per INV-63 (the fill is the signal). */}
-              <button
-                type="button"
-                onClick={() => void updatePreferences({ boardDefaultLens: value, boardDefaultViewId: null })}
-                aria-pressed={isHome}
-                aria-label={isHome ? `${def.label} is your board home` : `Set ${def.label} as board home`}
-                className={cn(
-                  "mr-1 shrink-0 rounded p-1.5 transition-colors",
-                  isHome ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
-                )}
-              >
-                <Pin className={cn("h-3.5 w-3.5", isHome && "fill-current")} />
-              </button>
-            </div>
-          )
-        })}
-      </nav>
-      <BoardSavedViews
-        workspaceId={workspaceId}
-        lens={lens}
-        activeViewId={activeViewId}
-        scopeStreamIds={scopeStreamIds}
-        excludeStreamIds={excludeStreamIds}
-        scopeStreamTypes={scopeStreamTypes}
-        excludeStreamTypes={excludeStreamTypes}
-        scopeLabelIds={scopeLabelIds}
-        excludeLabelIds={excludeLabelIds}
-        onNavigate={() => setOpen(false)}
-      />
-    </>
-  )
-
-  const trigger = (
-    <Button
-      variant={lens === DEFAULT_BOARD_LENS ? "outline" : "secondary"}
-      size="sm"
-      className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
-      aria-label={`Board lens: ${current.label}`}
-    >
-      <CurrentIcon className="h-3.5 w-3.5" />
-      {current.label}
-      <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
-    </Button>
-  )
-
-  return (
-    <FilterMenuShell title="Board lens" open={open} onOpenChange={setOpen} trigger={trigger}>
-      {content}
-    </FilterMenuShell>
-  )
-}
-
-/**
  * Stream picker: a searchable tri-state multi-select over the workspace's root
  * streams (channels, DMs, scratchpads, system). The row toggles include
- * (`?in=`), the ban toggle vetoes (`?not-in=`); both rewrite through the page.
+ * (`?in=`), the ban toggle vetoes (`?not-in=`); both rewrite through the caller.
  * Each list is capped at the shared server limit so the picker can't build a
  * URL the backend rejects.
  */
-function BoardScopePicker({
+export function BoardScopePicker({
   workspaceId,
   scopeStreamIds,
   excludeStreamIds,
@@ -732,7 +300,7 @@ function BoardScopePicker({
  * grains. Matches by the conversation's effective root — a thread under a
  * channel counts as Channels — mirroring the stream picker's root rule.
  */
-function BoardTypePicker({
+export function BoardTypePicker({
   scopeStreamTypes,
   excludeStreamTypes,
   onTypeFilterChange,
@@ -812,7 +380,7 @@ function BoardTypePicker({
  * matches a conversation by its anchor or effective root stream, the same rule
  * as the stream picker.
  */
-function BoardLabelPicker({
+export function BoardLabelPicker({
   myLabels,
   scopeLabelIds,
   excludeLabelIds,

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -1,11 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { MemoryRouter } from "react-router-dom"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, it, expect } from "vitest"
 import type { BoardView } from "@threa/types"
-import { ServicesProvider } from "@/contexts"
-import { BoardSavedViews, savedViewHref, isViewActive, type BoardViewSelection } from "./board-saved-views"
+import { savedViewHref, isViewActive, type BoardViewSelection } from "./board-saved-views"
 
 const view = (over: Partial<BoardView> = {}): BoardView => ({
   id: "boardview_1",
@@ -20,33 +15,6 @@ const view = (over: Partial<BoardView> = {}): BoardView => ({
   sortOrder: 0,
   ...over,
 })
-
-function mount(boardViews: Record<string, unknown>, props: Partial<Parameters<typeof BoardSavedViews>[0]> = {}) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ServicesProvider services={{ boardViews } as never}>
-        <MemoryRouter>
-          <BoardSavedViews
-            workspaceId="ws_1"
-            lens="mine"
-            activeViewId={null}
-            scopeStreamIds={["stream_1"]}
-            scopeStreamTypes={[]}
-            scopeLabelIds={[]}
-            excludeStreamIds={[]}
-            excludeStreamTypes={[]}
-            excludeLabelIds={[]}
-            onNavigate={() => {}}
-            {...props}
-          />
-        </MemoryRouter>
-      </ServicesProvider>
-    </QueryClientProvider>
-  )
-}
-
-afterEach(() => vi.restoreAllMocks())
 
 describe("isViewActive", () => {
   const selection = (over: Partial<BoardViewSelection> = {}): BoardViewSelection => ({
@@ -109,50 +77,5 @@ describe("savedViewHref", () => {
     expect(url.searchParams.get("not-in")).toBe("s9")
     expect(url.searchParams.get("not-is")).toBe("system")
     expect(url.searchParams.get("not-label")).toBe("label_b")
-  })
-})
-
-describe("BoardSavedViews", () => {
-  const base = {
-    list: vi.fn(async () => [view()]),
-    create: vi.fn(async () => view()),
-    update: vi.fn(async () => view()),
-    remove: vi.fn(async () => undefined),
-  }
-
-  it("lists saved views linking to their expanded URL", async () => {
-    mount({ ...base })
-    const link = await screen.findByRole("link", { name: /Design work/ })
-    expect(link.getAttribute("href")).toContain("/w/ws_1/board?lens=mine")
-  })
-
-  it("saves the current filter state as a named view", async () => {
-    const user = userEvent.setup()
-    const create = vi.fn(async () => view())
-    mount({ ...base, list: vi.fn(async () => []), create })
-
-    await user.click(await screen.findByText("Save current view"))
-    await user.type(await screen.findByPlaceholderText("View name"), "Design work")
-    await user.click(screen.getByRole("button", { name: "Save" }))
-
-    expect(create).toHaveBeenCalledWith("ws_1", {
-      name: "Design work",
-      baseLens: "mine",
-      scopeStreamIds: ["stream_1"],
-      scopeStreamTypes: [],
-      scopeLabelIds: [],
-      excludeStreamIds: [],
-      excludeStreamTypes: [],
-      excludeLabelIds: [],
-    })
-  })
-
-  it("deletes a saved view", async () => {
-    const user = userEvent.setup()
-    const remove = vi.fn(async () => undefined)
-    mount({ ...base, remove })
-
-    await user.click(await screen.findByRole("button", { name: "Delete Design work" }))
-    expect(remove).toHaveBeenCalledWith("ws_1", "boardview_1")
   })
 })

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -1,13 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Link } from "react-router-dom"
-import { Bookmark, Check, Pencil, Pin, Plus, Trash2 } from "lucide-react"
-import {
-  DEFAULT_BOARD_LENS,
-  MAX_BOARD_VIEW_NAME_LENGTH,
-  type BoardLens,
-  type BoardScopeStreamType,
-  type BoardView,
-} from "@threa/types"
+import { DEFAULT_BOARD_LENS, MAX_BOARD_VIEW_NAME_LENGTH, type BoardLens, type BoardView } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -18,15 +10,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { cn } from "@/lib/utils"
-import { usePreferencesOptional } from "@/contexts"
-import {
-  useBoardHome,
-  useBoardViews,
-  useSaveBoardView,
-  useUpdateBoardView,
-  useDeleteBoardView,
-} from "@/hooks/use-board-views"
+import { useSaveBoardView } from "@/hooks/use-board-views"
 import {
   BOARD_LENS_PARAM,
   BOARD_SCOPE_PARAM,
@@ -36,7 +20,7 @@ import {
   BOARD_EXCLUDE_TYPE_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
 } from "@/components/board/board-filter-params"
-import { isBoardFiltered, type BoardViewSelection } from "@/lib/board/filter-state"
+import type { BoardViewSelection } from "@/lib/board/filter-state"
 
 export type { BoardViewSelection }
 
@@ -56,8 +40,8 @@ export function savedViewHref(workspaceId: string, view: BoardView): string {
 
 /** The lens's URL (INV-59): `?lens=` rewritten in the current search so the
  *  filter axes (and an open `?panel=`) ride along a lens switch. Sibling of
- *  {@link savedViewHref}; shared by the filter bar's lens menu and the board-mode
- *  sidebar block so the two can't drift (INV-35). */
+ *  {@link savedViewHref}; shared by the board-mode sidebar block's lens list so
+ *  the two can't drift (INV-35). */
 export function lensHref(workspaceId: string, lens: BoardLens, search: string): string {
   const params = new URLSearchParams(search)
   params.set(BOARD_LENS_PARAM, lens)
@@ -123,184 +107,11 @@ export function summarizeBoardView(view: BoardView): string {
   return parts.join(" · ") || "Everything"
 }
 
-interface BoardSavedViewsProps {
-  workspaceId: string
-  /** The board's live filter state — captured when saving "the current view". */
-  lens: BoardLens
-  /** The saved view whose lens + filters match the live board, or `null`. Owned by
-   *  the lens menu so the lens list and this list never both mark a row. */
-  activeViewId: string | null
-  scopeStreamIds: string[]
-  scopeStreamTypes: BoardScopeStreamType[]
-  scopeLabelIds: string[]
-  excludeStreamIds: string[]
-  excludeStreamTypes: BoardScopeStreamType[]
-  excludeLabelIds: string[]
-  /** Close the enclosing lens menu after navigating to a saved view. */
-  onNavigate: () => void
-}
-
-/**
- * The "Saved views" section of the lens picker (board-view-design.md § "Lenses" —
- * "save our own lenses"). Each saved view is a `<Link>` that expands into the
- * canonical board URL (INV-40/INV-59). "Save current view" captures the board's
- * live lens + every include/exclude filter axis; rename/delete edit an existing
- * one. Success is silent — the list reflects it (INV-63).
- */
-export function BoardSavedViews({
-  workspaceId,
-  lens,
-  activeViewId,
-  scopeStreamIds,
-  scopeStreamTypes,
-  scopeLabelIds,
-  excludeStreamIds,
-  excludeStreamTypes,
-  excludeLabelIds,
-  onNavigate,
-}: BoardSavedViewsProps) {
-  const { data: views } = useBoardViews(workspaceId)
-  const prefs = usePreferencesOptional()
-  const { view: homeView } = useBoardHome(workspaceId)
-  const save = useSaveBoardView(workspaceId)
-  const update = useUpdateBoardView(workspaceId)
-  const remove = useDeleteBoardView(workspaceId)
-
-  // `null` closed; `{ id: null }` = save-current; `{ id }` = rename that view.
-  const [editing, setEditing] = useState<{ id: string | null; name: string } | null>(null)
-
-  // Only offer "save current view" when there's a narrowing to bookmark that
-  // isn't already bookmarked — the unfiltered baseline has nothing to save, and
-  // a selection that matches an existing view (activeViewId) IS that view.
-  const isFiltered =
-    activeViewId === null &&
-    isBoardFiltered({
-      lens,
-      scopeStreamIds,
-      scopeStreamTypes,
-      scopeLabelIds,
-      excludeStreamIds,
-      excludeStreamTypes,
-      excludeLabelIds,
-    })
-
-  const submit = (name: string) => {
-    if (editing?.id) update.mutate({ id: editing.id, input: { name } })
-    else
-      save.mutate({
-        name,
-        baseLens: lens,
-        scopeStreamIds,
-        scopeStreamTypes,
-        scopeLabelIds,
-        excludeStreamIds,
-        excludeStreamTypes,
-        excludeLabelIds,
-      })
-    setEditing(null)
-  }
-
-  return (
-    <>
-      {(views && views.length > 0) || isFiltered ? (
-        <div className="border-t pt-1">
-          <p className="px-3 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            Saved views
-          </p>
-          {views?.map((view) => {
-            const active = view.id === activeViewId
-            return (
-              <div
-                key={view.id}
-                className={cn(
-                  "group mx-1 flex items-start gap-1 rounded-item px-2.5 py-2 transition-colors hover:bg-muted",
-                  active && "bg-muted/60"
-                )}
-              >
-                <Link
-                  to={savedViewHref(workspaceId, view)}
-                  onClick={onNavigate}
-                  aria-current={active ? "true" : undefined}
-                  className="flex min-w-0 flex-1 items-start gap-2.5"
-                >
-                  <Bookmark className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm font-medium">{view.name}</span>
-                    <span className="block truncate text-xs text-muted-foreground">{summarizeBoardView(view)}</span>
-                  </span>
-                </Link>
-                {/* Pin this saved view as the board home (bare `/board` bounces to
-                    it). Filled when it's the current home; silent per INV-63. */}
-                <button
-                  type="button"
-                  onClick={() => void prefs?.updatePreferences({ boardDefaultViewId: view.id })}
-                  aria-pressed={view.id === homeView?.id}
-                  aria-label={
-                    view.id === homeView?.id ? `${view.name} is your board home` : `Set ${view.name} as board home`
-                  }
-                  className={cn(
-                    "mt-0.5 shrink-0 rounded p-1 transition-colors",
-                    view.id === homeView?.id ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
-                  )}
-                >
-                  <Pin className={cn("h-3.5 w-3.5", view.id === homeView?.id && "fill-current")} />
-                </button>
-                {/* Right slot: the active check sits at the row's right edge (same
-                    column as the lens list's check) and fades to the rename/delete
-                    actions on hover/focus — one indicator, never both. */}
-                <div className="relative flex shrink-0 items-start">
-                  <button
-                    type="button"
-                    onClick={() => setEditing({ id: view.id, name: view.name })}
-                    aria-label={`Rename ${view.name}`}
-                    className="rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => remove.mutate(view.id)}
-                    aria-label={`Delete ${view.name}`}
-                    className="rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                  {active && (
-                    <Check className="pointer-events-none absolute right-0 top-1 h-4 w-4 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0" />
-                  )}
-                </div>
-              </div>
-            )
-          })}
-          {isFiltered && (
-            <button
-              type="button"
-              onClick={() => setEditing({ id: null, name: "" })}
-              className="mx-1 flex w-[calc(100%-0.5rem)] items-center gap-2.5 rounded-item px-2.5 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <Plus className="h-4 w-4 shrink-0" />
-              Save current view
-            </button>
-          )}
-        </div>
-      ) : null}
-
-      <SaveViewDialog
-        open={editing !== null}
-        initialName={editing?.name ?? ""}
-        isRename={!!editing?.id}
-        onOpenChange={(open) => !open && setEditing(null)}
-        onSubmit={submit}
-      />
-    </>
-  )
-}
-
 /**
  * Save the board's live selection as a new view, reusing the same
- * {@link SaveViewDialog} the lens menu opens (INV-35 — one dialog, no duplicate).
- * Standalone so the board-mode sidebar chips can offer "Save view" without
- * re-hosting the whole saved-views list. Silent on success (INV-63).
+ * {@link SaveViewDialog} the rename flow opens (INV-35 — one dialog, no
+ * duplicate). Used by the board-mode sidebar chips' "Save view". Silent on
+ * success (INV-63).
  */
 export function SaveCurrentViewDialog({
   workspaceId,
@@ -345,7 +156,8 @@ interface SaveViewDialogProps {
   onSubmit: (name: string) => void
 }
 
-function SaveViewDialog({ open, initialName, isRename, onOpenChange, onSubmit }: SaveViewDialogProps) {
+/** The name prompt shared by "Save current view" and a view rename (INV-35). */
+export function SaveViewDialog({ open, initialName, isRename, onOpenChange, onSubmit }: SaveViewDialogProps) {
   const [value, setValue] = useState(initialName)
   // Re-seed only on an open transition, so a concurrent update to `initialName`
   // (e.g. a rename landing via the live list) can't wipe in-progress typing.

--- a/apps/frontend/src/components/layout/sidebar/board-filter-chips.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-filter-chips.tsx
@@ -8,7 +8,7 @@ import {
   useWorkspaceUsers,
 } from "@/stores/workspace-store"
 import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
-import { FilterChip } from "@/components/board/board-filter-bar"
+import { FilterChip } from "@/components/board/board-filter-pickers"
 import { SaveCurrentViewDialog } from "@/components/board/board-saved-views"
 import { useBoardSelection } from "@/hooks/use-board-selection"
 import { BOARD_STREAM_TYPE_LABELS } from "@/lib/board/stream-type-labels"

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { MemoryRouter } from "react-router-dom"
-import { render, screen } from "@/test"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import { render, screen, userEvent } from "@/test"
 import type { BoardView } from "@threa/types"
 import * as Contexts from "@/contexts"
 import * as BoardViewsHooks from "@/hooks/use-board-views"
+import * as ConversationsHooks from "@/hooks/use-conversations"
+import * as WorkspaceStore from "@/stores/workspace-store"
+import * as BoardExclusions from "@/stores/board-exclusions-store"
+import * as InputMode from "@/hooks/use-input-mode"
 import { setLastLocation } from "@/lib/last-location"
 import { BoardModeBlock } from "./board-mode-block"
 
@@ -26,22 +30,33 @@ function view(over: Partial<BoardView> = {}): BoardView {
   }
 }
 
+interface Mocks {
+  updatePreferences: ReturnType<typeof vi.fn>
+  update: { mutate: ReturnType<typeof vi.fn> }
+  remove: { mutate: ReturnType<typeof vi.fn> }
+}
+
 /** Stub the ambient hooks the block reads: sidebar (collapseOnMobile), the
- *  board-views query, the board home, and the preferences (home lens). */
+ *  board-views query, the board home, the preferences (home lens + writer), the
+ *  view mutations, and the filter-group's workspace stores + mute mutations. */
 function stub(
   opts: {
     views?: BoardView[]
     homeView?: BoardView | null
     boardDefaultLens?: string | null
   } = {}
-) {
+): Mocks {
+  const updatePreferences = vi.fn()
+  const update = { mutate: vi.fn() }
+  const remove = { mutate: vi.fn() }
+
   vi.spyOn(Contexts, "useSidebar").mockReturnValue({
     collapseOnMobile: vi.fn(),
   } as unknown as ReturnType<typeof Contexts.useSidebar>)
   vi.spyOn(Contexts, "usePreferencesOptional").mockReturnValue(
     opts.boardDefaultLens === undefined
       ? null
-      : ({ preferences: { boardDefaultLens: opts.boardDefaultLens } } as unknown as ReturnType<
+      : ({ preferences: { boardDefaultLens: opts.boardDefaultLens }, updatePreferences } as unknown as ReturnType<
           typeof Contexts.usePreferencesOptional
         >)
   )
@@ -51,11 +66,38 @@ function stub(
   vi.spyOn(BoardViewsHooks, "useBoardHome").mockReturnValue({
     view: opts.homeView ?? null,
   })
+  vi.spyOn(BoardViewsHooks, "useUpdateBoardView").mockReturnValue(
+    update as unknown as ReturnType<typeof BoardViewsHooks.useUpdateBoardView>
+  )
+  vi.spyOn(BoardViewsHooks, "useDeleteBoardView").mockReturnValue(
+    remove as unknown as ReturnType<typeof BoardViewsHooks.useDeleteBoardView>
+  )
+
+  vi.spyOn(InputMode, "useInputMode").mockReturnValue("mouse")
+  vi.spyOn(ConversationsHooks, "useMuteStream").mockReturnValue({ mutate: vi.fn() } as never)
+  vi.spyOn(ConversationsHooks, "useUnmuteStream").mockReturnValue({ mutate: vi.fn() } as never)
+  vi.spyOn(WorkspaceStore, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(WorkspaceStore, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(WorkspaceStore, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(WorkspaceStore, "useWorkspaceLabels").mockReturnValue([] as never)
+  vi.spyOn(BoardExclusions, "useBoardMutedStreamIds").mockReturnValue(new Set())
+
+  return { updatePreferences, update, remove }
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc">{`${loc.pathname}${loc.search}`}</div>
+}
+
+function currentLoc(): string {
+  return screen.getByTestId("loc").textContent ?? ""
 }
 
 function mountAt(path: string, props: Partial<Parameters<typeof BoardModeBlock>[0]> = {}) {
   return render(
     <MemoryRouter initialEntries={[path]}>
+      <LocationProbe />
       <BoardModeBlock workspaceId={WS} userId={USER} {...props} />
     </MemoryRouter>
   )
@@ -67,6 +109,11 @@ function hrefOf(name: RegExp | string): string {
 
 beforeEach(() => {
   localStorage.clear()
+  // Radix menus/popovers need these in jsdom (they aren't implemented there).
+  Element.prototype.scrollIntoView ??= () => {}
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => {}
+  Element.prototype.releasePointerCapture ??= () => {}
 })
 afterEach(() => vi.restoreAllMocks())
 
@@ -186,5 +233,89 @@ describe("BoardModeBlock", () => {
     mountAt(`/w/${WS}/board`, { lensTotals: null })
 
     expect(screen.getByRole("link", { name: "Active" })).toHaveTextContent(/^Active$/)
+  })
+
+  it("renders the Filters group with the stream and type pickers", () => {
+    stub()
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    expect(screen.getByText("Filters")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Filter the board by streams" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Filter the board by stream types" })).toBeInTheDocument()
+  })
+
+  it("opens the streams picker on click", async () => {
+    const user = userEvent.setup()
+    stub()
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    await user.click(screen.getByRole("button", { name: "Filter the board by streams" }))
+    expect(await screen.findByPlaceholderText("Find a stream")).toBeInTheDocument()
+  })
+
+  it("the Unread only toggle flips ?unread=true and back", async () => {
+    const user = userEvent.setup()
+    stub()
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    await user.click(screen.getByRole("button", { name: "Unread only" }))
+    expect(new URL(currentLoc(), "http://x").searchParams.get("unread")).toBe("true")
+
+    await user.click(screen.getByRole("button", { name: "Unread only" }))
+    expect(new URL(currentLoc(), "http://x").searchParams.get("unread")).toBeNull()
+  })
+
+  it("the Archived toggle flips ?archived=true", async () => {
+    const user = userEvent.setup()
+    stub()
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    await user.click(screen.getByRole("button", { name: "Archived" }))
+    expect(new URL(currentLoc(), "http://x").searchParams.get("archived")).toBe("true")
+  })
+
+  it("pinning a lens writes the home-lens preference and clears any view home", async () => {
+    const user = userEvent.setup()
+    const { updatePreferences } = stub({ boardDefaultLens: "all" })
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    await user.click(screen.getByRole("button", { name: "Set Active as board home" }))
+    expect(updatePreferences).toHaveBeenCalledWith({ boardDefaultLens: "active", boardDefaultViewId: null })
+  })
+
+  it("pinning a saved view writes the home-view preference", async () => {
+    const user = userEvent.setup()
+    const { updatePreferences } = stub({ views: [view()], boardDefaultLens: "all" })
+    mountAt(`/w/${WS}/board`)
+
+    await user.click(screen.getByRole("button", { name: "Actions for Design work" }))
+    await user.click(await screen.findByRole("menuitem", { name: /Set as board home/ }))
+    expect(updatePreferences).toHaveBeenCalledWith({ boardDefaultViewId: "boardview_1" })
+  })
+
+  it("renaming a saved view fires the update mutation with the new name", async () => {
+    const user = userEvent.setup()
+    const { update } = stub({ views: [view()], boardDefaultLens: "all" })
+    mountAt(`/w/${WS}/board`)
+
+    await user.click(screen.getByRole("button", { name: "Actions for Design work" }))
+    await user.click(await screen.findByRole("menuitem", { name: "Rename" }))
+    const input = await screen.findByPlaceholderText("View name")
+    await user.clear(input)
+    await user.type(input, "Renamed")
+    await user.click(screen.getByRole("button", { name: "Rename" }))
+
+    expect(update.mutate).toHaveBeenCalledWith({ id: "boardview_1", input: { name: "Renamed" } })
+  })
+
+  it("deleting a saved view fires the delete mutation", async () => {
+    const user = userEvent.setup()
+    const { remove } = stub({ views: [view()], boardDefaultLens: "all" })
+    mountAt(`/w/${WS}/board`)
+
+    await user.click(screen.getByRole("button", { name: "Actions for Design work" }))
+    await user.click(await screen.findByRole("menuitem", { name: "Delete" }))
+
+    expect(remove.mutate).toHaveBeenCalledWith("boardview_1")
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -147,15 +147,17 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
                   )}
                   <span className="min-w-0 flex-1 truncate">{view.name}</span>
                 </Link>
-                {/* Fixed-footprint trigger — always laid out, transparent until
-                    hover/focus/open — so revealing the actions never shifts the
-                    row (INV-21). Management verbs are actions, not navigation. */}
+                {/* Faint-but-visible resting state (same treatment as the lens
+                    pin below): the sidebar is the ONLY surface managing views
+                    now, and touch has no hover to reveal a hidden trigger.
+                    Fixed footprint per INV-21. Management verbs are actions,
+                    not navigation. */}
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
                       type="button"
                       aria-label={`Actions for ${view.name}`}
-                      className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+                      className="shrink-0 rounded p-1.5 text-muted-foreground/40 transition-colors hover:text-foreground focus-visible:text-foreground group-hover:text-muted-foreground data-[state=open]:text-foreground"
                     >
                       <MoreHorizontal className="h-4 w-4" />
                     </button>

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -1,14 +1,42 @@
-import { useMemo } from "react"
-import { Link, useLocation } from "react-router-dom"
-import { ArrowLeft, Bookmark, Pin } from "lucide-react"
-import { BOARD_LENSES, type BoardLens } from "@threa/types"
-import { useSidebar } from "@/contexts"
+import { useMemo, useState } from "react"
+import { Link, useLocation, useSearchParams } from "react-router-dom"
+import { Archive, ArrowLeft, Bookmark, Check, CircleDot, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
+import { BOARD_LENSES, DEFAULT_BOARD_LENS, type BoardLens, type BoardScopeStreamType } from "@threa/types"
+import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { cn } from "@/lib/utils"
-import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
+import { useBoardHome, useBoardViews, useDeleteBoardView, useUpdateBoardView } from "@/hooks/use-board-views"
 import { useBoardSelection } from "@/hooks/use-board-selection"
-import { isViewActive, lensHref, savedViewHref } from "@/components/board/board-saved-views"
+import { useMuteStream, useUnmuteStream } from "@/hooks/use-conversations"
+import {
+  useWorkspaceDmPeers,
+  useWorkspaceLabels,
+  useWorkspaceStreams,
+  useWorkspaceUsers,
+} from "@/stores/workspace-store"
+import { useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
+import { resolveStreamName } from "@/lib/streams"
+import { isViewActive, lensHref, savedViewHref, SaveViewDialog } from "@/components/board/board-saved-views"
+import {
+  BoardScopePicker,
+  BoardTypePicker,
+  BoardLabelPicker,
+  type FilterIcon,
+} from "@/components/board/board-filter-pickers"
+import {
+  BOARD_ARCHIVED_ON,
+  BOARD_ARCHIVED_PARAM,
+  BOARD_EXCLUDE_LABEL_PARAM,
+  BOARD_EXCLUDE_SCOPE_PARAM,
+  BOARD_EXCLUDE_TYPE_PARAM,
+  BOARD_LABEL_PARAM,
+  BOARD_SCOPE_PARAM,
+  BOARD_TYPE_PARAM,
+  BOARD_UNREAD_ON,
+  BOARD_UNREAD_PARAM,
+} from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { getLastLocation } from "@/lib/last-location"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { BoardFilterChips } from "./board-filter-chips"
 
 interface BoardModeBlockProps {
@@ -27,21 +55,28 @@ const SECTION_LABEL_CLASS =
 /**
  * The board block replaces the quick-links block in the sidebar while on
  * `/board` (board-centered-sidebar-exploration.md § V2 top blocks). Top-to-
- * bottom: a "← Chats" back link to the last visited stream, the viewer's saved
- * Views, and the board Lenses. Every entry is a `<Link>` — the board's whole
- * state is URL (INV-40/INV-59) — and the URLs are built with the same helpers
- * the filter bar uses (`lensHref`, `savedViewHref`) so the two surfaces can't
- * drift (INV-35). The filter axes ride along a lens switch, so scoping survives.
+ * bottom: a "← Chats" back link, the Filters group (the stream/type/label
+ * pickers + the unread/archived toggles the deleted filter header used to host),
+ * the active-filter chips, the viewer's saved Views, and the board Lenses. Every
+ * navigational entry is a `<Link>` — the board's whole state is URL
+ * (INV-40/INV-59) — built with the same helpers the pickers use
+ * (`lensHref`, `savedViewHref`) so the surfaces can't drift (INV-35).
  */
 export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlockProps) {
   const { collapseOnMobile } = useSidebar()
   const location = useLocation()
+  const prefs = usePreferencesOptional()
 
-  // One shared URL derivation (INV-35) — the chips block reads the same hook.
+  // One shared URL derivation (INV-35) — the chips block and filters read it too.
   const { currentLens, selection } = useBoardSelection()
 
   const { data: views } = useBoardViews(workspaceId)
   const { view: homeView } = useBoardHome(workspaceId)
+  const update = useUpdateBoardView(workspaceId)
+  const remove = useDeleteBoardView(workspaceId)
+
+  // `null` closed; `{ id, name }` = renaming that view.
+  const [renaming, setRenaming] = useState<{ id: string; name: string } | null>(null)
 
   // A saved view IS the selection when the live lens + every axis match it, so it
   // — not its base lens — reads as active; a lens is active only when no view is.
@@ -60,6 +95,10 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
     selection.excludeStreamTypes.length > 0 ||
     selection.excludeLabelIds.length > 0
 
+  // No lens reads as home while a saved-view home resolves (the view's pin is home).
+  const homeLens = prefs?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const homeViewActive = homeView != null
+
   return (
     <div className="mb-2 space-y-1">
       <Link
@@ -70,6 +109,8 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
         <ArrowLeft className="h-4 w-4" />
         Chats
       </Link>
+
+      <BoardModeFilters workspaceId={workspaceId} />
 
       {hasActiveFilters && <BoardFilterChips workspaceId={workspaceId} />}
 
@@ -83,20 +124,61 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
             const active = view.id === activeViewId
             const isHome = view.id === homeView?.id
             return (
-              <Link
+              <div
                 key={view.id}
-                to={savedViewHref(workspaceId, view)}
-                onClick={collapseOnMobile}
-                aria-current={active ? "true" : undefined}
-                className={cn(ROW_CLASS, active ? "bg-primary/10" : "hover:bg-muted/50 text-muted-foreground")}
-              >
-                {isHome ? (
-                  <Pin className="h-4 w-4 shrink-0 fill-current" aria-label="Board home" />
-                ) : (
-                  <Bookmark className="h-4 w-4 shrink-0" />
+                className={cn(
+                  "group flex items-center rounded-lg pr-2 transition-colors",
+                  active ? "bg-primary/10" : "hover:bg-muted/50"
                 )}
-                <span className="min-w-0 flex-1 truncate">{view.name}</span>
-              </Link>
+              >
+                <Link
+                  to={savedViewHref(workspaceId, view)}
+                  onClick={collapseOnMobile}
+                  aria-current={active ? "true" : undefined}
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-4 text-sm font-medium",
+                    !active && "text-muted-foreground"
+                  )}
+                >
+                  {isHome ? (
+                    <Pin className="h-4 w-4 shrink-0 fill-current" aria-label="Board home" />
+                  ) : (
+                    <Bookmark className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">{view.name}</span>
+                </Link>
+                {/* Fixed-footprint trigger — always laid out, transparent until
+                    hover/focus/open — so revealing the actions never shifts the
+                    row (INV-21). Management verbs are actions, not navigation. */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`Actions for ${view.name}`}
+                      className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => void prefs?.updatePreferences({ boardDefaultViewId: view.id })}>
+                      <Pin className={cn("mr-2 h-4 w-4", isHome && "fill-current")} />
+                      {isHome ? "Board home" : "Set as board home"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setRenaming({ id: view.id, name: view.name })}>
+                      <Pencil className="mr-2 h-4 w-4" />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => remove.mutate(view.id)}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             )
           })}
         </div>
@@ -109,25 +191,200 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
           const Icon = def.icon
           const active = value === currentLens && activeViewId === null
           const count = lensTotals?.[value] ?? null
+          const isHome = !homeViewActive && value === homeLens
           return (
-            <Link
+            <div
               key={value}
-              to={lensHref(workspaceId, value, location.search)}
-              onClick={collapseOnMobile}
-              aria-current={active ? "true" : undefined}
-              className={cn(ROW_CLASS, active ? "bg-primary/10" : "hover:bg-muted/50 text-muted-foreground")}
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-              <span className="min-w-0 flex-1 truncate">{def.label}</span>
-              {count !== null && (
-                <span aria-hidden className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                  {count}
-                </span>
+              className={cn(
+                "group flex items-center rounded-lg pr-2 transition-colors",
+                active ? "bg-primary/10" : "hover:bg-muted/50"
               )}
-            </Link>
+            >
+              <Link
+                to={lensHref(workspaceId, value, location.search)}
+                onClick={collapseOnMobile}
+                aria-current={active ? "true" : undefined}
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-4 text-sm font-medium",
+                  !active && "text-muted-foreground"
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span className="min-w-0 flex-1 truncate">{def.label}</span>
+                {count !== null && (
+                  <span aria-hidden className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {count}
+                  </span>
+                )}
+              </Link>
+              {/* Always laid out, faint until home — pinning a lens as the board
+                  home mirrors the appearance-settings radio; silent per INV-63
+                  (the fill is the signal), fixed footprint per INV-21. */}
+              <button
+                type="button"
+                onClick={() => void prefs?.updatePreferences({ boardDefaultLens: value, boardDefaultViewId: null })}
+                aria-pressed={isHome}
+                aria-label={isHome ? `${def.label} is your board home` : `Set ${def.label} as board home`}
+                className={cn(
+                  "ml-1 shrink-0 rounded p-1 transition-colors",
+                  isHome ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
+                )}
+              >
+                <Pin className={cn("h-3.5 w-3.5", isHome && "fill-current")} />
+              </button>
+            </div>
           )
         })}
       </div>
+
+      <SaveViewDialog
+        open={renaming !== null}
+        initialName={renaming?.name ?? ""}
+        isRename
+        onOpenChange={(open) => !open && setRenaming(null)}
+        onSubmit={(name) => {
+          if (renaming) update.mutate({ id: renaming.id, input: { name } })
+          setRenaming(null)
+        }}
+      />
     </div>
+  )
+}
+
+/**
+ * The board-mode "Filters" group: the stream/type/label pickers (the same
+ * components the deleted filter header hosted, popover on desktop / drawer on
+ * touch via `FilterMenuShell`) plus the unread-only and archived toggles. Every
+ * control rewrites the board's URL params (INV-59) — the sidebar holds no filter
+ * state, it just navigates. Filter rewrites `replace`, so toggling doesn't spam
+ * history. Shares the URL vocabulary SSOT (`board-filter-params`) with the page.
+ */
+function BoardModeFilters({ workspaceId }: { workspaceId: string }) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { selection } = useBoardSelection()
+
+  const streams = useWorkspaceStreams(workspaceId)
+  const users = useWorkspaceUsers(workspaceId)
+  const dmPeers = useWorkspaceDmPeers(workspaceId)
+  const allLabels = useWorkspaceLabels(workspaceId)
+  const myLabels = useMemo(
+    () => allLabels.filter((l) => !l.archivedAt).sort((a, b) => a.name.localeCompare(b.name)),
+    [allLabels]
+  )
+
+  const muted = useBoardMutedStreamIds(workspaceId)
+  const muteStream = useMuteStream(workspaceId)
+  const unmuteStream = useUnmuteStream(workspaceId)
+
+  const showArchived = searchParams.get(BOARD_ARCHIVED_PARAM) === BOARD_ARCHIVED_ON
+  const unreadOnly = searchParams.get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
+
+  const labelFor = (streamId: string) =>
+    resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
+
+  // The Labels picker only renders when there's something to pick (or a stale URL
+  // names labels the viewer no longer has — keep it so they can clear it).
+  const showLabelsPicker =
+    myLabels.length > 0 || selection.scopeLabelIds.length > 0 || selection.excludeLabelIds.length > 0
+
+  // One URL write per toggle: a dimension's include/exclude params rewrite
+  // together so moving an id between the two sides is a single history entry.
+  const setParamLists = (entries: Array<[param: string, values: string[]]>) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        for (const [param, values] of entries) {
+          if (values.length > 0) next.set(param, values.join(","))
+          else next.delete(param)
+        }
+        return next
+      },
+      { replace: true }
+    )
+  }
+  const setStreamFilter = (include: string[], exclude: string[]) =>
+    setParamLists([
+      [BOARD_SCOPE_PARAM, include],
+      [BOARD_EXCLUDE_SCOPE_PARAM, exclude],
+    ])
+  const setTypeFilter = (include: BoardScopeStreamType[], exclude: BoardScopeStreamType[]) =>
+    setParamLists([
+      [BOARD_TYPE_PARAM, include],
+      [BOARD_EXCLUDE_TYPE_PARAM, exclude],
+    ])
+  const setLabelFilter = (include: string[], exclude: string[]) =>
+    setParamLists([
+      [BOARD_LABEL_PARAM, include],
+      [BOARD_EXCLUDE_LABEL_PARAM, exclude],
+    ])
+
+  return (
+    <div className="pt-1">
+      <h3 className={SECTION_LABEL_CLASS}>Filters</h3>
+      <div className="flex flex-wrap items-center gap-1.5 px-4 py-1">
+        <BoardScopePicker
+          workspaceId={workspaceId}
+          scopeStreamIds={selection.scopeStreamIds}
+          excludeStreamIds={selection.excludeStreamIds}
+          onStreamFilterChange={setStreamFilter}
+          labelFor={labelFor}
+          mutedStreamIds={muted}
+          onToggleMute={(streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId))}
+        />
+        <BoardTypePicker
+          scopeStreamTypes={selection.scopeStreamTypes}
+          excludeStreamTypes={selection.excludeStreamTypes}
+          onTypeFilterChange={setTypeFilter}
+        />
+        {showLabelsPicker && (
+          <BoardLabelPicker
+            myLabels={myLabels}
+            scopeLabelIds={selection.scopeLabelIds}
+            excludeLabelIds={selection.excludeLabelIds}
+            onLabelFilterChange={setLabelFilter}
+          />
+        )}
+      </div>
+      <FilterToggleRow
+        icon={CircleDot}
+        label="Unread only"
+        active={unreadOnly}
+        onToggle={() => setParamLists([[BOARD_UNREAD_PARAM, unreadOnly ? [] : [BOARD_UNREAD_ON]]])}
+      />
+      <FilterToggleRow
+        icon={Archive}
+        label="Archived"
+        active={showArchived}
+        onToggle={() => setParamLists([[BOARD_ARCHIVED_PARAM, showArchived ? [] : [BOARD_ARCHIVED_ON]]])}
+      />
+    </div>
+  )
+}
+
+/** A full-width on/off filter toggle styled like the board-mode nav rows. The
+ *  URL param it reflects is the source of truth (INV-59); it's an action, not a
+ *  navigation, so a button (INV-40). */
+function FilterToggleRow({
+  icon: Icon,
+  label,
+  active,
+  onToggle,
+}: {
+  icon: FilterIcon
+  label: string
+  active: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={cn(ROW_CLASS, "w-full", active ? "bg-primary/10" : "text-muted-foreground hover:bg-muted/50")}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+      {active && <Check className="h-4 w-4 shrink-0" />}
+    </button>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -53,8 +53,8 @@ const SECTION_LABEL_CLASS =
   "m-0 px-4 pb-1 pt-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
 
 /**
- * The board block replaces the quick-links block in the sidebar while on
- * `/board` (board-centered-sidebar-exploration.md § V2 top blocks). Top-to-
+ * The board block sits below the quick links in the sidebar while on `/board`
+ * (board-centered-sidebar-exploration.md § V2 top blocks). Top-to-
  * bottom: a "← Chats" back link, the Filters group (the stream/type/label
  * pickers + the unread/archived toggles the deleted filter header used to host),
  * the active-filter chips, the viewer's saved Views, and the board Lenses. Every

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -232,6 +232,14 @@ export function SidebarStreamList({
         onDragEnd={handleDragEnd}
         onDragCancel={() => setDraggingStreamId(null)}
       >
+        {/* A provided slot renders at its section's position below; when the user's
+            layout has NO quicklinks section it renders first instead of vanishing.
+            Chats mode never hits this (its slot is built only when the section
+            exists) — it exists for board mode, whose slot carries the board's
+            filters/views/lenses and must survive the section's removal. */}
+        {quickLinksSlot && !resolvedSections.some(({ section }) => section.spec.kind === "quicklinks")
+          ? quickLinksSlot
+          : null}
         {resolvedSections.map(({ section, items }) => {
           // The Quick Links block renders its own link list at this position. The
           // slot owns its spacing (and may render null when every link is hidden),

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -366,30 +366,44 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // removing the section from the editor takes it out of both the normal list
   // (resolved as a positioned section) and the empty-streams state.
   const hasQuickLinksSection = sidebarConfig.sections.some((s) => s.spec.kind === "quicklinks")
-  // On `/board` the board block replaces the quick-links block in place; every
-  // other surface keeps the unchanged quick links.
+  const quickLinks = hasQuickLinksSection ? (
+    <SidebarQuickLinks
+      workspaceId={workspaceId}
+      quickLinks={sidebarConfig.quickLinks}
+      isDraftsPage={isDraftsPage}
+      draftCount={draftCount}
+      isSavedPage={isSavedPage}
+      savedCount={savedCount}
+      isScheduledPage={isScheduledPage}
+      scheduledCount={scheduledCount}
+      isActivityPage={isActivityPage}
+      isMemoryPage={isMemoryPage}
+      isFilesPage={isFilesPage}
+      isLabelsPage={isLabelsPage}
+      unreadActivityCount={unreadActivityCount}
+    />
+  ) : null
+  // Board mode keeps the board block (its filters/views/lenses) available even
+  // when the user drops the quick-links section, so the quick links sit above it
+  // only when present. Chats mode pairs the `Board` entry row with the quick
+  // links and stays hidden without the section, as it always has.
   let quickLinksSlot: ReactNode
-  if (hasQuickLinksSection) {
-    quickLinksSlot = isBoardPage ? (
-      <BoardModeBlock workspaceId={workspaceId} userId={user?.id ?? null} lensTotals={boardMode?.lensTotals ?? null} />
-    ) : (
+  if (isBoardPage) {
+    quickLinksSlot = (
+      <>
+        {quickLinks}
+        <BoardModeBlock
+          workspaceId={workspaceId}
+          userId={user?.id ?? null}
+          lensTotals={boardMode?.lensTotals ?? null}
+        />
+      </>
+    )
+  } else if (hasQuickLinksSection) {
+    quickLinksSlot = (
       <>
         <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
-        <SidebarQuickLinks
-          workspaceId={workspaceId}
-          quickLinks={sidebarConfig.quickLinks}
-          isDraftsPage={isDraftsPage}
-          draftCount={draftCount}
-          isSavedPage={isSavedPage}
-          savedCount={savedCount}
-          isScheduledPage={isScheduledPage}
-          scheduledCount={scheduledCount}
-          isActivityPage={isActivityPage}
-          isMemoryPage={isMemoryPage}
-          isFilesPage={isFilesPage}
-          isLabelsPage={isLabelsPage}
-          unreadActivityCount={unreadActivityCount}
-        />
+        {quickLinks}
       </>
     )
   }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -283,29 +283,6 @@ describe("BoardPage", () => {
     expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board?lens=all`)
   })
 
-  it("clears everything — including the saved-view home's own scope — keeping an open panel", async () => {
-    // "Clear filters" means everything (?lens=all), not "back to the home": the
-    // home's own filters must clear too, and the target is never the bare entry
-    // alias (which would bounce straight back). The open `?panel=` rides along.
-    vi.mocked(contextsModule.usePreferences).mockReturnValue({
-      preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    mountBoard([], {
-      boardViews: [makeBoardView()],
-      entry: `/w/${WORKSPACE_ID}/board?lens=active&is=channel&in=stream_x&panel=conv%3Aabc`,
-    })
-    const clear = await screen.findByRole("link", { name: "Clear filters" })
-    const url = new URL(clear.getAttribute("href") ?? "", "http://x")
-    expect(url.pathname).toBe(`/w/${WORKSPACE_ID}/board`)
-    expect(url.searchParams.get("lens")).toBe("all") // explicit — never the bare alias
-    expect(url.searchParams.get("panel")).toBe("conv:abc") // the open thread survives
-    expect(url.searchParams.get("is")).toBeNull() // the home view's own scope clears
-    expect(url.searchParams.get("in")).toBeNull() // the extra narrowing clears
-  })
-
   it("stays put when a saved view is pinned as home while on an explicit board URL", async () => {
     // Pinning a view as home is a preference change, not a navigation. Rendered
     // board URLs always carry `?lens=`, so the entry-alias redirect (which only
@@ -328,25 +305,6 @@ describe("BoardPage", () => {
 
     expect(screen.getByTestId("location").textContent).toBe(`/w/${WORKSPACE_ID}/board?lens=all`)
     expect(screen.getByText("Board still here.")).toBeTruthy()
-  })
-
-  it("shows no 'Clear filters' on the unfiltered All lens (the absolute baseline)", async () => {
-    const post = makePost({ id: "conv_x" }, { contentMarkdown: "A topic." })
-    mountBoard([post], { entry: `/w/${WORKSPACE_ID}/board?lens=all` })
-    await screen.findByText("A topic.")
-    expect(screen.queryByText("Clear filters")).toBeNull()
-  })
-
-  it("shows 'Clear filters' on a non-All lens — even the viewer's own home lens", async () => {
-    // A Mine home landing is still a narrowing of everything; its lens must be
-    // clearable (the home-relative baseline hid the affordance here).
-    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
-      preferences: { boardDefaultLens: "mine" },
-    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
-    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
-    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board?lens=mine` })
-    await screen.findByText("My own topic.")
-    expect(screen.getByText("Clear filters")).toBeTruthy()
   })
 
   it("shows the empty state without a 'Show everything' CTA on the unfiltered All lens", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -21,12 +21,7 @@ import {
 import { useStableBoardView, type BoardViewFilter, type BoardViewPost } from "@/hooks/use-stable-board-view"
 import { selectLabeledStreamIds } from "@/hooks/use-labels"
 import { useBoardStreamSubscriptions } from "@/hooks/use-board-stream-subscriptions"
-import {
-  useWorkspaceConversations,
-  useBoardExclusions,
-  useMuteStream,
-  useUnmuteStream,
-} from "@/hooks/use-conversations"
+import { useWorkspaceConversations, useBoardExclusions } from "@/hooks/use-conversations"
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
 import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
@@ -44,7 +39,6 @@ import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { openCompose, registerComposeOnPosted } from "@/stores/compose-overlay-store"
 import { setBoardFlash } from "@/stores/board-flash-store"
-import { BoardFilterBar } from "@/components/board/board-filter-bar"
 import { boardHomeHref } from "@/components/board/board-saved-views"
 import { useBoardViews } from "@/hooks/use-board-views"
 import { isBoardFiltered } from "@/lib/board/filter-state"
@@ -71,7 +65,6 @@ import {
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   type BoardLens,
-  type BoardScopeStreamType,
   type ConversationWithStaleness,
 } from "@threa/types"
 
@@ -211,7 +204,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // Id lists are deduped and capped at the shared server limits so a hand-built
   // URL can't produce a request the backend rejects; type tokens outside the
   // root grains are dropped rather than 400ing the fetch.
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
   const scopeParam = searchParams.get(BOARD_SCOPE_PARAM) ?? ""
   const scopeStreamIds = useMemo(() => parseIdListParam(scopeParam).slice(0, MAX_BOARD_SCOPE_STREAMS), [scopeParam])
   const excludeScopeParam = searchParams.get(BOARD_EXCLUDE_SCOPE_PARAM) ?? ""
@@ -306,38 +299,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       showArchived,
     ]
   )
-  // One URL write per toggle: a dimension's include/exclude params are rewritten
-  // together so moving an id between the two sides is a single history entry.
-  const setParamLists = (entries: Array<[param: string, values: string[]]>) => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev)
-        for (const [param, values] of entries) {
-          if (values.length > 0) next.set(param, values.join(","))
-          else next.delete(param)
-        }
-        return next
-      },
-      { replace: true }
-    )
-  }
-  const setStreamFilter = (include: string[], exclude: string[]) =>
-    setParamLists([
-      [BOARD_SCOPE_PARAM, include],
-      [BOARD_EXCLUDE_SCOPE_PARAM, exclude],
-    ])
-  const setTypeFilter = (include: BoardScopeStreamType[], exclude: BoardScopeStreamType[]) =>
-    setParamLists([
-      [BOARD_TYPE_PARAM, include],
-      [BOARD_EXCLUDE_TYPE_PARAM, exclude],
-    ])
-  const setLabelFilter = (include: string[], exclude: string[]) =>
-    setParamLists([
-      [BOARD_LABEL_PARAM, include],
-      [BOARD_EXCLUDE_LABEL_PARAM, exclude],
-    ])
-  const setShowArchived = (next: boolean) => setParamLists([[BOARD_ARCHIVED_PARAM, next ? [BOARD_ARCHIVED_ON] : []]])
-  const setUnreadOnly = (next: boolean) => setParamLists([[BOARD_UNREAD_PARAM, next ? [BOARD_UNREAD_ON] : []]])
   const {
     containerRef,
     panelWidth,
@@ -376,8 +337,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   useBoardExclusions(workspaceId)
   const hidden = useBoardHiddenConversations(workspaceId)
   const muted = useBoardMutedStreamIds(workspaceId)
-  const muteStream = useMuteStream(workspaceId)
-  const unmuteStream = useUnmuteStream(workspaceId)
   const exclusions = useMemo(
     () => ({ hidden, muted, muteActive: scopeStreamIds.length === 0 }),
     [hidden, muted, scopeStreamIds.length]
@@ -768,25 +727,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         <LayoutGrid className="h-5 w-5 shrink-0 text-muted-foreground" />
         <h1 className="truncate font-semibold">Board</h1>
       </header>
-      <BoardFilterBar
-        workspaceId={workspaceId}
-        lens={lens}
-        scopeStreamIds={scopeStreamIds}
-        excludeStreamIds={excludeStreamIds}
-        onStreamFilterChange={setStreamFilter}
-        scopeStreamTypes={scopeStreamTypes}
-        excludeStreamTypes={excludeStreamTypes}
-        onTypeFilterChange={setTypeFilter}
-        scopeLabelIds={scopeLabelIds}
-        excludeLabelIds={excludeLabelIds}
-        onLabelFilterChange={setLabelFilter}
-        mutedStreamIds={muted}
-        onToggleMute={(streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId))}
-        showArchived={showArchived}
-        onToggleArchived={setShowArchived}
-        unreadOnly={unreadOnly}
-        onToggleUnreadOnly={setUnreadOnly}
-      />
       <span className="sr-only" role="status" aria-live="polite">
         {newCount > 0 ? `${newCount} new ${newCount === 1 ? "post" : "posts"} available` : ""}
       </span>


### PR DESCRIPTION
## Problem

Board mode REPLACED the sidebar quick-links block with `BoardModeBlock`, so Drafts/Saved/Files/Scheduled/Memory/Labels/Activity disappeared whenever you were on the board. Kris flagged it during the drafts dogfood ("the board view has none of the Quick links in the sidebar, but that's for later" — later is now).

## Solution

`sidebar.tsx` builds the `SidebarQuickLinks` element once and renders it in BOTH modes: chats mode keeps `BoardLinkRow` + quick links; board mode renders quick links ABOVE `BoardModeBlock`. Same component, same sidebar-config ordering/visibility (incl. #1312 retired-key tolerance), same `collapseOnMobile` behavior.

**Fix folded in (verifier-caught, pre-existing from the parent PR):** `BoardModeBlock` was only rendered inside `if (hasQuickLinksSection)` — a user who removed the Quick Links section via the sidebar editor would silently lose ALL board filtering/views/lenses on `/board`. Board mode now always renders `BoardModeBlock`; only the quick-links child is gated on the section being enabled.

The 2-lens verify also killed an intermediate `composeQuickLinksSlot` helper module as unwarranted abstraction (INV-36) — final shape is plain JSX in `sidebar.tsx`.

## Modified files

| File | Change |
| ---- | ------ |
| `components/layout/sidebar/sidebar.tsx` | Quick links rendered in both modes; BoardModeBlock ungated from the quick-links section |
| `components/layout/sidebar/board-mode-block.tsx` | Stale "replaces the quick-links block" docstring corrected |

## Test plan

- [x] From `apps/frontend`: sidebar suites — 213 pass, 0 fail; `tsc --noEmit` clean
- [x] Opus 2-lens verify, 2 fix rounds: blocking tsc error in an intermediate test file resolved by deleting the abstraction it tested; the `hasQuickLinksSection` gating hole fixed; final round clean
- [x] Live-verified on dev:test (scripted Playwright, 1440px + 390px): quick links render on `/board` above the Filters group; mobile drawer shows them too

Stacked on #1337 (`feat/board-sidebar-owns-filters`).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786574884&installation_id=129946197&pr_number=1340&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1340&signature=e733c7bbd882727c9da76f5e458d64b1551d0e2ae5cd0f11736cb5d7df855460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->