### PR TITLE
feat(frontend): top-bar chip for running agent sessions

### DIFF
--- a/apps/frontend/src/components/timeline/agent-activity-header-chip.tsx
+++ b/apps/frontend/src/components/timeline/agent-activity-header-chip.tsx
@@ -1,0 +1,59 @@
+import { Link } from "react-router-dom"
+import { Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useTrace, useAgentActivitySummary } from "@/contexts"
+
+/**
+ * Top-bar chip shown while ≥1 agent session runs in the open stream (root or its
+ * threads). Single session: spinner + persona name + live step count. Two or
+ * more: "N agents working". Clicking opens the most recently started session's
+ * trace (navigation → getTraceUrl, INV-40). Renders nothing when idle.
+ *
+ * `compact` (mobile) drops to a spinner-only pill so the name button keeps its
+ * width; it still links to the trace.
+ */
+export function AgentActivityHeaderChip({ compact = false }: { compact?: boolean }) {
+  const summary = useAgentActivitySummary()
+  const { getTraceUrl } = useTrace()
+
+  if (summary.length === 0) return null
+
+  // "Most recent" click target — the summary is ordered most recently started first.
+  const target = summary[0]
+  const single = summary.length === 1
+  const label = single ? target.personaName : `${summary.length} agents working`
+  const ariaLabel = single
+    ? `${target.personaName} is working — open agent trace`
+    : `${summary.length} agents working — open agent trace`
+
+  if (compact) {
+    return (
+      <Link
+        to={getTraceUrl(target.sessionId)}
+        aria-label={ariaLabel}
+        className="inline-flex shrink-0 items-center rounded-full border border-primary/30 bg-primary/5 px-1.5 py-0.5 text-primary transition-colors hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      to={getTraceUrl(target.sessionId)}
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded-full border border-primary/30 bg-primary/5 px-2.5 py-0.5 text-xs font-semibold text-foreground transition-colors",
+        "hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      )}
+    >
+      <Loader2 className="h-3 w-3 animate-spin text-primary" aria-hidden="true" />
+      <span className="truncate">{label}</span>
+      {single && target.stepCount > 0 && (
+        <span className="text-muted-foreground tabular-nums">
+          · {target.stepCount} step{target.stepCount === 1 ? "" : "s"}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/apps/frontend/src/components/timeline/index.ts
+++ b/apps/frontend/src/components/timeline/index.ts
@@ -1,4 +1,5 @@
 export { TimelineView } from "./timeline-view"
+export { AgentActivityHeaderChip } from "./agent-activity-header-chip"
 export { StreamContent } from "./stream-content"
 export { EventList, groupTimelineItems } from "./event-list"
 export { EventItem } from "./event-item"

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -12,10 +12,12 @@ import {
   remapSuppressedWatermark,
   resolveUnreadMarkerOpen,
   resolveFollowPill,
+  buildAgentActivitySummary,
   type RunningSessionCard,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
 import type { StreamEvent } from "@threa/types"
+import type { MessageAgentActivity } from "@/hooks"
 
 const DEADLINE = 4000
 
@@ -640,5 +642,64 @@ describe("resolveFollowPill", () => {
       bottomIndex: 40,
     })
     expect(result).toMatchObject({ sessionId: "offscreen", personaName: "Ariadne", count: 1 })
+  })
+})
+
+describe("buildAgentActivitySummary", () => {
+  const activity = (over: Partial<MessageAgentActivity> & { sessionId: string }): MessageAgentActivity => ({
+    personaName: "Ariadne",
+    currentStepType: null,
+    stepCount: 0,
+    messageCount: 0,
+    substep: null,
+    ...over,
+  })
+  const startedEvent = (sessionId: string, startedAt: string) =>
+    ({
+      eventType: "agent_session:started",
+      payload: { sessionId, startedAt },
+    }) as unknown as StreamEvent
+
+  it("returns an empty array when no session is running", () => {
+    expect(buildAgentActivitySummary(new Map(), [])).toEqual([])
+    expect(buildAgentActivitySummary(undefined, [])).toEqual([])
+  })
+
+  it("returns one entry per running session with its live step count", () => {
+    const map = new Map<string, MessageAgentActivity>([
+      ["trigger_1", activity({ sessionId: "s1", personaName: "Ariadne", stepCount: 4 })],
+    ])
+    expect(buildAgentActivitySummary(map, [])).toEqual([{ sessionId: "s1", personaName: "Ariadne", stepCount: 4 }])
+  })
+
+  it("dedupes a thread session aliased under both its trigger and parent-message keys", () => {
+    // useAgentActivity keys a thread session under two ids; the summary is per session.
+    const shared = activity({ sessionId: "s1", stepCount: 2 })
+    const map = new Map<string, MessageAgentActivity>([
+      ["trigger_1", shared],
+      ["parent_msg_1", shared],
+    ])
+    expect(buildAgentActivitySummary(map, [])).toEqual([{ sessionId: "s1", personaName: "Ariadne", stepCount: 2 }])
+  })
+
+  it("orders most recently started first using the started events", () => {
+    const map = new Map<string, MessageAgentActivity>([
+      ["t_old", activity({ sessionId: "s_old", personaName: "Older" })],
+      ["t_new", activity({ sessionId: "s_new", personaName: "Newer" })],
+    ])
+    const events = [
+      startedEvent("s_old", "2026-07-16T10:00:00.000Z"),
+      startedEvent("s_new", "2026-07-16T10:05:00.000Z"),
+    ]
+    expect(buildAgentActivitySummary(map, events).map((e) => e.sessionId)).toEqual(["s_new", "s_old"])
+  })
+
+  it("sorts a session with no started event (socket-only channel view) after one that has one", () => {
+    const map = new Map<string, MessageAgentActivity>([
+      ["t_known", activity({ sessionId: "s_known" })],
+      ["t_socket", activity({ sessionId: "s_socket" })],
+    ])
+    const events = [startedEvent("s_known", "2026-07-16T10:00:00.000Z")]
+    expect(buildAgentActivitySummary(map, events).map((e) => e.sessionId)).toEqual(["s_known", "s_socket"])
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -878,7 +878,7 @@ export function StreamContent({
   // Track live agent session progress for all stream types (step/message counts on session cards).
   // In channels, session cards are hidden (responses go to threads) and inline activity shows on trigger messages instead.
   const isChannel = stream?.type === StreamTypes.CHANNEL
-  const agentActivity = useAgentActivity(events, socket, workspaceId, currentWorkspaceUserId)
+  const agentActivity = useAgentActivity(events, socket, workspaceId, currentWorkspaceUserId, streamId)
 
   // Publish a running-session summary up to the header chip. No-ops for a
   // thread-panel StreamContent (mounted outside the open stream's provider).

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -20,13 +20,20 @@ import {
   useIsMobile,
   useNewMessageIndicator,
   useAgentActivity,
+  type MessageAgentActivity,
   useAbortSession,
   useEditLastMessageTrigger,
   useKeyboardShortcuts,
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
-import { useSocket, useCoordinatedLoading, usePreferencesOptional } from "@/contexts"
+import {
+  useSocket,
+  useCoordinatedLoading,
+  usePreferencesOptional,
+  usePublishAgentActivitySummary,
+  type AgentActivitySummaryEntry,
+} from "@/contexts"
 import { useMessageService } from "@/contexts"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
@@ -57,6 +64,7 @@ import {
   type DelegationStatusChangedEventPayload,
   type BotAccessStatusChangedEventPayload,
   type UnreadOpenPosition,
+  type AgentSessionStartedPayload,
 } from "@threa/types"
 import {
   EventList,
@@ -534,6 +542,70 @@ function followPillEqual(a: FollowPillState | null, b: FollowPillState | null): 
   )
 }
 
+const EMPTY_ACTIVITY_SUMMARY: AgentActivitySummaryEntry[] = []
+
+/** One running session collapsed from the per-message activity map. */
+export interface DedupedRunningSession {
+  sessionId: string
+  personaName: string
+  stepCount: number
+  /** Every message id the session is aliased under (thread sessions appear under trigger + parent). */
+  anchors: string[]
+}
+
+/**
+ * Collapse the per-message agent-activity map to one entry per session. The map
+ * aliases a thread session under two keys (trigger + parent message), so first
+ * occurrence wins for personaName/stepCount while `anchors` accumulates every
+ * key. Single source of the dedup rule for both the header-chip summary and the
+ * follow-pill cards, so they can never disagree on a session's step count.
+ */
+export function dedupeRunningSessions(
+  agentActivity: Map<string, MessageAgentActivity> | undefined
+): DedupedRunningSession[] {
+  if (!agentActivity || agentActivity.size === 0) return []
+  const bySession = new Map<string, DedupedRunningSession>()
+  for (const [anchorMessageId, activity] of agentActivity) {
+    const existing = bySession.get(activity.sessionId)
+    if (existing) existing.anchors.push(anchorMessageId)
+    else
+      bySession.set(activity.sessionId, {
+        sessionId: activity.sessionId,
+        personaName: activity.personaName,
+        stepCount: activity.stepCount,
+        anchors: [anchorMessageId],
+      })
+  }
+  return Array.from(bySession.values())
+}
+
+/**
+ * Order the running sessions into the header chip's summary: most recently
+ * started first. Ordering keys off each session's `started` event when the
+ * timeline holds it (its own stream); channel-view sessions known only from
+ * socket carry no start time and sort last, so the chip's "most recent" click
+ * target favours a session whose lifecycle this stream actually owns.
+ */
+export function buildAgentActivitySummary(
+  agentActivity: Map<string, MessageAgentActivity> | undefined,
+  events: StreamEvent[]
+): AgentActivitySummaryEntry[] {
+  const sessions = dedupeRunningSessions(agentActivity)
+  if (sessions.length === 0) return EMPTY_ACTIVITY_SUMMARY
+  const startedAtBySession = new Map<string, string>()
+  for (const event of events) {
+    if (event.eventType === "agent_session:started") {
+      const payload = event.payload as AgentSessionStartedPayload
+      startedAtBySession.set(payload.sessionId, payload.startedAt)
+    }
+  }
+  const list = sessions.map(({ sessionId, personaName, stepCount }) => ({ sessionId, personaName, stepCount }))
+  list.sort((a, b) =>
+    (startedAtBySession.get(b.sessionId) ?? "").localeCompare(startedAtBySession.get(a.sessionId) ?? "")
+  )
+  return list
+}
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -807,6 +879,15 @@ export function StreamContent({
   // In channels, session cards are hidden (responses go to threads) and inline activity shows on trigger messages instead.
   const isChannel = stream?.type === StreamTypes.CHANNEL
   const agentActivity = useAgentActivity(events, socket, workspaceId, currentWorkspaceUserId)
+
+  // Publish a running-session summary up to the header chip. No-ops for a
+  // thread-panel StreamContent (mounted outside the open stream's provider).
+  const publishAgentActivitySummary = usePublishAgentActivitySummary()
+  const agentActivitySummary = useMemo(() => buildAgentActivitySummary(agentActivity, events), [agentActivity, events])
+  useEffect(() => {
+    publishAgentActivitySummary(agentActivitySummary)
+  }, [agentActivitySummary, publishAgentActivitySummary])
+  useEffect(() => () => publishAgentActivitySummary(EMPTY_ACTIVITY_SUMMARY), [publishAgentActivitySummary])
 
   // E2E streams search decrypted bodies client-side (the server only holds
   // ciphertext); pass the flag + viewer id so the hook can resolve the session.
@@ -2829,20 +2910,8 @@ function TimelineMessageList({
   // sessionId — the activity map aliases thread sessions under two keys.
   const [followPill, setFollowPill] = useState<FollowPillState | null>(null)
   const runningSessionCards = useMemo<RunningSessionCard[]>(() => {
-    if (!agentActivity || agentActivity.size === 0) return []
-    const bySession = new Map<string, { personaName: string; stepCount: number; anchors: string[] }>()
-    for (const [anchorMessageId, activity] of agentActivity) {
-      const existing = bySession.get(activity.sessionId)
-      if (existing) existing.anchors.push(anchorMessageId)
-      else
-        bySession.set(activity.sessionId, {
-          personaName: activity.personaName,
-          stepCount: activity.stepCount,
-          anchors: [anchorMessageId],
-        })
-    }
     const cards: RunningSessionCard[] = []
-    for (const [sessionId, info] of bySession) {
+    for (const { sessionId, personaName, stepCount, anchors } of dedupeRunningSessions(agentActivity)) {
       const sessionItemIndex = visibleItems.findIndex((it) => it.type === "session_group" && it.sessionId === sessionId)
       let itemIndex = sessionItemIndex
       // Anchor id keys the scroll driver: a session card resolves to its first
@@ -2853,7 +2922,7 @@ function TimelineMessageList({
         const item = visibleItems[sessionItemIndex]
         if (item.type === "session_group") anchorId = item.events[0]?.id ?? ""
       } else {
-        for (const anchor of info.anchors) {
+        for (const anchor of anchors) {
           const idx = findMessageItemIndex(visibleItems, anchor)
           if (idx >= 0) {
             itemIndex = idx
@@ -2862,7 +2931,7 @@ function TimelineMessageList({
           }
         }
       }
-      cards.push({ sessionId, personaName: info.personaName, stepCount: info.stepCount, itemIndex, anchorId })
+      cards.push({ sessionId, personaName, stepCount, itemIndex, anchorId })
     }
     return cards
   }, [agentActivity, visibleItems])

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -60,3 +60,9 @@ export { SidebarProvider, useSidebar, type UrgencyBlock, type CollapseState } fr
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
 export { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"
+export {
+  StreamAgentActivityProvider,
+  useAgentActivitySummary,
+  usePublishAgentActivitySummary,
+  type AgentActivitySummaryEntry,
+} from "./stream-agent-activity-context"

--- a/apps/frontend/src/contexts/stream-agent-activity-context.test.tsx
+++ b/apps/frontend/src/contexts/stream-agent-activity-context.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import type { ReactNode } from "react"
+import {
+  StreamAgentActivityProvider,
+  useAgentActivitySummary,
+  usePublishAgentActivitySummary,
+  type AgentActivitySummaryEntry,
+} from "./stream-agent-activity-context"
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <StreamAgentActivityProvider>{children}</StreamAgentActivityProvider>
+)
+
+const entry = (over: Partial<AgentActivitySummaryEntry> & { sessionId: string }): AgentActivitySummaryEntry => ({
+  personaName: "Ariadne",
+  stepCount: 0,
+  ...over,
+})
+
+describe("StreamAgentActivityProvider", () => {
+  it("starts empty and consumes a published summary", () => {
+    const { result } = renderHook(
+      () => ({ summary: useAgentActivitySummary(), publish: usePublishAgentActivitySummary() }),
+      { wrapper }
+    )
+
+    expect(result.current.summary).toEqual([])
+
+    const next = [entry({ sessionId: "s1", stepCount: 3 })]
+    act(() => result.current.publish(next))
+
+    expect(result.current.summary).toEqual(next)
+  })
+
+  it("does not re-render for an identical summary (referential stability across step-free ticks)", () => {
+    const { result } = renderHook(
+      () => ({ summary: useAgentActivitySummary(), publish: usePublishAgentActivitySummary() }),
+      { wrapper }
+    )
+
+    act(() => result.current.publish([entry({ sessionId: "s1", stepCount: 3 })]))
+    const first = result.current.summary
+
+    // A fresh array with identical contents — must not swap the state reference.
+    act(() => result.current.publish([entry({ sessionId: "s1", stepCount: 3 })]))
+    expect(result.current.summary).toBe(first)
+
+    // A real step change swaps it.
+    act(() => result.current.publish([entry({ sessionId: "s1", stepCount: 4 })]))
+    expect(result.current.summary).not.toBe(first)
+    expect(result.current.summary[0].stepCount).toBe(4)
+  })
+
+  it("clears back to empty when the timeline publishes an empty summary", () => {
+    const { result } = renderHook(
+      () => ({ summary: useAgentActivitySummary(), publish: usePublishAgentActivitySummary() }),
+      { wrapper }
+    )
+
+    act(() => result.current.publish([entry({ sessionId: "s1" })]))
+    expect(result.current.summary).toHaveLength(1)
+
+    act(() => result.current.publish([]))
+    expect(result.current.summary).toEqual([])
+  })
+
+  it("publish is a no-op without a provider (thread-panel StreamContent)", () => {
+    const { result } = renderHook(() => ({
+      summary: useAgentActivitySummary(),
+      publish: usePublishAgentActivitySummary(),
+    }))
+    expect(result.current.summary).toEqual([])
+    act(() => result.current.publish([entry({ sessionId: "s1" })]))
+    expect(result.current.summary).toEqual([])
+  })
+})

--- a/apps/frontend/src/contexts/stream-agent-activity-context.tsx
+++ b/apps/frontend/src/contexts/stream-agent-activity-context.tsx
@@ -1,0 +1,60 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+
+/** One running agent session in the open stream (or its threads), for the header chip. */
+export interface AgentActivitySummaryEntry {
+  sessionId: string
+  personaName: string
+  stepCount: number
+}
+
+interface StreamAgentActivityContextValue {
+  /** Running sessions in the open stream, most recently started first; empty when idle. */
+  summary: AgentActivitySummaryEntry[]
+  /** Called by the timeline to publish its running-session summary up to the header. */
+  publishSummary: (summary: AgentActivitySummaryEntry[]) => void
+}
+
+const EMPTY: AgentActivitySummaryEntry[] = []
+
+const StreamAgentActivityContext = createContext<StreamAgentActivityContextValue>({
+  summary: EMPTY,
+  // No-op when there's no provider (e.g. a thread-panel StreamContent, which is
+  // mounted outside the open stream's provider and must not publish into it).
+  publishSummary: () => {},
+})
+
+function summaryEqual(a: AgentActivitySummaryEntry[], b: AgentActivitySummaryEntry[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    if (x.sessionId !== y.sessionId || x.personaName !== y.personaName || x.stepCount !== y.stepCount) return false
+  }
+  return true
+}
+
+export function StreamAgentActivityProvider({ children }: { children: ReactNode }) {
+  const [summary, setSummary] = useState<AgentActivitySummaryEntry[]>(EMPTY)
+
+  // Skip the re-render when a step tick produces an identical summary — the
+  // timeline republishes on every agentActivity change, most of which don't
+  // touch the header's fields (sessionId / personaName / stepCount).
+  const publishSummary = useCallback((next: AgentActivitySummaryEntry[]) => {
+    setSummary((prev) => (summaryEqual(prev, next) ? prev : next))
+  }, [])
+
+  const value = useMemo<StreamAgentActivityContextValue>(() => ({ summary, publishSummary }), [summary, publishSummary])
+
+  return <StreamAgentActivityContext.Provider value={value}>{children}</StreamAgentActivityContext.Provider>
+}
+
+/** Read the open stream's running-session summary (header chip). */
+export function useAgentActivitySummary(): AgentActivitySummaryEntry[] {
+  return useContext(StreamAgentActivityContext).summary
+}
+
+/** Get the publish function the timeline uses to hand its summary to the header. */
+export function usePublishAgentActivitySummary(): (summary: AgentActivitySummaryEntry[]) => void {
+  return useContext(StreamAgentActivityContext).publishSummary
+}

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -186,4 +186,103 @@ describe("useAgentActivity", () => {
     expect(result.current.get("msg_parent")).toBeUndefined()
     expect(result.current.get("msg_in_thread")).toBeUndefined()
   })
+
+  // The socket is in every member stream's room (sync-engine joins them all for
+  // sidebar updates), so a stream-scoped view must not adopt other streams'
+  // sessions — without the `streamId` gate the header chip lit up on unrelated
+  // streams (caught in live browser QA).
+  test("stream-scoped view drops another stream's session but accepts its own", () => {
+    const { socket, handlers } = fakeSocket()
+    const { result } = renderHook(() => useAgentActivity([], socket, "ws_test", "usr_test", "stream_a"))
+
+    act(() => {
+      handlers.get("agent_session:progress")?.({
+        workspaceId: "ws_test",
+        streamId: "stream_b",
+        sessionId: "asess_foreign",
+        triggerMessageId: "msg_foreign",
+        personaName: "Ariadne",
+        stepCount: 4,
+        messageCount: 1,
+        currentStepType: "thinking",
+      })
+    })
+    expect(result.current.size).toBe(0)
+
+    act(() => {
+      handlers.get("agent_session:progress")?.({
+        workspaceId: "ws_test",
+        streamId: "stream_a",
+        sessionId: "asess_own",
+        triggerMessageId: "msg_own",
+        personaName: "Ariadne",
+        stepCount: 1,
+        messageCount: 0,
+        currentStepType: "thinking",
+      })
+    })
+    expect(result.current.get("msg_own")?.sessionId).toBe("asess_own")
+  })
+
+  test("stream-scoped view accepts a thread session only when its parent message is in this view", () => {
+    const { socket, handlers } = fakeSocket()
+    const parentMessageEvent: StreamEvent = {
+      id: "event_m1",
+      streamId: "stream_a",
+      sequence: "2",
+      eventType: "message_created",
+      payload: { messageId: "msg_parent" },
+      actorId: "usr_test",
+      actorType: AuthorTypes.USER,
+      createdAt: "2026-05-25T00:00:00.000Z",
+    }
+    const { result } = renderHook(() =>
+      useAgentActivity([parentMessageEvent], socket, "ws_test", "usr_test", "stream_a")
+    )
+
+    act(() => {
+      handlers.get("agent_session:activity_started")?.({
+        sessionId: "asess_1",
+        triggerMessageId: "msg_in_thread",
+        personaName: "Ariadne",
+        threadStreamId: "thread_1",
+        parentMessageId: "msg_parent",
+      })
+      handlers.get("agent_session:activity_started")?.({
+        sessionId: "asess_other",
+        triggerMessageId: "msg_in_other_thread",
+        personaName: "Ariadne",
+        threadStreamId: "thread_9",
+        parentMessageId: "msg_not_here",
+      })
+    })
+
+    expect(result.current.get("msg_parent")?.sessionId).toBe("asess_1")
+    expect(result.current.get("msg_not_here")).toBeUndefined()
+    expect(result.current.get("msg_in_other_thread")).toBeUndefined()
+  })
+
+  test("switching the view's stream resets socket-only entries", () => {
+    const { socket, handlers } = fakeSocket()
+    let streamId = "stream_a"
+    const { result, rerender } = renderHook(() => useAgentActivity([], socket, "ws_test", "usr_test", streamId))
+
+    act(() => {
+      handlers.get("agent_session:progress")?.({
+        workspaceId: "ws_test",
+        streamId: "stream_a",
+        sessionId: "asess_1",
+        triggerMessageId: "msg_1",
+        personaName: "Ariadne",
+        stepCount: 2,
+        messageCount: 0,
+        currentStepType: "thinking",
+      })
+    })
+    expect(result.current.get("msg_1")).toBeDefined()
+
+    streamId = "stream_b"
+    rerender()
+    expect(result.current.size).toBe(0)
+  })
 })

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -74,10 +74,49 @@ export function useAgentActivity(
   events: StreamEvent[],
   socket: Socket | null,
   workspaceId: string,
-  userId: string | null
+  userId: string | null,
+  streamId?: string
 ): Map<string, MessageAgentActivity> {
   const [progressBySession, setProgressBySession] = useState<Map<string, ProgressEntry>>(new Map())
   const reconnectCount = useSocketReconnectCount()
+
+  // The socket sits in EVERY member stream's room (sync-engine joins them all
+  // for sidebar updates), so progress/activity events for unrelated streams'
+  // sessions arrive here too. A stream view passes `streamId` to gate entry
+  // creation to its own sessions: the session's stream, its thread (payload
+  // threadStreamId), or a thread under one of this view's messages (payload
+  // parentMessageId). Omit it (board rows) to accept all sessions — those
+  // callers match by sessionId themselves.
+  const viewMessageIds = useMemo(() => {
+    if (streamId === undefined) return null
+    const ids = new Set<string>()
+    for (const event of events) {
+      if (event.eventType === "message_created") {
+        ids.add((event.payload as { messageId: string }).messageId)
+      }
+    }
+    return ids
+  }, [events, streamId])
+  const viewMessageIdsRef = useRef(viewMessageIds)
+  useEffect(() => {
+    viewMessageIdsRef.current = viewMessageIds
+  }, [viewMessageIds])
+
+  const belongsToView = useCallback(
+    (payload: { streamId?: string; threadStreamId?: string; parentMessageId?: string }) => {
+      if (streamId === undefined) return true
+      if (payload.streamId === streamId || payload.threadStreamId === streamId) return true
+      return payload.parentMessageId !== undefined && (viewMessageIdsRef.current?.has(payload.parentMessageId) ?? false)
+    },
+    [streamId]
+  )
+
+  // StreamContent persists across `streamId` changes (the route param swaps in
+  // place), so without a reset the previous stream's socket-only entries would
+  // leak into the next view's map.
+  useEffect(() => {
+    setProgressBySession((prev) => (prev.size === 0 ? prev : new Map()))
+  }, [streamId])
 
   // Mirror of `progressBySession` for synchronous reads inside event handlers —
   // lets a substep capture the session's step generation at *arrival* time so a
@@ -170,46 +209,54 @@ export function useAgentActivity(
   }, [runningSessions, events])
 
   // Activity started: session just began, no step yet (renders "Working...")
-  const handleActivityStarted = useCallback((payload: AgentActivityStartedPayload) => {
-    setProgressBySession((prev) => {
-      const next = new Map(prev)
-      next.set(payload.sessionId, {
-        triggerMessageId: payload.triggerMessageId,
-        personaName: payload.personaName,
-        currentStepType: null,
-        stepCount: 0,
-        messageCount: 0,
-        substep: null,
-        threadStreamId: payload.threadStreamId,
-        parentMessageId: payload.parentMessageId,
+  const handleActivityStarted = useCallback(
+    (payload: AgentActivityStartedPayload) => {
+      if (!belongsToView(payload)) return
+      setProgressBySession((prev) => {
+        const next = new Map(prev)
+        next.set(payload.sessionId, {
+          triggerMessageId: payload.triggerMessageId,
+          personaName: payload.personaName,
+          currentStepType: null,
+          stepCount: 0,
+          messageCount: 0,
+          substep: null,
+          threadStreamId: payload.threadStreamId,
+          parentMessageId: payload.parentMessageId,
+        })
+        return next
       })
-      return next
-    })
-  }, [])
+    },
+    [belongsToView]
+  )
 
   // Progress: step type update during active session.
   // When the stepCount changes, the previous step's live substep is stale — clear it
   // so we don't show e.g. "Evaluating results…" left over from workspace_search after
   // we've moved on to "thinking" or "message_sent".
-  const handleProgress = useCallback((payload: AgentSessionProgressPayload) => {
-    setProgressBySession((prev) => {
-      const prior = prev.get(payload.sessionId)
-      const sameStep = prior?.stepCount === payload.stepCount
-      const next = new Map(prev)
-      next.set(payload.sessionId, {
-        triggerMessageId: payload.triggerMessageId,
-        personaName: payload.personaName,
-        currentStepType: payload.currentStepType,
-        stepCount: payload.stepCount,
-        messageCount: payload.messageCount,
-        substep: sameStep ? (prior?.substep ?? null) : null,
-        substepUpdatedAt: sameStep ? prior?.substepUpdatedAt : undefined,
-        threadStreamId: payload.threadStreamId,
-        parentMessageId: payload.parentMessageId,
+  const handleProgress = useCallback(
+    (payload: AgentSessionProgressPayload) => {
+      if (!belongsToView(payload)) return
+      setProgressBySession((prev) => {
+        const prior = prev.get(payload.sessionId)
+        const sameStep = prior?.stepCount === payload.stepCount
+        const next = new Map(prev)
+        next.set(payload.sessionId, {
+          triggerMessageId: payload.triggerMessageId,
+          personaName: payload.personaName,
+          currentStepType: payload.currentStepType,
+          stepCount: payload.stepCount,
+          messageCount: payload.messageCount,
+          substep: sameStep ? (prior?.substep ?? null) : null,
+          substepUpdatedAt: sameStep ? prior?.substepUpdatedAt : undefined,
+          threadStreamId: payload.threadStreamId,
+          parentMessageId: payload.parentMessageId,
+        })
+        return next
       })
-      return next
-    })
-  }, [])
+    },
+    [belongsToView]
+  )
 
   // Apply a decoded substep, gated against races: drop it if the session's step
   // generation advanced since the substep arrived (`stepCountAtArrival`), or if a

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -39,11 +39,11 @@ import {
   useActiveBotPresence,
 } from "@/hooks"
 import { useWorkspaceDmPeers, useWorkspaceMetadata } from "@/stores/workspace-store"
-import { usePanel, useSidebar } from "@/contexts"
+import { usePanel, useSidebar, StreamAgentActivityProvider } from "@/contexts"
 import { useUserProfile } from "@/components/user-profile"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
-import { TimelineView } from "@/components/timeline"
+import { TimelineView, AgentActivityHeaderChip } from "@/components/timeline"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { LabelStack } from "@/components/labels/label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
@@ -663,185 +663,191 @@ export function StreamPage() {
   }
 
   const mainStreamContent = (
-    <div className="flex h-full flex-col">
-      <header className="relative flex h-12 items-center justify-between border-b px-4">
-        <div className={cn("flex items-center gap-2 flex-1 min-w-0", isTouchInput && !isEditing && "select-none")}>
-          <SidebarToggle location="page" />
-          {headerTitle}
-          {companionModeIndicator}
-          {/* Chip strip. The chips are non-shrinking (`shrink-0` leaves), so on a
+    <StreamAgentActivityProvider>
+      <div className="flex h-full flex-col">
+        <header className="relative flex h-12 items-center justify-between border-b px-4">
+          <div className={cn("flex items-center gap-2 flex-1 min-w-0", isTouchInput && !isEditing && "select-none")}>
+            <SidebarToggle location="page" />
+            {headerTitle}
+            {companionModeIndicator}
+            <AgentActivityHeaderChip compact={isMobile} />
+            {/* Chip strip. The chips are non-shrinking (`shrink-0` leaves), so on a
               phone-width header they would otherwise overflow the flex box and
               paint under the search/panel actions — the strip scrolls instead,
               same recipe as PageHeaderTabs' tab strip. On mobile the chips live
               in the stream sheet; the strip only renders when there is no sheet
               to hold them (drafts, archived non-scratchpads). */}
-          {(!isMobile || !canOpenSheet) && (
-            <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none">
-              {stream && !isDraft && (
-                <LabelStack
-                  workspaceId={workspaceId}
-                  resourceType={LabelableResourceTypes.STREAM}
-                  resourceId={streamId}
-                  className="shrink-0"
-                />
-              )}
-              {isEncryptedScratchpad && !isDraft && (
-                <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
-              )}
-              {stream && isScratchpad && !isDraft && (
-                <>
-                  <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
-                  <InviteBotButton workspaceId={workspaceId!} stream={stream} />
-                </>
-              )}
-              {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
-                <Badge variant="secondary" className="shrink-0">
-                  {getStreamTypeLabel(stream.type)}
-                </Badge>
-              )}
-              {isArchived && (
-                <Badge variant="secondary" className="gap-1 shrink-0">
-                  <ArchiveX className="h-3 w-3" />
-                  Archived
-                </Badge>
-              )}
-            </div>
-          )}
-        </div>
-        <div className="flex items-center gap-1 ml-1">
-          {!isThread && !isDraft && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              title="Search in conversation"
-              onClick={() => document.dispatchEvent(new CustomEvent("threa:open-stream-search"))}
-            >
-              <Search className="h-4 w-4" />
-            </Button>
-          )}
-          {stream && !isThread && !isDraft && !isMobile && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn("h-8 w-8", isContextOpen && "bg-accent text-accent-foreground")}
-              title="In this stream — links, files & memories"
-              aria-label="In this stream"
-              aria-pressed={isContextOpen}
-              onClick={() => setContextOpen(!isContextOpen)}
-            >
-              <PanelRight className="h-4 w-4" />
-            </Button>
-          )}
-          {(isChannel || isDm) && !isMobile && (
-            // Split button (the `GroupedItem` pattern from message-context-menu):
-            // primary tap toggles the conversation overlay; the chevron lists
-            // every conversation view — overlay first (default, font-medium),
-            // then the slide-out conversations list.
-            <div className="flex items-stretch">
+            {(!isMobile || !canOpenSheet) && (
+              <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none">
+                {stream && !isDraft && (
+                  <LabelStack
+                    workspaceId={workspaceId}
+                    resourceType={LabelableResourceTypes.STREAM}
+                    resourceId={streamId}
+                    className="shrink-0"
+                  />
+                )}
+                {isEncryptedScratchpad && !isDraft && (
+                  <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
+                )}
+                {stream && isScratchpad && !isDraft && (
+                  <>
+                    <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
+                    <InviteBotButton workspaceId={workspaceId!} stream={stream} />
+                  </>
+                )}
+                {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
+                  <Badge variant="secondary" className="shrink-0">
+                    {getStreamTypeLabel(stream.type)}
+                  </Badge>
+                )}
+                {isArchived && (
+                  <Badge variant="secondary" className="gap-1 shrink-0">
+                    <ArchiveX className="h-3 w-3" />
+                    Archived
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-1 ml-1">
+            {!isThread && !isDraft && (
               <Button
                 variant="ghost"
                 size="icon"
-                className={cn("h-8 w-8 rounded-r-none", isConversationOverlayOn && "bg-accent text-accent-foreground")}
-                title="Conversation overlay"
-                // Stable accessible name; on/off state is announced via
-                // aria-pressed (ARIA toggle-button pattern), so the label
-                // must not flip with the state.
-                aria-label="Conversation overlay"
-                aria-pressed={isConversationOverlayOn}
-                onClick={() => setConversationOverlayOn(!isConversationOverlayOn)}
+                className="h-8 w-8"
+                title="Search in conversation"
+                onClick={() => document.dispatchEvent(new CustomEvent("threa:open-stream-search"))}
               >
-                <Layers className="h-4 w-4" />
+                <Search className="h-4 w-4" />
               </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    // Wider on touch viewports — a 20px chevron is fiddly with
-                    // a finger; desktop keeps the compact split-button look.
-                    className="h-8 w-7 rounded-l-none border-l border-border/50 px-0 sm:w-5"
-                    aria-label="Other conversation views"
-                  >
-                    <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-[200px]">
-                  <DropdownMenuItem
-                    className="gap-2 cursor-pointer font-medium"
-                    onSelect={() => setConversationOverlayOn(!isConversationOverlayOn)}
-                  >
-                    <Layers className="h-4 w-4 text-muted-foreground" />
-                    Conversation overlay
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="gap-2 cursor-pointer"
-                    onSelect={() => setConversationViewOpen(!isConversationViewOpen)}
-                  >
-                    <MessageCircle className="h-4 w-4 text-muted-foreground" />
-                    Conversations list
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          )}
-          {stream &&
-            !isDraft &&
-            !(isArchived && !isScratchpad) &&
-            (isMobile ? (
-              <>
+            )}
+            {stream && !isThread && !isDraft && !isMobile && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("h-8 w-8", isContextOpen && "bg-accent text-accent-foreground")}
+                title="In this stream — links, files & memories"
+                aria-label="In this stream"
+                aria-pressed={isContextOpen}
+                onClick={() => setContextOpen(!isContextOpen)}
+              >
+                <PanelRight className="h-4 w-4" />
+              </Button>
+            )}
+            {(isChannel || isDm) && !isMobile && (
+              // Split button (the `GroupedItem` pattern from message-context-menu):
+              // primary tap toggles the conversation overlay; the chevron lists
+              // every conversation view — overlay first (default, font-medium),
+              // then the slide-out conversations list.
+              <div className="flex items-stretch">
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8"
-                  aria-label="Stream actions"
-                  onClick={() => setIsMenuDrawerOpen(true)}
+                  className={cn(
+                    "h-8 w-8 rounded-r-none",
+                    isConversationOverlayOn && "bg-accent text-accent-foreground"
+                  )}
+                  title="Conversation overlay"
+                  // Stable accessible name; on/off state is announced via
+                  // aria-pressed (ARIA toggle-button pattern), so the label
+                  // must not flip with the state.
+                  aria-label="Conversation overlay"
+                  aria-pressed={isConversationOverlayOn}
+                  onClick={() => setConversationOverlayOn(!isConversationOverlayOn)}
                 >
-                  <MoreHorizontal className="h-4 w-4" />
+                  <Layers className="h-4 w-4" />
                 </Button>
-                <StreamSheet
-                  open={isMenuDrawerOpen}
-                  onOpenChange={setIsMenuDrawerOpen}
-                  workspaceId={workspaceId}
-                  streamId={streamId}
-                  stream={stream}
-                  streamName={streamName}
-                  actions={[
-                    ...sheetViewActions,
-                    ...streamMenuActions.map((action, i) =>
-                      i === 0 && sheetViewActions.length > 0 ? { ...action, separatorBefore: true } : action
-                    ),
-                  ]}
-                />
-              </>
-            ) : (
-              <SidebarActionMenu
-                actions={streamMenuActions}
-                ariaLabel="Stream actions"
-                trigger={
-                  <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Stream actions">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      // Wider on touch viewports — a 20px chevron is fiddly with
+                      // a finger; desktop keeps the compact split-button look.
+                      className="h-8 w-7 rounded-l-none border-l border-border/50 px-0 sm:w-5"
+                      aria-label="Other conversation views"
+                    >
+                      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-[200px]">
+                    <DropdownMenuItem
+                      className="gap-2 cursor-pointer font-medium"
+                      onSelect={() => setConversationOverlayOn(!isConversationOverlayOn)}
+                    >
+                      <Layers className="h-4 w-4 text-muted-foreground" />
+                      Conversation overlay
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="gap-2 cursor-pointer"
+                      onSelect={() => setConversationViewOpen(!isConversationViewOpen)}
+                    >
+                      <MessageCircle className="h-4 w-4 text-muted-foreground" />
+                      Conversations list
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
+            {stream &&
+              !isDraft &&
+              !(isArchived && !isScratchpad) &&
+              (isMobile ? (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    aria-label="Stream actions"
+                    onClick={() => setIsMenuDrawerOpen(true)}
+                  >
                     <MoreHorizontal className="h-4 w-4" />
                   </Button>
-                }
-              />
-            ))}
-        </div>
-      </header>
-      <main className="relative flex-1 overflow-hidden" data-editor-zone="main">
-        <StreamEncryptionGate workspaceId={workspaceId} encrypted={isEncryptedScratchpad && !isDraft}>
-          <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
-        </StreamEncryptionGate>
-      </main>
-      {stream && !isDraft && (
-        <LabelPicker
-          workspaceId={workspaceId}
-          resourceType={LabelableResourceTypes.STREAM}
-          resourceId={streamId}
-          open={labelPickerOpen}
-          onOpenChange={setLabelPickerOpen}
-        />
-      )}
-    </div>
+                  <StreamSheet
+                    open={isMenuDrawerOpen}
+                    onOpenChange={setIsMenuDrawerOpen}
+                    workspaceId={workspaceId}
+                    streamId={streamId}
+                    stream={stream}
+                    streamName={streamName}
+                    actions={[
+                      ...sheetViewActions,
+                      ...streamMenuActions.map((action, i) =>
+                        i === 0 && sheetViewActions.length > 0 ? { ...action, separatorBefore: true } : action
+                      ),
+                    ]}
+                  />
+                </>
+              ) : (
+                <SidebarActionMenu
+                  actions={streamMenuActions}
+                  ariaLabel="Stream actions"
+                  trigger={
+                    <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Stream actions">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  }
+                />
+              ))}
+          </div>
+        </header>
+        <main className="relative flex-1 overflow-hidden" data-editor-zone="main">
+          <StreamEncryptionGate workspaceId={workspaceId} encrypted={isEncryptedScratchpad && !isDraft}>
+            <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
+          </StreamEncryptionGate>
+        </main>
+        {stream && !isDraft && (
+          <LabelPicker
+            workspaceId={workspaceId}
+            resourceType={LabelableResourceTypes.STREAM}
+            resourceId={streamId}
+            open={labelPickerOpen}
+            onOpenChange={setLabelPickerOpen}
+          />
+        )}
+      </div>
+    </StreamAgentActivityProvider>
   )
 
   // Conversation side panel - shown for channels and DMs


### PR DESCRIPTION
**Stacked on** #1360 (follow pill) — merge that first.

## Problem

The follow pill (#1360) helps once you're scrolled away from a running session's card, but there is no *persistent* anchor: nothing in the stream chrome says "an agent is working here right now", and nothing gives a stable one-click path to the trace dialog. The only header precedent — the scratchpad companion pill's live connection dot — is scratchpad-only and shows connection state, not work.

## Solution

A top-bar chip rendered while ≥1 agent session runs in the open stream (root or its threads): spinner + persona name + live step count; multiple sessions aggregate to `N agents working`. Clicking navigates to the trace dialog. Renders nothing when idle.

### How it works

1. **`StreamAgentActivityProvider`** (`contexts/stream-agent-activity-context.tsx`) carries an ordered summary `AgentActivitySummaryEntry[]` (`{sessionId, personaName, stepCount}`, most recently started first). The provider skips `setState` when a published summary is value-identical, so step-free `agentActivity` ticks don't re-render the header.
2. **`StreamContent` publishes** the summary from its existing `useAgentActivity` state via `buildAgentActivitySummary` — which shares a new `dedupeRunningSessions` helper with the follow pill's card resolution (the activity map aliases thread sessions under two keys; the collapse rule now lives in one place). Ordering derives from the stream's `agent_session:started` events; socket-only sessions with no started event in the window sort last.
3. **The provider wraps only the main stream content** in `pages/stream.tsx` — a thread-panel `StreamContent` (mounted via `PanelHost` outside the provider) publishes into the context default no-op and can't clobber the open stream's header summary.
4. **`AgentActivityHeaderChip`** sits beside the stream title (sibling of `companionModeIndicator`, matching its violet pill styling). It's a `<Link to={getTraceUrl(sessionId)}>` — opening the trace dialog is navigation (INV-40). `TraceProvider` is an ancestor of `StreamPage` (workspace layout), so `useTrace` resolves.
5. **Mobile** renders `compact`: a spinner-only pill that doesn't widen the name button, still linking to the trace.

### Key design decisions

**1. Lift a summary, not the map** — the header needs name/count/order, not substeps or per-message aliasing. Publishing a minimal ordered array keeps the context cheap and the header render-stable.

**2. `startedAt` dropped from the brief's entry shape** (caught during implementation) — `MessageAgentActivity` doesn't carry it and socket-only sessions (progress payloads in channel views) have no start time. Ordering is computed at publish time from persisted `agent_session:started` events instead of threading a partial field through the hook.

**3. `tabular-nums` on the live step counter** (review finding) — the title (`flex-1 min-w-0`) precedes the `shrink-0` chip, so per-tick digit-width jitter would shift title truncation (INV-21). Fixed-width digits limit width changes to digit-count boundaries.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/contexts/stream-agent-activity-context.tsx` | Provider + `useAgentActivitySummary` / `usePublishAgentActivitySummary` |
| `apps/frontend/src/contexts/stream-agent-activity-context.test.tsx` | Publish/consume + referential-stability cases |
| `apps/frontend/src/components/timeline/agent-activity-header-chip.tsx` | The chip (full + compact variants) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `dedupeRunningSessions` shared helper; `buildAgentActivitySummary`; publish effect |
| `apps/frontend/src/pages/stream.tsx` | Provider wrap around main content; chip beside the title (`compact={isMobile}`) |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | `buildAgentActivitySummary` cases |
| `apps/frontend/src/{contexts,components/timeline}/index.ts` | Barrel exports |

## Out of scope (deliberate)

Sidebar working-indicators (next PR) and bot message→trace provenance (PR 4). The chip also doesn't appear in `StreamSheet` (mobile sheet) — the compact top-bar pill covers mobile.

## Test plan

- [x] `bun run test src/components/timeline/stream-content.test.ts src/contexts/stream-agent-activity-context.test.tsx` — 75 pass (new summary + context cases)
- [x] Full monorepo typecheck + lint (pre-commit hook) — clean
- [x] Opus build → 2-lens adversarial review → fix: 2 findings applied (counter width jitter → tabular-nums; duplicated session-collapse → shared `dedupeRunningSessions`); final verify green
- [ ] Live in-browser verification — deferred to the stack-wide screenshot QA pass after PR 4

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jJRkyQ5e48EtnuKZJxKsv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786784210&installation_id=129946197&pr_number=1361&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1361&signature=7ac90ae91422a1dc641561087a05c8ebaaaa1e30c3c69e44a1b84b8da5ee4d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->