### PR TITLE
feat(frontend): align board per-message quick actions with the timeline

### DIFF
--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -652,7 +652,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         {moveToSubtopic.moveDialog}
         <div
           ref={listRef}
-          className="min-h-0 flex-1 overflow-y-auto px-4"
+          // pt-4 reserves headroom for the first row's hover toolbar, which floats
+          // ~14px above its row (MessageItem's float-above chip). Without it the
+          // scroll container's top edge clips the first message's toolbar — the
+          // stream timeline reserves the same room via its header spacer.
+          className="min-h-0 flex-1 overflow-y-auto px-4 pt-4"
           // pb-3 baseline, plus room for the mobile floating composer while one
           // is open so the conversation tail can scroll above the pill.
           style={{ paddingBottom: `calc(var(${FLOATING_COMPOSER_HEIGHT_VAR}, 0px) + 0.75rem)` }}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -14,6 +14,8 @@ import { actorRowTheme } from "@/components/message/actor-row-theme"
 import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 import { RelativeTime } from "@/components/relative-time"
 import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { CollapsibleBody, useMessageCollapseSettings } from "@/lib/markdown/collapsible-body"
 import { MarkdownBlockProvider } from "@/lib/markdown/markdown-block-context"
 import { LinkPreviewProvider } from "@/lib/markdown/link-preview-context"
@@ -25,6 +27,7 @@ import { MessageReactions } from "@/components/timeline/message-reactions"
 import { MessageContextMenu } from "@/components/timeline/message-context-menu"
 import { MessageActionDrawer } from "@/components/timeline/message-action-drawer"
 import { ReactionEmojiPicker } from "@/components/timeline/reaction-emoji-picker"
+import { SaveMessageButton } from "@/components/timeline/save-message-button"
 import { MessageEditForm } from "@/components/timeline/message-edit-form"
 import { DeleteMessageDialog } from "@/components/timeline/delete-message-dialog"
 import { EditedIndicator } from "@/components/timeline/edited-indicator"
