### PR TITLE
fix(frontend): close composer menus after use; dismiss trigger popovers on tap-outside

### DIFF
--- a/apps/frontend/src/components/composer/composer-action-bar.test.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.test.tsx
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest"
-import { planActionOverflow, planTriggerVisibility } from "./composer-action-bar"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import * as elementWidthModule from "@/hooks/use-element-width"
+import { ComposerActionBar, planActionOverflow, planTriggerVisibility } from "./composer-action-bar"
 
 // Mirrors the real bar's secondary actions: array order is the left-to-right
 // display order; `collapsePriority` (lower folds first) is independent of it.
@@ -99,5 +102,36 @@ describe("planTriggerVisibility", () => {
       const inlineControls = 3 + visible
       expect(inlineControls * CONTROL_PX).toBeLessThanOrEqual(width)
     }
+  })
+})
+
+describe("squeezed trigger mounting", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("keeps a dropped trigger mounted (hidden) so its shortcut registration survives", () => {
+    // 100px → 0 visible triggers (see planTriggerVisibility cases above). The
+    // stash trigger must stay in the DOM: the drafts picker registers the
+    // empty-composer Cmd/Ctrl+S handler on mount.
+    vi.spyOn(elementWidthModule, "useElementWidth").mockReturnValue(100)
+    render(
+      <TooltipProvider>
+        <ComposerActionBar
+          formatOpen={false}
+          onToggleFormat={() => {}}
+          onInsertEmoji={() => {}}
+          onInsertMention={() => {}}
+          onInsertCommand={() => {}}
+          onAttachClick={() => {}}
+          stashedDraftsTrigger={<button type="button" data-testid="stash-trigger" />}
+          sendButton={<button type="button">Send</button>}
+        />
+      </TooltipProvider>
+    )
+
+    const trigger = screen.getByTestId("stash-trigger")
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).not.toBeVisible()
   })
 })

--- a/apps/frontend/src/components/composer/composer-action-bar.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.tsx
@@ -320,6 +320,18 @@ export function ComposerActionBar({
       {visibleTriggers.map((t) => (
         <Fragment key={t.key}>{t.node}</Fragment>
       ))}
+      {/* Triggers dropped under extreme squeeze stay MOUNTED, just hidden:
+          the drafts picker registers the empty-composer Cmd/Ctrl+S open
+          handler on mount, and its popover anchors to the composer card
+          rather than the trigger — unmounting would silently kill the
+          shortcut whenever the bar is squeezed. */}
+      {triggers.length > visibleTriggerCount && (
+        <div hidden>
+          {triggers.slice(visibleTriggerCount).map((t) => (
+            <Fragment key={t.key}>{t.node}</Fragment>
+          ))}
+        </div>
+      )}
       {sendButton}
     </div>
   )

--- a/apps/frontend/src/components/composer/fab-drawer-close-context.ts
+++ b/apps/frontend/src/components/composer/fab-drawer-close-context.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react"
+
+/**
+ * Close signal for the expanded composer's mobile FAB action drawer. The
+ * drawer's contents (drafts/scheduled pickers) are passed into MessageComposer
+ * as opaque slot nodes by each host, so the "your action finished — collapse
+ * the drawer too" signal travels by context rather than props. Null outside
+ * the drawer: the compact toolbar pickers render with the default and no-op.
+ */
+export const FabDrawerCloseContext = createContext<(() => void) | null>(null)
+
+export function useFabDrawerClose(): (() => void) | null {
+  return useContext(FabDrawerCloseContext)
+}

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, fireEvent, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { MessageComposer } from "./message-composer"
+import { StashedDraftsPicker } from "./stashed-drafts-picker"
+import type { CachedDraft } from "@/hooks"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import type { JSONContent } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
@@ -421,6 +423,59 @@ describe("MessageComposer", () => {
       expect(screen.getByTestId("mobile-editor-toolbar")).toHaveAttribute("data-has-special-input-controls", "yes")
       expect(screen.getByRole("button", { name: "Indent" })).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Dedent" })).toBeInTheDocument()
+    })
+  })
+
+  describe("stash shortcut (Cmd/Ctrl+S)", () => {
+    const draft: CachedDraft = {
+      id: "draft_1",
+      workspaceId: "ws_1",
+      scope: "stream:stream_1",
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "stashed body" }] }] },
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    }
+
+    function renderWithPicker(props: Partial<Parameters<typeof MessageComposer>[0]> = {}) {
+      const onStashDraft = vi.fn()
+      const onRestore = vi.fn()
+      render(
+        <MessageComposer
+          {...defaultProps}
+          onStashDraft={onStashDraft}
+          stashedDraftsTrigger={
+            <StashedDraftsPicker
+              drafts={[draft]}
+              canStashCurrent={false}
+              onStashCurrent={vi.fn()}
+              onRestore={onRestore}
+              onDelete={vi.fn()}
+            />
+          }
+          {...props}
+        />
+      )
+      return { onStashDraft, onRestore }
+    }
+
+    it("opens the drafts picker instead of stashing when the composer is empty", async () => {
+      const { onStashDraft } = renderWithPicker({ content: EMPTY_DOC })
+
+      fireEvent.keyDown(screen.getByTestId("rich-editor"), { key: "s", metaKey: true })
+
+      expect(await screen.findByText("stashed body")).toBeInTheDocument()
+      expect(onStashDraft).not.toHaveBeenCalled()
+    })
+
+    it("stashes (and does not open the picker) when the composer has content", () => {
+      const { onStashDraft } = renderWithPicker({
+        content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "wip" }] }] },
+      })
+
+      fireEvent.keyDown(screen.getByTestId("rich-editor"), { key: "s", metaKey: true })
+
+      expect(onStashDraft).toHaveBeenCalledOnce()
+      expect(screen.queryByText("stashed body")).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -24,6 +24,7 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/comp
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
 import { MicButton, type MicButtonHandle } from "./mic-button"
 import { FabDrawerCloseContext } from "./fab-drawer-close-context"
+import { StashedDraftsOpenContext } from "./stashed-drafts-open-context"
 import { ComposerActionBar } from "./composer-action-bar"
 import { ComposerLinkPreviews } from "./composer-link-previews"
 import { ContextRefStrip } from "./context-ref-strip"
