### PR TITLE
fix(editor): never drop Android IME clipboard payloads in the composer

### DIFF
--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -27,7 +27,13 @@ import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { createEditorExtensions } from "./editor-extensions"
 import { EditorBehaviors, handleLinkToolbarAction, isSuggestionActive } from "./editor-behaviors"
-import { serializeToMarkdown, parseMarkdown, type MentionTypeLookup } from "./editor-markdown"
+import {
+  serializeToMarkdown,
+  parseMarkdown,
+  serializeClipboardSlice,
+  isProseMirrorClipboardEvent,
+  type MentionTypeLookup,
+} from "./editor-markdown"
 import { useMentionSuggestion, useChannelSuggestion, useEmojiSuggestion } from "./triggers"
 import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
@@ -148,7 +154,12 @@ export function DocumentEditorModal({
           "focus:outline-none"
         ),
       },
+      clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        if (isProseMirrorClipboardEvent(event)) {
+          return false
+        }
+
         const text = event.clipboardData?.getData("text/plain")
         if (!text || !editorRef.current) {
           return false

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -9,8 +9,9 @@
  * dispatching a slash command). The parsers stay unified so the two sides
  * can't drift.
  */
-import { parseMarkdown } from "@threa/prosemirror"
+import { parseMarkdown, serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
+import type { Slice } from "@tiptap/pm/model"
 
 export {
   serializeToMarkdown,
@@ -28,6 +29,31 @@ export {
  * carry no reference and must not resolve to slugs, so every interactive parse
  * flag is off. Shared by every prompt-authoring editor so they can't drift.
  */
+/**
+ * Clipboard `text/plain` serializer for editor copy/cut. The default
+ * ProseMirror text serialization is bare `textContent` — code fences, quote
+ * markers, list bullets, and chip references (mentions, quote replies, shared
+ * messages) all vanish, so pasting back can never restore them. Markdown is
+ * the editor's canonical text form and the paste path parses it, closing the
+ * copy → paste roundtrip.
+ */
+export function serializeClipboardSlice(slice: Slice): string {
+  const content = slice.content.toJSON() as JSONContent[] | null
+  if (!content) return ""
+  return serializeToMarkdown({ type: "doc", content })
+}
+
+/**
+ * Content copied from a ProseMirror editor carries a `data-pm-slice` HTML
+ * payload that restores the exact document, chips included. Paste handlers
+ * bail on such events so ProseMirror's native paste applies it losslessly
+ * instead of re-parsing the markdown `text/plain` fallback.
+ */
+export function isProseMirrorClipboardEvent(event: ClipboardEvent): boolean {
+  const html = event.clipboardData?.getData("text/html")
+  return !!html && html.includes("data-pm-slice")
+}
+
 export function parsePromptMarkdown(markdown: string): JSONContent {
   return parseMarkdown(markdown, undefined, undefined, {
     enableMentions: false,

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -40,7 +40,10 @@ export {
 export function serializeClipboardSlice(slice: Slice): string {
   const content = slice.content.toJSON() as JSONContent[] | null
   if (!content) return ""
-  return serializeToMarkdown({ type: "doc", content })
+  // A NodeSelection of an inline atom (a chip) yields a slice whose top level
+  // is inline content; the serializer expects blocks, so wrap it.
+  const blocks = slice.content.firstChild?.isInline ? [{ type: "paragraph", content }] : content
+  return serializeToMarkdown({ type: "doc", content: blocks })
 }
 
 /**

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -932,26 +932,29 @@ describe("handleBeforeInputKeyboardPaste (Gboard suggestion-bar paste)", () => {
     editor.destroy()
   })
 
-  it("intercepts insertFromPaste without the size/styling heuristic", () => {
-    const editor = createTestEditor("")
-    editor.commands.setTextSelection(editor.state.doc.content.size)
+  it.each(["insertFromPaste", "insertReplacementText"])(
+    "intercepts %s without the size/styling heuristic",
+    (inputType) => {
+      const editor = createTestEditor("")
+      editor.commands.setTextSelection(editor.state.doc.content.size)
 
-    const event = {
-      inputType: "insertFromPaste",
-      data: null,
-      dataTransfer: { getData: (format: string) => (format === "text/plain" ? "hi" : "") },
-      prevented: false,
-      preventDefault() {
-        this.prevented = true
-      },
+      const event = {
+        inputType,
+        data: null,
+        dataTransfer: { getData: (format: string) => (format === "text/plain" ? "hi" : "") },
+        prevented: false,
+        preventDefault() {
+          this.prevented = true
+        },
+      }
+      const handled = handleBeforeInputKeyboardPaste(editor, event)
+
+      expect(handled).toBe(true)
+      expect(event.prevented).toBe(true)
+      expect(serializeToMarkdown(editor.getJSON())).toBe("hi")
+      editor.destroy()
     }
-    const handled = handleBeforeInputKeyboardPaste(editor, event)
-
-    expect(handled).toBe(true)
-    expect(event.prevented).toBe(true)
-    expect(serializeToMarkdown(editor.getJSON())).toBe("hi")
-    editor.destroy()
-  })
+  )
 
   it("falls back to a plain-text insert when markdown parsing throws (payload never lost)", () => {
     const editor = createTestEditor("")

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -905,6 +905,70 @@ describe("handleBeforeInputKeyboardPaste (Gboard suggestion-bar paste)", () => {
     expect(event.prevented).toBe(false)
     editor.destroy()
   })
+
+  it("reads the payload from dataTransfer when data is null (Android large IME payloads)", () => {
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = {
+      inputType: "insertText",
+      data: null,
+      dataTransfer: { getData: (format: string) => (format === "text/plain" ? "line 1\nline 2" : "") },
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    const handled = handleBeforeInputKeyboardPaste(
+      editor,
+      event,
+      () => "user",
+      () => null
+    )
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("line 1\n\nline 2")
+    editor.destroy()
+  })
+
+  it("intercepts insertFromPaste without the size/styling heuristic", () => {
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = {
+      inputType: "insertFromPaste",
+      data: null,
+      dataTransfer: { getData: (format: string) => (format === "text/plain" ? "hi" : "") },
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    const handled = handleBeforeInputKeyboardPaste(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi")
+    editor.destroy()
+  })
+
+  it("falls back to a plain-text insert when markdown parsing throws (payload never lost)", () => {
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = makeBeforeInput("insertText", "hello @user\nworld")
+    const handled = handleBeforeInputKeyboardPaste(editor, event, () => {
+      throw new Error("lookup exploded")
+    })
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    // The raw payload survives as text — never an empty composer.
+    expect(editor.state.doc.textContent).toContain("hello @user")
+    expect(editor.state.doc.textContent).toContain("world")
+    editor.destroy()
+  })
 })
 
 describe("handleBeforeInputAtomDelete (Android atom deletion)", () => {

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -6,6 +6,7 @@ import { parseMarkdown, type EmojiLookup, type MentionTypeLookup, type ParseMark
 export interface BeforeInputEventLike {
   inputType: string
   data?: string | null
+  dataTransfer?: { getData(format: string): string } | null
   preventDefault(): void
 }
 
@@ -943,16 +944,40 @@ export function handleBeforeInputKeyboardPaste(
   getEmoji?: EmojiLookup,
   parseOptions?: ParseMarkdownOptions
 ): boolean {
-  if (event.inputType !== "insertText") return false
+  // `insertFromPaste` / `insertReplacementText` reaching this handler means no
+  // `paste` event was intercepted upstream (Android IMEs commit clipboard
+  // suggestions this way); they are definitively pastes, so the size/styling
+  // heuristic below is skipped for them.
+  const isPasteLike = event.inputType === "insertFromPaste" || event.inputType === "insertReplacementText"
+  if (event.inputType !== "insertText" && !isPasteLike) return false
   if (editor.view.composing) return false
-  const data = event.data
-  if (!data || data.length < 3) return false
-  if (!data.includes("\n") && !PASTE_STYLING_CHARS.test(data)) return false
+  // Chromium on Android delivers large IME clipboard payloads with `data`
+  // null and the text on `dataTransfer` instead.
+  const data = event.data ?? event.dataTransfer?.getData("text/plain")
+  if (!data) return false
+  if (!isPasteLike) {
+    if (data.length < 3) return false
+    if (!data.includes("\n") && !PASTE_STYLING_CHARS.test(data)) return false
+  }
   if (editor.isActive("codeBlock")) return false
 
   event.preventDefault()
-  if (!insertPastedText(editor, data, getMentionType, getEmoji, parseOptions)) {
-    editor.commands.insertContent(data)
+  try {
+    if (!insertPastedText(editor, data, getMentionType, getEmoji, parseOptions)) {
+      editor.commands.insertContent(data)
+    }
+  } catch {
+    // The event is already prevented, so a parse/insert failure must never
+    // eat the payload — fall back to a plain-text insert, which cannot
+    // reject any content shape.
+    editor
+      .chain()
+      .focus()
+      .command(({ tr }) => {
+        tr.insertText(data)
+        return true
+      })
+      .run()
   }
   return true
 }

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -961,15 +961,11 @@ export function handleBeforeInputKeyboardPaste(
   }
   if (editor.isActive("codeBlock")) return false
 
-  event.preventDefault()
-  try {
-    if (!insertPastedText(editor, data, getMentionType, getEmoji, parseOptions)) {
-      editor.commands.insertContent(data)
-    }
-  } catch {
-    // The event is already prevented, so a parse/insert failure must never
-    // eat the payload — fall back to a plain-text insert, which cannot
-    // reject any content shape.
+  // The event is prevented before inserting, so a parse/insert failure must
+  // never eat the payload — both fallbacks insert the raw text via
+  // `tr.insertText`, which cannot reject or reinterpret any content shape
+  // (`insertContent` would parse strings as HTML).
+  const insertRawText = () =>
     editor
       .chain()
       .focus()
@@ -978,6 +974,14 @@ export function handleBeforeInputKeyboardPaste(
         return true
       })
       .run()
+
+  event.preventDefault()
+  try {
+    if (!insertPastedText(editor, data, getMentionType, getEmoji, parseOptions)) {
+      insertRawText()
+    }
+  } catch {
+    insertRawText()
   }
   return true
 }

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -9,7 +9,13 @@ import { applyExternalEditorContent } from "./apply-external-content"
 import { getDictationChunkPositions } from "./dictation-chunk-extension"
 import { EditorBehaviors, isSuggestionActive } from "./editor-behaviors"
 import { EditorToolbar } from "./editor-toolbar"
-import { serializeToMarkdown, parseMarkdown, type MentionTypeLookup } from "./editor-markdown"
+import {
+  serializeToMarkdown,
+  parseMarkdown,
+  serializeClipboardSlice,
+  isProseMirrorClipboardEvent,
+  type MentionTypeLookup,
+} from "./editor-markdown"
 import {
   useMentionSuggestion,
   useChannelSuggestion,
@@ -625,7 +631,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           "focus:outline-none"
         ),
       },
+      clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        if (isProseMirrorClipboardEvent(event)) {
+          return false
+        }
+
         const files = event.clipboardData?.files
         if (files && files.length > 0 && onFileUploadRef.current && editorRef.current) {
           event.preventDefault()

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -633,6 +633,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       },
       clipboardTextSerializer: serializeClipboardSlice,
       handlePaste: (_view, event) => {
+        // Deliberately skips everything below, including snippet conversion:
+        // an internal paste restores the exact document (chips included), and
+        // converting a user's own composed content into a snippet would lose it.
         if (isProseMirrorClipboardEvent(event)) {
           return false
         }
@@ -948,41 +951,6 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // No additional focus-on-mount effect needed — the redundant focus()
   // dispatch caused a view update that raced with toolbar rendering,
   // briefly dropping focus in autoFocus editors (e.g. inline edit).
-
-  // Copy/cut handler: serialize selection to markdown
-  useEffect(() => {
-    if (!editor || !containerRef.current) return
-
-    const serializeSelection = (event: ClipboardEvent) => {
-      const { from, to } = editor.state.selection
-      if (from === to) return // No selection, use default behavior
-
-      const slice = editor.state.doc.slice(from, to)
-      const json = { type: "doc", content: slice.content.toJSON() }
-      const markdown = serializeToMarkdown(json)
-
-      event.clipboardData?.setData("text/plain", markdown)
-      event.preventDefault()
-    }
-
-    const handleCopy = (event: ClipboardEvent) => {
-      serializeSelection(event)
-    }
-
-    const handleCut = (event: ClipboardEvent) => {
-      serializeSelection(event)
-      // Delete the selected content after serializing to clipboard
-      editor.commands.deleteSelection()
-    }
-
-    const container = containerRef.current
-    container.addEventListener("copy", handleCopy)
-    container.addEventListener("cut", handleCut)
-    return () => {
-      container.removeEventListener("copy", handleCopy)
-      container.removeEventListener("cut", handleCut)
-    }
-  }, [editor])
 
   const focus = useCallback(() => {
     if (editor && !editor.isDestroyed) {

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1292,3 +1292,24 @@ describe("@threa/prosemirror blockquote paragraph round-trip", () => {
     expect(parsed.content?.[0]).toEqual({ type: "blockquote", content: [{ type: "paragraph" }] })
   })
 })
+
+describe("@threa/prosemirror blockquote empty-paragraph round-trip", () => {
+  it("preserves an empty paragraph between quoted paragraphs", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "one" }] },
+            { type: "paragraph" },
+            { type: "paragraph", content: [{ type: "text", text: "two" }] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> one\n>\n> two")
+    expect(parseMarkdown(markdown)).toEqual(doc)
+  })
+})

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1193,3 +1193,102 @@ describe("@threa/prosemirror normalizeMarkdownTables", () => {
     expect(parsed.content?.[0]?.content).toHaveLength(3)
   })
 })
+
+describe("@threa/prosemirror nested list round-trip", () => {
+  const nestedBulletDoc: JSONContent = {
+    type: "doc",
+    content: [
+      {
+        type: "bulletList",
+        content: [
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "one" }] }] },
+          {
+            type: "listItem",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "two" }] },
+              {
+                type: "bulletList",
+                content: [
+                  {
+                    type: "listItem",
+                    content: [{ type: "paragraph", content: [{ type: "text", text: "nested" }] }],
+                  },
+                  {
+                    type: "listItem",
+                    content: [
+                      { type: "paragraph", content: [{ type: "text", text: "deep parent" }] },
+                      {
+                        type: "orderedList",
+                        content: [
+                          {
+                            type: "listItem",
+                            content: [{ type: "paragraph", content: [{ type: "text", text: "deepest" }] }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "three" }] }] },
+        ],
+      },
+    ],
+  }
+
+  it("round-trips nested bullet and ordered lists through markdown", () => {
+    const markdown = serializeToMarkdown(nestedBulletDoc)
+    const parsed = parseMarkdown(markdown)
+    expect(parsed).toEqual(nestedBulletDoc)
+  })
+
+  it("parses indented list items into nested lists", () => {
+    const parsed = parseMarkdown("- one\n- two\n  - nested\n- three")
+    const list = parsed.content?.[0]
+    expect(list?.type).toBe("bulletList")
+    expect(list?.content).toHaveLength(3)
+    expect(list?.content?.[1]?.content?.[1]).toEqual({
+      type: "bulletList",
+      content: [{ type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "nested" }] }] }],
+    })
+  })
+
+  it("keeps bullet and ordered runs at the same level as separate lists", () => {
+    const parsed = parseMarkdown("- one\n1. first")
+    expect(parsed.content?.map((n) => n.type)).toEqual(["bulletList", "orderedList"])
+  })
+
+  it("parses a list that starts indented without dropping items", () => {
+    const parsed = parseMarkdown("  - indented start\n  - second")
+    const list = parsed.content?.[0]
+    expect(list?.type).toBe("bulletList")
+    expect(list?.content).toHaveLength(2)
+  })
+})
+
+describe("@threa/prosemirror blockquote paragraph round-trip", () => {
+  it("round-trips a multi-paragraph blockquote", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "quoted line one" }] },
+            { type: "paragraph", content: [{ type: "text", text: "quoted line two" }] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> quoted line one\n> quoted line two")
+    expect(parseMarkdown(markdown)).toEqual(doc)
+  })
+
+  it("parses an empty blockquote into a single empty paragraph", () => {
+    const parsed = parseMarkdown(">")
+    expect(parsed.content?.[0]).toEqual({ type: "blockquote", content: [{ type: "paragraph" }] })
+  })
+})

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -510,6 +510,60 @@ interface ParseOptions extends ParseMarkdownOptions {
   balancedLinkHrefs?: Map<string, string>
 }
 
+const LIST_LINE_PATTERN = /^(\s*)([-*]|\d+\.)\s(.*)$/
+
+interface ListLine {
+  indent: number
+  ordered: boolean
+  text: string
+}
+
+/**
+ * Build one list node starting at `startIndex`, consuming every line indented
+ * at least `baseIndent`. A line indented deeper than the current level becomes
+ * a nested list inside the preceding item; a marker-type switch at the same
+ * level ends the list so bullet and ordered runs stay separate nodes.
+ */
+function buildListNode(
+  listLines: ListLine[],
+  startIndex: number,
+  baseIndent: number,
+  options: ParseOptions
+): { node: JSONContent; nextIndex: number } {
+  const ordered = listLines[startIndex].ordered
+  const items: JSONContent[] = []
+  let i = startIndex
+
+  while (i < listLines.length && listLines[i].indent >= baseIndent) {
+    const listLine = listLines[i]
+
+    if (listLine.indent > baseIndent) {
+      const nested = buildListNode(listLines, i, listLine.indent, options)
+      const lastItem = items[items.length - 1]
+      if (lastItem) {
+        lastItem.content = [...(lastItem.content ?? []), nested.node]
+      } else {
+        items.push({ type: "listItem", content: [{ type: "paragraph" }, nested.node] })
+      }
+      i = nested.nextIndex
+      continue
+    }
+
+    if (listLine.ordered !== ordered) break
+
+    items.push({
+      type: "listItem",
+      content: [{ type: "paragraph", content: parseInlineMarkdown(listLine.text, options) }],
+    })
+    i++
+  }
+
+  return {
+    node: { type: ordered ? "orderedList" : "bulletList", content: items },
+    nextIndex: i,
+  }
+}
+
 export function parseMarkdown(
   markdown: string,
   getMentionType?: MentionTypeLookup,
@@ -592,54 +646,44 @@ export function parseMarkdown(
           attrs: { messageId, streamId, authorName, authorId, actorType, snippet },
         })
       } else {
+        // One paragraph per quoted line — the inverse of the serializer, which
+        // emits each blockquote paragraph as its own `> ` line. Blank quoted
+        // lines are paragraph separators, not content.
+        const quoteParagraphs = quoteLines
+          .filter((quoteLine) => quoteLine.trim().length > 0)
+          .map((quoteLine) => ({
+            type: "paragraph",
+            content: parseInlineMarkdown(quoteLine, options),
+          }))
         content.push({
           type: "blockquote",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(quoteLines.join("\n"), options),
-            },
-          ],
+          content: quoteParagraphs.length > 0 ? quoteParagraphs : [{ type: "paragraph" }],
         })
       }
       continue
     }
 
-    // Unordered list
-    if (line.match(/^[-*]\s/)) {
-      const listItems: JSONContent[] = []
-      while (i < lines.length && lines[i].match(/^[-*]\s/)) {
-        listItems.push({
-          type: "listItem",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(lines[i].replace(/^[-*]\s/, ""), options),
-            },
-          ],
+    // Bullet / ordered list, including nested items indented under a parent
+    // item (the serializer emits two spaces per nesting level).
+    if (LIST_LINE_PATTERN.test(line)) {
+      const listLines: ListLine[] = []
+      while (i < lines.length) {
+        const match = lines[i].match(LIST_LINE_PATTERN)
+        if (!match) break
+        listLines.push({
+          indent: match[1].length,
+          ordered: match[2] !== "-" && match[2] !== "*",
+          text: match[3],
         })
         i++
       }
-      content.push({ type: "bulletList", content: listItems })
-      continue
-    }
 
-    // Ordered list
-    if (line.match(/^\d+\.\s/)) {
-      const listItems: JSONContent[] = []
-      while (i < lines.length && lines[i].match(/^\d+\.\s/)) {
-        listItems.push({
-          type: "listItem",
-          content: [
-            {
-              type: "paragraph",
-              content: parseInlineMarkdown(lines[i].replace(/^\d+\.\s/, ""), options),
-            },
-          ],
-        })
-        i++
+      let itemIndex = 0
+      while (itemIndex < listLines.length) {
+        const built = buildListNode(listLines, itemIndex, listLines[itemIndex].indent, options)
+        content.push(built.node)
+        itemIndex = built.nextIndex
       }
-      content.push({ type: "orderedList", content: listItems })
       continue
     }
 

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -98,9 +98,11 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
 
     case "blockquote": {
       const quoted = node.content?.map((n) => serializeNode(n)).join("\n") ?? ""
+      // Bare `>` for empty lines: trailing whitespace is stripped by many
+      // markdown tools, which would break the empty-paragraph roundtrip.
       return quoted
         .split("\n")
-        .map((line) => "> " + line)
+        .map((line) => (line ? "> " + line : ">"))
         .join("\n")
     }
 
@@ -647,14 +649,12 @@ export function parseMarkdown(
         })
       } else {
         // One paragraph per quoted line — the inverse of the serializer, which
-        // emits each blockquote paragraph as its own `> ` line. Blank quoted
-        // lines are paragraph separators, not content.
-        const quoteParagraphs = quoteLines
-          .filter((quoteLine) => quoteLine.trim().length > 0)
-          .map((quoteLine) => ({
-            type: "paragraph",
-            content: parseInlineMarkdown(quoteLine, options),
-          }))
+        // emits each blockquote paragraph as its own `> ` line, including a
+        // bare `>` for an empty paragraph, so blank lines stay as paragraphs.
+        const quoteParagraphs = quoteLines.map((quoteLine): JSONContent => {
+          const inlineContent = parseInlineMarkdown(quoteLine, options)
+          return inlineContent.length > 0 ? { type: "paragraph", content: inlineContent } : { type: "paragraph" }
+        })
         content.push({
           type: "blockquote",
           content: quoteParagraphs.length > 0 ? quoteParagraphs : [{ type: "paragraph" }],

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect, type Page, type Locator } from "@playwright/test"
+import { expectApiOk, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * Regression coverage for the composer clipboard roundtrip:
+ *
+ * 1. A message containing every block/chip style, sent, then "Copy as
+ *    Markdown" → pasted into the composer → sent again must produce the
+ *    identical markdown (parseMarkdown is a true inverse of
+ *    serializeToMarkdown for the wire format).
+ * 2. Copy/cut from the composer itself must put markdown on the clipboard
+ *    (the editor's `clipboardTextSerializer`), so cut → paste restores the
+ *    full document instead of flattening it to plain text.
+ */
+
+/**
+ * Canonical wire-format markdown containing every style the composer can
+ * hold: heading, inline marks, mention/channel pointer chips, emoji, fenced
+ * code, nested bullet + ordered lists, a multi-paragraph blockquote, a
+ * quote-reply chip, and a shared-message chip. Written as a
+ * serializeToMarkdown fixed point so every roundtrip compares by string
+ * equality.
+ */
+function buildCanonicalMarkdown(refs: { streamId: string; messageId: string; authorId: string }): string {
+  return [
+    "## Roundtrip heading",
+    "",
+    "**bold** *italic* ~~strike~~ `code` and [link](https://example.com)",
+    "",
+    "[@alice](user:usr_01ROUNDTRIP) and [#general](channel:stream_01ROUNDTRIP) 🎉",
+    "",
+    "```ts",
+    "const x = 1",
+    'console.log("hi")',
+    "```",
+    "",
+    "- one",
+    "- two",
+    "  - nested",
+    "- three",
+    "",
+    "1. first",
+    "2. second",
+    "",
+    "> quoted one",
+    "> quoted two",
+    "",
+    "> reply snippet",
+    ">",
+    `> — [Alice](quote:${refs.streamId}/${refs.messageId}/${refs.authorId}/user)`,
+    "",
+    `Shared a message from [Alice](shared-message:${refs.streamId}/${refs.messageId})`,
+    "",
+    "tail paragraph",
+  ].join("\n")
+}
+
+function composerEditor(page: Page): Locator {
+  return page.getByRole("main").locator("[contenteditable='true']").first()
+}
+
+async function pastePlainText(page: Page, text: string): Promise<void> {
+  await composerEditor(page).click()
+  await page.evaluate((value) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const clipboardData = new DataTransfer()
+    clipboardData.setData("text/plain", value)
+    editor.dispatchEvent(new ClipboardEvent("paste", { clipboardData, bubbles: true, cancelable: true }))
+  }, text)
+}
+
+/**
+ * Fire a synthetic copy/cut on the editor selection and return what the
+ * editor wrote to `text/plain` — i.e. the output of the composer's
+ * `clipboardTextSerializer`.
+ */
+async function captureEditorClipboard(page: Page, kind: "copy" | "cut"): Promise<string> {
+  return page.evaluate((eventKind) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const clipboardData = new DataTransfer()
+    editor.dispatchEvent(new ClipboardEvent(eventKind, { clipboardData, bubbles: true, cancelable: true }))
+    return clipboardData.getData("text/plain")
+  }, kind)
+}
+
+/** Every style from {@link buildCanonicalMarkdown}, asserted against the live editor DOM. */
+async function expectEditorHasAllStyles(page: Page): Promise<void> {
+  const editor = composerEditor(page)
+  await expect(editor.locator("h2")).toHaveText("Roundtrip heading")
+  await expect(editor.locator("strong")).toHaveText("bold")
+  await expect(editor.locator("em")).toHaveText("italic")
+  await expect(editor.locator("s")).toHaveText("strike")
+  await expect(editor.locator("a[href='https://example.com']")).toHaveText("link")
+  await expect(editor.locator("[data-id='usr_01ROUNDTRIP']")).toBeVisible()
+  await expect(editor.locator("[data-id='stream_01ROUNDTRIP']")).toBeVisible()
+  await expect(editor.locator("pre code")).toContainText('console.log("hi")')
+  // Nested bullet list: "nested" sits inside a list within a list item.
+  await expect(editor.locator("ul ul li")).toHaveText("nested")
+  await expect(editor.locator("ol li")).toHaveCount(2)
+  await expect(editor.locator("blockquote").first()).toContainText("quoted one")
+  await expect(editor.locator("blockquote").first()).toContainText("quoted two")
+  await expect(editor.locator("[data-type='quote-reply']")).toBeVisible()
+  await expect(editor.locator("[data-type='shared-message']")).toBeVisible()
+}
+
+async function sendComposerContent(page: Page): Promise<void> {
+  await page.getByRole("main").getByRole("button", { name: "Send", exact: true }).click()
+  await expect(composerEditor(page)).not.toContainText("tail paragraph")
+}
+
+function sentMessageRows(page: Page): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: "tail paragraph" })
+}
+
+async function copyMessageAsMarkdown(page: Page, row: Locator): Promise<string> {
+  // Hover the row body (not the action pill area — resting on the pill's
+  // other buttons pops their tooltips over the target), then click the
+  // revealed actions button directly.
+  await row.hover()
+  const actionsButton = row.getByRole("button", { name: "Message actions" })
+  await expect(actionsButton).toBeVisible()
+  await actionsButton.click()
+  await page.getByRole("menuitem", { name: "Copy as Markdown" }).click()
+  return page.evaluate(() => navigator.clipboard.readText())
+}
+
+test.use({ permissions: ["clipboard-read", "clipboard-write"] })
+
+test.describe("Composer copy/paste roundtrip", () => {
+  let canonicalMarkdown: string
+
+  test.beforeEach(async ({ page }) => {
+    await loginAndCreateWorkspace(page, "copy-roundtrip")
+    const workspaceId = page.url().match(/\/w\/([^/]+)/)?.[1] ?? ""
+    expect(workspaceId).not.toBe("")
+    const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad" },
+    })
+    await expectApiOk(response, "Create scratchpad")
+    const body = (await response.json()) as { stream: { id: string } }
+    const streamId = body.stream.id
+
+    // The quote-reply and shared-message pointers must reference a message
+    // that actually exists — the backend's share-recording step 400s
+    // (SHARE_SOURCE_MESSAGE_NOT_FOUND) on a fabricated id.
+    const seedResponse = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+      data: {
+        streamId,
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "seed" }] }] },
+        contentMarkdown: "seed",
+      },
+    })
+    await expectApiOk(seedResponse, "Send seed message")
+    const seedBody = (await seedResponse.json()) as { message: { id: string; authorId: string } }
+    canonicalMarkdown = buildCanonicalMarkdown({
+      streamId,
+      messageId: seedBody.message.id,
+      authorId: seedBody.message.authorId,
+    })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(composerEditor(page)).toBeVisible({ timeout: 10000 })
+  })
+
+  test("send → Copy as Markdown → paste → send preserves every style", async ({ page }) => {
+    await pastePlainText(page, canonicalMarkdown)
+    await expectEditorHasAllStyles(page)
+    await sendComposerContent(page)
+
+    // The send pipeline converts the pasted 🎉 into an emoji atom, whose wire
+    // form is the shortcode — the one legitimate normalization in the cycle.
+    // Everything else must come back byte-identical, and the shortcode form
+    // is itself a fixed point (the second cycle returns it unchanged).
+    const expectedSentMarkdown = canonicalMarkdown.replace("🎉", ":tada:")
+
+    const firstRow = sentMessageRows(page).first()
+    await expect(firstRow).toBeVisible({ timeout: 10000 })
+    const copiedMarkdown = await copyMessageAsMarkdown(page, firstRow)
+    expect(copiedMarkdown).toBe(expectedSentMarkdown)
+
+    await pastePlainText(page, copiedMarkdown)
+    await expectEditorHasAllStyles(page)
+    await sendComposerContent(page)
+
+    const secondRow = sentMessageRows(page).nth(1)
+    await expect(secondRow).toBeVisible({ timeout: 10000 })
+    const secondMarkdown = await copyMessageAsMarkdown(page, secondRow)
+    expect(secondMarkdown).toBe(expectedSentMarkdown)
+  })
+
+  test("copy and cut from the composer serialize the selection to markdown", async ({ page }) => {
+    await pastePlainText(page, canonicalMarkdown)
+    await expectEditorHasAllStyles(page)
+
+    // Click a text block (not the editor's center, which can land on an
+    // atom chip and swallow focus), then select-all through the editor.
+    // Retried because the click can race the editor settling after paste,
+    // leaving the caret (and thus the selection) empty.
+    // Control (not ControlOrMeta): the suite's Desktop Chrome device emulates
+    // Linux, so ProseMirror binds select-all to Ctrl-A — the host-resolved
+    // Meta+A would be selected natively by the browser without ProseMirror's
+    // state ever seeing it, and the copy handler reads the state selection.
+    // Copy is non-destructive, so the whole select-all → copy sequence
+    // retries as a unit until ProseMirror's state selection has caught up
+    // (the DOM selection can briefly lead it after the click).
+    let copied = ""
+    await expect(async () => {
+      await composerEditor(page).locator("h2").click()
+      await page.keyboard.press("Control+a")
+      copied = await captureEditorClipboard(page, "copy")
+      expect(copied).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(copied).toBe(canonicalMarkdown)
+    // Copy must not disturb the document.
+    await expectEditorHasAllStyles(page)
+
+    const cut = await captureEditorClipboard(page, "cut")
+    expect(cut).toBe(canonicalMarkdown)
+    await expect(composerEditor(page)).not.toContainText("tail paragraph")
+
+    // Paste the cut markdown back — the full document must come back.
+    await pastePlainText(page, cut)
+    await expectEditorHasAllStyles(page)
+  })
+})

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -85,6 +85,29 @@ async function captureEditorClipboard(page: Page, kind: "copy" | "cut"): Promise
   }, kind)
 }
 
