### PR TITLE
feat(integrations): integer generation version on workspace_integrations (INV-66)

### DIFF
--- a/apps/backend/src/db/migrations/20260718120000_workspace_integration_version.sql
+++ b/apps/backend/src/db/migrations/20260718120000_workspace_integration_version.sql
@@ -1,0 +1,21 @@
+-- Add a `version` integer column to workspace_integrations for optimistic
+-- concurrency control on the cache/credential write paths (INV-66). The
+-- identity + status guards already close cross-installation corruption and
+-- disconnect resurrection, but SAME-installation lost updates remain: the
+-- rate-limit and repo-sync writes replace the ENTIRE credentials/metadata
+-- object, so a stale writer that read before a concurrent write can clobber it
+-- (e.g. a slow rate-limit write erasing a newer repo-sync's repositories list).
+-- An integer version compared-and-set makes the stale writer lose.
+--
+-- Follows scheduled_messages.version / link_previews.refresh_version: a
+-- monotonically increasing integer avoids the TIMESTAMPTZ-microsecond vs JS
+-- Date-millisecond mismatch that breaks a `fetched_at = $expected` CAS.
+--
+-- Default = 1 for both new rows and the back-fill. EVERY update increments the
+-- version; the cache/credential writes additionally CAS on it. Lifecycle
+-- writes (disconnect, deactivate, install/replace upsert) bump the version but
+-- do NOT CAS — a concurrent background refresh's version bump must never make a
+-- user's disconnect silently no-op.
+
+ALTER TABLE workspace_integrations
+  ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;

--- a/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
+++ b/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
@@ -52,6 +52,21 @@ function recordingPool(rows: Array<Record<string, unknown>>): { pool: Pool; call
   return { pool, calls }
 }
 
+/** A pool whose UPDATE matches 0 rows (a newer write / disconnect won the CAS). */
+function guardMissPoolShared(selectRows: Array<Record<string, unknown>>): { pool: Pool; calls: QueryCall[] } {
+  const calls: QueryCall[] = []
+  const pool = {
+    query: async (query: unknown, values: unknown[] = []) => {
+      const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+      calls.push({ text, values })
+      if (text.includes("UPDATE workspace_integrations")) return { rows: [], rowCount: 0 }
+      return { rows: selectRows, rowCount: selectRows.length }
+    },
+    release: () => {},
+  } as unknown as Pool
+  return { pool, calls }
+}
+
 function githubRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     id: "wsi_1",
@@ -191,6 +206,33 @@ describe("disconnectGithubIntegration route unregistration", () => {
     expect(routeEvents(spy)).toEqual([])
   })
 
+  it("does NOT version-CAS, so a concurrent background version bump can't no-op the disconnect (asymmetry)", async () => {
+    // Lifecycle writes express absolute user intent: the guarded UPDATE carries an
+    // installation-id guard but leaves the version guard ($12) NULL, so a
+    // concurrent rate-limit/refresh version bump does not make the disconnect miss.
+    const { pool, calls } = recordingPool([githubRow({ installation_id: "42", version: 9 })])
+    const spy = outboxSpy()
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+
+    await service.disconnectGithubIntegration("ws_1")
+
+    const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
+    expect(update?.values).toContain("inactive")
+    // $12 (expectedVersion) is null → no version CAS on the lifecycle write.
+    expect(update?.values[11]).toBeNull()
+    expect(routeEvents(spy)).toEqual([
+      {
+        eventType: "github_route:unregister",
+        payload: { workspaceId: "ws_1", installationId: "42", region: "eu-north-1" },
+      },
+    ])
+  })
+
   it("emits no route event when no region is configured (local dev)", async () => {
     const { pool } = recordingPool([githubRow()])
     const spy = outboxSpy()
@@ -219,6 +261,7 @@ describe("GitHub installation replacement route lifecycle", () => {
       metadata: {},
       installedBy: "user_1",
       installationId: "42",
+      version: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
     }
@@ -392,6 +435,110 @@ describe("backfillGithubRoute", () => {
   })
 })
 
+describe("syncGithubRepositories version-CAS retry (INV-66)", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  function githubCredentials(): Record<string, unknown> {
+    return encryptJson(
+      SECRET,
+      { installationId: 42, accessToken: "tok", tokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString() },
+      { workspaceId: "ws_1", provider: "github" }
+    )
+  }
+
+  // Fake the app octokit (token mint) so no JWT is signed, and stub fetch so the
+  // `GET /installation/repositories` Octokit inside `listInstallationRepositories`
+  // resolves to an empty list — no real network.
+  function stubGithubNetwork(service: WorkspaceIntegrationService): void {
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async () => ({
+        data: { token: "fresh-tok", expires_at: new Date(Date.now() + 3_600_000).toISOString(), permissions: {} },
+      }),
+    })
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ repositories: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
+  }
+
+  it("re-reads and retries once, then throws the 409 conflict when the second CAS also loses", async () => {
+    // Every UPDATE misses (version advanced concurrently). SELECTs return an
+    // active row. Expect exactly two UPDATE attempts (initial + one retry), then throw.
+    let updateCount = 0
+    const calls: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        calls.push({ text, values })
+        if (text.includes("UPDATE workspace_integrations")) {
+          updateCount += 1
+          return { rows: [], rowCount: 0 }
+        }
+        return {
+          rows: [githubRow({ installation_id: "42", credentials: githubCredentials(), version: 5 })],
+          rowCount: 1,
+        }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+    stubGithubNetwork(service)
+
+    let caught: unknown
+    try {
+      await service.syncGithubRepositories("ws_1")
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as { status?: number }).status).toBe(409)
+    expect((caught as { code?: string }).code).toBe("GITHUB_INTEGRATION_NOT_ACTIVE")
+    expect(updateCount).toBe(2)
+  })
+
+  it("succeeds when the retry against the re-read version wins", async () => {
+    let updateCount = 0
+    const pool = {
+      query: async (query: unknown) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        if (text.includes("UPDATE workspace_integrations")) {
+          updateCount += 1
+          // First CAS loses; the retry (against the re-read version) wins.
+          if (updateCount === 1) return { rows: [], rowCount: 0 }
+          return { rows: [githubRow({ installation_id: "42", version: 7 })], rowCount: 1 }
+        }
+        return {
+          rows: [githubRow({ installation_id: "42", credentials: githubCredentials(), version: 5 })],
+          rowCount: 1,
+        }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+    stubGithubNetwork(service)
+
+    const result = await service.syncGithubRepositories("ws_1")
+
+    expect(result.status).toBe("active")
+    expect(updateCount).toBe(2)
+  })
+})
+
 describe("listActiveWorkspaceIdsForInstallation", () => {
   it("returns every active workspace on the installation, scoped by (provider, installation_id, active)", async () => {
     const { pool, calls } = recordingPool([
@@ -500,8 +647,8 @@ describe("GitHub metadata write guards", () => {
     rateLimitResetAt: null,
   }
 
-  it("guards rate-limit metadata on the client's observed installation", async () => {
-    const { pool, calls } = recordingPool([githubRow({ installation_id: "42" })])
+  it("guards rate-limit metadata on the client's observed installation and version", async () => {
+    const { pool, calls } = recordingPool([githubRow({ installation_id: "42", version: 8 })])
     const service = new WorkspaceIntegrationService({
       pool,
       github: githubEnabled,
@@ -509,12 +656,19 @@ describe("GitHub metadata write guards", () => {
       region: "eu-north-1",
     })
 
-    const result = await service.updateGithubRateLimitMetadata("ws_1", metadata, "42", 100, null)
+    const result = await service.updateGithubRateLimitMetadata("ws_1", metadata, "42", 100, null, 7)
 
-    expect(result.rateLimitRemaining).toBe(100)
+    expect(result.metadata.rateLimitRemaining).toBe(100)
+    // A win returns the row's new version so a reused client can advance its cached
+    // generation instead of self-colliding on the frozen one.
+    expect(result.version).toBe(8)
     const update = calls.find((call) => call.text.includes("UPDATE workspace_integrations"))
+    expect(update?.text).toContain("version = version + 1")
+    expect(update?.text).toContain("version = $12")
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("42")
+    // Version-CAS: the observed generation is the last positional param ($12).
+    expect(update?.values[11]).toBe(7)
   })
 
   it("keeps the client's prior metadata when a replacement wins the guard", async () => {
@@ -526,7 +680,31 @@ describe("GitHub metadata write guards", () => {
       region: "eu-north-1",
     })
 
-    expect(await service.updateGithubRateLimitMetadata("ws_1", metadata, "42", 100, null)).toBe(metadata)
+    const result = await service.updateGithubRateLimitMetadata("ws_1", metadata, "42", 100, null, 7)
+    expect(result.metadata).toBe(metadata)
+    // A loss returns null version — the client keeps its cached version and defers
+    // to the concurrent writer that actually advanced the row.
+    expect(result.version).toBeNull()
+  })
+
+  it("returns prior metadata (loses) when a newer same-installation write advanced the version", async () => {
+    // SELECTs would show an active row, but the version-CAS UPDATE matches 0 rows
+    // because a concurrent repo-sync already bumped the version — the stale
+    // rate-limit write must NOT clobber the newer repositories list.
+    const { pool, calls } = guardMissPoolShared([])
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+
+    const result = await service.updateGithubRateLimitMetadata("ws_1", metadata, "42", 100, null, 3)
+
+    expect(result.metadata).toBe(metadata)
+    expect(result.version).toBeNull()
+    const update = calls.find((call) => call.text.includes("UPDATE workspace_integrations"))
+    expect(update?.values[11]).toBe(3)
   })
 })
 
@@ -545,16 +723,18 @@ describe("persistGithubIntegration token-refresh path (non-route)", () => {
   function persist(
     service: WorkspaceIntegrationService,
     params: UpsertWorkspaceIntegrationParams,
-    routeInstallationId?: string
+    routeInstallationId?: string,
+    expectedVersion?: number
   ): Promise<WorkspaceIntegrationRecord | null> {
     return (
       service as unknown as {
         persistGithubIntegration(
           p: UpsertWorkspaceIntegrationParams,
-          r?: string
+          r?: string,
+          v?: number
         ): Promise<WorkspaceIntegrationRecord | null>
       }
-    ).persistGithubIntegration(params, routeInstallationId)
+    ).persistGithubIntegration(params, routeInstallationId, expectedVersion)
   }
 
   it("uses the guarded UPDATE (not a blind upsert) and persists a normal refresh", async () => {
@@ -632,5 +812,34 @@ describe("persistGithubIntegration token-refresh path (non-route)", () => {
     expect(result).toBeNull()
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update?.values).toContain("42")
+  })
+
+  it("returns null (does not clobber) when a newer same-installation write advanced the version", async () => {
+    // A token refresh that read version 4 lands after a concurrent write bumped
+    // it: the version-CAS UPDATE matches nothing → null, so the stale credentials
+    // + metadata don't overwrite the newer write (INV-66).
+    const calls: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        calls.push({ text, values })
+        return { rows: [], rowCount: 0 }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+
+    const result = await persist(service, refreshParams, undefined, 4)
+
+    expect(result).toBeNull()
+    const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
+    expect(update?.text).toContain("version = $12")
+    expect(update?.values[11]).toBe(4)
+    expect(calls.find((c) => c.text.includes("INSERT INTO workspace_integrations"))).toBeUndefined()
   })
 })

--- a/apps/backend/src/features/workspace-integrations/linear-client.ts
+++ b/apps/backend/src/features/workspace-integrations/linear-client.ts
@@ -173,12 +173,21 @@ export class LinearClient {
       return
     }
 
-    this.metadata = await this.service.updateLinearRateLimitMetadata(this.workspaceId, this.metadata, {
-      requestsRemaining,
-      requestsResetAt,
-      complexityRemaining,
-      complexityResetAt,
-    })
+    const result = await this.service.updateLinearRateLimitMetadata(
+      this.workspaceId,
+      this.metadata,
+      {
+        requestsRemaining,
+        requestsResetAt,
+        complexityRemaining,
+        complexityResetAt,
+      },
+      this.record.version
+    )
+    this.metadata = result.metadata
+    // Advance the cached version on a win so this reused client's next capture
+    // CASes on the fresh generation instead of colliding with its own prior write.
+    if (result.version !== null) this.record = { ...this.record, version: result.version }
   }
 }
 

--- a/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
+++ b/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
@@ -73,6 +73,7 @@ function linearRecord(overrides: Partial<WorkspaceIntegrationRecord> = {}): Work
     metadata: {},
     installedBy: "user_1",
     installationId: null,
+    version: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -137,6 +138,9 @@ describe("persistLinearCredentials refresh path (isInstall:false)", () => {
     expect(update).toBeDefined()
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("org_123")
+    // Credential write → version-CAS on the record's observed generation (1).
+    expect(update?.text).toContain("version = $12")
+    expect(update?.values[11]).toBe(1)
     expect(calls.find((c) => c.text.includes("INSERT INTO workspace_integrations"))).toBeUndefined()
   })
 
@@ -184,7 +188,10 @@ describe("updateLinearRateLimitMetadata guards", () => {
 
     const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit)
 
-    expect(result.rateLimit.requestsRemaining).toBe(42)
+    expect(result.metadata.rateLimit.requestsRemaining).toBe(42)
+    // A win returns the row's new version so a reused client advances its cached
+    // generation instead of self-colliding on the frozen one.
+    expect(result.version).not.toBeNull()
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("org_123")
@@ -205,7 +212,25 @@ describe("updateLinearRateLimitMetadata guards", () => {
     const service = makeService(pool)
     const metadata = linearMetadata("org_123")
 
-    expect(await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit)).toBe(metadata)
+    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit)
+    expect(result.metadata).toBe(metadata)
+    expect(result.version).toBeNull()
+  })
+
+  it("passes the observed version as the CAS guard and loses (returns prior) when it is stale", async () => {
+    const { pool, calls } = guardMissPool([])
+    const service = makeService(pool)
+    const metadata = linearMetadata("org_123")
+
+    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit, 12)
+
+    expect(result.metadata).toBe(metadata)
+    expect(result.version).toBeNull()
+    const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
+    expect(update?.text).toContain("version = version + 1")
+    expect(update?.text).toContain("version = $12")
+    // $12 (expectedVersion) is the last positional param.
+    expect(update?.values[11]).toBe(12)
   })
 })
 

--- a/apps/backend/src/features/workspace-integrations/repository.ts
+++ b/apps/backend/src/features/workspace-integrations/repository.ts
@@ -16,6 +16,9 @@ export interface WorkspaceIntegrationRecord {
   // Plaintext reverse index for webhook fan-out (GitHub installation id as
   // text). Null on pre-backfill rows and for providers without one.
   installationId: string | null
+  // Optimistic-concurrency generation. Incremented by every update/upsert; the
+  // cache/credential write paths CAS on it (INV-66).
+  version: number
   createdAt: Date
   updatedAt: Date
 }
@@ -50,6 +53,16 @@ export interface UpdateWorkspaceIntegrationOptions {
    * installation it listed.
    */
   expectedInstallationId?: { value: string; allowNull: boolean }
+  /**
+   * Optimistic generation guard (INV-66). When set, the write only lands if the
+   * row's `version` still equals the value read before the out-of-transaction
+   * network work — so a stale full-object write (rate-limit/credential/metadata)
+   * can't clobber a newer concurrent write to the SAME installation. A miss
+   * matches 0 rows and returns null. Lifecycle writes (disconnect, deactivate,
+   * install/replace) deliberately OMIT this: they express absolute user/webhook
+   * intent and must not be no-op'd by a background refresh's version bump.
+   */
+  expectedVersion?: number
 }
 
 function mapRow(row: Record<string, unknown>): WorkspaceIntegrationRecord {
@@ -62,6 +75,7 @@ function mapRow(row: Record<string, unknown>): WorkspaceIntegrationRecord {
     metadata: (row.metadata as Record<string, unknown> | null) ?? {},
     installedBy: row.installed_by as string,
     installationId: (row.installation_id as string | null) ?? null,
+    version: (row.version as number | null) ?? 1,
     createdAt: new Date(row.created_at as string),
     updatedAt: new Date(row.updated_at as string),
   }
@@ -115,6 +129,7 @@ export const WorkspaceIntegrationRepository = {
               metadata = EXCLUDED.metadata,
               installed_by = EXCLUDED.installed_by,
               installation_id = COALESCE(EXCLUDED.installation_id, workspace_integrations.installation_id),
+              version = workspace_integrations.version + 1,
               updated_at = NOW()
           RETURNING *`,
       [
@@ -148,6 +163,7 @@ export const WorkspaceIntegrationRepository = {
             metadata = COALESCE($5::jsonb, metadata),
             installed_by = COALESCE($6, installed_by),
             installation_id = COALESCE($8, installation_id),
+            version = version + 1,
             updated_at = NOW()
           WHERE workspace_id = $1 AND provider = $2
             AND ($7::text IS NULL OR status = $7)
@@ -156,6 +172,7 @@ export const WorkspaceIntegrationRepository = {
               OR ($11::boolean AND (installation_id IS NULL OR installation_id = $10))
               OR ((NOT $11::boolean) AND installation_id IS NOT DISTINCT FROM $10)
             )
+            AND ($12::int IS NULL OR version = $12)
           RETURNING *`,
       [
         workspaceId,
@@ -169,6 +186,7 @@ export const WorkspaceIntegrationRepository = {
         installationGuard ? false : true,
         installationGuard?.value ?? null,
         installationGuard?.allowNull ?? false,
+        options?.expectedVersion ?? null,
       ]
     )
 

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -118,6 +118,7 @@ describe("GitHubClient captureRateLimit is best-effort", () => {
     metadata: {},
     installedBy: "user_1",
     installationId: "42",
+    version: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
   }
@@ -152,6 +153,39 @@ describe("GitHubClient captureRateLimit is best-effort", () => {
     expect(updateSpy).toHaveBeenCalled()
     expect(refreshSpy).toHaveBeenCalled()
   })
+
+  it("advances the cached version after a winning capture so a reused client's next capture CASes on the fresh generation", async () => {
+    // Regression: a memoized agent-turn client / multi-call preview reuses one
+    // GitHubClient across many requests. If a winning capture did not advance the
+    // cached version, request 2 would CAS on the stale frozen version, match 0
+    // rows, and drop every reading after the first — starving isNearGithubRateLimit.
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubEnabled,
+      linear: linearDisabled,
+    })
+    const captureSpy = spyOn(service, "updateGithubRateLimitMetadata")
+      .mockResolvedValueOnce({ metadata: { ...metadata, rateLimitRemaining: 90 }, version: 2 })
+      .mockResolvedValueOnce({ metadata: { ...metadata, rateLimitRemaining: 40 }, version: 3 })
+
+    const client = new GitHubClient(service, "ws_1", { ...record, version: 1 }, credentials, metadata)
+    let remaining = 90
+    ;(client as unknown as { octokit: { request: () => Promise<unknown> } }).octokit = {
+      request: async () => ({
+        data: {},
+        headers: { "x-ratelimit-remaining": String(remaining), "x-ratelimit-reset": "1234567890" },
+      }),
+    }
+
+    await client.request("GET /a")
+    remaining = 40
+    await client.request("GET /b")
+
+    // expectedVersion is the 6th positional arg. First capture CASes on the
+    // initial version; second CASes on the version the first win returned.
+    expect(captureSpy.mock.calls[0][5]).toBe(1)
+    expect(captureSpy.mock.calls[1][5]).toBe(2)
+  })
 })
 
 describe("LinearClient captureRateLimit is best-effort", () => {
@@ -184,6 +218,7 @@ describe("LinearClient captureRateLimit is best-effort", () => {
     metadata: {},
     installedBy: "user_1",
     installationId: "org_1",
+    version: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
   }
@@ -218,6 +253,38 @@ describe("LinearClient captureRateLimit is best-effort", () => {
     await expect(client.request("query { viewer { id } }")).rejects.toBeInstanceOf(LinearApiError)
     expect(updateSpy).toHaveBeenCalled()
     expect(refreshSpy).toHaveBeenCalled()
+  })
+
+  it("advances the cached version after a winning capture so a reused client's next capture CASes on the fresh generation", async () => {
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubDisabled,
+      linear: linearEnabled,
+    })
+    const captureSpy = spyOn(service, "updateLinearRateLimitMetadata")
+      .mockResolvedValueOnce({ metadata, version: 2 })
+      .mockResolvedValueOnce({ metadata, version: 3 })
+
+    let remaining = 900
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-ratelimit-requests-remaining": String(remaining),
+          "x-ratelimit-requests-reset": "1234567890",
+        },
+      })) as unknown as typeof fetch
+
+    const client = new LinearClient(service, "ws_1", { ...record, version: 1 }, credentials, metadata, fetchImpl)
+
+    await client.request("query { a }")
+    remaining = 100
+    await client.request("query { b }")
+
+    // expectedVersion is the 4th positional arg (index 3).
+    expect(captureSpy.mock.calls[0][3]).toBe(1)
+    expect(captureSpy.mock.calls[1][3]).toBe(2)
   })
 })
 

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -147,7 +147,8 @@ export class GitHubClient {
     try {
       // Anonymous clients have no integration record to persist against, and their
       // rate-limit headers are per-IP rather than workspace state.
-      if (!headers || !this.metadata || !this.credentials) return
+      if (!headers || !this.metadata || !this.credentials || !this.record) return
+      const record = this.record
       const remaining = parseIntegerHeader(headers["x-ratelimit-remaining"])
       const resetSeconds = parseIntegerHeader(headers["x-ratelimit-reset"])
       const resetAt = resetSeconds ? new Date(resetSeconds * 1000).toISOString() : null
@@ -156,13 +157,18 @@ export class GitHubClient {
         return
       }
 
-      this.metadata = await this.service.updateGithubRateLimitMetadata(
+      const result = await this.service.updateGithubRateLimitMetadata(
         this.workspaceId,
         this.metadata,
         String(this.credentials.installationId),
         remaining,
-        resetAt
+        resetAt,
+        record.version
       )
+      this.metadata = result.metadata
+      // Advance the cached version on a win so this reused client's next capture
+      // CASes on the fresh generation instead of colliding with its own prior write.
+      if (result.version !== null) this.record = { ...record, version: result.version }
     } catch (error) {
       log.warn({ err: error, workspaceId: this.workspaceId }, "GitHub rate-limit capture failed; continuing")
     }
@@ -474,33 +480,49 @@ export class WorkspaceIntegrationService {
       })
     }
 