@@ -655,6 +656,11 @@ export function MessageComposer({
   const preferencesCtx = usePreferencesOptional()
   const stashBinding = getEffectiveKeyBinding("draftStash", preferencesCtx?.preferences?.keyboardShortcuts ?? {})
 
+  // Cmd/Ctrl+S with nothing to stash flips to "show me my drafts": open the
+  // hosted picker (registered via context — the picker is a slot node).
+  const stashedDraftsOpenRef = useRef<(() => void) | null>(null)
+  const composerEmpty = isEmptyContent(content) && pendingAttachments.length === 0
+
   const handleStashKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (!stashBinding) return
@@ -662,9 +668,13 @@ export function MessageComposer({
 
       event.preventDefault()
       event.stopPropagation()
+      if (composerEmpty) {
+        stashedDraftsOpenRef.current?.()
+        return
+      }
       onStashDraft?.()
     },
-    [onStashDraft, stashBinding]
+    [onStashDraft, stashBinding, composerEmpty]
   )
 
   const sharedEditor = (
@@ -819,16 +829,290 @@ export function MessageComposer({
   if (expanded) {
     return (
       <TooltipProvider delayDuration={300}>
+        <StashedDraftsOpenContext.Provider value={stashedDraftsOpenRef}>
+          <div
+            ref={expandedShellRef}
+            className={cn("relative flex flex-col h-full bg-background", className)}
+            tabIndex={-1}
+            onKeyDown={handleExpandedShellKeyDown}
+            onKeyDownCapture={handleStashKeyDown}
+          >
+            <p id={instructionsId} className="sr-only">
+              {screenReaderInstructions}
+            </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={onFileSelect}
+              disabled={controlsDisabled}
+            />
+
+            {/* Editor — fills remaining space, toolbar + actions in one bar via toolbarTrailingContent */}
+            <div
+              className="flex-1 min-h-0 overflow-y-auto px-4 [&_.tiptap]:max-h-none [&_.tiptap]:min-h-[200px]"
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
+                  return
+                richEditorRef.current?.focus()
+              }}
+            >
+              <RichEditor
+                ref={setRichEditorHandle}
+                value={content}
+                onChange={handleContentChange}
+                onSubmit={handleSubmit}
+                onFileUpload={onFileUpload}
+                imageCount={imageCount}
+                placeholder={placeholder}
+                disabled={disabled}
+                messageSendMode="cmdEnter"
+                autoFocus
+                scopeId={scopeId}
+                staticToolbarOpen
+                disableSelectionToolbar
+                onEditLastMessage={onEditLastMessage}
+                toolbarTrailingContent={expandedTrailingContent}
+                ariaLabel="Fullscreen message editor"
+                ariaDescribedBy={instructionsId}
+                blurOnEscape
+                onEscapeBlur={focusExpandedShell}
+                streamContext={streamContext}
+                memoAnchorStreamId={memoAnchorStreamId}
+                belowToolbarContent={
+                  pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
+                    <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">
+                      <PendingAttachments
+                        attachments={pendingAttachments}
+                        onRemove={onRemoveAttachment}
+                        onCancelUpload={onCancelAttachmentUpload}
+                        workspaceId={workspaceId}
+                        beforePills={
+                          contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
+                            <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
+                          ) : null
+                        }
+                      />
+                    </div>
+                  ) : undefined
+                }
+              />
+              {/* Extra space so the writing position can be centered on screen */}
+              <div className="h-[50vh]" />
+            </div>
+
+            <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5">
+              {/* Action drawer — always visible on desktop; on touch (no hover) it
+                stays behind the + button and opens on tap. `inert` while
+                collapsed on mobile so its buttons drop out of tab order instead
+                of sitting invisibly ahead of the visible "+" button. */}
+              <div
+                inert={isMobile && !fabActionsOpen}
+                className={cn(
+                  "flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out",
+                  isMobile ? "max-w-0 opacity-0" : "max-w-[240px] opacity-100",
+                  fabActionsOpen && "max-w-[240px] opacity-100"
+                )}
+              >
+                <FabDrawerCloseContext.Provider value={closeFabDrawer}>
+                  {stashedDraftsTriggerFab}
+                  {scheduledMessagesTriggerFab}
+                </FabDrawerCloseContext.Provider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Insert emoji"
+                      className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
+                      onPointerDown={(e) => {
+                        e.preventDefault()
+                        closeFabDrawer()
+                        richEditorRef.current?.insertEmoji()
+                      }}
+                      disabled={controlsDisabled}
+                    >
+                      <span className="text-sm leading-none">😊</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Emoji
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Insert mention"
+                      className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
+                      onPointerDown={(e) => {
+                        e.preventDefault()
+                        closeFabDrawer()
+                        richEditorRef.current?.insertMention()
+                      }}
+                      disabled={controlsDisabled}
+                    >
+                      <AtSign className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Mention
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Insert command"
+                      className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
+                      onPointerDown={(e) => {
+                        e.preventDefault()
+                        closeFabDrawer()
+                        richEditorRef.current?.insertSlash()
+                      }}
+                      disabled={controlsDisabled}
+                    >
+                      <Slash className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Command
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Attach files"
+                      className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
+                      onClick={() => {
+                        closeFabDrawer()
+                        handleAttachClick()
+                      }}
+                      disabled={controlsDisabled}
+                    >
+                      <Paperclip className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Attach files
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              {isMobile ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={fabActionsOpen ? "Hide actions" : "Show actions"}
+                  aria-expanded={fabActionsOpen}
+                  onPointerDown={(e) => e.preventDefault()}
+                  onClick={() => setFabActionsOpen((v) => !v)}
+                  className={cn(
+                    "h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md [&_svg]:transition-transform",
+                    fabActionsOpen && "[&_svg]:rotate-45"
+                  )}
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {micButtonFab}
+              {hasFailed ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        disabled
+                        className="h-[30px] w-[30px] shrink-0 p-0 pointer-events-none rounded-md shadow-md"
+                        aria-label={submitLabel}
+                      >
+                        <ArrowUp className="h-4 w-4" />
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p>Remove failed uploads before sending</p>
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      onPointerDown={(e) => e.preventDefault()}
+                      onClick={handleSubmit}
+                      disabled={!canSubmit}
+                      aria-label={isSubmitting ? submittingLabel : submitLabel}
+                      className="h-[30px] w-[30px] shrink-0 p-0 rounded-md shadow-md"
+                    >
+                      <ArrowUp className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" className="text-xs">
+                    {sendHint}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+        </StashedDraftsOpenContext.Provider>
+      </TooltipProvider>
+    )
+  }
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <StashedDraftsOpenContext.Provider value={stashedDraftsOpenRef}>
+        {/* Message input wrapper — dvh units respect the virtual keyboard on mobile */}
         <div
-          ref={expandedShellRef}
-          className={cn("relative flex flex-col h-full bg-background", className)}
-          tabIndex={-1}
-          onKeyDown={handleExpandedShellKeyDown}
+          ref={mobileRootRef}
+          data-composer-expanded={mobileExpanded ? true : undefined}
+          className={cn(
+            // No transition on max/min-height: animating the shell's layout box
+            // re-runs layout every frame, and the timeline scroller above resizes
+            // with it — each frame fires its ResizeObserver, re-pins to bottom,
+            // and forces a virtua re-measure (~10fps on low-end Android, see
+            // docs/stream-timeline-perceived-performance.md). Snap instead, same
+            // as the keyboard choreography.
+            "flex flex-col",
+            mobileExpanded ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
+            className
+          )}
+          onFocusCapture={isMobile ? handleFocusCapture : undefined}
+          onBlurCapture={isMobile ? handleBlurCapture : undefined}
           onKeyDownCapture={handleStashKeyDown}
         >
           <p id={instructionsId} className="sr-only">
             {screenReaderInstructions}
           </p>
+          <PendingAttachments
+            attachments={pendingAttachments}
+            onRemove={onRemoveAttachment}
+            onCancelUpload={onCancelAttachmentUpload}
+            workspaceId={workspaceId}
+            beforePills={
+              contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
+                <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
+              ) : null
+            }
+          />
+
+          {/* Live in-app link previews for the draft. Above the card (like
+            attachments) so they read as attached to this message and stay clear
+            of the keyboard on mobile. Hidden in the mobile resting state to keep
+            the single-line bar minimal. */}
+          {workspaceId && (!isMobile || mobileChromeOpen) && (
+            <ComposerLinkPreviews content={content} workspaceId={workspaceId} className="mb-2" />
+          )}
+
           <input
             ref={fileInputRef}
             type="file"
@@ -838,343 +1122,74 @@ export function MessageComposer({
             disabled={controlsDisabled}
           />
 
-          {/* Editor — fills remaining space, toolbar + actions in one bar via toolbarTrailingContent */}
-          <div
-            className="flex-1 min-h-0 overflow-y-auto px-4 [&_.tiptap]:max-h-none [&_.tiptap]:min-h-[200px]"
-            onClick={(e) => {
-              if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']")) return
-              richEditorRef.current?.focus()
-            }}
-          >
-            <RichEditor
-              ref={setRichEditorHandle}
-              value={content}
-              onChange={handleContentChange}
-              onSubmit={handleSubmit}
-              onFileUpload={onFileUpload}
-              imageCount={imageCount}
-              placeholder={placeholder}
-              disabled={disabled}
-              messageSendMode="cmdEnter"
-              autoFocus
-              scopeId={scopeId}
-              staticToolbarOpen
-              disableSelectionToolbar
-              onEditLastMessage={onEditLastMessage}
-              toolbarTrailingContent={expandedTrailingContent}
-              ariaLabel="Fullscreen message editor"
-              ariaDescribedBy={instructionsId}
-              blurOnEscape
-              onEscapeBlur={focusExpandedShell}
-              streamContext={streamContext}
-              memoAnchorStreamId={memoAnchorStreamId}
-              belowToolbarContent={
-                pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
-                  <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">
-                    <PendingAttachments
-                      attachments={pendingAttachments}
-                      onRemove={onRemoveAttachment}
-                      onCancelUpload={onCancelAttachmentUpload}
-                      workspaceId={workspaceId}
-                      beforePills={
-                        contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
-                          <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
-                        ) : null
-                      }
-                    />
-                  </div>
-                ) : undefined
-              }
-            />
-            {/* Extra space so the writing position can be centered on screen */}
-            <div className="h-[50vh]" />
-          </div>
-
-          <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5">
-            {/* Action drawer — always visible on desktop; on touch (no hover) it
-                stays behind the + button and opens on tap. `inert` while
-                collapsed on mobile so its buttons drop out of tab order instead
-                of sitting invisibly ahead of the visible "+" button. */}
+          <div className="input-glow-wrapper flex-1 flex flex-col min-h-0">
             <div
-              inert={isMobile && !fabActionsOpen}
+              data-composer-card
               className={cn(
-                "flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out",
-                isMobile ? "max-w-0 opacity-0" : "max-w-[240px] opacity-100",
-                fabActionsOpen && "max-w-[240px] opacity-100"
+                "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
+                // Floating-composer shadow on the inline (non-expanded) card; the
+                // expanded fullscreen sheet stays flat.
+                !mobileExpanded && COLLAPSED_COMPOSER_SHADOW,
+                // Glass (translucent + backdrop-blur) lets the timeline show through
+                // the floating composer, but backdrop-filter re-rasterizes the blurred
+                // backdrop on every repaint — cheap on desktop, a frame-killer on
+                // mobile over a long, image-heavy timeline while typing. Opaque on
+                // mobile; keep the glass on desktop where the GPU absorbs it.
+                !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
+                // Compact padding when mobile-unfocused (single line), normal otherwise
+                isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
+                // When mobile-expanded, let the editor grow and override its internal max-height
+                mobileExpanded && "[&_.tiptap]:max-h-none"
               )}
-            >
-              <FabDrawerCloseContext.Provider value={closeFabDrawer}>
-                {stashedDraftsTriggerFab}
-                {scheduledMessagesTriggerFab}
-              </FabDrawerCloseContext.Provider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="Insert emoji"
-                    className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
-                    onPointerDown={(e) => {
-                      e.preventDefault()
-                      closeFabDrawer()
-                      richEditorRef.current?.insertEmoji()
-                    }}
-                    disabled={controlsDisabled}
-                  >
-                    <span className="text-sm leading-none">😊</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  Emoji
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="Insert mention"
-                    className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
-                    onPointerDown={(e) => {
-                      e.preventDefault()
-                      closeFabDrawer()
-                      richEditorRef.current?.insertMention()
-                    }}
-                    disabled={controlsDisabled}
-                  >
-                    <AtSign className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  Mention
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="Insert command"
-                    className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
-                    onPointerDown={(e) => {
-                      e.preventDefault()
-                      closeFabDrawer()
-                      richEditorRef.current?.insertSlash()
-                    }}
-                    disabled={controlsDisabled}
-                  >
-                    <Slash className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  Command
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="Attach files"
-                    className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
-                    onClick={() => {
-                      closeFabDrawer()
-                      handleAttachClick()
-                    }}
-                    disabled={controlsDisabled}
-                  >
-                    <Paperclip className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  Attach files
-                </TooltipContent>
-              </Tooltip>
-            </div>
-            {isMobile ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label={fabActionsOpen ? "Hide actions" : "Show actions"}
-                aria-expanded={fabActionsOpen}
-                onPointerDown={(e) => e.preventDefault()}
-                onClick={() => setFabActionsOpen((v) => !v)}
-                className={cn(
-                  "h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md [&_svg]:transition-transform",
-                  fabActionsOpen && "[&_svg]:rotate-45"
-                )}
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
-            ) : null}
-            {micButtonFab}
-            {hasFailed ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <Button
-                      disabled
-                      className="h-[30px] w-[30px] shrink-0 p-0 pointer-events-none rounded-md shadow-md"
-                      aria-label={submitLabel}
-                    >
-                      <ArrowUp className="h-4 w-4" />
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p>Remove failed uploads before sending</p>
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    onPointerDown={(e) => e.preventDefault()}
-                    onClick={handleSubmit}
-                    disabled={!canSubmit}
-                    aria-label={isSubmitting ? submittingLabel : submitLabel}
-                    className="h-[30px] w-[30px] shrink-0 p-0 rounded-md shadow-md"
-                  >
-                    <ArrowUp className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="left" className="text-xs">
-                  {sendHint}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-        </div>
-      </TooltipProvider>
-    )
-  }
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      {/* Message input wrapper — dvh units respect the virtual keyboard on mobile */}
-      <div
-        ref={mobileRootRef}
-        data-composer-expanded={mobileExpanded ? true : undefined}
-        className={cn(
-          // No transition on max/min-height: animating the shell's layout box
-          // re-runs layout every frame, and the timeline scroller above resizes
-          // with it — each frame fires its ResizeObserver, re-pins to bottom,
-          // and forces a virtua re-measure (~10fps on low-end Android, see
-          // docs/stream-timeline-perceived-performance.md). Snap instead, same
-          // as the keyboard choreography.
-          "flex flex-col",
-          mobileExpanded ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
-          className
-        )}
-        onFocusCapture={isMobile ? handleFocusCapture : undefined}
-        onBlurCapture={isMobile ? handleBlurCapture : undefined}
-        onKeyDownCapture={handleStashKeyDown}
-      >
-        <p id={instructionsId} className="sr-only">
-          {screenReaderInstructions}
-        </p>
-        <PendingAttachments
-          attachments={pendingAttachments}
-          onRemove={onRemoveAttachment}
-          onCancelUpload={onCancelAttachmentUpload}
-          workspaceId={workspaceId}
-          beforePills={
-            contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
-              <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
-            ) : null
-          }
-        />
-
-        {/* Live in-app link previews for the draft. Above the card (like
-            attachments) so they read as attached to this message and stay clear
-            of the keyboard on mobile. Hidden in the mobile resting state to keep
-            the single-line bar minimal. */}
-        {workspaceId && (!isMobile || mobileChromeOpen) && (
-          <ComposerLinkPreviews content={content} workspaceId={workspaceId} className="mb-2" />
-        )}
-
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          className="hidden"
-          onChange={onFileSelect}
-          disabled={controlsDisabled}
-        />
-
-        <div className="input-glow-wrapper flex-1 flex flex-col min-h-0">
-          <div
-            data-composer-card
-            className={cn(
-              "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
-              // Floating-composer shadow on the inline (non-expanded) card; the
-              // expanded fullscreen sheet stays flat.
-              !mobileExpanded && COLLAPSED_COMPOSER_SHADOW,
-              // Glass (translucent + backdrop-blur) lets the timeline show through
-              // the floating composer, but backdrop-filter re-rasterizes the blurred
-              // backdrop on every repaint — cheap on desktop, a frame-killer on
-              // mobile over a long, image-heavy timeline while typing. Opaque on
-              // mobile; keep the glass on desktop where the GPU absorbs it.
-              !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
-              // Compact padding when mobile-unfocused (single line), normal otherwise
-              isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
-              // When mobile-expanded, let the editor grow and override its internal max-height
-              mobileExpanded && "[&_.tiptap]:max-h-none"
-            )}
-            onClick={(e) => {
-              if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']")) return
-              // On mobile unfocused, focus the (still zero-height) editor now —
-              // raising the keyboard — and expand the chrome together with the
-              // keyboard's viewport resize, so the open is a single snap.
-              if (isMobile && !mobileChromeOpen) {
-                openMobileChromeWithKeyboard()
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
+                  return
+                // On mobile unfocused, focus the (still zero-height) editor now —
+                // raising the keyboard — and expand the chrome together with the
+                // keyboard's viewport resize, so the open is a single snap.
+                if (isMobile && !mobileChromeOpen) {
+                  openMobileChromeWithKeyboard()
+                  richEditorRef.current?.focus()
+                  return
+                }
                 richEditorRef.current?.focus()
-                return
-              }
-              richEditorRef.current?.focus()
-            }}
-          >
-            {isMobile && !mobileChromeOpen && (
-              <div className={cn(COLLAPSED_COMPOSER_ROW, "text-sm select-none pointer-events-none")}>
-                <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
-                <div className="pointer-events-auto">{sendButton}</div>
-              </div>
-            )}
+              }}
+            >
+              {isMobile && !mobileChromeOpen && (
+                <div className={cn(COLLAPSED_COMPOSER_ROW, "text-sm select-none pointer-events-none")}>
+                  <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
+                  <div className="pointer-events-auto">{sendButton}</div>
+                </div>
+              )}
 
