### PR TITLE
fix(editor): preserve formatting through composer copy/cut/paste roundtrip

### DIFF
--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -27,7 +27,13 @@ import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { createEditorExtensions } from "./editor-extensions"
 import { EditorBehaviors, handleLinkToolbarAction, isSuggestionActive } from "./editor-behaviors"
-import { serializeToMarkdown, parseMarkdown, type MentionTypeLookup } from "./editor-markdown"
+import {
+  serializeToMarkdown,
+  parseMarkdown,
+  serializeClipboardSlice,
+  isProseMirrorClipboardEvent,
+  type MentionTypeLookup,
+} from "./editor-markdown"
 import { useMentionSuggestion, useChannelSuggestion, useEmojiSuggestion } from "./triggers"
 import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
@@ -148,7 +154,12 @@ export function DocumentEditorModal({
           "focus:outline-none"
         ),
       },
+      clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        if (isProseMirrorClipboardEvent(event)) {
+          return false
+        }
+
         const text = event.clipboardData?.getData("text/plain")
         if (!text || !editorRef.current) {
           return false

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -9,8 +9,9 @@
  * dispatching a slash command). The parsers stay unified so the two sides
  * can't drift.
  */
-import { parseMarkdown } from "@threa/prosemirror"
+import { parseMarkdown, serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
+import type { Slice } from "@tiptap/pm/model"
 
 export {
   serializeToMarkdown,
@@ -28,6 +29,31 @@ export {
  * carry no reference and must not resolve to slugs, so every interactive parse
  * flag is off. Shared by every prompt-authoring editor so they can't drift.
  */
+/**
+ * Clipboard `text/plain` serializer for editor copy/cut. The default
+ * ProseMirror text serialization is bare `textContent` — code fences, quote
+ * markers, list bullets, and chip references (mentions, quote replies, shared
+ * messages) all vanish, so pasting back can never restore them. Markdown is
+ * the editor's canonical text form and the paste path parses it, closing the
+ * copy → paste roundtrip.
+ */
+export function serializeClipboardSlice(slice: Slice): string {
+  const content = slice.content.toJSON() as JSONContent[] | null
+  if (!content) return ""
+  return serializeToMarkdown({ type: "doc", content })
+}
+
+/**
+ * Content copied from a ProseMirror editor carries a `data-pm-slice` HTML
+ * payload that restores the exact document, chips included. Paste handlers
+ * bail on such events so ProseMirror's native paste applies it losslessly
+ * instead of re-parsing the markdown `text/plain` fallback.
+ */
+export function isProseMirrorClipboardEvent(event: ClipboardEvent): boolean {
+  const html = event.clipboardData?.getData("text/html")
+  return !!html && html.includes("data-pm-slice")
+}
+
 export function parsePromptMarkdown(markdown: string): JSONContent {
   return parseMarkdown(markdown, undefined, undefined, {
     enableMentions: false,

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -40,7 +40,10 @@ export {
 export function serializeClipboardSlice(slice: Slice): string {
   const content = slice.content.toJSON() as JSONContent[] | null
   if (!content) return ""
-  return serializeToMarkdown({ type: "doc", content })
+  // A NodeSelection of an inline atom (a chip) yields a slice whose top level
+  // is inline content; the serializer expects blocks, so wrap it.
+  const blocks = slice.content.firstChild?.isInline ? [{ type: "paragraph", content }] : content
+  return serializeToMarkdown({ type: "doc", content: blocks })
 }
 
 /**

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -9,7 +9,13 @@ import { applyExternalEditorContent } from "./apply-external-content"
 import { getDictationChunkPositions } from "./dictation-chunk-extension"
 import { EditorBehaviors, isSuggestionActive } from "./editor-behaviors"
 import { EditorToolbar } from "./editor-toolbar"
-import { serializeToMarkdown, parseMarkdown, type MentionTypeLookup } from "./editor-markdown"
+import {
+  serializeToMarkdown,
+  parseMarkdown,
+  serializeClipboardSlice,
+  isProseMirrorClipboardEvent,
+  type MentionTypeLookup,
+} from "./editor-markdown"
 import {
   useMentionSuggestion,
   useChannelSuggestion,
@@ -625,7 +631,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           "focus:outline-none"
         ),
       },
+      clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        if (isProseMirrorClipboardEvent(event)) {
+          return false
+        }
+
         const files = event.clipboardData?.files
         if (files && files.length > 0 && onFileUploadRef.current && editorRef.current) {
           event.preventDefault()

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -633,6 +633,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       },
       clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        // Deliberately skips everything below, including snippet conversion:
+        // an internal paste restores the exact document (chips included), and
+        // converting a user's own composed content into a snippet would lose it.
         if (isProseMirrorClipboardEvent(event)) {
           return false
         }
@@ -948,41 +951,6 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // No additional focus-on-mount effect needed — the redundant focus()
   // dispatch caused a view update that raced with toolbar rendering,
   // briefly dropping focus in autoFocus editors (e.g. inline edit).
-
-  // Copy/cut handler: serialize selection to markdown
-  useEffect(() => {
-    if (!editor || !containerRef.current) return
-
-    const serializeSelection = (event: ClipboardEvent) => {
-      const { from, to } = editor.state.selection
-      if (from === to) return // No selection, use default behavior
-
-      const slice = editor.state.doc.slice(from, to)
-      const json = { type: "doc", content: slice.content.toJSON() }
-      const markdown = serializeToMarkdown(json)
-
-      event.clipboardData?.setData("text/plain", markdown)
-      event.preventDefault()
-    }
-
-    const handleCopy = (event: ClipboardEvent) => {
-      serializeSelection(event)
-    }
-
-    const handleCut = (event: ClipboardEvent) => {
-      serializeSelection(event)
-      // Delete the selected content after serializing to clipboard
-      editor.commands.deleteSelection()
-    }
-
-    const container = containerRef.current
-    container.addEventListener("copy", handleCopy)
-    container.addEventListener("cut", handleCut)
-    return () => {
-      container.removeEventListener("copy", handleCopy)
-      container.removeEventListener("cut", handleCut)
-    }
-  }, [editor])
 
   const focus = useCallback(() => {
     if (editor && !editor.isDestroyed) {

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1292,3 +1292,24 @@ describe("@threa/prosemirror blockquote paragraph round-trip", () => {
     expect(parsed.content?.[0]).toEqual({ type: "blockquote", content: [{ type: "paragraph" }] })
   })
 })
+
+describe("@threa/prosemirror blockquote empty-paragraph round-trip", () => {
+  it("preserves an empty paragraph between quoted paragraphs", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "one" }] },
+            { type: "paragraph" },
+            { type: "paragraph", content: [{ type: "text", text: "two" }] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> one\n>\n> two")
+    expect(parseMarkdown(markdown)).toEqual(doc)
+  })
+})

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1193,3 +1193,102 @@ describe("@threa/prosemirror normalizeMarkdownTables", () => {
     expect(parsed.content?.[0]?.content).toHaveLength(3)
   })
 })
+
+describe("@threa/prosemirror nested list round-trip", () => {
+  const nestedBulletDoc: JSONContent = {
+    type: "doc",
+    content: [
+      {
+        type: "bulletList",
+        content: [
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "one" }] }] },
+          {
+            type: "listItem",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "two" }] },
+              {
+                type: "bulletList",
+                content: [
+                  {
+                    type: "listItem",
+                    content: [{ type: "paragraph", content: [{ type: "text", text: "nested" }] }],
+                  },
+                  {
+                    type: "listItem",
+                    content: [
+                      { type: "paragraph", content: [{ type: "text", text: "deep parent" }] },
+                      {
+                        type: "orderedList",
+                        content: [
+                          {
+                            type: "listItem",
+                            content: [{ type: "paragraph", content: [{ type: "text", text: "deepest" }] }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "three" }] }] },
+        ],
+      },
+    ],
+  }
+
+  it("round-trips nested bullet and ordered lists through markdown", () => {
+    const markdown = serializeToMarkdown(nestedBulletDoc)
+    const parsed = parseMarkdown(markdown)
+    expect(parsed).toEqual(nestedBulletDoc)
+  })
+
+  it("parses indented list items into nested lists", () => {
+    const parsed = parseMarkdown("- one\n- two\n  - nested\n- three")
+    const list = parsed.content?.[0]
+    expect(list?.type).toBe("bulletList")
+    expect(list?.content).toHaveLength(3)
+    expect(list?.content?.[1]?.content?.[1]).toEqual({
+      type: "bulletList",
+      content: [{ type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "nested" }] }] }],
+    })
+  })
+
+  it("keeps bullet and ordered runs at the same level as separate lists", () => {
+    const parsed = parseMarkdown("- one\n1. first")
+    expect(parsed.content?.map((n) => n.type)).toEqual(["bulletList", "orderedList"])
+  })
+
+  it("parses a list that starts indented without dropping items", () => {
+    const parsed = parseMarkdown("  - indented start\n  - second")
+    const list = parsed.content?.[0]
+    expect(list?.type).toBe("bulletList")
+    expect(list?.content).toHaveLength(2)
+  })
+})
+
+describe("@threa/prosemirror blockquote paragraph round-trip", () => {
+  it("round-trips a multi-paragraph blockquote", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "quoted line one" }] },
+            { type: "paragraph", content: [{ type: "text", text: "quoted line two" }] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> quoted line one\n> quoted line two")
+    expect(parseMarkdown(markdown)).toEqual(doc)
+  })
+
+  it("parses an empty blockquote into a single empty paragraph", () => {
+    const parsed = parseMarkdown(">")
+    expect(parsed.content?.[0]).toEqual({ type: "blockquote", content: [{ type: "paragraph" }] })
+  })
+})

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -510,6 +510,60 @@ interface ParseOptions extends ParseMarkdownOptions {
   balancedLinkHrefs?: Map<string, string>
 }
 
+const LIST_LINE_PATTERN = /^(\s*)([-*]|\d+\.)\s(.*)$/
+
+interface ListLine {
+  indent: number
+  ordered: boolean
+  text: string
+}
+
+/**
+ * Build one list node starting at `startIndex`, consuming every line indented
+ * at least `baseIndent`. A line indented deeper than the current level becomes
+ * a nested list inside the preceding item; a marker-type switch at the same
+ * level ends the list so bullet and ordered runs stay separate nodes.
+ */
+function buildListNode(
+  listLines: ListLine[],
+  startIndex: number,
+  baseIndent: number,
+  options: ParseOptions
+): { node: JSONContent; nextIndex: number } {
+  const ordered = listLines[startIndex].ordered
+  const items: JSONContent[] = []
+  let i = startIndex
+
+  while (i < listLines.length && listLines[i].indent >= baseIndent) {
+    const listLine = listLines[i]
+
+    if (listLine.indent > baseIndent) {
+      const nested = buildListNode(listLines, i, listLine.indent, options)
+      const lastItem = items[items.length - 1]
+      if (lastItem) {
+        lastItem.content = [...(lastItem.content ?? []), nested.node]
+      } else {
+        items.push({ type: "listItem", content: [{ type: "paragraph" }, nested.node] })
+      }
+      i = nested.nextIndex
+      continue
+    }
+
+    if (listLine.ordered !== ordered) break
+
+    items.push({
+      type: "listItem",
+      content: [{ type: "paragraph", content: parseInlineMarkdown(listLine.text, options) }],
+    })
+    i++
+  }
+
+  return {
+    node: { type: ordered ? "orderedList" : "bulletList", content: items },
+    nextIndex: i,
+  }
+}
+
 export function parseMarkdown(
   markdown: string,
   getMentionType?: MentionTypeLookup,
@@ -592,54 +646,44 @@ export function parseMarkdown(
           attrs: { messageId, streamId, authorName, authorId, actorType, snippet },
         })
       } else {
+        // One paragraph per quoted line — the inverse of the serializer, which
+        // emits each blockquote paragraph as its own `> ` line. Blank quoted
+        // lines are paragraph separators, not content.
+        const quoteParagraphs = quoteLines
+          .filter((quoteLine) => quoteLine.trim().length > 0)
+          .map((quoteLine) => ({
+            type: "paragraph",
+            content: parseInlineMarkdown(quoteLine, options),
+          }))
         content.push({
           type: "blockquote",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(quoteLines.join("\n"), options),
-            },
-          ],
+          content: quoteParagraphs.length > 0 ? quoteParagraphs : [{ type: "paragraph" }],
         })
       }
       continue
     }
 
-    // Unordered list
-    if (line.match(/^[-*]\s/)) {
-      const listItems: JSONContent[] = []
-      while (i < lines.length && lines[i].match(/^[-*]\s/)) {
-        listItems.push({
-          type: "listItem",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(lines[i].replace(/^[-*]\s/, ""), options),
-            },
-          ],
+    // Bullet / ordered list, including nested items indented under a parent
+    // item (the serializer emits two spaces per nesting level).
+    if (LIST_LINE_PATTERN.test(line)) {
+      const listLines: ListLine[] = []
+      while (i < lines.length) {
+        const match = lines[i].match(LIST_LINE_PATTERN)
+        if (!match) break
+        listLines.push({
+          indent: match[1].length,
+          ordered: match[2] !== "-" && match[2] !== "*",
+          text: match[3],
         })
         i++
       }
-      content.push({ type: "bulletList", content: listItems })
-      continue
-    }
 
-    // Ordered list
-    if (line.match(/^\d+\.\s/)) {
-      const listItems: JSONContent[] = []
-      while (i < lines.length && lines[i].match(/^\d+\.\s/)) {
-        listItems.push({
-          type: "listItem",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(lines[i].replace(/^\d+\.\s/, ""), options),
-            },
-          ],
-        })
-        i++
+      let itemIndex = 0
+      while (itemIndex < listLines.length) {
+        const built = buildListNode(listLines, itemIndex, listLines[itemIndex].indent, options)
+        content.push(built.node)
+        itemIndex = built.nextIndex
       }
-      content.push({ type: "orderedList", content: listItems })
       continue
     }
 

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -98,9 +98,11 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
 
     case "blockquote": {
       const quoted = node.content?.map((n) => serializeNode(n)).join("\n") ?? ""
+      // Bare `>` for empty lines: trailing whitespace is stripped by many
+      // markdown tools, which would break the empty-paragraph roundtrip.
       return quoted
         .split("\n")
-        .map((line) => "> " + line)
+        .map((line) => (line ? "> " + line : ">"))
         .join("\n")
     }
 
@@ -647,14 +649,12 @@ export function parseMarkdown(
         })
       } else {
         // One paragraph per quoted line — the inverse of the serializer, which
-        // emits each blockquote paragraph as its own `> ` line. Blank quoted
-        // lines are paragraph separators, not content.
-        const quoteParagraphs = quoteLines
-          .filter((quoteLine) => quoteLine.trim().length > 0)
-          .map((quoteLine) => ({
-            type: "paragraph",
-            content: parseInlineMarkdown(quoteLine, options),
-          }))
+        // emits each blockquote paragraph as its own `> ` line, including a
+        // bare `>` for an empty paragraph, so blank lines stay as paragraphs.
+        const quoteParagraphs = quoteLines.map((quoteLine): JSONContent => {
+          const inlineContent = parseInlineMarkdown(quoteLine, options)
+          return inlineContent.length > 0 ? { type: "paragraph", content: inlineContent } : { type: "paragraph" }
+        })
         content.push({
           type: "blockquote",
           content: quoteParagraphs.length > 0 ? quoteParagraphs : [{ type: "paragraph" }],

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect, type Page, type Locator } from "@playwright/test"
+import { expectApiOk, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * Regression coverage for the composer clipboard roundtrip:
+ *
+ * 1. A message containing every block/chip style, sent, then "Copy as
+ *    Markdown" → pasted into the composer → sent again must produce the
+ *    identical markdown (parseMarkdown is a true inverse of
+ *    serializeToMarkdown for the wire format).
+ * 2. Copy/cut from the composer itself must put markdown on the clipboard
+ *    (the editor's `clipboardTextSerializer`), so cut → paste restores the
+ *    full document instead of flattening it to plain text.
+ */
+
+/**
+ * Canonical wire-format markdown containing every style the composer can
+ * hold: heading, inline marks, mention/channel pointer chips, emoji, fenced
+ * code, nested bullet + ordered lists, a multi-paragraph blockquote, a
+ * quote-reply chip, and a shared-message chip. Written as a
+ * serializeToMarkdown fixed point so every roundtrip compares by string
+ * equality.
+ */
+function buildCanonicalMarkdown(refs: { streamId: string; messageId: string; authorId: string }): string {
+  return [
+    "## Roundtrip heading",
+    "",
+    "**bold** *italic* ~~strike~~ `code` and [link](https://example.com)",
+    "",
+    "[@alice](user:usr_01ROUNDTRIP) and [#general](channel:stream_01ROUNDTRIP) 🎉",
+    "",
+    "```ts",
+    "const x = 1",
+    'console.log("hi")',
+    "```",
+    "",
+    "- one",
+    "- two",
+    "  - nested",
+    "- three",
+    "",
+    "1. first",
+    "2. second",
+    "",
+    "> quoted one",
+    "> quoted two",
+    "",
+    "> reply snippet",
+    ">",
+    `> — [Alice](quote:${refs.streamId}/${refs.messageId}/${refs.authorId}/user)`,
+    "",
+    `Shared a message from [Alice](shared-message:${refs.streamId}/${refs.messageId})`,
+    "",
+    "tail paragraph",
+  ].join("\n")
+}
+
+function composerEditor(page: Page): Locator {
+  return page.getByRole("main").locator("[contenteditable='true']").first()
+}
+
+async function pastePlainText(page: Page, text: string): Promise<void> {
+  await composerEditor(page).click()
+  await page.evaluate((value) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const clipboardData = new DataTransfer()
+    clipboardData.setData("text/plain", value)
+    editor.dispatchEvent(new ClipboardEvent("paste", { clipboardData, bubbles: true, cancelable: true }))
+  }, text)
+}
+
+/**
+ * Fire a synthetic copy/cut on the editor selection and return what the
+ * editor wrote to `text/plain` — i.e. the output of the composer's
+ * `clipboardTextSerializer`.
+ */
+async function captureEditorClipboard(page: Page, kind: "copy" | "cut"): Promise<string> {
+  return page.evaluate((eventKind) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const clipboardData = new DataTransfer()
+    editor.dispatchEvent(new ClipboardEvent(eventKind, { clipboardData, bubbles: true, cancelable: true }))
+    return clipboardData.getData("text/plain")
+  }, kind)
+}
+
+/** Every style from {@link buildCanonicalMarkdown}, asserted against the live editor DOM. */
+async function expectEditorHasAllStyles(page: Page): Promise<void> {
+  const editor = composerEditor(page)
+  await expect(editor.locator("h2")).toHaveText("Roundtrip heading")
+  await expect(editor.locator("strong")).toHaveText("bold")
+  await expect(editor.locator("em")).toHaveText("italic")
+  await expect(editor.locator("s")).toHaveText("strike")
+  await expect(editor.locator("a[href='https://example.com']")).toHaveText("link")
+  await expect(editor.locator("[data-id='usr_01ROUNDTRIP']")).toBeVisible()
+  await expect(editor.locator("[data-id='stream_01ROUNDTRIP']")).toBeVisible()
+  await expect(editor.locator("pre code")).toContainText('console.log("hi")')
+  // Nested bullet list: "nested" sits inside a list within a list item.
+  await expect(editor.locator("ul ul li")).toHaveText("nested")
+  await expect(editor.locator("ol li")).toHaveCount(2)
+  await expect(editor.locator("blockquote").first()).toContainText("quoted one")
+  await expect(editor.locator("blockquote").first()).toContainText("quoted two")
+  await expect(editor.locator("[data-type='quote-reply']")).toBeVisible()
+  await expect(editor.locator("[data-type='shared-message']")).toBeVisible()
+}
+
+async function sendComposerContent(page: Page): Promise<void> {
+  await page.getByRole("main").getByRole("button", { name: "Send", exact: true }).click()
+  await expect(composerEditor(page)).not.toContainText("tail paragraph")
+}
+
+function sentMessageRows(page: Page): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: "tail paragraph" })
+}
+
+async function copyMessageAsMarkdown(page: Page, row: Locator): Promise<string> {
+  // Hover the row body (not the action pill area — resting on the pill's
+  // other buttons pops their tooltips over the target), then click the
+  // revealed actions button directly.
+  await row.hover()
+  const actionsButton = row.getByRole("button", { name: "Message actions" })
+  await expect(actionsButton).toBeVisible()
+  await actionsButton.click()
+  await page.getByRole("menuitem", { name: "Copy as Markdown" }).click()
+  return page.evaluate(() => navigator.clipboard.readText())
+}
+
+test.use({ permissions: ["clipboard-read", "clipboard-write"] })
+
+test.describe("Composer copy/paste roundtrip", () => {
+  let canonicalMarkdown: string
+
+  test.beforeEach(async ({ page }) => {
+    await loginAndCreateWorkspace(page, "copy-roundtrip")
+    const workspaceId = page.url().match(/\/w\/([^/]+)/)?.[1] ?? ""
+    expect(workspaceId).not.toBe("")
+    const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad" },
+    })
+    await expectApiOk(response, "Create scratchpad")
+    const body = (await response.json()) as { stream: { id: string } }
+    const streamId = body.stream.id
+
+    // The quote-reply and shared-message pointers must reference a message
+    // that actually exists — the backend's share-recording step 400s
+    // (SHARE_SOURCE_MESSAGE_NOT_FOUND) on a fabricated id.
+    const seedResponse = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+      data: {
+        streamId,
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "seed" }] }] },
+        contentMarkdown: "seed",
+      },
+    })
+    await expectApiOk(seedResponse, "Send seed message")
+    const seedBody = (await seedResponse.json()) as { message: { id: string; authorId: string } }
+    canonicalMarkdown = buildCanonicalMarkdown({
+      streamId,
+      messageId: seedBody.message.id,
+      authorId: seedBody.message.authorId,
+    })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(composerEditor(page)).toBeVisible({ timeout: 10000 })
+  })
+
+  test("send → Copy as Markdown → paste → send preserves every style", async ({ page }) => {
+    await pastePlainText(page, canonicalMarkdown)
+    await expectEditorHasAllStyles(page)
+    await sendComposerContent(page)
+
+    // The send pipeline converts the pasted 🎉 into an emoji atom, whose wire
+    // form is the shortcode — the one legitimate normalization in the cycle.
+    // Everything else must come back byte-identical, and the shortcode form
+    // is itself a fixed point (the second cycle returns it unchanged).
+    const expectedSentMarkdown = canonicalMarkdown.replace("🎉", ":tada:")
+
+    const firstRow = sentMessageRows(page).first()
+    await expect(firstRow).toBeVisible({ timeout: 10000 })
+    const copiedMarkdown = await copyMessageAsMarkdown(page, firstRow)
+    expect(copiedMarkdown).toBe(expectedSentMarkdown)
+
+    await pastePlainText(page, copiedMarkdown)
+    await expectEditorHasAllStyles(page)
+    await sendComposerContent(page)
+
+    const secondRow = sentMessageRows(page).nth(1)
+    await expect(secondRow).toBeVisible({ timeout: 10000 })
+    const secondMarkdown = await copyMessageAsMarkdown(page, secondRow)
+    expect(secondMarkdown).toBe(expectedSentMarkdown)
+  })
+
+  test("copy and cut from the composer serialize the selection to markdown", async ({ page }) => {
+    await pastePlainText(page, canonicalMarkdown)
+    await expectEditorHasAllStyles(page)
+
+    // Click a text block (not the editor's center, which can land on an
+    // atom chip and swallow focus), then select-all through the editor.
+    // Retried because the click can race the editor settling after paste,
+    // leaving the caret (and thus the selection) empty.
+    // Control (not ControlOrMeta): the suite's Desktop Chrome device emulates
+    // Linux, so ProseMirror binds select-all to Ctrl-A — the host-resolved
+    // Meta+A would be selected natively by the browser without ProseMirror's
+    // state ever seeing it, and the copy handler reads the state selection.
+    // Copy is non-destructive, so the whole select-all → copy sequence
+    // retries as a unit until ProseMirror's state selection has caught up
+    // (the DOM selection can briefly lead it after the click).
+    let copied = ""
+    await expect(async () => {
+      await composerEditor(page).locator("h2").click()
+      await page.keyboard.press("Control+a")
+      copied = await captureEditorClipboard(page, "copy")
+      expect(copied).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(copied).toBe(canonicalMarkdown)
+    // Copy must not disturb the document.
+    await expectEditorHasAllStyles(page)
+
+    const cut = await captureEditorClipboard(page, "cut")
+    expect(cut).toBe(canonicalMarkdown)
+    await expect(composerEditor(page)).not.toContainText("tail paragraph")
+
+    // Paste the cut markdown back — the full document must come back.
+    await pastePlainText(page, cut)
+    await expectEditorHasAllStyles(page)
+  })
+})

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -85,6 +85,29 @@ async function captureEditorClipboard(page: Page, kind: "copy" | "cut"): Promise
   }, kind)
 }
 