-    const metadata = this.parseMetadata(record.metadata)
-    const nextMetadata: GitHubIntegrationMetadata = {
-      ...metadata,
-      permissions: nextPermissions || metadata.permissions,
-      repositories,
+    const encryptedCredentials = encryptJson(
+      this.deps.github.integrationSecret,
+      { installationId: credentials.installationId, accessToken, tokenExpiresAt },
+      { workspaceId, provider: WorkspaceIntegrationProviders.GITHUB }
+    )
+
+    // CACHE WRITE — version-CAS. This replaces the whole metadata object (its
+    // `repositories` list especially), so a concurrent write must not be lost.
+    // Pin active status + the installation observed before the network calls
+    // (INV-20) AND the version read at the same point (INV-66). Because this is
+    // a user-facing sync (not a background telemetry write), a CAS miss re-reads
+    // and retries ONCE against the current version before surfacing the conflict.
+    const persistSync = async (base: WorkspaceIntegrationRecord): Promise<WorkspaceIntegrationRecord | null> => {
+      const baseMetadata = this.parseMetadata(base.metadata)
+      const nextMetadata: GitHubIntegrationMetadata = {
+        ...baseMetadata,
+        permissions: nextPermissions || baseMetadata.permissions,
+        repositories,
+      }
+      return WorkspaceIntegrationRepository.update(
+        this.deps.pool,
+        workspaceId,
+        WorkspaceIntegrationProviders.GITHUB,
+        { credentials: encryptedCredentials, metadata: nextMetadata },
+        {
+          expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
+          expectedInstallationId: { value: String(credentials.installationId), allowNull: true },
+          expectedVersion: base.version,
+        }
+      )
     }
 
-    // Pin both active status and the installation observed before the network
-    // calls. A concurrent disconnect or reconnect-to-B must make this stale A
-    // sync lose rather than overwrite the replacement (INV-20).
-    const updated = await WorkspaceIntegrationRepository.update(
-      this.deps.pool,
-      workspaceId,
-      WorkspaceIntegrationProviders.GITHUB,
-      {
-        credentials: encryptJson(
-          this.deps.github.integrationSecret,
-          { installationId: credentials.installationId, accessToken, tokenExpiresAt },
-          { workspaceId, provider: WorkspaceIntegrationProviders.GITHUB }
-        ),
-        metadata: nextMetadata,
-      },
-      {
-        expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-        expectedInstallationId: { value: String(credentials.installationId), allowNull: true },
+    let updated = await persistSync(record)
+    if (!updated) {
+      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
+        this.deps.pool,
+        workspaceId,
+        WorkspaceIntegrationProviders.GITHUB
+      )
+      if (reread && reread.status === WorkspaceIntegrationStatuses.ACTIVE) {
+        updated = await persistSync(reread)
       }
-    )
+    }
     if (!updated) {
       throw new HttpError("GitHub integration was disconnected during sync", {
         status: 409,
@@ -612,14 +634,19 @@ export class WorkspaceIntegrationService {
     metadata: GitHubIntegrationMetadata,
     installationId: string,
     remaining: number | null,
-    resetAt: string | null
-  ): Promise<GitHubIntegrationMetadata> {
+    resetAt: string | null,
+    expectedVersion?: number
+  ): Promise<{ metadata: GitHubIntegrationMetadata; version: number | null }> {
     const nextMetadata: GitHubIntegrationMetadata = {
       ...metadata,
       rateLimitRemaining: remaining,
       rateLimitResetAt: resetAt,
     }
 
+    // CACHE WRITE — version-CAS. This replaces the WHOLE metadata object, so a
+    // stale rate-limit write must not erase a newer concurrent write (e.g. a
+    // repo-sync that just refreshed `repositories`). A lost race matches 0 rows;
+    // keep the client's prior metadata rather than pretending the write stuck.
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
@@ -628,10 +655,17 @@ export class WorkspaceIntegrationService {
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
         expectedInstallationId: { value: installationId, allowNull: true },
+        expectedVersion,
       }
     )
 
-    return updated ? nextMetadata : metadata
+    // Return the new version on a win so a reused client (memoized agent turn,
+    // multi-call preview) advances its cached version and its NEXT capture CASes
+    // on the fresh generation instead of self-colliding on the frozen one and
+    // dropping every reading after the first (which would starve the near-limit
+    // breaker). `null` on a loss — the client keeps its version and defers to the
+    // concurrent writer that actually advanced the row.
+    return updated ? { metadata: nextMetadata, version: updated.version } : { metadata, version: null }
   }
 
   async refreshGithubCredentialsForClient(
@@ -689,6 +723,7 @@ export class WorkspaceIntegrationService {
         metadata: {},
         installedBy: installedByUserId,
         installationId: null,
+        version: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
@@ -787,7 +822,7 @@ export class WorkspaceIntegrationService {
         installationId: String(installationId),
       }
 
-      const updated = await this.persistGithubIntegration(upsertParams, routeInstallationId)
+      const updated = await this.persistGithubIntegration(upsertParams, routeInstallationId, record.version)
       if (!updated) {
         return null
       }
@@ -810,15 +845,18 @@ export class WorkspaceIntegrationService {
   /** Persist after all network work; replacement route events commit with the row. */
   private async persistGithubIntegration(
     params: UpsertWorkspaceIntegrationParams,
-    routeInstallationId?: string
+    routeInstallationId?: string,
+    expectedVersion?: number
   ): Promise<WorkspaceIntegrationRecord | null> {
     if (!routeInstallationId) {
-      // Token-refresh path (no route change). A blind upsert here would resurrect
-      // a row a concurrent disconnect just cleared, or clobber a row that
-      // reconnected to a DIFFERENT installation B back to A. Guard on status
-      // ACTIVE and installation_id == this install (or NULL for a pre-backfill
-      // row) so a lost race matches 0 rows and surfaces as a refresh failure the
-      // callers (401 retry, proactive refresh) already handle by returning null.
+      // CREDENTIAL WRITE (token refresh, no route change) — version-CAS. A blind
+      // upsert here would resurrect a row a concurrent disconnect just cleared,
+      // or clobber a row that reconnected to a DIFFERENT installation B back to A.
+      // Guard on status ACTIVE, installation_id == this install (or NULL for a
+      // pre-backfill row), AND the version read before the token round-trip so a
+      // stale refresh can't overwrite a newer same-installation write (INV-66).
+      // A lost race matches 0 rows and surfaces as a refresh failure the callers
+      // (401 retry, proactive refresh) already handle by returning null.
       return WorkspaceIntegrationRepository.update(
         this.deps.pool,
         params.workspaceId,
@@ -834,9 +872,14 @@ export class WorkspaceIntegrationService {
           expectedInstallationId: params.installationId
             ? { value: params.installationId, allowNull: true }
             : { value: "", allowNull: true },
+          expectedVersion,
         }
       )
     }
+
+    // LIFECYCLE WRITE (install / replace) — NO version-CAS. This upsert expresses
+    // an absolute install intent and serializes on the workspace lock; a
+    // concurrent background refresh's version bump must not make it lose.
 
     // Lock the workspace rather than the provider row: two first-time installs
     // must serialize even when no workspace_integrations row exists yet.
@@ -1064,14 +1107,17 @@ export class WorkspaceIntegrationService {
   async updateLinearRateLimitMetadata(
     workspaceId: string,
     metadata: LinearIntegrationMetadata,
-    rateLimit: LinearRateLimit
-  ): Promise<LinearIntegrationMetadata> {
+    rateLimit: LinearRateLimit,
+    expectedVersion?: number
+  ): Promise<{ metadata: LinearIntegrationMetadata; version: number | null }> {
     const nextMetadata: LinearIntegrationMetadata = { ...metadata, rateLimit }
 
-    // Guard on active status and the client's observed org so a stale rate-limit
-    // write can't land on a row a concurrent disconnect just cleared, or on a row
-    // reconnected to a different org (INV-20). A lost race matches 0 rows; keep the
-    // client's prior metadata rather than pretending the write stuck.
+    // CACHE WRITE — version-CAS. This replaces the whole metadata object, so
+    // guard on active status + the client's observed org (INV-20) AND the version
+    // read at the client's read (INV-66): a stale rate-limit write can't land on a
+    // row a concurrent disconnect cleared, a row reconnected to a different org, or
+    // a row a newer same-org write already advanced. A lost race matches 0 rows;
+    // keep the client's prior metadata rather than pretending the write stuck.
     const organizationId = metadata.organizationId
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
@@ -1081,10 +1127,14 @@ export class WorkspaceIntegrationService {
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
         expectedInstallationId: { value: organizationId ?? "", allowNull: true },
+        expectedVersion,
       }
     )
 
-    return updated ? nextMetadata : metadata
+    // Return the new version on a win so a reused client advances its cached
+    // version and its next capture CASes on the fresh generation rather than
+    // self-colliding on the frozen one (see updateGithubRateLimitMetadata).
+    return updated ? { metadata: nextMetadata, version: updated.version } : { metadata, version: null }
   }
 
   async refreshLinearCredentialsForPreview(
@@ -1124,9 +1174,12 @@ export class WorkspaceIntegrationService {
   }
 
   /**
-   * Flip a broken Linear integration to ERROR. Guarded on active status and the
-   * observed org so it can't resurrect a row a concurrent disconnect already
-   * cleared, nor stamp ERROR onto a row reconnected to a different org (INV-20).
+   * Flip a broken Linear integration to ERROR. CREDENTIAL WRITE — version-CAS.
+   * Guarded on active status + the observed org (INV-20) AND the version read
+   * with the record (INV-66) so it can't resurrect a row a concurrent disconnect
+   * already cleared, stamp ERROR onto a row reconnected to a different org, or
+   * clobber a newer same-org write. A background error flip; a 0-row miss is a
+   * no-op (nothing to surface).
    */
   private async markLinearIntegrationError(workspaceId: string, record: WorkspaceIntegrationRecord): Promise<void> {
     const organizationId = this.resolveLinearOrganizationId(record)
@@ -1138,6 +1191,7 @@ export class WorkspaceIntegrationService {
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
         expectedInstallationId: { value: organizationId ?? "", allowNull: true },
+        expectedVersion: record.version,
       }
     )
   }
@@ -1207,6 +1261,7 @@ export class WorkspaceIntegrationService {
       metadata: {},
       installedBy: installedByUserId,
       installationId: null,
+      version: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
     }
@@ -1264,9 +1319,12 @@ export class WorkspaceIntegrationService {
       return { record: updated, credentials, metadata }
     }
 
-    // Refresh path. A missing org id is pinned to a NULL/empty installation id
-    // rather than falling back to status-only, so even a malformed legacy client
-    // cannot overwrite a concurrently reconnected row with a populated org id.
+    // Refresh path — CREDENTIAL WRITE, version-CAS. A missing org id is pinned to
+    // a NULL/empty installation id rather than falling back to status-only, so even
+    // a malformed legacy client cannot overwrite a concurrently reconnected row
+    // with a populated org id. The version read with the record (INV-66) additionally
+    // stops a stale refresh clobbering a newer same-org write. A 0-row miss returns
+    // null, which callers (401 retry, proactive refresh) handle as a refresh failure.
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
@@ -1281,6 +1339,7 @@ export class WorkspaceIntegrationService {
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
         expectedInstallationId: { value: organizationId ?? "", allowNull: true },
+        expectedVersion: record.version,
       }
     )
     if (!updated) return null

--- a/apps/backend/tests/integration/github-installation-backfill-migration.test.ts
+++ b/apps/backend/tests/integration/github-installation-backfill-migration.test.ts
@@ -229,3 +229,128 @@ describe("workspace_integrations installation_id guard", () => {
     })
   })
 })
+
+/**
+ * INV-66 discipline: the compared version is produced by the repository's own
+ * NOW()-writing update path and read back through the repository — never a
+ * hand-crafted fixture — so the CAS is exercised against a value that actually
+ * round-tripped the driver. A stale-version write must lose without touching the
+ * row; the winner's write advances the version. Real Postgres because a mock
+ * can't prove the `version = $expected` predicate actually gates.
+ */
+describe("workspace_integrations version CAS (INV-66)", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function seed(client: Pool | import("pg").PoolClient): Promise<void> {
+    await client.query(
+      `INSERT INTO workspace_integrations (id, workspace_id, provider, status, installed_by, installation_id)
+       VALUES ('wsi_ver', 'ws_ver', 'github', 'active', 'usr_test', 'A')`
+    )
+  }
+
+  test("a write carrying the version read back from the repository lands and advances it", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await seed(client)
+      const before = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(client, "ws_ver", "github")
+      expect(before?.version).toBe(1)
+
+      const updated = await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { repositories: [{ fullName: "org/repo", private: false }] } },
+        { expectedVersion: before!.version }
+      )
+
+      expect(updated?.version).toBe(2)
+    })
+  })
+
+  test("a stale-version write matches 0 rows and leaves the row untouched", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await seed(client)
+      const before = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(client, "ws_ver", "github")
+
+      // A concurrent write advances the version first (through the same path).
+      const winner = await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { winner: true } },
+        { expectedVersion: before!.version }
+      )
+      expect(winner?.version).toBe(2)
+
+      // The loser still holds the pre-advance version — CAS miss, no write.
+      const loser = await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { loser: true } },
+        { expectedVersion: before!.version }
+      )
+      expect(loser).toBeNull()
+
+      const current = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(client, "ws_ver", "github")
+      expect(current?.version).toBe(2)
+      expect(current?.metadata).toEqual({ winner: true })
+    })
+  })
+
+  test("re-reading after a loss yields the advanced version, which then wins", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await seed(client)
+      const before = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(client, "ws_ver", "github")
+      await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { a: 1 } },
+        {
+          expectedVersion: before!.version,
+        }
+      )
+
+      const stale = await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { b: 2 } },
+        {
+          expectedVersion: before!.version,
+        }
+      )
+      expect(stale).toBeNull()
+
+      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(client, "ws_ver", "github")
+      const retried = await WorkspaceIntegrationRepository.update(
+        client,
+        "ws_ver",
+        "github",
+        { metadata: { b: 2 } },
+        {
+          expectedVersion: reread!.version,
+        }
+      )
+      expect(retried?.version).toBe(3)
+    })
+  })
+
+  test("an update without expectedVersion still bumps the version (every update increments)", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await seed(client)
+      const updated = await WorkspaceIntegrationRepository.update(client, "ws_ver", "github", {
+        metadata: { touched: true },
+      })
+      expect(updated?.version).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
Stacked on #1374 (layer 2 of stack #1392).

## Problem

Identity + status guards (shipped in #1374) close cross-installation corruption and disconnect resurrection, but same-installation lost-updates remained: rate-limit and repo-sync writes replace the **entire** `credentials`/`metadata` objects, so a stale writer that read before a concurrent write silently clobbers it — e.g. a slow rate-limit capture erasing a newer sync's repositories list. Flagged by CodeRabbit on #1374 (thread left open as the marker for this PR).

## Solution

An integer `version` on `workspace_integrations` (the `scheduled_messages.version` / `link_previews.refresh_version` precedent, INV-66): every `update`/`upsert` increments it; writes that replace whole objects CAS on the version they read.

**Deliberate asymmetry** (documented at the options type, pinned by test):
- **Cache/credential writes version-CAS** — both rate-limit captures, `syncGithubRepositories`' persist, the GitHub token-refresh persist, `persistLinearCredentials`' refresh branch, `markLinearIntegrationError`. Background losers skip or return prior state; the user-facing sync re-reads once and retries against the *fresh* metadata (preserving the winner's changes) before throwing its existing 409.
- **Lifecycle writes do NOT version-CAS** — disconnect, deactivate, backfill, install/replace. They express absolute user/webhook intent; a background refresh bumping the version must not make a user's disconnect silently no-op. Their status/identity guards are unchanged.

Rate-limit capture methods now return `{metadata, version}` and the provider clients advance their in-memory version on a winning write — a reused memoized client (agent turns memoize one; PR previews make ≥2 calls) would otherwise self-collide on its second capture and starve the rate-limit breaker (caught by the xhigh verify pass, regression-tested).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/db/migrations/20260718120000_workspace_integration_version.sql` | `version INTEGER NOT NULL DEFAULT 1` |
| `apps/backend/src/features/workspace-integrations/repository.ts` | unconditional `version = version + 1` on update/upsert; `expectedVersion` guard; record/mapRow |
| `apps/backend/src/features/workspace-integrations/service.ts` | version threading with the CAS asymmetry; sync retry-once; `{metadata, version}` returns |
| `apps/backend/src/features/workspace-integrations/linear-client.ts` | capture passes/advances the client version |
| tests (`installation-routes`, `linear-write-guards`, `service`, real-Postgres migration suite) | stale-loss, retry-once-then-409, disconnect-asymmetry, reused-client version advance, NOW()-write-path round-trip (INV-66 test discipline) |

## Test plan

- [x] `bun test src/features/workspace-integrations/` — 80 pass
- [x] Real-Postgres integration suite incl. version CAS round-trip via the repository's own write path — 13 pass
- [x] `check:migrations` 218 clean; backend typecheck clean
- [x] Opus-medium implement → Opus-xhigh 2-lens adversarial verify → fix (verify caught the reused-client self-collision)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
