### PR TITLE
fix(frontend): make the Working group fill the section, fix its mobile row

### DIFF
--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -115,8 +115,7 @@ describe("TraceStepList", () => {
       createStep({ id: "tool_2", stepNumber: 4 }),
     ])
 
-    const workingLabel = screen.getByText("Working")
-    expect(workingLabel.closest(".ml-6")).toBeInTheDocument()
+    expect(screen.getAllByText("Working")).toHaveLength(1)
     expect(screen.getByText("2 tool calls")).toBeInTheDocument()
   })
 

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -4,6 +4,7 @@ import type { StreamingSubstep } from "@/hooks/use-agent-trace"
 import { TraceStep } from "./trace-step"
 import { cn } from "@/lib/utils"
 import { STEP_DISPLAY_CONFIG } from "@/lib/step-config"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ChevronRight, Loader2, TerminalSquare } from "lucide-react"
 
@@ -16,7 +17,10 @@ const WORK_CONFIG = STEP_DISPLAY_CONFIG.tool_call
 const workHue = (alpha?: number) =>
   `hsl(${WORK_CONFIG.hue} ${WORK_CONFIG.saturation}% ${WORK_CONFIG.lightness}%${alpha === undefined ? "" : ` / ${alpha}`})`
 
+/** The row's own `N tool calls` carries the total, so the chips never need a "+N" tail. */
 const MAX_TOOL_CHIPS = 3
