### PR TITLE
fix(cli): text-by-default output, -o flag, config.json rename; archived-stream API consistency

### DIFF
--- a/.agents/skills/threa-cli/SKILL.md
+++ b/.agents/skills/threa-cli/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   claim_delegation). Use when working inside or against a Threa workspace:
   answering "what did we decide / how do we do X" from workspace memory, posting
   or resuming a conversation, running a delegated task to completion, searching
-  messages or attachments, or paging large lists. Covers the CLI's piped-JSON and
+  messages or attachments, or paging large lists. Covers the CLI's JSON output and
   exit-code contract, ref forms, identity-first ordering, memory-before-humans,
   the conversation resume pattern, the delegation claim/update/finish loop with
   persistent tokens, the one `search` command's what selection, cursor paging,
@@ -22,7 +22,7 @@ Prefer the CLI when you have a shell. Check for it first: `threa whoami` if it i
 
 ## The CLI contract
 
-- When output is piped (which is how you run it), the CLI prints JSON. On a terminal it prints short human text; pass `--json` to force JSON. Parse the JSON.
+- The CLI prints short human text by default, even when piped. Pass `-o json` (or `--json`, any position in the argv) when you want to parse the output as JSON.
 - Exit code `0` is success, `1` is an API or tool error, `2` is a usage error (unknown command or flag, missing argument). On `1` and `2` the error is one JSON object on stderr: `{ code, message, hint? }`.
 - Results follow the API envelope: a single resource under `data`, a list as `{ data, hasMore, cursor? }`, a search as `{ data: [...] }`.
 - The MCP tools return the same JSON; a failure is an `isError` result carrying `{ code, message, hint? }`.

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1976,7 +1976,7 @@ export function createPublicApiHandlers({
     },
 
     async listStreams(req: Request, res: Response) {
-      const { type, query, after: afterCursor, limit } = validateRequest(listStreamsSchema, req.query)
+      const { type, query, after: afterCursor, limit, includeArchived } = validateRequest(listStreamsSchema, req.query)
       const accessibleStreamIds = await getAccessibleStreamIds(req)
 
       if (accessibleStreamIds.length === 0) {
@@ -1992,6 +1992,7 @@ export function createPublicApiHandlers({
         limit: limit + 1,
         cursorCreatedAt: cursor?.sortKey,
         cursorId: cursor?.id,
+        includeArchived: includeArchived === "true",
       })
 
       const hasMore = streams.length > limit
@@ -2015,8 +2016,10 @@ export function createPublicApiHandlers({
 
       await assertStreamAccessible(req, streamId)
 
+      // Archived streams stay retrievable by id (the app opens them read-only);
+      // the payload's archivedAt tells the caller. Only list hides them.
       const stream = await StreamRepository.findById(pool, streamId)
-      if (!stream || stream.archivedAt) {
+      if (!stream) {
         throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
       }
 

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -70,6 +70,9 @@ export const listStreamsSchema = z.object({
   query: z.string().optional(),
   after: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  // Query-string boolean: only the literal "true" opts in (no transform — the
+  // OpenAPI generator cannot derive a schema through effects).
+  includeArchived: z.enum(["true", "false"]).optional(),
 })
 
 const LABEL_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/

--- a/apps/backend/src/features/streams/display-name.test.ts
+++ b/apps/backend/src/features/streams/display-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { getEffectiveDisplayName } from "./display-name"
+import type { Stream } from "./repository"
+
+function thread(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_thread",
+    workspaceId: "ws_1",
+    type: "thread",
+    displayName: null,
+    displayNameGeneratedAt: null,
+    slug: null,
+    parentStreamId: "stream_parent",
+    ...overrides,
+  } as Stream
+}
+
+describe("thread placeholder display names", () => {
+  test("channel parent renders with the # sigil", () => {
+    const result = getEffectiveDisplayName(thread(), {
+      parentStream: { slug: "general", displayName: null },
+    })
+    expect(result).toEqual({ displayName: "Thread in #general", source: "placeholder" })
+  })
+
+  test("slugless named parent (scratchpad) renders without a phantom # sigil", () => {
+    const result = getEffectiveDisplayName(thread(), {
+      parentStream: { slug: null, displayName: "Release planning" },
+    })
+    expect(result).toEqual({ displayName: "Thread in Release planning", source: "placeholder" })
+  })
+
+  test("slugless nameless parent falls back to plain Thread, never 'Thread in #channel'", () => {
+    const result = getEffectiveDisplayName(thread(), {
+      parentStream: { slug: null, displayName: null },
+    })
+    expect(result).toEqual({ displayName: "Thread", source: "placeholder" })
+  })
+
+  test("a generated thread name wins over any placeholder", () => {
+    const result = getEffectiveDisplayName(
+      thread({ displayName: "API redesign", displayNameGeneratedAt: new Date() }),
+      { parentStream: { slug: "general", displayName: null } }
+    )
+    expect(result).toEqual({ displayName: "API redesign", source: "generated" })
+  })
+})

--- a/apps/backend/src/features/streams/display-name.ts
+++ b/apps/backend/src/features/streams/display-name.ts
@@ -42,11 +42,15 @@ export function getEffectiveDisplayName(stream: Stream, context?: DisplayNameCon
         }
       }
       if (context?.parentStream) {
-        const parentName = context.parentStream.slug ?? context.parentStream.displayName ?? "channel"
-        return {
-          displayName: `Thread in #${parentName}`,
-          source: "placeholder",
+        // The # sigil is a channel affordance — a slugless parent (scratchpad,
+        // DM) must not render as a phantom "#channel".
+        if (context.parentStream.slug) {
+          return { displayName: `Thread in #${context.parentStream.slug}`, source: "placeholder" }
         }
+        if (context.parentStream.displayName) {
+          return { displayName: `Thread in ${context.parentStream.displayName}`, source: "placeholder" }
+        }
+        return { displayName: "Thread", source: "placeholder" }
       }
       return {
         displayName: "New thread",

--- a/apps/backend/src/features/streams/repository.test.ts
+++ b/apps/backend/src/features/streams/repository.test.ts
@@ -114,6 +114,22 @@ describe("purpose marker (sidebar exclusion)", () => {
     expect(db._query.mock.calls[0]![0] as string).toContain("purpose IS NULL")
   })
 
+  test("listByIds hides archived streams AND live threads under an archived root by default", async () => {
+    const db = makeDb([])
+    await StreamRepository.listByIds(db, "ws_1", ["stream_a"])
+    const text = db._query.mock.calls[0]![0] as string
+    expect(text).toContain("archived_at IS NULL")
+    expect(text).toContain("root.archived_at IS NOT NULL")
+  })
+
+  test("listByIds with includeArchived drops both archived filters", async () => {
+    const db = makeDb([])
+    await StreamRepository.listByIds(db, "ws_1", ["stream_a"], { includeArchived: true })
+    const text = db._query.mock.calls[0]![0] as string
+    expect(text).not.toContain("archived_at IS NULL")
+    expect(text).not.toContain("root.archived_at IS NOT NULL")
+  })
+
   test("insert persists the purpose marker and maps it back", async () => {
     const db = makeDb([streamRow({ purpose: StreamPurposes.PERSONA_TEST })])
     const stream = await StreamRepository.insert(db, {

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -411,12 +411,24 @@ export const StreamRepository = {
       limit?: number
       cursorCreatedAt?: Date
       cursorId?: string
+      includeArchived?: boolean
     }
   ): Promise<Stream[]> {
     if (ids.length === 0) return []
 
     const limit = filters?.limit ?? 50
-    const conditions = [`id = ANY($1)`, `workspace_id = $2`, `archived_at IS NULL`, purposeIsNull()]
+    const conditions = [`id = ANY($1)`, `workspace_id = $2`, purposeIsNull()]
+    if (!filters?.includeArchived) {
+      // A live thread under an archived root is invisible in the app's stream
+      // lists, so hide it here too — the row's own archived_at is not enough.
+      conditions.push(
+        `archived_at IS NULL`,
+        `NOT EXISTS (
+          SELECT 1 FROM streams root
+          WHERE root.id = streams.root_stream_id AND root.archived_at IS NOT NULL
+        )`
+      )
+    }
     const values: unknown[] = [ids, workspaceId]
     let paramIndex = 3
 

--- a/apps/backend/tests/integration/stream-naming.test.ts
+++ b/apps/backend/tests/integration/stream-naming.test.ts
@@ -189,7 +189,8 @@ describe("Stream Naming", () => {
         const result = getEffectiveDisplayName(stream, {
           parentStream: { slug: null, displayName: "My Scratchpad" },
         })
-        expect(result.displayName).toBe("Thread in #My Scratchpad")
+        // No # sigil — the parent has no slug, so it is not a channel.
+        expect(result.displayName).toBe("Thread in My Scratchpad")
         expect(result.source).toBe("placeholder")
       })
 

--- a/docs/public-api/mcp-server.md
+++ b/docs/public-api/mcp-server.md
@@ -108,7 +108,7 @@ Commands are grouped by noun, each with a verb subcommand (`threa messages send`
 
 Identity: `whoami` returns the principal, the resolved API version, and the base URL and workspace the client is bound to. Run it first to confirm the key.
 
-Streams: `streams list` filters by type and name and pages with `--after`. `streams read <ref>` returns one stream together with a page of its messages in a single call, paging the messages by numeric `--before` and `--after` sequence, and returns the stream's members too when `--members` is set.
+Streams: `streams list` filters by type and name and pages with `--after`; archived streams (and live threads under an archived root) are omitted unless `--archived` is passed. `streams read <ref>` returns one stream together with a page of its messages in a single call, paging the messages by numeric `--before` and `--after` sequence, and returns the stream's members too when `--members` is set.
 
 Users: `users list` filters by name or email, and pages with `--after`.
 

--- a/docs/public-api/mcp-server.md
+++ b/docs/public-api/mcp-server.md
@@ -14,7 +14,7 @@ One workspace and one API key, both fixed by configuration. Configuration resolv
 | Workspace id | `THREA_WORKSPACE_ID` | `workspaceId` | yes                                    |
 | Base URL     | `THREA_BASE_URL`     | `baseUrl`     | no, defaults to `https://app.threa.io` |
 
-The file is read from the path in `THREA_MCP_CONFIG`, or from `~/.threa/mcp.json` when that variable is unset. Its shape is `{ "apiKey": …, "workspaceId": …, "baseUrl": … }`. If the two required values cannot be resolved from either source, the CLI exits with a message naming what is missing. The key is never written to logs.
+The file is read from the path in `THREA_CONFIG`, or from `~/.threa/config.json` when that variable is unset (a legacy `~/.threa/mcp.json` is still read, with a hint to rename it). Its shape is `{ "apiKey": …, "workspaceId": …, "baseUrl": …, "output": … }`, where the optional `output` (`"text"` or `"json"`) sets the default output mode. If the two required values cannot be resolved from either source, the CLI exits with a message naming what is missing. The key is never written to logs.
 
 ## Running the CLI
 
@@ -26,7 +26,7 @@ Link the bin onto your PATH from `packages/cli` with `bun link`, or invoke the e
 bun /abs/path/to/threa/packages/cli/src/cli.ts whoami
 ```
 
-On a terminal the CLI prints concise human-readable text. When output is piped it prints JSON, which is what an agent or a script reads. The `--json` flag forces JSON on a terminal. Errors go to stderr as one JSON object with `code`, `message`, and an optional `hint`. The exit code is `0` on success, `1` on an API or tool error, and `2` on a usage error such as an unknown command or a missing argument. Run `threa --help` for the command list and `threa <command> --help` for a command's flags.
+The CLI prints concise human-readable text by default, piped or not. `-o json` (or `--json`) switches to JSON, works anywhere in the argv, and overrides the config default. Errors go to stderr as one JSON object with `code`, `message`, and an optional `hint`. The exit code is `0` on success, `1` on an API or tool error, and `2` on a usage error such as an unknown command or a missing argument. Run `threa --help` for the command list and `threa <command> --help` for a command's flags.
 
 ## Running the MCP server
 
@@ -90,7 +90,7 @@ The API allows 60 requests per minute per key and 600 per minute per workspace, 
 
 ## Results
 
-Command output is JSON when piped, or human-readable text on a terminal. MCP tool output is JSON text in the API envelope. A single resource comes back under `data`, a list as `{ data, hasMore, cursor? }`, and a search as `{ data: [...] }`. A failure returns an error object with `code`, `message`, and an optional `hint` that spells out the 404 scope case and the rate-limit case. Message content is passed through in full and is never truncated.
+Command output is human-readable text unless `-o json`/`--json` or the config default asks for JSON. MCP tool output is JSON text in the API envelope. A single resource comes back under `data`, a list as `{ data, hasMore, cursor? }`, and a search as `{ data: [...] }`. A failure returns an error object with `code`, `message`, and an optional `hint` that spells out the 404 scope case and the rate-limit case. Message content is passed through in full and is never truncated.
 
 ## Referencing streams and users
 

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -3795,6 +3795,12 @@
             "in": "query",
             "required": false,
             "schema": { "default": 50, "type": "integer", "minimum": 1, "maximum": 200 }
+          },
+          {
+            "name": "includeArchived",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["true", "false"] }
           }
         ],
         "responses": {

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -3795,6 +3795,12 @@
             "in": "query",
             "required": false,
             "schema": { "default": 50, "type": "integer", "minimum": 1, "maximum": 200 }
+          },
+          {
+            "name": "includeArchived",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["true", "false"] }
           }
         ],
         "responses": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,7 +33,7 @@ Config resolves from environment variables first, then from an optional JSON fil
 | Workspace id | `THREA_WORKSPACE_ID` | `workspaceId` | yes      | none                   |
 | Base URL     | `THREA_BASE_URL`     | `baseUrl`     | no       | `https://app.threa.io` |
 
-The JSON file is read from `THREA_MCP_CONFIG` if set, otherwise from `~/.threa/mcp.json` if it exists. Shape:
+The JSON file is read from `THREA_CONFIG` if set, otherwise from `~/.threa/config.json` if it exists (a legacy `~/.threa/mcp.json` is still read, with a hint to rename it). Shape:
 
 ```json
 {
@@ -47,7 +47,7 @@ If `THREA_API_KEY` or `THREA_WORKSPACE_ID` cannot be resolved from either source
 
 ## Output and exit codes
 
-On a terminal the CLI prints concise human-readable text. When output is piped (an agent or a script), it prints pretty JSON. `--json` forces JSON on a terminal too. Errors always go to stderr as one JSON object `{ code, message, hint? }`.
+The CLI prints concise human-readable text by default, piped or not. `-o json` (or `--json`) switches to pretty JSON, and the flag works anywhere in the argv (`threa --json streams list` == `threa streams list --json`). A config-file `"output": "json"` sets the default; an explicit flag wins. Errors always go to stderr as one JSON object `{ code, message, hint? }`.
 
 Exit codes:
 
@@ -109,7 +109,7 @@ Claim tokens are persisted to `~/.threa/state.json` (mode 0600), keyed by worksp
 
 ### Agent skill
 
-`threa skill install` copies the `threa-cli` skill into `~/.claude/skills/threa-cli/`, so Claude Code sessions in any project on this machine load it on demand. The skill teaches ref forms, the piped-JSON and exit-code contract, search selection, and the delegation loop. Re-run after pulling a newer checkout. The in-repo copy at `.agents/skills/threa-cli/SKILL.md` is the source of truth.
+`threa skill install` copies the `threa-cli` skill into `~/.claude/skills/threa-cli/`, so Claude Code sessions in any project on this machine load it on demand. The skill teaches ref forms, the JSON output and exit-code contract, search selection, and the delegation loop. Re-run after pulling a newer checkout. The in-repo copy at `.agents/skills/threa-cli/SKILL.md` is the source of truth.
 
 ### The two Threa MCP servers (do not confuse the sends)
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -19,7 +19,7 @@ test("whoami --json emits the /me principal with binding info to stdout, exit 0"
     })
   )
 
-  const result = await run(["whoami", "--json"], { config: TEST_CONFIG, isTTY: true })
+  const result = await run(["whoami", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect(result.stderr).toBe("")
@@ -34,23 +34,62 @@ test("whoami --json emits the /me principal with binding info to stdout, exit 0"
   expect(payload.workspaceId).toBe("ws_1")
 })
 
-test("whoami renders concise human text on a TTY and forces JSON with --json", async () => {
+test("whoami renders human text by default and forces JSON with --json", async () => {
   fetchSpy.mockImplementation(fetchByPath(() => jsonResponse(200, { data: { kind: "user", userId: "usr_1" } })))
 
-  const human = await run(["whoami"], { config: TEST_CONFIG, isTTY: true })
+  const human = await run(["whoami"], { config: TEST_CONFIG })
   expect(human.exitCode).toBe(0)
   expect(human.stdout).toContain("principal: user usr_1")
   expect(() => JSON.parse(human.stdout)).toThrow()
 
-  const json = await run(["whoami", "--json"], { config: TEST_CONFIG, isTTY: true })
+  const json = await run(["whoami", "--json"], { config: TEST_CONFIG })
   expect(() => JSON.parse(json.stdout)).not.toThrow()
 })
 
-test("piped output (no TTY) is JSON even without --json", async () => {
-  fetchSpy.mockResolvedValue(jsonResponse(200, { data: { kind: "user", userId: "usr_1" } }))
+test("output flags are position-independent: --json and -o work anywhere in argv", async () => {
+  fetchSpy.mockImplementation(fetchByPath(() => jsonResponse(200, { data: { kind: "user", userId: "usr_1" } })))
 
-  const result = await run(["whoami"], { config: TEST_CONFIG, isTTY: false })
+  for (const argv of [
+    ["--json", "whoami"],
+    ["whoami", "--json"],
+    ["-o", "json", "whoami"],
+    ["whoami", "-o", "json"],
+    ["-o=json", "whoami"],
+    ["--output=json", "whoami"],
+  ]) {
+    const result = await run(argv, { config: TEST_CONFIG })
+    expect(result.exitCode).toBe(0)
+    expect(() => JSON.parse(result.stdout)).not.toThrow()
+  }
+})
+
+test("output flags work between noun and verb", async () => {
+  fetchSpy.mockImplementation(fetchByPath(() => jsonResponse(200, { data: [], hasMore: false, cursor: null })))
+
+  const result = await run(["streams", "--json", "list"], { config: TEST_CONFIG })
+  expect(result.exitCode).toBe(0)
   expect(() => JSON.parse(result.stdout)).not.toThrow()
+})
+
+test("-o text overrides a config default of json", async () => {
+  fetchSpy.mockImplementation(fetchByPath(() => jsonResponse(200, { data: { kind: "user", userId: "usr_1" } })))
+
+  const jsonByConfig = await run(["whoami"], { config: { ...TEST_CONFIG, output: "json" } })
+  expect(() => JSON.parse(jsonByConfig.stdout)).not.toThrow()
+
+  const textByFlag = await run(["whoami", "-o", "text"], { config: { ...TEST_CONFIG, output: "json" } })
+  expect(textByFlag.stdout).toContain("principal: user usr_1")
+  expect(() => JSON.parse(textByFlag.stdout)).toThrow()
+})
+
+test("an invalid -o value is a usage error (exit 2)", async () => {
+  const result = await run(["whoami", "-o", "yaml"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(2)
+  const err = JSON.parse(result.stderr) as { code: string; message: string }
+  expect(err.code).toBe("USAGE")
+  expect(err.message).toContain("json")
+  expect(fetchSpy).not.toHaveBeenCalled()
 })
 
 test("stream #slug resolves the channel then reads the stream and its messages", async () => {
@@ -63,7 +102,7 @@ test("stream #slug resolves the channel then reads the stream and its messages",
     })
   )
 
-  const result = await run(["streams", "read", "#eng", "--json"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["streams", "read", "#eng", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   const payload = JSON.parse(result.stdout) as { stream: { id: string } }
@@ -75,7 +114,6 @@ test("stream #slug resolves the channel then reads the stream and its messages",
 test("search rejects a filter the chosen what does not support: exit 1, stderr JSON, no HTTP", async () => {
   const result = await run(["search", "x", "--what", "attachments", "--type", "channel"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(1)
@@ -91,7 +129,6 @@ test("search what=messages posts to /messages/search and maps --stream to stream
 
   const result = await run(["search", "deploy plan", "--what", "messages", "--stream", "stream_1", "--limit", "5"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(0)
@@ -108,7 +145,6 @@ test("find-by-metadata parses k=v positionals into the metadata body", async () 
 
   const result = await run(["messages", "find-by-metadata", "github.pr=org/repo#42", "--json"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(0)
@@ -119,7 +155,7 @@ test("find-by-metadata parses k=v positionals into the metadata body", async () 
 })
 
 test("unknown command exits 2 with the command list on stderr", async () => {
-  const result = await run(["frobnicate"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["frobnicate"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   const err = JSON.parse(result.stderr) as { code: string; hint?: string }
@@ -129,7 +165,7 @@ test("unknown command exits 2 with the command list on stderr", async () => {
 })
 
 test("an unknown flag is a usage error (exit 2) carrying the command usage", async () => {
-  const result = await run(["whoami", "--bogus"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["whoami", "--bogus"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   const err = JSON.parse(result.stderr) as { code: string; hint?: string }
@@ -138,14 +174,14 @@ test("an unknown flag is a usage error (exit 2) carrying the command usage", asy
 })
 
 test("a missing required positional is a usage error (exit 2)", async () => {
-  const result = await run(["streams", "read"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["streams", "read"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   expect((JSON.parse(result.stderr) as { code: string }).code).toBe("USAGE")
 })
 
 test("a bare noun with no subcommand is a usage error (exit 2) listing its verbs", async () => {
-  const result = await run(["delegations"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["delegations"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   const err = JSON.parse(result.stderr) as { code: string; message: string; hint?: string }
@@ -156,7 +192,7 @@ test("a bare noun with no subcommand is a usage error (exit 2) listing its verbs
 })
 
 test("an unknown subcommand under a noun is a usage error (exit 2) naming valid verbs", async () => {
-  const result = await run(["streams", "frobnicate"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["streams", "frobnicate"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   const err = JSON.parse(result.stderr) as { code: string; message: string }
@@ -166,7 +202,7 @@ test("an unknown subcommand under a noun is a usage error (exit 2) naming valid 
 })
 
 test("noun --help lists the noun's subcommands, exit 0", async () => {
-  const result = await run(["messages", "--help"], { config: TEST_CONFIG, isTTY: true })
+  const result = await run(["messages", "--help"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   for (const verb of ["send", "edit", "delete", "find-by-metadata"]) {
@@ -175,7 +211,7 @@ test("noun --help lists the noun's subcommands, exit 0", async () => {
 })
 
 test("noun verb --help documents that verb's flags, exit 0", async () => {
-  const result = await run(["messages", "send", "--help"], { config: TEST_CONFIG, isTTY: true })
+  const result = await run(["messages", "send", "--help"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect(result.stdout).toContain("threa messages send")
@@ -185,7 +221,7 @@ test("noun verb --help documents that verb's flags, exit 0", async () => {
 test("an API error surfaces as exit 1 with the scope hint on 404", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(404, { error: "gone", code: "NOT_FOUND" }))
 
-  const result = await run(["memos", "get", "memo_x", "--json"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["memos", "get", "memo_x", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(1)
   const err = JSON.parse(result.stderr) as { code: string; hint?: string }
@@ -194,7 +230,7 @@ test("an API error surfaces as exit 1 with the scope hint on 404", async () => {
 })
 
 test("top-level --help lists every command, exit 0", async () => {
-  const result = await run(["--help"], { config: TEST_CONFIG, isTTY: true })
+  const result = await run(["--help"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   for (const name of [
@@ -216,7 +252,7 @@ test("top-level --help lists every command, exit 0", async () => {
 })
 
 test("per-command --help documents flags to stdout, exit 0", async () => {
-  const result = await run(["search", "--help"], { config: TEST_CONFIG, isTTY: true })
+  const result = await run(["search", "--help"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect(result.stdout).toContain("--what")
@@ -224,12 +260,12 @@ test("per-command --help documents flags to stdout, exit 0", async () => {
 })
 
 test("mcp serve signals serve mode without touching HTTP; a bad subcommand is exit 2", async () => {
-  const serve = await run(["mcp", "serve"], { config: TEST_CONFIG, isTTY: false })
+  const serve = await run(["mcp", "serve"], { config: TEST_CONFIG })
   expect(serve.exitCode).toBe(0)
   expect(serve.serve).toBe(true)
   expect(fetchSpy).not.toHaveBeenCalled()
 
-  const bad = await run(["mcp", "wat"], { config: TEST_CONFIG, isTTY: false })
+  const bad = await run(["mcp", "wat"], { config: TEST_CONFIG })
   expect(bad.exitCode).toBe(2)
   expect((JSON.parse(bad.stderr) as { code: string }).code).toBe("USAGE")
 })

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -111,6 +111,20 @@ test("stream #slug resolves the channel then reads the stream and its messages",
   expect(calledPaths()).toContain("/api/v1/workspaces/ws_1/streams/stream_1")
 })
 
+test("streams list --archived passes includeArchived=true to the API", async () => {
+  fetchSpy.mockResolvedValue(jsonResponse(200, { data: [], hasMore: false, cursor: null }))
+
+  const result = await run(["streams", "list", "--archived"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  expect(calledPaths()[0]).toContain("includeArchived=true")
+
+  fetchSpy.mockClear()
+  fetchSpy.mockResolvedValue(jsonResponse(200, { data: [], hasMore: false, cursor: null }))
+  await run(["streams", "list"], { config: TEST_CONFIG })
+  expect(calledPaths()[0]).not.toContain("includeArchived")
+})
+
 test("search rejects a filter the chosen what does not support: exit 1, stderr JSON, no HTTP", async () => {
   const result = await run(["search", "x", "--what", "attachments", "--type", "channel"], {
     config: TEST_CONFIG,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import { usersNoun } from "./commands/users"
 import { loadConfig } from "./config"
 import {
   errorObject,
+  extractOutputMode,
   formatSuccess,
   stderrJson,
   UsageError,
@@ -69,8 +70,8 @@ function topHelp(): string {
     "Commands:",
     ...lines,
     "",
-    "Global flags: --json (force JSON output), --help (per-command help).",
-    "Config: THREA_API_KEY and THREA_WORKSPACE_ID (env, or ~/.threa/mcp.json); THREA_BASE_URL optional.",
+    "Global flags: -o json|text / --json (output mode, any position), --help (per-command help).",
+    'Config: THREA_API_KEY and THREA_WORKSPACE_ID (env, or ~/.threa/config.json); optional THREA_BASE_URL and "output": "json"|"text".',
     "Run `threa <command> --help` for a command's subcommands or flags.",
   ].join("\n")
 }
@@ -99,8 +100,7 @@ export interface RunResult {
 }
 
 export interface RunDeps {
-  config?: import("./config").ThreaMcpConfig
-  isTTY?: boolean
+  config?: import("./config").ThreaConfig
   readStdin?: () => Promise<string>
   tokenStore?: TokenStore
 }
@@ -114,7 +114,12 @@ function leafFlags(leaf: Leaf): { serve: boolean; noConfig: boolean } {
   }
 }
 
-async function executeLeaf(leaf: Leaf, args: string[], deps: RunDeps, isTTY: boolean): Promise<RunResult> {
+async function executeLeaf(
+  leaf: Leaf,
+  args: string[],
+  deps: RunDeps,
+  flagMode: import("./config").OutputMode | undefined
+): Promise<RunResult> {
   let parsed
   try {
     parsed = parseArgs({
@@ -145,7 +150,7 @@ async function executeLeaf(leaf: Leaf, args: string[], deps: RunDeps, isTTY: boo
       const payload = await leaf.run(SERVE_STUB, positionals, values)
       return {
         exitCode: 0,
-        stdout: `${formatSuccess(leaf, payload, { json: values.json === true, isTTY })}\n`,
+        stdout: `${formatSuccess(leaf, payload, { mode: flagMode ?? "text" })}\n`,
         stderr: "",
       }
     }
@@ -161,7 +166,7 @@ async function executeLeaf(leaf: Leaf, args: string[], deps: RunDeps, isTTY: boo
     const payload = await leaf.run({ client, resolver, config, tokenStore, readStdin }, positionals, values)
     return {
       exitCode: 0,
-      stdout: `${formatSuccess(leaf, payload, { json: values.json === true, isTTY })}\n`,
+      stdout: `${formatSuccess(leaf, payload, { mode: flagMode ?? config.output })}\n`,
       stderr: "",
     }
   } catch (error) {
@@ -176,7 +181,12 @@ async function executeLeaf(leaf: Leaf, args: string[], deps: RunDeps, isTTY: boo
   }
 }
 
-async function runNoun(noun: NounSpec, args: string[], deps: RunDeps, isTTY: boolean): Promise<RunResult> {
+async function runNoun(
+  noun: NounSpec,
+  args: string[],
+  deps: RunDeps,
+  flagMode: import("./config").OutputMode | undefined
+): Promise<RunResult> {
   const verbName = args[0]
 
   if (verbName === undefined) {
@@ -210,11 +220,18 @@ async function runNoun(noun: NounSpec, args: string[], deps: RunDeps, isTTY: boo
     }
   }
 
-  return executeLeaf(verb, args.slice(1), deps, isTTY)
+  return executeLeaf(verb, args.slice(1), deps, flagMode)
 }
 
-export async function run(argv: string[], deps: RunDeps = {}): Promise<RunResult> {
-  const isTTY = deps.isTTY ?? Boolean(process.stdout.isTTY)
+export async function run(rawArgv: string[], deps: RunDeps = {}): Promise<RunResult> {
+  let argv: string[]
+  let flagMode: import("./config").OutputMode | undefined
+  try {
+    ;({ argv, mode: flagMode } = extractOutputMode(rawArgv))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { exitCode: 2, stdout: "", stderr: stderrJson({ code: "USAGE", message }) }
+  }
 
   if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
     return { exitCode: 0, stdout: `${topHelp()}\n`, stderr: "" }
@@ -223,10 +240,10 @@ export async function run(argv: string[], deps: RunDeps = {}): Promise<RunResult
   const name = argv[0]!
 
   const flat = FLAT_REGISTRY.get(name)
-  if (flat) return executeLeaf(flat, argv.slice(1), deps, isTTY)
+  if (flat) return executeLeaf(flat, argv.slice(1), deps, flagMode)
 
   const noun = NOUN_REGISTRY.get(name)
-  if (noun) return runNoun(noun, argv.slice(1), deps, isTTY)
+  if (noun) return runNoun(noun, argv.slice(1), deps, flagMode)
 
   return {
     exitCode: 2,

--- a/packages/cli/src/commands/delegations.test.ts
+++ b/packages/cli/src/commands/delegations.test.ts
@@ -42,10 +42,9 @@ test("claim persists the token to the state file and prints it in the result", a
   fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "dlg_1", brief: "do it", claimToken: "tok_secret" } }))
 
   const result = await run(
-    ["delegations", "claim", "dlg_1", "--label", "Kris's MacBook", "--idempotency-key", "idem-key-12345"],
+    ["delegations", "claim", "dlg_1", "--label", "Kris's MacBook", "--idempotency-key", "idem-key-12345", "--json"],
     {
       config: TEST_CONFIG,
-      isTTY: false,
     }
   )
 
@@ -60,12 +59,11 @@ test("claim persists the token to the state file and prints it in the result", a
 
 test("claim then update reuses the stored token across separate invocations, then finish clears it", async () => {
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", claimToken: "tok_stored" } }))
-  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG, isTTY: false })
+  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG })
 
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1" } }))
   const updated = await run(["delegations", "update", "dlg_1", "--note", "halfway"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
   expect(updated.exitCode).toBe(0)
   expect(pathOf(1)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1/status")
@@ -75,7 +73,6 @@ test("claim then update reuses the stored token across separate invocations, the
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", status: "completed" } }))
   const finished = await run(["delegations", "finish", "dlg_1", "--outcome", "complete", "--result", "shipped"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
   expect(finished.exitCode).toBe(0)
   expect(pathOf(2)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1/complete")
@@ -85,7 +82,7 @@ test("claim then update reuses the stored token across separate invocations, the
   const state = JSON.parse(readFileSync(statePath, "utf8")) as { claimTokens: Record<string, unknown> }
   expect(state.claimTokens.ws_1).toBeUndefined()
 
-  const again = await run(["delegations", "update", "dlg_1", "--note", "again"], { config: TEST_CONFIG, isTTY: false })
+  const again = await run(["delegations", "update", "dlg_1", "--note", "again"], { config: TEST_CONFIG })
   expect(again.exitCode).toBe(1)
   expect((JSON.parse(again.stderr) as { code: string }).code).toBe("MISSING_CLAIM_TOKEN")
   expect(fetchSpy.mock.calls.length).toBe(3)
@@ -93,10 +90,10 @@ test("claim then update reuses the stored token across separate invocations, the
 
 test("update without a note posts a pure heartbeat carrying the stored token", async () => {
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", claimToken: "tok_hb" } }))
-  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG, isTTY: false })
+  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG })
 
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { claimExpiresAt: "2026-07-16T00:15:00.000Z" } }))
-  await run(["delegations", "update", "dlg_1"], { config: TEST_CONFIG, isTTY: false })
+  await run(["delegations", "update", "dlg_1"], { config: TEST_CONFIG })
 
   expect(pathOf(1)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1/heartbeat")
   expect(callbackHeader(1)).toBe("tok_hb")
@@ -105,7 +102,6 @@ test("update without a note posts a pure heartbeat carrying the stored token", a
 test("finish --outcome fail without --error is a usage error (exit 2) before any HTTP", async () => {
   const result = await run(["delegations", "finish", "dlg_1", "--outcome", "fail"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(2)
@@ -116,7 +112,7 @@ test("finish --outcome fail without --error is a usage error (exit 2) before any
 test("finish --outcome fail rejects --result and --metadata, naming them, before any HTTP", async () => {
   const result = await run(
     ["delegations", "finish", "dlg_1", "--outcome", "fail", "--error", "broke", "--result", "x", "--metadata", "k=v"],
-    { config: TEST_CONFIG, isTTY: false }
+    { config: TEST_CONFIG }
   )
 
   expect(result.exitCode).toBe(2)
@@ -128,7 +124,7 @@ test("finish --outcome fail rejects --result and --metadata, naming them, before
 })
 
 test("update with no stored or explicit token errors before any HTTP", async () => {
-  const result = await run(["delegations", "update", "dlg_unknown"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["delegations", "update", "dlg_unknown"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(1)
   expect((JSON.parse(result.stderr) as { code: string }).code).toBe("MISSING_CLAIM_TOKEN")
@@ -137,12 +133,11 @@ test("update with no stored or explicit token errors before any HTTP", async () 
 
 test("an explicit --claim-token overrides the stored one", async () => {
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", claimToken: "tok_stored" } }))
-  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG, isTTY: false })
+  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG })
 
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1" } }))
   await run(["delegations", "update", "dlg_1", "--note", "x", "--claim-token", "tok_explicit"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(callbackHeader(1)).toBe("tok_explicit")
@@ -153,7 +148,6 @@ test("delegations list returns the open queue with the since filter", async () =
 
   const result = await run(["delegations", "list", "--since", "2026-07-16T00:00:00.000Z"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(0)
@@ -165,7 +159,7 @@ test("delegations list returns the open queue with the since filter", async () =
 test("request-access posts to the request-access route", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(200, { data: { already_granted: false } }))
 
-  const result = await run(["delegations", "request-access", "dlg_1"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["delegations", "request-access", "dlg_1"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect(pathOf(0)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1/request-access")
@@ -173,12 +167,11 @@ test("request-access posts to the request-access route", async () => {
 
 test("finish --result `-` reads the result markdown from stdin", async () => {
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", claimToken: "tok_x" } }))
-  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG, isTTY: false })
+  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG })
 
   fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", status: "completed" } }))
   await run(["delegations", "finish", "dlg_1", "--outcome", "complete", "--result", "-"], {
     config: TEST_CONFIG,
-    isTTY: false,
     readStdin: () => Promise.resolve("# Report\nDone."),
   })
 

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -10,7 +10,7 @@ export const whoamiCommand: CommandSpec = {
     "Return the authenticated principal for the configured API key (user or bot), the resolved API version, " +
     "and the base URL and workspace this CLI is bound to. Use it to confirm the key works.\n\n" +
     "Flags:\n" +
-    "  --json    force JSON output (default when output is piped)\n" +
+    "  --json / -o json    force JSON output\n" +
     "  --help    show this help",
   options: {},
   run: (ctx) => whoami(ctx.client, ctx.config),

--- a/packages/cli/src/commands/labels.test.ts
+++ b/packages/cli/src/commands/labels.test.ts
@@ -13,7 +13,6 @@ test("label posts a stream assignment by name with appearance flags", async () =
 
   const result = await run(["labels", "add", "urgent", "stream_1", "--color", "#ff0000", "--emoji", "🔥"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(0)
@@ -32,7 +31,7 @@ test("label posts a stream assignment by name with appearance flags", async () =
 test("unlabel deletes the assignment via query params and reports the removal", async () => {
   fetchSpy.mockResolvedValue(new Response(null, { status: 204 }))
 
-  const result = await run(["labels", "remove", "urgent", "stream_1", "--json"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["labels", "remove", "urgent", "stream_1", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   const url = new URL(String(fetchSpy.mock.calls[0]![0]))
@@ -45,7 +44,7 @@ test("unlabel deletes the assignment via query params and reports the removal", 
 })
 
 test("label without a stream ref is a usage error (exit 2) before any HTTP", async () => {
-  const result = await run(["labels", "add", "urgent"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["labels", "add", "urgent"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(2)
   expect((JSON.parse(result.stderr) as { code: string }).code).toBe("USAGE")
@@ -55,7 +54,7 @@ test("label without a stream ref is a usage error (exit 2) before any HTTP", asy
 test("labels lists the actor's label catalog", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(200, { data: { labels: [{ id: "lbl_1", name: "urgent" }] } }))
 
-  const result = await run(["labels", "list", "--json"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["labels", "list", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("GET")

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,9 +1,9 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
-import type { ThreaMcpConfig } from "../config"
+import type { ThreaConfig } from "../config"
 import { UsageError, type CommandSpec } from "../output"
 import { createThreaMcpServer } from "../server"
 
-export async function serveMcp(config: ThreaMcpConfig): Promise<void> {
+export async function serveMcp(config: ThreaConfig): Promise<void> {
   const server = createThreaMcpServer(config)
   const transport = new StdioServerTransport()
   await server.connect(transport)

--- a/packages/cli/src/commands/send.test.ts
+++ b/packages/cli/src/commands/send.test.ts
@@ -15,10 +15,12 @@ function sendBody(): Record<string, unknown> {
 test("send with --new-conversation posts a new-intent directive and auto-generates a client message id", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(201, { data: { id: "msg_1" }, conversationId: "conv_1" }))
 
-  const result = await run(["messages", "send", "stream_1", "kickoff", "--new-conversation", "--metadata", "k=v"], {
-    config: TEST_CONFIG,
-    isTTY: false,
-  })
+  const result = await run(
+    ["messages", "send", "stream_1", "kickoff", "--new-conversation", "--metadata", "k=v", "--json"],
+    {
+      config: TEST_CONFIG,
+    }
+  )
 
   expect(result.exitCode).toBe(0)
   expect(new URL(String(fetchSpy.mock.calls[0]![0])).pathname).toBe("/api/v1/workspaces/ws_1/streams/stream_1/messages")
@@ -37,7 +39,6 @@ test("send with --conversation appends an existing-intent directive", async () =
 
   const result = await run(["messages", "send", "stream_1", "follow up", "--conversation", "conv_9"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(0)
@@ -47,7 +48,6 @@ test("send with --conversation appends an existing-intent directive", async () =
 test("send with both --new-conversation and --conversation is a usage error (exit 2) before any HTTP", async () => {
   const result = await run(["messages", "send", "stream_1", "x", "--new-conversation", "--conversation", "conv_9"], {
     config: TEST_CONFIG,
-    isTTY: false,
   })
 
   expect(result.exitCode).toBe(2)
@@ -61,7 +61,6 @@ test("send reads content from stdin when the content arg is `-`", async () => {
 
   const result = await run(["messages", "send", "stream_1", "-"], {
     config: TEST_CONFIG,
-    isTTY: false,
     readStdin: () => Promise.resolve("piped **body**\n"),
   })
 
@@ -72,7 +71,7 @@ test("send reads content from stdin when the content arg is `-`", async () => {
 test("edit sends a PATCH with the new content", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "msg_1", content: "edited" } }))
 
-  const result = await run(["messages", "edit", "msg_1", "edited"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["messages", "edit", "msg_1", "edited"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PATCH")
@@ -83,7 +82,7 @@ test("edit sends a PATCH with the new content", async () => {
 test("delete sends a DELETE and reports the id, handling a 204 body", async () => {
   fetchSpy.mockResolvedValue(new Response(null, { status: 204 }))
 
-  const result = await run(["messages", "delete", "msg_1", "--json"], { config: TEST_CONFIG, isTTY: false })
+  const result = await run(["messages", "delete", "msg_1", "--json"], { config: TEST_CONFIG })
 
   expect(result.exitCode).toBe(0)
   expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE")

--- a/packages/cli/src/commands/streams.ts
+++ b/packages/cli/src/commands/streams.ts
@@ -27,7 +27,7 @@ function streamLabel(s: StreamRow): string {
 const listVerb: VerbSpec = {
   name: "list",
   summary: "List streams this key can access",
-  usage: "threa streams list [--type t]... [--query q] [--after cursor] [--limit n]",
+  usage: "threa streams list [--type t]... [--query q] [--after cursor] [--limit n] [--archived]",
   help:
     "threa streams list [flags]\n\n" +
     "List streams this key can access. Page by passing the previous response's cursor back as --after.\n\n" +
@@ -38,6 +38,7 @@ const listVerb: VerbSpec = {
     "  --query q    text match on stream name\n" +
     "  --after c    pagination cursor from a previous response\n" +
     "  --limit n    max results, <= 200 (default 50)\n" +
+    "  --archived   include archived streams and threads under archived roots\n" +
     "  --json       force JSON output\n" +
     "  --help       show this help",
   options: {
@@ -45,6 +46,7 @@ const listVerb: VerbSpec = {
     query: { type: "string" },
     after: { type: "string" },
     limit: { type: "string" },
+    archived: { type: "boolean" },
   },
   run: (ctx, _positionals, values) =>
     listStreams(ctx.client, {
@@ -52,6 +54,7 @@ const listVerb: VerbSpec = {
       query: stringFlag(values, "query"),
       after: stringFlag(values, "after"),
       limit: intFlag(values, "limit"),
+      includeArchived: boolFlag(values, "archived"),
     }),
   render: (payload) =>
     renderList<StreamRow>(payload, (s) => `${s.id ?? "?"}  ${s.type ?? "?"}  ${streamLabel(s)}`, {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { loadConfig } from "./config"
 
-const ENV_KEYS = ["THREA_API_KEY", "THREA_WORKSPACE_ID", "THREA_BASE_URL", "THREA_MCP_CONFIG", "HOME"] as const
+const ENV_KEYS = ["THREA_API_KEY", "THREA_WORKSPACE_ID", "THREA_BASE_URL", "THREA_CONFIG", "HOME"] as const
 
 let saved: Record<string, string | undefined>
 let home: string
@@ -15,7 +15,7 @@ beforeEach(() => {
     saved[key] = process.env[key]
     delete process.env[key]
   }
-  home = mkdtempSync(join(tmpdir(), "threa-mcp-home-"))
+  home = mkdtempSync(join(tmpdir(), "threa-cli-home-"))
   process.env.HOME = home
 })
 
@@ -27,9 +27,9 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true })
 })
 
-function writeConfigFile(config: Record<string, unknown>): string {
+function writeConfigFile(config: Record<string, unknown>, filename = "config.json"): string {
   mkdirSync(join(home, ".threa"), { recursive: true })
-  const path = join(home, ".threa", "mcp.json")
+  const path = join(home, ".threa", filename)
   writeFileSync(path, JSON.stringify(config))
   return path
 }
@@ -41,6 +41,7 @@ test("env vars supply config and baseUrl defaults", () => {
     apiKey: "threa_uk_env",
     workspaceId: "ws_env",
     baseUrl: "https://app.threa.io",
+    output: "text",
   })
 })
 
@@ -49,8 +50,8 @@ test("missing required vars fail loudly and name each one", () => {
   expect(() => loadConfig()).toThrow(/THREA_WORKSPACE_ID/)
 })
 
-test("config file supplies values when env is absent", () => {
-  process.env.THREA_MCP_CONFIG = writeConfigFile({
+test("config file at ~/.threa/config.json supplies values when env is absent", () => {
+  writeConfigFile({
     apiKey: "threa_uk_file",
     workspaceId: "ws_file",
     baseUrl: "https://staging.threa.io",
@@ -59,11 +60,40 @@ test("config file supplies values when env is absent", () => {
     apiKey: "threa_uk_file",
     workspaceId: "ws_file",
     baseUrl: "https://staging.threa.io",
+    output: "text",
   })
 })
 
+test("legacy ~/.threa/mcp.json is still read when config.json is absent", () => {
+  writeConfigFile({ apiKey: "threa_uk_legacy", workspaceId: "ws_legacy" }, "mcp.json")
+  expect(loadConfig()).toEqual({
+    apiKey: "threa_uk_legacy",
+    workspaceId: "ws_legacy",
+    baseUrl: "https://app.threa.io",
+    output: "text",
+  })
+})
+
+test("config.json wins over a lingering mcp.json", () => {
+  writeConfigFile({ apiKey: "threa_uk_old", workspaceId: "ws_old" }, "mcp.json")
+  writeConfigFile({ apiKey: "threa_uk_new", workspaceId: "ws_new" })
+  const config = loadConfig()
+  expect(config.apiKey).toBe("threa_uk_new")
+  expect(config.workspaceId).toBe("ws_new")
+})
+
+test("config file sets the default output mode", () => {
+  writeConfigFile({ apiKey: "threa_uk_file", workspaceId: "ws_file", output: "json" })
+  expect(loadConfig().output).toBe("json")
+})
+
+test("an invalid output mode in the config fails loudly", () => {
+  writeConfigFile({ apiKey: "threa_uk_file", workspaceId: "ws_file", output: "yaml" })
+  expect(() => loadConfig()).toThrow(/output.*must be one of/i)
+})
+
 test("env wins over file per key", () => {
-  process.env.THREA_MCP_CONFIG = writeConfigFile({
+  writeConfigFile({
     apiKey: "threa_uk_file",
     workspaceId: "ws_file",
     baseUrl: "https://staging.threa.io",
@@ -75,25 +105,26 @@ test("env wins over file per key", () => {
   expect(config.baseUrl).toBe("https://staging.threa.io")
 })
 
-test("THREA_MCP_CONFIG points at an explicit file", () => {
-  const dir = mkdtempSync(join(tmpdir(), "threa-mcp-cfg-"))
+test("THREA_CONFIG points at an explicit file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "threa-cli-cfg-"))
   const path = join(dir, "custom.json")
   writeFileSync(path, JSON.stringify({ apiKey: "threa_uk_custom", workspaceId: "ws_custom" }))
-  process.env.THREA_MCP_CONFIG = path
+  process.env.THREA_CONFIG = path
   try {
     expect(loadConfig()).toEqual({
       apiKey: "threa_uk_custom",
       workspaceId: "ws_custom",
       baseUrl: "https://app.threa.io",
+      output: "text",
     })
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test("explicit THREA_MCP_CONFIG that cannot be read fails loudly", () => {
-  process.env.THREA_MCP_CONFIG = join(home, "does-not-exist.json")
-  expect(() => loadConfig()).toThrow(/THREA_MCP_CONFIG/)
+test("explicit THREA_CONFIG that cannot be read fails loudly", () => {
+  process.env.THREA_CONFIG = join(home, "does-not-exist.json")
+  expect(() => loadConfig()).toThrow(/THREA_CONFIG/)
 })
 
 test("loadConfig rejects a non-https base URL", () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,10 +2,14 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
-export interface ThreaMcpConfig {
+export const OUTPUT_MODES = ["text", "json"] as const
+export type OutputMode = (typeof OUTPUT_MODES)[number]
+
+export interface ThreaConfig {
   apiKey: string
   workspaceId: string
   baseUrl: string
+  output: OutputMode
 }
 
 const DEFAULT_BASE_URL = "https://app.threa.io"
@@ -14,19 +18,35 @@ interface FileConfig {
   apiKey?: string
   workspaceId?: string
   baseUrl?: string
+  output?: string
 }
 
 function readFileConfig(): FileConfig {
-  const explicit = process.env.THREA_MCP_CONFIG
-  const path = explicit ?? join(homedir(), ".threa", "mcp.json")
-  let raw: string
-  try {
-    raw = readFileSync(path, "utf8")
-  } catch {
+  const explicit = process.env.THREA_CONFIG
+  // process.env.HOME first: Bun's homedir() ignores a runtime HOME override,
+  // which would leak the developer's real ~/.threa config into tests.
+  const home = process.env.HOME ?? homedir()
+  const candidates = explicit ? [explicit] : [join(home, ".threa", "config.json"), join(home, ".threa", "mcp.json")]
+
+  let raw: string | undefined
+  let path: string | undefined
+  for (const candidate of candidates) {
+    try {
+      raw = readFileSync(candidate, "utf8")
+      path = candidate
+      break
+    } catch {
+      // try the next candidate
+    }
+  }
+  if (raw === undefined || path === undefined) {
     if (explicit) {
-      throw new Error(`[threa] THREA_MCP_CONFIG points to ${path}, but it could not be read.`)
+      throw new Error(`[threa] THREA_CONFIG points to ${explicit}, but it could not be read.`)
     }
     return {}
+  }
+  if (path.endsWith("mcp.json")) {
+    process.stderr.write(`[threa] Using legacy ${path} — rename it to ~/.threa/config.json.\n`)
   }
   let parsed: unknown
   try {
@@ -40,12 +60,13 @@ function readFileConfig(): FileConfig {
   return parsed as FileConfig
 }
 
-export function loadConfig(): ThreaMcpConfig {
+export function loadConfig(): ThreaConfig {
   const file = readFileConfig()
 
   const apiKey = process.env.THREA_API_KEY ?? file.apiKey
   const workspaceId = process.env.THREA_WORKSPACE_ID ?? file.workspaceId
   const baseUrl = process.env.THREA_BASE_URL ?? file.baseUrl ?? DEFAULT_BASE_URL
+  const output = file.output ?? "text"
 
   const missing: string[] = []
   if (!apiKey) missing.push("THREA_API_KEY")
@@ -53,14 +74,18 @@ export function loadConfig(): ThreaMcpConfig {
   if (missing.length > 0) {
     throw new Error(
       `[threa] Missing required config: ${missing.join(", ")}. ` +
-        `Set them as environment variables, or provide a JSON file at ~/.threa/mcp.json ` +
-        `(or the path in THREA_MCP_CONFIG) with { apiKey, workspaceId, baseUrl }. Environment variables win over the file.`
+        `Set them as environment variables, or provide a JSON file at ~/.threa/config.json ` +
+        `(or the path in THREA_CONFIG) with { apiKey, workspaceId, baseUrl }. Environment variables win over the file.`
     )
+  }
+
+  if (!(OUTPUT_MODES as readonly string[]).includes(output)) {
+    throw new Error(`[threa] Config "output" must be one of ${OUTPUT_MODES.join(", ")} — got "${output}".`)
   }
 
   assertSafeBaseUrl(baseUrl)
 
-  return { apiKey: apiKey!, workspaceId: workspaceId!, baseUrl }
+  return { apiKey: apiKey!, workspaceId: workspaceId!, baseUrl, output: output as OutputMode }
 }
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"])

--- a/packages/cli/src/ops.ts
+++ b/packages/cli/src/ops.ts
@@ -1,5 +1,5 @@
 import type { ThreaApiClient } from "./api-client"
-import type { ThreaMcpConfig } from "./config"
+import type { ThreaConfig } from "./config"
 import { enrichConversation, enrichMessages } from "./enrich"
 import type { RefResolver } from "./resolver"
 import type { TokenStore } from "./token-store"
@@ -18,7 +18,7 @@ interface Principal {
   [key: string]: unknown
 }
 
-export async function whoami(client: ThreaApiClient, config: ThreaMcpConfig): Promise<unknown> {
+export async function whoami(client: ThreaApiClient, config: ThreaConfig): Promise<unknown> {
   const { data } = await client.get<{ data: Principal }>("/me")
   return { principal: data, baseUrl: config.baseUrl, workspaceId: config.workspaceId }
 }

--- a/packages/cli/src/ops.ts
+++ b/packages/cli/src/ops.ts
@@ -28,10 +28,19 @@ export interface ListStreamsParams {
   query?: string
   after?: string
   limit?: number
+  includeArchived?: boolean
 }
 
 export function listStreams(client: ThreaApiClient, p: ListStreamsParams): Promise<unknown> {
-  return client.get(`/streams${buildQuery({ type: p.type, query: p.query, after: p.after, limit: p.limit })}`)
+  return client.get(
+    `/streams${buildQuery({
+      type: p.type,
+      query: p.query,
+      after: p.after,
+      limit: p.limit,
+      includeArchived: p.includeArchived ? "true" : undefined,
+    })}`
+  )
 }
 
 export interface ReadStreamParams {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,5 +1,5 @@
 import type { ParseArgsConfig } from "node:util"
-import type { ThreaMcpConfig } from "./config"
+import { OUTPUT_MODES, type OutputMode, type ThreaConfig } from "./config"
 import type { ThreaApiClient } from "./api-client"
 import type { RefResolver } from "./resolver"
 import type { TokenStore } from "./token-store"
@@ -15,7 +15,7 @@ export class UsageError extends Error {
 export interface CommandContext {
   client: ThreaApiClient
   resolver: RefResolver
-  config: ThreaMcpConfig
+  config: ThreaConfig
   tokenStore: TokenStore
   /** Reads piped stdin for a `-` content arg. Injectable so tests feed content without a real pipe. */
   readStdin: () => Promise<string>
@@ -62,9 +62,9 @@ export const errorObject = toErrorShape
 export function formatSuccess(
   spec: { render?(payload: unknown): string },
   payload: unknown,
-  opts: { json: boolean; isTTY: boolean }
+  opts: { mode: OutputMode }
 ): string {
-  if (opts.json || !opts.isTTY || !spec.render) return JSON.stringify(payload, null, 2)
+  if (opts.mode === "json" || !spec.render) return JSON.stringify(payload, null, 2)
   try {
     return spec.render(payload)
   } catch {
@@ -73,8 +73,44 @@ export function formatSuccess(
 }
 
 const GLOBAL_OPTIONS: ParseOptions = {
-  json: { type: "boolean" },
   help: { type: "boolean", short: "h" },
+}
+
+/**
+ * Pulls the position-independent output flags (`--json`, `-o/--output json|text`)
+ * out of argv before command routing, so `threa --json streams list` works the
+ * same as `threa streams list --json`. Everything after a literal `--` is left
+ * untouched. Later flags win when both forms appear.
+ */
+export function extractOutputMode(argv: string[]): { argv: string[]; mode?: OutputMode } {
+  const rest: string[] = []
+  let mode: OutputMode | undefined
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!
+    if (token === "--") {
+      rest.push(...argv.slice(i))
+      break
+    }
+    if (token === "--json") {
+      mode = "json"
+      continue
+    }
+    let value: string | undefined
+    if (token === "-o" || token === "--output") {
+      value = argv[++i]
+      if (value === undefined) throw new UsageError(`${token} requires a value: ${OUTPUT_MODES.join("|")}`)
+    } else if (token.startsWith("-o=") || token.startsWith("--output=")) {
+      value = token.slice(token.indexOf("=") + 1)
+    } else {
+      rest.push(token)
+      continue
+    }
+    if (!(OUTPUT_MODES as readonly string[]).includes(value)) {
+      throw new UsageError(`-o/--output must be one of ${OUTPUT_MODES.join("|")}, got "${value}"`)
+    }
+    mode = value as OutputMode
+  }
+  return { argv: rest, mode }
 }
 
 export function withGlobalOptions(options: ParseOptions): ParseOptions {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { ThreaApiClient } from "./api-client"
-import type { ThreaMcpConfig } from "./config"
+import type { ThreaConfig } from "./config"
 import { RefResolver } from "./resolver"
 import { TokenStore } from "./token-store"
 import { registerAttachmentTools } from "./tools/attachments"
@@ -51,7 +51,7 @@ export interface ThreaMcpServerDeps {
   tokenStore?: TokenStore
 }
 
-export function createThreaMcpServer(config: ThreaMcpConfig, deps: ThreaMcpServerDeps = {}): McpServer {
+export function createThreaMcpServer(config: ThreaConfig, deps: ThreaMcpServerDeps = {}): McpServer {
   const server = new McpServer({ name: "threa", version: "0.1.0" }, { instructions: INSTRUCTIONS })
   const client = new ThreaApiClient({
     baseUrl: config.baseUrl,

--- a/packages/cli/src/test-support.ts
+++ b/packages/cli/src/test-support.ts
@@ -4,13 +4,14 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createThreaMcpServer } from "./server"
-import type { ThreaMcpConfig } from "./config"
+import type { ThreaConfig } from "./config"
 import { TokenStore } from "./token-store"
 
-export const TEST_CONFIG: ThreaMcpConfig = {
+export const TEST_CONFIG: ThreaConfig = {
   apiKey: "threa_uk_secret",
   workspaceId: "ws_1",
   baseUrl: "https://app.threa.io",
+  output: "text",
 }
 
 export function jsonResponse(status: number, body: unknown): Response {
@@ -21,7 +22,7 @@ export function fetchByPath(handler: (path: string) => Response): typeof fetch {
   return (async (input: RequestInfo | URL) => handler(new URL(String(input)).pathname)) as unknown as typeof fetch
 }
 
-export async function connectClient(config: ThreaMcpConfig = TEST_CONFIG): Promise<Client> {
+export async function connectClient(config: ThreaConfig = TEST_CONFIG): Promise<Client> {
   const tokenStore = new TokenStore(join(tmpdir(), `threa-cli-test-${crypto.randomUUID()}.json`))
   const server = createThreaMcpServer(config, { tokenStore })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()

--- a/packages/cli/src/tools/identity.ts
+++ b/packages/cli/src/tools/identity.ts
@@ -1,10 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { ThreaApiClient } from "../api-client"
-import type { ThreaMcpConfig } from "../config"
+import type { ThreaConfig } from "../config"
 import { whoami } from "../ops"
 import { runTool } from "./result"
 
-export function registerIdentityTools(server: McpServer, client: ThreaApiClient, config: ThreaMcpConfig): void {
+export function registerIdentityTools(server: McpServer, client: ThreaApiClient, config: ThreaConfig): void {
   server.registerTool(
     "whoami",
     {

--- a/packages/cli/src/tools/streams.ts
+++ b/packages/cli/src/tools/streams.ts
@@ -14,15 +14,18 @@ export function registerStreamTools(server: McpServer, client: ThreaApiClient, r
       description:
         "List streams this key can access, newest-ish first. Filter with `type` (one or more of scratchpad, " +
         "channel, dm, thread, system) and `query` (text match on name). Page by passing the previous " +
-        "response's `cursor` value back as `after`; `hasMore` tells you when to stop. limit ≤ 200 (default 50).",
+        "response's `cursor` value back as `after`; `hasMore` tells you when to stop. limit ≤ 200 (default 50). " +
+        "Archived streams (and live threads under an archived root) are omitted unless `include_archived` is true.",
       inputSchema: {
         type: z.array(z.enum(STREAM_TYPES)).optional(),
         query: z.string().optional(),
         after: z.string().optional(),
         limit: z.number().int().min(1).max(200).optional(),
+        include_archived: z.boolean().optional(),
       },
     },
-    async ({ type, query, after, limit }) => runTool(() => listStreams(client, { type, query, after, limit }))
+    async ({ type, query, after, limit, include_archived }) =>
+      runTool(() => listStreams(client, { type, query, after, limit, includeArchived: include_archived }))
   )
 
   server.registerTool(


### PR DESCRIPTION
## Problem

Six CLI nits from dogfooding, two of them backend:

1. `--json` only worked trailing the verb; `threa --json streams list` was an unknown-command error.
2. No way to set a default output mode in the config file.
3. The config file was named `~/.threa/mcp.json` — wrong name for a CLI's config.
4. No `-o json` / `-o text` short form.
5. `threa streams list` showed orphaned rows like `stream_… thread "Thread in #channel"` — live threads under an archived root. The root itself 404'd on `GET /streams/{id}` (`getStream` rejected any `archivedAt` stream) while the app opens it read-only, and the placeholder invented a `#channel` sigil for slugless parents.
6. Piped output silently switched to JSON (`threa streams list | grep …` matched JSON lines while the bare call printed text) — surprising and inconsistent.

## Solution

**Output (1, 4, 6, commit 1).** TTY detection is gone. The CLI prints human text everywhere, piped or not; JSON only when asked. `extractOutputMode` in `output.ts` pulls `--json`, `-o json|text`, `--output=…` out of argv before command routing, so the flag works in any position (`threa -o json streams list`, `threa streams --json list`, trailing). Precedence: flag > config `output` > `"text"`. An invalid `-o` value is a usage error (exit 2) before any HTTP.

**Config (2, 3, commit 1).** File renamed to `~/.threa/config.json` with a new optional `"output": "text"|"json"` field (validated fail-loud, INV-11). A legacy `~/.threa/mcp.json` is still read when `config.json` is absent, with a one-line stderr hint to rename — no silent alias kept in docs (INV-49: all docs/help speak only the new name). `THREA_MCP_CONFIG` → `THREA_CONFIG`; `ThreaMcpConfig` → `ThreaConfig`. `config.ts` now reads `process.env.HOME` before `os.homedir()`: Bun's `homedir()` ignores a runtime `HOME` override, which let the developer's real `~/.threa/mcp.json` leak into the test suite (caught when four config tests went red against my actual config).

**Archived streams (5, commit 2).**
- `StreamRepository.listByIds` (public list's only caller) hides live threads under an archived root by default via a `NOT EXISTS` on `root_stream_id` — the row's own `archived_at IS NULL` was not enough. `includeArchived: true` drops both filters.
- `listStreams` accepts `includeArchived=true` (query param, literal-string boolean — no zod transform, the OpenAPI generator can't derive a schema through effects); CLI `threa streams list --archived`; MCP `list_streams.include_archived`.
- `getStream` no longer 404s archived streams: the app opens them read-only and the wire payload already carries `archivedAt`. Writes (`updateStream`) still reject archived.
- `getEffectiveDisplayName` thread placeholder: `Thread in #slug` for channel parents, `Thread in <displayName>` for named slugless parents (scratchpads), plain `Thread` when the parent has neither — never a phantom `#channel`.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/cli/src/output.ts` | `formatSuccess` takes `{mode}`; `extractOutputMode` position-independent flag extraction |
| `packages/cli/src/cli.ts` | pre-routing flag extraction, `isTTY` deleted from `RunDeps`, help text |
| `packages/cli/src/config.ts` | `config.json` + legacy fallback, `output` field, `THREA_CONFIG`, HOME-first path resolution |
| `packages/cli/src/ops.ts`, `tools/streams.ts`, `commands/streams.ts` | `includeArchived` param / `--archived` flag |
| `apps/backend/src/features/streams/repository.ts` | `listByIds` root-archived `NOT EXISTS` + `includeArchived` filter |
| `apps/backend/src/features/streams/display-name.ts` | thread placeholder no longer invents `#channel` |
| `apps/backend/src/features/public-api/handlers.ts` | `listStreams` passes `includeArchived`; `getStream` archived 404 dropped |
| `apps/backend/src/features/public-api/schemas.ts` | `includeArchived` enum query param |
| `docs/public-api/openapi.json`, `versions/2026-07-12.json` | regenerated (`generate-api-docs.ts`) |
| `packages/cli/README.md`, `docs/public-api/mcp-server.md`, `.agents/skills/threa-cli/SKILL.md` | new output/config semantics, `--archived` |

New: `apps/backend/src/features/streams/display-name.test.ts` (placeholder matrix).

## Out of scope (deliberate)

- Kris also saw messages with no visible content in that thread — likely E2E-placeholder or attachment-only rows, not chased here.
- `listByIds`'s `purpose IS NULL` vs `getStream` (which serves purpose streams by id) is a pre-existing asymmetry, untouched.

## Test plan

- [x] `packages/cli`: 138 tests pass, `tsc --noEmit` clean. New coverage: position-independent flags (6 argv shapes), noun-verb interleaving, `-o text` over config `json`, invalid `-o` exit 2, `--archived` passthrough + absence, config.json/mcp.json fallback + precedence, `output` validation.
- [x] Backend: `bun test src/features/streams` 178 pass, `src/features/public-api` 158 pass, `tsc --noEmit` clean. New: `listByIds` archived-filter SQL shape both ways, display-name placeholder matrix.
- [x] Live against prod (branch build, reads only): piped default is text, `-o json` before the noun, `--json` between noun and verb, legacy-config rename hint prints once on stderr.
- [ ] Backend archived behavior not live-verified (needs deploy); covered by SQL-shape stubs per the suite's existing pattern.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882201&installation_id=129946197&pr_number=1380&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1380&signature=d4b925c8c02d54e84d980d8a11e25f9992c6efb231f75632383f35ccbcdefc9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->