-            {/* Mobile-only table hint — the floating selection toolbar is
+              {/* Mobile-only table hint — the floating selection toolbar is
                suppressed on mobile (it conflicts with the OS selection popup),
                so without this banner there's no visible cue that the row /
                column / delete controls live behind the Aa button. */}
-            {isMobile && mobileChromeOpen && isInTable && !formatOpen && (
-              <button
-                type="button"
-                onClick={() => setFormatOpen(true)}
-                onMouseDown={(e) => e.preventDefault()}
-                className="flex items-center gap-2 self-start rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
-              >
-                Editing table — tap{" "}
-                <span className="rounded bg-background px-1 py-0.5 text-[11px] font-bold leading-none">Aa</span> to add
-                or delete rows and columns
-              </button>
-            )}
-
-            {/* Editor — always mounted to preserve state; hidden in preview mode */}
-            <div
-              className={cn(
-                isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
-                mobileExpanded && "overflow-y-auto"
+              {isMobile && mobileChromeOpen && isInTable && !formatOpen && (
+                <button
+                  type="button"
+                  onClick={() => setFormatOpen(true)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  className="flex items-center gap-2 self-start rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
+                >
+                  Editing table — tap{" "}
+                  <span className="rounded bg-background px-1 py-0.5 text-[11px] font-bold leading-none">Aa</span> to
+                  add or delete rows and columns
+                </button>
               )}
-            >
-              <div className="h-full">{sharedEditor}</div>
-            </div>
 
-            {/* Bottom action bar — visible on desktop always, on mobile when focused or dictating.
+              {/* Editor — always mounted to preserve state; hidden in preview mode */}
+              <div
+                className={cn(
+                  isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
+                  mobileExpanded && "overflow-y-auto"
+                )}
+              >
+                <div className="h-full">{sharedEditor}</div>
+              </div>
+
+              {/* Bottom action bar — visible on desktop always, on mobile when focused or dictating.
                onMouseDown preventDefault keeps editor focus on mobile so the virtual keyboard
                stays open when tapping any button in this bar.
 
@@ -1187,77 +1202,78 @@ export function MessageComposer({
                DOM-subtree guard below limits the suppression to elements actually
                living under this wrapper — buttons in our own action bar — and
                leaves portaled content untouched. */}
-            {(!isMobile || mobileChromeOpen) && (
-              <div
-                ref={actionBarWrapperRef}
-                onMouseDown={(e) => {
-                  if (!actionBarWrapperRef.current?.contains(e.target as Node)) return
-                  e.preventDefault()
-                }}
-              >
-                {isMobile ? (
-                  <EditorActionBar
-                    editorHandle={richEditorRef.current}
-                    disabled={controlsDisabled}
-                    formatOpen={formatOpen}
-                    onFormatOpenChange={setFormatOpen}
-                    mobileExpanded={mobileExpanded}
-                    onMobileExpandedChange={setMobileExpanded}
-                    showAttach
-                    onAttachClick={handleAttachClick}
-                    trailingContent={
-                      micButton || stashedDraftsTrigger || scheduledMessagesTrigger ? (
-                        <div className="flex items-center gap-1">
-                          {micButton}
-                          {stashedDraftsTrigger}
-                          {scheduledMessagesTrigger}
-                          {sendButton}
-                        </div>
-                      ) : (
-                        sendButton
-                      )
-                    }
-                  />
-                ) : (
-                  <ComposerActionBar
-                    disabled={controlsDisabled}
-                    formatOpen={formatOpen}
-                    onToggleFormat={() => setFormatOpen((v) => !v)}
-                    onInsertEmoji={insertEmoji}
-                    onInsertMention={insertMention}
-                    onInsertCommand={insertSlash}
-                    onAttachClick={handleAttachClick}
-                    onExpandClick={onExpandClick}
-                    micButton={micButton}
-                    stashedDraftsTrigger={stashedDraftsTrigger}
-                    scheduledMessagesTrigger={scheduledMessagesTrigger}
-                    sendButton={sendButton}
-                  />
-                )}
-              </div>
-            )}
+              {(!isMobile || mobileChromeOpen) && (
+                <div
+                  ref={actionBarWrapperRef}
+                  onMouseDown={(e) => {
+                    if (!actionBarWrapperRef.current?.contains(e.target as Node)) return
+                    e.preventDefault()
+                  }}
+                >
+                  {isMobile ? (
+                    <EditorActionBar
+                      editorHandle={richEditorRef.current}
+                      disabled={controlsDisabled}
+                      formatOpen={formatOpen}
+                      onFormatOpenChange={setFormatOpen}
+                      mobileExpanded={mobileExpanded}
+                      onMobileExpandedChange={setMobileExpanded}
+                      showAttach
+                      onAttachClick={handleAttachClick}
+                      trailingContent={
+                        micButton || stashedDraftsTrigger || scheduledMessagesTrigger ? (
+                          <div className="flex items-center gap-1">
+                            {micButton}
+                            {stashedDraftsTrigger}
+                            {scheduledMessagesTrigger}
+                            {sendButton}
+                          </div>
+                        ) : (
+                          sendButton
+                        )
+                      }
+                    />
+                  ) : (
+                    <ComposerActionBar
+                      disabled={controlsDisabled}
+                      formatOpen={formatOpen}
+                      onToggleFormat={() => setFormatOpen((v) => !v)}
+                      onInsertEmoji={insertEmoji}
+                      onInsertMention={insertMention}
+                      onInsertCommand={insertSlash}
+                      onAttachClick={handleAttachClick}
+                      onExpandClick={onExpandClick}
+                      micButton={micButton}
+                      stashedDraftsTrigger={stashedDraftsTrigger}
+                      scheduledMessagesTrigger={scheduledMessagesTrigger}
+                      sendButton={sendButton}
+                    />
+                  )}
+                </div>
+              )}
 
-            {/* Mobile formatting toolbar — rendered below action bar, above keyboard */}
-            {isMobile && formatOpen && (
-              <EditorToolbar
-                editor={mobileToolbarEditor}
-                isVisible
-                inline
-                inlinePosition="below"
-                linkPopoverOpen={mobileLinkPopoverOpen}
-                onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
-                showSpecialInputControls
-              />
-            )}
+              {/* Mobile formatting toolbar — rendered below action bar, above keyboard */}
+              {isMobile && formatOpen && (
+                <EditorToolbar
+                  editor={mobileToolbarEditor}
+                  isVisible
+                  inline
+                  inlinePosition="below"
+                  linkPopoverOpen={mobileLinkPopoverOpen}
+                  onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
+                  showSpecialInputControls
+                />
+              )}
+            </div>
+          </div>
+
+          <div className="flex justify-end px-1 pt-1">
+            <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
+              {sendHint}
+            </span>
           </div>
         </div>
-
-        <div className="flex justify-end px-1 pt-1">
-          <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
-            {sendHint}
-          </span>
-        </div>
-      </div>
+      </StashedDraftsOpenContext.Provider>
     </TooltipProvider>
   )
 }

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -24,7 +24,7 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/comp
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
 import { MicButton, type MicButtonHandle } from "./mic-button"
 import { FabDrawerCloseContext } from "./fab-drawer-close-context"
-import { StashedDraftsOpenContext } from "./stashed-drafts-open-context"
+import { StashedDraftsComposerBridgeContext, type StashedDraftsComposerBridge } from "./stashed-drafts-open-context"
 import { ComposerActionBar } from "./composer-action-bar"
 import { ComposerLinkPreviews } from "./composer-link-previews"
 import { ContextRefStrip } from "./context-ref-strip"
@@ -659,6 +659,13 @@ export function MessageComposer({
   // Cmd/Ctrl+S with nothing to stash flips to "show me my drafts": open the
   // hosted picker (registered via context — the picker is a slot node).
   const stashedDraftsOpenRef = useRef<(() => void) | null>(null)
+  const stashedDraftsBridge = useMemo<StashedDraftsComposerBridge>(
+    () => ({
+      openRef: stashedDraftsOpenRef,
+      focusComposer: () => richEditorRef.current?.focus(),
+    }),
+    []
+  )
   const composerEmpty = isEmptyContent(content) && pendingAttachments.length === 0
 
   const handleStashKeyDown = useCallback(
@@ -829,7 +836,7 @@ export function MessageComposer({
   if (expanded) {
     return (
       <TooltipProvider delayDuration={300}>
-        <StashedDraftsOpenContext.Provider value={stashedDraftsOpenRef}>
+        <StashedDraftsComposerBridgeContext.Provider value={stashedDraftsBridge}>
           <div
             ref={expandedShellRef}
             className={cn("relative flex flex-col h-full bg-background", className)}
@@ -1063,14 +1070,14 @@ export function MessageComposer({
               )}
             </div>
           </div>
-        </StashedDraftsOpenContext.Provider>
+        </StashedDraftsComposerBridgeContext.Provider>
       </TooltipProvider>
     )
   }
 
   return (
     <TooltipProvider delayDuration={300}>
-      <StashedDraftsOpenContext.Provider value={stashedDraftsOpenRef}>
+      <StashedDraftsComposerBridgeContext.Provider value={stashedDraftsBridge}>
         {/* Message input wrapper — dvh units respect the virtual keyboard on mobile */}
         <div
           ref={mobileRootRef}
@@ -1273,7 +1280,7 @@ export function MessageComposer({
             </span>
           </div>
         </div>
-      </StashedDraftsOpenContext.Provider>
+      </StashedDraftsComposerBridgeContext.Provider>
     </TooltipProvider>
   )
 }

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -23,6 +23,7 @@ import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
 import { MicButton, type MicButtonHandle } from "./mic-button"
+import { FabDrawerCloseContext } from "./fab-drawer-close-context"
 import { ComposerActionBar } from "./composer-action-bar"
 import { ComposerLinkPreviews } from "./composer-link-previews"
 import { ContextRefStrip } from "./context-ref-strip"
@@ -327,6 +328,9 @@ export function MessageComposer({
   // Expanded-mode FAB actions are always visible on desktop. Touch has no hover,
   // so a tap on the "+" toggles them instead.
   const [fabActionsOpen, setFabActionsOpen] = useState(false)
+  // Every drawer action collapses the drawer once it's done its job — the "+"
+  // toggle is for browsing, not a mode the user should have to un-toggle.
+  const closeFabDrawer = useCallback(() => setFabActionsOpen(false), [])
   const [mobileFocused, setMobileFocused] = useState(initialMobileChromeOpen)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
   // True while a dictation take is in flight. Keeps the mobile chrome (and the
@@ -899,8 +903,10 @@ export function MessageComposer({
                 fabActionsOpen && "max-w-[240px] opacity-100"
               )}
             >
-              {stashedDraftsTriggerFab}
-              {scheduledMessagesTriggerFab}
+              <FabDrawerCloseContext.Provider value={closeFabDrawer}>
+                {stashedDraftsTriggerFab}
+                {scheduledMessagesTriggerFab}
+              </FabDrawerCloseContext.Provider>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -911,6 +917,7 @@ export function MessageComposer({
                     className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
                     onPointerDown={(e) => {
                       e.preventDefault()
+                      closeFabDrawer()
                       richEditorRef.current?.insertEmoji()
                     }}
                     disabled={controlsDisabled}
@@ -932,6 +939,7 @@ export function MessageComposer({
                     className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
                     onPointerDown={(e) => {
                       e.preventDefault()
+                      closeFabDrawer()
                       richEditorRef.current?.insertMention()
                     }}
                     disabled={controlsDisabled}
@@ -953,6 +961,7 @@ export function MessageComposer({
                     className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
                     onPointerDown={(e) => {
                       e.preventDefault()
+                      closeFabDrawer()
                       richEditorRef.current?.insertSlash()
                     }}
                     disabled={controlsDisabled}
@@ -972,7 +981,10 @@ export function MessageComposer({
                     size="icon"
                     aria-label="Attach files"
                     className="h-[30px] w-[30px] shrink-0 p-0 rounded-md bg-background shadow-md"
-                    onClick={handleAttachClick}
+                    onClick={() => {
+                      closeFabDrawer()
+                      handleAttachClick()
+                    }}
                     disabled={controlsDisabled}
                   >
                     <Paperclip className="h-4 w-4" />

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, createEvent } from "@testing-library/react"
+import { render, screen, fireEvent, createEvent, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DEFAULT_WORK_SCHEDULE } from "@threa/types"
 import { spyOnExport } from "@/test/spy"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { ScheduledMessagesPicker } from "./scheduled-messages-picker"
+import { FabDrawerCloseContext } from "./fab-drawer-close-context"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import * as hooks from "@/hooks"
 import * as workScheduleModule from "@/hooks/use-work-schedule"
@@ -15,12 +16,15 @@ let isTouchMockValue = true
 
 function renderPicker() {
   const onSchedule = vi.fn()
+  const closeFabDrawer = vi.fn()
   const result = render(
     <TooltipProvider>
-      <ScheduledMessagesPicker workspaceId="ws_1" streamId="stream_1" canSchedule onSchedule={onSchedule} />
+      <FabDrawerCloseContext.Provider value={closeFabDrawer}>
+        <ScheduledMessagesPicker workspaceId="ws_1" streamId="stream_1" canSchedule onSchedule={onSchedule} />
+      </FabDrawerCloseContext.Provider>
     </TooltipProvider>
   )
-  return { ...result, onSchedule }
+  return { ...result, onSchedule, closeFabDrawer }
 }
 
 describe("ScheduledMessagesPicker", () => {
@@ -86,5 +90,25 @@ describe("ScheduledMessagesPicker", () => {
     const scheduledAt = onSchedule.mock.calls[0]?.[0] as Date
     expect(scheduledAt.getTime()).toBeGreaterThanOrEqual(before + 30 * 60_000)
     expect(scheduledAt.getTime()).toBeLessThanOrEqual(Date.now() + 30 * 60_000)
+  })
+
+  it("stays open through the picking flow and closes popover + FAB drawer only once a time is picked", async () => {
+    const { onSchedule, closeFabDrawer } = renderPicker()
+
+    await userEvent.click(screen.getByRole("button", { name: /scheduled/i }))
+    await userEvent.click(screen.getByRole("button", { name: /schedule send/i }))
+
+    // Mode switch is NOT the end of the flow — nothing closes yet.
+    expect(closeFabDrawer).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: /pick a time/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: /custom duration/i }))
+    expect(closeFabDrawer).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole("button", { name: /^schedule$/i }))
+
+    expect(onSchedule).toHaveBeenCalledOnce()
+    await waitFor(() => expect(screen.queryByRole("button", { name: /pick a time/i })).not.toBeInTheDocument())
+    expect(closeFabDrawer).toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -24,6 +24,7 @@ import { ScheduledActionDrawer } from "@/components/scheduled/scheduled-action-d
 import { ScheduledActions } from "@/components/scheduled/scheduled-actions"
 import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
+import { useFabDrawerClose } from "./fab-drawer-close-context"
 import { useComposerAnchor } from "./use-composer-anchor"
 
 interface ScheduledMessagesPickerProps {
@@ -84,6 +85,7 @@ export function ScheduledMessagesPicker({
   // bottom sheet). We instead close the popover when long-press fires and
   // render the drawer at the picker's top level, outside the popover tree.
   const [actionTarget, setActionTarget] = useState<ScheduledMessageView | null>(null)
+  const closeFabDrawer = useFabDrawerClose()
   const { setTriggerRef, anchor } = useComposerAnchor(open)
 
   const { items } = useScheduledList(workspaceId, "pending", streamId)
@@ -140,18 +142,24 @@ export function ScheduledMessagesPicker({
     setShowDuration(false)
   }
 
-  const handlePreset = (preset: ReminderPreset, overrideTz?: string) => {
-    // Default to device-local; pref-tz is opt-in via the split-button dropdown.
-    const when = computeRemindAt(preset, new Date(), overrideTz ?? timezone, workSchedule)
+  // A picked time is the END of the schedule flow — the popover and any
+  // hosting FAB drawer close together. The "Schedule send" mode switch and
+  // the picking UI itself never close: the flow stays open until a time is
+  // actually chosen.
+  const finishSchedule = (when: Date) => {
     onSchedule(when)
     setOpen(false)
+    closeFabDrawer?.()
     resetToList()
   }
 
+  const handlePreset = (preset: ReminderPreset, overrideTz?: string) => {
+    // Default to device-local; pref-tz is opt-in via the split-button dropdown.
+    finishSchedule(computeRemindAt(preset, new Date(), overrideTz ?? timezone, workSchedule))
+  }
+
   const handleDurationSubmit = (when: Date) => {
-    onSchedule(when)
-    setOpen(false)
-    resetToList()
+    finishSchedule(when)
   }
 
   const handleCustomSubmit = () => {
@@ -160,9 +168,7 @@ export function ScheduledMessagesPicker({
     // Clamp 30s into the future so the server's 5s clamp doesn't surprise a
     // user picking "now-ish" as a way of saying "send shortly".
     const minMs = Date.now() + 30_000
-    onSchedule(when.getTime() < minMs ? new Date(minMs) : when)
-    setOpen(false)
-    resetToList()
+    finishSchedule(when.getTime() < minMs ? new Date(minMs) : when)
   }
 
   const previewLabel = useMemo(() => {
@@ -178,6 +184,7 @@ export function ScheduledMessagesPicker({
     // overlay and dismiss it immediately. Same defer pattern is used by
     // the action drawer below.
     setOpen(false)
+    closeFabDrawer?.()
     setTimeout(() => setEditing(scheduled), 0)
   }
 
@@ -186,6 +193,7 @@ export function ScheduledMessagesPicker({
     // backdrop doesn't paint over the bottom sheet, then surface the drawer
     // (rendered at the top level below, outside the popover tree).
     setOpen(false)
+    closeFabDrawer?.()
     setTimeout(() => setActionTarget(scheduled), 0)
   }
 
@@ -239,7 +247,10 @@ export function ScheduledMessagesPicker({
               now={now}
               timezone={timezone}
               canSchedule={canSchedule}
-              onClose={() => handleOpenChange(false)}
+              onClose={() => {
+                handleOpenChange(false)
+                closeFabDrawer?.()
+              }}
               onSchedulePress={enterPickingMode}
               onEdit={handleEdit}
               onSendNow={(id) => sendNowMutation.mutate(id)}

--- a/apps/frontend/src/components/composer/stashed-drafts-open-context.ts
+++ b/apps/frontend/src/components/composer/stashed-drafts-open-context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext, useEffect, type MutableRefObject } from "react"
+
+/**
+ * Open signal from MessageComposer to the stashed-drafts picker it hosts.
+ * Cmd/Ctrl+S on an EMPTY composer opens the drafts popover (there is nothing
+ * to stash, so the shortcut flips to "show me my drafts"); the picker is a
+ * host-passed slot node, so — like FabDrawerCloseContext — the signal
+ * travels by context. The picker registers its `open` into the ref; the
+ * composer's stash key handler calls it. Null outside a composer that wires
+ * the shortcut.
+ */
+export const StashedDraftsOpenContext = createContext<MutableRefObject<(() => void) | null> | null>(null)
+
+export function useRegisterStashedDraftsOpen(open: () => void) {
+  const ref = useContext(StashedDraftsOpenContext)
+  useEffect(() => {
+    if (!ref) return
+    ref.current = open
+    return () => {
+      if (ref.current === open) ref.current = null
+    }
+  }, [ref, open])
+}

--- a/apps/frontend/src/components/composer/stashed-drafts-open-context.ts
+++ b/apps/frontend/src/components/composer/stashed-drafts-open-context.ts
@@ -1,23 +1,38 @@
 import { createContext, useContext, useEffect, type MutableRefObject } from "react"
 
 /**
- * Open signal from MessageComposer to the stashed-drafts picker it hosts.
- * Cmd/Ctrl+S on an EMPTY composer opens the drafts popover (there is nothing
- * to stash, so the shortcut flips to "show me my drafts"); the picker is a
- * host-passed slot node, so — like FabDrawerCloseContext — the signal
- * travels by context. The picker registers its `open` into the ref; the
- * composer's stash key handler calls it. Null outside a composer that wires
- * the shortcut.
+ * Two-way bridge between MessageComposer and the stashed-drafts picker it
+ * hosts as a slot node (same travel-by-context shape as FabDrawerCloseContext):
+ *
+ *  - composer → picker: Cmd/Ctrl+S on an EMPTY composer opens the drafts
+ *    popover (nothing to stash, so the shortcut flips to "show me my drafts").
+ *    The picker registers its `open` into `openRef`; the composer's stash key
+ *    handler calls it.
+ *  - picker → composer: after a restore, focus follows the restored content —
+ *    the picker calls `focusComposer` (editor focus lands at the end of the
+ *    doc; see applyExternalEditorContent for the caret staying at the end once
+ *    the async rehydrate delivers the body).
+ *
+ * Null outside a composer that wires the bridge.
  */
-export const StashedDraftsOpenContext = createContext<MutableRefObject<(() => void) | null> | null>(null)
+export interface StashedDraftsComposerBridge {
+  openRef: MutableRefObject<(() => void) | null>
+  focusComposer: () => void
+}
+
+export const StashedDraftsComposerBridgeContext = createContext<StashedDraftsComposerBridge | null>(null)
+
+export function useStashedDraftsBridge(): StashedDraftsComposerBridge | null {
+  return useContext(StashedDraftsComposerBridgeContext)
+}
 
 export function useRegisterStashedDraftsOpen(open: () => void) {
-  const ref = useContext(StashedDraftsOpenContext)
+  const bridge = useStashedDraftsBridge()
   useEffect(() => {
-    if (!ref) return
-    ref.current = open
+    if (!bridge) return
+    bridge.openRef.current = open
     return () => {
-      if (ref.current === open) ref.current = null
+      if (bridge.openRef.current === open) bridge.openRef.current = null
     }
-  }, [ref, open])
+  }, [bridge, open])
 }

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -115,6 +115,33 @@ describe("StashedDraftsPicker", () => {
     })
   })
 
+  describe("keyboard navigation (desktop)", () => {
+    it("focuses the first draft row on open and walks rows with ArrowUp/Down, Enter restores", async () => {
+      isTouchMockValue = false
+      const { onRestore } = renderPicker({
+        drafts: [makeDraft("draft_1", "Saved one"), makeDraft("draft_2", "Saved two")],
+      })
+
+      await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+
+      const rowOne = screen.getByText("Saved one").closest("button")!
+      const rowTwo = screen.getByText("Saved two").closest("button")!
+      expect(rowOne).toHaveFocus()
+
+      await userEvent.keyboard("{ArrowDown}")
+      expect(rowTwo).toHaveFocus()
+
+      await userEvent.keyboard("{ArrowDown}")
+      expect(rowOne).toHaveFocus()
+
+      await userEvent.keyboard("{ArrowUp}")
+      expect(rowTwo).toHaveFocus()
+
+      await userEvent.keyboard("{Enter}")
+      expect(onRestore).toHaveBeenCalledWith("draft_2")
+    })
+  })
+
   describe("preview rendering", () => {
     const sealed = makeDraft("draft_e", "placeholder")
     const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { StashedDraftsPicker } from "./stashed-drafts-picker"
 import { FabDrawerCloseContext } from "./fab-drawer-close-context"
+import { StashedDraftsComposerBridgeContext } from "./stashed-drafts-open-context"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import type { CachedDraft, DraftPreview } from "@/hooks"
 
@@ -30,14 +31,17 @@ function renderPicker(overrides: Partial<Parameters<typeof StashedDraftsPicker>[
     ...overrides,
   }
   const closeFabDrawer = vi.fn()
+  const focusComposer = vi.fn()
   render(
     <TooltipProvider>
       <FabDrawerCloseContext.Provider value={closeFabDrawer}>
-        <StashedDraftsPicker {...props} />
+        <StashedDraftsComposerBridgeContext.Provider value={{ openRef: { current: null }, focusComposer }}>
+          <StashedDraftsPicker {...props} />
+        </StashedDraftsComposerBridgeContext.Provider>
       </FabDrawerCloseContext.Provider>
     </TooltipProvider>
   )
-  return { ...props, closeFabDrawer }
+  return { ...props, closeFabDrawer, focusComposer }
 }
 
 describe("StashedDraftsPicker", () => {
@@ -112,6 +116,16 @@ describe("StashedDraftsPicker", () => {
       expect(onRestore).toHaveBeenCalledWith("draft_1")
       await waitFor(() => expect(screen.queryByText("Saved one")).not.toBeInTheDocument())
       expect(closeFabDrawer).toHaveBeenCalled()
+    })
+
+    it("focuses the composer after a restore instead of the trigger", async () => {
+      const { focusComposer } = renderPicker()
+
+      await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+      await userEvent.click(screen.getByText("Saved one"))
+
+      await waitFor(() => expect(focusComposer).toHaveBeenCalled())
+      expect(screen.getByRole("button", { name: /drafts/i })).not.toHaveFocus()
     })
   })
 

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, createEvent } from "@testing-library/react"
+import { render, screen, fireEvent, createEvent, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { StashedDraftsPicker } from "./stashed-drafts-picker"
+import { FabDrawerCloseContext } from "./fab-drawer-close-context"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import type { CachedDraft, DraftPreview } from "@/hooks"
 
@@ -28,12 +29,15 @@ function renderPicker(overrides: Partial<Parameters<typeof StashedDraftsPicker>[
     onDelete: vi.fn(),
     ...overrides,
   }
+  const closeFabDrawer = vi.fn()
   render(
     <TooltipProvider>
-      <StashedDraftsPicker {...props} />
+      <FabDrawerCloseContext.Provider value={closeFabDrawer}>
+        <StashedDraftsPicker {...props} />
+      </FabDrawerCloseContext.Provider>
     </TooltipProvider>
   )
-  return props
+  return { ...props, closeFabDrawer }
 }
 
 describe("StashedDraftsPicker", () => {
@@ -81,8 +85,34 @@ describe("StashedDraftsPicker", () => {
     await userEvent.click(screen.getByRole("button", { name: /save current/i }))
     expect(onStashCurrent).toHaveBeenCalledOnce()
 
+    // Save closes the popover; reopen it for the restore click.
+    await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
     await userEvent.click(screen.getByText("Saved one"))
     expect(onRestore).toHaveBeenCalledWith("draft_1")
+  })
+
+  describe("close on action", () => {
+    it("closes the popover and the hosting FAB drawer after Save current", async () => {
+      const { onStashCurrent, closeFabDrawer } = renderPicker()
+
+      await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+      await userEvent.click(screen.getByRole("button", { name: /save current/i }))
+
+      expect(onStashCurrent).toHaveBeenCalledOnce()
+      await waitFor(() => expect(screen.queryByRole("button", { name: /save current/i })).not.toBeInTheDocument())
+      expect(closeFabDrawer).toHaveBeenCalled()
+    })
+
+    it("closes the popover and the hosting FAB drawer after restoring a draft", async () => {
+      const { onRestore, closeFabDrawer } = renderPicker()
+
+      await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+      await userEvent.click(screen.getByText("Saved one"))
+
+      expect(onRestore).toHaveBeenCalledWith("draft_1")
+      await waitFor(() => expect(screen.queryByText("Saved one")).not.toBeInTheDocument())
+      expect(closeFabDrawer).toHaveBeenCalled()
+    })
   })
 
   describe("preview rendering", () => {

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react"
 import { FileEdit, FilePlus, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
 import { useFabDrawerClose } from "./fab-drawer-close-context"
+import { useRegisterStashedDraftsOpen } from "./stashed-drafts-open-context"
 import { useComposerAnchor } from "./use-composer-anchor"
 import type { CachedDraft, DraftPreview } from "@/hooks"
 
@@ -77,6 +78,12 @@ export function StashedDraftsPicker({
   const [draftToDelete, setDraftToDelete] = useState<string | null>(null)
   const closeFabDrawer = useFabDrawerClose()
   const { setTriggerRef, anchor } = useComposerAnchor(open)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // Cmd/Ctrl+S on an empty composer opens the list (registered with the
+  // hosting MessageComposer via context).
+  const openFromShortcut = useCallback(() => setOpen(true), [])
+  useRegisterStashedDraftsOpen(openFromShortcut)
   // Active input drives the virtual-keyboard guard and the "Tap"/"Press" +
   // keyboard-shortcut copy — a hardware keyboard is present only with a mouse.
   const isTouch = useInputMode() === "touch"
@@ -115,6 +122,21 @@ export function StashedDraftsPicker({
     if (draftToDelete) onDelete(draftToDelete)
     setDraftToDelete(null)
   }, [draftToDelete, onDelete])
+
+  // Arrow keys walk the draft rows so a keyboard-opened list (Cmd/Ctrl+S on an
+  // empty composer) is pick-able without a mouse; Enter activates the focused
+  // row natively.
+  const handleContentKeyDown = useCallback((e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+    const rows = Array.from(e.currentTarget.querySelectorAll<HTMLButtonElement>("[data-draft-row]"))
+    if (rows.length === 0) return
+    e.preventDefault()
+    const idx = rows.indexOf(document.activeElement as HTMLButtonElement)
+    const step = e.key === "ArrowDown" ? 1 : -1
+    // Focus outside the rows (idx -1): Down enters at the top, Up at the bottom.
+    const next = idx === -1 && step === -1 ? rows.length - 1 : (idx + step + rows.length) % rows.length
+    rows[next]?.focus()
+  }, [])
 
   const triggerSizeClass = size === "fab" ? "h-[30px] w-[30px] rounded-md bg-background shadow-md" : "h-7 w-7"
   const triggerIconClass = size === "fab" ? "h-4 w-4" : "h-3.5 w-3.5"
@@ -157,7 +179,31 @@ export function StashedDraftsPicker({
           </TooltipContent>
         </Tooltip>
 
-        <PopoverContent align="end" side="top" sideOffset={8} className="w-80 p-0" {...keepEditorFocusProps(isTouch)}>
+        <PopoverContent
+          ref={contentRef}
+          align="end"
+          side="top"
+          sideOffset={8}
+          className="w-80 p-0"
+          {...keepEditorFocusProps(isTouch)}
+          onKeyDown={handleContentKeyDown}
+          onOpenAutoFocus={(e) => {
+            // Touch keeps the editor focused (keepEditorFocusProps behavior,
+            // re-stated here because this prop overrides the spread). Desktop
+            // lands focus on the first draft row so ArrowUp/Down + Enter work
+            // immediately after a keyboard open; with no rows Radix's default
+            // content focus stands.
+            if (isTouch) {
+              e.preventDefault()
+              return
+            }
+            const first = contentRef.current?.querySelector<HTMLButtonElement>("[data-draft-row]")
+            if (first) {
+              e.preventDefault()
+              first.focus()
+            }
+          }}
+        >
           <div className="flex items-center justify-between gap-2 px-3 py-2 border-b">
             <p className="text-sm font-medium">
               Drafts
@@ -198,6 +244,7 @@ export function StashedDraftsPicker({
                     <div className="flex items-start gap-2 px-3 py-2 hover:bg-muted/60 focus-within:bg-muted/60">
                       <button
                         type="button"
+                        data-draft-row
                         onClick={() => handleRestore(draft.id)}
                         className="flex-1 min-w-0 text-left focus:outline-none"
                       >

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -9,6 +9,7 @@ import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
+import { useFabDrawerClose } from "./fab-drawer-close-context"
 import { useComposerAnchor } from "./use-composer-anchor"
 import type { CachedDraft, DraftPreview } from "@/hooks"
 
@@ -74,6 +75,7 @@ export function StashedDraftsPicker({
 }: StashedDraftsPickerProps) {
   const [open, setOpen] = useState(false)
   const [draftToDelete, setDraftToDelete] = useState<string | null>(null)
+  const closeFabDrawer = useFabDrawerClose()
   const { setTriggerRef, anchor } = useComposerAnchor(open)
   // Active input drives the virtual-keyboard guard and the "Tap"/"Press" +
   // keyboard-shortcut copy — a hardware keyboard is present only with a mouse.
@@ -83,27 +85,31 @@ export function StashedDraftsPicker({
 
   const handleStashCurrent = useCallback(() => {
     onStashCurrent()
-    // Keep the popover open so the user sees their draft land in the list —
-    // feels more affirmative than a silent close. Closing on restore is
-    // handled inside the row handler below.
-  }, [onStashCurrent])
+    setOpen(false)
+    closeFabDrawer?.()
+  }, [onStashCurrent, closeFabDrawer])
 
   const handleRestore = useCallback(
     (id: string) => {
       onRestore(id)
       setOpen(false)
+      closeFabDrawer?.()
     },
-    [onRestore]
+    [onRestore, closeFabDrawer]
   )
 
   // Two-step delete: the trash icon opens a confirm dialog (parity with the
   // Drafts explorer — a draft is a draft, so both surfaces guard a delete the
   // same way). Close the popover first so the modal isn't trapped behind it. No
   // success toast by design: the confirm already makes the delete deliberate.
-  const requestDelete = useCallback((id: string) => {
-    setOpen(false)
-    setDraftToDelete(id)
-  }, [])
+  const requestDelete = useCallback(
+    (id: string) => {
+      setOpen(false)
+      closeFabDrawer?.()
+      setDraftToDelete(id)
+    },
+    [closeFabDrawer]
+  )
 
   const confirmDelete = useCallback(() => {
     if (draftToDelete) onDelete(draftToDelete)

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -9,13 +9,12 @@ import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
+import { usePreferencesOptional } from "@/contexts"
+import { formatKeyBinding, getEffectiveKeyBinding } from "@/lib/keyboard-shortcuts"
 import { useFabDrawerClose } from "./fab-drawer-close-context"
-import { useRegisterStashedDraftsOpen } from "./stashed-drafts-open-context"
+import { useRegisterStashedDraftsOpen, useStashedDraftsBridge } from "./stashed-drafts-open-context"
 import { useComposerAnchor } from "./use-composer-anchor"
 import type { CachedDraft, DraftPreview } from "@/hooks"
-
-/** Keystroke hint for the "Save current" action. Rendered only for fine pointers (no hardware keyboard on touch). */
-const MOD_SYMBOL = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? "⌘" : "Ctrl+"
 
 interface StashedDraftsPickerProps {
   drafts: CachedDraft[]
@@ -77,13 +76,24 @@ export function StashedDraftsPicker({
   const [open, setOpen] = useState(false)
   const [draftToDelete, setDraftToDelete] = useState<string | null>(null)
   const closeFabDrawer = useFabDrawerClose()
+  const bridge = useStashedDraftsBridge()
   const { setTriggerRef, anchor } = useComposerAnchor(open)
   const contentRef = useRef<HTMLDivElement>(null)
+  // Set when a restore closes the popover: Radix's close-autofocus (back to
+  // the trigger) is suppressed so focus can follow the restored content into
+  // the editor instead.
+  const suppressCloseFocusRef = useRef(false)
 
   // Cmd/Ctrl+S on an empty composer opens the list (registered with the
-  // hosting MessageComposer via context).
+  // hosting MessageComposer via the bridge).
   const openFromShortcut = useCallback(() => setOpen(true), [])
   useRegisterStashedDraftsOpen(openFromShortcut)
+
+  // The stash shortcut hint mirrors the user's effective (remappable)
+  // `draftStash` binding rather than a hardcoded ⌘S.
+  const keyboardShortcuts = usePreferencesOptional()?.preferences?.keyboardShortcuts ?? {}
+  const stashBinding = getEffectiveKeyBinding("draftStash", keyboardShortcuts)
+  const stashBindingLabel = stashBinding ? formatKeyBinding(stashBinding) : null
   // Active input drives the virtual-keyboard guard and the "Tap"/"Press" +
   // keyboard-shortcut copy — a hardware keyboard is present only with a mouse.
   const isTouch = useInputMode() === "touch"
@@ -101,8 +111,15 @@ export function StashedDraftsPicker({
       onRestore(id)
       setOpen(false)
       closeFabDrawer?.()
+      // Focus follows the restored content: skip Radix's trigger refocus and
+      // land in the editor once the popover has torn down. The caret ends up
+      // after the restored body via applyExternalEditorContent's end-focus
+      // when the async rehydrate delivers it.
+      suppressCloseFocusRef.current = true
+      const focusComposer = bridge?.focusComposer
+      if (focusComposer) setTimeout(() => focusComposer(), 0)
     },
-    [onRestore, closeFabDrawer]
+    [onRestore, closeFabDrawer, bridge]
   )
 
   // Two-step delete: the trash icon opens a confirm dialog (parity with the
@@ -187,6 +204,13 @@ export function StashedDraftsPicker({
           className="w-80 p-0"
           {...keepEditorFocusProps(isTouch)}
           onKeyDown={handleContentKeyDown}
+          onCloseAutoFocus={(e) => {
+            // Touch never refocuses the trigger (keepEditorFocusProps
+            // behavior, re-stated since this prop overrides the spread); a
+            // restore-close skips it too so focus can land in the editor.
+            if (isTouch || suppressCloseFocusRef.current) e.preventDefault()
+            suppressCloseFocusRef.current = false
+          }}
           onOpenAutoFocus={(e) => {
             // Touch keeps the editor focused (keepEditorFocusProps behavior,
             // re-stated here because this prop overrides the spread). Desktop
@@ -219,18 +243,21 @@ export function StashedDraftsPicker({
             >
               <FilePlus className="h-3.5 w-3.5" />
               <span>Save current</span>
-              {!isTouch && <span className="text-muted-foreground ml-1">{MOD_SYMBOL}S</span>}
+              {!isTouch && stashBindingLabel && <span className="text-muted-foreground ml-1">{stashBindingLabel}</span>}
             </Button>
           </div>
 
           {drafts.length === 0 ? (
             <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-              {isTouch ? (
-                <>No saved drafts yet. Tap "Save current" to stash what you're typing and start fresh.</>
+              {isTouch || !stashBindingLabel ? (
+                <>
+                  No saved drafts yet. {isTouch ? "Tap" : "Use"} "Save current" to stash what you're typing and start
+                  fresh.
+                </>
               ) : (
                 <>
-                  No saved drafts yet. Press <span className="font-medium text-foreground">{MOD_SYMBOL}S</span> to stash
-                  what you're typing and start fresh.
+                  No saved drafts yet. Press <span className="font-medium text-foreground">{stashBindingLabel}</span> to
+                  stash what you're typing and start fresh.
                 </>
               )}
             </div>

--- a/apps/frontend/src/components/editor/apply-external-content.test.ts
+++ b/apps/frontend/src/components/editor/apply-external-content.test.ts
@@ -75,6 +75,27 @@ describe("applyExternalEditorContent", () => {
     applyExternalEditorContent(editor, DOC, isInternalUpdate)
 
     expect(focus).toHaveBeenCalledTimes(1)
+    expect(focus).toHaveBeenCalledWith("end")
+  })
+
+  it("moves the caret to the end when the doc is replaced while focused", () => {
+    // Focus follows the content: setContent leaves the selection at the doc
+    // start, which strands the caret before a just-restored draft body.
+    const { editor, focus } = makeEditor({ isFocused: true })
+    const isInternalUpdate = { current: false }
+
+    applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(focus).toHaveBeenCalledWith("end")
+  })
+
+  it("does not touch focus when the editor was not focused", () => {
+    const { editor, focus } = makeEditor({ isFocused: false })
+    const isInternalUpdate = { current: false }
+
+    applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(focus).not.toHaveBeenCalled()
   })
 
   it("does not try to restore focus when the content failed to apply", () => {

--- a/apps/frontend/src/components/editor/apply-external-content.ts
+++ b/apps/frontend/src/components/editor/apply-external-content.ts
@@ -9,7 +9,7 @@ export interface ExternalContentEditor {
   isFocused: boolean
   commands: {
     setContent: (content: JSONContent) => void
-    focus: () => void
+    focus: (position?: "end") => void
   }
 }
 
@@ -43,10 +43,14 @@ export function applyExternalEditorContent(
     isInternalUpdate.current = false
   }
 
-  // Mobile browsers can drop focus when contenteditable content is replaced.
-  // Restore it to keep the virtual keyboard open — only when we actually applied.
-  if (applied && hadFocus && !editor.isFocused) {
-    editor.commands.focus()
+  // Focus follows the content: a focused editor whose doc was just replaced
+  // (draft restore, send-clear) gets the caret at the END of the new body —
+  // `setContent` otherwise leaves the selection at the start, stranding the
+  // caret before the text the user just restored. This also covers mobile
+  // browsers dropping focus when contenteditable content is replaced (the
+  // refocus keeps the virtual keyboard open). Only when we actually applied.
+  if (applied && hadFocus) {
+    editor.commands.focus("end")
   }
 
   return applied

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -1047,7 +1047,14 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
         return
       }
 
-      editor.chain().focus().insertContent(trigger).run()
+      // The suggestion plugins only activate at a word boundary — inserting a
+      // bare trigger right after text appends a dead "@"/":"/"/" that opens
+      // nothing. Prepend a space when the caret follows a non-whitespace char
+      // (same rule as insertTranscribedText below).
+      const { from } = selection
+      const charBefore = from > 0 ? editor.state.doc.textBetween(from - 1, from) : ""
+      const prefix = charBefore && !/\s/.test(charBefore) ? " " : ""
+      editor.chain().focus().insertContent(`${prefix}${trigger}`).run()
     },
     [editor]
   )

--- a/apps/frontend/src/components/editor/triggers/use-emoji-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-emoji-suggestion.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo, type RefObject, type ReactNode } from "react"
+import { useState, useCallback, useEffect, useRef, useMemo, type RefObject, type ReactNode } from "react"
 import { createPortal } from "react-dom"
 import type { Editor } from "@tiptap/react"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
@@ -131,6 +131,23 @@ export function useEmojiSuggestion(config: UseEmojiSuggestionConfig): UseEmojiSu
     setState(null)
   }, [setPopupVisible])
 
+  // Outside-pointerdown dismiss, mirroring useSuggestion — see the comment
+  // there. Without it a `:` popup survives a tap-outside collapse on mobile
+  // and sits over the collapsed composer bar.
+  const isActive = state !== null
+  useEffect(() => {
+    if (!isActive) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.closest('[role="listbox"]')) return
+      const editor = editorRef.current
+      if (editor && !editor.isDestroyed && target && editor.view.dom.contains(target)) return
+      close()
+    }
+    document.addEventListener("pointerdown", onPointerDown, true)
+    return () => document.removeEventListener("pointerdown", onPointerDown, true)
+  }, [isActive, close])
+
   const onKeyDown = useCallback(
     (props: SuggestionKeyDownProps) => {
       if (props.event.key === "Escape") {
@@ -175,7 +192,7 @@ export function useEmojiSuggestion(config: UseEmojiSuggestionConfig): UseEmojiSu
   return {
     suggestionConfig,
     renderEmojiGrid,
-    isActive: state !== null,
+    isActive,
     close,
   }
 }

--- a/apps/frontend/src/components/editor/triggers/use-suggestion-outside-dismiss.test.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-suggestion-outside-dismiss.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { act, render, screen, fireEvent } from "@testing-library/react"
+import type { SuggestionProps } from "@tiptap/suggestion"
+import { useSuggestion } from "./use-suggestion"
+import { useEmojiSuggestion } from "./use-emoji-suggestion"
+import type { EmojiEntry } from "@threa/types"
+
+interface Item {
+  id: string
+  label: string
+}
+
+type Config = ReturnType<typeof useSuggestion<Item>>["suggestionConfig"]
+
+function Harness({ capture }: { capture: (cfg: Config) => void }) {
+  const { suggestionConfig, renderSuggestionList } = useSuggestion<Item>({
+    extensionName: "mention",
+    getItems: () => [],
+    filterItems: (items) => items,
+    renderList: ({ items, command }) => (
+      <div role="listbox" aria-label="suggestions">
+        {items.map((item) => (
+          <button key={item.id} role="option" aria-selected={false} onClick={() => command(item)}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+    ),
+  })
+  capture(suggestionConfig)
+  return <>{renderSuggestionList()}</>
+}
+
+// Minimal editor stand-in: onStart/pointer-dismiss only touch storage,
+// isDestroyed, and view.dom.
+function makeFakeEditor(storage: Record<string, unknown>, dom: HTMLElement) {
+  return { storage: { mention: storage, emoji: storage }, isDestroyed: false, view: { dom } }
+}
+
+function activate<T>(
+  cfg: { render: () => { onStart: (props: SuggestionProps<T>) => void } },
+  opts: {
+    editor: unknown
+    items: T[]
+  }
+) {
+  const props = {
+    editor: opts.editor,
+    items: opts.items,
+    query: "",
+    clientRect: () => new DOMRect(0, 0, 0, 0),
+    command: () => {},
+  } as unknown as SuggestionProps<T>
+  act(() => {
+    cfg.render().onStart(props)
+  })
+}
+
+let editorDom: HTMLDivElement
+
+beforeEach(() => {
+  editorDom = document.createElement("div")
+  document.body.appendChild(editorDom)
+})
+
+afterEach(() => {
+  editorDom.remove()
+})
+
+describe("useSuggestion outside-pointerdown dismiss", () => {
+  const items = [{ id: "a", label: "Alice" }]
+
+  function renderActive(storage: Record<string, unknown> = {}) {
+    let cfg: Config | null = null
+    render(<Harness capture={(c) => (cfg = c)} />)
+    activate(cfg!, { editor: makeFakeEditor(storage, editorDom), items })
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    return storage
+  }
+
+  it("closes the popup on a pointer down outside the popup and the editor", () => {
+    const storage = renderActive({ popupVisible: true })
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    expect(storage.popupVisible).toBe(false)
+  })
+
+  it("keeps the popup when the pointer down lands on a list option", () => {
+    renderActive()
+    fireEvent.pointerDown(screen.getByRole("option", { name: "Alice" }))
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+
+  it("keeps the popup when the pointer down lands inside the editor", () => {
+    renderActive()
+    fireEvent.pointerDown(editorDom)
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+})
+
+describe("useEmojiSuggestion outside-pointerdown dismiss", () => {
+  const smile = { emoji: "😄", label: "smile", group: 0, order: 0, tags: [] } as unknown as EmojiEntry
+
+  function EmojiHarness({
+    capture,
+  }: {
+    capture: (cfg: ReturnType<typeof useEmojiSuggestion>["suggestionConfig"]) => void
+  }) {
+    const { suggestionConfig, renderEmojiGrid } = useEmojiSuggestion({ emojis: [smile], emojiWeights: {} })
+    capture(suggestionConfig)
+    return <>{renderEmojiGrid()}</>
+  }
+
+  it("closes the emoji grid on a pointer down outside the popup and the editor", () => {
+    let cfg: ReturnType<typeof useEmojiSuggestion>["suggestionConfig"] | null = null
+    render(<EmojiHarness capture={(c) => (cfg = c)} />)
+    const storage: Record<string, unknown> = { popupVisible: true }
+    activate(cfg!, { editor: makeFakeEditor(storage, editorDom), items: [smile] })
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    expect(storage.popupVisible).toBe(false)
+  })
+})

--- a/apps/frontend/src/components/editor/triggers/use-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-suggestion.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, type RefObject, type ReactNode } from "react"
+import { useState, useCallback, useEffect, useMemo, useRef, type RefObject, type ReactNode } from "react"
 import { createPortal } from "react-dom"
 import type { Editor } from "@tiptap/react"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
@@ -166,6 +166,28 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
     setState(null)
   }, [setPopupVisible])
 
+  // A pointer down outside both the popup and the editor dismisses the popup
+  // (same contract as use-command-arg-picker). Blur alone never fires TipTap's
+  // onExit — the selection doesn't move — so without this a popup opened by a
+  // typed trigger survives a tap-outside and lingers over whatever replaced
+  // the editor (e.g. the collapsed mobile composer bar, where it swallows the
+  // reopen tap). Capture phase so the popup is gone before the tap's click
+  // lands; taps inside the editor stay with TipTap's own lifecycle, and taps
+  // on a list option pass through to the option's click handler.
+  const isActive = state !== null
+  useEffect(() => {
+    if (!isActive) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.closest('[role="listbox"]')) return
+      const editor = editorRef.current
+      if (editor && !editor.isDestroyed && target && editor.view.dom.contains(target)) return
+      close()
+    }
+    document.addEventListener("pointerdown", onPointerDown, true)
+    return () => document.removeEventListener("pointerdown", onPointerDown, true)
+  }, [isActive, close])
+
   const onKeyDown = useCallback(
     (props: SuggestionKeyDownProps) => {
       if (props.event.key === "Escape") {
@@ -210,7 +232,7 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
   return {
     suggestionConfig,
     renderSuggestionList,
-    isActive: state !== null,
+    isActive,
     close,
   }
 }


### PR DESCRIPTION
## Problem

Two families of composer interactions leave UI open after it has done its job (reported from mobile dogfooding):

1. **Menus that outlive their action.** The stashed-drafts picker deliberately kept its popover open after "Save current" (`handleStashCurrent` in `stashed-drafts-picker.tsx` had a keep-open comment), and the mobile fullscreen composer's FAB "+" action drawer (`fabActionsOpen` in `message-composer.tsx`) was never closed by anything except re-tapping "+" — so after restoring a draft or scheduling a send, the picker's popover closed but the drawer stayed on screen.
2. **Typed-trigger popups (`@` `#` `:` `/`) surviving tap-outside.** The suggestion popups portal to `document.body` and only closed on Escape-with-focus or a match-ending selection change (TipTap `onExit`). A blur never moves the ProseMirror selection, so tapping outside on mobile collapsed the composer chrome (`handleBlurCapture` → `collapse()`) but left the popup floating at `z-50` above the collapsed bar — where its `role="option"` buttons matched the collapsed bar's closest-interactive tap guard and swallowed the reopen tap.

## Solution

Close things at the moment their job completes, using the dismiss pattern the codebase already had in one place.

### How it works

- **Drafts picker closes on every action.** `handleStashCurrent` now does `setOpen(false)`; restore and delete already closed the popover.
- **`FabDrawerCloseContext`** (`fab-drawer-close-context.ts`, new): the FAB drawer's contents are host-passed slot nodes (`stashedDraftsTriggerFab` / `scheduledMessagesTriggerFab`), so the "action finished — collapse the drawer too" signal travels by context. `MessageComposer` provides `() => setFabActionsOpen(false)` around the drawer slots; both pickers call it wherever an action closes their popover. Compact toolbar pickers get the `null` default and no-op. The drawer's direct buttons (insert emoji/mention/command, attach) also call it inline.
- **Scheduled picker stays open until a time is picked** (explicit ruling from Kris): the "Schedule send" mode switch and the picking UI never close; the terminal paths (preset chip, custom duration submit, custom date/time submit) funnel through a new `finishSchedule(when)` that closes popover + drawer together. Edit/long-press handoffs and "View all →" also close both.
- **Outside-pointerdown dismiss for suggestion popups**: `useSuggestion` and `useEmojiSuggestion` attach a capture-phase `document` `pointerdown` listener while active — taps inside `[role="listbox"]` pass through to the option handler, taps inside `editor.view.dom` stay with TipTap's own lifecycle, anything else calls the hook's existing `close()`. This is the exact contract `use-command-arg-picker.tsx` already implemented for the `/model` arg picker; the popup dies on the same tap that collapses the mobile composer, and desktop gets outside-click dismissal too.
- **Trigger buttons insert at a word boundary** (`handleTriggerClick` in `rich-editor.tsx`): the suggestion plugins only activate at a boundary, so Insert mention/emoji/command after existing text appended a dead `@`/`:`/`/` that opened nothing (caught during live verification). Now prepends a space when the caret follows a non-whitespace char — same rule as `insertTranscribedText` directly below it.

### Key design decisions

**1. Context, not render-props, for the drawer close signal** — the pickers are constructed at three host call sites (`message-input.tsx`, `board-inline-composer.tsx`, `stream-panel.tsx`) and passed in as opaque `ReactNode`s. A context provider scoped to the drawer subtree closes the loop without touching any host, and the compact (non-drawer) picker instances are unaffected by the null default.

**2. Dismiss on `pointerdown`, not editor blur** — suggestion list options select via `onClick` with no `mousedown` preventDefault, so a blur-driven close would tear the popup down before the option's click lands. The capture-phase outside-pointerdown check (popup and editor exempt) keeps item selection working on both input types, and mirrors `use-command-arg-picker`'s established listener.

**3. Drawer closes only on actions, not on popover dismissal** — tapping outside a picker popover returns you to the drawer (you may want the sibling button); completing an action closes everything.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/composer/fab-drawer-close-context.ts` | Close signal from FAB-drawer-hosted pickers back to `MessageComposer` |
| `apps/frontend/src/components/editor/triggers/use-suggestion-outside-dismiss.test.tsx` | Outside-pointerdown dismiss coverage for `useSuggestion` + `useEmojiSuggestion` |

## Modified files

| File | Change |
| ---- | ------ |
| `composer/stashed-drafts-picker.tsx` | Save current closes popover; save/restore/delete also close the FAB drawer |
| `composer/scheduled-messages-picker.tsx` | `finishSchedule` closes popover + drawer on terminal picks only; edit/actions/view-all close both |
| `composer/message-composer.tsx` | `closeFabDrawer` + context provider around drawer slots; direct drawer buttons close on use |
| `editor/rich-editor.tsx` | `handleTriggerClick` prepends a space at a non-boundary caret |
| `editor/triggers/use-suggestion.tsx`, `use-emoji-suggestion.tsx` | Capture-phase outside-pointerdown dismiss while active |
| picker test files | Provider-wrapped harnesses, close-on-action tests, picking-flow-stays-open test |

## Out of scope (deliberate)

- Leftover trigger text after a dismissed popup (a bare `@` stays in the draft) — removing user-typed content on blur is riskier than the popup fix and wasn't the complaint.
- The board "New post" overlay doesn't host drafts/scheduled pickers in its FAB drawer (only the docked board composer passes those slots) — pre-existing, unchanged.

## Follow-up in this PR: Cmd/Ctrl+S on empty composer opens the drafts picker

Requested after the first commit: with nothing to stash, the stash shortcut flips to "show me my drafts". `handleStashKeyDown` (message-composer.tsx) branches on `isEmptyContent(content) && pendingAttachments.length === 0` and opens the hosted picker through `StashedDraftsOpenContext` (`stashed-drafts-open-context.ts`, new — the picker registers its `open` into a context-provided ref, mirroring the FabDrawerCloseContext shape since the picker is a slot node). Desktop open lands focus on the first draft row (`onOpenAutoFocus`; Radix default stands when the list is empty); ArrowUp/Down walk `[data-draft-row]` buttons with wrapping, Enter restores natively; touch keeps the editor focused as before. Non-empty Cmd+S stashes exactly as before.

Additional tests: 2 MessageComposer integration tests (empty → picker opens + no stash; non-empty → stash + no picker) and a picker keyboard-navigation test. Live-verified on `dev:test` desktop viewport 4/4: seeded two drafts via Cmd+S, empty Cmd+S opened the list with first row focused, ArrowDown+Enter restored the right draft and closed the picker.

### Focus follows restored content + remappable hint (`b6060698`)

Restore — keyboard or mouse — now lands focus in the editor with the caret after the restored body: the picker suppresses Radix's close-autofocus (trigger refocus) and calls `focusComposer` on the `StashedDraftsComposerBridge` (the open-context grown two-way; MessageComposer supplies `richEditorRef.focus()` = focus("end")). Because the restored body arrives via the async rehydrate, `applyExternalEditorContent` now moves the caret to the END whenever a focused doc is replaced — `setContent` otherwise left the selection at the start. That end-focus also covers send-clear (end == start of the empty doc) and subsumes the existing mobile focus-drop refocus.

The picker's shortcut hint ("Save current ⌘S" and the empty-state copy) now renders the user's effective `draftStash` binding via `getEffectiveKeyBinding` + `formatKeyBinding` instead of a hardcoded ⌘S — the shortcut handler itself already went through the remappable-binding system. Unbound (`"none"`) hides the hint.

Live-verified 4/4 on dev:test desktop: Enter-restore and mouse-restore both leave the editor focused, and immediate typing appends after the restored text. Unit: 472 composer/editor tests (3 new: caret-to-end in apply-external-content, focus-not-on-trigger after restore).

## Test plan

- [x] `vitest run src/components/composer src/components/editor` — 466 pass (incl. 8 new: 2 drafts close-on-action, 1 scheduled stays-open-until-picked, 4 outside-dismiss, 1 updated save-then-reopen)
- [x] `tsc --noEmit` frontend clean; pre-commit ran full monorepo lint + typecheck
- [x] Live verify on `dev:test` (scripted Playwright, 390×844 + touch, stub auth): 8/8 — mention popup dies on tap-outside collapse and the composer reopens on the next tap; drafts popover closes after Save current and after restore; FAB drawer opens on "+", collapses after Insert mention, popup opens (post space-fix) and dismisses on outside tap in fullscreen
- [ ] Scheduled-picker drawer close not driven live (needs the docked board composer path) — covered by unit tests via the context mock

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01PDwQGTdZ9BDgzKoZzxWH5J

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786776038&installation_id=129946197&pr_number=1356&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1356&signature=3547a821d0a8de9d1b6fa48f25f1af5c4f793025b3837d1a6d0a8f74ea29c4d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