+/** A phone fits two chips on the wrapped line; a third truncates all of them to noise. */
+const MAX_TOOL_CHIPS_MOBILE = 2
 
 interface TraceStepListProps {
   steps: AgentSessionStep[]
@@ -32,7 +36,7 @@ interface TraceStepListProps {
 
 type TraceStepDisplayItem =
   | { kind: "step"; step: AgentSessionStep }
-  | { kind: "phase"; id: string; nested: boolean; tools: AgentSessionStep[] }
+  | { kind: "phase"; id: string; tools: AgentSessionStep[] }
 
 export function TraceStepList({
   steps,
@@ -105,7 +109,6 @@ export function TraceStepList({
             key={item.id}
             tools={item.tools}
             active={item.id === activePhaseId}
-            nested={item.nested}
             highlightedMessageId={highlightMessageId}
             renderStep={renderStep}
           />
@@ -118,16 +121,15 @@ export function TraceStepList({
 function BotWorkingSection({
   tools,
   active,
-  nested,
   highlightedMessageId,
   renderStep,
 }: {
   tools: AgentSessionStep[]
   active: boolean
-  nested: boolean
   highlightedMessageId: string | null
   renderStep: (step: AgentSessionStep) => ReactNode
 }) {
+  const isMobile = useIsMobile()
   const errorCount = tools.filter((step) => step.stepType === "tool_error").length
   const containsHighlight = tools.some((step) => step.messageId === highlightedMessageId)
   const [detailsOpen, setDetailsOpen] = useState(errorCount > 0)
@@ -139,19 +141,20 @@ function BotWorkingSection({
     if (errorCount > 0) setDetailsOpen(true)
   }, [errorCount])
   const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
-  const chips = tools.slice(0, MAX_TOOL_CHIPS)
-  const overflow = tools.length - chips.length
+  const chips = tools.slice(0, isMobile ? MAX_TOOL_CHIPS_MOBILE : MAX_TOOL_CHIPS)
 
   return (
     <div
-      className={cn("border-b border-border", nested && "ml-6")}
+      className="border-b border-border"
       style={{
         background: workHue(open ? 0.05 : 0.035),
         borderLeft: `2px solid ${workHue(open ? 0.55 : 0.3)}`,
       }}
     >
       <Collapsible open={open} onOpenChange={setDetailsOpen}>
-        <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-2.5 px-5 py-2 text-left transition-colors hover:bg-foreground/[0.03]">
+        {/* pl-[22px] + the 2px rail lands the icon on the same left edge as the
+            step pills in the rows above and below. */}
+        <CollapsibleTrigger className="group flex min-h-11 w-full flex-wrap items-center gap-x-2.5 gap-y-1 py-2 pl-[22px] pr-4 text-left transition-colors hover:bg-foreground/[0.03]">
           <span
             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
             style={{ background: workHue(0.12), color: workHue(), boxShadow: `inset 0 0 0 1px ${workHue(0.22)}` }}
@@ -162,11 +165,7 @@ function BotWorkingSection({
             Working
           </span>
           <span className="sr-only">{active ? "Working in progress" : "Working complete"}</span>
-          {/* While a phase runs, a phone's width goes to the live preview, not
-              the count — the preview names the tool the count only totals. */}
-          <span className={cn("shrink-0 text-[11px] tabular-nums text-muted-foreground", preview && "max-sm:hidden")}>
-            {toolLabel}
-          </span>
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{toolLabel}</span>
           {errorCount > 0 && (
             <span className="shrink-0 text-[11px] font-medium text-destructive">
               {errorCount} {errorCount === 1 ? "error" : "errors"}
@@ -175,21 +174,23 @@ function BotWorkingSection({
 
           {/* The collapsed row carries the work itself: the live tool headline
               while the phase runs, else a chip per call. Once expanded the rows
-              below say it in full, so the chips step aside. */}
+              below say it in full, so the chips step aside.
+
+              Both wrap to a full-width second line below `sm` (order-last keeps
+              them under the label + chevron); on `sm` and up they take the rest
+              of the first line. A phone can't fit a headline and its output on
+              one 44px line without truncating both to nothing. */}
           {preview && (
-            <span className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
+            <span className="order-last flex min-w-0 basis-full flex-col gap-0.5 sm:order-none sm:basis-0 sm:flex-1 sm:flex-row sm:items-baseline sm:gap-2">
               <span className="truncate font-mono text-[11.5px] text-foreground/90">{preview.headline}</span>
               {preview.detail && <span className="truncate text-[11px] text-muted-foreground">{preview.detail}</span>}
             </span>
           )}
           {!preview && !open && (
-            <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+            <span className="order-last flex min-w-0 basis-full items-center gap-1.5 overflow-hidden sm:order-none sm:basis-0 sm:flex-1">
               {chips.map((step) => (
                 <ToolChip key={step.id} step={step} />
               ))}
-              {overflow > 0 && (
-                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">+{overflow}</span>
-              )}
             </span>
           )}
 
@@ -214,7 +215,7 @@ function ToolChip({ step }: { step: AgentSessionStep }) {
   return (
     <span
       className={cn(
-        "max-w-[180px] shrink-0 truncate rounded-full px-2 py-0.5 font-mono text-[10.5px] leading-[1.45]",
+        "max-w-[42vw] shrink-0 truncate rounded-full px-2 py-0.5 font-mono text-[10.5px] leading-[1.45] sm:max-w-[180px]",
         isError ? "bg-destructive/10 text-destructive ring-1 ring-inset ring-destructive/25" : "text-foreground/75"
       )}
       style={isError ? undefined : { background: workHue(0.09), boxShadow: `inset 0 0 0 1px ${workHue(0.22)}` }}
@@ -226,19 +227,17 @@ function ToolChip({ step }: { step: AgentSessionStep }) {
 
 function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem[] {
   const items: TraceStepDisplayItem[] = []
-  let nested = false
   let activePhase: Extract<TraceStepDisplayItem, { kind: "phase" }> | null = null
 
   for (const step of steps) {
     if (step.stepType === "thinking") {
       items.push({ kind: "step", step })
-      nested = true
       activePhase = null
       continue
     }
     if (isLowLevelBotToolStep(step)) {
       if (!activePhase) {
-        activePhase = { kind: "phase", id: `${nested ? "nested" : "work"}-${step.id}`, nested, tools: [] }
+        activePhase = { kind: "phase", id: `work-${step.id}`, tools: [] }
         items.push(activePhase)
       }
       activePhase.tools.push(step)


### PR DESCRIPTION
## Problem

Kris ran #1368/#1369 on a phone and didn't like it. Two things, one of which I should have caught before shipping:

1. **The group is inset.** `BotWorkingSection` carried `ml-6` (inherited from #1366's nesting model), so the Working row — and every expanded `TraceStep` under it — sat 24px in from the left while the thinking and response rows around it ran full width. It reads as a floating strip with a dead gutter, not a row of the trace. Kris: *"I want them to fill the entire section too, not be inset like they are now."*
2. **The chip rail clips at phone width.** The chips are `flex-nowrap` inside `overflow-hidden`, so at 390px the second chip is sliced by the container edge and the third and the `+N` never appear — visible in Kris's screenshot as `Running shell c` cut mid-word.

The root cause of shipping both: #1368 was verified against a hand-built HTML mock, which got the widths wrong and didn't model `ml-6` at all. Kris: *"Please try them out in a browser first."*

## Solution

Verified in a browser this time — the real `TraceStepList` mounted in Chromium against the app's real CSS, screenshotted at 390px and 900px in both themes: https://seer.build/b/traces-real-7893d9/

1. **Full-bleed group.** `ml-6` is gone; the group spans the section like every other row, and the cyan rail is what marks the tools as belonging to the thinking above. With the inset gone, `nested` no longer changes any rendering, so the flag and its `nested-`/`work-` id prefixing are deleted from `TraceStepDisplayItem` and `groupBotWorkByThinking` (INV-38). Phase ids stay unique on `step.id`.
2. **Left edge aligned.** The trigger is `pl-[22px]` + the 2px rail = the 24px the `THINKING`/`TOOL CALL` pills start at, so the group's icon lines up with the pills above and below instead of floating 2px off.
3. **The row wraps below `sm`.** The chip rail and the live preview take `basis-full order-last` on a phone (their own full-width second line under the label and chevron) and `sm:basis-0 sm:flex-1` on the first line from `sm` up. Nothing clips.
4. **Two chips on a phone, three from `sm`.** `MAX_TOOL_CHIPS_MOBILE = 2` via `useIsMobile()` (the existing 640px hook, same breakpoint as Tailwind's `sm`), with `max-w-[42vw] sm:max-w-[180px]`. A third chip truncates all of them to noise at that width. The count is a JS decision rather than a `max-sm:hidden` because a CSS-hidden chip would leave the tail lying about the total.
5. **`+N` deleted.** The row already says `5 tool calls`; a `+3` next to it was both redundant and the thing that wrapped to a third line.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-step-list.tsx` | `ml-6` removed; `nested` deleted from the display item, grouping fn, and component; trigger left-aligned to the pills and wrapping below `sm`; mobile chip cap; `+N` removed |
| `apps/frontend/src/components/trace/trace-step-list.test.tsx` | The `.ml-6` assertion asserted the inset that's now deliberately gone — replaced with the rule it was standing in for (tools stay in one phase across an incidental row) |

## Test plan

- [x] `bunx vitest run src/components/trace/` — 39 pass (3 files)
- [x] `tsc --noEmit` + `eslint src/components/trace/` clean
- [x] Rendered in Chromium at 390px and 900px, light and dark, across three phase states (error/auto-open, settled/chips, running) — screenshots linked above
- [ ] Still not driven against a live agent session; the harness mounts `TraceStepList` with fixture steps in the real app CSS. It catches layout (which the mock didn't), not socket/live-substep behavior.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786814553&installation_id=129946197&pr_number=1370&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1370&signature=b8cfea783b1b6812795f4d7123da7a16dc14ca40c93adff325e6f02b6dbf377a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->