### PR TITLE
fix: archived-scratchpad channel wedge (ifArchived=replace) + WorkOS 10s fail-fast

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -325,6 +325,41 @@ describe("BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession", (
   })
 })
 
+describe("BotRuntimeSessionLinkRepository.retireArchivedByRuntimeSession", () => {
+  afterEach(() => mock.restore())
+
+  it("retires the newest archived link (identity renamed, terminal 'ended') only while its root stream is still archived", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [
+      makeSessionLinkRow({ status: "ended", runtime_session_id: "sess_1:retired:brsl_1" }),
+    ])
+
+    const result = await BotRuntimeSessionLinkRepository.retireArchivedByRuntimeSession(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      runtimeKind: "claude-code-channel",
+      instanceId: "inst_99",
+      runtimeSessionId: "sess_1",
+    })
+
+    // Same race-safe CTE shape as reactivate, with the INVERSE stream guard:
+    // only retire while the scratchpad IS archived, so a concurrent unarchive
+    // serializes against the share lock instead of racing the row.
+    expect(captured.text).toContain("SET status = 'ended'")
+    expect(captured.text).toContain("runtime_session_id = l.runtime_session_id || ':retired:' || l.id")
+    expect(captured.text).toContain("status = 'archived'")
+    expect(captured.text).toContain("JOIN streams s")
+    expect(captured.text).toContain("archived_at IS NOT NULL")
+    expect(captured.text).toContain("FOR UPDATE OF l SKIP LOCKED")
+    expect(captured.text).toContain("FOR SHARE OF s")
+    expect(captured.text).toContain("LIMIT 1")
+    expect(captured.values).toEqual(
+      expect.arrayContaining(["ws_1", "bot_alice", "claude-code-channel", "inst_99", "sess_1"])
+    )
+    expect(result?.status).toBe("ended")
+  })
+})
+
 describe("BotRuntimeSessionLinkRepository.findArchivedByRuntimeSession", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -565,6 +565,53 @@ export const BotRuntimeSessionLinkRepository = {
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
 
+  /**
+   * Retire the newest archive-ended link for one runtime session identity —
+   * the session-create `ifArchived: "replace"` path. The identity's unique key
+   * (workspace, bot, kind, instance, session) is unconditional, so an archived
+   * link permanently blocks a fresh create until its runtime_session_id is
+   * renamed out of the way; the terminal 'ended' status keeps a later
+   * stream:unarchived from reviving a link no connector can reach anymore.
+   *
+   * The stream guard is the inverse of reactivate's: only retire while the
+   * scratchpad IS still archived, with the stream row share-locked in the same
+   * candidate select so a concurrent unarchive serializes against this commit
+   * (its consumer then finds no 'archived' link — the retire won) instead of
+   * racing the same row. Call inside a transaction.
+   */
+  async retireArchivedByRuntimeSession(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      runtimeKind: BotRuntimeKind
+      instanceId: string
+      runtimeSessionId: string
+    }
+  ): Promise<BotRuntimeSessionLink | null> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(sql`WITH candidate AS (
+        SELECT l.id FROM bot_runtime_session_links l
+        JOIN streams s
+          ON s.workspace_id = l.workspace_id AND s.id = l.root_stream_id AND s.archived_at IS NOT NULL
+        WHERE l.workspace_id = ${params.workspaceId}
+          AND l.bot_id = ${params.botId}
+          AND l.runtime_kind = ${params.runtimeKind}
+          AND l.instance_id = ${params.instanceId}
+          AND l.runtime_session_id = ${params.runtimeSessionId}
+          AND l.status = 'archived'
+        ORDER BY l.updated_at DESC
+        LIMIT 1
+        FOR UPDATE OF l SKIP LOCKED
+        FOR SHARE OF s
+      )
+      UPDATE bot_runtime_session_links l
+      SET status = 'ended', runtime_session_id = l.runtime_session_id || ':retired:' || l.id, updated_at = NOW()
+      FROM candidate
+      WHERE l.id = candidate.id
+      RETURNING l.*`)
+    return result.rows[0] ? mapSessionLink(result.rows[0]) : null
+  },
+
   /** Newest archive-ended link for one runtime session identity (regardless of the stream's archive state). */
   async findArchivedByRuntimeSession(
     db: Querier,

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -544,6 +544,38 @@ export class BotRuntimeService {
     })
   }
 
