### PR TITLE
feat(frontend): add app status and manual updates

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -390,7 +390,7 @@ no separate "see all" route.
 
 - `sidebar-header.tsx` — workspace switcher, search affordance.
 - `sidebar-actions.tsx` — per-row contextual action menu/drawer.
-- `sidebar-footer.tsx` — settings, account, etc.
+- `sidebar-footer.tsx` — settings, AI usage, app status, admin portal, and account actions.
 - `quick-links.tsx` — top-level nav (Drafts, Saved, Scheduled, Threads, Activity, Memory, Files).
 - `scratchpad-item.tsx` — scratchpad-specific row variant.
 - `use-urgency-tracking.ts` — drives `urgencyBlocks` exposed by `useSidebar()`.
@@ -427,6 +427,7 @@ Workspace-scoped (`/w/:workspaceId`):
 - `/memos/:memoId` — `LegacyMemoRedirect` → `/memory?memo=…`.
 - `/share` — `SharePickerPage` (in-app share picker).
 - `/admin/ai-usage` — `AIUsageAdminPage`.
+- `/app-status` — `AppStatusPage` (build metadata, device readiness, and manual PWA update checks).
 
 ---
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
@@ -131,6 +131,7 @@ describe("SidebarFooter", () => {
     // status set in this fixture, so it invites the user to set one).
     expect(screen.getByRole("button", { name: "Set a status" })).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "AI Usage" })).toHaveAttribute("href", "/w/workspace_1/admin/ai-usage")
+    expect(screen.getByRole("link", { name: "App status" })).toHaveAttribute("href", "/w/workspace_1/app-status")
 
     // A single Settings entry — Profile is the dialog's default tab, not a
     // second menu row into the same dialog.

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -7,6 +7,7 @@ import {
   DollarSign,
   FileText,
   Hash,
+  Info,
   ListChecks,
   LogOut,
   Moon,
@@ -424,6 +425,13 @@ export function SidebarFooter({
             } satisfies SidebarActionItem,
           ]
         : []),
+      {
+        id: "app-status",
+        label: "App status",
+        icon: Info,
+        href: `/w/${workspaceId}/app-status`,
+        onSelect: collapseOnMobile,
+      },
       {
         id: "switch-account",
         label: "Switch account",

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -417,9 +417,11 @@ export async function checkForAppUpdate(): Promise<ManualUpdateCheckResult> {
   const latestPromise = fetchLatestVersion()
   await requestRegistrationUpdate(registration)
 
-  const waiting = registration.waiting ?? (await waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS))
+  if (!registration.waiting) {
+    await waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS)
+  }
   const latest = await settleWithin(latestPromise, CLICK_UPDATE_TIMEOUT_MS, null)
-  if (waiting) return { status: "ready", latestVersion: latest }
+  if (registration.waiting) return { status: "ready", latestVersion: latest }
   if (shouldRecoverForVersion(currentAppVersion(), latest)) {
     return { status: "available", latestVersion: latest }
   }

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useState } from "react"
+import { useEffect, useCallback, useRef, useState, useSyncExternalStore } from "react"
 import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
@@ -104,21 +104,43 @@ function waitForInstallingWorker(
   })
 }
 
+function settleWithin<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(fallback), timeoutMs)
+    void promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(fallback)
+      }
+    )
+  })
+}
+
+function requestRegistrationUpdate(registration: ServiceWorkerRegistration): Promise<boolean> {
+  try {
+    return settleWithin(
+      registration.update().then(() => true),
+      CLICK_UPDATE_TIMEOUT_MS,
+      false
+    )
+  } catch {
+    return Promise.resolve(false)
+  }
+}
+
 async function findWaitingWorker(registration: ServiceWorkerRegistration): Promise<ServiceWorker | null> {
   if (registration.waiting) return registration.waiting
 
   const alreadyInstalling = await waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS)
   if (registration.waiting || alreadyInstalling) return registration.waiting ?? alreadyInstalling
 
-  try {
-    // update() has no timeout of its own; on a stalled mobile network the
-    // awaited click would look dead for as long as the browser waits. Bound it
-    // and fall through — a plain reload is offline-safe, and reconcilePostReload
-    // catches a reload that landed stale.
-    await Promise.race([registration.update(), new Promise((resolve) => setTimeout(resolve, CLICK_UPDATE_TIMEOUT_MS))])
-  } catch {
-    return null
-  }
+  // update() has no timeout of its own; bound user-triggered checks so a stalled
+  // mobile network cannot leave the action looking dead indefinitely.
+  await requestRegistrationUpdate(registration)
   if (registration.waiting) return registration.waiting
   return waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS)
 }
@@ -307,6 +329,37 @@ export function currentAppBuiltAt(): string | null {
   return typeof __APP_BUILT_AT__ === "string" ? __APP_BUILT_AT__ : null
 }
 
