### PR TITLE
fix(frontend): route trace controls through external runtimes

### DIFF
--- a/apps/backend/tests/integration/setup.ts
+++ b/apps/backend/tests/integration/setup.ts
@@ -52,6 +52,30 @@ export async function setupTestDatabase(): Promise<Pool> {
   return pool
 }
 
+export async function setupIsolatedTestDatabase(label: string): Promise<{ pool: Pool; cleanup: () => Promise<void> }> {
+  const safeLabel = label
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, "_")
+    .slice(0, 24)
+  const databaseName = `threa_test_${safeLabel}_${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`
+  const adminPool = new Pool({ connectionString: ADMIN_DATABASE_URL })
+  await adminPool.query(`CREATE DATABASE "${databaseName}"`)
+
+  const connectionUrl = new URL(process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL)
+  connectionUrl.pathname = `/${databaseName}`
+  const pool = createDatabasePool(connectionUrl.toString())
+  await createMigrator(pool).up()
+
+  return {
+    pool,
+    cleanup: async () => {
+      await pool.end()
+      await adminPool.query(`DROP DATABASE "${databaseName}" WITH (FORCE)`)
+      await adminPool.end()
+    },
+  }
+}
+
 /**
  * Test transaction wrapper that ALWAYS rolls back.
  * Use this instead of withTransaction in tests to ensure data isolation.

--- a/apps/backend/tests/integration/sync-reconciliation.test.ts
+++ b/apps/backend/tests/integration/sync-reconciliation.test.ts
@@ -1,19 +1,22 @@
 import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test"
 import { Pool, type PoolClient } from "pg"
 import type { Server } from "socket.io"
-import { setupTestDatabase } from "./setup"
+import { setupIsolatedTestDatabase } from "./setup"
 import { SyncLogRepository, SyncLogReconciliationWorker } from "../../src/features/sync"
 
 describe("SyncLogReconciliationWorker", () => {
   let pool: Pool
+  let cleanupDatabase: () => Promise<void>
 
   beforeAll(async () => {
-    pool = await setupTestDatabase()
+    const isolated = await setupIsolatedTestDatabase("sync_reconciliation")
+    pool = isolated.pool
+    cleanupDatabase = isolated.cleanup
     await SyncLogRepository.ensureSweepState(pool)
   })
 
   afterAll(async () => {
-    await pool.end()
+    await cleanupDatabase()
   })
 
   function uniqueId(prefix: string): string {

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,5 +1,5 @@
 import type { StreamEvent } from "@threa/types"
-import { useAbortSession } from "@/hooks"
+import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
@@ -385,7 +385,9 @@ function BoardRunningSessionRow({
   onRedirectSession?: () => void
 }) {
   const socket = useSocket()
-  const abortSession = useAbortSession(socket)
+  const streamId = events[0]!.streamId
+  const stopAgentSession = useStopAgentSession(socket, workspaceId, streamId)
+  const steerAgentSession = useSteerAgentSession(workspaceId, streamId)
   const userId = useWorkspaceUserId(workspaceId)
   const activity = useAgentActivity(events, socket, workspaceId, userId)
   const sessionId = events.reduce<string | null>((found, event) => found ?? getSessionId(event), null)
@@ -406,8 +408,9 @@ function BoardRunningSessionRow({
       events={events}
       liveCounts={live ? { stepCount: live.stepCount, messageCount: live.messageCount } : undefined}
       liveSubstep={live?.substep ?? null}
-      onStopSession={(sessionId) => abortSession({ sessionId, workspaceId })}
+      onStopSession={stopAgentSession}
       onRedirect={onRedirectSession}
+      onSteerSession={steerAgentSession}
     />
   )
 }

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -13,6 +13,7 @@ import * as editorModule from "@/components/editor"
 import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 let isMobileMockValue = false
+const mockRichEditorFocus = vi.fn()
 
 type MockEditorInstance = {
   id: string
@@ -62,7 +63,7 @@ const MockRichEditor = forwardRef<
   useImperativeHandle(
     ref,
     () => ({
-      focus: () => undefined,
+      focus: mockRichEditorFocus,
       insertMention: () => undefined,
       insertSlash: () => undefined,
       insertEmoji: () => undefined,
@@ -139,6 +140,7 @@ const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 describe("MessageComposer", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    mockRichEditorFocus.mockClear()
     isMobileMockValue = false
     vi.useRealTimers()
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileMockValue)
@@ -204,6 +206,7 @@ describe("MessageComposer", () => {
           ],
         })
       )
+      await waitFor(() => expect(mockRichEditorFocus).toHaveBeenCalledTimes(1))
     })
 
     it("should render the upload button", () => {

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { spyOnExport } from "@/test/spy"
-import { render, screen, fireEvent, act } from "@testing-library/react"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { MessageComposer } from "./message-composer"
@@ -10,6 +10,7 @@ import type { PendingAttachment } from "@/hooks/use-attachments"
 import type { JSONContent } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
 import * as editorModule from "@/components/editor"
+import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 let isMobileMockValue = false
 
@@ -170,6 +171,39 @@ describe("MessageComposer", () => {
       render(<MessageComposer {...defaultProps} />)
 
       expect(screen.getByTestId("rich-editor")).toBeInTheDocument()
+    })
+
+    it("prepends a queued runtime command without dropping the existing draft", async () => {
+      const onContentChange = vi.fn()
+      const content: JSONContent = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "focus on tests" }] }],
+      }
+      render(
+        <MessageComposer
+          {...defaultProps}
+          streamId="stream_steer"
+          content={content}
+          onContentChange={onContentChange}
+        />
+      )
+
+      act(() => queueComposerCommandRequest("stream_steer", "/steer "))
+
+      await waitFor(() =>
+        expect(onContentChange).toHaveBeenCalledWith({
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "/steer " },
+                { type: "text", text: "focus on tests" },
+              ],
+            },
+          ],
+        })
+      )
     })
 
     it("should render the upload button", () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -36,6 +36,31 @@ import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
 import type { MessageSendMode, JSONContent } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import type { Editor } from "@tiptap/react"
+import { consumeComposerCommandRequest, subscribeComposerCommandRequest } from "@/stores/composer-command-request-store"
+
+function prependComposerCommand(content: JSONContent, command: string): JSONContent {
+  const first = content.content?.[0]
+  if (first?.type === "paragraph") {
+    const firstInline = first.content?.[0]
+    const commandName = command.trim()
+    const alreadyPrefixed =
+      (typeof firstInline?.text === "string" &&
+        (firstInline.text === commandName || firstInline.text.startsWith(`${commandName} `))) ||
+      (firstInline?.type === "slashCommand" && firstInline.attrs?.name === commandName.slice(1))
+    if (alreadyPrefixed) return content
+    return {
+      ...content,
+      content: [
+        { ...first, content: [{ type: "text", text: command }, ...(first.content ?? [])] },
+        ...(content.content ?? []).slice(1),
+      ],
+    }
+  }
+  return {
+    ...content,
+    content: [{ type: "paragraph", content: [{ type: "text", text: command }] }, ...(content.content ?? [])],
+  }
+}
 
 /** Check whether the document has content beyond a single line. */
 function isMultiLine(doc: JSONContent): boolean {
@@ -319,6 +344,18 @@ export function MessageComposer({
   const controlsDisabled = disabled || isSubmitting
 
   const richEditorRef = useRef<RichEditorHandle>(null)
+
+  useEffect(() => {
+    if (!streamId) return
+    const consumeRequest = () => {
+      const command = consumeComposerCommandRequest(streamId)
+      if (!command) return
+      onContentChange(prependComposerCommand(content, command))
+      requestAnimationFrame(() => richEditorRef.current?.focus())
+    }
+    consumeRequest()
+    return subscribeComposerCommandRequest(streamId, consumeRequest)
+  }, [content, onContentChange, streamId])
   const mobileRootRef = useRef<HTMLDivElement>(null)
   const expandedShellRef = useRef<HTMLDivElement>(null)
   const actionBarWrapperRef = useRef<HTMLDivElement>(null)

--- a/apps/frontend/src/components/timeline/agent-session-event.test.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.test.tsx
@@ -233,13 +233,14 @@ describe("AgentSessionEvent", () => {
       expect(onStopSession).toHaveBeenCalledWith("session_run")
     })
 
-    it("Redirect focuses the surface's composer and shows the fold-in hint", () => {
+    it("Redirect prepares runtime steering, focuses the surface's composer, and shows the fold-in hint", () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
+      const onSteerSession = vi.fn()
 
       render(
         <div data-editor-zone="main">
           <MemoryRouter>
-            <AgentSessionEvent events={runningEvents} onStopSession={vi.fn()} />
+            <AgentSessionEvent events={runningEvents} onStopSession={vi.fn()} onSteerSession={onSteerSession} />
           </MemoryRouter>
           <div data-testid="zone-editor" contentEditable />
         </div>
@@ -257,6 +258,7 @@ describe("AgentSessionEvent", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
 
+      expect(onSteerSession).toHaveBeenCalledTimes(1)
       expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor)
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })
@@ -264,14 +266,23 @@ describe("AgentSessionEvent", () => {
     it("Redirect calls onRedirect (board card) instead of walking the DOM, and shows the hint", () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
       const onRedirect = vi.fn()
+      const onSteerSession = vi.fn()
 
       // No [data-editor-zone] in the tree — the board card has none; the surface
       // owns opening + focusing its own composer via onRedirect.
-      renderEvent(<AgentSessionEvent events={runningEvents} onStopSession={vi.fn()} onRedirect={onRedirect} />)
+      renderEvent(
+        <AgentSessionEvent
+          events={runningEvents}
+          onStopSession={vi.fn()}
+          onRedirect={onRedirect}
+          onSteerSession={onSteerSession}
+        />
+      )
 
       fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
 
       expect(onRedirect).toHaveBeenCalledTimes(1)
+      expect(onSteerSession).toHaveBeenCalledTimes(1)
       expect(focusAtEnd).not.toHaveBeenCalled()
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })

--- a/apps/frontend/src/components/timeline/agent-session-event.test.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import type { StreamEvent } from "@threa/types"
 import * as contextsModule from "@/contexts"
@@ -233,7 +233,7 @@ describe("AgentSessionEvent", () => {
       expect(onStopSession).toHaveBeenCalledWith("session_run")
     })
 
-    it("Redirect prepares runtime steering, focuses the surface's composer, and shows the fold-in hint", () => {
+    it("Redirect prepares runtime steering before focusing the surface's composer", async () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
       const onSteerSession = vi.fn()
 
@@ -259,14 +259,20 @@ describe("AgentSessionEvent", () => {
       fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
 
       expect(onSteerSession).toHaveBeenCalledTimes(1)
-      expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor)
+      await waitFor(() => expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor))
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })
 
-    it("Redirect calls onRedirect (board card) instead of walking the DOM, and shows the hint", () => {
+    it("Redirect prepares steering before opening the board composer", async () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
       const onRedirect = vi.fn()
-      const onSteerSession = vi.fn()
+      let finishSteer!: () => void
+      const onSteerSession = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSteer = resolve
+          })
+      )
 
       // No [data-editor-zone] in the tree — the board card has none; the surface
       // owns opening + focusing its own composer via onRedirect.
@@ -281,8 +287,10 @@ describe("AgentSessionEvent", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
 
-      expect(onRedirect).toHaveBeenCalledTimes(1)
       expect(onSteerSession).toHaveBeenCalledTimes(1)
+      expect(onRedirect).not.toHaveBeenCalled()
+      finishSteer()
+      await waitFor(() => expect(onRedirect).toHaveBeenCalledTimes(1))
       expect(focusAtEnd).not.toHaveBeenCalled()
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })

--- a/apps/frontend/src/components/timeline/agent-session-event.test.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.test.tsx
@@ -263,16 +263,18 @@ describe("AgentSessionEvent", () => {
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })
 
-    it("Redirect prepares steering before opening the board composer", async () => {
+    it("keeps Redirect single-flight while preparing steering and allows a later redirect", async () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
       const onRedirect = vi.fn()
       let finishSteer!: () => void
-      const onSteerSession = vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            finishSteer = resolve
-          })
-      )
+      let steerCall = 0
+      const onSteerSession = vi.fn(() => {
+        steerCall += 1
+        if (steerCall > 1) return Promise.resolve()
+        return new Promise<void>((resolve) => {
+          finishSteer = resolve
+        })
+      })
 
       // No [data-editor-zone] in the tree — the board card has none; the surface
       // owns opening + focusing its own composer via onRedirect.
@@ -285,12 +287,18 @@ describe("AgentSessionEvent", () => {
         />
       )
 
-      fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
+      const redirect = screen.getByRole("button", { name: "Redirect" })
+      fireEvent.click(redirect)
+      fireEvent.click(redirect)
 
       expect(onSteerSession).toHaveBeenCalledTimes(1)
       expect(onRedirect).not.toHaveBeenCalled()
       finishSteer()
       await waitFor(() => expect(onRedirect).toHaveBeenCalledTimes(1))
+
+      fireEvent.click(redirect)
+      await waitFor(() => expect(onSteerSession).toHaveBeenCalledTimes(2))
+      await waitFor(() => expect(onRedirect).toHaveBeenCalledTimes(2))
       expect(focusAtEnd).not.toHaveBeenCalled()
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })

--- a/apps/frontend/src/components/timeline/agent-session-event.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.tsx
@@ -315,6 +315,7 @@ export function AgentSessionEvent({
 
   const [redirectHintVisible, setRedirectHintVisible] = useState(false)
   const redirectHintTimer = useRef<number | null>(null)
+  const redirectInFlight = useRef(false)
   useEffect(
     () => () => {
       if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)
@@ -327,22 +328,22 @@ export function AgentSessionEvent({
   // Redirect focuses the composer. External runtimes prepend /steer to the
   // next message; hosted agents keep their existing mid-run fold-in path.
   const handleRedirect = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (onRedirect) {
-      // The surface owns opening + focusing its composer (board card).
+    const editor = onRedirect ? null : findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
+    if (!onRedirect && !editor) return
+    if (redirectInFlight.current) return
+
+    redirectInFlight.current = true
+    try {
       await onSteerSession?.()
-      onRedirect()
-    } else {
-      // No composer on this surface (non-member public channel, archived or
-      // locked stream) — bail before the hint, or it promises a fold-in that
-      // can't happen.
-      const editor = findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
-      if (!editor) return
-      await onSteerSession?.()
-      focusAtEnd(editor)
+      if (onRedirect) onRedirect()
+      else if (editor) focusAtEnd(editor)
+
+      if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)
+      setRedirectHintVisible(true)
+      redirectHintTimer.current = window.setTimeout(() => setRedirectHintVisible(false), REDIRECT_HINT_MS)
+    } finally {
+      redirectInFlight.current = false
     }
-    if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)
-    setRedirectHintVisible(true)
-    redirectHintTimer.current = window.setTimeout(() => setRedirectHintVisible(false), REDIRECT_HINT_MS)
   }
 
   // Stop and Redirect are gated on "session running", not on which tool is

--- a/apps/frontend/src/components/timeline/agent-session-event.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.tsx
@@ -40,7 +40,7 @@ interface AgentSessionEventProps {
    */
   onRedirect?: () => void
   /** Route the next composed message through the runtime's /steer command when available. */
-  onSteerSession?: () => void
+  onSteerSession?: () => Promise<void>
 }
 
 type SessionStatus = "running" | "retrying" | "completed" | "failed" | "deleted"
@@ -326,10 +326,10 @@ export function AgentSessionEvent({
 
   // Redirect focuses the composer. External runtimes prepend /steer to the
   // next message; hosted agents keep their existing mid-run fold-in path.
-  const handleRedirect = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleRedirect = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (onRedirect) {
       // The surface owns opening + focusing its composer (board card).
-      onSteerSession?.()
+      await onSteerSession?.()
       onRedirect()
     } else {
       // No composer on this surface (non-member public channel, archived or
@@ -337,7 +337,7 @@ export function AgentSessionEvent({
       // can't happen.
       const editor = findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
       if (!editor) return
-      onSteerSession?.()
+      await onSteerSession?.()
       focusAtEnd(editor)
     }
     if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)

--- a/apps/frontend/src/components/timeline/agent-session-event.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.tsx
@@ -39,6 +39,8 @@ interface AgentSessionEventProps {
    * `[data-editor-zone]` editor instead (timeline, thread panel).
    */
   onRedirect?: () => void
+  /** Route the next composed message through the runtime's /steer command when available. */
+  onSteerSession?: () => void
 }
 
 type SessionStatus = "running" | "retrying" | "completed" | "failed" | "deleted"
@@ -295,6 +297,7 @@ export function AgentSessionEvent({
   liveSubstep,
   onStopSession,
   onRedirect,
+  onSteerSession,
 }: AgentSessionEventProps) {
   const { getTraceUrl } = useTrace()
   const { status, sessionId, startedPayload, completedPayload, failedPayload, interruptedPayload, deletedPayload } =
@@ -321,12 +324,12 @@ export function AgentSessionEvent({
 
   if (!sessionId) return null
 
-  // Redirect needs no backend call: the runtime already folds mid-run messages
-  // into the running session (NewMessageAwareness → reconsidering). The button
-  // just pulls the cursor into a composer and hints at what typing will do.
+  // Redirect focuses the composer. External runtimes prepend /steer to the
+  // next message; hosted agents keep their existing mid-run fold-in path.
   const handleRedirect = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (onRedirect) {
       // The surface owns opening + focusing its composer (board card).
+      onSteerSession?.()
       onRedirect()
     } else {
       // No composer on this surface (non-member public channel, archived or
@@ -334,6 +337,7 @@ export function AgentSessionEvent({
       // can't happen.
       const editor = findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
       if (!editor) return
+      onSteerSession?.()
       focusAtEnd(editor)
     }
     if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -730,7 +730,7 @@ export interface TimelineItemRenderContext {
   /** Click handler for the session card's Stop button. */
   onStopSession?: (sessionId: string) => void
   /** Prepare the composer to dispatch its next message through /steer when supported. */
-  onSteerSession?: () => void
+  onSteerSession?: () => Promise<void>
   /**
    * followUpIds that have a matching `agent:follow_up_cancelled` row in the
    * loaded window. Lets a scheduled follow-up card show its cancelled state

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -13,7 +13,7 @@ import {
 import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "./session-grouping"
 import type { MessageAgentActivity } from "@/hooks"
 import { useSocket, useCoordinatedLoading } from "@/contexts"
-import { useAbortSession } from "@/hooks"
+import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { Loader2 } from "lucide-react"
 import { EventItem } from "./event-item"
 import { AgentSessionEvent } from "./agent-session-event"
@@ -729,6 +729,8 @@ export interface TimelineItemRenderContext {
   sessionLiveSubsteps: Map<string, string | null>
   /** Click handler for the session card's Stop button. */
   onStopSession?: (sessionId: string) => void
+  /** Prepare the composer to dispatch its next message through /steer when supported. */
+  onSteerSession?: () => void
   /**
    * followUpIds that have a matching `agent:follow_up_cancelled` row in the
    * loaded window. Lets a scheduled follow-up card show its cancelled state
@@ -859,6 +861,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
             liveCounts={ctx.sessionLiveCounts.get(item.sessionId)}
             liveSubstep={ctx.sessionLiveSubsteps.get(item.sessionId)}
             onStopSession={ctx.onStopSession}
+            onSteerSession={ctx.onSteerSession}
           />
         </div>
       )}
@@ -1096,7 +1099,8 @@ export function EventList({
 }: EventListProps) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
-  const abortSession = useAbortSession(socket)
+  const stopAgentSession = useStopAgentSession(socket, workspaceId, streamId)
+  const steerAgentSession = useSteerAgentSession(workspaceId, streamId)
 
   const { sessionLiveCounts, sessionLiveSubsteps } = useMemo(() => {
     const counts = new Map<string, { stepCount: number; messageCount: number }>()
@@ -1113,10 +1117,7 @@ export function EventList({
     return { sessionLiveCounts: counts, sessionLiveSubsteps: substeps }
   }, [agentActivity])
 
-  const handleStopSession = useMemo(
-    () => (sessionId: string) => abortSession({ sessionId, workspaceId }),
-    [abortSession, workspaceId]
-  )
+  const handleStopSession = useMemo(() => (sessionId: string) => stopAgentSession(sessionId), [stopAgentSession])
 
   // Day boundaries between rows from different local days (INV-42). Threads
   // render all events with no zero-height filtering, so dividers go straight
@@ -1179,6 +1180,7 @@ export function EventList({
     sessionLiveCounts,
     sessionLiveSubsteps,
     onStopSession: handleStopSession,
+    onSteerSession: steerAgentSession,
     cancelledFollowUpIds,
     delegationStatusPatches,
     botAccessStatusPatches,

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -21,7 +21,8 @@ import {
   useNewMessageIndicator,
   useAgentActivity,
   type MessageAgentActivity,
-  useAbortSession,
+  useSteerAgentSession,
+  useStopAgentSession,
   useEditLastMessageTrigger,
   useKeyboardShortcuts,
   streamKeys,
@@ -2772,7 +2773,8 @@ function TimelineMessageList({
 }) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
-  const abortSession = useAbortSession(socket)
+  const stopAgentSession = useStopAgentSession(socket, workspaceId, streamId)
+  const steerAgentSession = useSteerAgentSession(workspaceId, streamId)
 
   // Tracks whether this component has ever rendered with real timeline content.
   // Drives the empty fallback below: until the first paint, useEvents has not
@@ -2805,10 +2807,7 @@ function TimelineMessageList({
     return { sessionLiveCounts: counts, sessionLiveSubsteps: substeps }
   }, [agentActivity])
 
-  const handleStopSession = useCallback(
-    (sessionId: string) => abortSession({ sessionId, workspaceId }),
-    [abortSession, workspaceId]
-  )
+  const handleStopSession = useCallback((sessionId: string) => stopAgentSession(sessionId), [stopAgentSession])
 
   // First-message lookup for the context-bag attachment badge anchor.
   // Computed once per timeline change; the Virtuoso path threads this through
@@ -2831,6 +2830,7 @@ function TimelineMessageList({
       sessionLiveCounts,
       sessionLiveSubsteps,
       onStopSession: handleStopSession,
+      onSteerSession: steerAgentSession,
       cancelledFollowUpIds,
       delegationStatusPatches,
       botAccessStatusPatches,
@@ -2851,6 +2851,7 @@ function TimelineMessageList({
       sessionLiveCounts,
       sessionLiveSubsteps,
       handleStopSession,
+      steerAgentSession,
       cancelledFollowUpIds,
       delegationStatusPatches,
       botAccessStatusPatches,

--- a/apps/frontend/src/components/trace/trace-dialog.test.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.test.tsx
@@ -11,6 +11,7 @@ import * as relativeTimeModule from "@/components/relative-time"
 import * as hooksModule from "@/hooks"
 import { commandsApi } from "@/api"
 import { toast } from "sonner"
+import { consumeComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 let mockSessionId = "session_1"
 let mockSessionIndex = 0
@@ -230,7 +231,7 @@ describe("TraceDialog", () => {
     expect(commandsApi.dispatch).not.toHaveBeenCalled()
   })
 
-  it("dispatches advertised runtime stop and steer commands from the running trace", async () => {
+  it("dispatches runtime stop and prepares the composer with advertised /steer", async () => {
     mockSessionId = "session_run"
     mockSession = {
       id: "session_run",
@@ -263,9 +264,7 @@ describe("TraceDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
     fireEvent.click(screen.getByRole("button", { name: "Stop" }))
 
-    await waitFor(() =>
-      expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" })
-    )
+    await waitFor(() => expect(consumeComposerCommandRequest("stream_1")).toBe("/steer "))
     await waitFor(() =>
       expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" })
     )

--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -16,6 +16,7 @@ import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { TraceStepList } from "./trace-step-list"
 import { commandsApi } from "@/api"
 import { findVisibleZoneEditor } from "@/components/timeline/message-event"
+import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 import { X } from "lucide-react"
 import { toast } from "sonner"
 import { formatDuration } from "@/lib/dates"
@@ -128,10 +129,7 @@ export function TraceDialog() {
     void (async () => {
       if (workspaceId && session?.streamId) {
         const advertised = await resolveRuntimeCommands({ workspaceId, streamId: session.streamId, runtimeCommands })
-        if (advertised.has("steer")) {
-          await commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/steer" })
-          return
-        }
+        if (advertised.has("steer")) queueComposerCommandRequest(session.streamId, "/steer ")
       }
 
       for (const zone of document.querySelectorAll<HTMLElement>("[data-editor-zone]")) {

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -164,6 +164,8 @@ export { useThreadAncestors } from "./use-thread-ancestors"
 export { useAgentActivity, getStepLabel, type MessageAgentActivity } from "./use-agent-activity"
 
 export { useAbortSession } from "./use-abort-session"
+export { useStopAgentSession } from "./use-stop-agent-session"
+export { useSteerAgentSession } from "./use-steer-agent-session"
 
 export { usePreloadImages } from "./use-preload-images"
 

--- a/apps/frontend/src/hooks/use-steer-agent-session.test.ts
+++ b/apps/frontend/src/hooks/use-steer-agent-session.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 import { commandsApi } from "@/api"
 import { consumeComposerCommandRequest } from "@/stores/composer-command-request-store"
 import { useSteerAgentSession } from "./use-steer-agent-session"
@@ -16,18 +16,18 @@ describe("useSteerAgentSession", () => {
     ])
     const { result } = renderHook(() => useSteerAgentSession("ws_1", "stream_1"))
 
-    act(() => result.current())
+    await act(() => result.current())
 
-    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalledWith("ws_1", "stream_1"))
-    await waitFor(() => expect(consumeComposerCommandRequest("stream_1")).toBe("/steer "))
+    expect(commandsApi.listForStream).toHaveBeenCalledWith("ws_1", "stream_1")
+    expect(consumeComposerCommandRequest("stream_1")).toBe("/steer ")
   })
 
   it("leaves persona composers unchanged when no runtime steer command is advertised", async () => {
     const { result } = renderHook(() => useSteerAgentSession("ws_1", "stream_2"))
 
-    act(() => result.current())
+    await act(() => result.current())
 
-    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalled())
+    expect(commandsApi.listForStream).toHaveBeenCalled()
     expect(consumeComposerCommandRequest("stream_2")).toBeNull()
   })
 })

--- a/apps/frontend/src/hooks/use-steer-agent-session.test.ts
+++ b/apps/frontend/src/hooks/use-steer-agent-session.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { commandsApi } from "@/api"
+import { consumeComposerCommandRequest } from "@/stores/composer-command-request-store"
+import { useSteerAgentSession } from "./use-steer-agent-session"
+
+describe("useSteerAgentSession", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+  })
+
+  it("queues /steer for the stream when the external runtime advertises it", async () => {
+    vi.mocked(commandsApi.listForStream).mockResolvedValue([
+      { name: "steer", description: "Steer", kind: "bot-runtime", scope: "stream" },
+    ])
+    const { result } = renderHook(() => useSteerAgentSession("ws_1", "stream_1"))
+
+    act(() => result.current())
+
+    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalledWith("ws_1", "stream_1"))
+    await waitFor(() => expect(consumeComposerCommandRequest("stream_1")).toBe("/steer "))
+  })
+
+  it("leaves persona composers unchanged when no runtime steer command is advertised", async () => {
+    const { result } = renderHook(() => useSteerAgentSession("ws_1", "stream_2"))
+
+    act(() => result.current())
+
+    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalled())
+    expect(consumeComposerCommandRequest("stream_2")).toBeNull()
+  })
+})

--- a/apps/frontend/src/hooks/use-steer-agent-session.ts
+++ b/apps/frontend/src/hooks/use-steer-agent-session.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react"
+import { commandsApi } from "@/api"
+import { CommandKinds } from "@threa/types"
+import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
+
+export function useSteerAgentSession(workspaceId: string, streamId: string) {
+  return useCallback(() => {
+    void commandsApi
+      .listForStream(workspaceId, streamId)
+      .then((commands) => {
+        const advertised = commands.some(
+          (command) => command.kind === CommandKinds.BOT_RUNTIME && command.name === "steer"
+        )
+        if (advertised) queueComposerCommandRequest(streamId, "/steer ")
+      })
+      .catch((error: unknown) => {
+        console.warn("[useSteerAgentSession] failed to resolve runtime steer command", error)
+      })
+  }, [streamId, workspaceId])
+}

--- a/apps/frontend/src/hooks/use-steer-agent-session.ts
+++ b/apps/frontend/src/hooks/use-steer-agent-session.ts
@@ -4,17 +4,15 @@ import { CommandKinds } from "@threa/types"
 import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 export function useSteerAgentSession(workspaceId: string, streamId: string) {
-  return useCallback(() => {
-    void commandsApi
-      .listForStream(workspaceId, streamId)
-      .then((commands) => {
-        const advertised = commands.some(
-          (command) => command.kind === CommandKinds.BOT_RUNTIME && command.name === "steer"
-        )
-        if (advertised) queueComposerCommandRequest(streamId, "/steer ")
-      })
-      .catch((error: unknown) => {
-        console.warn("[useSteerAgentSession] failed to resolve runtime steer command", error)
-      })
+  return useCallback(async () => {
+    try {
+      const commands = await commandsApi.listForStream(workspaceId, streamId)
+      const advertised = commands.some(
+        (command) => command.kind === CommandKinds.BOT_RUNTIME && command.name === "steer"
+      )
+      if (advertised) queueComposerCommandRequest(streamId, "/steer ")
+    } catch (error) {
+      console.warn("[useSteerAgentSession] failed to resolve runtime steer command", error)
+    }
   }, [streamId, workspaceId])
 }

--- a/apps/frontend/src/hooks/use-stop-agent-session.test.ts
+++ b/apps/frontend/src/hooks/use-stop-agent-session.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { Socket } from "socket.io-client"
+import { commandsApi } from "@/api"
+import { toast } from "sonner"
+import { useStopAgentSession } from "./use-stop-agent-session"
+
+function makeSocket() {
+  return { emit: vi.fn() } as unknown as Socket
+}
+
+describe("useStopAgentSession", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+    vi.spyOn(commandsApi, "dispatch").mockResolvedValue({} as Awaited<ReturnType<typeof commandsApi.dispatch>>)
+    vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+  })
+
+  it("dispatches /stop when the stream advertises the external runtime command", async () => {
+    const socket = makeSocket()
+    vi.mocked(commandsApi.listForStream).mockResolvedValue([
+      { name: "stop", description: "Stop", kind: "bot-runtime", scope: "stream" },
+    ])
+    const { result } = renderHook(() => useStopAgentSession(socket, "ws_1", "stream_1"))
+
+    act(() => result.current("session_1"))
+
+    await waitFor(() =>
+      expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" })
+    )
+    expect(socket.emit).not.toHaveBeenCalled()
+  })
+
+  it("uses the local session abort when no runtime stop command is advertised", async () => {
+    const socket = makeSocket()
+    const { result } = renderHook(() => useStopAgentSession(socket, "ws_1", "stream_1"))
+
+    act(() => result.current("session_1"))
+
+    await waitFor(() =>
+      expect(socket.emit).toHaveBeenCalledWith(
+        "agent_session:research:abort",
+        { sessionId: "session_1", workspaceId: "ws_1" },
+        expect.any(Function)
+      )
+    )
+    expect(commandsApi.dispatch).not.toHaveBeenCalled()
+  })
+
+  it("falls back to local abort when runtime dispatch fails", async () => {
+    const socket = makeSocket()
+    vi.mocked(commandsApi.listForStream).mockResolvedValue([
+      { name: "stop", description: "Stop", kind: "bot-runtime", scope: "stream" },
+    ])
+    vi.mocked(commandsApi.dispatch).mockRejectedValue(new Error("network down"))
+    const { result } = renderHook(() => useStopAgentSession(socket, "ws_1", "stream_1"))
+
+    act(() => result.current("session_1"))
+
+    await waitFor(() => expect(socket.emit).toHaveBeenCalled())
+    expect(toast.error).toHaveBeenCalledWith("Runtime stop failed — using local stop instead")
+  })
+})

--- a/apps/frontend/src/hooks/use-stop-agent-session.ts
+++ b/apps/frontend/src/hooks/use-stop-agent-session.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react"
+import type { Socket } from "socket.io-client"
+import { toast } from "sonner"
+import { commandsApi } from "@/api"
+import { CommandKinds } from "@threa/types"
+import { useAbortSession } from "./use-abort-session"
+
+function advertisesRuntimeStop(commands: Awaited<ReturnType<typeof commandsApi.listForStream>>): boolean {
+  return commands.some((command) => command.kind === CommandKinds.BOT_RUNTIME && command.name === "stop")
+}
+
+export function useStopAgentSession(socket: Socket | null, workspaceId: string, streamId: string) {
+  const abortSession = useAbortSession(socket)
+
+  return useCallback(
+    (sessionId: string) => {
+      void commandsApi
+        .listForStream(workspaceId, streamId)
+        .then(async (commands) => {
+          if (!advertisesRuntimeStop(commands)) {
+            abortSession({ sessionId, workspaceId })
+            return
+          }
+
+          try {
+            await commandsApi.dispatch(workspaceId, { streamId, command: "/stop" })
+          } catch (error) {
+            console.warn("[useStopAgentSession] /stop dispatch failed, falling back to local abort", error)
+            toast.error("Runtime stop failed — using local stop instead")
+            abortSession({ sessionId, workspaceId })
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn("[useStopAgentSession] failed to resolve runtime stop command", error)
+          toast.error("Failed to stop session")
+          abortSession({ sessionId, workspaceId })
+        })
+    },
+    [abortSession, streamId, workspaceId]
+  )
+}

--- a/apps/frontend/src/stores/composer-command-request-store.ts
+++ b/apps/frontend/src/stores/composer-command-request-store.ts
@@ -1,0 +1,29 @@
+const HANDOFF_TTL_MS = 30 * 1000
+
+const requests = new Map<string, { command: string; expiresAt: number }>()
+const listeners = new Map<string, Set<() => void>>()
+
+export function queueComposerCommandRequest(streamId: string, command: string): void {
+  requests.set(streamId, { command, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  for (const listener of listeners.get(streamId) ?? []) listener()
+}
+
+export function consumeComposerCommandRequest(streamId: string): string | null {
+  const request = requests.get(streamId)
+  if (!request) return null
+  requests.delete(streamId)
+  return request.expiresAt >= Date.now() ? request.command : null
+}
+
+export function subscribeComposerCommandRequest(streamId: string, listener: () => void): () => void {
+  let streamListeners = listeners.get(streamId)
+  if (!streamListeners) {
+    streamListeners = new Set()
+    listeners.set(streamId, streamListeners)
+  }
+  streamListeners.add(listener)
+  return () => {
+    streamListeners.delete(listener)
+    if (streamListeners.size === 0) listeners.delete(streamId)
+  }
+}

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -614,7 +614,7 @@ describe("mergeReconnectWorkspaceBootstrap", () => {
 })
 
 function createTestSocket() {
-  const handlers = new Map<string, Set<(payload: unknown) => void>>()
+  const handlers = new Map<string, Set<(payload: unknown) => unknown>>()
 
   const socket = {
     on(event: string, handler: (payload: unknown) => void) {
@@ -633,6 +633,9 @@ function createTestSocket() {
     socket,
     emit(event: string, payload: unknown) {
       handlers.get(event)?.forEach((handler) => handler(payload))
+    },
+    async emitAsync(event: string, payload: unknown) {
+      await Promise.all(Array.from(handlers.get(event) ?? [], (handler) => handler(payload)))
     },
   }
 }
@@ -2040,11 +2043,6 @@ describe("latest ordinal seeding and reconnect merge (sync phase 2c)", () => {
 })
 
 describe("agent-activity sidebar socket handlers", () => {
-  // The started/progress/activity handlers await db.streams.get (fake-indexeddb),
-  // which settles over several ticks — a macrotask flush guarantees the async
-  // upsert lands before the assertion and never leaks into the next test.
-  const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
-
   const handlerRefs = {
     getCurrentStreamId: () => undefined,
     getCurrentUser: () => ({ id: "workos_1" }),
@@ -2081,15 +2079,14 @@ describe("agent-activity sidebar socket handlers", () => {
   it("upserts on started (wrapped outbox shape), resolving the channel root, and removes on the flat session-room completed shape", async () => {
     await putStream("stream_ch", null)
     const queryClient = new QueryClient()
-    const { socket, emit } = createTestSocket()
+    const { socket, emit, emitAsync } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
-    emit("agent_session:started", {
+    await emitAsync("agent_session:started", {
       workspaceId: "ws_1",
       streamId: "stream_ch",
       event: { payload: { sessionId: "sess_1", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    await flush()
 
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_1"])
 
@@ -2104,24 +2101,22 @@ describe("agent-activity sidebar socket handlers", () => {
     await putStream("stream_ch", null)
     await putStream("stream_thr", "stream_ch")
     const queryClient = new QueryClient()
-    const { socket, emit } = createTestSocket()
+    const { socket, emitAsync } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
-    emit("agent_session:started", {
+    await emitAsync("agent_session:started", {
       workspaceId: "ws_1",
       streamId: "stream_thr",
       event: { payload: { sessionId: "sess_thr", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    await flush()
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_thr"])
 
     // Different workspace — ignored.
-    emit("agent_session:started", {
+    await emitAsync("agent_session:started", {
       workspaceId: "ws_other",
       streamId: "stream_ch",
       event: { payload: { sessionId: "sess_other", personaName: "X", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    await flush()
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_thr"])
 
     cleanup()
@@ -2130,32 +2125,29 @@ describe("agent-activity sidebar socket handlers", () => {
   it("skips an uncached thread and leaves progress on a tracked session a no-op", async () => {
     await putStream("stream_ch", null)
     const queryClient = new QueryClient()
-    const { socket, emit } = createTestSocket()
+    const { socket, emitAsync } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
     // Started for a stream not in the cache — skipped, nothing tracked.
-    emit("agent_session:started", {
+    await emitAsync("agent_session:started", {
       workspaceId: "ws_1",
       streamId: "stream_uncached",
       event: { payload: { sessionId: "sess_u", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    await flush()
     expect(getAgentActivityForStream("ws_1", "stream_uncached")).toEqual([])
 
-    emit("agent_session:started", {
+    await emitAsync("agent_session:started", {
       workspaceId: "ws_1",
       streamId: "stream_ch",
       event: { payload: { sessionId: "sess_p", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    await flush()
 
-    emit("agent_session:progress", {
+    await emitAsync("agent_session:progress", {
       workspaceId: "ws_1",
       streamId: "stream_ch",
       sessionId: "sess_p",
       personaName: "Ariadne",
     })
-    await flush()
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_p"])
 
     cleanup()


### PR DESCRIPTION
## Problem

The activity-card Stop action always emitted `agent_session:research:abort`. That reaches hosted persona and enclave sessions, but cannot interrupt work owned by an external bot runtime. Redirect also relied on ordinary mid-run message folding, which does not match `/steer` for every external runtime.

## Solution

Route activity-card controls through the stream's advertised bot-runtime commands. External sessions use `/stop` and `/steer`; hosted sessions retain the existing socket-abort and ordinary-message behavior.

### How it works

1. `useStopAgentSession` resolves the stream command list. An advertised bot-runtime `stop` dispatches `/stop`; otherwise it emits the existing local session abort. Failed runtime dispatches surface an error and fall back to local abort.
2. `useSteerAgentSession` checks for an advertised bot-runtime `steer` command and queues a `/steer ` composer prefix. Redirect awaits that lookup before opening or focusing the composer, so a delayed response cannot modify a later draft.
3. `composer-command-request-store.ts` hands that prefix to the mounted stream composer, or retains it for up to 30 seconds while a collapsed board composer opens. Existing draft content is preserved after the prefix.
4. Timeline, thread, board, and trace-dialog controls use the same runtime-aware paths.

### Key design decisions

**Capability-driven routing** — command availability is the source of truth. Actor-id prefixes cannot reliably distinguish hosted and external sessions.

**Preserve hosted behavior** — streams without advertised runtime controls keep `useAbortSession` and ordinary composer focus, so persona and enclave controls do not regress.

**Prefix the next composed message instead of dispatching empty `/steer`** — external runtimes receive the user's instruction as the command argument. An empty `/steer` can legitimately have nothing to inject.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-stop-agent-session.ts` | Select runtime `/stop` or hosted socket abort. |
| `apps/frontend/src/hooks/use-steer-agent-session.ts` | Queue `/steer ` when the runtime advertises steering. |
| `apps/frontend/src/stores/composer-command-request-store.ts` | Hand command prefixes to mounted or soon-to-mount stream composers. |
| `apps/frontend/src/hooks/use-stop-agent-session.test.ts` | Runtime, hosted, and dispatch-failure stop coverage. |
| `apps/frontend/src/hooks/use-steer-agent-session.test.ts` | Runtime and hosted steering coverage. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/{stream-content,event-list,agent-session-event}.tsx` | Wire runtime-aware Stop and Redirect through virtualized and non-virtualized timeline cards. |
| `apps/frontend/src/components/board/board-row-item.tsx` | Apply the same controls to board session rows. |
| `apps/frontend/src/components/trace/trace-dialog.tsx` | Replace empty `/steer` dispatch with composer-prefixed steering. |
| `apps/frontend/src/components/composer/message-composer.tsx` | Consume queued command prefixes while preserving draft JSON. |
| `apps/frontend/src/hooks/index.ts` | Export the new hooks. |
| Frontend component tests | Cover command preparation, focus behavior, and stop routing. |

## Out of scope

No bot-runtime API, command-routing, schema, or external extension changes. The existing `/stop` and `/steer` backend/runtime paths remain authoritative.

## Test plan

- [x] Focused frontend suites — 74 pass
- [x] Frontend `tsc --noEmit`
- [x] Frontend ESLint
- [x] Pre-commit repository lint, monorepo typecheck, OpenAPI check, Dockerfile workspace check, and migration check
- [x] Terra code review — 1 async steering race accepted and fixed in `74b5dcf8`
- [x] Frontend `workspace-sync.test.ts` — 47 pass across 3 consecutive runs; replaced CI-flaky timer flushes with awaited handler completion in `fbc381f0`
- [x] Backend `sync-reconciliation.test.ts` — 3 pass across 2 runs; isolated its database from concurrent CI dispatchers in `f95d39bc`

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make Stop and Redirect controls on agent trace surfaces behave like `/stop` and `/steer` when the running session belongs to an external bot runtime, without changing hosted persona or enclave behavior.

## What Was Built

### Runtime-aware control hooks

- `useStopAgentSession` checks advertised stream commands and dispatches `/stop` for external runtimes, with local abort as the hosted path and runtime-dispatch fallback.
- `useSteerAgentSession` checks advertised stream commands and requests a `/steer ` prefix for the next composer submission; the card awaits this preparation before exposing the composer.

### Composer handoff

- `composer-command-request-store.ts` provides a per-stream, 30-second handoff for mounted timeline composers and board composers that mount after Redirect opens them.
- `MessageComposer` prepends the command without replacing existing ProseMirror JSON content or duplicating an existing `/steer` command.

### Surface wiring

- Timeline, thread, board, and trace-dialog session actions use the runtime-aware controls.
- Hosted sessions continue using the existing socket abort and normal mid-run message fold-in.

## Design Decisions

### Resolve behavior from advertised commands

**Chose:** inspect `commandsApi.listForStream` for bot-runtime `stop` and `steer` entries.
**Why:** the command list already reflects the live linked runtime and its capabilities.
**Alternatives considered:** infer external ownership from actor ids or session payloads; those do not encode live command availability.

### Send steering text through the composer

**Chose:** prefix the next draft with `/steer `.
**Why:** the command needs the user's instruction. Dispatching bare `/steer` before text exists can complete without changing the running turn.

## Design Evolution

- The initial Stop-only diagnosis expanded after verifying that trace-dialog Redirect dispatched an empty `/steer` and activity-card Redirect depended on runtime-specific ordinary-message folding. Both controls now use the slash-command semantics requested.
- Terra found that an unresolved capability request could prefix a later draft if the user submitted first. Redirect now awaits command resolution before opening or focusing the composer.

## Schema Changes

None.

## What's NOT Included

- No backend command-routing changes.
- No bot-runtime extension changes.
- No persistent composer mode; the request is a one-shot command prefix.

## Status

- [x] Runtime-aware Stop
- [x] Runtime-aware Redirect
- [x] Timeline, thread, board, and trace-dialog wiring
- [x] Focused tests, typecheck, and lint

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786826272&installation_id=129946197&pr_number=1375&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1375&signature=1466d3264f01013014a70be8e6996e2806b294d32e9af4a182bbea1f70d28a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