+  /**
+   * Session-create `ifArchived: "replace"`: the caller is a cold-started
+   * runtime whose deterministic identity points at an archived scratchpad the
+   * user is done with. Retire that link (terminal, identity renamed out of the
+   * unique key's way) so a fresh scratchpad can be created under the same
+   * identity. Returns false when there was nothing to retire — either the
+   * scratchpad got unarchived concurrently (the caller should retry the
+   * reattach) or the link is already gone.
+   */
+  async retireArchivedRuntimeSession(params: {
+    workspaceId: string
+    botId: string
+    runtimeKind: BotRuntimeKind
+    instanceId: string
+    runtimeSessionId: string
+  }): Promise<boolean> {
+    return withTransaction(this.pool, async (db) => {
+      const retired = await BotRuntimeSessionLinkRepository.retireArchivedByRuntimeSession(db, params)
+      if (!retired) return false
+      logger.info(
+        {
+          workspaceId: params.workspaceId,
+          botId: params.botId,
+          rootStreamId: retired.rootStreamId,
+          linkId: retired.id,
+        },
+        "Retired archived runtime session link for replacement"
+      )
+      return true
+    })
+  }
+
   async createInvocation(params: {
     workspaceId: string
     rootStreamId: string

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -986,13 +986,22 @@ export function createPublicApiHandlers({
       // (same scratchpad) rather than minting a duplicate; while the scratchpad
       // is still archived, refuse loudly so a self-healing client can tell
       // "wait" apart from "create" (INV-11).
-      const reattach = await botRuntimeService.reattachArchivedRuntimeSession({
+      const reattachParams = {
         workspaceId: req.workspaceId!,
         botId: bot.id,
         runtimeKind: data.runtimeKind,
         instanceId: data.instanceId,
         runtimeSessionId: data.runtimeSessionId,
-      })
+      }
+      let reattach = await botRuntimeService.reattachArchivedRuntimeSession(reattachParams)
+      if (reattach.status === "archived_stream" && data.ifArchived === "replace") {
+        // A cold start doesn't wait on an archived scratchpad the user is done
+        // with: retire its link (frees the identity) and fall through to a
+        // fresh create. Nothing to retire means a concurrent unarchive won the
+        // row — re-run the reattach so that revived link is resumed instead.
+        const retired = await botRuntimeService.retireArchivedRuntimeSession(reattachParams)
+        reattach = retired ? { status: "none" } : await botRuntimeService.reattachArchivedRuntimeSession(reattachParams)
+      }
       if (reattach.status === "archived_stream") {
         throw new HttpError("The linked scratchpad is archived; unarchive it to reattach", {
           status: 409,

--- a/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
@@ -215,21 +215,24 @@ describe("createBotRuntimeSession reattach after unarchive", () => {
   })
 
   it("ifArchived=wait (and default) keeps the 409 SCRATCHPAD_ARCHIVED contract", async () => {
-    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
-    const retireArchivedRuntimeSession = mock(() => Promise.resolve(true))
-    const handlers = createHandlers({
-      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
-      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "archived_stream" })),
-      retireArchivedRuntimeSession,
-      createLinkedScratchpadSession: mock(() => Promise.reject(new Error("must not create a new scratchpad"))),
-    })
-    const req = botRequest()
-    ;(req.body as Record<string, unknown>).ifArchived = "wait"
+    for (const ifArchived of ["wait", undefined]) {
+      spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+      const retireArchivedRuntimeSession = mock(() => Promise.resolve(true))
+      const handlers = createHandlers({
+        findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+        reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "archived_stream" })),
+        retireArchivedRuntimeSession,
+        createLinkedScratchpadSession: mock(() => Promise.reject(new Error("must not create a new scratchpad"))),
+      })
+      const req = botRequest()
+      if (ifArchived !== undefined) (req.body as Record<string, unknown>).ifArchived = ifArchived
 
-    await expect(handlers.createBotRuntimeSession(req, createResponse().res)).rejects.toMatchObject({
-      status: 409,
-      code: "SCRATCHPAD_ARCHIVED",
-    })
-    expect(retireArchivedRuntimeSession).not.toHaveBeenCalled()
+      await expect(handlers.createBotRuntimeSession(req, createResponse().res)).rejects.toMatchObject({
+        status: 409,
+        code: "SCRATCHPAD_ARCHIVED",
+      })
+      expect(retireArchivedRuntimeSession).not.toHaveBeenCalled()
+      mock.restore()
+    }
   })
 })

--- a/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
@@ -157,4 +157,79 @@ describe("createBotRuntimeSession reattach after unarchive", () => {
     expect(createLinkedScratchpadSession).toHaveBeenCalled()
     expect(cap.body()).toMatchObject({ data: { linkId: "brsl_new", rootStreamId: "stream_new" } })
   })
