### PR TITLE
feat(frontend): fuzzy, separator-insensitive search across pickers

### DIFF
--- a/apps/frontend/src/components/board/board-filter-pickers.tsx
+++ b/apps/frontend/src/components/board/board-filter-pickers.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import type { CachedLabel } from "@/hooks/use-labels"
+import { scoreMatch } from "@/lib/match-score"
 import { STREAM_ICONS } from "@/lib/streams"
 import { toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { BOARD_STREAM_TYPE_LABELS as TYPE_LABELS } from "@/lib/board/stream-type-labels"
@@ -185,7 +186,7 @@ export function BoardScopePicker({
       .filter((s) => SCOPE_STREAM_TYPES.has(s.type))
       .filter((s) => !s.archivedAt || isSelected(s.id))
       .map((stream) => ({ stream, label: labelFor(stream.id) }))
-      .filter(({ label }) => !lower || label.toLowerCase().includes(lower))
+      .filter(({ label }) => !lower || scoreMatch(lower, [label]) !== Infinity)
       .sort((a, b) => {
         const bySelected = Number(isSelected(b.stream.id)) - Number(isSelected(a.stream.id))
         return bySelected !== 0 ? bySelected : a.label.localeCompare(b.label)
@@ -407,7 +408,7 @@ export function BoardLabelPicker({
     const lower = search.trim().toLowerCase()
     const isSelected = (id: string) => included.has(id) || excluded.has(id)
     return myLabels
-      .filter((label) => !lower || label.name.toLowerCase().includes(lower))
+      .filter((label) => !lower || scoreMatch(lower, [label.name]) !== Infinity)
       .sort((a, b) => {
         const bySelected = Number(isSelected(b.id)) - Number(isSelected(a.id))
         return bySelected !== 0 ? bySelected : a.name.localeCompare(b.name)

--- a/apps/frontend/src/components/composer/stream-target-picker.tsx
+++ b/apps/frontend/src/components/composer/stream-target-picker.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { StreamSortToggle } from "./stream-sort-toggle"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useStreamPickerGroups } from "@/hooks/use-stream-picker-groups"
+import { scoreMatch } from "@/lib/match-score"
 import { useStoredStreamSortMode } from "@/lib/stream-sort"
 import {
   useWorkspaceStreams,
@@ -89,7 +90,8 @@ export function StreamTargetPicker({
   const isSearching = lower.length > 0
 
   const newOptions = useMemo(
-    () => (includeNewOptions ? NEW_OPTIONS.filter((o) => !isSearching || o.label.toLowerCase().includes(lower)) : []),
+    () =>
+      includeNewOptions ? NEW_OPTIONS.filter((o) => !isSearching || scoreMatch(lower, [o.label]) !== Infinity) : [],
     [includeNewOptions, isSearching, lower]
   )
 

--- a/apps/frontend/src/components/editor/triggers/use-command-arg-picker.test.ts
+++ b/apps/frontend/src/components/editor/triggers/use-command-arg-picker.test.ts
@@ -65,8 +65,12 @@ describe("filterArgSuggestions", () => {
     ])
   })
 
-  it("matches on the human label", () => {
-    expect(filterArgSuggestions(MODEL_SUGGESTIONS, "opus").map((s) => s.value)).toEqual(["anthropic/claude-opus-4"])
+  it("matches on the human label, ranking it above fuzzy tail matches", () => {
+    // "opus" is also an in-order subsequence of "anthropic/claude-sonnet-4",
+    // so the fuzzy tier admits it — but only below the substring match.
+    const values = filterArgSuggestions(MODEL_SUGGESTIONS, "opus").map((s) => s.value)
+    expect(values[0]).toBe("anthropic/claude-opus-4")
+    expect(values).not.toContain("openai/gpt-5")
   })
 
   it("matches on the raw value the backend resolves on", () => {

--- a/apps/frontend/src/components/editor/triggers/use-command-arg-picker.test.ts
+++ b/apps/frontend/src/components/editor/triggers/use-command-arg-picker.test.ts
@@ -70,6 +70,7 @@ describe("filterArgSuggestions", () => {
     // so the fuzzy tier admits it — but only below the substring match.
     const values = filterArgSuggestions(MODEL_SUGGESTIONS, "opus").map((s) => s.value)
     expect(values[0]).toBe("anthropic/claude-opus-4")
+    expect(values).toContain("anthropic/claude-sonnet-4")
     expect(values).not.toContain("openai/gpt-5")
   })
 

--- a/apps/frontend/src/components/labels/label-picker.tsx
+++ b/apps/frontend/src/components/labels/label-picker.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 import { useIsOnline } from "@/components/layout/connection-status"
+import { rankMatches } from "@/lib/match-score"
 import { cn } from "@/lib/utils"
 import { LabelGlyph } from "./label-chip"
 import { useAssignLabel, useLabelsView, useResourceLabelAssignments, useUnassignLabel, type CachedLabel } from "@/hooks"
@@ -136,10 +137,10 @@ export function LabelPicker({ workspaceId, resourceType, resourceId, open, onOpe
     mutation.mutate({ labelId, resourceType, resourceId }, { onSettled })
   }
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    return q ? myLabels.filter((label) => label.name.toLowerCase().includes(q)) : myLabels
-  }, [myLabels, query])
+  const filtered = useMemo(
+    () => rankMatches(myLabels, query.trim(), (label) => ({ labels: [label.name] })),
+    [myLabels, query]
+  )
 
   return (
     <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>

--- a/apps/frontend/src/components/quick-switcher/filter-select.tsx
+++ b/apps/frontend/src/components/quick-switcher/filter-select.tsx
@@ -4,6 +4,7 @@ import { Calendar } from "@/components/ui/calendar"
 import { formatISODate } from "@/lib/dates"
 import { useFormattedDate } from "@/hooks"
 import type { StreamType, User, Stream } from "@threa/types"
+import { rankMatches } from "@/lib/match-score"
 import { getStreamName, streamLabel } from "@/lib/streams"
 
 interface StreamTypeOption {
@@ -82,13 +83,10 @@ interface UserSelectProps {
 function UserSelect({ users, onSelect }: UserSelectProps) {
   const [search, setSearch] = useState("")
 
-  const filtered = useMemo(() => {
-    const searchLower = search.toLowerCase()
-    return users.filter((u) => {
-      const name = u.name || u.slug
-      return name.toLowerCase().includes(searchLower) || u.slug.toLowerCase().includes(searchLower)
-    })
-  }, [users, search])
+  const filtered = useMemo(
+    () => rankMatches(users, search, (u) => ({ labels: [u.name || u.slug, u.slug] })),
+    [users, search]
+  )
 
   return (
     <div className="w-48">
@@ -170,10 +168,7 @@ interface StreamSelectProps {
 function StreamSelect({ streams, onSelect }: StreamSelectProps) {
   const [search, setSearch] = useState("")
 
-  const filtered = streams.filter((s) => {
-    const name = getStreamName(s) ?? ""
-    return name.toLowerCase().includes(search.toLowerCase())
-  })
+  const filtered = rankMatches(streams, search, (s) => ({ labels: [getStreamName(s) ?? ""] }))
 
   const resolvedName = (stream: Stream) => streamLabel(stream)
 

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
+import { scoreMatch } from "@/lib/match-score"
 import { compareStreamEntries, scoreStreamMatch } from "@/lib/stream-sort"
 import { FilterSelect } from "./filter-select"
 import {
@@ -223,14 +224,10 @@ export function useStreamItems(context: ModeContext): ModeResult {
     const virtualDmItems = users!
       .filter((workspaceUser) => workspaceUser.id !== currentUserId)
       .filter((workspaceUser) => !existingDmPeerIds.has(workspaceUser.id))
-      .map((workspaceUser) => {
-        const name = workspaceUser.name
-        let score = 0
-        if (searchText && !name.toLowerCase().includes(lowerQuery)) {
-          score = Infinity
-        }
-        return { workspaceUser, score }
-      })
+      .map((workspaceUser) => ({
+        workspaceUser,
+        score: searchText ? scoreMatch(lowerQuery, [workspaceUser.name]) : 0,
+      }))
       .filter(({ score }) => score !== Infinity)
       .sort((a, b) => a.workspaceUser.name.localeCompare(b.workspaceUser.name))
       .map(

--- a/apps/frontend/src/components/search/search-filter-menu.tsx
+++ b/apps/frontend/src/components/search/search-filter-menu.tsx
@@ -22,6 +22,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { FILTER_TYPE_OPTIONS } from "@/components/editor/triggers/filter-type-extension"
 import { STATUS_FILTER_OPTIONS } from "@/components/editor/triggers/status-filter-extension"
 import { formatISODate, getFutureDatePresets, getPastDatePresets } from "@/lib/dates"
+import { rankMatches } from "@/lib/match-score"
 import { addFilterToQuery, type FilterType } from "@/lib/search-query-parser"
 import { getStreamName, streamLabel } from "@/lib/streams"
 import { cn } from "@/lib/utils"
@@ -255,12 +256,10 @@ function ChannelPicker({ workspaceId, onSelect }: { workspaceId: string; onSelec
 
   const channels = useMemo(() => {
     const withSlugs = streams.filter((s): s is typeof s & { slug: string } => Boolean(s.slug))
-    if (!search) return withSlugs
-    const lowerQuery = search.toLowerCase()
-    return withSlugs.filter(
-      (s) =>
-        s.slug.toLowerCase().includes(lowerQuery) || (getStreamName(s)?.toLowerCase().includes(lowerQuery) ?? false)
-    )
+    return rankMatches(withSlugs, search, (s) => {
+      const name = getStreamName(s)
+      return { labels: name ? [s.slug, name] : [s.slug] }
+    })
   }, [streams, search])
 
   return (

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -24,6 +24,7 @@ import { useInviteActor } from "@/hooks/use-invite-actor"
 import { useStreamService } from "@/contexts"
 import { botsApi } from "@/api/bots"
 import { useWorkspaceUsers, useWorkspaceBots } from "@/stores/workspace-store"
+import { rankMatches } from "@/lib/match-score"
 import { hasPermission } from "@/lib/permissions"
 import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type Stream, type StreamMember } from "@threa/types"
 import { toast } from "sonner"
@@ -79,11 +80,10 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
     return enriched.sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug))
   }, [streamMembers, workspaceUsers])
 
-  const filteredMembers = useMemo(() => {
-    if (!search) return enrichedMembers
-    const q = search.toLowerCase()
-    return enrichedMembers.filter((m) => m.name.toLowerCase().includes(q) || m.slug.toLowerCase().includes(q))
-  }, [enrichedMembers, search])
+  const filteredMembers = useMemo(
+    () => rankMatches(enrichedMembers, search, (m) => ({ labels: [m.name, m.slug] })),
+    [enrichedMembers, search]
+  )
 
   const availableToAdd = useMemo(() => {
     return workspaceUsers

--- a/apps/frontend/src/lib/emoji-picker.test.ts
+++ b/apps/frontend/src/lib/emoji-picker.test.ts
@@ -77,6 +77,21 @@ describe("filterBySearch", () => {
     expect(matches.map((e) => e.shortcode)).toEqual(["poop"])
   })
 
+  it("matches regardless of whitespace/dash/underscore separators", () => {
+    const thumbsUp = make("thumbs_up", "people", 1, ["thumbs_up", "+1"])
+    for (const query of ["thumbs up", "thumbs-up", "thumbsup"]) {
+      expect(filterBySearch([smile, thumbsUp], query).map((e) => e.shortcode)).toEqual(["thumbs_up"])
+    }
+  })
+
+  it("admits fuzzy subsequence matches after substring matches", () => {
+    const thumbsUp = make("thumbs_up", "people", 1, ["thumbs_up", "+1"])
+    const tulip = make("tulip", "animals", 1)
+    // "tup" is a raw substring of neither; both match as subsequences.
+    const matches = filterBySearch([smile, thumbsUp, tulip], "tup")
+    expect(new Set(matches.map((e) => e.shortcode))).toEqual(new Set(["thumbs_up", "tulip"]))
+  })
+
   it("ranks visible shortcode matches above hidden alias matches regardless of input order", () => {
     const happy = make("happy_face", "people", 1, ["happy_face", "smile_alt"])
     const matches = filterBySearch([happy, smile], "smile")

--- a/apps/frontend/src/lib/emoji-picker.test.ts
+++ b/apps/frontend/src/lib/emoji-picker.test.ts
@@ -87,9 +87,11 @@ describe("filterBySearch", () => {
   it("admits fuzzy subsequence matches after substring matches", () => {
     const thumbsUp = make("thumbs_up", "people", 1, ["thumbs_up", "+1"])
     const tulip = make("tulip", "animals", 1)
-    // "tup" is a raw substring of neither; both match as subsequences.
-    const matches = filterBySearch([smile, thumbsUp, tulip], "tup")
-    expect(new Set(matches.map((e) => e.shortcode))).toEqual(new Set(["thumbs_up", "tulip"]))
+    const setup = make("setup", "objects", 1)
+    // "setup" contains "tup" raw; thumbs_up (boundary-aligned, quality 1) and
+    // tulip (gapped) only match as subsequences, in quality order behind it.
+    const matches = filterBySearch([smile, tulip, thumbsUp, setup], "tup")
+    expect(matches.map((e) => e.shortcode)).toEqual(["setup", "thumbs_up", "tulip"])
   })
 
   it("ranks visible shortcode matches above hidden alias matches regardless of input order", () => {

--- a/apps/frontend/src/lib/fuzzy.test.ts
+++ b/apps/frontend/src/lib/fuzzy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { foldSeparators, fuzzyQuality } from "./fuzzy"
+
+describe("foldSeparators", () => {
+  it("removes whitespace, underscores, and dashes", () => {
+    expect(foldSeparators("thumbs up")).toBe("thumbsup")
+    expect(foldSeparators("thumbs_up")).toBe("thumbsup")
+    expect(foldSeparators("thumbs-up")).toBe("thumbsup")
+    expect(foldSeparators("a - b_c d")).toBe("abcd")
+  })
+
+  it("leaves other characters untouched", () => {
+    expect(foldSeparators("+1")).toBe("+1")
+    expect(foldSeparators("café")).toBe("café")
+  })
+})
+
+describe("fuzzyQuality", () => {
+  it("returns 0 when the query is not a subsequence", () => {
+    expect(fuzzyQuality("xyz", "general")).toBe(0)
+    expect(fuzzyQuality("generall", "general")).toBe(0)
+  })
+
+  it("returns 1 for a fully contiguous match from a boundary", () => {
+    expect(fuzzyQuality("general", "general")).toBe(1)
+    expect(fuzzyQuality("up", "thumbs_up")).toBe(1)
+  })
+
+  it("scores boundary-aligned abbreviations highly", () => {
+    // t-h contiguous from start, u-p contiguous from the "_" boundary.
+    expect(fuzzyQuality("thup", "thumbs_up")).toBe(1)
+  })
+
+  it("scores scattered matches below compact ones", () => {
+    const scattered = fuzzyQuality("cat", "congratulations")
+    const compact = fuzzyQuality("cat", "cat_face")
+    expect(scattered).toBeGreaterThan(0)
+    expect(compact).toBeGreaterThan(scattered)
+  })
+
+  it("matches case-insensitively against the text", () => {
+    expect(fuzzyQuality("vs", "View Saved")).toBeGreaterThan(0)
+  })
+
+  it("handles empty and oversized queries", () => {
+    expect(fuzzyQuality("", "anything")).toBe(0)
+    expect(fuzzyQuality("abcd", "abc")).toBe(0)
+  })
+})

--- a/apps/frontend/src/lib/fuzzy.ts
+++ b/apps/frontend/src/lib/fuzzy.ts
@@ -1,0 +1,67 @@
+/**
+ * Separator-insensitive fuzzy matching primitives shared by the suggestion
+ * scorers (lib/match-score.ts, lib/stream-sort.ts).
+ *
+ * Two building blocks:
+ * - `foldSeparators` makes whitespace/underscore/dash interchangeable, so
+ *   "thumbs up", "thumbs-up", and "thumbs_up" all compare equal.
+ * - `fuzzyQuality` scores an in-order subsequence match, rewarding contiguous
+ *   runs and word-boundary starts so "thup" → "thumbs_up" scores well while
+ *   scattered matches sink.
+ */
+
+const SEPARATOR = /[\s_-]/
+const SEPARATORS = /[\s_-]+/g
+
+/** Lowercased text with whitespace/underscore/dash removed. */
+export function foldSeparators(text: string): string {
+  return text.replace(SEPARATORS, "")
+}
+
+function isBoundary(text: string, index: number): boolean {
+  return index === 0 || SEPARATOR.test(text[index - 1])
+}
+
+/**
+ * Subsequence match quality in (0, 1]; 0 when `query` is not an in-order
+ * subsequence of `text`. Expects a lowercased, separator-folded query; the
+ * text keeps its separators so boundary bonuses can see them.
+ *
+ * Each matched char scores 1, plus 1 when it extends a contiguous run or sits
+ * at a word boundary; quality is the best total over all alignments divided
+ * by the maximum (2 per query char).
+ */
+export function fuzzyQuality(query: string, text: string): number {
+  const m = query.length
+  const n = text.length
+  if (m === 0 || m > n) return 0
+  const lower = text.toLowerCase()
+
+  // endAt[j]: best score for the query prefix so far with its last char
+  // matched exactly at text index j; -1 when unreachable.
+  let endAt: number[] = new Array(n).fill(-1)
+  for (let i = 0; i < m; i++) {
+    const qc = query[i]
+    const next: number[] = new Array(n).fill(-1)
+    let bestBefore = -1
+    for (let j = 0; j < n; j++) {
+      if (i > 0 && j > 0 && endAt[j - 1] > bestBefore) bestBefore = endAt[j - 1]
+      if (lower[j] !== qc) continue
+      const bonus = isBoundary(lower, j) ? 1 : 0
+      if (i === 0) {
+        next[j] = 1 + bonus
+        continue
+      }
+      const contiguous = j > 0 && endAt[j - 1] >= 0 ? endAt[j - 1] + 2 : -1
+      const gapped = bestBefore >= 0 ? bestBefore + 1 + bonus : -1
+      next[j] = Math.max(contiguous, gapped)
+    }
+    endAt = next
+  }
+
+  let best = -1
+  for (const score of endAt) {
+    if (score > best) best = score
+  }
+  return best > 0 ? best / (2 * m) : 0
+}

--- a/apps/frontend/src/lib/match-score.test.ts
+++ b/apps/frontend/src/lib/match-score.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from "vitest"
 import { scoreMatch, rankMatches } from "./match-score"
 
 describe("scoreMatch", () => {
-  it("returns 0 for an empty query (no scoring required)", () => {
+  it("returns 0 for an empty or whitespace-only query (no scoring required)", () => {
     expect(scoreMatch("", ["View Saved"], ["bookmark"])).toBe(0)
+    expect(scoreMatch("   ", ["View Saved"], ["bookmark"])).toBe(0)
   })
 
   it("tiers label matches: exact < prefix < contains", () => {
@@ -52,10 +53,14 @@ describe("scoreMatch", () => {
   it("ranks label fuzzy above keyword fuzzy, and compact fuzzy above scattered", () => {
     const labelFuzzy = scoreMatch("thup", ["thumbs_up"])
     const keywordFuzzy = scoreMatch("thup", ["Something Else"], ["thumbs_up"])
+    // Both sides must be admitted matches — an Infinity on the right would
+    // let a broken fuzzy band pass a bare lessThan comparison.
+    expect(keywordFuzzy).not.toBe(Infinity)
     expect(labelFuzzy).toBeLessThan(keywordFuzzy)
 
     const compact = scoreMatch("cat", ["cat_face"])
     const scattered = scoreMatch("cat", ["congratulations"])
+    expect(scattered).not.toBe(Infinity)
     expect(compact).toBeLessThan(scattered)
   })
 
@@ -86,9 +91,10 @@ describe("rankMatches", () => {
   }
   const text = (item: Item) => ({ labels: [item.label], keywords: item.keywords })
 
-  it("returns the input unchanged for an empty query", () => {
+  it("returns the input unchanged for an empty or whitespace-only query", () => {
     const items: Item[] = [{ label: "b" }, { label: "a" }]
     expect(rankMatches(items, "", text)).toEqual(items)
+    expect(rankMatches(items, "  ", text)).toEqual(items)
   })
 
   it("drops non-matches", () => {

--- a/apps/frontend/src/lib/match-score.test.ts
+++ b/apps/frontend/src/lib/match-score.test.ts
@@ -8,20 +8,55 @@ describe("scoreMatch", () => {
 
   it("tiers label matches: exact < prefix < contains", () => {
     expect(scoreMatch("view saved", ["View Saved"])).toBe(0)
-    expect(scoreMatch("view", ["View Saved"])).toBe(1)
-    expect(scoreMatch("saved", ["View Saved"])).toBe(2)
+    expect(scoreMatch("view", ["View Saved"])).toBe(2)
+    expect(scoreMatch("saved", ["View Saved"])).toBe(4)
+  })
+
+  it("treats whitespace, underscore, and dash as interchangeable separators", () => {
+    expect(scoreMatch("thumbs up", ["thumbs_up"])).toBe(1)
+    expect(scoreMatch("thumbsup", ["thumbs_up"])).toBe(1)
+    expect(scoreMatch("thumbs-up", ["thumbs_up"])).toBe(1)
+    expect(scoreMatch("thumbsu", ["thumbs_up"])).toBe(3)
+    expect(scoreMatch("bs up", ["thumbs_up"])).toBe(5)
+  })
+
+  it("ranks a raw match above its separator-normalized counterpart", () => {
+    expect(scoreMatch("thumbs_up", ["thumbs_up"])).toBeLessThan(scoreMatch("thumbs up", ["thumbs_up"]))
+    expect(scoreMatch("thumbs", ["thumbs_up"])).toBeLessThan(scoreMatch("thumbsu", ["thumbs_up"]))
   })
 
   it("tiers keyword matches a whole band below label matches", () => {
-    expect(scoreMatch("saved", ["Add To-do"], ["saved"])).toBe(3)
-    expect(scoreMatch("sav", ["Add To-do"], ["saved"])).toBe(4)
-    expect(scoreMatch("ave", ["Add To-do"], ["saved"])).toBe(5)
+    expect(scoreMatch("saved", ["Add To-do"], ["saved"])).toBe(6)
+    expect(scoreMatch("sav", ["Add To-do"], ["saved"])).toBe(8)
+    expect(scoreMatch("ave", ["Add To-do"], ["saved"])).toBe(10)
   })
 
-  it("ranks any label match above any keyword match", () => {
+  it("ranks any label substring match above any keyword substring match", () => {
     const labelContains = scoreMatch("saved", ["View Saved"], [])
     const keywordExact = scoreMatch("saved", ["Add To-do"], ["saved"])
     expect(labelContains).toBeLessThan(keywordExact)
+  })
+
+  it("admits fuzzy subsequence matches below every substring match", () => {
+    const fuzzy = scoreMatch("thup", ["thumbs_up"])
+    expect(fuzzy).not.toBe(Infinity)
+    expect(fuzzy).toBeGreaterThan(scoreMatch("ave", ["Add To-do"], ["saved"]))
+  })
+
+  it("ranks a keyword substring match above a label fuzzy match", () => {
+    const keywordContains = scoreMatch("humb", ["Something Else"], ["thumbs"])
+    const labelFuzzy = scoreMatch("thup", ["thumbs_up"])
+    expect(keywordContains).toBeLessThan(labelFuzzy)
+  })
+
+  it("ranks label fuzzy above keyword fuzzy, and compact fuzzy above scattered", () => {
+    const labelFuzzy = scoreMatch("thup", ["thumbs_up"])
+    const keywordFuzzy = scoreMatch("thup", ["Something Else"], ["thumbs_up"])
+    expect(labelFuzzy).toBeLessThan(keywordFuzzy)
+
+    const compact = scoreMatch("cat", ["cat_face"])
+    const scattered = scoreMatch("cat", ["congratulations"])
+    expect(compact).toBeLessThan(scattered)
   })
 
   it("takes the best score across multiple labels", () => {
@@ -30,11 +65,17 @@ describe("scoreMatch", () => {
 
   it("returns Infinity when nothing matches", () => {
     expect(scoreMatch("zzz", ["View Saved"], ["bookmark"])).toBe(Infinity)
+    expect(scoreMatch("vwx", ["View Saved"])).toBe(Infinity)
   })
 
   it("is case-insensitive on both sides", () => {
-    expect(scoreMatch("SAVED", ["view saved"])).toBe(2)
-    expect(scoreMatch("saved", ["VIEW SAVED"])).toBe(2)
+    expect(scoreMatch("SAVED", ["view saved"])).toBe(4)
+    expect(scoreMatch("saved", ["VIEW SAVED"])).toBe(4)
+  })
+
+  it("handles separator-only queries without matching everything", () => {
+    expect(scoreMatch("-", ["View Saved"])).toBe(Infinity)
+    expect(scoreMatch("-", ["to-do"])).toBe(4)
   })
 })
 
@@ -65,5 +106,11 @@ describe("rankMatches", () => {
     const items: Item[] = [{ label: "saver" }, { label: "saved" }]
     // Both are label-prefix matches for "save"; definition order decides.
     expect(rankMatches(items, "save", text)).toEqual(items)
+  })
+
+  it("appends fuzzy matches after substring matches", () => {
+    const items: Item[] = [{ label: "thumbs_up" }, { label: "setup" }, { label: "sun_with_face" }]
+    // "setup" contains "tup" raw; "thumbs_up" only matches as a subsequence.
+    expect(rankMatches(items, "tup", text)).toEqual([{ label: "setup" }, { label: "thumbs_up" }])
   })
 })

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -60,8 +60,10 @@ function bestFuzzy(texts: readonly string[], normQuery: string): number {
 }
 
 export function scoreMatch(query: string, labels: readonly string[], keywords: readonly string[] = []): number {
-  if (!query) return 0
-  const lowerQuery = query.toLowerCase()
+  // A whitespace-only query is "not searching yet", same as empty — without
+  // the trim it would fold to an empty normQuery and match nothing at all.
+  const lowerQuery = query.trim().toLowerCase()
+  if (!lowerQuery) return 0
   const normQuery = foldSeparators(lowerQuery)
   let best = Infinity
   for (const label of labels) {
@@ -84,14 +86,15 @@ export function scoreMatch(query: string, labels: readonly string[], keywords: r
 /**
  * Filter and rank items by `scoreMatch`. Non-matches are dropped; ties keep
  * input order (sort is stable), so each surface's curated ordering still
- * breaks ties within a tier. An empty query returns the input unchanged.
+ * breaks ties within a tier. An empty or whitespace-only query returns the
+ * input unchanged.
  */
 export function rankMatches<T>(
   items: readonly T[],
   query: string,
   getText: (item: T) => { labels: readonly string[]; keywords?: readonly string[] }
 ): T[] {
-  if (!query) return [...items]
+  if (!query.trim()) return [...items]
   return items
     .map((item) => {
       const { labels, keywords } = getText(item)

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -5,38 +5,80 @@
  * The problem this solves: pickers used to flat-filter with a boolean
  * substring test over "label + keywords", so an item matching only on a
  * hidden alias ranked identically to one whose visible label matched, and
- * definition order decided. Tiers encode WHERE the match landed: any visible
- * label match sorts above any hidden keyword match, and exact beats prefix
- * beats substring within each band. Mirrors the heuristic `scoreStreamMatch`
- * (lib/stream-sort.ts) already applies to streams.
+ * definition order decided. Tiers encode WHERE and HOW the match landed:
+ *
+ *   labels, substring family   0..5   exact < norm-exact < prefix <
+ *                                     norm-prefix < contains < norm-contains
+ *   keywords, substring family 6..11  same ladder, one band below
+ *   labels, fuzzy subsequence  12..13 ordered by fuzzyQuality within the band
+ *   keywords, fuzzy            13..14
+ *
+ * "norm-" tiers compare with separators folded (foldSeparators), so
+ * "thumbs up" and "thumbsup" hit "thumbs_up". Fuzzy tiers admit in-order
+ * subsequences ("thup" → "thumbs_up") but always rank below every substring
+ * match, so the fuzzy tail can only add results, never displace them.
+ * Mirrors `scoreStreamMatch` (lib/stream-sort.ts), which delegates here.
  *
  * Lower score = better match; Infinity = no match.
  */
 
-/** exact (0) < prefix (1) < contains (2), Infinity for no match. */
-function scoreText(text: string, lowerQuery: string): number {
+import { foldSeparators, fuzzyQuality } from "@/lib/fuzzy"
+
+/** exact (0) < norm-exact (1) < prefix (2) < norm-prefix (3) < contains (4) < norm-contains (5). */
+function scoreText(text: string, lowerQuery: string, normQuery: string): number {
   const lower = text.toLowerCase()
   if (lower === lowerQuery) return 0
-  if (lower.startsWith(lowerQuery)) return 1
-  if (lower.includes(lowerQuery)) return 2
+  const norm = foldSeparators(lower)
+  if (normQuery && norm === normQuery) return 1
+  if (lower.startsWith(lowerQuery)) return 2
+  if (normQuery && norm.startsWith(normQuery)) return 3
+  if (lower.includes(lowerQuery)) return 4
+  if (normQuery && norm.includes(normQuery)) return 5
   return Infinity
 }
 
-/** Keyword tiers sit one whole band below label tiers (3/4/5 vs 0/1/2). */
-const KEYWORD_TIER_OFFSET = 3
+/** Keyword substring tiers sit one whole band below label tiers (6..11 vs 0..5). */
+const KEYWORD_TIER_OFFSET = 6
+const LABEL_FUZZY_TIER = 12
+const KEYWORD_FUZZY_TIER = 13
+
+/**
+ * Fuzzy matches below this quality are rejected: compact abbreviation-style
+ * matches ("thup" → "thumbs_up") score near 1, while a query scattered thinly
+ * across a long sentence ("inv" → "Open a side-conversation") lands well
+ * under it and would only add noise to the tail.
+ */
+const FUZZY_MIN_QUALITY = 0.7
+
+function bestFuzzy(texts: readonly string[], normQuery: string): number {
+  let best = 0
+  for (const text of texts) {
+    const quality = fuzzyQuality(normQuery, text)
+    if (quality > best) best = quality
+  }
+  return best >= FUZZY_MIN_QUALITY ? best : 0
+}
 
 export function scoreMatch(query: string, labels: readonly string[], keywords: readonly string[] = []): number {
   if (!query) return 0
   const lowerQuery = query.toLowerCase()
+  const normQuery = foldSeparators(lowerQuery)
   let best = Infinity
   for (const label of labels) {
-    best = Math.min(best, scoreText(label, lowerQuery))
+    best = Math.min(best, scoreText(label, lowerQuery, normQuery))
   }
   if (best === 0) return best
   for (const keyword of keywords) {
-    best = Math.min(best, KEYWORD_TIER_OFFSET + scoreText(keyword, lowerQuery))
+    best = Math.min(best, KEYWORD_TIER_OFFSET + scoreText(keyword, lowerQuery, normQuery))
   }
-  return best
+  // Any substring match outranks every fuzzy match, so only fall through when
+  // nothing matched at all.
+  if (best !== Infinity || !normQuery) return best
+  const labelQuality = bestFuzzy(labels, normQuery)
+  if (labelQuality > 0) return LABEL_FUZZY_TIER + (1 - labelQuality)
+  const keywordQuality = bestFuzzy(keywords, normQuery)
+  if (keywordQuality > 0) return KEYWORD_FUZZY_TIER + (1 - keywordQuality)
+  return Infinity
 }
 
 /**

--- a/apps/frontend/src/lib/stream-sort.test.ts
+++ b/apps/frontend/src/lib/stream-sort.test.ts
@@ -58,16 +58,29 @@ describe("scoreStreamMatch", () => {
     expect(scoreStreamMatch(makeStream({ slug: "general" }), "")).toBe(0)
   })
 
-  it("ranks exact match best, then prefix, then substring, then id-fallback", () => {
+  it("ranks exact match best, then prefix, then substring, then fuzzy, then id-fallback", () => {
     const general = makeStream({ id: "stream_a", slug: "general" })
     const generic = makeStream({ id: "stream_b", slug: "generic" })
     const ageneral = makeStream({ id: "stream_c", slug: "ageneral" })
+    const fuzzy = makeStream({ id: "stream_d", slug: "growth-plan" })
     const idMatch = makeStream({ id: "stream_general_id", slug: "elsewhere" })
 
-    expect(scoreStreamMatch(general, "#general")).toBe(0)
-    expect(scoreStreamMatch(generic, "#gen")).toBe(1)
-    expect(scoreStreamMatch(ageneral, "general")).toBe(2)
-    expect(scoreStreamMatch(idMatch, "general")).toBe(3)
+    const scores = [
+      scoreStreamMatch(general, "#general"),
+      scoreStreamMatch(generic, "#gen"),
+      scoreStreamMatch(ageneral, "general"),
+      scoreStreamMatch(fuzzy, "grpl"),
+      scoreStreamMatch(idMatch, "general"),
+    ]
+    expect(scores[0]).toBe(0)
+    expect(scores.every((s) => s !== Infinity)).toBe(true)
+    expect([...scores]).toEqual([...scores].sort((a, b) => a - b))
+  })
+
+  it("matches across separator differences", () => {
+    const stream = makeStream({ slug: "growth-plan" })
+    expect(scoreStreamMatch(stream, "growth plan")).not.toBe(Infinity)
+    expect(scoreStreamMatch(stream, "growthplan")).not.toBe(Infinity)
   })
 
   it("returns Infinity when no part of the stream matches", () => {

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react"
 import type { Stream } from "@threa/types"
 import type { UrgencyLevel } from "@/components/layout/sidebar/types"
 import { getActivityTime } from "@/components/layout/sidebar/utils"
+import { scoreMatch } from "@/lib/match-score"
 import { streamLabel } from "@/lib/streams"
 
 /** Sort modes used by stream pickers (quick switcher, share modal, share picker). */
@@ -17,21 +18,24 @@ export type SortableStream = Pick<Stream, "id" | "type" | "createdAt"> & {
   lastMessagePreview?: { createdAt: string } | null
 }
 
+/** Sorts after every name tier in scoreMatch (substring 0..11, fuzzy 12..14). */
+const STREAM_ID_MATCH_SCORE = 100
+
 /**
  * Score a stream against a lowercased query. Lower = better match.
- * Returns Infinity for non-matches. Mirrors the quick-switcher heuristic so
- * search results land in the same order across every picker surface.
+ * Returns Infinity for non-matches. Delegates to the shared `scoreMatch`
+ * tiers (exact/prefix/contains, separator-normalized, fuzzy subsequence) so
+ * search results land in the same order across every picker surface; a raw
+ * stream-id substring is the last-resort tier below all name matches.
  */
 export function scoreStreamMatch(
   stream: Pick<Stream, "id" | "type" | "displayName" | "slug">,
   lowerQuery: string
 ): number {
   if (!lowerQuery) return 0
-  const name = streamLabel(stream).toLowerCase()
-  if (name === lowerQuery) return 0
-  if (name.startsWith(lowerQuery)) return 1
-  if (name.includes(lowerQuery)) return 2
-  if (stream.id.toLowerCase().includes(lowerQuery)) return 3
+  const score = scoreMatch(lowerQuery, [streamLabel(stream)])
+  if (score !== Infinity) return score
+  if (stream.id.toLowerCase().includes(lowerQuery)) return STREAM_ID_MATCH_SCORE
   return Infinity
 }
 


### PR DESCRIPTION
## Problem

Every client-side picker matches on strict substrings. `scoreMatch` (`apps/frontend/src/lib/match-score.ts`) and `scoreStreamMatch` (`lib/stream-sort.ts`) tier exact/prefix/contains over `toLowerCase()` — so the emoji picker misses `thumbs up` and `thumbsup` for `thumbs_up`, the quick switcher misses `growthplan` for `#growth-plan`, and abbreviation queries (`grpl`, `thup`) find nothing. Seven more surfaces (members tab, label picker, board filter pickers, search filter menu, quick-switcher filter selects, target-picker new-options, virtual DM rows) hand-rolled the same boolean `.includes()` inline.

## Solution

One new primitive module, `lib/fuzzy.ts`, slotted into the two shared scorers as lower-priority tiers — fuzzy can only *append* results, never displace a substring match — plus a sweep of the inline `.includes()` stragglers onto the shared scorer.

### How it works

1. **`foldSeparators(text)`** strips `[\s_-]+`, making whitespace/dash/underscore interchangeable: `thumbs up` ≡ `thumbs-up` ≡ `thumbsup` ≡ `thumbs_up`.
2. **`fuzzyQuality(query, text)`** scores an in-order subsequence match via a small DP (O(len(query)·len(text))): each matched char scores 1, +1 when it extends a contiguous run or sits at a word boundary; quality = best total / (2·query length), in (0, 1]. `thup` → `thumbs_up` scores 1.0 (t-h contiguous from start, u-p contiguous from the `_` boundary); `inv` scattered across "Open a side-conversation" scores 0.67.
3. **`scoreMatch` tier ladder** (lower = better): label exact(0) < norm-exact(1) < prefix(2) < norm-prefix(3) < contains(4) < norm-contains(5); keywords the same ladder one band below (6–11); label fuzzy 12+(1−quality); keyword fuzzy 13+(1−quality). All previous relative orderings are preserved — the old 0/1/2 tiers map onto 0/2/4.
4. **`FUZZY_MIN_QUALITY = 0.7`** rejects scatter-noise. Found in self-review via a failing test: `inv` fuzzy-matched the *description* "Open a side-conversation" and polluted the slash-command menu. Compact abbreviation matches land near 1.0; thin scatter across sentences lands well under 0.7.
5. **`scoreStreamMatch` delegates to `scoreMatch`**, keeping the raw stream-id substring as a last-resort tier (score 100, below the fuzzy band — previously it sat directly after contains).
6. Everything already routed through `rankMatches`/`scoreStreamMatch` upgrades for free: emoji picker, quick switcher (streams + commands), mention/`#channel`/slash-command/arg-picker triggers, `in:#` filter, share modal, share picker, explorer stream filter, composer target picker.

### Key design decisions

**1. Hand-rolled scorer over a dependency.** No fuzzy library exists in the repo (fuse.js/fzf/match-sorter all absent); the need is ~60 lines of separator folding + subsequence DP with full unit coverage. A library brings its own scoring model that would fight the existing tier ladder the surfaces already rely on (label-above-keyword, exact-above-prefix).

**2. Fuzzy as a strictly-worse band, not a replacement scorer.** Rewriting the tiers around a single fuzzy score would reshuffle results users already know. Appending fuzzy below every substring tier means existing queries return identical top results; only previously-empty tails gain entries.

**3. Quality floor at 0.7 instead of per-surface gating.** The alternative — fuzzy only on labels, not keywords — would lose real matches (emoji alias abbreviations) to kill noise the floor already kills. The floor is centralized in `bestFuzzy`, so every surface inherits the same junk cutoff.

**4. Straggler sweep to the shared scorer (INV-35).** The seven inline `.includes()` sites now call `rankMatches`/`scoreMatch`. Board filter pickers keep their own selected-first sort and use `scoreMatch(...) !== Infinity` as a boolean, since reordering by score would fight the selected-pinning.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/fuzzy.ts` | `foldSeparators` + `fuzzyQuality` subsequence scorer |
| `apps/frontend/src/lib/fuzzy.test.ts` | Unit coverage: folding, boundary bonuses, scatter vs compact, edge cases |

## Modified files

| File | Change |
| ---- | ------ |
| `lib/match-score.ts` | Tier ladder grew normalized + fuzzy bands; `FUZZY_MIN_QUALITY` floor |
| `lib/match-score.test.ts` | Updated tier numbers; new normalization/fuzzy/ordering cases |
| `lib/stream-sort.ts` | `scoreStreamMatch` delegates to `scoreMatch`; id fallback → 100 |
| `lib/stream-sort.test.ts` | Ordering-based assertions + separator cases |
| `lib/emoji-picker.test.ts` | Separator + fuzzy regression tests for `filterBySearch` |
| `components/search/search-filter-menu.tsx` | ChannelPicker inline filter → `rankMatches` over `[slug, name]` |
| `components/quick-switcher/filter-select.tsx` | UserSelect/StreamSelect → `rankMatches` |
| `components/quick-switcher/use-stream-items.tsx` | Virtual DM rows → `scoreMatch` |
| `components/stream-settings/members-tab.tsx` | Member search → `rankMatches` over `[name, slug]` |
| `components/board/board-filter-pickers.tsx` | Stream/label scope pickers → `scoreMatch` boolean (keeps selected-first sort) |
| `components/labels/label-picker.tsx` | Label filter → `rankMatches` |
| `components/composer/stream-target-picker.tsx` | NEW_OPTIONS filter → `scoreMatch` |
| `components/editor/triggers/use-command-arg-picker.test.ts` | `opus` now legitimately fuzzy-admits `anthropic/claude-sonnet-4` below the substring match; assert ranking instead of exact set |

## Out of scope (deliberate)

- `SearchableSelect` (timezone picker, add-member/add-bot pickers) already gets fuzzy-ish matching from cmdk's built-in `command-score`; left as is.
- Server-side search (messages, memos, attachments) — different layer, ILIKE/similarity on the backend.
- No typo tolerance (edit distance). Subsequence + separator folding covers the reported misses; Levenshtein is a separate, noisier tradeoff.

## Test plan

- [x] `bun run test` (frontend) — 4403 pass, 0 fail
- [x] Full monorepo typecheck + eslint via pre-commit hook — clean
- [x] Live browser verification (dev:test stack + Playwright): emoji picker finds 👍 for `thumbs up` / `thumbs-up` / `thumbsup` / `thup`, 🙄 for `eye roll` / `rolleyes`; junk query `xqzv` still shows the empty state. Quick switcher finds `#growth-plan` for `growth plan` / `growthplan` / `grpl` and `#project-alpha` for `pralpha`.
- [ ] Straggler surfaces (members tab, board pickers, label picker) verified via unit tiers + typecheck only — not driven individually in the browser; they call the same scorer the driven surfaces do.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01NHpwiZxCcVBfTVQLVtiYUw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773297&installation_id=129946197&pr_number=1355&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1355&signature=eddf690b72d6da705b083e85c6ed6055624b464583aec248b19ca357c30c0152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->