### PR TITLE
feat: deep-link external-bot messages to their agent trace

### DIFF
--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -562,11 +562,15 @@ export const AgentSessionRepository = {
   /**
    * Find a running session for a stream.
    *
-   * NOTE: This is a utility method for inspection/debugging. The main session
-   * creation flow uses `insertRunningOrSkip()` which atomically prevents duplicates
-   * via the partial unique index on (stream_id) WHERE status='running'.
+   * NOTE: Session *creation* never uses this — that goes through
+   * `insertRunningOrSkip()`, which atomically prevents duplicates via the partial
+   * unique index on (stream_id) WHERE status='running'. This read is for
+   * opportunistic trace stamping: the public-API bot `sendMessage` path calls it
+   * to deep-link a bot message to its live session.
    *
-   * Uses FOR UPDATE SKIP LOCKED to avoid blocking concurrent transactions.
+   * FOR UPDATE SKIP LOCKED means a momentarily-locked session row is treated as
+   * absent (returns null), so a caller racing an in-flight invocation simply skips
+   * the stamp rather than blocking — best-effort by design.
    */
   async findRunningByStream(db: Querier, streamId: string): Promise<AgentSession | null> {
     const result = await db.query<SessionRow>(

--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -302,6 +302,91 @@ describe("public API E2E-stream plaintext gate", () => {
   })
 })
 
+describe("public API bot send trace stamping", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  function botRequest(extra: Partial<Request> = {}): Request {
+    return {
+      workspaceId: "ws_1",
+      params: { streamId: "stream_1" },
+      body: { content: "hello" },
+      botApiKey: { botId: "bot_1" },
+      ...extra,
+    } as unknown as Request
+  }
+
+  function sendHarness() {
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Bot", archivedAt: null } as never)
+    const createMessageReturningConversation = mock(() =>
+      Promise.resolve({
+        message: {
+          id: "msg_new",
+          streamId: "stream_1",
+          sequence: 1n,
+          authorId: "bot_1",
+          authorType: "bot",
+          contentJson: { type: "doc", content: [] },
+          contentMarkdown: "hello",
+          reactions: {},
+          metadata: {},
+          editedAt: null,
+          createdAt: new Date(),
+        },
+        conversationId: undefined,
+      })
+    )
+    const botChannelService = {
+      isStreamAccessibleForBot: mock(() => Promise.resolve(true)),
+    } as unknown as PublicApiDeps["botChannelService"]
+    const handlers = createHandlers({
+      eventService: {
+        createMessageReturningConversation,
+        getMessageById: mock(() => Promise.resolve(null)),
+      } as unknown as EventService,
+      botChannelService,
+    })
+    return { handlers, createMessageReturningConversation }
+  }
+
+  it("stamps sessionId when a running session on the stream belongs to this bot", async () => {
+    spyOn(AgentSessionRepository, "findRunningByStream").mockResolvedValue({
+      id: "session_1",
+      personaId: "bot_1",
+    } as never)
+    const { handlers, createMessageReturningConversation } = sendHarness()
+
+    await handlers.sendMessage(botRequest(), createResponse())
+
+    expect(createMessageReturningConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session_1", authorId: "bot_1" })
+    )
+  })
+
+  it("does not stamp when the running session belongs to a different bot", async () => {
+    spyOn(AgentSessionRepository, "findRunningByStream").mockResolvedValue({
+      id: "session_1",
+      personaId: "bot_2",
+    } as never)
+    const { handlers, createMessageReturningConversation } = sendHarness()
+
+    await handlers.sendMessage(botRequest(), createResponse())
+
+    expect(createMessageReturningConversation).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }))
+  })
+
+  it("does not stamp when no session is running on the stream", async () => {
+    spyOn(AgentSessionRepository, "findRunningByStream").mockResolvedValue(null)
+    const { handlers, createMessageReturningConversation } = sendHarness()
+
+    await handlers.sendMessage(botRequest(), createResponse())
+
+    expect(createMessageReturningConversation).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }))
+  })
+})
+
 // E2E uploads are bot-only: a sealed harness turn can bind the row via the
 // sealed-messages/sealed-complete `attachmentIds`, but a user API key has no
 // sealed message-write path, so its E2E upload could never be referenced.

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -2361,6 +2361,19 @@ export function createPublicApiHandlers({
           throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
         }
 
+        // Stamp the message with the bot's running session so it deep-links to
+        // the trace (parity with the enclave path). Bot invocations register the
+        // session on `responseStreamId` under `personaId = bot.id`; match only a
+        // session on this exact stream owned by this bot — a plaintext send with
+        // no active invocation stays unstamped (bots CAN post without a claim).
+        // Known limitation: if a prior invocation's session sticks at
+        // status='running' (missed terminal event), a later unrelated plaintext
+        // send by the same bot on this stream mis-stamps to that stale session.
+        // The partial unique index caps it at one running session per stream, so
+        // this only misfires under the abnormal stuck-running state.
+        const runningSession = await AgentSessionRepository.findRunningByStream(pool, streamId)
+        const sessionId = runningSession?.personaId === bot.id ? runningSession.id : undefined
+
         const { message, conversationId } = await eventService.createMessageReturningConversation({
           workspaceId,
           streamId,
@@ -2372,6 +2385,7 @@ export function createPublicApiHandlers({
           clientMessageId,
           metadata,
           conversation,
+          sessionId,
         })
 
         res.status(201).json({

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -37,6 +37,19 @@ describe("getVisibleActions", () => {
     expect(ids).toEqual(["show-trace", "reply-in-thread", "copy-as-markdown", "copy-as-plain-text"])
   })
 
+  it("should include show-trace for bot messages with sessionId and traceUrl", () => {
+    const actions = getVisibleActions(
+      createContext({
+        actorType: "bot",
+        sessionId: "session_123",
+        traceUrl: "/trace/session_123",
+      })
+    )
+    const ids = actions.map((a) => a.id)
+
+    expect(ids).toContain("show-trace")
+  })
+
   it("should not include show-trace for persona messages without sessionId", () => {
     const actions = getVisibleActions(createContext({ actorType: "persona", traceUrl: "/trace/x" }))
     const ids = actions.map((a) => a.id)

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -29,6 +29,15 @@ import { stripMarkdown } from "@/lib/markdown"
 import { buildStreamLink, buildConversationLink } from "@/lib/stream-links"
 
 /**
+ * Actor types whose messages can carry an agent trace. The single source of
+ * truth shared with the `traceUrl` derivation in message-event.tsx so the two
+ * gates cannot drift when a new trace-eligible actor is added.
+ */
+export function isAgentTraceActor(actorType: string | null | undefined): boolean {
+  return actorType === "persona" || actorType === "bot"
+}
+
+/**
  * Context available to message actions.
  * Mirrors the Command pattern used in quick-switcher/commands.ts.
  */
@@ -40,7 +49,7 @@ export interface MessageActionContext {
   isThreadParent?: boolean
   /** URL for "reply in thread" */
   replyUrl: string
-  /** URL for "show trace" (only for persona messages) */
+  /** URL for "show trace" (persona or bot messages sent during a session) */
   traceUrl?: string
   /** Message ID for edit/delete operations */
   messageId?: string
@@ -316,7 +325,7 @@ export const messageActions: MessageAction[] = [
     id: "show-trace",
     label: "Show trace and sources",
     icon: Sparkles,
-    when: (ctx) => ctx.actorType === "persona" && !!ctx.sessionId && !!ctx.traceUrl,
+    when: (ctx) => isAgentTraceActor(ctx.actorType) && !!ctx.sessionId && !!ctx.traceUrl,
     getHref: (ctx) => ctx.traceUrl,
   },
   {

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -60,6 +60,7 @@ import { ReminderPickerSheet } from "./reminder-picker-sheet"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
 import { MessageActionDrawer } from "./message-action-drawer"
+import { isAgentTraceActor } from "./message-actions"
 import { ThreadSlot } from "./thread-slot"
 import { DeleteMessageDialog } from "./delete-message-dialog"
 import { MessageEditForm } from "./message-edit-form"
@@ -1149,7 +1150,7 @@ function SentMessageEvent({
       isThreadParent: panelId === threadId || isThreadParentProp,
       replyUrl: effectiveThreadId ? getPanelUrl(effectiveThreadId) : draftPanelUrl,
       traceUrl:
-        event.actorType === "persona" && payload.sessionId
+        isAgentTraceActor(event.actorType) && payload.sessionId
           ? getTraceUrl(payload.sessionId, payload.messageId)
           : undefined,
       messageId: payload.messageId,


### PR DESCRIPTION
**Stacked on** #1363 (sidebar) ← #1361 (header chip) ← #1360 (follow pill). Closes the stack.

## Problem

A message from an external bot can't be traced back to the agent session that produced it. Personas stamp `sessionId` onto the `message_created` payload (`event-service.ts:686`) and the enclave bot path does too (`enclave-runtimes/session-handlers.ts:268`), but a plaintext public-API bot send carries nothing — so the trace deep link (`?trace=<sessionId>&highlight=<messageId>`, which already scrolls to the producing step) has no way in from the message.

## Solution

Stamp the session on plaintext bot sends when the bot has a running session on the target stream, and widen the existing frontend trace-action gate from persona-only to persona-or-bot. No schema change, no new endpoints.

### How it works

1. **Backend** (`public-api/handlers.ts`, `sendMessage` bot branch): resolve `AgentSessionRepository.findRunningByStream(pool, streamId)` and pass `sessionId` into `createMessageReturningConversation` only when `runningSession.personaId === bot.id` (bot invocations register their session under `personaId = bot.id` on `responseStreamId`). A send with no active invocation stays unstamped — bots can post without a claim, unchanged.
2. **Frontend**: the trace-URL derivation in `message-event.tsx` and the `show-trace` `when` predicate in `message-actions.ts` now accept bot authors alongside personas. The existing "Show trace and sources" item appears automatically for bot messages carrying `payload.sessionId` — same label, same `getTraceUrl(sessionId, messageId)` destination.
3. **Other bot write paths need nothing**: the runtime step/complete message endpoints already run inside the claimed invocation lifecycle and stamp `session.id`.

### Key design decisions

**1. Conservative match: exact stream + same bot.** No root/thread cross-matching — a session on the root doesn't stamp a send into one of its threads. That would need an extra query for an uncommon case; the brief's rule was "stamp only on confident matches". Cross-thread sends stay unstamped (an acceptable miss, not a wrong link).

**2. `findRunningByStream` reused as-is.** Its `FOR UPDATE SKIP LOCKED` means a concurrently-locked session row reads as absent → stamp skipped. Best-effort by design; documented on the method (its old "inspection/debugging only" NOTE was stale — review finding, fixed).

**3. Known edge (documented in-code):** if a prior invocation's session is stuck at `status='running'` (missed terminal event), a later unrelated plaintext send by the same bot on that stream would stamp to the stale session. The partial unique index caps exposure at one running session per stream; only occurs in an already-abnormal state.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/public-api/handlers.ts` | Session stamp in the bot `sendMessage` branch |
| `apps/backend/src/features/public-api/e2e-stream-gate.test.ts` | 3 stamping cases (stamps on own running session; not without one; not on another bot's) |
| `apps/backend/src/features/agents/session-repository.ts` | `findRunningByStream` doc corrected to its real contract |
| `apps/frontend/src/components/timeline/message-event.tsx` | Trace-URL gate: persona → persona-or-bot |
| `apps/frontend/src/components/timeline/message-actions.ts` (+test) | `show-trace` predicate widened; bot case covered |

## Out of scope (deliberate)

Root↔thread session cross-matching (above). Retroactive stamping of past bot messages. The `sent_message_ids` reverse lookup (bot paths already record `message_sent` steps with `messageId`).

## Test plan

- [x] Backend `bun test src/features/public-api/e2e-stream-gate.test.ts` — 12 pass (3 new)
- [x] Frontend `vitest run src/components/timeline/message-actions.test.ts` — 74 pass (new bot show-trace case)
- [x] Full monorepo typecheck + lint (pre-commit hook) — clean
- [x] Opus build → 2-lens adversarial review → fix: 1 finding applied (stale doc comment on `findRunningByStream`)
- [ ] Live end-to-end with a real bot invocation — covered in the stack-wide browser QA pass (reported on the stack)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jJRkyQ5e48EtnuKZJxKsv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786788244&installation_id=129946197&pr_number=1364&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1364&signature=215a05e688721be931f48524288045c004bd49d95c9686935b3e547288d90aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->