+/** Select an exact text run inside the composer via a DOM range (ProseMirror syncs from selectionchange). */
+async function selectEditorText(page: Page, text: string): Promise<void> {
+  await page.evaluate((needle) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+    let current: Node | null
+    while ((current = walker.nextNode())) {
+      const index = (current.textContent ?? "").indexOf(needle)
+      if (index === -1) continue
+      const range = document.createRange()
+      range.setStart(current, index)
+      range.setEnd(current, index + needle.length)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      ;(editor as HTMLElement).focus()
+      return
+    }
+    throw new Error(`Text not found in editor: ${needle}`)
+  }, text)
+}
+
 /** Every style from {@link buildCanonicalMarkdown}, asserted against the live editor DOM. */
 async function expectEditorHasAllStyles(page: Page): Promise<void> {
   const editor = composerEditor(page)
@@ -193,6 +216,17 @@ test.describe("Composer copy/paste roundtrip", () => {
   test("copy and cut from the composer serialize the selection to markdown", async ({ page }) => {
     await pastePlainText(page, canonicalMarkdown)
     await expectEditorHasAllStyles(page)
+
+    // Partial (single-block) selection: the slice arrives inline-wrapped in
+    // its parent block, and the marks must survive — this was the everyday
+    // copy shape the old container copy handler serialized to "".
+    let partial = ""
+    await expect(async () => {
+      await selectEditorText(page, "bold")
+      partial = await captureEditorClipboard(page, "copy")
+      expect(partial).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(partial).toBe("**bold**")
 
     // Click a text block (not the editor's center, which can land on an
     // atom chip and swallow focus), then select-all through the editor.


### PR DESCRIPTION
## Problem

Copying or cutting from the composer flattened everything to plain text. The `RichEditor` had no `clipboardTextSerializer`, so ProseMirror's default wrote bare `textContent` to `text/plain` — no code fences, no `>` quote markers, no list bullets, no mention/quote-reply/shared-message references. Since `handlePaste` re-parses `text/plain` as markdown, a cut → paste inside the composer destroyed all block structure and every chip.

Two parser gaps compounded it on the Copy as Markdown → paste path:

- `parseMarkdown` had no nested-list support: `  - nested` under a parent item came back as a literal paragraph containing "  - nested".
- Multi-paragraph blockquotes (`> line one\n> line two`) collapsed into one paragraph with a raw `\n` inside the text node — not the inverse of the serializer, which emits one `> ` line per blockquote paragraph.

## Solution

Make the composer's clipboard speak markdown — the editor's canonical text form (INV-58) — and make `parseMarkdown` a true inverse of `serializeToMarkdown` for lists and blockquotes.

### How it works

1. **Copy/cut serializes to markdown.** `serializeClipboardSlice` (new in `editor-markdown.ts`) runs the copied `Slice` through `serializeToMarkdown` and is wired as `clipboardTextSerializer` in both `rich-editor.tsx` and `document-editor-modal.tsx`. Copying out of the composer now yields paste-able markdown anywhere.
2. **Internal paste takes ProseMirror's native path.** `isProseMirrorClipboardEvent` detects the `data-pm-slice` HTML payload that PM puts on the clipboard and both `handlePaste` handlers return `false` for it, so PM applies the slice losslessly — chips, atoms and all — instead of the `text/plain` markdown re-parse. All custom nodes (mention, channelLink, quoteReply, sharedMessage, attachment, memo, giphy, inAppLink) already round-trip their attrs through `renderHTML`/`parseHTML`, so nothing is lost.
3. **Nested lists parse.** `buildListNode` builds list nodes indent-aware (the serializer emits two spaces per level): deeper-indented lines nest inside the preceding item, a bullet↔ordered marker switch at the same level ends the list so runs stay separate nodes (matching prior behavior for flat mixed lists). Side effect: a list starting with leading indentation now parses as a list instead of literal paragraphs.
4. **Blockquotes parse one paragraph per `> ` line** — the serializer's exact inverse (it joins blockquote paragraphs with `\n`, one line each). Blank `>` lines are separators; an all-blank quote falls back to a single empty paragraph.

### Key design decisions

**1. Markdown on `text/plain`, not a smarter internal format** — markdown is already the wire format external callers see and the format `handlePaste`/`handleBeforeInputKeyboardPaste` parse, so one serializer closes the loop for both external copy targets and internal roundtrip. The `data-pm-slice` bypass then makes the internal case exact rather than "markdown-equivalent", covering anything markdown can't express.

**2. Parser stays line-based.** The nested-list support extends the existing hand-rolled line scanner rather than swapping in a full CommonMark parser — smallest change that makes parse ∘ serialize the identity on the wire format, verified by fixed-point tests.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/markdown.ts` | `buildListNode` indent-aware list parsing; blockquote lines → one paragraph each |
| `packages/prosemirror/src/markdown.test.ts` | Nested-list + blockquote round-trip fixed-point tests (+6) |
| `apps/frontend/src/components/editor/editor-markdown.ts` | New `serializeClipboardSlice` + `isProseMirrorClipboardEvent` helpers |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Wire both helpers into `editorProps` |
| `apps/frontend/src/components/editor/document-editor-modal.tsx` | Same treatment for the fullscreen document editor |

## New files

| File | Purpose |
| ---- | ------- |
| `tests/browser/composer-copy-paste-roundtrip.spec.ts` | Regression: full style matrix (heading, marks, mention/channel pointers, emoji, fenced code, nested bullet + ordered lists, multi-paragraph quote, quote-reply chip, shared-message chip) through send → Copy as Markdown → paste → send with byte-identical markdown compares, plus composer copy/cut serialization and paste-back |

## Verified live (dev:test stack, real Chromium)

Pasted the full canonical doc, then: Ctrl+A → synthetic copy returned the exact canonical markdown; Ctrl+X emptied the editor; Ctrl+V restored the full document with nesting and chips intact; Copy as Markdown on the sent message returned identical markdown.

Findings from the live pass, folded into the regression test:

- Quote-reply/shared-message pointers to a nonexistent message are **rejected by the backend** (`SHARE_SOURCE_MESSAGE_NOT_FOUND`) and the send sticks as a failed optimistic row — the spec seeds a real message to point at.
- The send pipeline normalizes a pasted unicode 🎉 into an emoji atom whose wire form is `:tada:`; the spec expects that one transform (it is itself a fixed point on the second cycle).
- The suite's Desktop Chrome device emulates Linux, so select-all must be `Control+a` — the host-resolved Meta+A is handled natively by the browser without ProseMirror's state ever seeing it.

## Design evolution (review rounds)

- **CodeRabbit:** blank quoted lines were dropped on parse, mutating `[p("one"), p(), p("two")]` on roundtrip. Fixed in `62dbf00c` — every quoted line maps to a paragraph, and the serializer emits a bare `>` for empty lines (trailing whitespace is stripped by many markdown tools, which would break the inverse; also matches the quoteReply serializer).
- **Opus multi-agent review (4 lenses):** caught that a *pre-existing* `containerRef` copy/cut listener in `rich-editor.tsx` shadowed the new `clipboardTextSerializer` — and serialized single-block selections to `""` via `doc.slice(from, to)` (no parent wrapping), then `preventDefault`ed with no fallback. Copying a word/phrase/line put an **empty string** on the clipboard — likely the original everyday-copy bug. Removed in `2a0dcb66`; the prop path gets the parent-wrapped `selection.content()` slice, covers cut via ProseMirror's native delete, and falls back to native text when the serializer returns `""`. `serializeClipboardSlice` also wraps inline-only slices (chip `NodeSelection`) in a paragraph, and the e2e gained a partial-selection assertion (select "bold" → clipboard `**bold**`).
- Review also confirmed the `data-pm-slice` bypass skips large-paste snippet conversion for internal pastes — kept as deliberate (restoring your own composed content losslessly beats snippet-ifying it) and documented in a comment.

## Out of scope (deliberate)

- `hardBreak` still serializes to a plain newline and re-parses as a paragraph split — pre-existing, and the composer already unifies Shift+Enter into paragraphs, so it's unreachable from normal authoring.
- Blank lines between list items still end the list (two lists), unchanged from before.
- Timeline partial-selection copy (`use-message-markdown-copy` whole-message heuristic) untouched.

## Test plan

- [x] `packages/prosemirror` unit tests — 150 pass (6 new fixed-point tests)
- [x] Frontend editor unit tests (`src/components/editor/`) — 379 pass
- [x] Frontend composer + markdown-lib unit tests — 224 pass; drafts/stash e2e (`drafts-modal.spec.ts`) — 11 pass (stash/restore moves `contentJson` verbatim, untouched by this PR)
- [x] New e2e spec (incl. partial-selection copy) — 4/4 with `--repeat-each 2`, previously 6/6 with `--repeat-each 3`
- [x] Neighboring editor e2e suites (`rich-text-editing`, `markdown-shortcuts`, `emoji-shortcuts`, `inline-code-boundary-caret`) — 87 pass
- [x] `bun run typecheck` monorepo — clean
- [x] Live browser verification against `dev:test` (see above)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883766&installation_id=129946197&pr_number=1382&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1382&signature=74106db985f6d0461ed3056dded0cd0cd008b5bd72ff9ca084b755e3b67b55bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
