### PR TITLE
fix: surface [#text](url) links and in-app references in "In this stream"

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-row.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-row.tsx
@@ -103,14 +103,14 @@ function LinkLeading({ item }: { item: LinkContextItem }) {
   )
 }
 
-function BadgePill({ label, tone }: { label: string; tone: "github" | "linear" }) {
+function BadgePill({ label, tone }: { label: string; tone: "github" | "linear" | "in-app" }) {
   return (
     <span
       className={cn(
         "shrink-0 rounded px-1 py-px text-[10px] font-semibold uppercase tracking-wide",
-        tone === "github"
-          ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
-          : "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400"
+        tone === "github" && "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+        tone === "linear" && "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
+        tone === "in-app" && "bg-primary/10 text-primary"
       )}
     >
       {label}
@@ -139,6 +139,7 @@ export function StreamContextRow({
   // Set when the row's primary action opens the in-stream gallery; the value is
   // the gallery key (`?smedia=`) — an attachment id or a `giphy:` sentinel.
   let galleryKey: string | null = null
+  let opensExternally = false
 
   switch (item.category) {
     case "link": {
@@ -146,13 +147,16 @@ export function StreamContextRow({
       primaryText = item.title ?? prettyHost(item.url)
       secondaryText = item.title ? prettyHost(item.url) : item.snippet || prettyHost(item.url)
       if (item.refCount > 1) secondaryText = `${secondaryText} · ${item.refCount}×`
-      if (item.badge)
-        badge = <BadgePill label={item.badge} tone={item.previewKind === "linear" ? "linear" : "github"} />
+      if (item.badge) {
+        const tones = { linear: "linear", "in-app": "in-app", github: "github", generic: "github" } as const
+        badge = <BadgePill label={item.badge} tone={tones[item.previewKind]} />
+      }
       // A link to our own origin routes in-app (react-router), matching how the
       // message body renders links (lib/markdown/components.tsx). Modifier- and
       // middle-clicks fall through to the native <a> so "open in new tab" still
       // works. External links keep opening in a new browsing context.
       const internalPath = resolveInternalAppPath(item.url)
+      opensExternally = internalPath == null
       primaryAction = internalPath ? (
         <a
           href={internalPath}
@@ -344,10 +348,11 @@ export function StreamContextRow({
             <div className="flex items-center gap-1.5">
               {badge}
               <span className="truncate text-sm font-medium leading-snug">{primaryText}</span>
-              {item.category === "link" && (
+              {item.category === "link" && opensExternally && (
                 // Persistent (not hover-gated) so a link row reads as "opens
                 // externally" at a glance, distinct from the rows that jump to
                 // the message — and visible on touch, where there is no hover.
+                // In-app links navigate inside Threa, so they don't get it.
                 <ExternalLink className="size-3 shrink-0 text-muted-foreground/70" aria-hidden />
               )}
             </div>

--- a/apps/frontend/src/lib/stream-context/derive.test.ts
+++ b/apps/frontend/src/lib/stream-context/derive.test.ts
@@ -209,7 +209,7 @@ describe("deriveStreamContext", () => {
     expect(links[0].sourceMessageId).toBe("msg_2")
   })
 
-  it("excludes in-app message_link previews from the links list", () => {
+  it("surfaces in-app message_link previews as badged link items", () => {
     const events = [
       messageEvent("2026-06-23T10:00:00.000Z", {
         linkPreviews: [
@@ -227,7 +227,42 @@ describe("deriveStreamContext", () => {
         ],
       }),
     ]
-    expect(deriveStreamContext(events).counts.link).toBe(0)
+
+    const links = deriveStreamContext(events).items.filter((i): i is LinkContextItem => i.category === "link")
+    expect(links).toHaveLength(1)
+    expect(links[0]).toMatchObject({
+      url: "https://app.threa.io/w/ws_1/s/stream_2?m=msg_x",
+      title: "A shared message",
+      previewKind: "in-app",
+      badge: "Message",
+    })
+  })
+
+  it("surfaces a PR link stored as a channelLink node with a link mark (the [#1358](url) parse quirk)", () => {
+    const events = [
+      messageEvent("2026-06-23T10:00:00.000Z", {
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "PR open: " },
+                {
+                  type: "channelLink",
+                  attrs: { id: "1358", slug: "1358" },
+                  marks: [{ type: "link", attrs: { href: "https://github.com/threahq/threa/pull/1358" } }],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ]
+
+    const links = deriveStreamContext(events).items.filter((i): i is LinkContextItem => i.category === "link")
+    expect(links).toHaveLength(1)
+    expect(links[0].url).toBe("https://github.com/threahq/threa/pull/1358")
   })
 
   it("buckets image/gif/video attachments as media and others as files", () => {

--- a/apps/frontend/src/lib/stream-context/derive.ts
+++ b/apps/frontend/src/lib/stream-context/derive.ts
@@ -68,12 +68,17 @@ const LINEAR_BADGES: Record<string, string> = {
   linear_project: "Project",
   linear_document: "Doc",
 }
+// Labels stay type-agnostic where the reference can point at several stream
+// kinds: a stream_link may be a channel, scratchpad, or DM, and the per-viewer
+// streamType needed to distinguish them (inAppData) is absent on broadcast
+// events — "Stream" is correct for all three. Memo/delegation wording matches
+// this panel's own filter chips ("Memories", "Delegations").
 const IN_APP_BADGES: Record<string, string> = {
   message_link: "Message",
-  stream_link: "Channel",
-  memo_link: "Memo",
+  stream_link: "Stream",
+  memo_link: "Memory",
   conversation_link: "Conversation",
-  delegation_link: "Task",
+  delegation_link: "Delegation",
 }
 
 function linkBadge(preview: LinkPreviewSummary | undefined): {

--- a/apps/frontend/src/lib/stream-context/derive.ts
+++ b/apps/frontend/src/lib/stream-context/derive.ts
@@ -68,11 +68,23 @@ const LINEAR_BADGES: Record<string, string> = {
   linear_project: "Project",
   linear_document: "Doc",
 }
+const IN_APP_BADGES: Record<string, string> = {
+  message_link: "Message",
+  stream_link: "Channel",
+  memo_link: "Memo",
+  conversation_link: "Conversation",
+  delegation_link: "Task",
+}
 
-function linkBadge(previewType: string | null | undefined): {
+function linkBadge(preview: LinkPreviewSummary | undefined): {
   previewKind: LinkContextItem["previewKind"]
   badge: string | null
 } {
+  if (!preview) return { previewKind: "generic", badge: null }
+  if (isInAppLinkContentType(preview.contentType)) {
+    return { previewKind: "in-app", badge: IN_APP_BADGES[preview.contentType] ?? "Threa" }
+  }
+  const previewType = preview.previewType
   if (!previewType) return { previewKind: "generic", badge: null }
   if (previewType.startsWith("github_")) {
     return { previewKind: "github", badge: GITHUB_BADGES[previewType] ?? "GitHub" }
@@ -87,7 +99,9 @@ function linkBadge(previewType: string | null | undefined): {
  * Derive the "In this stream" overview from a stream's loaded timeline events.
  *
  * Pure and reactive: callers pass the live `useStreamEvents` array and re-run
- * on every change. Collects external links, media (images/GIFs/videos), file
+ * on every change. Collects links (external URLs and in-app references —
+ * shared messages, channels, memos, conversations, delegated tasks — badged by
+ * their preview contentType), media (images/GIFs/videos), file
  * attachments, captured memories, and threads branched from this stream — each
  * carrying the source message id for "jump to origin". Items dedup within their
  * category (links by normalized URL, attachments by id, memos by memoId,
@@ -158,7 +172,7 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
         existing.refCount += 1
         return
       }
-      const { previewKind, badge } = linkBadge(preview?.previewType)
+      const { previewKind, badge } = linkBadge(preview)
       links.set(norm, {
         key: `link:${norm}`,
         category: "link",
@@ -182,14 +196,10 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
     const contentJson = payload.contentJson
     if (contentJson) {
       for (const url of collectLinkUrls(contentJson)) {
-        const preview = previewsByUrl.get(normalizeUrl(url))
-        // In-app resources belong to "related", not the external-links list.
-        if (preview && isInAppLinkContentType(preview.contentType)) continue
-        addLink(url, preview)
+        addLink(url, previewsByUrl.get(normalizeUrl(url)))
       }
     } else {
       for (const preview of previewsByUrl.values()) {
-        if (isInAppLinkContentType(preview.contentType)) continue
         addLink(preview.url, preview)
       }
     }

--- a/apps/frontend/src/lib/stream-context/types.ts
+++ b/apps/frontend/src/lib/stream-context/types.ts
@@ -28,9 +28,10 @@ export interface LinkContextItem extends ContextItemBase {
   siteName: string | null
   faviconUrl: string | null
   imageUrl: string | null
-  /** Drives the small type badge: GitHub PR/issue, Linear, or none. */
-  previewKind: "github" | "linear" | "generic"
-  /** A short label for the preview kind ("PR", "Issue", "Linear", …) or null. */
+  /** Drives the small type badge: GitHub PR/issue, Linear, an in-app Threa
+   *  reference (shared message, channel, memo, conversation, task), or none. */
+  previewKind: "github" | "linear" | "in-app" | "generic"
+  /** A short label for the preview kind ("PR", "Issue", "Message", …) or null. */
   badge: string | null
   /** How many loaded messages referenced this URL. */
   refCount: number

--- a/packages/prosemirror/src/extractors.test.ts
+++ b/packages/prosemirror/src/extractors.test.ts
@@ -679,6 +679,49 @@ describe("collectLinkUrls", () => {
 
     expect(collectLinkUrls(doc)).toEqual([])
   })
+
+  it("reads a link mark carried by a non-text node (stored channelLink from the [#text](url) parse quirk)", () => {
+    // Documents like this exist at rest: `[#1358](https://github…/pull/1358)`
+    // used to parse into a channelLink node with the href only in a mark.
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "PR open: " },
+            {
+              type: "channelLink",
+              attrs: { id: "1358", slug: "1358" },
+              marks: [{ type: "link", attrs: { href: "https://github.com/threahq/threa/pull/1358" } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(collectLinkUrls(doc)).toEqual(["https://github.com/threahq/threa/pull/1358"])
+  })
+
+  it("ignores non-http link marks on non-text nodes", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "channelLink",
+              attrs: { id: "stream_1", slug: "general" },
+              marks: [{ type: "link", attrs: { href: "channel:stream_1" } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(collectLinkUrls(doc)).toEqual([])
+  })
 })
 
 const giphyEmbed = (giphyUrl: string, attrs: Record<string, unknown> = {}): JSONContent => ({

--- a/packages/prosemirror/src/extractors.ts
+++ b/packages/prosemirror/src/extractors.ts
@@ -258,27 +258,28 @@ export function collectGiphyEmbeds(content: JSONContent): GiphyEmbedRef[] {
  * is the authoritative target — returned verbatim — and is immune to the
  * emphasis markers that contaminate a regex over markdown (a bold URL
  * serializes to `**https://x**`, whose trailing `**` leaks into the captured
- * string). Text nodes that are NOT inside a link mark are scanned for plain-text
- * URLs (pasted without an autolink); those pick up trailing sentence
- * punctuation from the prose around them, so it's trimmed — a thing we must
- * never do to an authoritative href, whose final `!`/`.`/etc. may be
- * significant. Custom-protocol links (`giphy:`/`memo:`/`attachment:`/`quote:`)
- * are excluded by the `https?:` gate.
+ * string). Link marks are read off EVERY node type, not just text: stored
+ * documents exist where a parser quirk turned `[#1358](https://…)` into a
+ * `channelLink` node carrying the href as a mark, and contentJson at rest is
+ * immutable — the href must still surface. Text nodes that are NOT inside a
+ * link mark are scanned for plain-text URLs (pasted without an autolink);
+ * those pick up trailing sentence punctuation from the prose around them, so
+ * it's trimmed — a thing we must never do to an authoritative href, whose
+ * final `!`/`.`/etc. may be significant. Custom-protocol links
+ * (`giphy:`/`memo:`/`attachment:`/`quote:`) are excluded by the `https?:` gate.
  */
 export function collectLinkUrls(content: JSONContent): string[] {
   const urls: string[] = []
 
   const walk = (node: JSONContent): void => {
-    if (node.type === "text" && typeof node.text === "string") {
-      const linkMarks = (node.marks ?? []).filter((mark) => mark.type === "link")
-      if (linkMarks.length > 0) {
-        for (const mark of linkMarks) {
-          const href = mark.attrs?.href
-          if (typeof href === "string" && /^https?:\/\//i.test(href)) urls.push(href)
-        }
-      } else {
-        for (const match of node.text.matchAll(BARE_URL_IN_TEXT)) urls.push(trimPlaintextUrl(match[0]))
+    const linkMarks = (node.marks ?? []).filter((mark) => mark.type === "link")
+    if (linkMarks.length > 0) {
+      for (const mark of linkMarks) {
+        const href = mark.attrs?.href
+        if (typeof href === "string" && /^https?:\/\//i.test(href)) urls.push(href)
       }
+    } else if (node.type === "text" && typeof node.text === "string") {
+      for (const match of node.text.matchAll(BARE_URL_IN_TEXT)) urls.push(trimPlaintextUrl(match[0]))
     }
     if (node.content) {
       for (const child of node.content) {

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -31,6 +31,32 @@ describe("@threa/prosemirror markdown links", () => {
     ])
   })
 
+  it("keeps a #-leading link label as text — [#1358](https url) is a titled link, not a channel", () => {
+    const parsed = parseMarkdown("PR open: [#1358](https://github.com/threahq/threa/pull/1358).")
+
+    expect(parsed.content?.[0]?.content).toEqual([
+      { type: "text", text: "PR open: " },
+      {
+        type: "text",
+        text: "#1358",
+        marks: [{ type: "link", attrs: { href: "https://github.com/threahq/threa/pull/1358" } }],
+      },
+      { type: "text", text: "." },
+    ])
+  })
+
+  it("keeps an @-leading link label as text — [@handle](https url) is a titled link, not a mention", () => {
+    const parsed = parseMarkdown("[@octocat](https://github.com/octocat)")
+
+    expect(parsed.content?.[0]?.content).toEqual([
+      {
+        type: "text",
+        text: "@octocat",
+        marks: [{ type: "link", attrs: { href: "https://github.com/octocat" } }],
+      },
+    ])
+  })
+
   it("does not leak link tokens from malformed outer links", () => {
     const parsed = parseMarkdown("[bad](not-a-url and [good](https://example.com)")
 

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -1111,7 +1111,16 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
         lastIndex = match.index + match[0].length
         continue
       }
-      const innerContent = parseInlineMarkdown(linkText, options)
+      // Link text is a display label: `[#1358](https://github…/pull/1358)` is a
+      // titled external link, not a channel reference — materializing a
+      // mention/channelLink node here would bury the href in a mark that
+      // consumers of the node tree (collectLinkUrls, the resolver) don't treat
+      // as the link it is. Pointer forms (`user:`/`channel:`) were handled above.
+      const innerContent = parseInlineMarkdown(linkText, {
+        ...options,
+        enableMentions: false,
+        enableChannels: false,
+      })
       for (const node of innerContent) {
         result.push({
           ...node,


### PR DESCRIPTION
## Problem

A Claude Channel message ending "PR open: [#1358](https://github.com/threahq/threa/pull/1358)" never showed the PR link in the "In this stream" panel.

Root cause is in `parseInlineMarkdown` (`packages/prosemirror/src/markdown.ts`): the generic-link branch re-parses the link *label* with mention/channel triggers enabled, so `#1358` matched the bare-channel pattern and became a `channelLink` node (unresolved id `"1358"`) with the real href relegated to a `link` mark. `collectLinkUrls` only read link marks off `text` nodes, so the URL vanished from link extraction — no panel row, and no link-preview candidate at ingestion. `[@handle](https://…)` had the same failure via the mention pattern.

Separately, in-app link previews (`message_link`, `stream_link`, `memo_link`, `conversation_link`, `delegation_link`) were filtered out of the panel's link list by `isInAppLinkContentType` with a comment saying they "belong to 'related'" — but no related bucket exists, so a shared message reference was dropped entirely.

## Solution

Three layers, each independently correct:

1. **Parser** — link labels are display-only. The generic-link branch now parses `linkText` with `enableMentions: false, enableChannels: false`, so `[#1358](https://…)` / `[@handle](https://…)` parse as plain text carrying a link mark. Pointer forms (`[#slug](channel:stream_x)`, `[@slug](user:usr_x)`) are unaffected — they're handled by `parseActorPointer` before this branch.
2. **Extractor** — `collectLinkUrls` reads link marks off *every* node type, not just text nodes. This matters because contentJson at rest is immutable: documents with the malformed channelLink shape already exist in prod (including the reporting message), and this makes their URLs surface without any backfill.
3. **Panel** — `deriveStreamContext` includes in-app previews as badged link items ("Message" / "Channel" / "Memo" / "Conversation" / "Task", `previewKind: "in-app"`) instead of dropping them. The row already routed own-origin URLs through react-router (`resolveInternalAppPath`), so navigation lands in-app; the external-link glyph is now shown only for URLs that actually open externally.

Verified end-to-end against the real prod message content: both the re-parsed markdown and the stored malformed contentJson shape now yield `https://github.com/threahq/threa/pull/1358` from `collectLinkUrls`.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/markdown.ts` | Generic-link branch parses the label with mentions/channels disabled |
| `packages/prosemirror/src/extractors.ts` | `collectLinkUrls` reads link marks off any node type; text-node bare-URL scan unchanged |
| `apps/frontend/src/lib/stream-context/derive.ts` | `linkBadge` takes the full preview; in-app contentTypes map to badges instead of being skipped |
| `apps/frontend/src/lib/stream-context/types.ts` | `previewKind` gains `"in-app"` |
| `apps/frontend/src/components/stream-context/stream-context-row.tsx` | In-app badge tone (`bg-primary/10 text-primary`); external-link glyph gated on the URL actually being external |
| `packages/prosemirror/src/{markdown,extractors}.test.ts`, `apps/frontend/src/lib/stream-context/derive.test.ts` | Regression tests for the parse quirk, the stored malformed shape, and in-app badging (the old "excludes in-app" test now asserts inclusion) |

## Out of scope (deliberate)

- `quoteReply` nodes and `memoEmbed` references aren't surfaced as panel items — quote-replies are usually intra-stream noise; memo references only appear when a `memo_link` preview row exists. Follow-up if wanted.
- Old malformed messages keep their `channelLink` node in contentJson (rendered body unchanged); only extraction is healed. Re-serializing such a message on edit still produces the odd `[#1358](channel:1358)` form — pre-existing, untouched.
- No link previews are retro-generated for old messages (previews are created at ingestion); their panel rows show the bare URL without title/favicon.

## Test plan

- [x] `packages/prosemirror` `bun test` — 144 pass (incl. 4 new: `[#…](url)` / `[@…](url)` parse, link marks on non-text nodes, non-http marks excluded)
- [x] Frontend `vitest run src/lib/stream-context src/components/stream-context` — 33 pass (incl. new in-app badge + stored-malformed-shape tests)
- [x] Frontend `vitest run src/lib/markdown src/components/editor` — 503 pass
- [x] Backend `bun test src/features/{messaging,mentions,link-previews,public-api}` — 490 pass
- [x] `bun run typecheck` — monorepo clean
- [x] End-to-end sanity: real prod message markdown and its stored malformed contentJson both yield the PR URL from `collectLinkUrls`
- [ ] Live UI check of the prod message's panel row — needs this deployed; the stored-shape unit test reproduces the exact contentJson

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786778021&installation_id=129946197&pr_number=1359&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1359&signature=6b8f28dcbe510ced7c0cfc74b4c69f394010492924feca79e863b51cd0433650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->