+
+  it("ifArchived=replace retires the archived link and creates a fresh scratchpad instead of 409ing", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const retireArchivedRuntimeSession = mock(() => Promise.resolve(true))
+    const createLinkedScratchpadSession = mock(() =>
+      Promise.resolve({
+        link: { id: "brsl_new", rootStreamId: "stream_new", activeStreamId: "stream_new", runtimeSessionId: "sess_1" },
+        stream: { id: "stream_new" },
+      })
+    )
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "archived_stream" })),
+      retireArchivedRuntimeSession,
+      createLinkedScratchpadSession,
+    })
+    const req = botRequest()
+    ;(req.body as Record<string, unknown>).ifArchived = "replace"
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(req, cap.res)
+
+    expect(retireArchivedRuntimeSession).toHaveBeenCalled()
+    expect(createLinkedScratchpadSession).toHaveBeenCalled()
+    expect(cap.body()).toMatchObject({ data: { linkId: "brsl_new", rootStreamId: "stream_new" } })
+  })
+
+  it("ifArchived=replace resumes the revived link when a concurrent unarchive wins the retire race", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    spyOn(db, "withTransaction").mockImplementation(async (_pool, fn) => fn({} as never))
+    const createLinkedScratchpadSession = mock(() => Promise.reject(new Error("must not create a new scratchpad")))
+    // Nothing to retire (the stream is no longer archived) → the handler re-runs
+    // the reattach and resumes the link the unarchive consumer revived.
+    const reattach = mock()
+      .mockResolvedValueOnce({ status: "archived_stream" })
+      .mockResolvedValueOnce({
+        status: "reattached",
+        link: { id: "brsl_1", rootStreamId: "stream_old", activeStreamId: "stream_old", runtimeSessionId: "sess_1" },
+      })
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: reattach,
+      retireArchivedRuntimeSession: mock(() => Promise.resolve(false)),
+      repairBotTraitsInTransaction: mock(() => Promise.resolve()),
+      createLinkedScratchpadSession,
+    })
+    const req = botRequest()
+    ;(req.body as Record<string, unknown>).ifArchived = "replace"
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(req, cap.res)
+
+    expect(createLinkedScratchpadSession).not.toHaveBeenCalled()
+    expect(cap.body()).toMatchObject({ data: { linkId: "brsl_1", rootStreamId: "stream_old" } })
+  })
+
+  it("ifArchived=wait (and default) keeps the 409 SCRATCHPAD_ARCHIVED contract", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const retireArchivedRuntimeSession = mock(() => Promise.resolve(true))
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "archived_stream" })),
+      retireArchivedRuntimeSession,
+      createLinkedScratchpadSession: mock(() => Promise.reject(new Error("must not create a new scratchpad"))),
+    })
+    const req = botRequest()
+    ;(req.body as Record<string, unknown>).ifArchived = "wait"
+
+    await expect(handlers.createBotRuntimeSession(req, createResponse().res)).rejects.toMatchObject({
+      status: 409,
+      code: "SCRATCHPAD_ARCHIVED",
+    })
+    expect(retireArchivedRuntimeSession).not.toHaveBeenCalled()
+  })
 })

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -165,6 +165,13 @@ export const createRuntimeSessionSchema = z.object({
   // follow-up provisioning call, because the wrap AAD binds to the server-minted
   // stream id. Personal bots only (a shared bot has no owner to wrap to).
   e2e: z.object({ ownerKeyId: z.string().min(1).max(128) }).optional(),
+  // What to do when this identity's link exists but its scratchpad is archived.
+  // "wait" (default) 409s with SCRATCHPAD_ARCHIVED — the archive-grace reattach
+  // probe uses it so an unarchive within the window revives the SAME scratchpad.
+  // "replace" retires the archived link (terminal, identity freed) and creates a
+  // fresh scratchpad — cold starts use it so a deliberately archived scratchpad
+  // can never wedge auto-connect for its project directory.
+  ifArchived: z.enum(["wait", "replace"]).optional(),
 })
 
 // Generation-0 SSK wraps a sealed harness provisions right after creating its

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -256,16 +256,16 @@ describe("claude-code-channel runtime sessions", () => {
     await archiveStream(client, workspace.id, first.data.data.rootStreamId)
 
     // Wait for the outbox to end the link (the default/wait contract 409s).
-    let sawArchivedConflict = false
-    for (let i = 0; i < 50 && !sawArchivedConflict; i++) {
+    let archivedConflict: { status: number; data: { code?: string } } | undefined
+    for (let i = 0; i < 50 && !archivedConflict; i++) {
       const whileArchived = await botApiPost<{ code?: string }>(client, workspace.id, "/bot-runtime/sessions", apiKey, {
         ...body,
         ifArchived: "wait",
       })
-      if (whileArchived.status === 409) sawArchivedConflict = true
+      if (whileArchived.status === 409) archivedConflict = whileArchived
       else await new Promise((resolve) => setTimeout(resolve, 200))
     }
-    expect(sawArchivedConflict).toBe(true)
+    expect(archivedConflict).toMatchObject({ status: 409, data: { code: "SCRATCHPAD_ARCHIVED" } })
 
     const replaced = await botApiPost<{ data: SessionLinkData }>(
       client,

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -218,6 +218,86 @@ describe("claude-code-channel runtime sessions", () => {
     expect(claimed.promptMarkdown).toContain("back-from-archive")
   })
 
+  // Cold-start replace: a fresh channel launch whose deterministic identity
+  // points at a scratchpad the user archived must NOT wedge on 409s —
+  // `ifArchived: "replace"` retires the archived link and mints a fresh
+  // scratchpad under the same identity. A later unarchive of the old
+  // scratchpad must not hijack the identity back.
+  test("ifArchived=replace creates a fresh scratchpad when the linked scratchpad is archived", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-repl-${testRunId}@test.com`, "CC Replace User")
+    const workspace = await createWorkspace(client, `CC Replace WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCP ${testRunId}`,
+      slug: `ccp-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+    ])
+
+    const body = {
+      runtimeKind: "claude-code-channel",
+      instanceId: `ccp-inst-${testRunId}`,
+      runtimeSessionId: `ccp-sess-${testRunId}`,
+      displayName: "Claude Code - repl",
+      localCwd: "/tmp/threa-cc-repl",
+    }
+    const first = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      body
+    )
+    expect(first.status).toBe(200)
+    await archiveStream(client, workspace.id, first.data.data.rootStreamId)
+
+    // Wait for the outbox to end the link (the default/wait contract 409s).
+    let sawArchivedConflict = false
+    for (let i = 0; i < 50 && !sawArchivedConflict; i++) {
+      const whileArchived = await botApiPost<{ code?: string }>(client, workspace.id, "/bot-runtime/sessions", apiKey, {
+        ...body,
+        ifArchived: "wait",
+      })
+      if (whileArchived.status === 409) sawArchivedConflict = true
+      else await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    expect(sawArchivedConflict).toBe(true)
+
+    const replaced = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      {
+        ...body,
+        ifArchived: "replace",
+      }
+    )
+    expect(replaced.status).toBe(200)
+    // A fresh scratchpad under the same identity — not the archived one.
+    expect(replaced.data.data.rootStreamId).not.toBe(first.data.data.rootStreamId)
+    expect(replaced.data.data.linkId).not.toBe(first.data.data.linkId)
+    expect(replaced.data.data.runtimeSessionId).toBe(body.runtimeSessionId)
+
+    // Unarchiving the OLD scratchpad must not steal the identity back: the
+    // retired link is terminal, so a repeat create resumes the replacement.
+    await unarchiveStream(client, workspace.id, first.data.data.rootStreamId)
+    const after = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      body
+    )
+    expect(after.status).toBe(200)
+    expect(after.data.data.linkId).toBe(replaced.data.data.linkId)
+    expect(after.data.data.rootStreamId).toBe(replaced.data.data.rootStreamId)
+  })
+
   test("rejects a link-free runtime kind", async () => {
     const client = new TestClient()
     await loginAs(client, `cc-reject-${testRunId}@test.com`, "CC Reject User")

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1119,7 +1119,8 @@
                     "properties": { "ownerKeyId": { "type": "string", "minLength": 1, "maxLength": 128 } },
                     "required": ["ownerKeyId"],
                     "additionalProperties": false
-                  }
+                  },
+                  "ifArchived": { "type": "string", "enum": ["wait", "replace"] }
                 },
                 "required": ["runtimeKind", "instanceId", "runtimeSessionId", "displayName"],
                 "additionalProperties": false

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -1119,7 +1119,8 @@
                     "properties": { "ownerKeyId": { "type": "string", "minLength": 1, "maxLength": 128 } },
                     "required": ["ownerKeyId"],
                     "additionalProperties": false
