### PR TITLE
feat(frontend): group bot tool traces by thinking phase

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -209,6 +209,7 @@ export function TraceDialog() {
           workspaceId={workspaceId!}
           streamId={session?.streamId ?? ""}
           userId={userId}
+          isSessionRunning={status === "running"}
           onStopSession={status === "running" ? handleStopSession : undefined}
           onSteerSession={status === "running" ? handleSteerSession : undefined}
         />
@@ -346,6 +347,7 @@ function TraceBody({
   workspaceId,
   streamId,
   userId,
+  isSessionRunning,
   onStopSession,
   onSteerSession,
 }: {
@@ -357,6 +359,7 @@ function TraceBody({
   workspaceId: string
   streamId: string
   userId: string | null
+  isSessionRunning: boolean
   onStopSession?: () => void
   onSteerSession?: () => void
 }) {
@@ -368,6 +371,7 @@ function TraceBody({
       streamId={streamId}
       userId={userId}
       streamingSubsteps={streamingSubsteps}
+      isSessionRunning={isSessionRunning}
       onStopSession={onStopSession}
       onSteerSession={onSteerSession}
     />

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -105,6 +105,19 @@ describe("TraceStepList", () => {
     expect(screen.queryByText("old preview")).not.toBeInTheDocument()
   })
 
+  it("keeps later tool runs nested under the same thinking phase across incidental rows", () => {
+    renderList([
+      thinking("think_1", 1, "Plan"),
+      createStep({ id: "tool_1", stepNumber: 2 }),
+      createStep({ id: "reply_1", stepNumber: 3, stepType: "message_sent", content: "Interim" }),
+      createStep({ id: "tool_2", stepNumber: 4 }),
+    ])
+
+    const workingLabels = screen.getAllByText("Working")
+    expect(workingLabels).toHaveLength(2)
+    expect(workingLabels.every((label) => label.closest(".ml-6"))).toBe(true)
+  })
+
   it("previews a truncated latest tool without exposing malformed content", () => {
     renderList(
       [
@@ -176,12 +189,13 @@ describe("TraceStepList", () => {
     expect(screen.getAllByText("live boom")).toHaveLength(2)
   })
 
-  it("opens full details when a grouped tool step is highlighted", () => {
-    renderList(
-      [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2, messageId: "msg_tool" })],
-      false,
-      "msg_tool"
-    )
+  it("opens full details when an existing grouped tool step becomes highlighted", () => {
+    const steps = [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2, messageId: "msg_tool" })]
+    const view = renderList(steps)
+
+    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "false")
+
+    view.rerender(listElement(steps, false, "msg_tool"))
 
     expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "true")
     expect(screen.getByText("Run bash")).toBeInTheDocument()

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -222,7 +222,7 @@ describe("TraceStepList", () => {
   it("leaves non-bot tool steps as regular trace rows", () => {
     renderList([
       createStep({
-        content: JSON.stringify({ tool: "workspace_search", args: { query: "pricing" } }),
+        content: JSON.stringify({ tool: "workspace_search", args: { query: "pricing", format: PI_TOOL_TRACE_FORMAT } }),
       }),
     ])
 

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -27,18 +27,22 @@ function thinking(id: string, stepNumber: number, content: string): AgentSession
   return createStep({ id, stepNumber, stepType: "thinking", content })
 }
 
-function renderList(steps: AgentSessionStep[], isSessionRunning = false) {
-  return render(
+function listElement(steps: AgentSessionStep[], isSessionRunning = false, highlightMessageId: string | null = null) {
+  return (
     <MemoryRouter>
       <TraceStepList
         steps={steps}
-        highlightMessageId={null}
+        highlightMessageId={highlightMessageId}
         workspaceId="ws_1"
         streamId="stream_1"
         isSessionRunning={isSessionRunning}
       />
     </MemoryRouter>
   )
+}
+
+function renderList(steps: AgentSessionStep[], isSessionRunning = false, highlightMessageId: string | null = null) {
+  return render(listElement(steps, isSessionRunning, highlightMessageId))
 }
 
 describe("TraceStepList", () => {
@@ -101,6 +105,22 @@ describe("TraceStepList", () => {
     expect(screen.queryByText("old preview")).not.toBeInTheDocument()
   })
 
+  it("previews a truncated latest tool without exposing malformed content", () => {
+    renderList(
+      [
+        thinking("think_1", 1, "Plan"),
+        createStep({
+          id: "tool_1",
+          stepNumber: 2,
+          content: `{"format":"${PI_TOOL_TRACE_FORMAT}","headline":"Run command","sections":[`,
+        }),
+      ],
+      true
+    )
+
+    expect(screen.getByText("Tool trace was truncated")).toBeInTheDocument()
+  })
+
   it("removes the previous preview when a new thinking header starts", () => {
     renderList(
       [
@@ -126,6 +146,45 @@ describe("TraceStepList", () => {
     expect(screen.getByText("Working")).toBeInTheDocument()
     expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
     expect(screen.queryByText("first output line")).not.toBeInTheDocument()
+  })
+
+  it("opens an existing phase when a live tool error arrives", () => {
+    const initial = [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2 })]
+    const view = renderList(initial, true)
+
+    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "false")
+
+    view.rerender(
+      listElement(
+        [
+          ...initial,
+          createStep({
+            id: "tool_2",
+            stepNumber: 3,
+            stepType: "tool_error",
+            content: JSON.stringify({
+              format: PI_TOOL_TRACE_FORMAT,
+              headline: "Run bash",
+              sections: [{ label: PiToolTraceSectionLabels.ERROR_OUTPUT, body: "live boom", lang: null }],
+            }),
+          }),
+        ],
+        true
+      )
+    )
+
+    expect(screen.getAllByText("live boom")).toHaveLength(2)
+  })
+
+  it("opens full details when a grouped tool step is highlighted", () => {
+    renderList(
+      [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2, messageId: "msg_tool" })],
+      false,
+      "msg_tool"
+    )
+
+    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("Run bash")).toBeInTheDocument()
   })
 
   it("shows error counts, opens error groups, and preserves full tool detail", async () => {

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { PI_TOOL_TRACE_FORMAT, PiToolTraceSectionLabels, type AgentSessionStep } from "@threa/types"
+import { TraceStepList } from "./trace-step-list"
+import * as relativeTimeModule from "@/components/relative-time"
+
+function createStep(overrides: Partial<AgentSessionStep> = {}): AgentSessionStep {
+  return {
+    id: "step_1",
+    sessionId: "session_1",
+    stepNumber: 1,
+    stepType: "tool_call",
+    content: JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Run bash",
+      sections: [{ label: PiToolTraceSectionLabels.OUTPUT, body: "first output line", lang: null }],
+    }),
+    startedAt: "2026-02-19T18:00:00.000Z",
+    completedAt: "2026-02-19T18:00:01.000Z",
+    ...overrides,
+  }
+}
+
+function thinking(id: string, stepNumber: number, content: string): AgentSessionStep {
+  return createStep({ id, stepNumber, stepType: "thinking", content })
+}
+
+function renderList(steps: AgentSessionStep[], isSessionRunning = false) {
+  return render(
+    <MemoryRouter>
+      <TraceStepList
+        steps={steps}
+        highlightMessageId={null}
+        workspaceId="ws_1"
+        streamId="stream_1"
+        isSessionRunning={isSessionRunning}
+      />
+    </MemoryRouter>
+  )
+}
+
+describe("TraceStepList", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((() => (
+      <span>just now</span>
+    )) as unknown as typeof relativeTimeModule.RelativeTime)
+  })
+
+  it("keeps thinking top-level and groups each following run of bot tools beneath it", () => {
+    renderList([
+      thinking("think_1", 1, "First plan"),
+      createStep({ id: "tool_1", stepNumber: 2 }),
+      createStep({ id: "tool_2", stepNumber: 3 }),
+      thinking("think_2", 4, "Revised plan"),
+      createStep({ id: "tool_3", stepNumber: 5 }),
+    ])
+
+    expect(screen.getByText("First plan")).toBeInTheDocument()
+    expect(screen.getByText("Revised plan")).toBeInTheDocument()
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("1 tool call")).toBeInTheDocument()
+    expect(screen.getAllByText("Full tool details")).toHaveLength(2)
+    expect(screen.queryByText(/0 errors/)).not.toBeInTheDocument()
+  })
+
+  it("previews only the latest tool in the active thinking phase", () => {
+    renderList(
+      [
+        thinking("think_1", 1, "First plan"),
+        createStep({
+          id: "tool_1",
+          stepNumber: 2,
+          content: JSON.stringify({
+            format: PI_TOOL_TRACE_FORMAT,
+            headline: "Read old file",
+            sections: [{ label: PiToolTraceSectionLabels.OUTPUT, body: "old preview", lang: null }],
+          }),
+        }),
+        thinking("think_2", 3, "Next plan"),
+        createStep({
+          id: "tool_2",
+          stepNumber: 4,
+          content: JSON.stringify({
+            format: PI_TOOL_TRACE_FORMAT,
+            headline: "Run current test",
+            sections: [{ label: PiToolTraceSectionLabels.OUTPUT, body: "latest preview", lang: null }],
+          }),
+        }),
+        createStep({ id: "reply_1", stepNumber: 5, stepType: "message_sent", content: "Done" }),
+      ],
+      true
+    )
+
+    expect(screen.getAllByText("Working")).toHaveLength(2)
+    expect(screen.getByText("Run current test")).toBeInTheDocument()
+    expect(screen.getByText("latest preview")).toBeInTheDocument()
+    expect(screen.queryByText("Read old file")).not.toBeInTheDocument()
+    expect(screen.queryByText("old preview")).not.toBeInTheDocument()
+  })
+
+  it("removes the previous preview when a new thinking header starts", () => {
+    renderList(
+      [
+        thinking("think_1", 1, "First plan"),
+        createStep({ id: "tool_1", stepNumber: 2 }),
+        thinking("think_2", 3, "New plan"),
+      ],
+      true
+    )
+
+    expect(screen.getByText("New plan")).toBeInTheDocument()
+    expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
+    expect(screen.queryByText("first output line")).not.toBeInTheDocument()
+  })
+
+  it("removes the latest-step preview when the session completes", () => {
+    renderList([
+      thinking("think_1", 1, "Plan"),
+      createStep({ id: "tool_1", stepNumber: 2 }),
+      createStep({ id: "tool_2", stepNumber: 3 }),
+    ])
+
+    expect(screen.getByText("Working")).toBeInTheDocument()
+    expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
+    expect(screen.queryByText("first output line")).not.toBeInTheDocument()
+  })
+
+  it("shows error counts, opens error groups, and preserves full tool detail", async () => {
+    const user = userEvent.setup()
+    renderList([
+      thinking("think_1", 1, "Plan"),
+      createStep({ id: "tool_1", stepNumber: 2 }),
+      createStep({
+        id: "tool_2",
+        stepNumber: 3,
+        stepType: "tool_error",
+        content: JSON.stringify({
+          format: PI_TOOL_TRACE_FORMAT,
+          headline: "Run bash",
+          sections: [{ label: PiToolTraceSectionLabels.ERROR_OUTPUT, body: "boom stack", lang: null }],
+        }),
+      }),
+    ])
+
+    expect(screen.getByText(/1 error/)).toBeInTheDocument()
+    expect(screen.getByText("boom stack")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /full tool details/i }))
+    expect(screen.queryByText("boom stack")).not.toBeInTheDocument()
+  })
+
+  it("groups bot tools without thinking under a bare Working section", () => {
+    renderList([createStep({ id: "tool_1", stepNumber: 1 }), createStep({ id: "tool_2", stepNumber: 2 })])
+
+    expect(screen.getByText("Working")).toBeInTheDocument()
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+    expect(screen.queryByText("Thinking")).not.toBeInTheDocument()
+  })
+
+  it("leaves non-bot tool steps as regular trace rows", () => {
+    renderList([
+      createStep({
+        content: JSON.stringify({ tool: "workspace_search", args: { query: "pricing" } }),
+      }),
+    ])
+
+    expect(screen.queryByText("Full tool details")).not.toBeInTheDocument()
+    expect(screen.getByText("workspace_search")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -99,6 +99,7 @@ describe("TraceStepList", () => {
     )
 
     expect(screen.getAllByText("Working")).toHaveLength(2)
+    expect(screen.getByText("Working in progress")).toBeInTheDocument()
     expect(screen.getByText("Run current test")).toBeInTheDocument()
     expect(screen.getByText("latest preview")).toBeInTheDocument()
     expect(screen.queryByText("Read old file")).not.toBeInTheDocument()
@@ -113,9 +114,9 @@ describe("TraceStepList", () => {
       createStep({ id: "tool_2", stepNumber: 4 }),
     ])
 
-    const workingLabels = screen.getAllByText("Working")
-    expect(workingLabels).toHaveLength(2)
-    expect(workingLabels.every((label) => label.closest(".ml-6"))).toBe(true)
+    const workingLabel = screen.getByText("Working")
+    expect(workingLabel.closest(".ml-6")).toBeInTheDocument()
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
   })
 
   it("previews a truncated latest tool without exposing malformed content", () => {
@@ -157,6 +158,7 @@ describe("TraceStepList", () => {
     ])
 
     expect(screen.getByText("Working")).toBeInTheDocument()
+    expect(screen.getByText("Working complete")).toBeInTheDocument()
     expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
     expect(screen.queryByText("first output line")).not.toBeInTheDocument()
   })

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -1,26 +1,26 @@
-import { useRef, useEffect } from "react"
-import type { AgentSessionStep, AgentStepType } from "@threa/types"
+import { useRef, useEffect, type ReactNode } from "react"
+import { PI_TOOL_TRACE_FORMAT, type AgentSessionStep, type AgentStepType } from "@threa/types"
 import type { StreamingSubstep } from "@/hooks/use-agent-trace"
 import { TraceStep } from "./trace-step"
 import { cn } from "@/lib/utils"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { ChevronRight, Loader2, TerminalSquare } from "lucide-react"
 
 interface TraceStepListProps {
   steps: AgentSessionStep[]
   highlightMessageId: string | null
   workspaceId: string
   streamId: string
-  /** Viewer's user id, threaded to each step for decrypting sealed (enclave) content. */
   userId?: string | null
-  /**
-   * Live substep history keyed by step type. Merged with each step's persisted
-   * substeps inside `TraceStep` so the phase timeline shows both pre-refresh
-   * history and post-refresh streaming entries.
-   */
   streamingSubsteps?: Partial<Record<AgentStepType, StreamingSubstep[]>>
-  /** Running-session controls rendered on the in-progress step. */
+  isSessionRunning?: boolean
   onStopSession?: () => void
   onSteerSession?: () => void
 }
+
+type TraceStepDisplayItem =
+  | { kind: "step"; step: AgentSessionStep }
+  | { kind: "phase"; id: string; thinking?: AgentSessionStep; tools: AgentSessionStep[] }
 
 export function TraceStepList({
   steps,
@@ -29,10 +29,25 @@ export function TraceStepList({
   streamId,
   userId,
   streamingSubsteps,
+  isSessionRunning = false,
   onStopSession,
   onSteerSession,
 }: TraceStepListProps) {
   const highlightRef = useRef<HTMLDivElement>(null)
+  const displayItems = groupBotWorkByThinking(steps)
+  let latestPhaseIndex = -1
+  for (let index = displayItems.length - 1; index >= 0; index--) {
+    if (displayItems[index]?.kind === "phase") {
+      latestPhaseIndex = index
+      break
+    }
+  }
+  const newerThinkingExists = displayItems
+    .slice(latestPhaseIndex + 1)
+    .some((item) => item.kind === "step" && item.step.stepType === "thinking")
+  const latestPhase = latestPhaseIndex >= 0 ? displayItems[latestPhaseIndex] : undefined
+  const activePhaseId =
+    isSessionRunning && latestPhase?.kind === "phase" && !newerThinkingExists ? latestPhase.id : null
 
   useEffect(() => {
     if (highlightMessageId && highlightRef.current) {
@@ -46,34 +61,168 @@ export function TraceStepList({
     return <div className="p-6 text-center text-muted-foreground">No steps recorded yet.</div>
   }
 
+  const renderStep = (step: AgentSessionStep) => {
+    const isHighlighted = step.messageId === highlightMessageId
+    const isInProgress = !step.completedAt
+    const liveSubsteps = isInProgress ? streamingSubsteps?.[step.stepType] : undefined
+    return (
+      <div
+        key={step.id}
+        ref={isHighlighted ? highlightRef : undefined}
+        className={cn(isHighlighted && "ring-2 ring-primary/20 ring-inset")}
+      >
+        <TraceStep
+          step={step}
+          workspaceId={workspaceId}
+          streamId={streamId}
+          userId={userId}
+          liveSubsteps={liveSubsteps}
+          onStopSession={onStopSession}
+          onSteerSession={onSteerSession}
+        />
+      </div>
+    )
+  }
+
   return (
     <div>
-      {steps.map((step) => {
-        const isHighlighted = step.messageId === highlightMessageId
-        // Only pass live substeps to the in-progress step. Substeps are keyed by
-        // step type, so without this guard a completed workspace_search step
-        // (e.g. search_users) would incorrectly show the phases from an
-        // in-flight workspace_research tool that shares the same step type.
-        const isInProgress = !step.completedAt
-        const liveSubsteps = isInProgress ? streamingSubsteps?.[step.stepType] : undefined
+      {displayItems.map((item) => {
+        if (item.kind === "step") return renderStep(item.step)
         return (
-          <div
-            key={step.id}
-            ref={isHighlighted ? highlightRef : undefined}
-            className={cn(isHighlighted && "ring-2 ring-primary/20 ring-inset")}
-          >
-            <TraceStep
-              step={step}
-              workspaceId={workspaceId}
-              streamId={streamId}
-              userId={userId}
-              liveSubsteps={liveSubsteps}
-              onStopSession={onStopSession}
-              onSteerSession={onSteerSession}
+          <div key={item.id}>
+            {item.thinking && renderStep(item.thinking)}
+            <BotWorkingSection
+              tools={item.tools}
+              active={item.id === activePhaseId}
+              nested={Boolean(item.thinking)}
+              renderStep={renderStep}
             />
           </div>
         )
       })}
     </div>
   )
+}
+
+function BotWorkingSection({
+  tools,
+  active,
+  nested,
+  renderStep,
+}: {
+  tools: AgentSessionStep[]
+  active: boolean
+  nested: boolean
+  renderStep: (step: AgentSessionStep) => ReactNode
+}) {
+  const errorCount = tools.filter((step) => step.stepType === "tool_error").length
+  const lastTool = tools.at(-1)!
+  const preview = active ? toolPreview(lastTool.content) : null
+  const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
+  const errorLabel = errorCount > 0 ? ` • ${errorCount} ${errorCount === 1 ? "error" : "errors"}` : ""
+
+  return (
+    <div className={cn("border-b border-border bg-muted/15", nested && "ml-6 border-l")}>
+      <div className="flex items-start gap-2 px-5 py-3.5">
+        <div className="mt-0.5 rounded-md bg-muted px-2 py-1 text-muted-foreground">
+          {active ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <TerminalSquare className="h-3.5 w-3.5" />}
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Working</div>
+          <div className="text-xs text-muted-foreground">
+            {toolLabel}
+            {errorLabel}
+          </div>
+          {preview && (
+            <div className="rounded-md border border-border/70 bg-background/70 px-3 py-2 text-xs">
+              <div className="font-mono text-foreground/90">{preview.headline}</div>
+              {preview.detail && <div className="mt-1 truncate text-muted-foreground">{preview.detail}</div>}
+            </div>
+          )}
+        </div>
+      </div>
+      <Collapsible defaultOpen={errorCount > 0}>
+        <CollapsibleTrigger className="group flex w-full items-center gap-1.5 px-5 pb-3 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+          Full tool details
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t border-border bg-background/70">{tools.map(renderStep)}</div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  )
+}
+
+function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem[] {
+  const items: TraceStepDisplayItem[] = []
+  let thinking: AgentSessionStep | undefined
+  let tools: AgentSessionStep[] = []
+
+  const flush = () => {
+    if (tools.length > 0) {
+      items.push({ kind: "phase", id: `${thinking?.id ?? "work"}-${tools[0]!.id}`, thinking, tools })
+    } else if (thinking) {
+      items.push({ kind: "step", step: thinking })
+    }
+    thinking = undefined
+    tools = []
+  }
+
+  for (const step of steps) {
+    if (step.stepType === "thinking") {
+      flush()
+      thinking = step
+      continue
+    }
+    if (isLowLevelBotToolStep(step)) {
+      tools.push(step)
+      continue
+    }
+    flush()
+    items.push({ kind: "step", step })
+  }
+  flush()
+
+  return items
+}
+
+function isLowLevelBotToolStep(step: AgentSessionStep): boolean {
+  if (step.stepType !== "tool_call" && step.stepType !== "tool_error") return false
+  if (!step.completedAt) return false
+  return parseToolTrace(step.content)?.format === PI_TOOL_TRACE_FORMAT || looksLikeTruncatedToolTrace(step.content)
+}
+
+function toolPreview(content: unknown): { headline: string; detail: string | null } | null {
+  const parsed = parseToolTrace(content)
+  if (!parsed) return null
+  const headline = typeof parsed.headline === "string" && parsed.headline.trim() ? parsed.headline.trim() : "Tool call"
+  const sections: unknown[] = Array.isArray(parsed.sections) ? parsed.sections : []
+  const lastSection = sections.at(-1)
+  const body =
+    lastSection && typeof lastSection === "object" && "body" in lastSection && typeof lastSection.body === "string"
+      ? lastSection.body
+      : ""
+  const firstLine = body
+    .split("\n")
+    .map((line: string) => line.trim())
+    .find(Boolean)
+  let detail = firstLine ?? null
+  if (detail && detail.length > 140) detail = `${detail.slice(0, 137)}...`
+  return { headline, detail }
+}
+
+function parseToolTrace(content: unknown): Record<string, unknown> | null {
+  if (content && typeof content === "object") return content as Record<string, unknown>
+  if (typeof content !== "string") return null
+  try {
+    const parsed = JSON.parse(content)
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function looksLikeTruncatedToolTrace(content: unknown): boolean {
+  return typeof content === "string" && new RegExp(`"format"\\s*:\\s*"${PI_TOOL_TRACE_FORMAT}"`).test(content)
 }

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -136,6 +136,7 @@ function BotWorkingSection({
         </div>
         <div className="min-w-0 flex-1 space-y-1">
           <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Working</div>
+          <span className="sr-only">{active ? "Working in progress" : "Working complete"}</span>
           <div className="text-xs text-muted-foreground">
             {toolLabel}
             {errorLabel}
@@ -164,30 +165,25 @@ function BotWorkingSection({
 function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem[] {
   const items: TraceStepDisplayItem[] = []
   let nested = false
-  let tools: AgentSessionStep[] = []
-
-  const flush = () => {
-    if (tools.length > 0) {
-      items.push({ kind: "phase", id: `${nested ? "nested" : "work"}-${tools[0]!.id}`, nested, tools })
-    }
-    tools = []
-  }
+  let activePhase: Extract<TraceStepDisplayItem, { kind: "phase" }> | null = null
 
   for (const step of steps) {
     if (step.stepType === "thinking") {
-      flush()
       items.push({ kind: "step", step })
       nested = true
+      activePhase = null
       continue
     }
     if (isLowLevelBotToolStep(step)) {
-      tools.push(step)
+      if (!activePhase) {
+        activePhase = { kind: "phase", id: `${nested ? "nested" : "work"}-${step.id}`, nested, tools: [] }
+        items.push(activePhase)
+      }
+      activePhase.tools.push(step)
       continue
     }
-    flush()
     items.push({ kind: "step", step })
   }
-  flush()
 
   return items
 }

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type ReactNode } from "react"
+import { useRef, useEffect, useState, type ReactNode } from "react"
 import { PI_TOOL_TRACE_FORMAT, type AgentSessionStep, type AgentStepType } from "@threa/types"
 import type { StreamingSubstep } from "@/hooks/use-agent-trace"
 import { TraceStep } from "./trace-step"
@@ -95,6 +95,7 @@ export function TraceStepList({
               tools={item.tools}
               active={item.id === activePhaseId}
               nested={Boolean(item.thinking)}
+              highlightedMessageId={highlightMessageId}
               renderStep={renderStep}
             />
           </div>
@@ -108,16 +109,24 @@ function BotWorkingSection({
   tools,
   active,
   nested,
+  highlightedMessageId,
   renderStep,
 }: {
   tools: AgentSessionStep[]
   active: boolean
   nested: boolean
+  highlightedMessageId: string | null
   renderStep: (step: AgentSessionStep) => ReactNode
 }) {
   const errorCount = tools.filter((step) => step.stepType === "tool_error").length
+  const containsHighlight = tools.some((step) => step.messageId === highlightedMessageId)
+  const [detailsOpen, setDetailsOpen] = useState(errorCount > 0 || containsHighlight)
   const lastTool = tools.at(-1)!
   const preview = active ? toolPreview(lastTool.content) : null
+
+  useEffect(() => {
+    if (errorCount > 0 || containsHighlight) setDetailsOpen(true)
+  }, [errorCount, containsHighlight])
   const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
   const errorLabel = errorCount > 0 ? ` • ${errorCount} ${errorCount === 1 ? "error" : "errors"}` : ""
 
@@ -135,13 +144,13 @@ function BotWorkingSection({
           </div>
           {preview && (
             <div className="rounded-md border border-border/70 bg-background/70 px-3 py-2 text-xs">
-              <div className="font-mono text-foreground/90">{preview.headline}</div>
+              <div className="break-all font-mono text-foreground/90">{preview.headline}</div>
               {preview.detail && <div className="mt-1 truncate text-muted-foreground">{preview.detail}</div>}
             </div>
           )}
         </div>
       </div>
-      <Collapsible defaultOpen={errorCount > 0}>
+      <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
         <CollapsibleTrigger className="group flex w-full items-center gap-1.5 px-5 pb-3 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
           <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
           Full tool details
@@ -195,7 +204,9 @@ function isLowLevelBotToolStep(step: AgentSessionStep): boolean {
 
 function toolPreview(content: unknown): { headline: string; detail: string | null } | null {
   const parsed = parseToolTrace(content)
-  if (!parsed) return null
+  if (!parsed) {
+    return looksLikeTruncatedToolTrace(content) ? { headline: "Tool trace was truncated", detail: null } : null
+  }
   const headline = typeof parsed.headline === "string" && parsed.headline.trim() ? parsed.headline.trim() : "Tool call"
   const sections: unknown[] = Array.isArray(parsed.sections) ? parsed.sections : []
   const lastSection = sections.at(-1)

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -20,7 +20,7 @@ interface TraceStepListProps {
 
 type TraceStepDisplayItem =
   | { kind: "step"; step: AgentSessionStep }
-  | { kind: "phase"; id: string; thinking?: AgentSessionStep; tools: AgentSessionStep[] }
+  | { kind: "phase"; id: string; nested: boolean; tools: AgentSessionStep[] }
 
 export function TraceStepList({
   steps,
@@ -89,16 +89,14 @@ export function TraceStepList({
       {displayItems.map((item) => {
         if (item.kind === "step") return renderStep(item.step)
         return (
-          <div key={item.id}>
-            {item.thinking && renderStep(item.thinking)}
-            <BotWorkingSection
-              tools={item.tools}
-              active={item.id === activePhaseId}
-              nested={Boolean(item.thinking)}
-              highlightedMessageId={highlightMessageId}
-              renderStep={renderStep}
-            />
-          </div>
+          <BotWorkingSection
+            key={item.id}
+            tools={item.tools}
+            active={item.id === activePhaseId}
+            nested={item.nested}
+            highlightedMessageId={highlightMessageId}
+            renderStep={renderStep}
+          />
         )
       })}
     </div>
@@ -120,13 +118,13 @@ function BotWorkingSection({
 }) {
   const errorCount = tools.filter((step) => step.stepType === "tool_error").length
   const containsHighlight = tools.some((step) => step.messageId === highlightedMessageId)
-  const [detailsOpen, setDetailsOpen] = useState(errorCount > 0 || containsHighlight)
+  const [detailsOpen, setDetailsOpen] = useState(errorCount > 0)
   const lastTool = tools.at(-1)!
   const preview = active ? toolPreview(lastTool.content) : null
 
   useEffect(() => {
-    if (errorCount > 0 || containsHighlight) setDetailsOpen(true)
-  }, [errorCount, containsHighlight])
+    if (errorCount > 0) setDetailsOpen(true)
+  }, [errorCount])
   const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
   const errorLabel = errorCount > 0 ? ` • ${errorCount} ${errorCount === 1 ? "error" : "errors"}` : ""
 
@@ -150,7 +148,7 @@ function BotWorkingSection({
           )}
         </div>
       </div>
-      <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+      <Collapsible open={containsHighlight || detailsOpen} onOpenChange={setDetailsOpen}>
         <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-1.5 px-5 py-2 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
           <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
           Full tool details
@@ -165,23 +163,21 @@ function BotWorkingSection({
 
 function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem[] {
   const items: TraceStepDisplayItem[] = []
-  let thinking: AgentSessionStep | undefined
+  let nested = false
   let tools: AgentSessionStep[] = []
 
   const flush = () => {
     if (tools.length > 0) {
-      items.push({ kind: "phase", id: `${thinking?.id ?? "work"}-${tools[0]!.id}`, thinking, tools })
-    } else if (thinking) {
-      items.push({ kind: "step", step: thinking })
+      items.push({ kind: "phase", id: `${nested ? "nested" : "work"}-${tools[0]!.id}`, nested, tools })
     }
-    thinking = undefined
     tools = []
   }
 
   for (const step of steps) {
     if (step.stepType === "thinking") {
       flush()
-      thinking = step
+      items.push({ kind: "step", step })
+      nested = true
       continue
     }
     if (isLowLevelBotToolStep(step)) {

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -151,7 +151,7 @@ function BotWorkingSection({
         </div>
       </div>
       <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
-        <CollapsibleTrigger className="group flex w-full items-center gap-1.5 px-5 pb-3 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
+        <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-1.5 px-5 py-2 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
           <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
           Full tool details
         </CollapsibleTrigger>
@@ -235,5 +235,7 @@ function parseToolTrace(content: unknown): Record<string, unknown> | null {
 }
 
 function looksLikeTruncatedToolTrace(content: unknown): boolean {
-  return typeof content === "string" && new RegExp(`"format"\\s*:\\s*"${PI_TOOL_TRACE_FORMAT}"`).test(content)
+  return (
+    typeof content === "string" && new RegExp(`^\\s*\\{\\s*"format"\\s*:\\s*"${PI_TOOL_TRACE_FORMAT}"`).test(content)
+  )
 }


### PR DESCRIPTION
## Problem

Bot runtimes emit each thinking block, tool invocation, tool result, and failure as a separate agent trace row. Long Pi or Claude Code turns therefore bury the model's reasoning transitions under low-level tool traffic.

## Solution

Keep bot thinking steps top-level and fold each following run of structured `pi_tool_trace` tool rows into a compact **Working** section. The active section previews its latest tool; every original step remains available through **Full tool details**.

### How it works

- `groupBotWorkByThinking` partitions trace steps at thinking boundaries while leaving native agent and research-tool trace formats unchanged.
- `BotWorkingSection` reports tool calls and non-zero error counts, opens error groups by default, and exposes the existing `TraceStep` rendering in a disclosure.
- `TraceDialog` passes session status into `TraceStepList`; only the latest running phase shows a spinner and latest-tool preview. A new thinking step or terminal session removes that preview.
- Tool-only runs form a standalone **Working** section.

### Key design decisions

**Presentation-only projection** — persisted backend rows and socket events remain unchanged. This preserves per-step idempotency, ordering, live updates, and detailed history.

**Structured bot traces only** — grouping requires `PI_TOOL_TRACE_FORMAT`. Native companion/research traces and ordinary `tool_call` payloads retain their existing UI.

**Stable phase identity** — a phase key uses its thinking step and first tool, so appending live tools does not remount the disclosure.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/trace/trace-step-list.test.tsx` | Covers thinking boundaries, tool-only runs, active previews, completion, errors, and non-bot steps. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-step-list.tsx` | Builds thinking/tool display phases and renders compact Working sections with expandable details. |
| `apps/frontend/src/components/trace/trace-dialog.tsx` | Passes running-session state to the trace list. |

## Out of scope

- Backend trace compaction or schema changes.
- Grouping encrypted step content the frontend cannot classify before per-step decryption.
- Changing native companion and research trace visualization.

## Test plan

- [x] Frontend trace tests — 39 passed across `trace-step-list`, `trace-step`, and `trace-dialog`.
- [x] Frontend TypeScript — `tsc --noEmit` passed.
- [x] Repository pre-commit checks — lint, monorepo typecheck, migration checks, Dockerfile workspace checks, and generated API docs check passed.
- [x] `git diff --check` passed.

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Reduce bot-runtime trace noise without discarding diagnostics: reasoning transitions stay visible, low-level tool work becomes compact, and readers can still inspect every original step.

## What Was Built

### Thinking-scoped trace projection

`TraceStepList` derives display-only phases from the existing ordered step array. A thinking step starts a phase; following structured bot tool calls and errors belong to it until another top-level step creates a boundary. Tool calls without thinking use a bare Working phase.

### Working section

`BotWorkingSection` renders tool/error counts, an active spinner, and the latest tool headline plus bounded first-line detail while the session runs. Full `TraceStep` rows remain behind a disclosure; error-bearing sections open by default.

### Session lifecycle wiring

`TraceDialog` passes `status === "running"` through `TraceBody`. The latest phase previews work only while running, and a newer thinking header suppresses the previous phase preview.

## Design Decisions

### Preserve backend rows

**Chose:** Derive grouping in the trace UI.
**Why:** Backend rows are the idempotent, ordered source for bootstrap and socket updates; changing persistence would couple display grouping to delivery semantics.
**Alternative considered:** Squash rows in backend projection. Rejected because it would complicate per-frame acknowledgements, replay deduplication, and full-detail access.

### Identify bot traces by wire format

**Chose:** Group only completed `tool_call` and `tool_error` steps carrying `pi_tool_trace`.
**Why:** This identifies Pi/Claude runtime diagnostics without changing native agent trace behavior.

## Design Evolution

- Replaced an initial standalone adjacent-tool grouping with thinking-scoped phases after clarifying the intended hierarchy.
- Added active latest-step previews and standalone Working phases for tool-only runs.
- Kept error counts conditional so zero-error phases do not display noise.
- **Terra review:** made disclosures controlled so live errors and deep-linked tools open automatically; added a safe fallback preview for truncated traces and wrapped unbroken mobile headlines, anchored truncated-trace detection, and enlarged the disclosure touch target, preserved thinking context across incidental rows, and forced highlighted disclosures open synchronously, aggregated one Working section per thinking phase, and exposed active/completed state to screen readers.

## Schema Changes

None.

## What's NOT Included

Backend compaction, trace protocol changes, and changes to native agent/research visualization.

## Status

- [x] Thinking-scoped grouping
- [x] Tool-only Working sections
- [x] Active latest-tool preview
- [x] Expandable full details
- [x] Focused tests and verification

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
