### PR TITLE
docs: use Seer for HTML previews instead of Claude artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,28 @@ Default to Bun instead of Node.js:
 - `bun run <script>` instead of `npm run <script>`
 - Bun auto-loads `.env` - do not use `dotenv`
 
+## Previewing HTML
+
+**Use Seer, not Claude/Anthropic artifacts.** Claude artifacts do not render for this user — never publish a preview there. When you build anything meant to be looked at in a browser (a page, mockup, chart, dashboard, diagram, rendered report), be eager to publish it to Seer and hand back the URL.
+
+Seer hosts self-contained HTML bundles behind a bearer token. The token is `SEER_API_KEY` in this runtime (already set; never print it).
+
+Upload flow:
+
+1. Build a directory with `index.html` at its root; use relative asset paths (`./style.css`, `assets/app.js`) since bundles serve under `/b/<slug>/`. Prefer inlined/self-contained assets over external requests.
+2. Zip from inside the build dir: `zip -r ../bundle.zip .`
+3. `PUT` it under a slug matching `[a-z0-9][a-z0-9-]{0,63}`:
+
+```sh
+curl -X PUT --data-binary @bundle.zip \
+  -H "Authorization: Bearer $SEER_API_KEY" \
+  https://seer.build/api/bundles/<slug>
+```
+
+The `200` response JSON carries `url` (latest, live-reload) and `versionUrl` (pinned) — give the user the `url`. Re-`PUT`ting the same slug publishes a new version at the same URL. Limit 50 MB; `..`/absolute-path zip entries are rejected; viewing requires the user's Google sign-in.
+
+Full contract: https://seer.build/skill.md
+
 ## Workflow and Verification
 
 Prefer test-first development: write or update a failing test that captures the desired behavior, then implement the fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,18 +59,18 @@ Default to Bun instead of Node.js:
 
 ## Previewing HTML
 
-**Use Seer, not Claude/Anthropic artifacts.** Claude artifacts do not render for this user — never publish a preview there. When you build anything meant to be looked at in a browser (a page, mockup, chart, dashboard, diagram, rendered report), be eager to publish it to Seer and hand back the URL.
+**Use Seer, not Claude/Anthropic artifacts.** Claude artifacts do not render for this user — never publish a preview there. Reach for Seer liberally: plans, diagrams, examples, mockups, charts, dashboards, rendered reports — anything easier to grasp as a rendered page than as terminal text belongs here. Default to publishing and handing back the URL rather than pasting a wall of HTML or ASCII.
 
 Seer hosts self-contained HTML bundles behind a bearer token. The token is `SEER_API_KEY` in this runtime (already set; never print it).
 
 Upload flow:
 
-1. Build a directory with `index.html` at its root; use relative asset paths (`./style.css`, `assets/app.js`) since bundles serve under `/b/<slug>/`. Prefer inlined/self-contained assets over external requests.
-2. Zip from inside the build dir: `zip -r ../bundle.zip .`
-3. `PUT` it under a slug matching `[a-z0-9][a-z0-9-]{0,63}`:
+1. Build in a fresh temp dir so parallel sessions never clobber each other: `dir=$(mktemp -d)`. Put `index.html` at its root; use relative asset paths (`./style.css`, `assets/app.js`) since bundles serve under `/b/<slug>/`. Prefer inlined/self-contained assets over external requests.
+2. Zip from inside the build dir: `(cd "$dir" && zip -r bundle.zip . -x bundle.zip)`
+3. `PUT` under a slug matching `[a-z0-9][a-z0-9-]{0,63}`. Make it unique so concurrent sessions don't overwrite each other's previews — suffix a short random token (e.g. `plan-$(openssl rand -hex 3)`). Reuse the same slug only when you deliberately want to update an existing preview at its URL.
 
 ```sh
-curl -X PUT --data-binary @bundle.zip \
+curl -X PUT --data-binary @"$dir/bundle.zip" \
   -H "Authorization: Bearer $SEER_API_KEY" \
   https://seer.build/api/bundles/<slug>
 ```


### PR DESCRIPTION
## Problem

Claude/Anthropic artifacts never render for this user, so browser-viewable output (plans, diagrams, mockups, charts, rendered reports) had no reliable preview path — it ended up pasted as HTML/ASCII walls into the terminal. A `SEER_API_KEY` for the Seer AdHoc bundle host was added to the runtime, but nothing in the repo told an agent it exists or how to use it.

## Solution

Add a **Previewing HTML** section to `CLAUDE.md` (between Runtime/Build and Workflow) documenting Seer as the default preview host, with a collision-safe upload flow and a pointer to the full contract at https://seer.build/skill.md.

### How it works

- **Use it liberally** — plans, diagrams, examples, mockups, charts, dashboards, reports. Default to publishing a URL over pasting markup.
- **Auth** — `SEER_API_KEY` (in runtime, never printed).
- **Collision-safe build** — `dir=$(mktemp -d)`; `index.html` at root; zip from inside the dir.
- **Unique slugs** — suffix a random token (`plan-$(openssl rand -hex 3)`) so parallel sessions don't overwrite each other's previews; reuse a slug only to deliberately update a preview at its URL.
- `PUT https://seer.build/api/bundles/<slug>` returns JSON with `url` (latest, live-reload) and `versionUrl` (pinned); hand back `url`. 50 MB limit, `..`/absolute-path entries rejected, Google sign-in to view.

## Files changed

| File | Change |
| ---- | ------ |
| `CLAUDE.md` | New "Previewing HTML" section: Seer over Claude artifacts, `mktemp -d` builds, unique slugs, upload flow, link to seer.build/skill.md |

## Test plan

- [x] Live smoke test of the documented flow against seer.build: `mktemp -d` build → `zip` → `PUT` with `SEER_API_KEY` returned `200` with `url`/`versionUrl` as documented (https://seer.build/b/smoke-f1caa3/)
- [ ] No automated suite — docs-only change to `CLAUDE.md`, nothing to unit-test

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_0165Jn2YpCEPUJMC7fyW5ihQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786735428&installation_id=129946197&pr_number=1354&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1354&signature=2010ef424d78bdfa674cf79e773e9d3098672330e0aee4304e5be8c37e8e7b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->