+export function currentAppInstalledAt(now: Date = new Date()): Date | null {
+  const version = currentAppVersion()
+  if (!version) return null
+
+  try {
+    const key = `app-version-installed-at:${version}`
+    const stored = localStorage.getItem(key)
+    if (stored) {
+      const parsed = new Date(stored)
+      if (!Number.isNaN(parsed.getTime())) return parsed
+    }
+    localStorage.setItem(key, now.toISOString())
+    return now
+  } catch {
+    return null
+  }
+}
+
+export function useIsServiceWorkerControlled(): boolean {
+  return useSyncExternalStore(
+    (notify) => {
+      const serviceWorker = navigator.serviceWorker
+      if (!serviceWorker) return () => {}
+      serviceWorker.addEventListener("controllerchange", notify)
+      return () => serviceWorker.removeEventListener("controllerchange", notify)
+    },
+    () => Boolean(navigator.serviceWorker?.controller),
+    () => false
+  )
+}
+
 /**
  * The latest deployed build version from the server, or null if it can't be read.
  * `no-store` bypasses the HTTP cache; `/version.json` is excluded from the SW's
@@ -392,14 +445,11 @@ export async function checkForAppUpdate(): Promise<ManualUpdateCheckResult> {
       : { status: "offline", latestVersion: null }
   }
 
-  try {
-    await registration.update()
-  } catch {
-    // The version probe below distinguishes offline from an otherwise failed check.
-  }
+  const latestPromise = fetchLatestVersion()
+  await requestRegistrationUpdate(registration)
 
   const waiting = registration.waiting ?? (await waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS))
-  const latest = await fetchLatestVersion()
+  const latest = await settleWithin(latestPromise, CLICK_UPDATE_TIMEOUT_MS, null)
   if (waiting) return { status: "ready", latestVersion: latest }
   if (shouldRecoverForVersion(currentAppVersion(), latest)) {
     return { status: "available", latestVersion: latest }

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -444,6 +444,7 @@ export function useManualAppUpdate(): {
   const [state, setState] = useState<ManualUpdateState>("idle")
   const [latestVersion, setLatestVersion] = useState<string | null>(null)
   const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null)
+  const readyRef = useRef(false)
 
   useEffect(() => {
     const serviceWorker = navigator.serviceWorker
@@ -454,7 +455,10 @@ export function useManualAppUpdate(): {
     const workerCleanups: Array<() => void> = []
 
     const adoptWaitingWorker = () => {
-      if (!disposed && registration?.waiting) setState("ready")
+      if (disposed || !registration?.waiting) return
+      readyRef.current = true
+      setLatestVersion(null)
+      setState("ready")
     }
     const trackInstalling = (worker: ServiceWorker | null) => {
       if (!worker) return
@@ -495,11 +499,15 @@ export function useManualAppUpdate(): {
     setState("checking")
     try {
       const result = await checkForAppUpdate()
+      if (readyRef.current && result.status !== "ready") return
+      if (result.status === "ready") readyRef.current = true
       setLatestVersion(result.latestVersion)
       setState(result.status)
     } catch {
-      setLatestVersion(null)
-      setState(navigator.onLine ? "unavailable" : "offline")
+      if (!readyRef.current) {
+        setLatestVersion(null)
+        setState(navigator.onLine ? "unavailable" : "offline")
+      }
     } finally {
       setLastCheckedAt(new Date())
     }

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -4,6 +4,9 @@ import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
 import * as swRecovery from "@/lib/sw-recovery"
 import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
+import { currentAppVersion } from "@/lib/app-build"
+
+export { currentAppBuiltAt, currentAppInstalledAt, currentAppVersion } from "@/lib/app-build"
 
 export const APP_UPDATE_POLL_INTERVAL_MS = 300_000
 const TOAST_ID = "app-update"
@@ -12,12 +15,6 @@ const IS_DEV = import.meta.env.DEV
 export const WAITING_WORKER_TIMEOUT_MS = 1500
 export const RELOAD_FALLBACK_TIMEOUT_MS = 3000
 export const CLICK_UPDATE_TIMEOUT_MS = 5000
-
-// The build version baked into this bundle at build time (vite `define`). The
-// running app otherwise has no idea which build it is, so it can't tell whether a
-// reload actually swapped in new code — see reconcilePostReload.
-declare const __APP_VERSION__: string
-declare const __APP_BUILT_AT__: string
 
 // True only in the Playwright E2E build (vite `define`, gated on VITE_BACKEND_PORT).
 // The update toast uses `duration: Infinity` and renders in the aria-live
@@ -317,34 +314,6 @@ async function announceIfPageStale(registration: ServiceWorkerRegistration): Pro
   if (registration.waiting || registration.installing) return
   announcedStaleVersion = latest
   showUpdateToast()
-}
-
-/** This bundle's build version, or null if the `define` wasn't applied (e.g. some test envs). */
-export function currentAppVersion(): string | null {
-  return typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null
-}
-
-/** UTC timestamp for when this bundle was built. */
-export function currentAppBuiltAt(): string | null {
-  return typeof __APP_BUILT_AT__ === "string" ? __APP_BUILT_AT__ : null
-}
-
-export function currentAppInstalledAt(now: Date = new Date()): Date | null {
-  const version = currentAppVersion()
-  if (!version) return null
-
-  try {
-    const key = `app-version-installed-at:${version}`
-    const stored = localStorage.getItem(key)
-    if (stored) {
-      const parsed = new Date(stored)
-      if (!Number.isNaN(parsed.getTime())) return parsed
-    }
-    localStorage.setItem(key, now.toISOString())
-    return now
-  } catch {
-    return null
-  }
 }
 
 export function useIsServiceWorkerControlled(): boolean {

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -445,6 +445,52 @@ export function useManualAppUpdate(): {
   const [latestVersion, setLatestVersion] = useState<string | null>(null)
   const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null)
 
+  useEffect(() => {
+    const serviceWorker = navigator.serviceWorker
+    if (!serviceWorker) return
+
+    let disposed = false
+    let registration: ServiceWorkerRegistration | null = null
+    const workerCleanups: Array<() => void> = []
+
+    const adoptWaitingWorker = () => {
+      if (!disposed && registration?.waiting) setState("ready")
+    }
+    const trackInstalling = (worker: ServiceWorker | null) => {
+      if (!worker) return
+      if (worker.state === "installed" || worker.state === "activated" || worker.state === "redundant") {
+        adoptWaitingWorker()
+        return
+      }
+      const onStateChange = () => {
+        adoptWaitingWorker()
+        if (worker.state === "installed" || worker.state === "redundant") {
+          worker.removeEventListener("statechange", onStateChange)
+        }
+      }
+      worker.addEventListener("statechange", onStateChange)
+      workerCleanups.push(() => worker.removeEventListener("statechange", onStateChange))
+    }
+    const onUpdateFound = () => {
+      adoptWaitingWorker()
+      trackInstalling(registration?.installing ?? null)
+    }
+
+    void serviceWorker.getRegistration().then((found) => {
+      if (!found || disposed) return
+      registration = found
+      adoptWaitingWorker()
+      trackInstalling(found.installing)
+      found.addEventListener("updatefound", onUpdateFound)
+    })
+
+    return () => {
+      disposed = true
+      registration?.removeEventListener("updatefound", onUpdateFound)
+      for (const cleanup of workerCleanups) cleanup()
+    }
+  }, [])
+
   const check = useCallback(async () => {
     setState("checking")
     try {

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -1,11 +1,11 @@
-import { useEffect, useCallback, useRef } from "react"
+import { useEffect, useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
 import * as swRecovery from "@/lib/sw-recovery"
 import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
 
-const POLL_INTERVAL = 300_000 // 5 minutes
+export const APP_UPDATE_POLL_INTERVAL_MS = 300_000
 const TOAST_ID = "app-update"
 const IS_DEV = import.meta.env.DEV
 
@@ -17,6 +17,7 @@ export const CLICK_UPDATE_TIMEOUT_MS = 5000
 // running app otherwise has no idea which build it is, so it can't tell whether a
 // reload actually swapped in new code — see reconcilePostReload.
 declare const __APP_VERSION__: string
+declare const __APP_BUILT_AT__: string
 
 // True only in the Playwright E2E build (vite `define`, gated on VITE_BACKEND_PORT).
 // The update toast uses `duration: Infinity` and renders in the aria-live
@@ -301,12 +302,15 @@ export function currentAppVersion(): string | null {
   return typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null
 }
 
+/** UTC timestamp for when this bundle was built. */
+export function currentAppBuiltAt(): string | null {
+  return typeof __APP_BUILT_AT__ === "string" ? __APP_BUILT_AT__ : null
+}
+
 /**
  * The latest deployed build version from the server, or null if it can't be read.
  * `no-store` bypasses the HTTP cache; `/version.json` is excluded from the SW's
  * navigation handler and matches no other SW route, so this reaches the network.
- * A null return means "couldn't verify" (offline, server hiccup, or a poisoned
- * non-JSON response) — never treated as a mismatch.
  */
 export async function fetchLatestVersion(): Promise<string | null> {
   try {
@@ -366,6 +370,81 @@ export async function reconcilePostReload(): Promise<boolean> {
   const latest = await fetchLatestVersion()
   if (!shouldRecoverForVersion(current, latest)) return false
   return swRecovery.runSwRecovery({ force: true })
+}
+
+export type ManualUpdateCheckResult =
+  | { status: "current"; latestVersion: string }
+  | { status: "ready" | "available"; latestVersion: string | null }
+  | { status: "offline"; latestVersion: null }
+  | { status: "unavailable"; latestVersion: null }
+
+/** Run the same service-worker update probe as the background checker and report its result. */
+export async function checkForAppUpdate(): Promise<ManualUpdateCheckResult> {
+  let registration: ServiceWorkerRegistration | undefined
+  try {
+    registration = await navigator.serviceWorker?.getRegistration()
+  } catch {
+    registration = undefined
+  }
+  if (!registration) {
+    return navigator.onLine
+      ? { status: "unavailable", latestVersion: null }
+      : { status: "offline", latestVersion: null }
+  }
+
+  try {
+    await registration.update()
+  } catch {
+    // The version probe below distinguishes offline from an otherwise failed check.
+  }
+
+  const waiting = registration.waiting ?? (await waitForInstallingWorker(registration, WAITING_WORKER_TIMEOUT_MS))
+  const latest = await fetchLatestVersion()
+  if (waiting) return { status: "ready", latestVersion: latest }
+  if (shouldRecoverForVersion(currentAppVersion(), latest)) {
+    return { status: "available", latestVersion: latest }
+  }
+  if (latest && latest === currentAppVersion()) {
+    return { status: "current", latestVersion: latest }
+  }
+  if (!navigator.onLine) return { status: "offline", latestVersion: null }
+  return { status: "unavailable", latestVersion: null }
+}
+
+export type ManualUpdateState = "idle" | "checking" | ManualUpdateCheckResult["status"]
+
+export function useManualAppUpdate(): {
+  state: ManualUpdateState
+  latestVersion: string | null
+  lastCheckedAt: Date | null
+  check: () => Promise<void>
+  reload: () => Promise<void>
+} {
+  const [state, setState] = useState<ManualUpdateState>("idle")
+  const [latestVersion, setLatestVersion] = useState<string | null>(null)
+  const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null)
+
+  const check = useCallback(async () => {
+    setState("checking")
+    try {
+      const result = await checkForAppUpdate()
+      setLatestVersion(result.latestVersion)
+      setState(result.status)
+    } catch {
+      setLatestVersion(null)
+      setState(navigator.onLine ? "unavailable" : "offline")
+    } finally {
+      setLastCheckedAt(new Date())
+    }
+  }, [])
+
+  return {
+    state,
+    latestVersion,
+    lastCheckedAt,
+    check,
+    reload: reloadForUpdate,
+  }
 }
 
 export function useAppUpdate(): void {
@@ -472,7 +551,7 @@ export function useAppUpdate(): void {
 
   useEffect(() => {
     if (IS_DEV) return
-    const id = setInterval(checkForUpdate, POLL_INTERVAL)
+    const id = setInterval(checkForUpdate, APP_UPDATE_POLL_INTERVAL_MS)
     return () => clearInterval(id)
   }, [checkForUpdate])
 

--- a/apps/frontend/src/lib/app-build.test.ts
+++ b/apps/frontend/src/lib/app-build.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { currentAppBuiltAt, currentAppInstalledAt, currentAppVersion } from "./app-build"
+
+describe("app build metadata", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal("__APP_VERSION__", "abc1234")
+    vi.stubGlobal("__APP_BUILT_AT__", "2026-07-14T12:30:00.000Z")
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("reads the metadata embedded by Vite", () => {
+    expect(currentAppVersion()).toBe("abc1234")
+    expect(currentAppBuiltAt()).toBe("2026-07-14T12:30:00.000Z")
+  })
+
+  it("preserves when a build first ran instead of replacing it on a later page visit", () => {
+    const firstRun = new Date("2026-07-14T13:00:00.000Z")
+    const laterVisit = new Date("2026-07-16T09:00:00.000Z")
+
+    expect(currentAppInstalledAt(firstRun)).toEqual(firstRun)
+    expect(currentAppInstalledAt(laterVisit)).toEqual(firstRun)
+  })
+})

--- a/apps/frontend/src/lib/app-build.ts
+++ b/apps/frontend/src/lib/app-build.ts
@@ -1,0 +1,34 @@
+declare const __APP_VERSION__: string
+declare const __APP_BUILT_AT__: string
+
+/** This bundle's git-derived build version. */
+export function currentAppVersion(): string | null {
+  return typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null
+}
+
+/** UTC timestamp for when this bundle was built. */
+export function currentAppBuiltAt(): string | null {
+  return typeof __APP_BUILT_AT__ === "string" ? __APP_BUILT_AT__ : null
+}
+
+/**
+ * Record and return when this build first executed on the device. Called during
+ * bundle startup so the value does not depend on when App status is first opened.
+ */
+export function currentAppInstalledAt(now: Date = new Date()): Date | null {
+  const version = currentAppVersion()
+  if (!version) return null
+
+  try {
+    const key = `app-version-installed-at:${version}`
+    const stored = localStorage.getItem(key)
+    if (stored) {
+      const parsed = new Date(stored)
+      if (!Number.isNaN(parsed.getTime())) return parsed
+    }
+    localStorage.setItem(key, now.toISOString())
+    return now
+  } catch {
+    return null
+  }
+}

--- a/apps/frontend/src/lib/dates.test.ts
+++ b/apps/frontend/src/lib/dates.test.ts
@@ -200,54 +200,57 @@ describe("dates", () => {
   })
 
   describe("formatFutureTime", () => {
-    const NOW = new Date("2026-04-16T12:00:00.000Z")
+    // Local constructors keep the no-timezone cases tied to device-local time
+    // (INV-42), regardless of the test runner's TZ.
+    const NOW = new Date(2026, 3, 16, 12, 0, 0)
+    const UTC_NOW = new Date("2026-04-16T12:00:00.000Z")
 
     it("shows minutes for times within the next hour", () => {
-      expect(formatFutureTime(new Date("2026-04-16T12:05:00.000Z"), NOW, { timeFormat: "24h" })).toBe("5m")
-      expect(formatFutureTime(new Date("2026-04-16T12:47:00.000Z"), NOW, { timeFormat: "24h" })).toBe("47m")
+      expect(formatFutureTime(new Date(2026, 3, 16, 12, 5), NOW, { timeFormat: "24h" })).toBe("5m")
+      expect(formatFutureTime(new Date(2026, 3, 16, 12, 47), NOW, { timeFormat: "24h" })).toBe("47m")
     })
 
     it("clamps past dates to 0m (UI clamping per spec)", () => {
-      expect(formatFutureTime(new Date("2026-04-16T11:45:00.000Z"), NOW, { timeFormat: "24h" })).toBe("0m")
+      expect(formatFutureTime(new Date(2026, 3, 16, 11, 45), NOW, { timeFormat: "24h" })).toBe("0m")
     })
 
     it("shows absolute time for later today", () => {
-      expect(formatFutureTime(new Date("2026-04-16T18:30:00.000Z"), NOW, { timeFormat: "24h" })).toBe("18:30")
+      expect(formatFutureTime(new Date(2026, 3, 16, 18, 30), NOW, { timeFormat: "24h" })).toBe("18:30")
     })
 
     it("prefixes 'tomorrow' for next-day times", () => {
-      expect(formatFutureTime(new Date("2026-04-17T09:00:00.000Z"), NOW, { timeFormat: "24h" })).toBe("tomorrow 09:00")
+      expect(formatFutureTime(new Date(2026, 3, 17, 9), NOW, { timeFormat: "24h" })).toBe("tomorrow 09:00")
     })
 
     it("shows weekday for dates 2-6 days out", () => {
-      const label = formatFutureTime(new Date("2026-04-20T14:00:00.000Z"), NOW, { timeFormat: "24h" })
+      const label = formatFutureTime(new Date(2026, 3, 20, 14), NOW, { timeFormat: "24h" })
       expect(label).toMatch(/^Mon 14:00$/)
     })
 
     it("shows month+day beyond 6 days same year", () => {
-      const label = formatFutureTime(new Date("2026-05-15T09:00:00.000Z"), NOW, { timeFormat: "24h" })
+      const label = formatFutureTime(new Date(2026, 4, 15, 9), NOW, { timeFormat: "24h" })
       expect(label).toMatch(/^May 15 09:00$/)
     })
 
     it("adds year suffix for different years", () => {
-      const label = formatFutureTime(new Date("2099-01-01T00:00:00.000Z"), NOW, { timeFormat: "24h" })
+      const label = formatFutureTime(new Date(2099, 0, 1), NOW, { timeFormat: "24h" })
       expect(label).toMatch(/99/)
     })
 
     it("respects 12h time preference", () => {
-      expect(formatFutureTime(new Date("2026-04-16T18:30:00.000Z"), NOW, { timeFormat: "12h" })).toMatch(/PM|pm/i)
+      expect(formatFutureTime(new Date(2026, 3, 16, 18, 30), NOW, { timeFormat: "12h" })).toMatch(/PM|pm/i)
     })
 
     it("resolves 'today/tomorrow' boundaries in the user's timezone (INV-42)", () => {
       // 2026-04-17T02:00Z is still *April 16th* in Los Angeles (UTC-7), so in
       // an LA-timezoned user it's "today" not "tomorrow".
-      const la = formatFutureTime(new Date("2026-04-17T02:00:00.000Z"), NOW, {
+      const la = formatFutureTime(new Date("2026-04-17T02:00:00.000Z"), UTC_NOW, {
         timeFormat: "24h",
         timezone: "America/Los_Angeles",
       })
       expect(la).not.toMatch(/tomorrow/)
       // Same instant in Tokyo (UTC+9) is well into the next day.
-      const tokyo = formatFutureTime(new Date("2026-04-17T02:00:00.000Z"), NOW, {
+      const tokyo = formatFutureTime(new Date("2026-04-17T02:00:00.000Z"), UTC_NOW, {
         timeFormat: "24h",
         timezone: "Asia/Tokyo",
       })
@@ -256,7 +259,7 @@ describe("dates", () => {
 
     it("formats same-day absolute time in the user's timezone", () => {
       // 18:30 UTC is 11:30 in LA (UTC-7).
-      const label = formatFutureTime(new Date("2026-04-16T18:30:00.000Z"), NOW, {
+      const label = formatFutureTime(new Date("2026-04-16T18:30:00.000Z"), UTC_NOW, {
         timeFormat: "24h",
         timezone: "America/Los_Angeles",
       })

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -7,10 +7,15 @@ import { setNotificationIntent } from "./lib/notification-intent"
 import { hydrateCollapseCache } from "./lib/markdown/collapse-cache"
 import { applyPersistedComposerHeight } from "./lib/composer-height-storage"
 import { installCrashRecovery } from "./lib/crash-recovery"
+import { currentAppInstalledAt } from "./lib/app-build"
 // Side-effect import: attaches the live pointer listener and sets <html data-input>
 // before first paint so the CSS reveal model (.reveal-*) is correct from the start.
 import "./hooks/use-input-mode"
 import "./index.css"
+
+// Record at bundle startup rather than when App status opens, so this is the
+// first time the installed build actually ran on the device.
+currentAppInstalledAt()
 
 // Catch uncaught errors that wedge the app after the PWA returns from the
 // background (e.g. resuming after "Open in Firefox") and reload instead of

--- a/apps/frontend/src/pages/app-status.test.tsx
+++ b/apps/frontend/src/pages/app-status.test.tsx
@@ -24,9 +24,18 @@ interface FakeRegistration {
 
 function installServiceWorker(registration: FakeRegistration, controlled = true) {
   const listeners = new Set<() => void>()
+  const registrationListeners = new Set<() => void>()
+  const liveRegistration = Object.assign(registration, {
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "updatefound") registrationListeners.add(listener)
+    }),
+    removeEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "updatefound") registrationListeners.delete(listener)
+    }),
+  })
   const serviceWorker = {
     controller: controlled ? {} : null,
-    getRegistration: vi.fn().mockResolvedValue(registration),
+    getRegistration: vi.fn().mockResolvedValue(liveRegistration),
     addEventListener: vi.fn((type: string, listener: () => void) => {
       if (type === "controllerchange") listeners.add(listener)
     }),
@@ -36,6 +45,10 @@ function installServiceWorker(registration: FakeRegistration, controlled = true)
     takeControl() {
       serviceWorker.controller = {}
       for (const listener of listeners) listener()
+    },
+    parkUpdate(worker: ServiceWorker) {
+      liveRegistration.waiting = worker
+      for (const listener of registrationListeners) listener()
     },
   }
   Object.defineProperty(navigator, "serviceWorker", { configurable: true, value: serviceWorker })
@@ -101,7 +114,6 @@ describe("AppStatusPage", () => {
 
     expect(await screen.findByText("Update ready")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload and update" })).toBeInTheDocument()
-    expect(screen.getByText("def5678")).toBeInTheDocument()
   })
 
   it("downloads again instead of reloading before an update is parked", async () => {
@@ -139,6 +151,26 @@ describe("AppStatusPage", () => {
 
     expect(await screen.findByText("Up to date")).toBeInTheDocument()
     expect(screen.queryByText("Update ready")).not.toBeInTheDocument()
+  })
+
+  it("switches from download to reload when the worker finishes in the background", async () => {
+    const serviceWorker = installServiceWorker({
+      waiting: null,
+      installing: null,
+      update: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "def5678" }),
+    } as Response)
+
+    renderPage()
+    await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
+    expect(await screen.findByRole("button", { name: "Download update" })).toBeInTheDocument()
+
+    act(() => serviceWorker.parkUpdate({ postMessage: vi.fn() } as unknown as ServiceWorker))
+
+    expect(screen.getByRole("button", { name: "Reload and update" })).toBeInTheDocument()
   })
 
   it("finishes a manual check when registration.update stalls", async () => {

--- a/apps/frontend/src/pages/app-status.test.tsx
+++ b/apps/frontend/src/pages/app-status.test.tsx
@@ -104,6 +104,43 @@ describe("AppStatusPage", () => {
     expect(screen.getByText("def5678")).toBeInTheDocument()
   })
 
+  it("downloads again instead of reloading before an update is parked", async () => {
+    installServiceWorker({
+      waiting: null,
+      installing: null,
+      update: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "def5678" }),
+    } as Response)
+
+    renderPage()
+    await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
+
+    expect(await screen.findByText("Update available")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download update" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Reload and update" })).not.toBeInTheDocument()
+  })
+
+  it("does not call a first service-worker activation an app update", async () => {
+    installServiceWorker({
+      waiting: null,
+      installing: { state: "activated" } as ServiceWorker,
+      update: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc1234" }),
+    } as Response)
+
+    renderPage()
+    await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
+
+    expect(await screen.findByText("Up to date")).toBeInTheDocument()
+    expect(screen.queryByText("Update ready")).not.toBeInTheDocument()
+  })
+
   it("finishes a manual check when registration.update stalls", async () => {
     vi.useFakeTimers()
     installServiceWorker({

--- a/apps/frontend/src/pages/app-status.test.tsx
+++ b/apps/frontend/src/pages/app-status.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { render, screen, userEvent } from "@/test"
+import * as contextsModule from "@/contexts"
+import { AppStatusPage } from "./app-status"
+
+const serviceWorkerDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/w/workspace_1/app-status"]}>
+      <Routes>
+        <Route path="/w/:workspaceId/app-status" element={<AppStatusPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("AppStatusPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("__APP_VERSION__", "abc1234")
+    vi.stubGlobal("__APP_BUILT_AT__", "2026-07-14T12:30:00.000Z")
+    vi.spyOn(contextsModule, "useSidebar").mockReturnValue({
+      state: "collapsed",
+      isMobile: false,
+      togglePinned: vi.fn(),
+    } as unknown as ReturnType<typeof contextsModule.useSidebar>)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    if (serviceWorkerDescriptor) {
+      Object.defineProperty(navigator, "serviceWorker", serviceWorkerDescriptor)
+    } else {
+      delete (navigator as { serviceWorker?: unknown }).serviceWorker
+    }
+  })
+
+  it("shows build details and confirms a manual update check", async () => {
+    const update = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        controller: {},
+        getRegistration: vi.fn().mockResolvedValue({ waiting: null, installing: null, update }),
+      },
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc1234", builtAt: "2026-07-14T12:30:00.000Z" }),
+    } as Response)
+
+    renderPage()
+
+    expect(screen.getByText("abc1234")).toBeInTheDocument()
+    expect(screen.getByText("Last updated")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
+
+    expect(update).toHaveBeenCalledOnce()
+    expect(await screen.findByText("Up to date")).toBeInTheDocument()
+    expect(screen.getByText(/Last checked/)).toBeInTheDocument()
+  })
+
+  it("offers to reload once a new worker is ready", async () => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        controller: {},
+        getRegistration: vi.fn().mockResolvedValue({
+          waiting: { postMessage: vi.fn() },
+          installing: null,
+          update: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "def5678", builtAt: "2026-07-14T13:00:00.000Z" }),
+    } as Response)
+
+    renderPage()
+    await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
+
+    expect(await screen.findByText("Update ready")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Reload and update" })).toBeInTheDocument()
+    expect(screen.getByText("def5678")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/pages/app-status.test.tsx
+++ b/apps/frontend/src/pages/app-status.test.tsx
@@ -171,6 +171,8 @@ describe("AppStatusPage", () => {
     act(() => serviceWorker.parkUpdate({ postMessage: vi.fn() } as unknown as ServiceWorker))
 
     expect(screen.getByRole("button", { name: "Reload and update" })).toBeInTheDocument()
+    expect(screen.getByText("A new build is downloaded and ready.")).toBeInTheDocument()
+    expect(screen.queryByText("def5678")).not.toBeInTheDocument()
   })
 
   it("finishes a manual check when registration.update stalls", async () => {

--- a/apps/frontend/src/pages/app-status.test.tsx
+++ b/apps/frontend/src/pages/app-status.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
-import { render, screen, userEvent } from "@/test"
+import { act, render, screen, userEvent } from "@/test"
 import * as contextsModule from "@/contexts"
 import { AppStatusPage } from "./app-status"
 
@@ -16,6 +16,32 @@ function renderPage() {
   )
 }
 
+interface FakeRegistration {
+  waiting: ServiceWorker | null
+  installing: ServiceWorker | null
+  update: () => Promise<unknown>
+}
+
+function installServiceWorker(registration: FakeRegistration, controlled = true) {
+  const listeners = new Set<() => void>()
+  const serviceWorker = {
+    controller: controlled ? {} : null,
+    getRegistration: vi.fn().mockResolvedValue(registration),
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "controllerchange") listeners.add(listener)
+    }),
+    removeEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "controllerchange") listeners.delete(listener)
+    }),
+    takeControl() {
+      serviceWorker.controller = {}
+      for (const listener of listeners) listener()
+    },
+  }
+  Object.defineProperty(navigator, "serviceWorker", { configurable: true, value: serviceWorker })
+  return serviceWorker
+}
+
 describe("AppStatusPage", () => {
   beforeEach(() => {
     vi.stubGlobal("__APP_VERSION__", "abc1234")
@@ -28,6 +54,7 @@ describe("AppStatusPage", () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     if (serviceWorkerDescriptor) {
@@ -39,13 +66,7 @@ describe("AppStatusPage", () => {
 
   it("shows build details and confirms a manual update check", async () => {
     const update = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, "serviceWorker", {
-      configurable: true,
-      value: {
-        controller: {},
-        getRegistration: vi.fn().mockResolvedValue({ waiting: null, installing: null, update }),
-      },
-    })
+    installServiceWorker({ waiting: null, installing: null, update })
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       json: async () => ({ version: "abc1234", builtAt: "2026-07-14T12:30:00.000Z" }),
@@ -54,7 +75,8 @@ describe("AppStatusPage", () => {
     renderPage()
 
     expect(screen.getByText("abc1234")).toBeInTheDocument()
-    expect(screen.getByText("Last updated")).toBeInTheDocument()
+    expect(screen.getByText("Updated on this device")).toBeInTheDocument()
+    expect(screen.getByText("Build created")).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole("button", { name: "Check for updates" }))
 
@@ -64,16 +86,10 @@ describe("AppStatusPage", () => {
   })
 
   it("offers to reload once a new worker is ready", async () => {
-    Object.defineProperty(navigator, "serviceWorker", {
-      configurable: true,
-      value: {
-        controller: {},
-        getRegistration: vi.fn().mockResolvedValue({
-          waiting: { postMessage: vi.fn() },
-          installing: null,
-          update: vi.fn().mockResolvedValue(undefined),
-        }),
-      },
+    installServiceWorker({
+      waiting: { postMessage: vi.fn() } as unknown as ServiceWorker,
+      installing: null,
+      update: vi.fn().mockResolvedValue(undefined),
     })
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
@@ -86,5 +102,39 @@ describe("AppStatusPage", () => {
     expect(await screen.findByText("Update ready")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload and update" })).toBeInTheDocument()
     expect(screen.getByText("def5678")).toBeInTheDocument()
+  })
+
+  it("finishes a manual check when registration.update stalls", async () => {
+    vi.useFakeTimers()
+    installServiceWorker({
+      waiting: null,
+      installing: null,
+      update: vi.fn(() => new Promise(() => {})),
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc1234" }),
+    } as Response)
+
+    renderPage()
+    act(() => screen.getByRole("button", { name: "Check for updates" }).click())
+    await act(async () => vi.advanceTimersByTimeAsync(5_000))
+
+    expect(screen.getByText("Up to date")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Check for updates" })).toBeEnabled()
+  })
+
+  it("updates offline readiness when the service worker takes control", () => {
+    const serviceWorker = installServiceWorker(
+      { waiting: null, installing: null, update: vi.fn().mockResolvedValue(undefined) },
+      false
+    )
+
+    renderPage()
+    expect(screen.getByText("Starting")).toBeInTheDocument()
+
+    act(() => serviceWorker.takeControl())
+
+    expect(screen.getByText("Ready")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/pages/app-status.tsx
+++ b/apps/frontend/src/pages/app-status.tsx
@@ -76,10 +76,10 @@ function statusCopy(state: ManualUpdateState, latestVersion: string | null): Sta
       title: "Update available",
       description: latestVersion ? (
         <>
-          Version <span className="font-mono text-foreground">{latestVersion}</span> is available.
+          Version <span className="font-mono text-foreground">{latestVersion}</span> is available to download.
         </>
       ) : (
-        "A newer build is available."
+        "A newer build is available to download."
       ),
       icon: Download,
       iconClassName: "text-primary",
@@ -186,7 +186,7 @@ export function AppStatusPage() {
                     </p>
                   )}
                 </div>
-                {update.state === "ready" || update.state === "available" ? (
+                {update.state === "ready" ? (
                   <Button onClick={() => void update.reload()}>
                     <RefreshCw />
                     Reload and update
@@ -194,7 +194,7 @@ export function AppStatusPage() {
                 ) : (
                   <Button variant="outline" disabled={update.state === "checking"} onClick={() => void update.check()}>
                     {update.state === "checking" ? <Loader2 className="animate-spin" /> : <RefreshCw />}
-                    Check for updates
+                    {update.state === "available" ? "Download update" : "Check for updates"}
                   </Button>
                 )}
               </div>

--- a/apps/frontend/src/pages/app-status.tsx
+++ b/apps/frontend/src/pages/app-status.tsx
@@ -1,0 +1,250 @@
+import type { ReactNode } from "react"
+import { Link, useParams } from "react-router-dom"
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  CircleGauge,
+  CloudDownload,
+  Download,
+  Globe2,
+  HardDrive,
+  Info,
+  Loader2,
+  MonitorSmartphone,
+  RefreshCw,
+  Wifi,
+  WifiOff,
+} from "lucide-react"
+import { SidebarToggle } from "@/components/layout"
+import { useIsOnline } from "@/components/layout/connection-status"
+import { ThreaLogo } from "@/components/threa-logo"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  APP_UPDATE_POLL_INTERVAL_MS,
+  currentAppBuiltAt,
+  currentAppVersion,
+  useManualAppUpdate,
+  type ManualUpdateState,
+} from "@/hooks/use-app-update"
+import { formatFullDateTime, formatTime } from "@/lib/dates"
+import { cn } from "@/lib/utils"
+
+interface StatusCopy {
+  title: string
+  description: ReactNode
+  icon: typeof CircleGauge
+  iconClassName: string
+}
+
+function statusCopy(state: ManualUpdateState, latestVersion: string | null): StatusCopy {
+  if (state === "checking") {
+    return {
+      title: "Checking for updates…",
+      description: "Looking for a newer Threa build.",
+      icon: Loader2,
+      iconClassName: "animate-spin text-primary",
+    }
+  }
+  if (state === "current") {
+    return {
+      title: "Up to date",
+      description: "You're running the latest available build.",
+      icon: CheckCircle2,
+      iconClassName: "text-primary",
+    }
+  }
+  if (state === "ready") {
+    return {
+      title: "Update ready",
+      description: latestVersion ? (
+        <>
+          Version <span className="font-mono text-foreground">{latestVersion}</span> is downloaded and ready.
+        </>
+      ) : (
+        "A new build is downloaded and ready."
+      ),
+      icon: Download,
+      iconClassName: "text-primary",
+    }
+  }
+  if (state === "available") {
+    return {
+      title: "Update available",
+      description: latestVersion ? (
+        <>
+          Version <span className="font-mono text-foreground">{latestVersion}</span> is available.
+        </>
+      ) : (
+        "A newer build is available."
+      ),
+      icon: Download,
+      iconClassName: "text-primary",
+    }
+  }
+  if (state === "offline") {
+    return {
+      title: "Can't check while offline",
+      description: "Reconnect, then try the check again.",
+      icon: WifiOff,
+      iconClassName: "text-muted-foreground",
+    }
+  }
+  if (state === "unavailable") {
+    return {
+      title: "Update check unavailable",
+      description: "The update service could not be reached. Your current app remains available.",
+      icon: AlertTriangle,
+      iconClassName: "text-destructive",
+    }
+  }
+  return {
+    title: "Current installation",
+    description: "Threa checks for updates automatically. You can also run a check now.",
+    icon: CircleGauge,
+    iconClassName: "text-primary",
+  }
+}
+
+function DetailRow({ icon: Icon, label, children }: { icon: typeof Info; label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-start gap-3 py-3 first:pt-0 last:pb-0">
+      <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        <Icon className="h-4 w-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <div className="mt-0.5 text-sm text-foreground">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+function isStandaloneApp(): boolean {
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean }
+  return (
+    navigatorWithStandalone.standalone === true || window.matchMedia?.("(display-mode: standalone)").matches === true
+  )
+}
+
+function offlineSupportLabel(): string {
+  if (!("serviceWorker" in navigator)) return "Not supported"
+  return navigator.serviceWorker.controller ? "Ready" : "Starting"
+}
+
+export function AppStatusPage() {
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+  const isOnline = useIsOnline()
+  const update = useManualAppUpdate()
+  const copy = statusCopy(update.state, update.latestVersion)
+  const StatusIcon = copy.icon
+  const version = currentAppVersion() ?? "Development"
+  const builtAtValue = currentAppBuiltAt()
+  const builtAt = builtAtValue ? new Date(builtAtValue) : null
+  const hasValidBuildDate = builtAt !== null && !Number.isNaN(builtAt.getTime())
+
+  if (!workspaceId) return null
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex h-12 items-center gap-2 border-b px-4">
+        <SidebarToggle location="page" />
+        <Button asChild variant="ghost" size="icon" className="h-8 w-8">
+          <Link to={`/w/${workspaceId}`} aria-label="Back to workspace">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <Info className="h-5 w-5 text-muted-foreground" />
+          <h1 className="font-semibold">App status</h1>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-auto p-4 sm:p-6">
+        <div className="mx-auto max-w-4xl space-y-6">
+          <Card className="overflow-hidden">
+            <CardContent className="relative p-5 sm:p-6">
+              <div className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-primary" />
+              <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+                  <ThreaLogo size="lg" />
+                </div>
+                <div className="min-w-0 flex-1" aria-live="polite">
+                  <div className="flex items-center gap-2">
+                    <StatusIcon className={cn("h-5 w-5 shrink-0", copy.iconClassName)} />
+                    <h2 className="font-semibold">{copy.title}</h2>
+                  </div>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{copy.description}</p>
+                  {update.lastCheckedAt && (
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Last checked {formatTime(update.lastCheckedAt)}
+                    </p>
+                  )}
+                </div>
+                {update.state === "ready" || update.state === "available" ? (
+                  <Button onClick={() => void update.reload()}>
+                    <RefreshCw />
+                    Reload and update
+                  </Button>
+                ) : (
+                  <Button variant="outline" disabled={update.state === "checking"} onClick={() => void update.check()}>
+                    {update.state === "checking" ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+                    Check for updates
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader className="pb-4">
+                <CardTitle className="text-base">Build details</CardTitle>
+                <CardDescription>The version currently running on this device.</CardDescription>
+              </CardHeader>
+              <CardContent className="divide-y">
+                <DetailRow icon={HardDrive} label="Current version">
+                  <span className="font-mono tabular-nums">{version}</span>
+                </DetailRow>
+                <DetailRow icon={CloudDownload} label="Last updated">
+                  {hasValidBuildDate && builtAt ? (
+                    <time dateTime={builtAt.toISOString()}>{formatFullDateTime(builtAt)}</time>
+                  ) : (
+                    "Not available for this build"
+                  )}
+                </DetailRow>
+                <DetailRow icon={Globe2} label="App host">
+                  <span className="break-all font-mono text-xs">{window.location.hostname || "Local development"}</span>
+                </DetailRow>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-4">
+                <CardTitle className="text-base">Device readiness</CardTitle>
+                <CardDescription>Local capabilities that keep Threa available.</CardDescription>
+              </CardHeader>
+              <CardContent className="divide-y">
+                <DetailRow icon={isOnline ? Wifi : WifiOff} label="Connection">
+                  <span className={cn(!isOnline && "text-muted-foreground")}>{isOnline ? "Online" : "Offline"}</span>
+                </DetailRow>
+                <DetailRow icon={CloudDownload} label="Offline support">
+                  {offlineSupportLabel()}
+                </DetailRow>
+                <DetailRow icon={MonitorSmartphone} label="Running as">
+                  {isStandaloneApp() ? "Installed app" : "Web browser"}
+                </DetailRow>
+              </CardContent>
+            </Card>
+          </div>
+
+          <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+            Updates are checked every {APP_UPDATE_POLL_INTERVAL_MS / 60_000} minutes, when Threa returns to the
+            foreground, and after reconnecting. Threa downloads updates before asking you to reload.
+          </p>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/app-status.tsx
+++ b/apps/frontend/src/pages/app-status.tsx
@@ -154,7 +154,7 @@ export function AppStatusPage() {
     <div className="flex h-full flex-col">
       <header className="flex h-12 items-center gap-2 border-b px-4">
         <SidebarToggle location="page" />
-        <Button asChild variant="ghost" size="icon" className="h-8 w-8">
+        <Button asChild variant="ghost" size="icon" className="h-11 w-11">
           <Link to={`/w/${workspaceId}`} aria-label="Back to workspace">
             <ArrowLeft className="h-4 w-4" />
           </Link>

--- a/apps/frontend/src/pages/app-status.tsx
+++ b/apps/frontend/src/pages/app-status.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 import { Link, useParams } from "react-router-dom"
 import {
   AlertTriangle,
@@ -24,7 +24,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import {
   APP_UPDATE_POLL_INTERVAL_MS,
   currentAppBuiltAt,
+  currentAppInstalledAt,
   currentAppVersion,
+  useIsServiceWorkerControlled,
   useManualAppUpdate,
   type ManualUpdateState,
 } from "@/hooks/use-app-update"
@@ -128,15 +130,17 @@ function isStandaloneApp(): boolean {
   )
 }
 
-function offlineSupportLabel(): string {
+function offlineSupportLabel(isControlled: boolean): string {
   if (!("serviceWorker" in navigator)) return "Not supported"
-  return navigator.serviceWorker.controller ? "Ready" : "Starting"
+  return isControlled ? "Ready" : "Starting"
 }
 
 export function AppStatusPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const isOnline = useIsOnline()
+  const isServiceWorkerControlled = useIsServiceWorkerControlled()
   const update = useManualAppUpdate()
+  const [installedAt] = useState(() => currentAppInstalledAt())
   const copy = statusCopy(update.state, update.latestVersion)
   const StatusIcon = copy.icon
   const version = currentAppVersion() ?? "Development"
@@ -207,7 +211,14 @@ export function AppStatusPage() {
                 <DetailRow icon={HardDrive} label="Current version">
                   <span className="font-mono tabular-nums">{version}</span>
                 </DetailRow>
-                <DetailRow icon={CloudDownload} label="Last updated">
+                <DetailRow icon={RefreshCw} label="Updated on this device">
+                  {installedAt ? (
+                    <time dateTime={installedAt.toISOString()}>{formatFullDateTime(installedAt)}</time>
+                  ) : (
+                    "Not available"
+                  )}
+                </DetailRow>
+                <DetailRow icon={CloudDownload} label="Build created">
                   {hasValidBuildDate && builtAt ? (
                     <time dateTime={builtAt.toISOString()}>{formatFullDateTime(builtAt)}</time>
                   ) : (
@@ -230,7 +241,7 @@ export function AppStatusPage() {
                   <span className={cn(!isOnline && "text-muted-foreground")}>{isOnline ? "Online" : "Offline"}</span>
                 </DetailRow>
                 <DetailRow icon={CloudDownload} label="Offline support">
-                  {offlineSupportLabel()}
+                  {offlineSupportLabel(isServiceWorkerControlled)}
                 </DetailRow>
                 <DetailRow icon={MonitorSmartphone} label="Running as">
                   {isStandaloneApp() ? "Installed app" : "Web browser"}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -146,6 +146,11 @@ export const router = createBrowserRouter([
             lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
           },
           {
+            path: "app-status",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/app-status")).AppStatusPage }),
+          },
+          {
             path: "settings/personas/:personaId",
             HydrateFallback: FallbackLoader,
             lazy: async () => ({ Component: (await import("@/pages/persona-editor")).PersonaEditorPage }),

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -19,11 +19,12 @@ const isE2ETest = !!process.env.VITE_BACKEND_PORT
 
 // Build version from git short hash — used for auto-update detection.
 // Falls back to a build timestamp so auto-update still works in gitless CI environments.
+const buildTimestamp = new Date().toISOString()
 let buildVersion: string
 try {
   buildVersion = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim()
 } catch {
-  buildVersion = `build-${Date.now()}`
+  buildVersion = `build-${Date.parse(buildTimestamp)}`
 }
 
 function versionJsonPlugin(): Plugin {
@@ -34,7 +35,7 @@ function versionJsonPlugin(): Plugin {
       this.emitFile({
         type: "asset",
         fileName: "version.json",
-        source: JSON.stringify({ version: buildVersion }),
+        source: JSON.stringify({ version: buildVersion, builtAt: buildTimestamp }),
       })
     },
   }
@@ -125,6 +126,7 @@ export default defineConfig({
   // Same value as the emitted version.json, so a post-reload mismatch is decisive.
   define: {
     __APP_VERSION__: JSON.stringify(buildVersion),
+    __APP_BUILT_AT__: JSON.stringify(buildTimestamp),
     // True only in the Playwright E2E build (VITE_BACKEND_PORT is set). Lets the
     // app suppress the persistent "new version available" update toast, which
     // otherwise parks over the composer in the aria-live region and intercepts


### PR DESCRIPTION
## Problem

Threa's PWA update machinery already polls for and parks new service workers, but users cannot inspect the running build or request an update check. The avatar menu exposes AI Usage and the Admin Portal without an app-level status destination.

## Solution

Add `/w/:workspaceId/app-status` and link it from the avatar menu beside AI Usage/Admin Portal. The page reports the running build and device readiness, and reuses the existing service-worker activation path for manual checks and reloads.

### How it works

1. `vite.config.ts` generates one `buildTimestamp`, embeds it as `__APP_BUILT_AT__`, and includes it in `version.json` beside the existing git-hash version.
2. `checkForAppUpdate` calls `ServiceWorkerRegistration.update()`, waits up to `WAITING_WORKER_TIMEOUT_MS` for an installer, then distinguishes `current`, `ready`, `available`, `offline`, and `unavailable` states.
3. `useManualAppUpdate` owns the page's check lifecycle and delegates activation to the existing `reloadForUpdate` path; no second service-worker activation implementation is introduced.
4. `AppStatusPage` renders current version, first-seen-on-device time, build time in device-local time, app host, connectivity, reactive offline support, browser/install mode, last-check time, and the appropriate check/reload action.

### Key design decisions

**Reuse the parked-worker lifecycle** — manual checks call the same browser registration and `reloadForUpdate` path as automatic checks. This preserves the existing offline-safe activation, `controllerchange` fallback, and stale-build recovery behavior.

**Separate “available” from “ready”** — a version mismatch can exist before a worker is parked. Only `registration.waiting` enables Reload; an `available` build keeps a Download update action until the browser parks it. Manual registration and version probes are bounded so a stalled network cannot wedge the page in “Checking”.

**Track device update time per build** — `currentAppInstalledAt` records when each version is first observed on this device. The page reports that separately from the artifact build timestamp, avoiding a misleading “last updated” label for delayed/offline PWA activation.

**Report the runtime host, not a baked release channel** — staging and production share one frontend build. `import.meta.env.PROD` would label staging as production, so the page shows `window.location.hostname` instead (caught in self-review).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/pages/app-status.tsx` | Responsive status page and update-state presentation |
| `apps/frontend/src/pages/app-status.test.tsx` | Integration coverage for build details, bounded manual checks, reactive readiness, and ready updates |
| `apps/frontend/src/lib/app-build.ts` | Pure build metadata access and per-version first-run persistence |
| `apps/frontend/src/lib/app-build.test.ts` | Verifies embedded metadata and first-run timestamp preservation |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-app-update.ts` | Bounded manual check result model, service-worker readiness subscription, and `useManualAppUpdate` |
| `apps/frontend/vite.config.ts` | Emits and embeds one ISO build timestamp |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | Adds the App status menu link |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx` | Verifies menu discoverability and route |
| `apps/frontend/src/routes/index.tsx` | Lazy-loads `/app-status` |
| `apps/frontend/src/main.tsx` | Records the current version when its bundle first executes |
| `apps/frontend/src/lib/dates.test.ts` | Makes device-local date tests independent of the runner timezone |
| `DESIGN.md` | Records the route and sidebar destination |

## Out of scope

- No backend endpoint or schema change; build/update state is owned by Vite and the browser service-worker lifecycle.
- No forced update. Users keep the existing parked-worker behavior until they choose Reload.

## Test plan

- [x] Frontend unit/integration suite — 4,340 pass on clean rerun (one unrelated `useAllDrafts` first-pass flake passed isolated replay before the clean run)
- [x] Focused build/app-update/status/sidebar/date suites — 87 pass
- [x] Repository lint and monorepo typecheck — clean via pre-commit hooks
- [x] Frontend production/PWA build — clean
- [ ] Browser E2E not run — update activation requires a deployed multi-build service-worker lifecycle; registration states are covered in integration/unit tests

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Give every workspace member a small app-status view reachable from the avatar menu, with current build metadata and a manual way to discover and activate updates without replacing Threa's offline-safe PWA update lifecycle.

## What Was Built

### Navigation and page

- Add `App status` in the avatar menu section containing AI Usage and Admin Portal.
- Add the lazy workspace route `/w/:workspaceId/app-status`.
- Render build details, device readiness, automatic-check behavior, and manual actions with existing Shadcn primitives and Threa tokens.

**Files:**
- `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx`
- `apps/frontend/src/routes/index.tsx`
- `apps/frontend/src/pages/app-status.tsx`

### Build metadata

- Create one ISO timestamp per Vite build.
- Embed it in the running bundle and emitted `version.json` alongside the existing git short hash.
- Record each build's first-seen timestamp on the device.
- Format both timestamps in the device's locale/timezone via `formatFullDateTime` (INV-42).

**Files:**
- `apps/frontend/vite.config.ts`
- `apps/frontend/src/lib/app-build.ts`
- `apps/frontend/src/main.tsx`
- `apps/frontend/src/hooks/use-app-update.ts`

### Manual updates

- Trigger `registration.update()` on demand with a 5-second bound.
- Wait briefly for an in-progress installation and bound the server-version probe.
- Report current, ready, available, offline, and unavailable states.
- Offer Download while a newer build is available but not parked.
- Activate through `reloadForUpdate` only when `registration.waiting` exists, preserving the existing parked-worker and recovery behavior.

**Files:**
- `apps/frontend/src/hooks/use-app-update.ts`
- `apps/frontend/src/pages/app-status.tsx`

### Verification

- Mount the real status page and exercise current/ready checks.
- Verify the avatar menu route.
- Keep date tests device-local and runner-timezone independent.

**Files:**
- `apps/frontend/src/pages/app-status.test.tsx`
- `apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx`
- `apps/frontend/src/lib/dates.test.ts`

## Design Decisions

### Reuse update infrastructure

**Chose:** Extend `use-app-update.ts` with a manual result model and hook.
**Why:** `reloadForUpdate` already handles waiting workers, missing `controllerchange`, offline-safe reload, and confirmed stale-build recovery.
**Alternative considered:** A page-specific service-worker implementation; rejected because activation/recovery behavior would drift.

### Device update time and build time

**Chose:** Display the version's first-seen timestamp on this device separately from the artifact build timestamp.
**Why:** Delayed/offline PWAs can activate well after a build was created; the two timestamps answer different questions without a backend API.

### Runtime host instead of environment label

**Chose:** Display the actual hostname.
**Why:** One production-mode frontend artifact serves staging and production; build mode cannot identify the deployment channel.

## Design Evolution

- **Environment reporting:** The first implementation displayed `import.meta.env.PROD` as “Release channel”. Self-review found that staging uses the same production-mode build, so the page now reports the runtime app host.
- **Date verification:** The full frontend suite exposed UTC literals in device-local date tests. Their fixtures now use local constructors for no-timezone behavior and preserve UTC anchors only for explicit timezone cases.
- **Terra review:** The first review found an unbounded manual `registration.update()`, build time mislabeled as device update time, and stale service-worker readiness. The follow-up bounds probes and subscribes readiness to `controllerchange`. A second pass caught that first-seen time was recorded only when the status page opened; recording now happens in `main.tsx` when the bundle executes. A third pass separated available/download from ready/reload and stopped treating first service-worker activation as a parked app update. A fourth pass added live `updatefound`/worker-state observation so Download changes to Reload as soon as the browser parks the worker. A fifth pass made readiness monotonic across manual/background races and clears stale target-version copy when a different worker parks. A sixth pass enlarged the page's primary mobile exit target to 44px.

## Schema Changes

None.

## What's NOT Included

- Backend health checks or deployment history.
- Forced/background activation without user confirmation.
- Browser E2E across two deployed frontend versions.

## Status

- [x] Avatar-menu navigation
- [x] App-status route and responsive page
- [x] Build version and timestamp
- [x] Manual check and reload flow
- [x] Unit/integration tests, lint, typecheck, and production build
- [x] Initial Terra review findings fixed

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
