### PR TITLE
fix(search): in:@user DM scoping + thread coverage across all search surfaces

### DIFF
--- a/apps/backend/src/features/agents/tools/search-workspace-tool.ts
+++ b/apps/backend/src/features/agents/tools/search-workspace-tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import { AgentStepTypes, AgentToolNames, TOOL_CATEGORIES_BY_NAME, STREAM_TYPES, StreamTypes } from "@threa/types"
 import { logger } from "../../../lib/logger"
 import { searchDmStreamsByParticipant, StreamRepository } from "../../streams"
+import { SearchRepository } from "../../search"
 import { UserRepository } from "../../workspaces"
 import { MessageRepository } from "../../messaging"
 import { PersonaRepository } from "../persona-repository"
@@ -123,7 +124,9 @@ Optionally filter by stream using ID (stream_xxx), slug (general), or prefixed s
                 message: "No matching messages found",
               }),
             }
-          filterStreamIds = [resolved.id]
+          // Replies live in thread streams under the resolved stream (INV-62);
+          // filtering by the bare id would silently exclude them.
+          filterStreamIds = await SearchRepository.expandStreamIdsWithThreads(db, workspaceId, [resolved.id])
         }
 
         const { results: searchResults } = await searchService.search({

--- a/apps/backend/src/features/api-keys/service.ts
+++ b/apps/backend/src/features/api-keys/service.ts
@@ -21,7 +21,16 @@ export class BotChannelService {
       BotChannelAccessRepository.getGrantedStreamIds(this.pool, workspaceId, botId),
     ])
 
-    return [...new Set([...publicStreamIds, ...grantedStreamIds])]
+    // A grant on a private channel must cover its threads (INV-62): they
+    // inherit the root's private visibility, so getPublicStreams never
+    // includes them. isStreamAccessibleForBot already maps thread -> root;
+    // this keeps the list-shaped scope consistent with that point check.
+    const grantedWithThreads =
+      grantedStreamIds.length > 0
+        ? await SearchRepository.expandStreamIdsWithThreads(this.pool, workspaceId, grantedStreamIds)
+        : []
+
+    return [...new Set([...publicStreamIds, ...grantedWithThreads])]
   }
 
   async isStreamAccessibleForBot(workspaceId: string, botId: string, streamId: string): Promise<boolean> {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
 import type { SearchFilters, SearchService } from "../search"
-import { serializeSearchResult, resolveUserAccessibleStreamIds } from "../search"
+import { serializeSearchResult, resolveUserAccessibleStreamIds, SearchRepository } from "../search"
 import { BotChannelAccessRepository, type BotChannelService } from "../api-keys"
 import { MessageRepository, type EventService, type Message } from "../messaging"
 import {
@@ -1845,12 +1845,23 @@ export function createPublicApiHandlers({
         return res.json({ data: [] })
       }
 
+      // Replies live in thread streams under the requested streams (INV-62); an
+      // unexpanded filter would silently exclude them. A filter that resolves to
+      // nothing must return empty, not fall back to an unfiltered search.
+      let filterStreamIds: string[] | undefined
+      if (streams && streams.length > 0) {
+        filterStreamIds = await SearchRepository.expandStreamIdsWithThreads(pool, workspaceId, streams)
+        if (filterStreamIds.length === 0) {
+          return res.json({ data: [] })
+        }
+      }
+
       const { results } = await searchService.search({
         workspaceId,
         permissions: { accessibleStreamIds },
         query,
         filters: {
-          streamIds: streams,
+          streamIds: filterStreamIds,
           authorId: from,
           streamTypes: type,
           before: before ? new Date(before) : undefined,
@@ -1889,6 +1900,16 @@ export function createPublicApiHandlers({
         return res.json({ data: [] })
       }
 
+      // Same expansion as searchMessages: memos captured from thread
+      // conversations carry the thread's stream id (INV-62).
+      let memoFilterStreamIds: string[] | undefined
+      if (streams && streams.length > 0) {
+        memoFilterStreamIds = await SearchRepository.expandStreamIdsWithThreads(pool, workspaceId, streams)
+        if (memoFilterStreamIds.length === 0) {
+          return res.json({ data: [] })
+        }
+      }
+
       const results = await memoExplorerService.search({
         workspaceId,
         // A user API key's principal owns its user-scoped memos; a bot key has no
@@ -1897,7 +1918,7 @@ export function createPublicApiHandlers({
         query: normalized.query,
         exact: normalized.exact,
         filters: {
-          streamIds: streams,
+          streamIds: memoFilterStreamIds,
           memoTypes: memoType,
           knowledgeTypes: knowledgeType,
           tags,
@@ -1938,8 +1959,12 @@ export function createPublicApiHandlers({
         return res.json({ data: [] })
       }
 
-      const filterStreamIds = streams?.length
-        ? streams.filter((streamId) => accessibleStreamIds.includes(streamId))
+      // Expand to thread descendants (INV-62) before intersecting with access.
+      const requestedStreamIds = streams?.length
+        ? await SearchRepository.expandStreamIdsWithThreads(pool, workspaceId, streams)
+        : null
+      const filterStreamIds = requestedStreamIds
+        ? requestedStreamIds.filter((streamId) => accessibleStreamIds.includes(streamId))
         : accessibleStreamIds
 
       if (filterStreamIds.length === 0) {

--- a/apps/backend/src/features/search/access.ts
+++ b/apps/backend/src/features/search/access.ts
@@ -1,4 +1,5 @@
 import type { Querier } from "../../db"
+import { StreamRepository } from "../streams"
 import { SearchRepository } from "./repository"
 import type { SearchFilters } from "./service"
 
@@ -7,6 +8,36 @@ import type { SearchFilters } from "./service"
  * Extracted from SearchService so callers can resolve access
  * before passing to the auth-agnostic SearchService.search().
  */
+/**
+ * Resolve the `in:` filter's mixed entries to concrete stream IDs.
+ *
+ * Entries are either stream IDs (in:#channel) or user IDs (in:@user, meaning
+ * the requester's DM with that user). Resolved streams expand to include their
+ * thread descendants so "in this conversation" covers replies. A user with no
+ * DM resolves to nothing — the caller must treat an empty result as "no
+ * matches", not as an absent filter.
+ */
+export async function resolveInFilterStreamIds(
+  db: Querier,
+  workspaceId: string,
+  userId: string,
+  inIds: string[]
+): Promise<string[]> {
+  const streamIds = inIds.filter((id) => !id.startsWith("usr_"))
+  const dmUserIds = inIds.filter((id) => id.startsWith("usr_"))
+
+  if (dmUserIds.length > 0) {
+    const dmPeers = await StreamRepository.listDmPeersForMember(db, workspaceId, userId)
+    const streamIdByPeer = new Map(dmPeers.map((peer) => [peer.userId, peer.streamId]))
+    for (const dmUserId of dmUserIds) {
+      const dmStreamId = streamIdByPeer.get(dmUserId)
+      if (dmStreamId) streamIds.push(dmStreamId)
+    }
+  }
+
+  return SearchRepository.expandStreamIdsWithThreads(db, workspaceId, streamIds)
+}
+
 export async function resolveUserAccessibleStreamIds(
   db: Querier,
   workspaceId: string,

--- a/apps/backend/src/features/search/handlers.ts
+++ b/apps/backend/src/features/search/handlers.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import type { SearchService } from "./service"
 import type { SearchResult } from "./repository"
-import { resolveUserAccessibleStreamIds } from "./access"
+import { resolveInFilterStreamIds, resolveUserAccessibleStreamIds } from "./access"
 import { validateRequest } from "../../lib/validation"
 import { STREAM_TYPES } from "@threa/types"
 
@@ -54,10 +54,23 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
 
       const { query, from, with: withParticipants, in: inStreams, type, status, before, after, exact, limit } = data
 
+      // `in` mixes stream ids and user ids (in:@user = the DM with that user).
+      // An unresolvable filter (e.g. no DM exists) must yield zero results, not
+      // fall through to an unfiltered search — the service treats an empty
+      // streamIds array as "no filter".
+      let resolvedInStreamIds: string[] | undefined
+      if (inStreams && inStreams.length > 0) {
+        resolvedInStreamIds = await resolveInFilterStreamIds(pool, workspaceId, userId, inStreams)
+        if (resolvedInStreamIds.length === 0) {
+          res.json({ results: [], excludedE2eStreamCount: 0 })
+          return
+        }
+      }
+
       const filters = {
         authorId: from,
         userIds: withParticipants,
-        streamIds: inStreams,
+        streamIds: resolvedInStreamIds,
         streamTypes: type,
         archiveStatus: status,
         before: before ? new Date(before) : undefined,

--- a/apps/backend/src/features/search/repository.ts
+++ b/apps/backend/src/features/search/repository.ts
@@ -424,6 +424,25 @@ export const SearchRepository = {
   },
 
   /**
+   * Expand stream IDs to include their thread descendants, scoped to the
+   * workspace. Used by the `in:` filter so "in this stream" covers replies
+   * living in thread streams under it.
+   */
+  async expandStreamIdsWithThreads(db: Querier, workspaceId: string, streamIds: string[]): Promise<string[]> {
+    if (streamIds.length === 0) {
+      return []
+    }
+
+    const result = await db.query<{ id: string }>(sql`
+      SELECT id FROM streams
+      WHERE workspace_id = ${workspaceId}
+        AND (id = ANY(${streamIds}) OR root_stream_id = ANY(${streamIds}))
+    `)
+
+    return result.rows.map((r) => r.id)
+  },
+
+  /**
    * Get accessible streams for an agent based on its access spec.
    *
    * Unlike getAccessibleStreamsWithMembers (which determines what a USER can access),

--- a/apps/backend/src/features/search/repository.ts
+++ b/apps/backend/src/features/search/repository.ts
@@ -110,6 +110,8 @@ export const SearchRepository = {
    * Participant filtering (AND logic):
    * - If userIds provided, stream must have ALL specified participants
    * - Participants can be users (stream_members) or personas (stream_persona_participants)
+   * - Threads carry no member rows (INV-62), so a thread qualifies when its
+   *   root stream has all specified participants
    *
    * Archive status:
    * - ["active"] (default) → only non-archived streams
@@ -159,9 +161,10 @@ export const SearchRepository = {
         GROUP BY stream_id
         HAVING COUNT(DISTINCT member_id) = ${userIds.length}
       )
-      SELECT a.id
+      SELECT DISTINCT a.id
       FROM accessible a
-      JOIN member_streams m ON a.id = m.stream_id
+      JOIN streams st ON st.id = a.id
+      JOIN member_streams m ON m.stream_id = a.id OR m.stream_id = st.root_stream_id
     `)
 
     return result.rows.map((r) => r.id)

--- a/apps/backend/tests/client.ts
+++ b/apps/backend/tests/client.ts
@@ -293,6 +293,22 @@ export async function sendMessage(
   return data.message
 }
 
+export async function sendDmMessage(
+  client: TestClient,
+  workspaceId: string,
+  dmUserId: string,
+  content: string
+): Promise<Message> {
+  const { status, data } = await client.post<{ message: Message }>(`/api/workspaces/${workspaceId}/messages`, {
+    dmUserId,
+    content,
+  })
+  if (status !== 201) {
+    throw new Error(`Send DM message failed: ${JSON.stringify(data)}`)
+  }
+  return data.message
+}
+
 export async function listEvents(
   client: TestClient,
   workspaceId: string,

--- a/apps/backend/tests/e2e/public-api-search.test.ts
+++ b/apps/backend/tests/e2e/public-api-search.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, test, expect, beforeAll } from "bun:test"
-import { TestClient, loginAs, createWorkspace, createChannel, sendMessage } from "../client"
+import { TestClient, loginAs, createWorkspace, createChannel, createThread, sendMessage } from "../client"
 
 const testRunId = Math.random().toString(36).substring(7)
 const testEmail = (name: string) => `${name}-pubapi-${testRunId}@test.com`
@@ -194,6 +194,52 @@ describe("Public API v1 — Message Search", () => {
       for (const result of data.data) {
         expect(result.streamId).toBe(ctx.publicChannelId)
       }
+    })
+
+    test("should include thread replies in granted private channels and streams-filtered searches", async () => {
+      const client = new TestClient()
+      await loginAs(client, testEmail("threads"), "Thread Setup User")
+      const workspace = await createWorkspace(client, `PubAPI Threads WS ${testRunId}`)
+      const privateChannel = await createChannel(client, workspace.id, `priv-threads-${testRunId}`, "private")
+
+      const botRes = await client.post(`/api/workspaces/${workspace.id}/bots`, {
+        type: "shared",
+        name: `Thread Bot ${testRunId}`,
+        slug: `thread-bot-${testRunId}`,
+      })
+      const bot = (botRes.data as { data: { id: string } }).data
+      const keyRes = await client.post(`/api/workspaces/${workspace.id}/bots/${bot.id}/keys`, {
+        name: "thread-key",
+        scopes: ["messages:search"],
+      })
+      const botApiKey = (keyRes.data as { value: string }).value
+
+      const grantRes = await client.post(
+        `/api/workspaces/${workspace.id}/bots/${bot.id}/streams/${privateChannel.id}/grant`,
+        {}
+      )
+      expect([200, 201, 204]).toContain(grantRes.status)
+
+      const keyword = `cockatrice${testRunId}`
+      const rootMessage = await sendMessage(client, workspace.id, privateChannel.id, `Root ${keyword}`)
+      const thread = await createThread(client, workspace.id, privateChannel.id, rootMessage.id)
+      await sendMessage(client, workspace.id, thread.id, `Thread reply ${keyword}`)
+
+      // Bot scope: the grant on the private channel must cover its threads
+      const scopeRes = await publicApiRequest(workspace.id, { query: keyword }, botApiKey)
+      expect(scopeRes.status).toBe(200)
+      const scopeData = (await scopeRes.json()) as { data: Array<{ streamId: string }> }
+      expect(scopeData.data.map((r) => r.streamId).sort()).toEqual([privateChannel.id, thread.id].sort())
+
+      // streams filter: filtering by the channel id must include its thread replies
+      const filterRes = await publicApiRequest(
+        workspace.id,
+        { query: keyword, streams: [privateChannel.id] },
+        botApiKey
+      )
+      expect(filterRes.status).toBe(200)
+      const filterData = (await filterRes.json()) as { data: Array<{ streamId: string }> }
+      expect(filterData.data.map((r) => r.streamId).sort()).toEqual([privateChannel.id, thread.id].sort())
     })
 
     test("should filter by date range", async () => {

--- a/apps/backend/tests/e2e/search.test.ts
+++ b/apps/backend/tests/e2e/search.test.ts
@@ -12,6 +12,8 @@ import {
   createScratchpad,
   createChannel,
   sendMessage,
+  sendDmMessage,
+  createThread,
   search,
   joinWorkspace,
   joinStream,
@@ -240,6 +242,63 @@ describe("Search E2E Tests", () => {
 
       expect(results.length).toBe(1)
       expect(results[0].streamId).toBe(channelShared.id)
+    })
+
+    test("should scope search to the DM when in contains a user id", async () => {
+      const clientA = new TestClient()
+      await loginAs(clientA, testEmail("indmA"), "InDm User A")
+      const workspace = await createWorkspace(clientA, `InDm WS ${testRunId}`)
+      const scratchpad = await createScratchpad(clientA, workspace.id, "off")
+
+      const clientB = new TestClient()
+      await loginAs(clientB, testEmail("indmB"), "InDm User B")
+      const memberB = await joinWorkspace(clientB, workspace.id)
+
+      const keyword = `wyvern${testRunId}`
+      const dmMessage = await sendDmMessage(clientA, workspace.id, memberB.id, `DM ${keyword}`)
+      await sendMessage(clientA, workspace.id, scratchpad.id, `Scratchpad ${keyword}`)
+
+      const results = await search(clientA, workspace.id, { query: keyword, in: [memberB.id] })
+
+      expect(results.length).toBe(1)
+      expect(results[0]).toMatchObject({ id: dmMessage.id, streamId: dmMessage.streamId })
+    })
+
+    test("should include thread replies when in filters by stream", async () => {
+      const client = new TestClient()
+      await loginAs(client, testEmail("inthread"), "InThread Test")
+      const workspace = await createWorkspace(client, `InThread WS ${testRunId}`)
+      const channel = await createChannel(client, workspace.id, `inthread-${testRunId}`, "private")
+      const otherChannel = await createChannel(client, workspace.id, `inother-${testRunId}`, "private")
+
+      const keyword = `basilisk${testRunId}`
+      const rootMessage = await sendMessage(client, workspace.id, channel.id, `Root ${keyword}`)
+      const thread = await createThread(client, workspace.id, channel.id, rootMessage.id)
+      await sendMessage(client, workspace.id, thread.id, `Thread reply ${keyword}`)
+      await sendMessage(client, workspace.id, otherChannel.id, `Other ${keyword}`)
+
+      const results = await search(client, workspace.id, { query: keyword, in: [channel.id] })
+
+      const streamIds = results.map((r) => r.streamId).sort()
+      expect(streamIds).toEqual([channel.id, thread.id].sort())
+    })
+
+    test("should return no results when in targets a user without a DM", async () => {
+      const clientA = new TestClient()
+      await loginAs(clientA, testEmail("nodmA"), "NoDm User A")
+      const workspace = await createWorkspace(clientA, `NoDm WS ${testRunId}`)
+      const scratchpad = await createScratchpad(clientA, workspace.id, "off")
+
+      const clientB = new TestClient()
+      await loginAs(clientB, testEmail("nodmB"), "NoDm User B")
+      const memberB = await joinWorkspace(clientB, workspace.id)
+
+      const keyword = `manticore${testRunId}`
+      await sendMessage(clientA, workspace.id, scratchpad.id, `Scratchpad ${keyword}`)
+
+      const results = await search(clientA, workspace.id, { query: keyword, in: [memberB.id] })
+
+      expect(results).toEqual([])
     })
 
     test("should combine multiple filters", async () => {

--- a/apps/backend/tests/e2e/search.test.ts
+++ b/apps/backend/tests/e2e/search.test.ts
@@ -301,6 +301,28 @@ describe("Search E2E Tests", () => {
       expect(results).toEqual([])
     })
 
+    test("should include thread replies in with-filtered shared streams", async () => {
+      const clientA = new TestClient()
+      await loginAs(clientA, testEmail("withThreadA"), "WithThread User A")
+      const workspace = await createWorkspace(clientA, `WithThread WS ${testRunId}`)
+      const channel = await createChannel(clientA, workspace.id, `withthread-${testRunId}`, "private")
+
+      const clientB = new TestClient()
+      await loginAs(clientB, testEmail("withThreadB"), "WithThread User B")
+      const memberB = await joinWorkspace(clientB, workspace.id)
+      await joinStream(clientB, workspace.id, channel.id)
+
+      const keyword = `chimera${testRunId}`
+      const rootMessage = await sendMessage(clientA, workspace.id, channel.id, `Root ${keyword}`)
+      const thread = await createThread(clientA, workspace.id, channel.id, rootMessage.id)
+      await sendMessage(clientA, workspace.id, thread.id, `Thread reply ${keyword}`)
+
+      const results = await search(clientA, workspace.id, { query: keyword, with: [memberB.id] })
+
+      const streamIds = results.map((r) => r.streamId).sort()
+      expect(streamIds).toEqual([channel.id, thread.id].sort())
+    })
+
     test("should combine multiple filters", async () => {
       const client = new TestClient()
       await loginAs(client, testEmail("combo"), "Combo Test")

--- a/apps/frontend/src/components/search/use-message-search.ts
+++ b/apps/frontend/src/components/search/use-message-search.ts
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useRef } from "react"
 import { useSearch } from "@/hooks"
 import { localStartOfDayISO } from "@/lib/dates"
-import { useWorkspaceStreams, useWorkspaceUsers } from "@/stores/workspace-store"
+import {
+  useWorkspaceBots,
+  useWorkspacePersonas,
+  useWorkspaceStreams,
+  useWorkspaceUsers,
+} from "@/stores/workspace-store"
 import { parseSearchQuery, type ParsedFilter } from "@/lib/search-query-parser"
 import type { SearchFilters, SearchResultItem } from "@/api"
 import type { ArchiveStatus } from "@/api"
-import type { StreamType } from "@threa/types"
+import { STREAM_TYPES, type StreamType } from "@threa/types"
 
 export const SEARCH_DEBOUNCE_MS = 300
 const SEARCH_RESULT_LIMIT = 50
@@ -30,6 +35,8 @@ export interface MessageSearchState {
  */
 export function useMessageSearch(workspaceId: string, query: string): MessageSearchState {
   const users = useWorkspaceUsers(workspaceId)
+  const personas = useWorkspacePersonas(workspaceId)
+  const bots = useWorkspaceBots(workspaceId)
   const streams = useWorkspaceStreams(workspaceId)
   const { results, isLoading, error, search, clear } = useSearch({ workspaceId, limit: SEARCH_RESULT_LIMIT })
 
@@ -40,25 +47,38 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
     const filters: SearchFilters = {}
 
     const resolveUserSlug = (slug: string) => users.find((u) => u.slug === slug)?.id ?? null
+    // The from:/with: pickers suggest personas and bots too; authors and stream
+    // participants can be any actor. Collision precedence user > persona > bot (INV-64).
+    const resolveActorSlug = (slug: string) =>
+      resolveUserSlug(slug) ??
+      personas.find((p) => p.slug === slug)?.id ??
+      bots.find((b) => b.slug === slug)?.id ??
+      null
     const resolveStreamSlug = (slug: string) => streams.find((s) => s.slug === slug)?.id ?? null
 
     for (const filter of parsedFilters) {
       switch (filter.type) {
         case "from": {
-          const userId = resolveUserSlug(filter.value)
-          if (userId) filters.from = userId
+          const actorId = resolveActorSlug(filter.value)
+          if (actorId) filters.from = actorId
           break
         }
         case "with": {
-          const userId = resolveUserSlug(filter.value)
-          if (userId) filters.with = [...(filters.with ?? []), userId]
+          const actorId = resolveActorSlug(filter.value)
+          if (actorId) filters.with = [...(filters.with ?? []), actorId]
           break
         }
+        // Invalid type/status values degrade like unresolved slugs (silent skip)
+        // instead of failing the whole request on backend validation.
         case "type":
-          filters.type = [...(filters.type ?? []), filter.value as StreamType]
+          if ((STREAM_TYPES as readonly string[]).includes(filter.value)) {
+            filters.type = [...(filters.type ?? []), filter.value as StreamType]
+          }
           break
         case "status":
-          filters.status = [...(filters.status ?? []), filter.value as ArchiveStatus]
+          if (filter.value === "active" || filter.value === "archived") {
+            filters.status = [...(filters.status ?? []), filter.value as ArchiveStatus]
+          }
           break
         case "in": {
           // in:#channel resolves a stream slug; in:@user resolves the user id
@@ -85,7 +105,7 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
     }
 
     return filters
-  }, [parsedFilters, users, streams])
+  }, [parsedFilters, users, personas, bots, streams])
 
   const hasQuery = searchText.trim().length > 0 || parsedFilters.length > 0
 


### PR DESCRIPTION
## Problem

`in:@user hype` in message search always returns zero results. The frontend resolves `in:@pierre-boberg` to the raw `usr_` id and sends it as an `in` entry (`use-message-search.ts`, whose comment claims "the backend maps it to the DM stream with that user"), but no backend mapping ever existed — PR #883 shipped the frontend comment with no backend counterpart. The `usr_` id lands in `filters.streamIds`, `SearchService.resolveStreamIds` intersects it with accessible *stream* ids, matches nothing, and the search short-circuits to empty. Verified against prod: the requester↔pierre DM has 9 FTS matches for "hype" that the filter could never surface.

A follow-up audit of every other search surface (session filters, agent tools, public API, bot access scope, frontend resolution) found the same bug class recurring — threads are separate streams with `root_stream_id` and no `stream_members` rows (INV-62), and every list-shaped stream filter forgot that:

| Surface | Bug |
| ------- | --- |
| Session `in:` | `usr_` id never mapped to DM; no thread descendants; empty resolution fell back to **unfiltered** |
| Session `with:` | Participant filter reads `stream_members` — threads have no rows, so all thread replies dropped |
| Agent `search_messages` stream filter | Bare resolved id, no thread descendants |
| Public API messages/memos/attachments `streams` filter | Bare ids, no thread descendants |
| Bot access scope | Grant on a private channel excluded its (private, inherited-visibility) threads — inconsistent with `isStreamAccessibleForBot`, which does map thread→root |
| Frontend `from:`/`with:` | Pickers suggest personas/bots but the resolver only resolved users → filter silently dropped, search ran unfiltered |
| Frontend `is:`/`status:` | Values sent unvalidated; hand-typed `is:archived` 400'd the whole request |

Audited and found **correct**: thread visibility inheritance (threads under public roots are themselves public, so `public_only` agent access covers them), the `user_intersection` agent spec's thread→root SQL, attachment search's resolved-to-nothing guard, and the memo explorer's access intersection.

## Solution

One shared primitive plus per-surface wiring: `SearchRepository.expandStreamIdsWithThreads` (workspace-scoped `id = ANY(..) OR root_stream_id = ANY(..)`) is the single thread-expansion helper, reused by every list-shaped stream filter.

### How it works

1. **Session `in:`** — `resolveInFilterStreamIds` (new, `features/search/access.ts`) partitions entries: `usr_` ids resolve to the requester's DM via `StreamRepository.listDmPeersForMember`; all resolved ids expand to thread descendants. The handler returns `{ results: [], excludedE2eStreamCount: 0 }` early when a non-empty `in` resolves to nothing — an empty `streamIds` array must never silently mean "no filter".
2. **Session `with:`** — the participant-filtered branch of `getAccessibleStreamsWithMembers` now joins `member_streams` against `a.id OR st.root_stream_id`, so a thread qualifies when its root has all requested participants.
3. **Agent `search_messages`** — the resolved stream filter runs through `expandStreamIdsWithThreads`.
4. **Public API** — `searchMessages`/`searchMemos` expand their `streams` filter and early-return empty on resolved-to-nothing; `searchAttachments` expands before its (already-guarded) access intersection.
5. **Bot scope** — `getAccessibleStreamIdsForBot` expands granted stream ids with their threads, matching the `isStreamAccessibleForBot` point check.
6. **Frontend** — `from:`/`with:` resolve through users → personas → bots (collision precedence user › persona › bot, INV-64; the backend genuinely accepts persona/bot author ids, and bots can hold `stream_members` rows via the invite path). Invalid `is:`/`status:` values are skipped client-side, degrading like unresolved slugs instead of failing the whole request.

### Key design decisions

**Backend mapping for `in:@user`, not frontend.** The frontend already documents it as backend behavior, and the DM stream may not be in the client's streams cache.

**Handler-layer, not service.** `SearchService` is auth-agnostic; DM resolution needs the requester's identity — same placement as `resolveUserAccessibleStreamIds`.

**Widen the `from:`/`with:` resolver instead of narrowing the pickers.** The `in:@` picker was deliberately restricted to users ("would commit a chip whose filter silently never applies"); for `from:`/`with:` the backend supports the wider actor set, so resolving it is strictly better than hiding it.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/search/access.ts` | New `resolveInFilterStreamIds`: usr_→DM mapping + thread expansion |
| `apps/backend/src/features/search/handlers.ts` | Resolve `in` before building filters; empty-resolution early return |
| `apps/backend/src/features/search/repository.ts` | New `expandStreamIdsWithThreads`; `with:` participant filter admits threads via root |
| `apps/backend/src/features/agents/tools/search-workspace-tool.ts` | Thread-expand the `stream` filter |
| `apps/backend/src/features/public-api/handlers.ts` | Thread-expand `streams` in messages/memos/attachments search + empty guards |
| `apps/backend/src/features/api-keys/service.ts` | Bot scope: expand grants with thread descendants |
| `apps/frontend/src/components/search/use-message-search.ts` | `from:`/`with:` resolve personas/bots; validate `is:`/`status:` values |
| `apps/backend/tests/client.ts` | `sendDmMessage` helper |
| `apps/backend/tests/e2e/search.test.ts` | 4 new tests: DM scoping, `in:` thread inclusion, no-DM → empty, `with:` thread inclusion |
| `apps/backend/tests/e2e/public-api-search.test.ts` | New test: bot grant + `streams` filter both cover thread replies |

## Out of scope (deliberate)

- `in:@user status:archived` won't resolve an archived DM (`listDmPeersForMember` excludes archived) — niche, pre-existing method semantics.
- CLI `--stream @user` still throws `UnresolvedRefError` by design (public API exposes no DM-lookup), and a raw `usr_` passed to `--stream` still yields empty from the public endpoint — the public API `streams` field remains stream-ids-only.
- Unresolved-slug chips (`from:@typo`) still silently drop the filter with no UI hint — needs chip-state UX design, flagged as follow-up.
- `is:` autocomplete doesn't offer `system` (valid type) — left as-is.

## Test plan

- [x] `tests/e2e/search.test.ts` — 27 pass (4 new; DM, `in:`-thread, and `with:`-thread tests all confirmed red before their fixes)
- [x] `tests/e2e/public-api-search.test.ts` — 17 pass (new thread test confirmed red with the two backend fixes stashed, green restored)
- [x] `tests/integration/search-streams-tool-dm.test.ts` + `src/features/agents/tools/` + `src/features/public-api/` — 255 pass
- [x] Frontend `src/components/search` under vitest — 45 pass
- [x] Backend + frontend `tsc --noEmit` clean; full monorepo lint/typecheck via pre-commit hook
- [x] Prod read-only check: requester↔pierre DM has 9 `websearch_to_tsquery('hype')` matches the `in:` fix will surface
- [ ] `with:@bot` end-to-end unverified — bots *can* hold `stream_members` rows (invite path) but prod currently has zero; resolver change is safe either way (no match → filter drops as before)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