-                  }
+                  },
+                  "ifArchived": { "type": "string", "enum": ["wait", "replace"] }
                 },
                 "required": ["runtimeKind", "instanceId", "runtimeSessionId", "displayName"],
                 "additionalProperties": false

--- a/extensions/remote-session/src/client.ts
+++ b/extensions/remote-session/src/client.ts
@@ -128,16 +128,26 @@ export class ThreaClient {
       // cap it — a proxy/server 5xx can return a large HTML page, which we must
       // not pull into memory.
       let code: string | undefined
+      let serverMessage: string | undefined
       if (response.headers.get("content-type")?.includes("application/json")) {
         try {
           const body = (await response.text()).slice(0, 2000)
-          const parsed = JSON.parse(body) as { code?: unknown }
+          const parsed = JSON.parse(body) as { code?: unknown; error?: unknown }
           if (typeof parsed.code === "string") code = parsed.code
+          if (typeof parsed.error === "string") serverMessage = parsed.error
         } catch {
           code = undefined
         }
       }
-      throw new ThreaApiError(`Threa API ${response.status}: ${response.statusText}`, response.status, code)
+      // Carry the structured code + server message in the text too — most call
+      // sites log `error.message` only, and "Threa API 409: Conflict" gives the
+      // user nothing to act on.
+      const detail = [code, serverMessage].filter(Boolean).join(" — ")
+      throw new ThreaApiError(
+        `Threa API ${response.status}${detail ? ` (${detail})` : `: ${response.statusText}`}`,
+        response.status,
+        code
+      )
     }
     if (response.status === 204) return undefined as T
     return (await response.json()) as T

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -451,9 +451,38 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     await new Promise((resolve) => setTimeout(resolve, 250))
 
     expect(created.length).toBeGreaterThanOrEqual(1)
+    // The probe WAITS on the archived scratchpad (grace-window reattach) — it
+    // must never ask the server to replace it with a fresh one.
+    expect((created[0] as Record<string, unknown>).ifArchived).toBe("wait")
     expect(asInternal(session).archivePending).toBeUndefined()
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
     expect(archived).toEqual([])
+    await session.shutdown()
+  })
+
+  test("a cold-start link asks the server to replace an archived scratchpad (ifArchived=replace)", async () => {
+    const created: unknown[] = []
+    const client = {
+      createSession: async (body: unknown) => {
+        created.push(body)
+        return {
+          linkId: "brsl_1",
+          rootStreamId: "stream_root",
+          activeStreamId: "stream_root",
+          runtimeSessionId: "rts-test",
+          streamUrlPath: "/w/ws_1/s/stream_root",
+        }
+      },
+    } as unknown as ThreaClient
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport)
+
+    await (session as unknown as { ensureLink: () => Promise<void> }).ensureLink()
+
+    // No archivePending at cold start: a deterministic identity pointing at a
+    // scratchpad the user archived must mint a fresh one, not wedge on 409s.
+    expect(created).toHaveLength(1)
+    expect((created[0] as Record<string, unknown>).ifArchived).toBe("replace")
     await session.shutdown()
   })
 

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -443,8 +443,20 @@ export class RemoteSession {
       this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
       await this.syncPresence()
     } catch (error) {
-      this.log(`could not link to Threa (will retry): ${this.summarize(error)}`)
+      this.log(`could not link to Threa (will retry): ${this.summarize(error)}${this.linkErrorHint(error)}`)
     }
+  }
+
+  /** Actionable next step for the link failures a retry alone will never fix. */
+  private linkErrorHint(error: unknown): string {
+    if (!(error instanceof ThreaApiError)) return ""
+    if (error.status === 401 || error.status === 403) {
+      return " — check THREA_API_KEY (must be a bot key, threa_bk_…) and THREA_WORKSPACE_ID"
+    }
+    if (error.code === "SCRATCHPAD_ARCHIVED" && !this.archivePending) {
+      return " — the server does not support ifArchived replace yet; unarchive the scratchpad in Threa to link"
+    }
+    return ""
   }
 
   async shutdown(): Promise<void> {
@@ -497,6 +509,12 @@ export class RemoteSession {
       runtimeSessionId: this.config.runtimeSessionId,
       displayName: this.config.displayName,
       localCwd: process.cwd(),
+      // Detached-pending-restore probes must WAIT on the archived scratchpad so
+      // an unarchive inside the grace window reattaches the same one. A cold
+      // start must not: the deterministic identity pointing at a scratchpad the
+      // user archived would otherwise wedge linking forever — replace it with a
+      // fresh scratchpad instead.
+      ifArchived: this.archivePending ? "wait" : "replace",
       ...(this.config.defaultLabel && { labelName: this.config.defaultLabel }),
       ...(e2e ? { e2e: { ownerKeyId: e2e.ownerKeyId } } : {}),
     })

--- a/packages/backend-common/src/auth/api-key-service.ts
+++ b/packages/backend-common/src/auth/api-key-service.ts
@@ -1,6 +1,6 @@
 import { WorkOS } from "@workos-inc/node"
 import { logger } from "../logger"
