### PR TITLE
fix(frontend): keep the live tool output readable on mobile

### DIFF
--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -162,7 +162,11 @@ function BotWorkingSection({
             Working
           </span>
           <span className="sr-only">{active ? "Working in progress" : "Working complete"}</span>
-          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{toolLabel}</span>
+          {/* While a phase runs, a phone's width goes to the live preview, not
+              the count — the preview names the tool the count only totals. */}
+          <span className={cn("shrink-0 text-[11px] tabular-nums text-muted-foreground", preview && "max-sm:hidden")}>
+            {toolLabel}
+          </span>
           {errorCount > 0 && (
             <span className="shrink-0 text-[11px] font-medium text-destructive">
               {errorCount} {errorCount === 1 ? "error" : "errors"}
@@ -173,11 +177,9 @@ function BotWorkingSection({
               while the phase runs, else a chip per call. Once expanded the rows
               below say it in full, so the chips step aside. */}
           {preview && (
-            <span className="flex min-w-0 flex-1 items-baseline gap-2">
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
               <span className="truncate font-mono text-[11.5px] text-foreground/90">{preview.headline}</span>
-              {preview.detail && (
-                <span className="hidden truncate text-[11px] text-muted-foreground sm:inline">{preview.detail}</span>
-              )}
+              {preview.detail && <span className="truncate text-[11px] text-muted-foreground">{preview.detail}</span>}
             </span>
           )}
           {!preview && !open && (


### PR DESCRIPTION
## Problem

Follow-up to #1368, taking CodeRabbit's one finding on it — Kris's call ("make it two lines on mobile. I think that's fair").

While a tool phase runs, the collapsed `Working` row shows the live tool headline plus the first line of its output (`preview.detail`). That second piece was `hidden … sm:inline`, so on a phone you got the headline and nothing else. The row is the only place a running phase reports what it's actually doing, and mobile got the half of it that says least.

## Solution

The live preview stacks below `sm` instead of hiding half of itself.

- `preview` span goes `flex-col gap-0.5` → `sm:flex-row sm:items-baseline sm:gap-2`. Headline on line one, output on line two; the desktop row is byte-identical to before. `min-h-11` still holds the touch target.
- **`toolLabel` gets `max-sm:hidden` while a preview is live.** Two lines only help if they have width to use: icon + `Working` + `6 tool calls` + chevron left ~150px for the preview on a 375px screen, so both lines truncated to nothing. The preview names the tool that the count only totals — while the phase runs, the preview wins. The count returns the moment the phase settles and the chip rail comes back, so nothing is permanently hidden.

Rendered (bottom of the page, "Running state — mobile"): https://seer.build/b/traces-503e54/

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-step-list.tsx` | Live preview stacks below `sm`; `toolLabel` hidden on mobile while a preview is showing |

## Test plan

- [x] `bunx vitest run src/components/trace/` — 39 pass (3 files)
- [x] `tsc --noEmit` clean
- [ ] No new test. This is a responsive-class change and jsdom doesn't evaluate media queries, so a test could only assert the class string — which is the implementation, not the behavior (INV-23's spirit). The existing test already asserts the detail is rendered; what changed is only which breakpoint shows it. Verified by rendering, not asserted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786808264&installation_id=129946197&pr_number=1369&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1369&signature=4436e7ff5bad7e7a8b619066233fd6d059587addfb5cdca218be5dc1320b6bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->