### PR TITLE
feat(frontend): refine the collapsed agent-trace group

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -180,7 +180,7 @@ export function TraceDialog() {
   return (
     <ResponsiveDialog open onOpenChange={(open) => !open && closeTraceModal()}>
       <ResponsiveDialogContent
-        desktopClassName="max-w-3xl max-h-[85vh] sm:flex flex-col p-0 gap-0 [&>button:last-child]:hidden"
+        desktopClassName="max-w-4xl max-h-[90vh] sm:flex flex-col p-0 gap-0 [&>button:last-child]:hidden"
         drawerClassName="flex flex-col p-0"
         hideCloseButton
       >

--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -66,11 +66,11 @@ describe("TraceStepList", () => {
     expect(screen.getByText("Revised plan")).toBeInTheDocument()
     expect(screen.getByText("2 tool calls")).toBeInTheDocument()
     expect(screen.getByText("1 tool call")).toBeInTheDocument()
-    expect(screen.getAllByText("Full tool details")).toHaveLength(2)
+    expect(screen.getAllByRole("button", { name: /working/i })).toHaveLength(2)
     expect(screen.queryByText(/0 errors/)).not.toBeInTheDocument()
   })
 
-  it("previews only the latest tool in the active thinking phase", () => {
+  it("previews the latest tool in the active phase and summarises settled phases as chips", () => {
     renderList(
       [
         thinking("think_1", 1, "First plan"),
@@ -102,7 +102,8 @@ describe("TraceStepList", () => {
     expect(screen.getByText("Working in progress")).toBeInTheDocument()
     expect(screen.getByText("Run current test")).toBeInTheDocument()
     expect(screen.getByText("latest preview")).toBeInTheDocument()
-    expect(screen.queryByText("Read old file")).not.toBeInTheDocument()
+    // The settled phase keeps its headline as a chip, but never a stale preview body.
+    expect(screen.getByText("Read old file")).toBeInTheDocument()
     expect(screen.queryByText("old preview")).not.toBeInTheDocument()
   })
 
@@ -146,7 +147,6 @@ describe("TraceStepList", () => {
     )
 
     expect(screen.getByText("New plan")).toBeInTheDocument()
-    expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
     expect(screen.queryByText("first output line")).not.toBeInTheDocument()
   })
 
@@ -159,7 +159,6 @@ describe("TraceStepList", () => {
 
     expect(screen.getByText("Working")).toBeInTheDocument()
     expect(screen.getByText("Working complete")).toBeInTheDocument()
-    expect(screen.queryByText("Run bash")).not.toBeInTheDocument()
     expect(screen.queryByText("first output line")).not.toBeInTheDocument()
   })
 
@@ -167,7 +166,7 @@ describe("TraceStepList", () => {
     const initial = [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2 })]
     const view = renderList(initial, true)
 
-    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "false")
+    expect(screen.getByRole("button", { name: /working/i })).toHaveAttribute("aria-expanded", "false")
 
     view.rerender(
       listElement(
@@ -195,11 +194,11 @@ describe("TraceStepList", () => {
     const steps = [thinking("think_1", 1, "Plan"), createStep({ id: "tool_1", stepNumber: 2, messageId: "msg_tool" })]
     const view = renderList(steps)
 
-    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "false")
+    expect(screen.getByRole("button", { name: /working/i })).toHaveAttribute("aria-expanded", "false")
 
     view.rerender(listElement(steps, false, "msg_tool"))
 
-    expect(screen.getByRole("button", { name: /full tool details/i })).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("button", { name: /working/i })).toHaveAttribute("aria-expanded", "true")
     expect(screen.getByText("Run bash")).toBeInTheDocument()
   })
 
@@ -223,7 +222,7 @@ describe("TraceStepList", () => {
     expect(screen.getByText(/1 error/)).toBeInTheDocument()
     expect(screen.getByText("boom stack")).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: /full tool details/i }))
+    await user.click(screen.getByRole("button", { name: /working/i }))
     expect(screen.queryByText("boom stack")).not.toBeInTheDocument()
   })
 

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -3,8 +3,20 @@ import { PI_TOOL_TRACE_FORMAT, type AgentSessionStep, type AgentStepType } from 
 import type { StreamingSubstep } from "@/hooks/use-agent-trace"
 import { TraceStep } from "./trace-step"
 import { cn } from "@/lib/utils"
+import { STEP_DISPLAY_CONFIG } from "@/lib/step-config"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ChevronRight, Loader2, TerminalSquare } from "lucide-react"
+
+/**
+ * Tool work borrows the `tool_call` hue so a Working group reads as the same
+ * family as the rows it collapses — and as a different type from the thinking
+ * (amber) and response (green) rows it sits between.
+ */
+const WORK_CONFIG = STEP_DISPLAY_CONFIG.tool_call
+const workHue = (alpha?: number) =>
+  `hsl(${WORK_CONFIG.hue} ${WORK_CONFIG.saturation}% ${WORK_CONFIG.lightness}%${alpha === undefined ? "" : ` / ${alpha}`})`
+
+const MAX_TOOL_CHIPS = 3
 
 interface TraceStepListProps {
   steps: AgentSessionStep[]
@@ -119,6 +131,7 @@ function BotWorkingSection({
   const errorCount = tools.filter((step) => step.stepType === "tool_error").length
   const containsHighlight = tools.some((step) => step.messageId === highlightedMessageId)
   const [detailsOpen, setDetailsOpen] = useState(errorCount > 0)
+  const open = containsHighlight || detailsOpen
   const lastTool = tools.at(-1)!
   const preview = active ? toolPreview(lastTool.content) : null
 
@@ -126,39 +139,86 @@ function BotWorkingSection({
     if (errorCount > 0) setDetailsOpen(true)
   }, [errorCount])
   const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
-  const errorLabel = errorCount > 0 ? ` • ${errorCount} ${errorCount === 1 ? "error" : "errors"}` : ""
+  const chips = tools.slice(0, MAX_TOOL_CHIPS)
+  const overflow = tools.length - chips.length
 
   return (
-    <div className={cn("border-b border-border bg-muted/15", nested && "ml-6 border-l")}>
-      <div className="flex items-start gap-2 px-5 py-3.5">
-        <div className="mt-0.5 rounded-md bg-muted px-2 py-1 text-muted-foreground">
-          {active ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <TerminalSquare className="h-3.5 w-3.5" />}
-        </div>
-        <div className="min-w-0 flex-1 space-y-1">
-          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Working</div>
+    <div
+      className={cn("border-b border-border", nested && "ml-6")}
+      style={{
+        background: workHue(open ? 0.05 : 0.035),
+        borderLeft: `2px solid ${workHue(open ? 0.55 : 0.3)}`,
+      }}
+    >
+      <Collapsible open={open} onOpenChange={setDetailsOpen}>
+        <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-2.5 px-5 py-2 text-left transition-colors hover:bg-foreground/[0.03]">
+          <span
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+            style={{ background: workHue(0.12), color: workHue(), boxShadow: `inset 0 0 0 1px ${workHue(0.22)}` }}
+          >
+            {active ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <TerminalSquare className="h-3.5 w-3.5" />}
+          </span>
+          <span className="shrink-0 text-[11px] font-semibold uppercase tracking-[0.08em]" style={{ color: workHue() }}>
+            Working
+          </span>
           <span className="sr-only">{active ? "Working in progress" : "Working complete"}</span>
-          <div className="text-xs text-muted-foreground">
-            {toolLabel}
-            {errorLabel}
-          </div>
-          {preview && (
-            <div className="rounded-md border border-border/70 bg-background/70 px-3 py-2 text-xs">
-              <div className="break-all font-mono text-foreground/90">{preview.headline}</div>
-              {preview.detail && <div className="mt-1 truncate text-muted-foreground">{preview.detail}</div>}
-            </div>
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{toolLabel}</span>
+          {errorCount > 0 && (
+            <span className="shrink-0 text-[11px] font-medium text-destructive">
+              {errorCount} {errorCount === 1 ? "error" : "errors"}
+            </span>
           )}
-        </div>
-      </div>
-      <Collapsible open={containsHighlight || detailsOpen} onOpenChange={setDetailsOpen}>
-        <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-1.5 px-5 py-2 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
-          <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
-          Full tool details
+
+          {/* The collapsed row carries the work itself: the live tool headline
+              while the phase runs, else a chip per call. Once expanded the rows
+              below say it in full, so the chips step aside. */}
+          {preview && (
+            <span className="flex min-w-0 flex-1 items-baseline gap-2">
+              <span className="truncate font-mono text-[11.5px] text-foreground/90">{preview.headline}</span>
+              {preview.detail && (
+                <span className="hidden truncate text-[11px] text-muted-foreground sm:inline">{preview.detail}</span>
+              )}
+            </span>
+          )}
+          {!preview && !open && (
+            <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+              {chips.map((step) => (
+                <ToolChip key={step.id} step={step} />
+              ))}
+              {overflow > 0 && (
+                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">+{overflow}</span>
+              )}
+            </span>
+          )}
+
+          <ChevronRight
+            className="ml-auto h-4 w-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+            aria-hidden
+          />
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t border-border bg-background/70">{tools.map(renderStep)}</div>
+          <div className="border-t bg-background/60" style={{ borderColor: workHue(0.18) }}>
+            {tools.map(renderStep)}
+          </div>
         </CollapsibleContent>
       </Collapsible>
     </div>
+  )
+}
+
+function ToolChip({ step }: { step: AgentSessionStep }) {
+  const isError = step.stepType === "tool_error"
+  const label = toolPreview(step.content)?.headline ?? "Tool call"
+  return (
+    <span
+      className={cn(
+        "max-w-[180px] shrink-0 truncate rounded-full px-2 py-0.5 font-mono text-[10.5px] leading-[1.45]",
+        isError ? "bg-destructive/10 text-destructive ring-1 ring-inset ring-destructive/25" : "text-foreground/75"
+      )}
+      style={isError ? undefined : { background: workHue(0.09), boxShadow: `inset 0 0 0 1px ${workHue(0.22)}` }}
+    >
+      {label}
+    </span>
   )
 }
 


### PR DESCRIPTION
## Problem

The grouped tool phase from #1366 (`BotWorkingSection` in `apps/frontend/src/components/trace/trace-step-list.tsx`) is functionally right and visually wrong. Collapsed, it renders four stacked things — a `bg-muted` icon tile, a "Working" label, a "N tool calls" line, an optional preview card, then a *separate* `min-h-11` row whose only job is to offer "Full tool details". That's ~118px of vertical space in a `max-h-[85vh]` dialog to say a number, and it's grey-on-grey: the one row type that hides the most content has no colour identity, sitting between an amber `thinking` row and a green `message_sent` row that both do.

## Solution

One row, and the row is the disclosure — spending the width on the tool headlines instead of a count, in the `tool_call` hue.

### How it works

1. **The trigger is the row.** The header block and the "Full tool details" row collapse into a single `CollapsibleTrigger`: icon chip, `Working`, `N tool calls`, error count, summary, chevron. `min-h-11` (44px, touch target preserved) replaces ~118px. Open state is still `containsHighlight || detailsOpen`, so the highlight- and error-forces-open paths are unchanged.
2. **The summary carries real content.** Collapsed and settled → a `ToolChip` per call (up to `MAX_TOOL_CHIPS = 3`, then `+N`), each labelled with the trace's own `headline` via the existing `toolPreview`; `tool_error` chips go destructive, so a failed call is visible before opening anything. Collapsed and running → the chips yield to the live headline + first output line. Expanded → both step aside; the `TraceStep` rows below say it in full.
3. **Colour identity from the existing config.** `WORK_CONFIG = STEP_DISPLAY_CONFIG.tool_call` (hue 200) drives the left rail, icon chip, label, and chip rings — the same hue as the rows the group collapses, and distinct from thinking/response. Rail and background deepen on open (`0.3 → 0.55` border alpha, `0.035 → 0.05` fill), which is the same hue-tint vocabulary `TraceStep` and `SubstepTimeline` already use.
4. **More room.** `TraceDialog`: `max-w-3xl max-h-[85vh]` → `max-w-4xl max-h-[90vh]`. The chip rail needs the width; the trace is a dense read.

### Key design decision

**Chips render for settled phases, not just the active one.** #1366's rule was "only the active phase shows a preview", which the tests encoded as "an old phase's headline must not appear at all". The preview and a chip are different affordances: the preview is a live, stale-able body; a chip is a static label for a call that has finished. Keeping the phase's headlines visible when collapsed is the whole point of the redesign, so two tests were rewritten to assert the invariant that actually matters — a settled phase shows its headline but never a stale preview *body* (`old preview`, `first output line`). No live-preview leak was loosened.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-step-list.tsx` | `BotWorkingSection` rebuilt as a single hue-accented trigger row; new `ToolChip`; `WORK_CONFIG`/`workHue`/`MAX_TOOL_CHIPS` |
| `apps/frontend/src/components/trace/trace-step-list.test.tsx` | Trigger queried by `/working/i` (the "Full tool details" row is gone); settled-phase assertions moved from headline to preview body |
| `apps/frontend/src/components/trace/trace-dialog.tsx` | `max-w-3xl max-h-[85vh]` → `max-w-4xl max-h-[90vh]` |

## Out of scope (deliberate)

The uncollapsed rows are untouched — Kris's ask was "uncollapsed, of course, just normal traces". `TraceStep`, `SubstepTimeline`, `STEP_DISPLAY_CONFIG` unchanged; no new hue was invented for tool work, it reuses `tool_call`'s.

## Test plan

- [x] `bunx vitest run src/components/trace/` — 39 pass (3 files)
- [x] Repo-wide `lint` + `typecheck` via pre-commit — clean
- [x] Rendered before/after (light + dark, collapsed / expanded / running) as a Seer preview: https://seer.build/b/traces-503e54/
- [ ] Not driven in the live dialog — that needs a real companion session with tool calls. Verification is the unit suite plus the mock above, which mirrors the component's exact classes and hue values.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786806050&installation_id=129946197&pr_number=1368&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1368&signature=8686c1b238f241bae6e1817999f84ae99adb2a86ddb660594ad72c4e3fe9b3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->