-import type { WorkosConfig } from "./types"
+import { WORKOS_REQUEST_TIMEOUT_MS, type WorkosConfig } from "./types"
 
 export interface ValidatedApiKey {
   id: string
@@ -17,7 +17,7 @@ export class WorkosApiKeyService implements ApiKeyService {
   private workos: WorkOS
 
   constructor(config: WorkosConfig) {
-    this.workos = new WorkOS(config.apiKey, { clientId: config.clientId })
+    this.workos = new WorkOS(config.apiKey, { clientId: config.clientId, timeout: WORKOS_REQUEST_TIMEOUT_MS })
   }
 
   async validateApiKey(value: string): Promise<ValidatedApiKey | null> {

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -80,16 +80,17 @@ export class StubAuthService implements AuthService {
         success: false,
         refreshed: false,
         reason: "no_session_cookie_provided",
+        terminal: true,
       }
     }
 
     const match = sealedSession.match(/^test_session_(.+)$/)
     if (!match) {
-      return { success: false, refreshed: false, reason: "invalid_session_format" }
+      return { success: false, refreshed: false, reason: "invalid_session_format", terminal: true }
     }
 
     if (this.revoked.has(sealedSession)) {
-      return { success: false, refreshed: false, reason: "session_revoked" }
+      return { success: false, refreshed: false, reason: "session_revoked", terminal: true }
     }
 
     const userId = match[1]

--- a/packages/backend-common/src/auth/auth-service.test.ts
+++ b/packages/backend-common/src/auth/auth-service.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { WorkosAuthService } from "./auth-service"
+
+const CONFIG = {
+  apiKey: "sk_test",
+  clientId: "client_test",
+  redirectUri: "https://app.test/callback",
+  cookiePassword: "x".repeat(32),
+}
+
+interface FakeSession {
+  authenticate: () => Promise<unknown>
+  refresh: () => Promise<unknown>
+}
+
+/** Service whose loadSealedSession returns the given fake session (no WorkOS network). */
+function makeService(session: FakeSession): { service: WorkosAuthService; refreshCalls: () => number } {
+  const service = new WorkosAuthService(CONFIG)
+  let refreshCalls = 0
+  const wrapped: FakeSession = {
+    authenticate: session.authenticate,
+    refresh: () => {
+      refreshCalls++
+      return session.refresh()
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(service as any).workos = { userManagement: { loadSealedSession: () => wrapped } }
+  return { service, refreshCalls: () => refreshCalls }
+}
+
+const USER = { id: "user_1", email: "u@example.com", firstName: null, lastName: null }
+
+describe("WorkosAuthService.authenticateSession failure classification", () => {
+  test("invalid_grant refresh rejection is NOT terminal (concurrent rotation race must not clear the cookie)", async () => {
+    const { service } = makeService({
+      authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
+      refresh: async () => ({ authenticated: false, reason: "invalid_grant" }),
+    })
+
+    const result = await service.authenticateSession("sealed")
+
+    expect(result).toMatchObject({ success: false, reason: "invalid_grant", terminal: false })
+  })
+
+  test("a refresh that throws (WorkOS unreachable) is NOT terminal — an outage must not force logouts", async () => {
+    const { service } = makeService({
+      authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
+      refresh: async () => {
+        throw new Error("Request timeout")
+      },
+    })
+
+    const result = await service.authenticateSession("sealed")
+
+    expect(result).toMatchObject({ success: false, terminal: false })
+  })
+
+  test("mfa_enrollment / sso_required refresh rejections are terminal (fresh login flow required)", async () => {
+    for (const reason of ["mfa_enrollment", "sso_required"]) {
+      const { service } = makeService({
+        authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
+        refresh: async () => ({ authenticated: false, reason }),
+      })
+      expect(await service.authenticateSession("sealed")).toMatchObject({ success: false, reason, terminal: true })
+    }
+  })
+
+  test("an unsealable cookie is terminal and never reaches refresh (which would throw on the same unseal)", async () => {
+    const { service, refreshCalls } = makeService({
+      authenticate: async () => ({ authenticated: false, reason: "invalid_session_cookie" }),
+      refresh: async () => {
+        throw new Error("unseal failed")
+      },
+    })
+
+    const result = await service.authenticateSession("sealed")
+
+    expect(result).toMatchObject({ success: false, reason: "invalid_session_cookie", terminal: true })
+    expect(refreshCalls()).toBe(0)
+  })
+
+  test("an empty cookie value is terminal", async () => {
+    const { service } = makeService({
+      authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
+      refresh: async () => ({ authenticated: false, reason: "invalid_grant" }),
+    })
+    expect(await service.authenticateSession("")).toMatchObject({ success: false, terminal: true })
+  })
+
+  test("a successful refresh returns the rotated sealed session", async () => {
+    const { service } = makeService({
+      authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
+      refresh: async () => ({
+        authenticated: true,
+        sealedSession: "sealed_v2",
+        user: USER,
+        permissions: ["messages:read"],
+      }),
+    })
+
+    const result = await service.authenticateSession("sealed_v1")
+
+    expect(result).toMatchObject({
+      success: true,
+      refreshed: true,
+      sealedSession: "sealed_v2",
+      user: { id: "user_1", permissions: ["messages:read"] },
+    })
+  })
+})

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from "@workos-inc/node"
 import type { SocialProvider } from "@threa/types"
 import { logger } from "../logger"
-import type { WorkosConfig } from "./types"
+import { WORKOS_REQUEST_TIMEOUT_MS, type WorkosConfig } from "./types"
 
 export interface AuthResult {
   success: boolean
@@ -110,7 +110,7 @@ export class WorkosAuthService implements AuthService {
     this.clientId = config.clientId
     this.cookiePassword = config.cookiePassword
     this.redirectUri = config.redirectUri
-    this.workos = new WorkOS(config.apiKey, { clientId: this.clientId })
+    this.workos = new WorkOS(config.apiKey, { clientId: this.clientId, timeout: WORKOS_REQUEST_TIMEOUT_MS })
   }
 
   async authenticateSession(sealedSession: string): Promise<AuthResult> {

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -1,4 +1,8 @@
-import { WorkOS } from "@workos-inc/node"
+import {
+  AuthenticateWithSessionCookieFailureReason,
+  RefreshAndSealSessionDataFailureReason,
+  WorkOS,
+} from "@workos-inc/node"
 import type { SocialProvider } from "@threa/types"
 import { logger } from "../logger"
 import { WORKOS_REQUEST_TIMEOUT_MS, type WorkosConfig } from "./types"
@@ -25,6 +29,18 @@ export interface AuthResult {
   sealedSession?: string
   refreshed: boolean
   reason?: string
+  /**
+   * Set on failures: true only when WorkOS definitively rejected the SESSION
+   * itself (unsealable cookie, MFA/SSO required), so clearing the cookie is
+   * safe. False for `invalid_grant` — in a concurrent-request burst it usually
+   * means a sibling request just rotated this refresh token and its Set-Cookie
+   * is already on the wire (WorkOS rotates refresh tokens on use); clearing
+   * here would destroy that newer session. Also false when WorkOS was simply
+   * unreachable (timeout/network/5xx) — an outage says nothing about the
+   * session's validity, and clearing turned the 2026-07-16 WorkOS incident
+   * into mass forced logouts.
+   */
+  terminal?: boolean
 }
 
 /**
@@ -100,6 +116,19 @@ export interface AuthService {
   revokeSession(sealedSession: string): Promise<boolean>
 }
 
+/**
+ * Whether a WorkOS refresh rejection kills the session for good.
+ * `invalid_grant` deliberately is NOT terminal: with rotating refresh tokens
+ * it usually means a concurrent request already rotated this token (its
+ * Set-Cookie is on the wire); a genuinely revoked session just keeps 401ing
+ * until the client re-authenticates — no cookie clearing needed. MFA/SSO
+ * requirements ARE terminal: the session cannot proceed without a fresh login
+ * flow, so keeping the cookie only loops the failure.
+ */
+function isTerminalRefreshReason(reason: RefreshAndSealSessionDataFailureReason): boolean {
+  return reason !== RefreshAndSealSessionDataFailureReason.INVALID_GRANT
+}
+
 export class WorkosAuthService implements AuthService {
   private workos: WorkOS
   private clientId: string
@@ -119,6 +148,7 @@ export class WorkosAuthService implements AuthService {
         success: false,
         refreshed: false,
         reason: "no_session_cookie_provided",
+        terminal: true,
       }
     }
 
@@ -143,7 +173,11 @@ export class WorkosAuthService implements AuthService {
       }
     }
 
-    if (authRes.reason !== "no_session_cookie_provided") {
+    // Refresh only when the cookie unsealed fine but its JWT is stale
+    // (INVALID_JWT). An unsealable cookie must not reach refresh(): the SDK
+    // re-unseals there WITHOUT a catch, so it would throw into the
+    // network-error path below and the dead cookie would never be cleared.
+    if (authRes.reason === AuthenticateWithSessionCookieFailureReason.INVALID_JWT) {
       try {
         const refreshResult = await session.refresh({
           cookiePassword: this.cookiePassword,
@@ -163,8 +197,22 @@ export class WorkosAuthService implements AuthService {
             refreshed: true,
           }
         }
+        // WorkOS definitively rejected the refresh (the SDK returns instead of
+        // throwing for known OAuth errors). Only a subset is terminal — see
+        // isTerminalRefreshReason for why invalid_grant is deliberately not.
+        if (!refreshResult.authenticated) {
+          return {
+            success: false,
+            refreshed: false,
+            reason: refreshResult.reason,
+            terminal: isTerminalRefreshReason(refreshResult.reason),
+          }
+        }
       } catch (error) {
+        // WorkOS unreachable (timeout / network / 5xx): says nothing about the
+        // session's validity — never terminal, the client retries.
         logger.error({ err: error, reason: authRes.reason }, "Session refresh error")
+        return { success: false, refreshed: false, reason: authRes.reason, terminal: false }
       }
     }
 
@@ -172,6 +220,9 @@ export class WorkosAuthService implements AuthService {
       success: false,
       refreshed: false,
       reason: authRes.reason,
+      // Reached with an unsealable/empty cookie (no refresh was possible) —
+      // retrying the same value can never succeed, so clearing is safe.
+      terminal: true,
     }
   }
 

--- a/packages/backend-common/src/auth/middleware.test.ts
+++ b/packages/backend-common/src/auth/middleware.test.ts
@@ -27,10 +27,17 @@ class FakeAuthService implements AuthService {
   }
 }
 
-function makeRes(): Response {
+interface CapturingRes {
+  statusCode: number
+  body: unknown
+  clearedCookies: string[]
+}
+
+function makeRes(): Response & CapturingRes {
   const res = {
     statusCode: 0,
     body: undefined as unknown,
+    clearedCookies: [] as string[],
     status(code: number) {
       this.statusCode = code
       return this
@@ -39,14 +46,15 @@ function makeRes(): Response {
       this.body = body
       return this
     },
-    clearCookie() {
+    clearCookie(name: string) {
+      this.clearedCookies.push(name)
       return this
     },
     cookie() {
       return this
     },
   }
-  return res as unknown as Response
+  return res as unknown as Response & CapturingRes
 }
 
 describe("createAuthMiddleware", () => {
@@ -130,5 +138,36 @@ describe("createAuthMiddleware", () => {
     await middleware(req, makeRes(), () => {})
 
     expect(req.authUser?.permissions).toBeNull()
+  })
+
+  test("non-terminal auth failure 401s WITHOUT clearing the session cookie (refresh race / WorkOS outage)", async () => {
+    const middleware = createAuthMiddleware({
+      authService: new FakeAuthService({ success: false, refreshed: false, reason: "invalid_grant", terminal: false }),
+    })
+
+    const req = { cookies: { [sessionCookieName]: "session" } } as unknown as Request
+    const res = makeRes()
+    await middleware(req, res, () => {})
+
+    expect(res.statusCode).toBe(401)
+    expect(res.clearedCookies).toEqual([])
+  })
+
+  test("terminal auth failure clears the session cookie", async () => {
+    const middleware = createAuthMiddleware({
+      authService: new FakeAuthService({
+        success: false,
+        refreshed: false,
+        reason: "invalid_session_cookie",
+        terminal: true,
+      }),
+    })
+
+    const req = { cookies: { [sessionCookieName]: "session" } } as unknown as Request
+    const res = makeRes()
+    await middleware(req, res, () => {})
+
+    expect(res.statusCode).toBe(401)
+    expect(res.clearedCookies).toContain(sessionCookieName)
   })
 })

--- a/packages/backend-common/src/auth/middleware.ts
+++ b/packages/backend-common/src/auth/middleware.ts
@@ -48,7 +48,13 @@ export function createAuthMiddleware({ authService }: Dependencies) {
     const result = await authService.authenticateSession(session)
 
     if (!result.success || !result.user) {
-      clearSessionCookie(res)
+      // Clear the cookie only when the session is definitively dead
+      // (result.terminal). On an invalid_grant race a sibling request just
+      // rotated the token and its Set-Cookie is already on the wire — clearing
+      // here would arrive later and destroy that newer session. On a WorkOS
+      // outage (refresh threw) the session may be perfectly valid — clearing
+      // turns a provider blip into a mass forced logout.
+      if (result.terminal) clearSessionCookie(res)
       return res.status(401).json({ error: "Session expired" })
     }
 

--- a/packages/backend-common/src/auth/types.ts
+++ b/packages/backend-common/src/auth/types.ts
@@ -4,3 +4,13 @@ export interface WorkosConfig {
   redirectUri: string
   cookiePassword: string
 }
+
+/**
+ * Timeout for every WorkOS API call. The SDK's default is 60s, which turned
+ * the 2026-07-16 WorkOS platform incident into 60-second request hangs on the
+ * auth hot path (session refresh runs inside request middleware): the browser's
+ * per-origin connection pool filled with hung requests and the whole app froze
+ * ("Sending…", reconnect pill, archival timeouts). Failing fast keeps a WorkOS
+ * blip a quick 401 the client can retry instead of a minute-long stall.
+ */
+export const WORKOS_REQUEST_TIMEOUT_MS = 10_000

--- a/packages/backend-common/src/auth/workos-org-service.ts
+++ b/packages/backend-common/src/auth/workos-org-service.ts
@@ -1,6 +1,6 @@
 import { WorkOS } from "@workos-inc/node"
 import { logger } from "../logger"
-import type { WorkosConfig } from "./types"
+import { WORKOS_REQUEST_TIMEOUT_MS, type WorkosConfig } from "./types"
 
 type WidgetScope =
   | "widgets:api-keys:manage"
@@ -146,7 +146,7 @@ export class WorkosOrgServiceImpl implements WorkosOrgService {
   private workos: WorkOS
 
   constructor(config: WorkosConfig) {
-    this.workos = new WorkOS(config.apiKey, { clientId: config.clientId })
+    this.workos = new WorkOS(config.apiKey, { clientId: config.clientId, timeout: WORKOS_REQUEST_TIMEOUT_MS })
   }
 
   async createOrganization(params: { name: string; externalId: string }): Promise<{ id: string }> {


### PR DESCRIPTION
Two connectivity fixes from today's troubleshooting session: the archived-scratchpad auto-connect wedge for channel connectors, and the WorkOS 60s-hang amplification that froze the app during today's WorkOS incident.

## Problem

**1. Archived scratchpad wedges channel auto-connect forever.** A connector's `runtimeSessionId` is a deterministic hash of `host:cwd` (`deriveStableId` in `extensions/remote-session/src/identity.ts`), and `bot_runtime_session_links` has an unconditional `UNIQUE (workspace_id, bot_id, runtime_kind, instance_id, runtime_session_id)`. Once a project's scratchpad is archived, its link row (status `archived`) permanently occupies that identity: every future channel launch in that directory gets `409 SCRATCHPAD_ARCHIVED` from session-create, and the SDK's `ensureLink` logs a generic "could not link (will retry)" to stderr and retries forever. From the user's side the project silently never connects (observed with the `seer` project).

**2. WorkOS blips freeze the whole app for 60s per request.** The `@workos-inc/node` SDK's default fetch timeout is 60s. Session auth runs in request middleware; when an access token is expired, `session.refresh()` calls api.workos.com. During today's WorkOS platform incident (08:26–~10:30 UTC, confirmed on status.workos.com), prod logs show bursts of bootstrap/sync/drafts/commands requests hanging **exactly 60003–60007ms then 401ing** (~100 `Session refresh error: OauthException: Request timeout` per hour). Hung requests filled the browser's per-origin connection pool — reconnect pill, messages stuck in "Sending…", archival timing out at the frontend's 20s. Backend itself was healthy the whole time (0.15/32 vCPU, 13–266ms normal response times).

## Solution

### Archived-scratchpad replace (`ifArchived`)

Session-create gains `ifArchived: "wait" | "replace"` (`createRuntimeSessionSchema`):

- **`"wait"` (default, wire-compatible)** keeps the exact 409 contract — the archive-grace reattach probe depends on it so an unarchive within the grace window revives the SAME scratchpad (PR #1266 semantics untouched).
- **`"replace"`** retires the archived link and falls through to a fresh scratchpad create under the same deterministic identity.

Mechanism:

1. `BotRuntimeSessionLinkRepository.retireArchivedByRuntimeSession` — same race-safe CTE shape as `reactivateArchivedByRuntimeSession` with the **inverse stream guard** (`s.archived_at IS NOT NULL`, `FOR SHARE OF s`, `FOR UPDATE OF l SKIP LOCKED`): sets status to terminal `ended` and renames `runtime_session_id` to `<id>:retired:<linkId>`, freeing the unique key. Terminal + renamed means a later unarchive of the old scratchpad cannot revive a link no connector can reach, and cannot steal the identity back.
2. `createBotRuntimeSession` handler: on `archived_stream` + `ifArchived === "replace"`, retire → create fresh. If the retire finds nothing (a concurrent unarchive won the row — the share lock serializes this), it re-runs the reattach and resumes the revived link instead. The existing 23505 recovery path is unchanged.
3. SDK (`extensions/remote-session/src/session.ts`): `createSession` sends `ifArchived: this.archivePending ? "wait" : "replace"` — cold starts replace, detached-pending-restore probes wait.
4. `ThreaApiError` now carries the server's structured `code` + `error` message in its text (`Threa API 409 (SCRATCHPAD_ARCHIVED — …)`), and `ensureLink` appends actionable hints for 401/403 (check `THREA_API_KEY`) and the archived-wedge-on-old-server case.

Old client + new server: default `wait`, behavior unchanged. New client + old server: Zod strips the unknown key, old wedge behavior remains but is now loudly diagnosed.

### Race-tolerant session middleware (Kris's ruling: distributed-correct, not process-local)

The originally floated per-process single-flight refresh map was dropped as too local for a distributed app. Instead the middleware is now race-*tolerant*, stateless, correct on any replica/region topology:

- `AuthResult.terminal` (auth-service.ts): set only when WorkOS definitively killed the session — unsealable cookie, `mfa_enrollment`, `sso_required`, empty value. `invalid_grant` is deliberately NOT terminal: with rotating refresh tokens it usually means a sibling request just rotated the token and its `Set-Cookie` is already on the wire; a genuinely revoked session keeps 401ing until the client re-authenticates. A **thrown** refresh (WorkOS unreachable) is also non-terminal — during today's incident the unconditional clear force-logged users out.
- `createAuthMiddleware` clears the session cookie only on `terminal`; otherwise plain 401 and the client retries with whatever cookie it now holds.
- Refresh is now gated on `INVALID_JWT` (was: anything except `no_session_cookie_provided`): the SDK's `refresh()` re-unseals the cookie without a catch, so an unsealable cookie reaching it would throw into the outage path and never clear.
- Control-plane's explicit `clearSessionCookie` calls (logout/remove-account flows) are deliberate and untouched; socket auth has no cookie to clear.

Follow-up (own design doc + PR): client-side refresh coordination — middleware verifies only and 401s fast, the frontend fetch layer performs exactly one refresh (shared promise + Web Lock across tabs) and replays.

### WorkOS fail-fast

`WORKOS_REQUEST_TIMEOUT_MS = 10_000` in `packages/backend-common/src/auth/types.ts`, passed to every WorkOS client construction (`auth-service.ts`, `workos-org-service.ts`, `api-key-service.ts` — the only three; control-plane consumes these). A WorkOS blip becomes a fast retryable 401 instead of a minute-long app freeze. The constant's comment records today's incident as the why.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/public-api/schemas.ts` | `ifArchived: z.enum(["wait", "replace"]).optional()` on `createRuntimeSessionSchema` |
| `apps/backend/src/features/public-api/handlers.ts` | replace branch: retire → fresh create; retire-miss re-runs reattach |
| `apps/backend/src/features/bot-runtimes/repository.ts` | `retireArchivedByRuntimeSession` (race-safe CTE, terminal rename) |
| `apps/backend/src/features/bot-runtimes/service.ts` | `retireArchivedRuntimeSession` transaction wrapper |
| `extensions/remote-session/src/session.ts` | cold-start `replace` vs probe `wait`; `linkErrorHint` on link failures |
| `extensions/remote-session/src/client.ts` | `ThreaApiError` message carries structured code + server message |
| `packages/backend-common/src/auth/{types,auth-service,workos-org-service,api-key-service}.ts` | `WORKOS_REQUEST_TIMEOUT_MS = 10_000` on all WorkOS clients |
| `packages/backend-common/src/auth/auth-service.ts` | `AuthResult.terminal` classification; refresh gated on `INVALID_JWT` |
| `packages/backend-common/src/auth/middleware.ts` | clear session cookie only on terminal failures |
| `packages/backend-common/src/auth/auth-service.stub.ts` | stub session failures marked terminal |
| `packages/backend-common/src/auth/auth-service.test.ts` | NEW — failure-classification matrix (6 tests) |
| `docs/public-api/{openapi.json,versions/2026-07-12.json,CHANGELOG.md}` | regenerated for the schema change |

Tests: `repository.test.ts` (retire SQL shape), `runtime-session-reattach.test.ts` (+3: replace creates fresh, retire-race resumes revived link, wait keeps 409), `session.test.ts` (+2: cold-start replace, probe wait), `tests/e2e/claude-code-channel-session.test.ts` (+1: archive → replace mints fresh pad → unarchive of old pad does NOT steal the identity back).

## Out of scope (deliberate)

- **Pi remote plugin** (`extensions/pi-remote/`) mirrors the SDK rather than consuming it — it keeps `wait` behavior until updated (`/update-pi-remote-plugin`).
- **Client-side refresh coordination** (middleware verify-only + frontend single-flight refresh with Web Lock) — the agreed real fix for refresh races, its own design doc + PR. The per-process server-side dedupe map was considered and dropped (too local for a distributed app — Kris's ruling).
- **Short-TTL session cache / stale-while-error** for surviving a full WorkOS outage — security tradeoff, needs a ruling.
- Pre-existing pg `client.query()`-while-busy deprecation warning at `bot-runtimes/service.ts:669` (`findActiveForBot` inside `withClient`) noticed in prod logs — separate follow-up.

## Test plan

- [x] `bun test apps/backend/src/features/bot-runtimes apps/backend/src/features/public-api` — 155 + 48 pass
- [x] `extensions/remote-session` — 110 pass; `extensions/claude-code-remote` — 90 pass
- [x] `packages/backend-common` — 42 pass (incl. new auth-service classification + middleware clear-gating tests); control-plane unit 34 pass
- [x] E2E `tests/e2e/claude-code-channel-session.test.ts` against real DB — 7/7 pass (incl. new replace test)
- [x] `tsc --noEmit` backend, backend-common, remote-session clean (full pre-commit typecheck matrix ran on commit)
- [ ] `schemas.test.ts` fails when run as a lone file on a pre-existing routes.ts↔schemas.ts import-order TDZ (`publicSearchSchema`) — passes in the full-directory run; unrelated to this diff (fails on clean main too)
- [ ] WorkOS timeout not unit-tested — the SDK's `timeout` option is upstream behavior; asserting our constructor args would mock the SDK constructor (INV-48)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