@@ -444,19 +447,41 @@ export function MessageItem({
   // `reveal-host`, and `reveal-actions-hover-only` keeps this cluster
   // opacity-0 + pointer-events-none for touch (so a tap can't trigger the
   // invisible button — it passes through), revealing it on mouse hover / focus.
-  // Touch reaches the same actions through the long-press drawer below. Inset from
-  // the row's top-right corner (not flush to the surface edge); the body columns
-  // carry `pr-16` so this absolute react+overflow cluster never overlays the row's
-  // top-right content (INV-21).
+  // Desktop hover toolbar, mirroring the stream timeline (`MessageEvent`): the same
+  // quick actions (react · save · quote reply · overflow) in a chip that floats just
+  // above the row (`bottom-[calc(100%-20px)]`) rather than inline, so it needs no
+  // content-padding reserve and holds the full set without crowding. `hidden sm:block`
+  // keeps it off phones entirely; touch reaches these via the long-press drawer.
+  // Reply-in-thread is timeline-only — a board/conversation row is already inside its
+  // conversation, and its branch gesture ("New sub-topic") lives in the overflow menu.
   const overflowMenu = (
-    <div className="reveal-actions-hover-only absolute right-2 top-1.5 flex items-center gap-0.5">
-      <ReactionEmojiPicker
-        workspaceId={workspaceId}
-        onSelect={handleAddReaction}
-        activeShortcodes={activeReactionShortcodes}
-        allReactionShortcodes={allReactionShortcodes}
-      />
-      <MessageContextMenu context={menuContext} />
+    <div className="reveal-actions-hover-only absolute right-4 bottom-[calc(100%-20px)] z-10 hidden sm:block">
+      <div className="flex items-center gap-0.5 rounded-md border border-border/60 bg-popover/95 px-1 py-1 shadow-md backdrop-blur-sm">
+        <ReactionEmojiPicker
+          workspaceId={workspaceId}
+          onSelect={handleAddReaction}
+          activeShortcodes={activeReactionShortcodes}
+          allReactionShortcodes={allReactionShortcodes}
+        />
+        <SaveMessageButton workspaceId={workspaceId} messageId={message.id} conversationId={conversationId} />
+        {quoteReplyCtx && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Quote reply"
+                onClick={triggerQuote}
+              >
+                <Quote className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Quote reply</TooltipContent>
+          </Tooltip>
+        )}
+        <MessageContextMenu context={menuContext} />
+      </div>
     </div>
   )
 
@@ -694,7 +719,7 @@ export function MessageItem({
           >
             {formatTime(sentAt)}
           </div>
-          <div className="message-content min-w-0 flex-1 pr-16">
+          <div className="message-content min-w-0 flex-1">
             {inlineEditing ? (
               editForm
             ) : (
@@ -758,7 +783,7 @@ export function MessageItem({
           alt={authorName}
           showStatus={false}
         />
-        <div className="message-content min-w-0 flex-1 pr-16">
+        <div className="message-content min-w-0 flex-1">
           <div className="mb-0.5 flex items-baseline gap-2">
             {interactiveName ? (
               <button

--- a/apps/frontend/src/components/timeline/save-message-button.tsx
+++ b/apps/frontend/src/components/timeline/save-message-button.tsx
@@ -10,6 +10,10 @@ import { ReminderPopoverContent } from "./reminder-popover-content"
 interface SaveMessageButtonProps {
   workspaceId: string
   messageId: string
+  /** Set on conversation surfaces (board card / panel) so the saved row — and any
+   * reminder created from the popover — deep-links back into the conversation
+   * panel. Omitted in the stream timeline, where a message has no conversation. */
+  conversationId?: string
 }
 
 /**
@@ -18,7 +22,7 @@ interface SaveMessageButtonProps {
  * (matches the spec: "pressing the bookmark saves, hovering shows the
  * popover").
  */
-export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonProps) {
+export function SaveMessageButton({ workspaceId, messageId, conversationId }: SaveMessageButtonProps) {
   const saved = useSavedForMessage(workspaceId, messageId)
   const saveMutation = useSaveMessage(workspaceId)
   const updateMutation = useUpdateSaved(workspaceId)
@@ -37,7 +41,7 @@ export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonP
     if (isPending) return
     if (!saved) {
       saveMutation.mutate(
-        { messageId },
+        { messageId, conversationId },
         {
           onError: () => toast.error("Could not save message"),
         }
@@ -47,7 +51,7 @@ export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonP
     if (saved.status !== "saved") {
       // Re-saving a done/archived item brings it back to the Saved tab per spec.
       saveMutation.mutate(
-        { messageId },
+        { messageId, conversationId },
         {
           onError: () => toast.error("Could not restore saved item"),
         }
@@ -78,7 +82,12 @@ export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonP
         </Button>
       </HoverCardTrigger>
       <HoverCardContent align="end" className="w-72 p-0">
-        <ReminderPopoverContent workspaceId={workspaceId} messageId={messageId} saved={saved ?? null} />
+        <ReminderPopoverContent
+          workspaceId={workspaceId}
+          messageId={messageId}
+          conversationId={conversationId}
+          saved={saved ?? null}
+        />
       </HoverCardContent>
     </HoverCard>
   )


### PR DESCRIPTION
## Problem

The per-message hover toolbar is inconsistent between surfaces. The stream timeline (`MessageEvent`) surfaces four quick actions — **react · save · quote reply · reply-in-thread** — plus the overflow menu. The board card / conversation panel / label page (all `MessageItem`) showed only **react · ⋯**, so Save and Quote reply were reachable only by opening the overflow menu. Same messages, different affordances.

## Solution

Bring `MessageItem`'s toolbar up to the timeline's set and placement: adopt the timeline's float-above chip and add **Save** and **Quote reply**. The board toolbar is now **react · save · quote reply · ⋯**, matching the timeline's first three quick actions.

Reply-in-thread stays timeline-only by design — a board/conversation row is already inside its conversation; its branch gesture is "New sub-topic," which is conditional (only when no thread exists yet) and lives in the overflow menu. A fixed toolbar button for it would shuffle in/out, which the timeline deliberately avoids.

### How it works

- **Float-above chip instead of the inline pill.** `MessageItem`'s cluster moves from the inline top-right pill (`right-2 top-1.5`, shipped in #1349) to the timeline's exact treatment: `reveal-actions-hover-only absolute right-4 bottom-[calc(100%-20px)] z-10 hidden sm:block`, wrapping the buttons in the same `rounded-md border bg-popover/95 shadow-md` chip. Floating above the row means it needs no content-padding reserve, so the `pr-16` reserve on the content column is dropped. `hidden sm:block` keeps it off phones entirely (touch reaches these via the long-press drawer, unchanged).
- **Save.** Reuses the timeline's `SaveMessageButton`. Extended it with an optional `conversationId` prop, threaded into the save mutation and the reminder popover (`ReminderPopoverContent` already accepted one). The board/panel pass `conversationId` so a saved board message — and any reminder created from the popover — deep-links back into the conversation panel; the timeline passes nothing, so its behavior is byte-for-byte unchanged.
- **Quote reply.** A ghost icon button gated on the quote-reply provider (`quoteReplyCtx`), calling the existing guarded `triggerQuote`. It auto-hides on the label page, which has no composer/provider — the same field-one-side-sets gate the overflow action already uses.

### Key design decisions

**1. Adopt the timeline's placement, not a widened inline reserve.** Four buttons (~110px) don't fit the #1349 inline pill's `pr-16` reserve without a large content-padding bump that squeezes narrow widths. The timeline already solved this by floating the toolbar above the row. Since the goal is *alignment with the timeline*, matching its placement is both the truest alignment and the fix for the reserve problem. Per Kris: the toolbar should not be visible on phones — `hidden sm:block` delivers that (it's genuinely not rendered below `sm`, not just input-gated).

**2. `conversationId` on `SaveMessageButton` is optional, not required.** The timeline has no conversation to attach, so making it required would force a meaningless value there. Optional keeps the timeline call site unchanged and lets the conversation surfaces opt in.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/message/message-item.tsx` | Swap the inline pill for the timeline's float-above chip; add Save + Quote reply; drop the `pr-16` content reserve; import `SaveMessageButton`, `Button`, `Tooltip`. |
| `apps/frontend/src/components/timeline/save-message-button.tsx` | Add optional `conversationId` prop, threaded into the two save mutations and `ReminderPopoverContent`. |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | `pt-4` on the message-list container so the first row's float-above toolbar isn't clipped by the scroll-container top (self-review — see below). |

## Design evolution (self-review)

The float-above chip floats ~14px above its row. That's fine where the container has top headroom, but review flagged the containers that don't. Verified each `MessageItem` host live:

- **Board card** — has header + padding above the first message. Fine (verified: chip lands in the band below the header).
- **Conversation panel** — the list container was `overflow-y-auto px-4` with **no** padding-top, so the first message's toolbar clipped ~12px at the scroll-container top edge (buttons ~2/3 visible). **Fixed** with `pt-4` — same headroom the stream timeline reserves via its header spacer. Verified live: chip top now sits 2px inside the container, fully visible.
- **Label page** — the `py-3` cell padding (12px) already covers the poke; only a ~2px cosmetic edge sits under the container's `overflow-hidden`, buttons fully visible. Left as-is.

## Out of scope (deliberate)

- **Reply-in-thread on the board.** No board analog (see Solution). "New sub-topic" stays in the overflow menu.
- **Timeline behavior.** `MessageEvent` is untouched; `SaveMessageButton`'s new prop defaults to `undefined`, so the timeline is unchanged.

## Test plan

- [x] `apps/frontend` typecheck clean; pre-commit hooks (prettier, eslint across apps, migrations/docker/api-docs) green.
- [x] `message-event.test.tsx` + `board-card.test.tsx` + `actor-row-theme.test.tsx` — 48 pass.
- [x] Live (stub-auth stack, real bot message): DOM enumerates `["Add reaction","Save for later","Quote reply","Message actions"]` on every board row. First row's float-above toolbar clears the sticky card header (no collision/clipping). Bot actor accent + hover wash survive under the toolbar. Screenshots captured.
- [x] Live: conversation panel first-row toolbar — reproduced the clip, applied `pt-4`, re-verified the chip top sits inside the container (2px headroom, fully visible).
- [x] Pre-PR review (4 reviewer agents: spec+design, correctness+data-flow, UX, mobile): 1 finding fixed (conversation-panel first-row clip), 0 others surviving.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
