### PR TITLE
revert: client-coordinated session refresh (#1376) — denied handshake permanently kills the socket

### DIFF
--- a/apps/backend/src/lib/socket-auth.test.ts
+++ b/apps/backend/src/lib/socket-auth.test.ts
@@ -10,14 +10,9 @@ function fakeSocket(cookie?: string) {
 const COOKIE = "wos_session=tok"
 
 describe("createSocketAuthMiddleware", () => {
-  it("stamps the workos user id on success — via verify-only, never the refreshing path", async () => {
-    // A WS handshake can't carry Set-Cookie back, so a refresh here would
-    // rotate the WorkOS refresh token into a sealed session the browser never
-    // receives. The middleware must use verifySession exclusively.
-    const authenticateSession = mock(async () => ({ success: true, user: { id: "workos_wrong" } }))
+  it("stamps the workos user id on success", async () => {
     const authService = {
-      verifySession: mock(async () => ({ success: true, user: { id: "workos_1" } })),
-      authenticateSession,
+      authenticateSession: mock(async () => ({ success: true, user: { id: "workos_1" } })),
     } as unknown as AuthService
     const middleware = createSocketAuthMiddleware(authService)
     const socket = fakeSocket(COOKIE)
@@ -27,33 +22,21 @@ describe("createSocketAuthMiddleware", () => {
 
     expect(next).toHaveBeenCalledWith()
     expect(socket.data.workosUserId).toBe("workos_1")
-    expect(authenticateSession).not.toHaveBeenCalled()
   })
 
   it("rejects when the session cookie is missing", async () => {
-    const authService = { verifySession: mock(async () => ({ success: true })) } as unknown as AuthService
+    const authService = { authenticateSession: mock(async () => ({ success: true })) } as unknown as AuthService
     const next = mock((_err?: unknown) => {})
 
     await createSocketAuthMiddleware(authService)(fakeSocket(), next)
 
-    expect(authService.verifySession).not.toHaveBeenCalled()
+    expect(authService.authenticateSession).not.toHaveBeenCalled()
     expect(next.mock.calls[0][0]).toBeInstanceOf(Error)
   })
 
-  it("rejects an expired token so the client refreshes over HTTP and reconnects", async () => {
+  it("fails closed when authenticateSession throws", async () => {
     const authService = {
-      verifySession: mock(async () => ({ success: false, reason: "invalid_jwt", terminal: false })),
-    } as unknown as AuthService
-    const next = mock((_err?: unknown) => {})
-
-    await createSocketAuthMiddleware(authService)(fakeSocket(COOKIE), next)
-
-    expect(next.mock.calls[0][0]).toBeInstanceOf(Error)
-  })
-
-  it("fails closed when verifySession throws", async () => {
-    const authService = {
-      verifySession: mock(async () => {
+      authenticateSession: mock(async () => {
         throw new Error("WorkOS unreachable")
       }),
     } as unknown as AuthService

--- a/apps/backend/src/lib/socket-auth.ts
+++ b/apps/backend/src/lib/socket-auth.ts
@@ -21,12 +21,7 @@ export function createSocketAuthMiddleware(authService: AuthService) {
     // throwing auth call (network/WorkOS error) would hang the connection until
     // timeout. Fail closed: reject the connection rather than leave it pending.
     try {
-      // Verify-only, NEVER refresh: a WS handshake can't carry Set-Cookie back,
-      // so a server-side refresh here rotates the WorkOS refresh token into a
-      // sealed session the browser never receives — silently consuming the
-      // token the browser's cookie still holds. An expired cookie is rejected
-      // instead; the HTTP layer refreshes it and socket.io's reconnect succeeds.
-      const result = await authService.verifySession(session)
+      const result = await authService.authenticateSession(session)
       if (!result.success || !result.user) return next(new Error("Authentication failed"))
       socket.data.workosUserId = result.user.id
       next()

--- a/apps/control-plane/src/features/accounts/service.test.ts
+++ b/apps/control-plane/src/features/accounts/service.test.ts
@@ -51,10 +51,6 @@ class ProgrammableAuthService implements AuthService {
     this.replies.set(sealed, reply)
   }
 
-  async verifySession(sealed: string): Promise<AuthResult> {
-    return this.authenticateSession(sealed)
-  }
-
   async authenticateSession(sealed: string): Promise<AuthResult> {
     const reply = this.replies.get(sealed)
     if (!reply) return { success: false, refreshed: false, reason: "not_found" }

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -264,22 +264,6 @@ export function createControlPlaneAuthHandlers({
       res.redirect(sameAppOrigin)
     },
 
-    /**
-     * Explicit session refresh for client-coordinated auth. All the work
-     * happens in the auth middleware this route mounts in LEGACY mode (the
-     * coordinator's call deliberately omits the client-refresh header): an
-     * expired token is refreshed and the rotated cookie rides this response's
-     * Set-Cookie; a still-valid token (another tab refreshed first) is a
-     * no-op — no redundant rotation. The client serializes calls per session
-     * (shared promise + Web Lock), so rotating-refresh-token races never form.
-     */
-    async refresh(req: Request, res: Response) {
-      if (!req.authUser) {
-        throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
-      }
-      res.json({ data: { ok: true } })
-    },
-
     async me(req: Request, res: Response) {
       const authUser = req.authUser
       if (!authUser) {

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -131,7 +131,6 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   }
 
   app.get("/api/auth/me", auth, authHandlers.me)
-  app.post("/api/auth/refresh", authLimit, auth, authHandlers.refresh)
   app.get("/api/integrations/github/callback", auth, integrations.githubCallback)
   app.get("/api/integrations/linear/callback", auth, integrations.linearCallback)
 

--- a/apps/control-plane/tests/e2e/auth.test.ts
+++ b/apps/control-plane/tests/e2e/auth.test.ts
@@ -44,18 +44,6 @@ describe("Auth", () => {
     expect(afterRes.status).toBe(401)
   })
 
-  test("POST /api/auth/refresh returns ok for a live session and 401 without one", async () => {
-    const anonymous = new TestClient()
-    const anonRes = await anonymous.post("/api/auth/refresh")
-    expect(anonRes.status).toBe(401)
-
-    const client = new TestClient()
-    await loginAs(client, "refresh-test@example.com", "Refresh Tester")
-    const res = await client.post<{ data: { ok: boolean } }>("/api/auth/refresh")
-    expect(res.status).toBe(200)
-    expect(res.data.data.ok).toBe(true)
-  })
-
   test("GET /readyz returns ok", async () => {
     const client = new TestClient()
     const res = await client.get<{ status: string }>("/readyz")

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { THREA_AUTH_MODE_HEADER } from "@threa/types"
 import { api, ApiError, parseApiError } from "./client"
 
 const originalFetch = globalThis.fetch
@@ -101,95 +100,6 @@ describe("apiFetch request timeout", () => {
 
     await vi.advanceTimersByTimeAsync(1)
     expect(((await p) as Error).message).toBe("Request timed out after 1000ms")
-  })
-})
-
-describe("apiFetch client-coordinated session refresh", () => {
-  beforeEach(() => {
-    globalThis.fetch = vi.fn() as unknown as typeof fetch
-  })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  const expired = () => mockResponse(401, { error: "Session expired", code: "TOKEN_EXPIRED" })
-  const ok = (body: unknown) => mockResponse(200, body)
-
-  function fetchCalls(): Array<{ url: string; init: RequestInit | undefined }> {
-    return vi.mocked(globalThis.fetch).mock.calls.map(([url, init]) => ({ url: String(url), init }))
-  }
-
-  it("sends the auth-mode header on every request", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(ok({ fine: true }))
-    await api.get("/anything")
-    const headers = fetchCalls()[0]!.init?.headers as Record<string, string>
-    expect(headers[THREA_AUTH_MODE_HEADER]).toBe("client-refresh")
-  })
-
-  it("on TOKEN_EXPIRED: refreshes once (without the header) and retries the request once", async () => {
-    vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(expired()) // original request
-      .mockResolvedValueOnce(ok({ data: { ok: true } })) // POST /api/auth/refresh
-      .mockResolvedValueOnce(ok({ answer: 42 })) // retried request
-
-    const result = await api.get<{ answer: number }>("/data")
-
-    expect(result).toEqual({ answer: 42 })
-    const calls = fetchCalls()
-    expect(calls.map((c) => c.url)).toEqual(["/data", "/api/auth/refresh", "/data"])
-    // The refresh call must take the LEGACY implicit-refresh path — no auth-mode header.
-    const refreshHeaders = (calls[1]!.init?.headers ?? {}) as Record<string, string>
-    expect(refreshHeaders[THREA_AUTH_MODE_HEADER]).toBeUndefined()
-  })
-
-  it("coalesces concurrent TOKEN_EXPIRED failures into ONE refresh", async () => {
-    let refreshCount = 0
-    vi.mocked(globalThis.fetch).mockImplementation(async (url: RequestInfo | URL) => {
-      const path = String(url)
-      if (path === "/api/auth/refresh") {
-        refreshCount++
-        // Yield so both callers are queued on the shared promise before it settles.
-        await new Promise((r) => setTimeout(r, 10))
-        return ok({ data: { ok: true } })
-      }
-      return refreshCount > 0 ? ok({ path }) : expired()
-    })
-
-    const [a, b] = await Promise.all([api.get<{ path: string }>("/a"), api.get<{ path: string }>("/b")])
-
-    expect(refreshCount).toBe(1)
-    expect([a.path, b.path]).toEqual(["/a", "/b"])
-  })
-
-  it("a dead session (SESSION_INVALID refresh) rethrows the original 401 so the login redirect fires", async () => {
-    vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(expired())
-      .mockResolvedValueOnce(mockResponse(401, { error: "Session expired", code: "SESSION_INVALID" }))
-
-    const err = (await api.get("/data").catch((e) => e)) as ApiError
-    expect(ApiError.isApiError(err)).toBe(true)
-    expect(err).toMatchObject({ status: 401, code: "TOKEN_EXPIRED" })
-    expect(fetchCalls()).toHaveLength(2) // no retry of the original request
-  })
-
-  it("an unavailable refresh (outage) throws a NON-ApiError so the app is not bounced to login", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(expired()).mockRejectedValueOnce(new TypeError("Failed to fetch"))
-
-    const err = (await api.get("/data").catch((e) => e)) as Error
-    expect(err).toBeInstanceOf(Error)
-    expect(ApiError.isApiError(err)).toBe(false)
-    expect(err.message).toContain("Session refresh unavailable")
-  })
-
-  it("a 401 with a non-expired code (e.g. SESSION_INVALID) is thrown as-is with no refresh attempt", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      mockResponse(401, { error: "Session expired", code: "SESSION_INVALID" })
-    )
-
-    const err = (await api.get("/data").catch((e) => e)) as ApiError
-    expect(err).toMatchObject({ status: 401, code: "SESSION_INVALID" })
-    expect(fetchCalls()).toHaveLength(1)
   })
 })
 

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -1,10 +1,3 @@
-import {
-  AUTH_SESSION_INVALID_CODE,
-  AUTH_TOKEN_EXPIRED_CODE,
-  THREA_AUTH_MODE_CLIENT_REFRESH,
-  THREA_AUTH_MODE_HEADER,
-} from "@threa/types"
-
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -67,28 +60,15 @@ export async function postMultipartFile<T>(
   fieldName: string,
   fallback: { code?: string; message?: string } = {}
 ): Promise<T> {
-  const post = async (): Promise<Response> => {
-    // Fresh FormData per attempt: a File re-reads fine, but a consumed
-    // FormData body is not guaranteed re-sendable everywhere.
-    const formData = new FormData()
-    formData.append(fieldName, file)
-    return fetch(`${API_BASE}${path}`, {
-      method: "POST",
-      credentials: "include",
-      headers: { [THREA_AUTH_MODE_HEADER]: THREA_AUTH_MODE_CLIENT_REFRESH },
-      body: formData,
-    })
-  }
-  let response = await post()
+  const formData = new FormData()
+  formData.append(fieldName, file)
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  })
   if (!response.ok) {
-    const error = await parseApiError(response, fallback)
-    if (error.status !== 401 || error.code !== AUTH_TOKEN_EXPIRED_CODE) throw error
-    // Same refresh-once-and-retry as apiFetch (see ensureFreshSession).
-    const outcome = await ensureFreshSession()
-    if (outcome === "session-dead") throw error
-    if (outcome === "unavailable") throw new Error("Session refresh unavailable; upload not retried")
-    response = await post()
-    if (!response.ok) throw await parseApiError(response, fallback)
+    throw await parseApiError(response, fallback)
   }
   return (await response.json()) as T
 }
@@ -107,90 +87,9 @@ export function postAvatarUpload<T>(path: string, file: File): Promise<T> {
 // override per-call via `options.timeoutMs`.
 const DEFAULT_TIMEOUT_MS = 20000
 
-// --- Client-coordinated session refresh -------------------------------------
-//
-// Every request opts into verify-only auth (THREA_AUTH_MODE_HEADER): the
-// server never refreshes the WorkOS session inline, so an expired access
-// token 401s fast with TOKEN_EXPIRED. This layer then runs EXACTLY ONE
-// refresh — deduped across concurrent queries by a shared promise and across
-// tabs by a Web Lock — and retries the failed request once. WorkOS rotates
-// refresh tokens on use, so two concurrent refreshes with the same cookie
-// invalidate each other (the random-logout generator this replaces); the
-// browser is the natural singleton for its session, which makes this correct
-// on any number of backend replicas, regions, or services.
-
-const REFRESH_LOCK_NAME = "threa-session-refresh"
-
-/** Outcome of a coordinated refresh attempt. */
-type RefreshOutcome = "refreshed" | "session-dead" | "unavailable"
-
-let refreshInflight: Promise<RefreshOutcome> | null = null
-
-async function requestRefresh(): Promise<RefreshOutcome> {
-  // Deliberately WITHOUT the auth-mode header: the refresh endpoint mounts the
-  // legacy implicit-refresh middleware, which rotates the cookie onto this
-  // response. A still-valid token (another tab refreshed first while we waited
-  // on the lock) is a no-op 200 — no redundant rotation.
-  let response: Response
-  try {
-    response = await fetch(`${API_BASE}/api/auth/refresh`, { method: "POST", credentials: "include" })
-  } catch {
-    return "unavailable"
-  }
-  if (response.ok) return "refreshed"
-  if (response.status !== 401) return "unavailable"
-  const body = (await response.json().catch(() => ({}))) as ErrorResponse
-  // AUTH_UNAVAILABLE (WorkOS outage / refresh race) is transient: the session
-  // may be fine — do not treat it as dead.
-  return body.code === AUTH_SESSION_INVALID_CODE ? "session-dead" : "unavailable"
-}
-
-/**
- * Run one coordinated session refresh. Callers that hit TOKEN_EXPIRED await
- * this and retry once; all concurrent callers (and other tabs, via the Web
- * Lock) share a single WorkOS refresh.
- */
-export function ensureFreshSession(): Promise<RefreshOutcome> {
-  if (refreshInflight) return refreshInflight
-  // Web Locks serialize refreshes across tabs; a tab that waited here very
-  // likely finds a fresh cookie and its refresh call no-ops server-side.
-  // Older browsers without the API fall back to in-tab dedupe only.
-  const run = async (): Promise<RefreshOutcome> =>
-    typeof navigator !== "undefined" && navigator.locks
-      ? ((await navigator.locks.request(REFRESH_LOCK_NAME, requestRefresh)) as RefreshOutcome)
-      : requestRefresh()
-  refreshInflight = run().finally(() => {
-    refreshInflight = null
-  })
-  return refreshInflight
-}
-
 export type ApiRequestInit = RequestInit & { timeoutMs?: number }
 
 async function apiFetch<T>(path: string, options: ApiRequestInit = {}): Promise<T> {
-  try {
-    return await apiFetchOnce<T>(path, options)
-  } catch (error) {
-    // Expired access token: refresh once (coordinated across queries + tabs)
-    // and retry once. Any other outcome — session dead, refresh unavailable,
-    // retry failing again — falls through to the normal error paths.
-    if (!(error instanceof ApiError) || error.status !== 401 || error.code !== AUTH_TOKEN_EXPIRED_CODE) {
-      throw error
-    }
-    if (options.signal?.aborted) throw error
-    const outcome = await ensureFreshSession()
-    if (outcome === "session-dead") throw error
-    if (outcome === "unavailable") {
-      // A plain Error (not ApiError) so handleGlobalError can't read it as a
-      // 401 and bounce to login while auth is merely unreachable — queries
-      // settle to cached/IDB state, same as the timeout path.
-      throw new Error("Session refresh unavailable; request not retried")
-    }
-    return await apiFetchOnce<T>(path, options)
-  }
-}
-
-async function apiFetchOnce<T>(path: string, options: ApiRequestInit = {}): Promise<T> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...init } = options
 
   const controller = new AbortController()
@@ -214,7 +113,6 @@ async function apiFetchOnce<T>(path: string, options: ApiRequestInit = {}): Prom
       signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
-        [THREA_AUTH_MODE_HEADER]: THREA_AUTH_MODE_CLIENT_REFRESH,
         ...init.headers,
       },
     })

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useRef, type ReactNode } from "react"
 import { io, Socket } from "socket.io-client"
 import { HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
-import { api, ensureFreshSession } from "@/api/client"
+import { api } from "@/api/client"
 import { getCachedWsConfig, setCachedWsConfig } from "@/lib/cached-ws-config"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
@@ -116,19 +116,6 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
       s.on("error", (error: { message: string }) => {
         if (isStale()) return
         console.error("[Socket] Error:", error.message)
-      })
-
-      s.on("connect_error", (error) => {
-        if (isStale()) return
-        // Server-side socket auth is verify-only (it can't Set-Cookie on a WS
-        // handshake, so it never rotates the session). A rejected handshake
-        // with an auth message means the cookie's access token expired while
-        // only the socket was talking — run the coordinated refresh so the
-        // next automatic reconnect attempt presents a fresh cookie.
-        // ensureFreshSession self-dedupes, so per-attempt calls don't storm.
-        if (/authentication failed|no session cookie/i.test(error.message)) {
-          void ensureFreshSession()
-        }
       })
 
       // Socket.io manager events for reconnection tracking

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -74,11 +74,6 @@ export class StubAuthService implements AuthService {
     return true
   }
 
-  // Stub sessions never expire, so verify-only and full auth are the same path.
-  async verifySession(sealedSession: string): Promise<AuthResult> {
-    return this.authenticateSession(sealedSession)
-  }
-
   async authenticateSession(sealedSession: string): Promise<AuthResult> {
     if (!sealedSession) {
       return {

--- a/packages/backend-common/src/auth/auth-service.test.ts
+++ b/packages/backend-common/src/auth/auth-service.test.ts
@@ -31,52 +31,6 @@ function makeService(session: FakeSession): { service: WorkosAuthService; refres
 
 const USER = { id: "user_1", email: "u@example.com", firstName: null, lastName: null }
 
-describe("WorkosAuthService.verifySession", () => {
-  test("verifies a valid token locally without ever calling refresh", async () => {
-    const { service, refreshCalls } = makeService({
-      authenticate: async () => ({ authenticated: true, user: USER, permissions: ["messages:read"] }),
-      refresh: async () => {
-        throw new Error("verify-only must never refresh")
-      },
-    })
-
-    const result = await service.verifySession("sealed")
-
-    expect(result).toMatchObject({ success: true, refreshed: false, user: { id: "user_1" } })
-    expect(refreshCalls()).toBe(0)
-  })
-
-  test("an expired token fails non-terminal (the client refreshes) — still no refresh call", async () => {
-    const { service, refreshCalls } = makeService({
-      authenticate: async () => ({ authenticated: false, reason: "invalid_jwt" }),
-      refresh: async () => {
-        throw new Error("verify-only must never refresh")
-      },
-    })
-
-    const result = await service.verifySession("sealed")
-
-    expect(result).toMatchObject({ success: false, reason: "invalid_jwt", terminal: false })
-    expect(refreshCalls()).toBe(0)
-  })
-
-  test("an unsealable cookie fails terminal", async () => {
-    const { service } = makeService({
-      authenticate: async () => ({ authenticated: false, reason: "invalid_session_cookie" }),
-      refresh: async () => ({ authenticated: false }),
-    })
-    expect(await service.verifySession("sealed")).toMatchObject({ success: false, terminal: true })
-  })
-
-  test("an empty cookie value fails terminal", async () => {
-    const { service } = makeService({
-      authenticate: async () => ({ authenticated: true, user: USER }),
-      refresh: async () => ({ authenticated: false }),
-    })
-    expect(await service.verifySession("")).toMatchObject({ success: false, terminal: true })
-  })
-})
-
 describe("WorkosAuthService.authenticateSession failure classification", () => {
   test("invalid_grant refresh rejection is NOT terminal (concurrent rotation race must not clear the cookie)", async () => {
     const { service } = makeService({

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -60,15 +60,6 @@ export function pickSealed(result: AuthResult, original: string): string {
 
 export interface AuthService {
   authenticateSession(sealedSession: string): Promise<AuthResult>
-  /**
-   * Verify-only: local JWT check against the cached JWKS, NEVER a WorkOS
-   * refresh. The client-refresh auth mode uses this on the data-plane hot
-   * path — an expired token fails fast with `reason: "invalid_jwt"`
-   * (non-terminal) and the CLIENT coordinates the single refresh via the
-   * refresh endpoint, which is what keeps rotating-refresh-token races out of
-   * the server entirely.
-   */
-  verifySession(sealedSession: string): Promise<AuthResult>
   authenticateWithCode(code: string): Promise<AuthResult>
   /**
    * Build the WorkOS authorization URL.
@@ -149,38 +140,6 @@ export class WorkosAuthService implements AuthService {
     this.cookiePassword = config.cookiePassword
     this.redirectUri = config.redirectUri
     this.workos = new WorkOS(config.apiKey, { clientId: this.clientId, timeout: WORKOS_REQUEST_TIMEOUT_MS })
-  }
-
-  async verifySession(sealedSession: string): Promise<AuthResult> {
-    if (!sealedSession) {
-      return { success: false, refreshed: false, reason: "no_session_cookie_provided", terminal: true }
-    }
-    const session = this.workos.userManagement.loadSealedSession({
-      sessionData: sealedSession,
-      cookiePassword: this.cookiePassword,
-    })
-    const authRes = await session.authenticate()
-    if (authRes.authenticated) {
-      return {
-        success: true,
-        user: {
-          id: authRes.user.id,
-          email: authRes.user.email,
-          firstName: authRes.user.firstName,
-          lastName: authRes.user.lastName,
-          permissions: authRes.permissions ?? null,
-        },
-        refreshed: false,
-      }
-    }
-    return {
-      success: false,
-      refreshed: false,
-      reason: authRes.reason,
-      // An expired-but-well-formed cookie (INVALID_JWT) heals via the client's
-      // refresh; anything else (unsealable, empty) never will.
-      terminal: authRes.reason !== AuthenticateWithSessionCookieFailureReason.INVALID_JWT,
-    }
   }
 
   async authenticateSession(sealedSession: string): Promise<AuthResult> {

--- a/packages/backend-common/src/auth/middleware.test.ts
+++ b/packages/backend-common/src/auth/middleware.test.ts
@@ -4,14 +4,7 @@ import type { AuthResult, AuthService } from "./auth-service"
 
 class FakeAuthService implements AuthService {
   constructor(private result: AuthResult) {}
-  authenticateSessionCalls = 0
-  verifySessionCalls = 0
   async authenticateSession(): Promise<AuthResult> {
-    this.authenticateSessionCalls++
-    return this.result
-  }
-  async verifySession(): Promise<AuthResult> {
-    this.verifySessionCalls++
     return this.result
   }
   async authenticateWithCode(): Promise<AuthResult> {
@@ -158,70 +151,6 @@ describe("createAuthMiddleware", () => {
 
     expect(res.statusCode).toBe(401)
     expect(res.clearedCookies).toEqual([])
-  })
-
-  test("client-refresh mode: expired token 401s TOKEN_EXPIRED without clearing or refreshing server-side", async () => {
-    const service = new FakeAuthService({ success: false, refreshed: false, reason: "invalid_jwt", terminal: false })
-    const middleware = createAuthMiddleware({ authService: service })
-
-    const req = {
-      cookies: { [sessionCookieName]: "session" },
-      headers: { "x-threa-auth-mode": "client-refresh" },
-    } as unknown as Request
-    const res = makeRes()
-    await middleware(req, res, () => {})
-
-    expect({ status: res.statusCode, body: res.body, cleared: res.clearedCookies }).toEqual({
-      status: 401,
-      body: { error: "Session expired", code: "TOKEN_EXPIRED" },
-      cleared: [],
-    })
-    // Verify-only: the implicit-refresh path must never run in this mode.
-    expect(service.verifySessionCalls).toBe(1)
-    expect(service.authenticateSessionCalls).toBe(0)
-  })
-
-  test("client-refresh mode: terminal failure 401s SESSION_INVALID and clears the cookie", async () => {
-    const service = new FakeAuthService({
-      success: false,
-      refreshed: false,
-      reason: "invalid_session_cookie",
-      terminal: true,
-    })
-    const middleware = createAuthMiddleware({ authService: service })
-
-    const req = {
-      cookies: { [sessionCookieName]: "session" },
-      headers: { "x-threa-auth-mode": "client-refresh" },
-    } as unknown as Request
-    const res = makeRes()
-    await middleware(req, res, () => {})
-
-    expect(res.statusCode).toBe(401)
-    expect((res.body as { code?: string }).code).toBe("SESSION_INVALID")
-    expect(res.clearedCookies).toContain(sessionCookieName)
-  })
-
-  test("client-refresh mode: a valid token passes through on the verify-only path", async () => {
-    const service = new FakeAuthService({
-      success: true,
-      refreshed: false,
-      user: { id: "user_123", email: "u@example.com", firstName: null, lastName: null, permissions: null },
-    })
-    const middleware = createAuthMiddleware({ authService: service })
-
-    const req = {
-      cookies: { [sessionCookieName]: "session" },
-      headers: { "x-threa-auth-mode": "client-refresh" },
-    } as unknown as Request
-    let nextCalled = false
-    await middleware(req, makeRes(), () => {
-      nextCalled = true
-    })
-
-    expect(nextCalled).toBe(true)
-    expect(service.verifySessionCalls).toBe(1)
-    expect(service.authenticateSessionCalls).toBe(0)
   })
 
   test("terminal auth failure clears the session cookie", async () => {

--- a/packages/backend-common/src/auth/middleware.ts
+++ b/packages/backend-common/src/auth/middleware.ts
@@ -1,11 +1,4 @@
 import type { Request, Response, NextFunction } from "express"
-import {
-  AUTH_SESSION_INVALID_CODE,
-  AUTH_TOKEN_EXPIRED_CODE,
-  AUTH_UNAVAILABLE_CODE,
-  THREA_AUTH_MODE_CLIENT_REFRESH,
-  THREA_AUTH_MODE_HEADER,
-} from "@threa/types"
 import type { AuthService } from "./auth-service"
 import { pickSealed } from "./auth-service"
 import { SESSION_COOKIE_NAME, clearSessionCookie, setSessionCookie } from "../cookies"
@@ -44,36 +37,15 @@ interface Dependencies {
   authService: AuthService
 }
 
-// Express lower-cases incoming header names.
-const AUTH_MODE_HEADER_LOWER = THREA_AUTH_MODE_HEADER.toLowerCase()
-
 export function createAuthMiddleware({ authService }: Dependencies) {
   return async function authMiddleware(req: Request, res: Response, next: NextFunction) {
     const session = req.cookies[SESSION_COOKIE_NAME]
 
     if (!session) {
-      return res.status(401).json({ error: "Not authenticated", code: AUTH_SESSION_INVALID_CODE })
+      return res.status(401).json({ error: "Not authenticated" })
     }
 
-    // Client-refresh mode (see THREA_AUTH_MODE_HEADER in @threa/types): verify
-    // the JWT locally, NEVER refresh inline — an expired token 401s fast and
-    // the client coordinates the single refresh. Keeps rotating-refresh-token
-    // races out of the server on any replica/region topology. Requests without
-    // the header (older cached bundles, scripts) keep the implicit refresh.
-    const clientRefresh = req.headers?.[AUTH_MODE_HEADER_LOWER] === THREA_AUTH_MODE_CLIENT_REFRESH
-    const result = clientRefresh
-      ? await authService.verifySession(session)
-      : await authService.authenticateSession(session)
-
-    if (clientRefresh && !result.success) {
-      // Verify-only failure: expiry is the client's cue to refresh-and-retry;
-      // only a session that can never heal (terminal) clears the cookie.
-      if (result.terminal) clearSessionCookie(res)
-      return res.status(401).json({
-        error: "Session expired",
-        code: result.terminal ? AUTH_SESSION_INVALID_CODE : AUTH_TOKEN_EXPIRED_CODE,
-      })
-    }
+    const result = await authService.authenticateSession(session)
 
     if (!result.success || !result.user) {
       // Clear the cookie only when the session is definitively dead
@@ -83,12 +55,7 @@ export function createAuthMiddleware({ authService }: Dependencies) {
       // outage (refresh threw) the session may be perfectly valid — clearing
       // turns a provider blip into a mass forced logout.
       if (result.terminal) clearSessionCookie(res)
-      // The code lets a client tell a dead session (redirect to login) from a
-      // transient validation failure (keep the session, retry later).
-      return res.status(401).json({
-        error: "Session expired",
-        code: result.terminal ? AUTH_SESSION_INVALID_CODE : AUTH_UNAVAILABLE_CODE,
-      })
+      return res.status(401).json({ error: "Session expired" })
     }
 
     if (result.refreshed && result.sealedSession) {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1112,20 +1112,6 @@ export const THREA_CALLBACK_TOKEN_HEADER = "X-Threa-Callback-Token"
 // it's a documented public header, named like Stripe-Version.
 export const THREA_VERSION_HEADER = "Threa-Version"
 
-// Client-coordinated session refresh. A request carrying
-// `X-Threa-Auth-Mode: client-refresh` opts into verify-only auth: the server
-// never refreshes the WorkOS session inline — an expired token 401s fast with
-// TOKEN_EXPIRED and the CLIENT runs exactly one refresh (deduped across
-// queries and tabs) against POST /api/auth/refresh, then retries. Requests
-// without the header keep the legacy implicit-refresh middleware behavior.
-export const THREA_AUTH_MODE_HEADER = "X-Threa-Auth-Mode"
-export const THREA_AUTH_MODE_CLIENT_REFRESH = "client-refresh"
-// 401 codes the auth middleware emits: refresh-then-retry vs. dead session vs.
-// transient validation outage (keep the session, do NOT bounce to login).
-export const AUTH_TOKEN_EXPIRED_CODE = "TOKEN_EXPIRED"
-export const AUTH_SESSION_INVALID_CODE = "SESSION_INVALID"
-export const AUTH_UNAVAILABLE_CODE = "AUTH_UNAVAILABLE"
-
 // Original client-facing host (e.g. `admin.threa.io`, `pr-204-staging.threa.io`)
 // carried from the Cloudflare routers to the control-plane.
 //

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -253,12 +253,6 @@ export {
   THREA_CALLBACK_TOKEN_HEADER,
   // Public API version negotiation
   THREA_VERSION_HEADER,
-  // Client-coordinated session refresh (auth mode header + 401 codes)
-  THREA_AUTH_MODE_HEADER,
-  THREA_AUTH_MODE_CLIENT_REFRESH,
-  AUTH_TOKEN_EXPIRED_CODE,
-  AUTH_SESSION_INVALID_CODE,
-  AUTH_UNAVAILABLE_CODE,
   // Original client host forwarded through the CF routers (survives Railway)
   ORIGINAL_HOST_HEADER,
   // Socket heartbeat


### PR DESCRIPTION
Reverts #1376. Live regression: stuck connecting pill, and messages appearing to need a full page refresh to send.

## Root cause

`socket.io-client` does **not** reconnect after a handshake denied by server middleware. In `socket.io-client/build/cjs/socket.js`, the `CONNECT_ERROR` packet path calls `this.destroy()` *before* emitting `connect_error`; `destroy()` clears subscriptions specifically "to avoid reconnections", and `manager._destroy()` then closes the underlying connection. `socket.active` is false and only a manual `socket.connect()` revives it.

#1376 made socket handshake auth verify-only (`verifySession` instead of `authenticateSession`) and handled the resulting denial in `socket-context.tsx` by firing `void ensureFreshSession()`, with a comment asserting "the next automatic reconnect attempt presents a fresh cookie". There is no next attempt. The cookie was refreshed and then never used.

Before #1376 the handshake refreshed inline, so denials were rare — only genuinely dead sessions. After it, every WorkOS access-token expiry (5 minutes) that coincided with a handshake killed the socket until a page reload.

One cause, both reported symptoms:

- **Connecting pill** — the socket dies and never returns; provider status latches on `reconnecting`/`disconnected` until remount.
- **Sends need a full refresh** — with the socket dead, SyncEngine gets no delivery or confirmation, so a sent message doesn't land in the UI. Reloading rebuilds the socket.

## Why revert rather than fix forward

The fix itself is small (call `socket.connect()` once the coordinated refresh resolves `refreshed`), but the reason this shipped is that real WorkOS token expiry isn't exercisable locally — stub sessions never expire — which is the exact gap called out in #1376's own description. Fixing forward would mean shipping a second unverifiable auth change onto a live regression. Reverting restores known-good behavior now; the redo carries a test that actually exercises a denied handshake.

The revert restores the pre-existing WS-handshake refresh-token burn that #1376 also fixed. That bug is silent and was tolerated for months; a dead socket is not.

## Redo plan (separate PR)

- Explicit `s.connect()` after `ensureFreshSession()` resolves `refreshed`, with a bounded retry so a genuinely dead session can't spin.
- A socket-context test that denies a handshake and asserts a reconnect actually follows — the assertion this PR lacked.
- Revisit the `authLimit` (20/min per IP, shared with login and `/api/accounts`) on `POST /api/auth/refresh`: a reconnect storm can exhaust it, and a 429 degrades to `unavailable`, which silently skips the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786870571&installation_id=129946197&pr_number=1378&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1378&signature=f0ba32f50d211249cda43f840251f2548165672121198f4193849b464d95c686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->