+/** Select an exact text run inside the composer via a DOM range (ProseMirror syncs from selectionchange). */
+async function selectEditorText(page: Page, text: string): Promise<void> {
+  await page.evaluate((needle) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+    let current: Node | null
+    while ((current = walker.nextNode())) {
+      const index = (current.textContent ?? "").indexOf(needle)
+      if (index === -1) continue
+      const range = document.createRange()
+      range.setStart(current, index)
+      range.setEnd(current, index + needle.length)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      ;(editor as HTMLElement).focus()
+      return
+    }
+    throw new Error(`Text not found in editor: ${needle}`)
+  }, text)
+}
+
 /** Every style from {@link buildCanonicalMarkdown}, asserted against the live editor DOM. */
 async function expectEditorHasAllStyles(page: Page): Promise<void> {
   const editor = composerEditor(page)
@@ -193,6 +216,17 @@ test.describe("Composer copy/paste roundtrip", () => {
   test("copy and cut from the composer serialize the selection to markdown", async ({ page }) => {
     await pastePlainText(page, canonicalMarkdown)
     await expectEditorHasAllStyles(page)
+
+    // Partial (single-block) selection: the slice arrives inline-wrapped in
+    // its parent block, and the marks must survive — this was the everyday
+    // copy shape the old container copy handler serialized to "".
+    let partial = ""
+    await expect(async () => {
+      await selectEditorText(page, "bold")
+      partial = await captureEditorClipboard(page, "copy")
+      expect(partial).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(partial).toBe("**bold**")
 
     // Click a text block (not the editor's center, which can land on an
     // atom chip and swallow focus), then select-all through the editor.


### PR DESCRIPTION
**Stacked on** #1382 (`fix/editor-copy-markdown`).

## Problem

On Android, pasting a large payload via Gboard's clipboard-suggestion bar can leave the composer **empty** — the text flashes in "at once" and vanishes — while the OS paste menu works fine. Reported by Kris on-device.

The clipboard bar doesn't fire a `paste` event; it commits through `beforeinput` (a quirk [ProseMirror's maintainer Marijn Haverbeke confirmed is unfixable upstream](https://discuss.prosemirror.net/t/transformpasted-doesnt-catch-pasted/8157) — see the comment on `handleBeforeInputKeyboardPaste`). Two failure modes in that handler explain the empty composer:

1. **Prevent-then-throw eats the payload.** `event.preventDefault()` runs before `insertPastedText`; if the markdown parse/insert throws on a large or pathological payload, the exception propagates, the fallback never runs, and the already-canceled event inserts nothing.
2. **Large IME payloads arrive with `data: null`.** Chromium on Android delivers big clipboard commits with the text on `event.dataTransfer` (and sometimes as `insertFromPaste` / `insertReplacementText` instead of `insertText`). The handler bailed on `!data`, leaving the browser's giant native insertion to fight ProseMirror's DOM reconciliation.

## Solution

Harden `handleBeforeInputKeyboardPaste` (`apps/frontend/src/components/editor/multiline-blocks.ts`) so an intercepted payload can never be lost:

1. Payload resolution falls back to `event.dataTransfer?.getData("text/plain")` when `data` is null.
2. `insertFromPaste` and `insertReplacementText` input types are accepted and skip the 3-char/styling-char heuristic — they are definitively pastes, not typing. They only reach `beforeinput` when no `paste` event was intercepted upstream, so there is no double-handling.
3. The insert is wrapped in try/catch; on failure the raw text is inserted via `tr.insertText` (plain-text path, cannot reject any content shape). The composer can end up with unparsed text, never empty.

Both consumers (composer `rich-editor.tsx` and the fullscreen `document-editor-modal.tsx`) share the handler and get the fix.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/multiline-blocks.ts` | `dataTransfer` fallback, paste-like input types, try/catch plain-text fallback; `BeforeInputEventLike` gains `dataTransfer` |
| `apps/frontend/src/components/editor/multiline-blocks.test.ts` | +3 tests: null-`data`/`dataTransfer` payload, `insertFromPaste` without heuristic, parse-throw → plain-text fallback |

## Out of scope (deliberate)

- The `beforeinput` path still skips the ≥4 MB paste-to-snippet conversion (same as before) — the payloads at issue are far below that bound.
- No device-level e2e: Gboard's IME commit sequence can't be reproduced by Playwright; the unit tests drive the handler with the exact event shapes Chromium emits. Needs an on-device sanity pass (Kris has the repro).

## Test plan

- [x] `multiline-blocks.test.ts` — 67 pass (3 new)
- [x] Full editor unit suite — 382 pass
- [x] Frontend `tsc --noEmit` clean (pre-commit hook: monorepo lint + typecheck green)
- [x] On-device Gboard repro — cannot be simulated; awaiting Kris's verification on Android

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786903350&installation_id=129946197&pr_number=1384&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1384&signature=10063c37a1cb84053d56166ba0c872be43918a2af19a6383d358afbd98ba90ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
