### PR TITLE
feat(frontend): rank conversation move targets by time

### DIFF
--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -247,9 +247,13 @@ export function ConversationOverlayRow({
   const isDimmed = focusedConversationId != null && annotation.conversationId !== focusedConversationId
   const isPending = pendingMessageIds.has(messageId)
   const [correctionMenuOpen, setCorrectionMenuOpen] = useState(false)
-  const conversationCandidates = correctionMenuOpen
-    ? sortConversationsByTemporalProximity(model.conversations, messageCreatedAt)
-    : model.conversations
+  const conversationCandidates = useMemo(
+    () =>
+      correctionMenuOpen
+        ? sortConversationsByTemporalProximity(model.conversations, messageCreatedAt)
+        : model.conversations,
+    [correctionMenuOpen, model.conversations, messageCreatedAt]
+  )
 
   // React 19 ref-callback cleanup: registration is undone when the row
   // unmounts or its conversation changes (reassignment). MUST be memoized —

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from "react"
+import { useCallback, useMemo, useState, type ReactNode } from "react"
 import { Check, ChevronUp, Layers, Loader2, Plus, Sparkles, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -14,7 +14,12 @@ import {
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { ConversationWithStaleness } from "@threa/types"
-import { conversationColor, type ConversationOverlayContext, type ConversationRowAnnotation } from "./model"
+import {
+  conversationColor,
+  sortConversationsByTemporalProximity,
+  type ConversationOverlayContext,
+  type ConversationRowAnnotation,
+} from "./model"
 import { ConversationOverlayRowProvider } from "./row-context"
 
 /**
@@ -222,12 +227,14 @@ export function ConversationOverlayRow({
   overlay,
   annotation,
   messageId,
+  messageCreatedAt,
   selectionActive = false,
   children,
 }: {
   overlay: ConversationOverlayContext
   annotation: ConversationRowAnnotation
   messageId: string
+  messageCreatedAt: string
   /** While a split selection is active the row is a selection toggle; the
    *  single-message correction swatch is hidden so it can't intercept the tap. */
   selectionActive?: boolean
@@ -239,6 +246,10 @@ export function ConversationOverlayRow({
   const colorIndex = conversation ? (model.colorIndexById.get(conversation.id) ?? 0) : null
   const isDimmed = focusedConversationId != null && annotation.conversationId !== focusedConversationId
   const isPending = pendingMessageIds.has(messageId)
+  const [correctionMenuOpen, setCorrectionMenuOpen] = useState(false)
+  const conversationCandidates = correctionMenuOpen
+    ? sortConversationsByTemporalProximity(model.conversations, messageCreatedAt)
+    : model.conversations
 
   // React 19 ref-callback cleanup: registration is undone when the row
   // unmounts or its conversation changes (reassignment). MUST be memoized —
@@ -299,7 +310,7 @@ export function ConversationOverlayRow({
           </span>
         )}
         {!selectionActive && (
-          <DropdownMenu>
+          <DropdownMenu open={correctionMenuOpen} onOpenChange={setCorrectionMenuOpen}>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
@@ -329,7 +340,7 @@ export function ConversationOverlayRow({
               <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
                 This message belongs to…
               </DropdownMenuLabel>
-              {model.conversations.map((candidate) => {
+              {conversationCandidates.map((candidate) => {
                 const isCurrent = candidate.id === annotation.conversationId
                 const candidateColorIndex = model.colorIndexById.get(candidate.id) ?? 0
                 return (
@@ -381,24 +392,30 @@ export function ConversationPickerDrawer({
   overlay,
   annotation,
   messageId,
+  messageCreatedAt,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   overlay: ConversationOverlayContext
   annotation: ConversationRowAnnotation
   messageId: string
+  messageCreatedAt: string
 }) {
   const { model, onReassignMessage, pendingMessageIds } = overlay
   // Mirror the rail swatch menu: ignore picks while this message's
   // reassignment is already in flight, so rapid taps can't enqueue
   // duplicate corrections.
   const isPending = pendingMessageIds.has(messageId)
+  const conversationCandidates = useMemo(
+    () => sortConversationsByTemporalProximity(model.conversations, messageCreatedAt),
+    [model.conversations, messageCreatedAt]
+  )
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent>
         <DrawerTitle className="px-5 pb-2 pt-1 text-sm font-semibold">This message belongs to…</DrawerTitle>
         <div className="max-h-[60dvh] overflow-y-auto px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
-          {model.conversations.map((candidate) => {
+          {conversationCandidates.map((candidate) => {
             const isCurrent = candidate.id === annotation.conversationId
             const colorIndex = model.colorIndexById.get(candidate.id) ?? 0
             return (

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
@@ -27,11 +27,13 @@ function makeConversation(overrides: Partial<ConversationWithStaleness>): Conver
   }
 }
 
-function makeOverlay(onReassignMessage: ConversationOverlayContext["onReassignMessage"]): ConversationOverlayContext {
-  const conversations = [
+function makeOverlay(
+  onReassignMessage: ConversationOverlayContext["onReassignMessage"],
+  conversations = [
     makeConversation({ id: "conv_a", topicSummary: "Pizza", messageIds: ["msg_1"] }),
     makeConversation({ id: "conv_b", topicSummary: "Deploys", messageIds: ["msg_2"] }),
   ]
+): ConversationOverlayContext {
   return {
     model: buildConversationOverlayModel(conversations, "stream_123"),
     focusedConversationId: null,
@@ -52,10 +54,36 @@ describe("ConversationPickerDrawer", () => {
         overlay={makeOverlay(onReassignMessage)}
         annotation={{ conversationId: "conv_a", blockStart: true }}
         messageId="msg_1"
+        messageCreatedAt="2026-06-01T00:00:00.000Z"
       />
     )
     fireEvent.click(screen.getByText("Deploys"))
     expect(onReassignMessage).toHaveBeenCalledWith("msg_1", "conv_b")
+  })
+
+  it("orders suggestions by createdAt distance from the message", () => {
+    const onReassignMessage = vi.fn<(messageId: string, toConversationId: string | null) => void>()
+    const conversations = [
+      makeConversation({ id: "conv_oldest", topicSummary: "Oldest", createdAt: "2026-06-01T09:00:00.000Z" }),
+      makeConversation({ id: "conv_after", topicSummary: "After", createdAt: "2026-06-01T10:01:00.000Z" }),
+      makeConversation({ id: "conv_before", topicSummary: "Before", createdAt: "2026-06-01T09:59:00.000Z" }),
+    ]
+    render(
+      <ConversationPickerDrawer
+        open
+        onOpenChange={vi.fn()}
+        overlay={makeOverlay(onReassignMessage, conversations)}
+        annotation={{ conversationId: null, blockStart: false }}
+        messageId="msg_1"
+        messageCreatedAt="2026-06-01T10:00:00.000Z"
+      />
+    )
+
+    expect(screen.getAllByText(/^(Before|After|Oldest)$/).map((element) => element.textContent)).toEqual([
+      "Before",
+      "After",
+      "Oldest",
+    ])
   })
 
   it("moves the message to a new conversation with a null target", () => {
@@ -67,6 +95,7 @@ describe("ConversationPickerDrawer", () => {
         overlay={makeOverlay(onReassignMessage)}
         annotation={{ conversationId: "conv_a", blockStart: true }}
         messageId="msg_1"
+        messageCreatedAt="2026-06-01T00:00:00.000Z"
       />
     )
     fireEvent.click(screen.getByText("New conversation"))

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ConversationWithStaleness } from "@threa/types"
-import { ConversationPickerDrawer } from "./conversation-overlay"
+import { ConversationOverlayRow, ConversationPickerDrawer } from "./conversation-overlay"
 import { buildConversationOverlayModel, type ConversationOverlayContext } from "./model"
 
 function makeConversation(overrides: Partial<ConversationWithStaleness>): ConversationWithStaleness {
@@ -44,7 +45,7 @@ function makeOverlay(
   }
 }
 
-describe("ConversationPickerDrawer", () => {
+describe("conversation correction pickers", () => {
   it("reassigns to an existing conversation by id", () => {
     const onReassignMessage = vi.fn<(messageId: string, toConversationId: string | null) => void>()
     render(
@@ -78,6 +79,33 @@ describe("ConversationPickerDrawer", () => {
         messageCreatedAt="2026-06-01T10:00:00.000Z"
       />
     )
+
+    expect(screen.getAllByText(/^(Before|After|Oldest)$/).map((element) => element.textContent)).toEqual([
+      "Before",
+      "After",
+      "Oldest",
+    ])
+  })
+
+  it("orders rail-dropdown suggestions by createdAt distance from the message", async () => {
+    const onReassignMessage = vi.fn<(messageId: string, toConversationId: string | null) => void>()
+    const conversations = [
+      makeConversation({ id: "conv_oldest", topicSummary: "Oldest", createdAt: "2026-06-01T09:00:00.000Z" }),
+      makeConversation({ id: "conv_after", topicSummary: "After", createdAt: "2026-06-01T10:01:00.000Z" }),
+      makeConversation({ id: "conv_before", topicSummary: "Before", createdAt: "2026-06-01T09:59:00.000Z" }),
+    ]
+    render(
+      <ConversationOverlayRow
+        overlay={makeOverlay(onReassignMessage, conversations)}
+        annotation={{ conversationId: null, blockStart: false }}
+        messageId="msg_1"
+        messageCreatedAt="2026-06-01T10:00:00.000Z"
+      >
+        <span>Message</span>
+      </ConversationOverlayRow>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Correct conversation for this message" }))
 
     expect(screen.getAllByText(/^(Before|After|Oldest)$/).map((element) => element.textContent)).toEqual([
       "Before",

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -6,6 +6,7 @@ import {
   buildMessageConversationMap,
   CONVERSATION_COLOR_COUNT,
   conversationColor,
+  sortConversationsByTemporalProximity,
 } from "./model"
 
 function makeConversation(overrides: Partial<ConversationWithStaleness>): ConversationWithStaleness {
@@ -129,6 +130,33 @@ describe("buildMessageConversationMap", () => {
 
     const lastId = model.conversations[CONVERSATION_COLOR_COUNT].id
     expect(model.colorIndexById.get(lastId)).toBe(0)
+  })
+})
+
+describe("sortConversationsByTemporalProximity", () => {
+  it("ranks conversations by createdAt distance from the message, with stable chronological ties", () => {
+    const conversations = [
+      makeConversation({
+        id: "conv_oldest",
+        createdAt: "2026-06-01T09:00:00.000Z",
+        lastActivityAt: "2026-06-01T10:01:00.000Z",
+      }),
+      makeConversation({
+        id: "conv_after",
+        createdAt: "2026-06-01T10:01:00.000Z",
+        lastActivityAt: "2026-06-01T09:00:00.000Z",
+      }),
+      makeConversation({
+        id: "conv_before",
+        createdAt: "2026-06-01T09:59:00.000Z",
+        lastActivityAt: "2026-06-01T08:00:00.000Z",
+      }),
+    ]
+
+    const ranked = sortConversationsByTemporalProximity(conversations, "2026-06-01T10:00:00.000Z")
+
+    expect(ranked.map((conversation) => conversation.id)).toEqual(["conv_before", "conv_after", "conv_oldest"])
+    expect(conversations.map((conversation) => conversation.id)).toEqual(["conv_oldest", "conv_after", "conv_before"])
   })
 })
 

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -54,6 +54,31 @@ export function buildConversationOverlayModel(
   return { conversations: ordered, conversationsById, colorIndexById, conversationIdByMessageId }
 }
 
+/** Picker-only ranking; palette assignment remains chronological and stable. */
+export function sortConversationsByTemporalProximity(
+  conversations: readonly ConversationWithStaleness[],
+  messageCreatedAt: string
+): ConversationWithStaleness[] {
+  const messageTime = Date.parse(messageCreatedAt)
+  if (!Number.isFinite(messageTime)) throw new RangeError(`Invalid message createdAt: ${messageCreatedAt}`)
+
+  return conversations
+    .map((conversation) => {
+      const createdAt = Date.parse(conversation.createdAt)
+      if (!Number.isFinite(createdAt)) {
+        throw new RangeError(`Invalid conversation createdAt: ${conversation.createdAt}`)
+      }
+      return { conversation, createdAt }
+    })
+    .sort(
+      (a, b) =>
+        Math.abs(a.createdAt - messageTime) - Math.abs(b.createdAt - messageTime) ||
+        a.createdAt - b.createdAt ||
+        a.conversation.id.localeCompare(b.conversation.id)
+    )
+    .map(({ conversation }) => conversation)
+}
+
 /**
  * Map every message id in `conversations` to the conversation it belongs to,
  * for the "Show in conversation" action. Unlike {@link buildConversationOverlayModel}

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -804,6 +804,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
           overlay={ctx.conversationOverlay}
           annotation={item.conversationRow}
           messageId={overlayMessageId}
+          messageCreatedAt={item.event.createdAt}
           // Split-select keeps the overlay mounted for its coloring, but the row
           // is a selection toggle then — hide the single-message correction swatch
           // so it can't steal the tap (it renders outside the row's `inert` slot).

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1585,6 +1585,7 @@ function SentMessageEvent({
           overlay={conversationOverlayRow.overlay}
           annotation={conversationOverlayRow.annotation}
           messageId={payload.messageId}
+          messageCreatedAt={event.createdAt}
         />
       )}
     </>


### PR DESCRIPTION
## Problem

`ConversationOverlayModel.conversations` is intentionally oldest-first for stable palette assignment. The move-to-conversation pickers reused that order, forcing users to scroll to reach nearby conversations when correcting a recent or mid-stream message.

## Solution

Rank move targets by the absolute distance between the message's `createdAt` and each conversation's `createdAt`. The closest conversation appears first on both paths:

- the desktop overlay rail dropdown in `ConversationOverlayRow`
- the context-menu drawer in `ConversationPickerDrawer`, used on desktop and mobile

### How it works

- `sortConversationsByTemporalProximity` returns a sorted copy; equal distances prefer the earlier conversation, then id.
- `event-list.tsx` and `message-event.tsx` pass the source message timestamp into their picker surfaces.
- The base overlay model remains oldest-first, preserving stable color assignments and the in-view legend.
- The per-row dropdown computes the ranking only while open; closed timeline rows retain the existing model array.

### Key design decision

**Creation time, not activity time** — `lastActivityAt` would rank revived conversations near the message despite an old origin. `createdAt` measures the requested temporal distance and avoids changing as conversations receive replies.

## Files changed

| File | Change |
| ---- | ------ |
| `conversation-overlay/model.ts` | Adds temporal-proximity ranking without mutating the overlay model. |
| `conversation-overlay/conversation-overlay.tsx` | Applies ranking to the rail dropdown and responsive context-menu drawer. |
| `timeline/event-list.tsx` | Supplies message creation time to row-level correction dropdowns. |
| `timeline/message-event.tsx` | Supplies message creation time to context-menu pickers. |
| `conversation-overlay/model.test.ts` | Covers distance ranking, tie-breaking, `lastActivityAt` independence, and input immutability. |
| `conversation-overlay/conversation-picker.test.tsx` | Verifies rendered suggestion order and existing move behavior. |

## Test plan

- [x] Frontend unit suite: `bun run --cwd apps/frontend test` — 4,384 passed
- [x] Focused conversation-overlay suites — 19 passed
- [x] Frontend ESLint — clean
- [x] Frontend TypeScript — clean
- [x] Commit hook: monorepo lint, monorepo typecheck, Dockerfile/migration checks, generated API docs check — clean
- [ ] Browser E2E not run; ordering is covered by the component and pure-model tests

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786734303&installation_id=129946197&pr_number=1353&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1353&signature=51dfc2abfa662bd2376a15d4a1ca21d98110295d23ee89180b3a7ca285d95b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->