### PR TITLE
feat(frontend): board hover redesign — drop card lift, inset action pill, Slack per-message hover

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -620,7 +620,7 @@ export function BoardCard({
         <div
           ref={cardRef}
           className={cn(
-            "board-card-lift rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]",
+            "board-card-hover rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]",
             flash && "board-post-flash"
           )}
         >

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -444,11 +444,12 @@ export function MessageItem({
   // `reveal-host`, and `reveal-actions-hover-only` keeps this cluster
   // opacity-0 + pointer-events-none for touch (so a tap can't trigger the
   // invisible button — it passes through), revealing it on mouse hover / focus.
-  // Touch reaches the same actions through the long-press drawer below. The body
-  // columns carry `pr-14` so this absolute react+overflow cluster never overlays
-  // the row's top-right content (INV-21).
+  // Touch reaches the same actions through the long-press drawer below. Inset from
+  // the row's top-right corner (not flush to the surface edge); the body columns
+  // carry `pr-16` so this absolute react+overflow cluster never overlays the row's
+  // top-right content (INV-21).
   const overflowMenu = (
-    <div className="reveal-actions-hover-only absolute right-0 top-0 flex items-center gap-0.5">
+    <div className="reveal-actions-hover-only absolute right-2 top-1.5 flex items-center gap-0.5">
       <ReactionEmojiPicker
         workspaceId={workspaceId}
         onSelect={handleAddReaction}
@@ -669,11 +670,18 @@ export function MessageItem({
         {swipeReveal}
         <div
           className={cn(
-            "group reveal-host relative flex gap-3",
+            // transition scoped to bg + opacity (NOT transform): the swipe gesture
+            // drives `transform` via inline style, and transitioning it would lag
+            // the drag.
+            "group reveal-host relative flex gap-3 transition-[background-color,opacity]",
+            // Slack-style per-message hover wash — `.message-hover-wash` is gated
+            // to mouse input in index.css (no sticky hover on touch); composes
+            // under the actor accent so persona/bot stays colored on hover.
+            "message-hover-wash",
             MESSAGE_ROW_CONTINUATION_PADDING,
             surfaceClassName,
             rowAccentClass,
-            longPress.isPressed && "opacity-70 transition-opacity",
+            longPress.isPressed && "opacity-70",
             isHighlighted && "animate-highlight-flash"
           )}
           style={swipeStyle}
@@ -686,7 +694,7 @@ export function MessageItem({
           >
             {formatTime(sentAt)}
           </div>
-          <div className="message-content min-w-0 flex-1 pr-14">
+          <div className="message-content min-w-0 flex-1 pr-16">
             {inlineEditing ? (
               editForm
             ) : (
@@ -726,11 +734,18 @@ export function MessageItem({
       {swipeReveal}
       <div
         className={cn(
-          "group reveal-host relative flex items-start gap-3",
+          // transition scoped to bg + opacity (NOT transform): the swipe gesture
+          // drives `transform` via inline style, and transitioning it would lag
+          // the drag.
+          "group reveal-host relative flex items-start gap-3 transition-[background-color,opacity]",
+          // Slack-style per-message hover wash — `.message-hover-wash` is gated
+          // to mouse input in index.css (no sticky hover on touch); composes
+          // under the actor accent so persona/bot stays colored on hover.
+          "message-hover-wash",
           MESSAGE_ROW_HEAD_PADDING,
           surfaceClassName,
           rowAccentClass,
-          longPress.isPressed && "opacity-70 transition-opacity",
+          longPress.isPressed && "opacity-70",
           isHighlighted && "animate-highlight-flash"
         )}
         style={swipeStyle}
@@ -743,7 +758,7 @@ export function MessageItem({
           alt={authorName}
           showStatus={false}
         />
-        <div className="message-content min-w-0 flex-1 pr-14">
+        <div className="message-content min-w-0 flex-1 pr-16">
           <div className="mb-0.5 flex items-baseline gap-2">
             {interactiveName ? (
               <button

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -741,11 +741,19 @@ function MessageLayout({
       )}
       <div
         className={cn(
-          // Opaque background so swipe-to-quote icon shows behind the message
-          "message-item group reveal-host relative flex gap-3 px-3 sm:px-6 bg-background",
+          // Opaque background so swipe-to-quote icon shows behind the message.
+          // `transition-[background-color]` (NOT transform — the swipe drives
+          // transform via inline style and a transition would lag the drag).
+          "message-item group reveal-host relative flex gap-3 px-3 sm:px-6 bg-background transition-[background-color]",
           rowVerticalPadding,
           // Per-actor accent (gradient + inset stripe) — see ACTOR_ROW_THEME.
           theme.rowAccent,
+          // Slack-style per-message hover wash — `.message-hover-wash` is gated
+          // to mouse input in index.css (no sticky hover on touch); a
+          // background-COLOR change, so it composes UNDER the actor accent's
+          // gradient + inset stripe (persona/bot accent survives the hover).
+          // Suppressed in batch mode, where the selection tint owns the bg.
+          !batchEnabled && "message-hover-wash",
           // Edit mode: pseudo-element background so no layout shift — applied
           // only when the row doesn't already have an actor-accent gradient to
           // avoid stacking two backgrounds.

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -60,6 +60,19 @@
   }
 }
 
+/* Per-message hover wash (Slack-style row highlight) — GATED to mouse input via
+   the same `html[data-input]` model as the reveal-actions above, so a tap on
+   touch never sticks a hover background (we already carry enough awkward mobile
+   hover states). Unlayered on purpose: it must win over the row's own
+   `bg-card`/`bg-background` utility on hover, which a @layer rule wouldn't. It's
+   a background-COLOR change, so it composes UNDER the actor-accent gradient
+   (background-image) + inset stripe (box-shadow) — the persona/bot accent
+   survives the hover instead of washing flat. Applied by MessageItem (board /
+   conversation / label) and MessageEvent (stream timeline). */
+html[data-input="mouse"] .message-hover-wash:hover {
+  background-color: hsl(var(--muted) / 0.8);
+}
+
 /*
  * Threa - Golden Thread Theme
  *
@@ -450,42 +463,22 @@
   }
 }
 
-/* Board card hover life: on pointer hover the card lifts and its border warms to
-   the primary (Ariadne thread) tint over a deeper float shadow, so the board
-   reads as tactile rather than static. A border-color change (constant width) +
-   transform + box-shadow — nothing reflows (INV-21). A warmed border, not an
-   inset left bar, so it doesn't compete with the per-message actor accent already
-   on the card's left. Gated to a real hover pointer so a tap on touch can't stick
-   the lifted state; the light/dark shadow split matches the card's rest shadow. */
+/* Board card hover: the card holds still and its border warms to the primary
+   (Ariadne thread) tint — a link-style highlight, no lift or float shadow, so
+   nothing moves or reflows (INV-21). Per-message hover is a separate row-level
+   wash (see MessageItem); the card only warms its border, so the two hover
+   levels never compete. A warmed border, not an inset left bar, so it doesn't
+   collide with the per-message actor accent already on the card's left. Gated to
+   a real hover pointer so a tap on touch can't stick the hover state. */
 @media (hover: hover) and (pointer: fine) {
-  .board-card-lift {
-    transition:
-      transform 200ms ease-out,
-      box-shadow 200ms ease-out,
-      border-color 200ms ease-out;
+  .board-card-hover {
+    transition: border-color 200ms ease-out;
   }
-  .board-card-lift:hover {
-    transform: translateY(-3px);
+  .board-card-hover:hover {
     border-color: hsl(var(--primary) / 0.5);
-    box-shadow:
-      0 4px 6px rgb(0 0 0 / 0.07),
-      0 16px 30px -12px rgb(0 0 0 / 0.22);
   }
-  .dark .board-card-lift:hover {
+  .dark .board-card-hover:hover {
     border-color: hsl(var(--primary) / 0.55);
-    box-shadow:
-      0 4px 6px rgb(0 0 0 / 0.55),
-      0 20px 36px -12px rgb(0 0 0 / 0.65);
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .board-card-lift {
-      transition:
-        box-shadow 200ms ease-out,
-        border-color 200ms ease-out;
-    }
-    .board-card-lift:hover {
-      transform: none;
-    }
   }
 }
 


### PR DESCRIPTION
## Problem

Two things on the board read as rough on desktop:

1. **The card lifts on hover.** `.board-card-lift:hover` applied `transform: translateY(-3px)` plus a deeper float shadow (`index.css`). The card physically moves up under the pointer — a content shift we deliberately avoid everywhere else (INV-21), and jarring on a dense feed.
2. **The message action pill sits flush to the card wall.** The per-message react + overflow cluster was `absolute right-0 top-0` (`message-item.tsx`), so on hover it butts right against the card's right edge with no breathing room.

Separately, the board (and the timeline) had no per-message hover affordance at all — you couldn't tell which row you were pointing at, and there was nowhere natural for the row's actions to belong.

## Solution

Keep the card, drop the movement, and add a Slack-style per-message hover. The card becomes a static container whose border warms on hover (a link-style highlight, no motion); the row you point at gets a background wash and its inset action pill. The two hover levels don't compete because only one of them touches the background — the card only warms its border.

### How it works

- **No more lift.** `.board-card-lift` → `.board-card-hover`: the hover rule now changes `border-color` only (still gated to `@media (hover: hover) and (pointer: fine)`). The `translateY`, the float shadows, and the now-moot `prefers-reduced-motion` transform-off block are deleted. The card's rest shadow is unchanged (it lives on the Tailwind class in `board-card.tsx`, not the hover rule).
- **Pill inset.** The cluster moves `right-0 top-0` → `right-2 top-1.5`, and the content column's reserved padding widens `pr-14` → `pr-16` so text never tucks under it (INV-21 — the reserve is permanent, so nothing shifts when the pill fades in). The two triggers are already `variant="outline"` buttons with their own border/shadow, so they read as a pill without an extra chip wrapper. This matches the treatment the timeline row (`MessageEvent`) already used (`right-4` + chip).
- **Per-message hover wash.** A new `.message-hover-wash` class on the row, applied by both message components: `MessageItem` (board card / conversation panel / label page) and `MessageEvent` (stream timeline). The rule is `html[data-input="mouse"] .message-hover-wash:hover { background-color: hsl(var(--muted) / 0.8) }`.

### Key design decisions

**1. The wash is a `background-color` change, layered under the actor accent — not over it.** Persona/bot/system rows already carry the `actor-row-theme` accent: a gradient (`background-image`) plus a 3px inset stripe (`box-shadow`). Because the hover only changes `background-color`, and image + inset-shadow paint above the background color, the emerald/gold accent survives the hover instead of washing flat. No overlay element or z-index juggling — the CSS paint order does it. Verified live: hovering a bot row keeps its green stripe + tint (light and dark).

**2. Gated to mouse input, not `:hover`.** A plain `group-hover`/`:hover` sticks after a tap on touch — exactly the awkward mobile hover state we're trying not to add more of (Kris's call). The wash keys on `html[data-input="mouse"]`, the same live-input-mode model the reveal-actions pills already use (`use-input-mode.tsx` mirrors the active pointer onto `<html data-input>`). On touch the row never washes; touch reaches the same actions via long-press.

**3. The rule is unlayered.** It has to win over the row's own `bg-card` / `bg-background` utility on hover. A `@layer components` rule would lose to a utility regardless of specificity, so the wash is written as plain (unlayered) CSS — same as the existing `.board-card-hover` rule right below it.

**4. Transition scoped to `background-color` + `opacity`, never `transform`.** The swipe-to-quote gesture drives `transform` via inline style; a transition on transform would lag the drag. Both row components transition only the properties that actually animate here.

**5. Suppressed in timeline batch mode.** `MessageEvent` applies the wash as `!batchEnabled && "message-hover-wash"` — in multi-select/move mode the selection tint owns the row background, so the hover wash stays out of its way.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/index.css` | Add the mouse-gated `.message-hover-wash:hover` rule (unlayered). Rewrite the board-card hover: drop `translateY` + float shadow + reduced-motion block, keep border-warm; rename `.board-card-lift` → `.board-card-hover`. |
| `apps/frontend/src/components/message/message-item.tsx` | Inset the action pill (`right-0 top-0` → `right-2 top-1.5`), widen reserved padding (`pr-14` → `pr-16`), add `.message-hover-wash` + scoped transition to both row layouts (head + continuation). |
| `apps/frontend/src/components/timeline/message-event.tsx` | Add `.message-hover-wash` (suppressed in batch mode) + scoped transition to the timeline row. |
| `apps/frontend/src/components/board/board-card.tsx` | Point the card at the renamed `.board-card-hover` class. |

## Out of scope (deliberate)

- **The board's cardless / filled-panel directions.** We explored a rail-only cardless layout and a borderless filled panel; both were set aside for the bordered card. Not touched here.
- **The card border-warm gate.** `.board-card-hover` keeps its existing `@media (hover: hover)` gate (unchanged from before); only the new wash uses the more robust `data-input` model. Not reconciling the two gates in this PR.

## Test plan

- [x] `apps/frontend` — `message-event.test.tsx` + `board-card.test.tsx` + `actor-row-theme.test.tsx`: 48 pass (no assertions on the touched classes; behavior unchanged).
- [x] `bun run typecheck` (full monorepo) clean; pre-commit hooks (prettier, eslint across all apps, migrations/docker/api-docs checks) green.
- [x] Live, stub-auth stack with a real bot message — **light + dark**: no card lift; pill inset with breathing room; wash composes under the emerald bot accent (accent survives).
- [x] Live, `pointer: coarse` touch context: `data-input="touch"`, row `background-color` identical before and after a tap (`rgb(251,250,249)` → `rgb(251,250,249)`) — no sticky hover. Mouse context flips to the muted wash on hover (`rgba(239,238,235,0.8)`).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786684749&installation_id=129946197&pr_number=1349&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1349&signature=cb7f1cf78991139d7e235ba01c33178108317745b35c21004b74979651298a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->