### PR TITLE
fix(scheduled-messages): Send Now fires future rows regardless of clock skew + editor gains Send now/Delete

### DIFF
--- a/apps/backend/src/features/scheduled-messages/repository.test.ts
+++ b/apps/backend/src/features/scheduled-messages/repository.test.ts
@@ -256,6 +256,28 @@ describe("ScheduledMessagesRepository.tryStartSend (worker CAS)", () => {
 
     expect(captured.values).toContain(true)
   })
+
+  it("drops the scheduled_for guard when force=true so Send Now fires a still-future row regardless of clock skew", async () => {
+    // Send Now must not depend on scheduled_for <= NOW(): the row is
+    // future-scheduled and the user asked to send it now. `force` short-
+    // circuits the schedule check in SQL (the OR branch) rather than the
+    // service rewriting scheduled_for to a JS `new Date()` and racing DB
+    // clock skew.
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured)
+
+    await ScheduledMessagesRepository.tryStartSend(db, {
+      workspaceId: "ws_1",
+      id: "sched_01",
+      ttlSeconds: 10,
+      force: true,
+    })
+
+    // The guard survives only as an OR branch behind the force flag.
+    expect(captured.text).toContain("OR scheduled_for <= NOW()")
+    // force=true is passed (bypassFence defaults false), so a `true` appears.
+    expect(captured.values).toContain(true)
+  })
 })
 
 describe("ScheduledMessagesRepository.releaseEditFence", () => {

--- a/apps/backend/src/features/scheduled-messages/repository.ts
+++ b/apps/backend/src/features/scheduled-messages/repository.ts
@@ -357,18 +357,28 @@ export const ScheduledMessagesRepository = {
    * worker defers because of the fence, and the user's PATCH 409s with
    * NOT_PENDING because of the same fence.
    *
+   * `force: true` additionally drops the `scheduled_for <= NOW()` guard so a
+   * user-initiated Send Now fires a still-future row immediately. This anchors
+   * the send on the DB clock (the CAS) rather than a JS `new Date()`: forcing
+   * a future row by rewriting `scheduled_for = new Date()` and re-running the
+   * guard raced app↔DB clock skew — an app clock a few hundred ms ahead of
+   * Postgres put the rewritten time just past the DB's NOW() and the send
+   * silently 409'd. Only the user-initiated `sendNow` path forces; the worker
+   * and the past-time save keep the guard.
+   *
    * Returns null on:
    *  - status not pending (cancelled, already sending/sent, failed)
-   *  - scheduled_for in the future (stale leased queue row that survived a
-   *    reschedule cancel — see service.fire's pre-check comment)
+   *  - scheduled_for in the future AND `force` is false (stale leased queue
+   *    row that survived a reschedule cancel — see service.fire's pre-check)
    *  - edit_active_until in the future AND `bypassFence` is false (worker
    *    path only; an editor is active, defer)
    */
   async tryStartSend(
     db: Querier,
-    params: { workspaceId: string; id: string; ttlSeconds: number; bypassFence?: boolean }
+    params: { workspaceId: string; id: string; ttlSeconds: number; bypassFence?: boolean; force?: boolean }
   ): Promise<ScheduledMessage | null> {
     const bypassFence = params.bypassFence ?? false
+    const force = params.force ?? false
     const result = await db.query<ScheduledMessageRow>(sql`
       UPDATE scheduled_messages SET
         status = ${ScheduledMessageStatuses.SENDING},
@@ -379,7 +389,7 @@ export const ScheduledMessagesRepository = {
       WHERE id = ${params.id}
         AND workspace_id = ${params.workspaceId}
         AND status = ${ScheduledMessageStatuses.PENDING}
-        AND scheduled_for <= NOW()
+        AND (${force}::boolean OR scheduled_for <= NOW())
         AND (
           ${bypassFence}::boolean
           OR edit_active_until IS NULL

--- a/apps/backend/src/features/scheduled-messages/service.test.ts
+++ b/apps/backend/src/features/scheduled-messages/service.test.ts
@@ -443,6 +443,60 @@ describe("ScheduledMessagesService.update (optimistic CAS)", () => {
   })
 })
 
+describe("ScheduledMessagesService.sendNow", () => {
+  afterEach(() => mock.restore())
+
+  it("forces a still-future row to send now in one CAS, without rewriting scheduled_for", async () => {
+    // Regression: sendNow used to force a future row by rewriting
+    // scheduled_for = new Date() and re-running the worker CAS (which
+    // requires scheduled_for <= NOW()). An app clock a few hundred ms ahead
+    // of Postgres put the rewritten instant just past the DB's NOW(), the
+    // reclaim CAS matched nothing, and the send silently 409'd. The fix
+    // forces the guard off in a single CAS anchored on the DB clock — no
+    // scheduled_for rewrite, no second round-trip.
+    const service = setupService()
+    const row = fakeScheduled({ version: 2, scheduledFor: FUTURE, queueMessageId: "q_1" })
+
+    spyOn(ScheduledMessagesRepository, "findById").mockResolvedValue(row)
+    const update = spyOn(ScheduledMessagesRepository, "update").mockResolvedValue(row)
+    const tryStartSend = spyOn(ScheduledMessagesRepository, "tryStartSend").mockResolvedValue({
+      ...row,
+      status: ScheduledMessageStatuses.SENDING,
+    })
+    spyOn(ScheduledMessagesRepository, "markSent").mockResolvedValue({
+      ...row,
+      status: ScheduledMessageStatuses.SENT,
+      sentMessageId: "msg_42",
+    })
+    const cancelById = spyOn(QueueRepository, "cancelById").mockResolvedValue(undefined as any)
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.sendNow({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: SCHEDULED_ID })
+
+    expect(result.status).toBe(ScheduledMessageStatuses.SENT)
+    // One CAS, forced past both the schedule guard and the user's own fence.
+    expect(tryStartSend).toHaveBeenCalledTimes(1)
+    expect(tryStartSend).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ force: true, bypassFence: true })
+    )
+    // No scheduled_for rewrite — the clock-skew source is gone.
+    expect(update).not.toHaveBeenCalled()
+    // The pending queue job is cancelled so the worker can't double-fire.
+    expect(cancelById).toHaveBeenCalledWith(expect.anything(), "q_1")
+  })
+
+  it("throws NOT_PENDING when the row already left pending before the CAS", async () => {
+    const service = setupService()
+    spyOn(ScheduledMessagesRepository, "findById").mockResolvedValue(fakeScheduled())
+    spyOn(ScheduledMessagesRepository, "tryStartSend").mockResolvedValue(null)
+
+    await expect(service.sendNow({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: SCHEDULED_ID })).rejects.toThrow(
+      /no longer pending/i
+    )
+  })
+})
+
 describe("ScheduledMessagesService.fire (worker entry)", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/scheduled-messages/service.ts
+++ b/apps/backend/src/features/scheduled-messages/service.ts
@@ -347,48 +347,27 @@ export class ScheduledMessagesService {
     return withTransaction(this.pool, async (client) => {
       const existing = await this.assertPendingOrThrow(client, params)
 
-      // Take the worker-style CAS atomically (status flip → sending). Bypass
-      // the fence — the user explicitly asked to send right now; their own
-      // (or a sibling tab's) `lockForEdit` shouldn't block them.
+      // Claim the row atomically (status flip → sending). `force` drops the
+      // `scheduled_for <= NOW()` guard so a still-future row fires now, and
+      // `bypassFence` drops the user's own edit-dialog lock. Anchoring on the
+      // CAS (DB clock) rather than rewriting `scheduled_for = new Date()` and
+      // retrying the guard is the fix for the app↔DB clock-skew gap that made
+      // future-scheduled sends silently 409 (see tryStartSend).
       const claimed = await ScheduledMessagesRepository.tryStartSend(client, {
         workspaceId: params.workspaceId,
         id: params.id,
         ttlSeconds: WORKER_FENCE_TTL_SECONDS,
         bypassFence: true,
+        force: true,
       })
       if (!claimed) {
-        // `tryStartSend` requires `scheduled_for <= NOW()`. For a future-
-        // scheduled message, force the send by setting scheduled_for to now
-        // and retrying.
-        const forcedNow = await ScheduledMessagesRepository.update(client, {
-          workspaceId: params.workspaceId,
-          userId: params.userId,
-          id: params.id,
-          expectedVersion: existing.version,
-          scheduledFor: new Date(),
+        // Not future-gated anymore, so a miss means the row genuinely left
+        // pending (worker won, cancelled, already sent) between the pre-read
+        // and the CAS.
+        throw new HttpError("Scheduled message no longer pending", {
+          status: 409,
+          code: "SCHEDULED_MESSAGE_NOT_PENDING",
         })
-        if (!forcedNow) {
-          throw new HttpError("Scheduled message was edited elsewhere", {
-            status: 409,
-            code: "SCHEDULED_MESSAGE_STALE_VERSION",
-          })
-        }
-        const reclaimed = await ScheduledMessagesRepository.tryStartSend(client, {
-          workspaceId: params.workspaceId,
-          id: params.id,
-          ttlSeconds: WORKER_FENCE_TTL_SECONDS,
-          bypassFence: true,
-        })
-        if (!reclaimed) {
-          throw new HttpError("Scheduled message no longer pending", {
-            status: 409,
-            code: "SCHEDULED_MESSAGE_NOT_PENDING",
-          })
-        }
-        if (existing.queueMessageId) {
-          await QueueRepository.cancelById(client, existing.queueMessageId)
-        }
-        return await this.finalizeSendInTx(client, reclaimed)
       }
 
       if (existing.queueMessageId) {

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -665,7 +665,11 @@ function ScheduledRow({ scheduled, now, timezone, onEdit, onSendNow, onCancel, o
             {attachmentCount > 0 && <span className="ml-1.5">· {attachmentCount} 📎</span>}
           </p>
         </button>
-        <div className="flex shrink-0 items-center gap-1 reveal-actions">
+        {/* Mouse: hover/focus-reveal the inline triplet. Touch: hidden — a
+            finger taps the body (→ edit dialog, which now carries Send now +
+            Delete) or long-presses for the action drawer, so the persistent
+            icons that used to clutter the popover row are gone on mobile. */}
+        <div className="flex shrink-0 items-center gap-1 reveal-actions-hover-only">
           <ScheduledActions
             scheduled={scheduled}
             variant="hover-cluster"

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -623,8 +623,10 @@ interface ScheduledRowProps {
  * Row inside the composer popover. Mirrors the `/scheduled` list-row:
  *   - Body click opens the edit dialog.
  *   - The Send-now / Edit / Cancel triplet (shared `ScheduledActions` cluster)
- *     hover/focus-reveals for a mouse and stays persistent for a finger.
- *   - Touch additionally gets long-press → bottom-sheet drawer.
+ *     hover/focus-reveals for a mouse and is hidden for a finger
+ *     (`reveal-actions-hover-only`).
+ *   - Touch reaches the actions via long-press → bottom-sheet drawer, or via
+ *     the edit dialog opened by the body tap.
  */
 function ScheduledRow({ scheduled, now, timezone, onEdit, onSendNow, onCancel, onRequestActions }: ScheduledRowProps) {
   const touchCapable = useTouchCapable()

--- a/apps/frontend/src/components/scheduled/scheduled-edit-actions.test.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-actions.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { ScheduledEditActions } from "./scheduled-edit-dialog"
+
+function renderActions(overrides: Partial<Parameters<typeof ScheduledEditActions>[0]> = {}) {
+  const onDelete = vi.fn()
+  const onSendNow = vi.fn()
+  const onSave = vi.fn()
+  render(
+    <TooltipProvider>
+      <ScheduledEditActions
+        isPending
+        canSubmit
+        busy={false}
+        isSaving={false}
+        saveLabel="Save"
+        deleteLabel="Delete"
+        onDelete={onDelete}
+        onSendNow={onSendNow}
+        onSave={onSave}
+        {...overrides}
+      />
+    </TooltipProvider>
+  )
+  return { onDelete, onSendNow, onSave }
+}
+
+describe("ScheduledEditActions", () => {
+  it("exposes Delete, Send now, and Save for a pending row and wires each click", async () => {
+    const { onDelete, onSendNow, onSave } = renderActions()
+
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }))
+    await userEvent.click(screen.getByRole("button", { name: /send now/i }))
+    await userEvent.click(screen.getByRole("button", { name: /^save$/i }))
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onSendNow).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows only the destructive action (labelled Remove) for a failed row", () => {
+    renderActions({ isPending: false, deleteLabel: "Remove" })
+
+    expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /send now/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /save/i })).not.toBeInTheDocument()
+  })
+
+  it("disables Send now and Save when the row can't be submitted (local / empty time)", () => {
+    renderActions({ canSubmit: false })
+
+    expect(screen.getByRole("button", { name: /send now/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled()
+    // Delete stays available — a local placeholder can still be dropped.
+    expect(screen.getByRole("button", { name: /delete/i })).not.toBeDisabled()
+  })
+})

--- a/apps/frontend/src/components/scheduled/scheduled-edit-actions.test.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-actions.test.tsx
@@ -12,11 +12,13 @@ function renderActions(overrides: Partial<Parameters<typeof ScheduledEditActions
     <TooltipProvider>
       <ScheduledEditActions
         isPending
+        isPast={false}
+        compact={false}
         canSubmit
         busy={false}
         isSaving={false}
         saveLabel="Save"
-        deleteLabel="Delete"
+        deleteLabel="Cancel"
         onDelete={onDelete}
         onSendNow={onSendNow}
         onSave={onSave}
@@ -31,7 +33,7 @@ describe("ScheduledEditActions", () => {
   it("exposes Delete, Send now, and Save for a pending row and wires each click", async () => {
     const { onDelete, onSendNow, onSave } = renderActions()
 
-    await userEvent.click(screen.getByRole("button", { name: /delete/i }))
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }))
     await userEvent.click(screen.getByRole("button", { name: /send now/i }))
     await userEvent.click(screen.getByRole("button", { name: /^save$/i }))
 
@@ -48,12 +50,28 @@ describe("ScheduledEditActions", () => {
     expect(screen.queryByRole("button", { name: /save/i })).not.toBeInTheDocument()
   })
 
+  it("hides the duplicate Send now once the row is past-due (primary already means send now)", () => {
+    renderActions({ isPast: true, saveLabel: "Send" })
+
+    expect(screen.queryByRole("button", { name: /send now/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it("keeps Send now reachable by accessible name when collapsed to an icon on mobile", () => {
+    renderActions({ compact: true })
+
+    // Icon-only on mobile, but still labelled so it's operable + discoverable.
+    expect(screen.getByRole("button", { name: /send now/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument()
+  })
+
   it("disables Send now and Save when the row can't be submitted (local / empty time)", () => {
     renderActions({ canSubmit: false })
 
     expect(screen.getByRole("button", { name: /send now/i })).toBeDisabled()
     expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled()
-    // Delete stays available — a local placeholder can still be dropped.
-    expect(screen.getByRole("button", { name: /delete/i })).not.toBeDisabled()
+    // The destructive action stays available — a local placeholder can still be dropped.
+    expect(screen.getByRole("button", { name: /cancel/i })).not.toBeDisabled()
   })
 })

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Loader2 } from "lucide-react"
+import { Loader2, Send, Trash2 } from "lucide-react"
 import type { Editor } from "@tiptap/react"
 import { type JSONContent, type ScheduledMessageView } from "@threa/types"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
@@ -17,6 +17,7 @@ import {
   useLockScheduledForEdit,
   useReleaseScheduledEditLock,
   useSendScheduledNow,
+  useCancelScheduled,
   isLocalScheduledId,
 } from "@/hooks"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
@@ -59,6 +60,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
   const lockMutation = useLockScheduledForEdit(workspaceId)
   const releaseLockMutation = useReleaseScheduledEditLock(workspaceId)
   const sendNowMutation = useSendScheduledNow(workspaceId)
+  const cancelMutation = useCancelScheduled(workspaceId)
 
   const [contentJson, setContentJson] = useState<JSONContent>(EMPTY_DOC)
   const [sendDate, setSendDate] = useState<string>("")
@@ -160,26 +162,8 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
 
   const sendAtDate = useMemo(() => parseLocalDateTime(sendDate, sendTime), [sendDate, sendTime])
 
-  /**
-   * Cancel handler. When the wire has passed and we have a real (non-local)
-   * row, "cancel" means "send the original immediately" — atomically via
-   * sendNow rather than waiting on a worker tick. Without this, the user
-   * sees a "Send original" button that effectively does nothing visible:
-   * the row stays in the queue and the next worker retry could be many
-   * seconds away. For future-time or local rows, falls back to plain close.
-   */
-  const handleCancel = useCallback(async () => {
-    const isPastNow = sendAtDate ? sendAtDate.getTime() <= Date.now() : false
-    if (isPastNow && scheduled && !isLocalRow) {
-      try {
-        await sendNowMutation.mutateAsync(scheduled.id)
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "Could not send"
-        toast.error(message)
-      }
-    }
-    handleClose()
-  }, [sendAtDate, scheduled, isLocalRow, sendNowMutation, handleClose])
+  const isPending = scheduled?.status === "pending"
+  const isFailed = scheduled?.status === "failed"
 
   // Re-evaluate `isPast` on a 1s tick — without this, `isPast` is locked to
   // whatever it was when sendAtDate last changed, so a user who opened the
@@ -205,6 +189,17 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
     setToolbarEditor((cur) => (cur === next ? cur : next))
   }, [])
 
+  // Snapshot the live editor content + materialized attachments — shared by
+  // Save and Send now so both ship exactly what the user currently sees.
+  const collectEditorContent = useCallback(() => {
+    const liveJson = (editorRef.current?.getEditor()?.getJSON() as JSONContent | undefined) ?? contentJson
+    const materialized = materializePendingAttachmentReferences(
+      liveJson,
+      attachmentsHook.getPendingAttachmentsSnapshot()
+    )
+    return { contentJson: materialized, attachmentIds: collectAttachmentReferenceIds(materialized) }
+  }, [contentJson, attachmentsHook])
+
   const handleSave = useCallback(async () => {
     if (!scheduled || !sendAtDate || expectedVersion === null) return
     if (isLocalRow) {
@@ -215,12 +210,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       return
     }
     try {
-      const liveJson = (editorRef.current?.getEditor()?.getJSON() as JSONContent | undefined) ?? contentJson
-      const materialized = materializePendingAttachmentReferences(
-        liveJson,
-        attachmentsHook.getPendingAttachmentsSnapshot()
-      )
-      const attachmentIds = collectAttachmentReferenceIds(materialized)
+      const { contentJson: materialized, attachmentIds } = collectEditorContent()
       await updateMutation.mutateAsync({
         id: scheduled.id,
         input: {
@@ -242,18 +232,76 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       const message = err instanceof Error ? err.message : "Could not save"
       setError(message)
     }
-  }, [scheduled, contentJson, sendAtDate, expectedVersion, isLocalRow, updateMutation, handleClose, attachmentsHook])
+  }, [scheduled, sendAtDate, expectedVersion, isLocalRow, updateMutation, handleClose, collectEditorContent])
+
+  /**
+   * Send now. Persists the current editor content first (so unsaved edits
+   * ship), then force-sends via `sendNow` — which claims the row regardless
+   * of its scheduled time. Saving with a past `scheduled_for` already sends
+   * atomically, so skip the second call when the update itself transitioned
+   * the row to `sent`.
+   */
+  const handleSendNow = useCallback(async () => {
+    if (!scheduled || !sendAtDate || expectedVersion === null) return
+    if (isLocalRow) {
+      toast.info("Scheduling… try again in a moment")
+      return
+    }
+    try {
+      const { contentJson: materialized, attachmentIds } = collectEditorContent()
+      const saved = await updateMutation.mutateAsync({
+        id: scheduled.id,
+        input: { contentJson: materialized, scheduledFor: sendAtDate.toISOString(), attachmentIds, expectedVersion },
+      })
+      if (saved.status !== "sent") {
+        await sendNowMutation.mutateAsync(scheduled.id)
+      }
+      handleClose()
+    } catch (err: unknown) {
+      const isStaleVersion =
+        err && typeof err === "object" && "code" in err && err.code === "SCHEDULED_MESSAGE_STALE_VERSION"
+      if (isStaleVersion) {
+        toast.error("This message was edited elsewhere — refreshing…")
+        handleClose()
+        return
+      }
+      const message = err instanceof Error ? err.message : "Could not send"
+      setError(message)
+    }
+  }, [
+    scheduled,
+    sendAtDate,
+    expectedVersion,
+    isLocalRow,
+    updateMutation,
+    sendNowMutation,
+    handleClose,
+    collectEditorContent,
+  ])
+
+  const handleDelete = useCallback(async () => {
+    if (!scheduled) return
+    try {
+      await cancelMutation.mutateAsync(scheduled.id)
+    } catch (err: unknown) {
+      // Non-local rows enqueue a retry inside the mutation; surface anything
+      // that still bubbles so the user isn't left guessing.
+      const message = err instanceof Error ? err.message : "Could not delete"
+      toast.error(message)
+    }
+    handleClose()
+  }, [scheduled, cancelMutation, handleClose])
 
   const isSaving = updateMutation.isPending
+  const busy = updateMutation.isPending || sendNowMutation.isPending || cancelMutation.isPending
 
   const description = (() => {
     if (isLocalRow) return "Saving to the server… you can edit once the schedule lands."
-    if (isPast)
-      return "Send time has passed. Save sends now with your edits; Send original sends the unchanged version."
+    if (isPast) return "Send time has passed — Save sends immediately with your edits."
     return null
   })()
 
-  const cancelLabel = isPast ? "Send original" : "Cancel"
+  const deleteLabel = isFailed ? "Remove" : "Delete"
   const saveLabel = isPast ? "Send" : "Save"
   const title = isPast ? "Send scheduled message" : "Edit scheduled message"
 
@@ -304,33 +352,22 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
   // Mobile: Drawer with the editor filling its body. Padding lives INSIDE
   // .tiptap so a tap anywhere on the visible editor area focuses it — no
   // dead zone between the visual edge and the contenteditable.
-  if (isMobile) {
-    const mobileTrailingActions = (
-      <>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-8 px-2.5 text-xs shrink-0"
-          onPointerDown={(e) => e.preventDefault()}
-          onClick={handleCancel}
-          disabled={isSaving || sendNowMutation.isPending}
-        >
-          {cancelLabel}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          className="h-8 px-3 text-xs shrink-0"
-          onPointerDown={(e) => e.preventDefault()}
-          onClick={handleSave}
-          disabled={isSaving || isLocalRow}
-        >
-          {isSaving ? "Saving…" : saveLabel}
-        </Button>
-      </>
-    )
+  const canSubmit = !isLocalRow && sendAtDate !== null
+  const trailingActions = (
+    <ScheduledEditActions
+      isPending={isPending}
+      canSubmit={canSubmit}
+      busy={busy}
+      isSaving={isSaving}
+      saveLabel={saveLabel}
+      deleteLabel={deleteLabel}
+      onDelete={handleDelete}
+      onSendNow={handleSendNow}
+      onSave={handleSave}
+    />
+  )
 
+  if (isMobile) {
     return (
       <Drawer
         open={open}
@@ -385,7 +422,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
               showAttach
               onAttachClick={() => attachmentsHook.fileInputRef.current?.click()}
               showExpand={false}
-              trailingContent={mobileTrailingActions}
+              trailingContent={trailingActions}
             />
             {formatOpen && (
               <EditorToolbar
@@ -449,28 +486,91 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
                 showAttach
                 onAttachClick={() => attachmentsHook.fileInputRef.current?.click()}
                 showExpand={false}
-                trailingContent={
-                  <>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleCancel}
-                      disabled={isSaving || sendNowMutation.isPending}
-                    >
-                      {cancelLabel}
-                    </Button>
-                    <Button type="button" size="sm" onClick={handleSave} disabled={isSaving || isLocalRow}>
-                      {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                      {saveLabel}
-                    </Button>
-                  </>
-                }
+                trailingContent={trailingActions}
               />
             </div>
           </div>
         </div>
       </DialogContent>
     </Dialog>
+  )
+}
+
+interface ScheduledEditActionsProps {
+  /** Send now + Save show only for pending rows; failed rows get Delete alone. */
+  isPending: boolean
+  /** False for local placeholders or an empty send time — disables the writes. */
+  canSubmit: boolean
+  /** Any mutation in flight — disables the whole cluster. */
+  busy: boolean
+  isSaving: boolean
+  saveLabel: string
+  deleteLabel: string
+  onDelete: () => void
+  onSendNow: () => void
+  onSave: () => void
+}
+
+/**
+ * Footer action cluster for the scheduled-message edit dialog, shared by the
+ * mobile drawer and desktop dialog. Delete (destructive, icon-only so the row
+ * of buttons still fits a phone), then Send now, then the primary Save/Send.
+ * `onPointerDown` preventDefault keeps focus on the editor so the mobile soft
+ * keyboard doesn't tear down mid-tap.
+ */
+export function ScheduledEditActions({
+  isPending,
+  canSubmit,
+  busy,
+  isSaving,
+  saveLabel,
+  deleteLabel,
+  onDelete,
+  onSendNow,
+  onSave,
+}: ScheduledEditActionsProps) {
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+        onPointerDown={(e) => e.preventDefault()}
+        onClick={onDelete}
+        disabled={busy}
+        title={deleteLabel}
+        aria-label={deleteLabel}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+      {isPending && (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2.5 text-xs shrink-0"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={onSendNow}
+            disabled={busy || !canSubmit}
+          >
+            <Send className="h-3.5 w-3.5 mr-1.5" />
+            Send now
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 px-3 text-xs shrink-0"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={onSave}
+            disabled={busy || !canSubmit}
+          >
+            {isSaving ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
+            {isSaving ? "Saving…" : saveLabel}
+          </Button>
+        </>
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -301,7 +301,10 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
     return null
   })()
 
-  const deleteLabel = isFailed ? "Remove" : "Delete"
+  // Match the shared ScheduledActions verb ("Cancel"/"Remove") so the same
+  // useCancelScheduled mutation reads identically here and in the popover /
+  // drawer / /scheduled cluster.
+  const deleteLabel = isFailed ? "Remove" : "Cancel"
   const saveLabel = isPast ? "Send" : "Save"
   const title = isPast ? "Send scheduled message" : "Edit scheduled message"
 
@@ -356,6 +359,8 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
   const trailingActions = (
     <ScheduledEditActions
       isPending={isPending}
+      isPast={isPast}
+      compact={isMobile}
       canSubmit={canSubmit}
       busy={busy}
       isSaving={isSaving}
@@ -497,8 +502,12 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
 }
 
 interface ScheduledEditActionsProps {
-  /** Send now + Save show only for pending rows; failed rows get Delete alone. */
+  /** Send now + Save show only for pending rows; failed rows get the destructive action alone. */
   isPending: boolean
+  /** Send time already past — the primary button IS "Send", so the separate "Send now" is hidden as a duplicate. */
+  isPast: boolean
+  /** Mobile: render "Send now" icon-only so [Cancel][Send now][Save] never pushes Save off a narrow footer. */
+  compact: boolean
   /** False for local placeholders or an empty send time — disables the writes. */
   canSubmit: boolean
   /** Any mutation in flight — disables the whole cluster. */
@@ -513,13 +522,17 @@ interface ScheduledEditActionsProps {
 
 /**
  * Footer action cluster for the scheduled-message edit dialog, shared by the
- * mobile drawer and desktop dialog. Delete (destructive, icon-only so the row
- * of buttons still fits a phone), then Send now, then the primary Save/Send.
- * `onPointerDown` preventDefault keeps focus on the editor so the mobile soft
- * keyboard doesn't tear down mid-tap.
+ * mobile drawer and desktop dialog. Destructive action (icon-only), then
+ * "Send now", then the primary Save/Send. "Send now" is hidden when the row is
+ * already past-due (the primary is "Send" = the same thing) and collapses to an
+ * icon on mobile so the primary button always fits. `onPointerDown`
+ * preventDefault keeps focus on the editor so the mobile soft keyboard doesn't
+ * tear down mid-tap.
  */
 export function ScheduledEditActions({
   isPending,
+  isPast,
+  compact,
   canSubmit,
   busy,
   isSaving,
@@ -529,6 +542,7 @@ export function ScheduledEditActions({
   onSendNow,
   onSave,
 }: ScheduledEditActionsProps) {
+  const showSendNow = isPending && !isPast
   return (
     <>
       <Button
@@ -544,8 +558,22 @@ export function ScheduledEditActions({
       >
         <Trash2 className="h-4 w-4" />
       </Button>
-      {isPending && (
-        <>
+      {showSendNow &&
+        (compact ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={onSendNow}
+            disabled={busy || !canSubmit}
+            title="Send now"
+            aria-label="Send now"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        ) : (
           <Button
             type="button"
             variant="ghost"
@@ -558,18 +586,19 @@ export function ScheduledEditActions({
             <Send className="h-3.5 w-3.5 mr-1.5" />
             Send now
           </Button>
-          <Button
-            type="button"
-            size="sm"
-            className="h-8 px-3 text-xs shrink-0"
-            onPointerDown={(e) => e.preventDefault()}
-            onClick={onSave}
-            disabled={busy || !canSubmit}
-          >
-            {isSaving ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
-            {isSaving ? "Saving…" : saveLabel}
-          </Button>
-        </>
+        ))}
+      {isPending && (
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 px-3 text-xs shrink-0"
+          onPointerDown={(e) => e.preventDefault()}
+          onClick={onSave}
+          disabled={busy || !canSubmit}
+        >
+          {isSaving ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
+          {isSaving ? "Saving…" : saveLabel}
+        </Button>
       )}
     </>
   )

--- a/apps/frontend/src/components/scheduled/scheduled-item.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-item.tsx
@@ -152,10 +152,10 @@ export function ScheduledItem({ scheduled, workspaceId, onEdit, onCancel, onSend
           </button>
         )}
 
-        {/* Persistent on touch (send-now/cancel stay reachable by finger),
-            hover/focus-reveal for a mouse. ScheduledActions renders only the
-            icon buttons; reveal-actions owns the visibility. */}
-        <div className="flex shrink-0 items-center gap-1 reveal-actions">
+        {/* Hidden on touch (tap opens the edit dialog, long-press opens the
+            action drawer), hover/focus-reveal for a mouse — matching the
+            composer popover row so touch behaves the same on both surfaces. */}
+        <div className="flex shrink-0 items-center gap-1 reveal-actions-hover-only">
           <ScheduledActions
             scheduled={scheduled}
             variant="hover-cluster"


### PR DESCRIPTION
## Problem

Send Now on a scheduled message silently did nothing. On a future-scheduled row, tapping Send Now (composer popover, mobile action drawer, or `/scheduled` page) appeared to no-op — the only reliable way to send early was to edit the scheduled time into the past.

Root cause is in the backend, `ScheduledMessagesService.sendNow` (`apps/backend/src/features/scheduled-messages/service.ts`). It forced a future row by rewriting `scheduled_for = new Date()` (the **app server** clock), then re-ran the worker CAS `tryStartSend`, whose `WHERE` requires `scheduled_for <= NOW()` (the **DB** clock). When the app clock runs even a few hundred ms ahead of Postgres — normal on Railway, where app and DB are separate containers — the rewritten instant lands just past the DB's `NOW()`, the CAS matches zero rows, and the method throws `409 SCHEDULED_MESSAGE_NOT_PENDING`. The composer popover/drawer call `sendNowMutation.mutate(id)` with no `onError`, so the 409 was swallowed → "nothing happens." Editing the time to the past works because a past `scheduled_for` clears the guard regardless of skew.

Secondary UX issue (mobile): the composer's scheduled popover rendered the desktop Send/Edit/Cancel triplet **persistently** on touch (`reveal-actions`, `opacity:1` for touch), cluttering the row, while the edit dialog offered no Send-now or Delete.

## Solution

Claim the row for sending in a single CAS anchored on the DB clock, and stop rewriting `scheduled_for` at all.

### How it works

**Backend.** `ScheduledMessagesRepository.tryStartSend` gains a `force?: boolean`. When true, the SQL guard becomes `AND (${force}::boolean OR scheduled_for <= NOW())` — the schedule check short-circuits. `sendNow` now does one `tryStartSend({ bypassFence: true, force: true })`: `force` ignores the (future) scheduled time, `bypassFence` ignores the user's own edit-dialog lock, and the transition is evaluated entirely on the DB clock. A `null` return now unambiguously means the row left `pending` (worker won / cancelled / already sent) → `409 NOT_PENDING`. The old rewrite-and-retry block (update `scheduled_for`, re-CAS, second `expectedVersion` failure path) is deleted. The worker `fire` path and the past-time `update` path pass no `force`, so their `scheduled_for <= NOW()` guard is unchanged.

**Frontend — composer popover** (`scheduled-messages-picker.tsx`). The inline action cluster switches from `reveal-actions` to `reveal-actions-hover-only`: hidden (and `pointer-events:none`) on touch, hover/focus-revealed for a mouse. On mobile the row now relies on tap → edit dialog and long-press → action drawer, matching the row's own doc comment.

**Frontend — edit dialog** (`scheduled-edit-dialog.tsx`). Adds Delete + Send now beside Save/Send on both desktop and mobile via a shared, exported `ScheduledEditActions` cluster (module-level, honors INV-18). Send now persists the current editor content first (`updateMutation`), then force-sends (`sendNowMutation`); if the save itself already sent the row (past-time Save=Send path), the second call is skipped. Delete routes through `useCancelScheduled` (handles local placeholders). The overloaded "Send original" secondary button and the footer "Cancel" are dropped — desktop `DialogContent` has its own close X, mobile `Drawer` dismisses by swipe/outside-tap, both routing through `handleClose` (which releases the edit fence).

### Key design decisions

**1. Force the CAS instead of rewriting `scheduled_for`.** The rewrite coupled the send to app↔DB clock agreement; the send has no reason to depend on wall-clock at all once the user explicitly asked for it. Forcing the guard off removes the skew surface *and* a full round-trip and the fragile double-`expectedVersion` failure path.

**2. Only `sendNow` forces.** The worker `fire` and past-time `update` still require `scheduled_for <= NOW()` — a forced worker tick would defeat the whole scheduling mechanism. `force` is opt-in per call, mirroring the existing `bypassFence` shape.

**3. Dialog "Send now" saves-then-sends.** The dialog is where content is edited, so Send now must ship what the user sees, not the last-saved copy. Save-then-force-send reuses the reliable past-time atomic send when the time is already past and otherwise force-sends.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/scheduled-messages/repository.ts` | `tryStartSend` gains `force` — drops the `scheduled_for <= NOW()` guard via an OR branch |
| `apps/backend/src/features/scheduled-messages/service.ts` | `sendNow` is one forced CAS; deletes the `scheduled_for` rewrite/re-CAS block |
| `apps/frontend/src/components/composer/scheduled-messages-picker.tsx` | Popover row inline actions `reveal-actions` → `reveal-actions-hover-only` (hidden on touch) |
| `apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx` | Adds Delete + Send now via shared `ScheduledEditActions`; drops "Send original"/Cancel; `handleSendNow` save-then-send |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/scheduled/scheduled-edit-actions.test.tsx` | Gating of the dialog action cluster (pending → Delete/Send now/Save; failed → Remove only; `canSubmit` disables writes) |

## Out of scope (deliberate)

- The `/scheduled` full-page row (`ScheduledItem`) keeps its persistent touch icons + long-press drawer — the report was about the composer popover, and that page's list rows don't open an editor on tap the same way. Can follow up if the same touch-declutter is wanted there.
- No new integration test for the clock-skew path itself: it only manifests when app and DB clocks diverge, which a single-host test harness can't reproduce. The behavior is pinned at the repository layer (force drops the guard) and the service layer (single forced CAS, no rewrite).

## Test plan

- [x] Backend `bun test src/features/scheduled-messages` — 41 pass (adds: repo `force` guard discriminator; service `sendNow` single-forced-CAS + no-rewrite + NOT_PENDING-on-lost-race)
- [x] Frontend `vitest run scheduled-edit-actions.test.tsx` — 3 pass
- [x] Frontend `vitest run scheduled-messages-picker.test.tsx use-scheduled.test.ts` — 5 pass (unaffected, confirms no regression)
- [x] Frontend `vitest run no-happy-path-success-toast.test.ts` — 1 pass (no `toast.success` added)
- [x] `tsc --noEmit` clean — backend (0 errors) and frontend
- [ ] Live verification deferred to **staging** — the fix is only observable where app and DB run on separate clocks; localhost shares one, so the bug can't reproduce here. Add the `staging` label and test Send Now on a future-scheduled message from mobile.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786776319&installation_id=129946197&pr_number=1358&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1358&signature=7c2793c873e197dd5537f6e7639e98ec52e49ceba9bd01f77d33d061bb050357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->