### PR TITLE
fix(frontend): board auto-read pin releases on the next attention cycle

### DIFF
--- a/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
@@ -401,6 +401,78 @@ describe("useConversationAutoRead", () => {
     expect(markRead).toHaveBeenCalledWith("m_a")
   })
 
+  it("wedge fix: a pin on a static, continuously-attended card releases on a blur→refocus cycle", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    const { rerender } = mount(messages, { m_a: "unread", m_b: "unread" })
+
+    // Rows are on screen; the viewer marks the card unread while attentive.
+    enter("m_a", "m_b")
+    act(() => explicitUnreadPin!())
+
+    // Static board, attention never drops: the pin sticks, nothing re-reads —
+    // the exact wedge that used to persist forever.
+    advance(60_000)
+    expect(markRead).not.toHaveBeenCalled()
+
+    // The viewer tabs away and back: a genuine re-attention boundary.
+    attention = false
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+    attention = true
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+
+    // The rebuilt observer sees the rows still on screen; the pin has released,
+    // so they dwell and auto-read.
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_b")
+  })
+
+  it("stick-while-looking: a pin with no re-attention boundary never auto-reads", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "unread", m_b: "unread" })
+
+    enter("m_a", "m_b")
+    act(() => explicitUnreadPin!())
+
+    // No blur, no leave — the viewer keeps looking. Re-reported intersections of
+    // the still-on-screen rows must not un-stick the pin.
+    advance(60_000)
+    enter("m_a", "m_b")
+    advance(60_000)
+    expect(markRead).not.toHaveBeenCalled()
+  })
+
+  it("cross-device pin parity: a regression pin engaged while attentive releases on the same attention cycle", () => {
+    const messages = [msg("m_a", 0, "1"), msg("m_b", 1, "2")]
+    messages.forEach((m) => addRow(m.id))
+    readTruth[ROOT] = { lastReadSequence: "2", readMessageIds: [] }
+    const { rerender } = mount(messages, { m_a: "read", m_b: "read" })
+
+    // On screen and attentive; another device marks unread from m_a — the
+    // watermark regresses and the rows derive unread.
+    enter("m_a", "m_b")
+    readTruth[ROOT] = { lastReadSequence: "0", readMessageIds: [] }
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+
+    // Pinned: static + attentive → no re-mark.
+    advance(10_000)
+    expect(markRead).not.toHaveBeenCalled()
+
+    // The same blur→refocus boundary releases the cross-device pin too.
+    attention = false
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+    attention = true
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_b")
+  })
+
   it("releases the dedup after a failed mark so a later evaluation retries", async () => {
     markRead.mockRejectedValueOnce(new Error("offline"))
     const messages = [msg("m_a", 0), msg("m_b", 1)]

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -88,14 +88,30 @@ interface UseConversationAutoReadOptions {
  *   state: derivation flaps (the `unreadCounts === 0` short-circuit falling
  *   back to a stale frontier when a count leaves zero, a stale `lastReadAt`
  *   time fallback after compaction) would read as mass regressions and
- *   false-pin — and a pinned card on a static board never releases, wedging
- *   auto-read (first dogfood's board failure). Suppression covers all
- *   eligible rows, not just the currently-visible set: visibility is
- *   unknowable across observer teardowns (attention loss, id-set changes),
- *   and under-suppressing would let a still-on-screen row dwell and
- *   cutoff-mark right back over the explicit unread. Each row's suppression
- *   releases when the observer reports it off-screen — immediately for rows
- *   that weren't visible, on leave for the ones that were.
+ *   false-pin. Suppression covers all eligible rows, not just the
+ *   currently-visible set: visibility is unknowable across observer teardowns
+ *   (attention loss, id-set changes), and under-suppressing would let a
+ *   still-on-screen row dwell and cutoff-mark right back over the explicit
+ *   unread.
+ * - Pin release — the mark sticks while the viewer keeps looking (that IS the
+ *   pin's purpose) and lifts only at the next genuine RE-ATTENTION boundary,
+ *   never on a timer. Two boundaries release it:
+ *   (a) Per-row viewport exit — a row's observer reporting it off-screen
+ *       releases that row's suppression (immediately for rows that were never
+ *       visible after a rebuild, on leave for the ones that were). A static
+ *       board never fires this, which is why (b) exists.
+ *   (b) Attention cycle — a blur→refocus (or hide→show on a phone-like device,
+ *       per `useAutoReadAttention`) lifts the whole pin, but only once the
+ *       viewer has ATTENDED to it: a pin engaged while attentive that then
+ *       loses and regains attention has crossed the boundary; a pin engaged
+ *       while attention is off (a background cross-device regression) treats
+ *       the coming refocus as the viewer's first look, not a boundary, and
+ *       waits for the cycle AFTER that. This is the board wedge fix — a static,
+ *       continuously-focused card that earlier never released now releases the
+ *       moment the viewer tabs away and back.
+ *   Unmounting the surface (panel close, card scrolled off the board window)
+ *   discards the pin with the hook's refs; a remount re-reads from a clean
+ *   slate, so navigate-away-and-back is a third, implicit release.
  * - A pending debounce fires on unmount, and without re-checking attention:
  *   the dwell already happened while the viewer was attending, so the read is
  *   real — only the batching timer is late.
@@ -112,6 +128,8 @@ export function useConversationAutoRead({
   getReadTruth,
 }: UseConversationAutoReadOptions): void {
   const canAutoRead = useAutoReadAttention()
+  const canAutoReadRef = useRef(canAutoRead)
+  canAutoReadRef.current = canAutoRead
 
   const eligible = messages.filter((m) => !m.id.startsWith("temp_"))
   const eligibleIdsKey = eligible.map((m) => m.id).join(",")
@@ -129,6 +147,12 @@ export function useConversationAutoRead({
   const dwellTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>())
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
+  // The attention-cycle release state (see the pin doc): whether the viewer has
+  // attended to the page since the pin engaged, and whether attention has since
+  // dropped. A pin engaged while attentive that then loses and regains attention
+  // has crossed a full re-attention boundary and releases.
+  const pinAttendedRef = useRef(false)
+  const pinBlurredAfterAttendedRef = useRef(false)
 
   const stateOf = useCallback(
     (m: RenderableMessage): RowReadState =>
@@ -198,7 +222,26 @@ export function useConversationAutoRead({
     }
     lastMarkedRef.current = null
     for (const m of eligibleRef.current) suppressedRef.current.add(m.id)
+    // Baseline the attention-cycle release: a pin engaged while the viewer is
+    // attending starts "attended", so the next blur→refocus releases it. A pin
+    // engaged while attention is off (a cross-device regression that lands in
+    // the background) is NOT attended yet — the coming refocus is the viewer's
+    // FIRST look at it, not a re-attention boundary, so it must not release.
+    pinAttendedRef.current = canAutoReadRef.current
+    pinBlurredAfterAttendedRef.current = false
   }, [])
+
+  /** Lift the whole pin (all suppressions) — the attention-cycle release. */
+  const releasePin = useCallback(() => {
+    suppressedRef.current.clear()
+    pinAttendedRef.current = false
+    pinBlurredAfterAttendedRef.current = false
+    // Rows that became `seen` mid-pin (a reply streaming in dwells into seenRef
+    // while evaluate is blocked) re-fire as already-seen after release and never
+    // re-schedule — evaluate once now so they mark immediately instead of
+    // waiting for an unrelated future dwell.
+    scheduleEvaluate()
+  }, [scheduleEvaluate])
 
   // The controller invokes this synchronously at the top of the menu "Mark as
   // unread", before the request departs — closing the window where a pending
@@ -207,6 +250,29 @@ export function useConversationAutoRead({
     registerExplicitUnread(pin)
     return () => registerExplicitUnread(null)
   }, [registerExplicitUnread, pin])
+
+  // The attention-cycle arm of the pin release: a blur→refocus (or, on a
+  // phone-like device, a hide→show) after the viewer has attended to the pin is
+  // a genuine re-attention boundary — the pin has served its "don't re-read what
+  // I just marked" purpose and lifts. Runs before the observer effect so the
+  // rebuilt observer re-arms against cleared suppressions.
+  useEffect(() => {
+    if (suppressedRef.current.size === 0) {
+      pinAttendedRef.current = false
+      pinBlurredAfterAttendedRef.current = false
+      return
+    }
+    if (canAutoRead) {
+      if (pinBlurredAfterAttendedRef.current) {
+        autoReadDebug("pin: released on re-attention")
+        releasePin()
+      } else {
+        pinAttendedRef.current = true
+      }
+    } else if (pinAttendedRef.current) {
+      pinBlurredAfterAttendedRef.current = true
+    }
+  }, [canAutoRead, releasePin])
 
   const cancelDwell = (id: string) => {
     const timer = dwellTimersRef.current.get(id)


### PR DESCRIPTION
## Problem

Kris reported messages clearly inside the board viewport not turning read. Root cause was already documented in the hook itself: an explicit "Mark as unread" (local menu action, or a cross-device read-truth regression detected via watermark/overlay diffing) "pins" the card — suppressing every row's auto-read — and suppression only released when a row's IntersectionObserver reported it LEAVING the viewport. A short board that never scrolls stays wedged forever; the code's own comment called it "the first dogfood's board failure". This is the 5th footgun in the board/timeline auto-read family, so the fix is deliberately narrow and test-anchored.

## Solution

The pin gains a second, deterministic release boundary: the **attention cycle** — matching the timeline unread-divider latch semantics from #1262.

- Mark-as-unread still STICKS while the user keeps looking (that is the pin's purpose): no release trigger → never auto-reads, and re-reported intersections do not un-stick it.
- A blur→refocus cycle releases the pin: leaving and coming back is a new attention session, so what's on screen reads as read again.
- A pin that lands while attention is OFF (a cross-device regression arriving in the background) is not yet "attended" — the coming refocus is the viewer's FIRST look, so it takes a full further cycle to release. This preserves the existing regression-while-blurred test.
- `releasePin` schedules one evaluate so rows that became `seen` mid-pin (a reply streaming in) mark immediately on release instead of waiting for an unrelated future dwell (verifier-caught).
- Per-row viewport-exit release stays; unmount→remount releases implicitly (fresh refs). Deliberately NO pointer-down release (clicking to react/quote must not clear a pin the user wants kept) and NO time-based release (per the design brief).

The hook header now states the release contract instead of the old failure admission.

## Test plan

- [x] `use-conversation-auto-read.test.tsx` — 18 pass (15 pre-existing + 3 new: wedge release, stick-while-looking, cross-device parity), plus `board-card-auto-read` + `use-auto-mark-as-read` — 11 pass; `tsc --noEmit` clean
- [x] Opus 2-lens verify: reusability lens fully clean (single-owner hook, #1262 pattern reuse, no speculative abstraction); correctness lens's one minor (missing evaluate on release) fixed
- [ ] Not live-verified against Kris's original repro — he never confirmed the trigger path (asked 2026-07-12); the fix addresses the documented wedge, and `window.__threaAutoReadDebug = true` remains available if the report recurs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786581981&installation_id=129946197&pr_number=1344&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1344&signature=2a38384268e22ad05c38247ab062ff8f64492abd0cb6533b27670c245fe15c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->