### PR TITLE
feat(control-plane): retention sweep for github_webhook_deliveries

### DIFF
--- a/apps/control-plane/src/db/migrations/014_github_webhook_deliveries_created_at_index.sql
+++ b/apps/control-plane/src/db/migrations/014_github_webhook_deliveries_created_at_index.sql
@@ -1,0 +1,8 @@
+-- Index the retention sweep. github_webhook_deliveries grows one row per routed
+-- webhook (every push to any PR branch across every installation) and is never
+-- bounded elsewhere, so an hourly sweep deletes rows older than the retention
+-- window. Without this index the sweep's `WHERE created_at < cutoff` is a seq
+-- scan over the whole table; with it the delete's row-selection is a cheap
+-- range scan.
+CREATE INDEX idx_github_webhook_deliveries_created_at
+    ON github_webhook_deliveries (created_at);

--- a/apps/control-plane/src/features/github-webhooks/constants.ts
+++ b/apps/control-plane/src/features/github-webhooks/constants.ts
@@ -30,3 +30,23 @@ export interface GithubWebhookDispatchPayload {
   deliveryId: string
   region: string
 }
+
+/**
+ * Retention window for delivery rows. A row is an idempotency guard (the GUID
+ * unique index dedupes GitHub retries) plus an operator forensic trail — not an
+ * archive; GitHub's own Recent Deliveries UI covers ~30 days, so nothing older
+ * is worth keeping. Sweeping a >30-day-old row technically reopens dedupe for
+ * its GUID, but a GitHub redelivery that old is effectively nonexistent and the
+ * regional queue's `ghwh_<guid>` PK dedupes independently, so the reopen is inert.
+ */
+export const GITHUB_WEBHOOK_RETENTION_DAYS = 30
+
+/** How often the retention sweep runs. */
+export const GITHUB_WEBHOOK_SWEEP_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Rows deleted per DELETE statement. Bounding the batch keeps each delete's lock
+ * footprint small so a large backlog can't hold row/index locks long enough to
+ * stall concurrent inserts; the sweeper loops until a batch comes back short.
+ */
+export const GITHUB_WEBHOOK_SWEEP_BATCH_SIZE = 500

--- a/apps/control-plane/src/features/github-webhooks/index.ts
+++ b/apps/control-plane/src/features/github-webhooks/index.ts
@@ -3,10 +3,12 @@ export {
   GITHUB_PROVIDER,
   OUTBOX_GITHUB_WEBHOOK_DISPATCH,
   FORWARDED_GITHUB_EVENT_TYPES,
+  GITHUB_WEBHOOK_RETENTION_DAYS,
   type GithubWebhookDispatchPayload,
 } from "./constants"
 export { createGithubWebhookHandlers } from "./handlers"
 export { GithubWebhookService, type ReceiveWebhookInput, type ReceiveWebhookResult } from "./service"
 export { GithubWebhookDispatchService } from "./dispatch"
 export { GithubWebhookDeliveryRepository, type GithubWebhookDeliveryRow } from "./repository"
+export { GithubWebhookRetentionSweeper } from "./retention"
 export { verifyGithubSignature } from "./signature"

--- a/apps/control-plane/src/features/github-webhooks/repository.ts
+++ b/apps/control-plane/src/features/github-webhooks/repository.ts
@@ -55,6 +55,28 @@ export const GithubWebhookDeliveryRepository = {
     return result.rows[0] ?? null
   },
 
+  /**
+   * Delete up to `limit` delivery rows older than `cutoff`, oldest first, and
+   * return how many were removed. Bounded so a large backlog drains across many
+   * short-locking statements instead of one long-locking sweep (see
+   * GITHUB_WEBHOOK_SWEEP_BATCH_SIZE); the caller loops until a batch comes back
+   * short of `limit`. Deleting the oldest rows first (ORDER BY created_at)
+   * shrinks the range the next batch scans and keeps progress monotonic.
+   */
+  async deleteOlderThanBatch(db: Querier, cutoff: Date, limit: number): Promise<number> {
+    const result = await db.query(
+      `DELETE FROM github_webhook_deliveries
+       WHERE id IN (
+         SELECT id FROM github_webhook_deliveries
+         WHERE created_at < $1
+         ORDER BY created_at
+         LIMIT $2
+       )`,
+      [cutoff, limit]
+    )
+    return result.rowCount ?? 0
+  },
+
   async getById(db: Querier, id: string): Promise<GithubWebhookDeliveryRow | null> {
     const result = await db.query<GithubWebhookDeliveryRow>(
       `SELECT id, delivery_guid, event_type, action, installation_id, repository_full_name,

--- a/apps/control-plane/src/features/github-webhooks/retention.ts
+++ b/apps/control-plane/src/features/github-webhooks/retention.ts
@@ -1,0 +1,73 @@
+import type { Pool } from "pg"
+import { logger, Ticker } from "@threa/backend-common"
+import {
+  GITHUB_WEBHOOK_RETENTION_DAYS,
+  GITHUB_WEBHOOK_SWEEP_BATCH_SIZE,
+  GITHUB_WEBHOOK_SWEEP_INTERVAL_MS,
+} from "./constants"
+import { GithubWebhookDeliveryRepository } from "./repository"
+
+interface Dependencies {
+  pool: Pool
+  retentionDays?: number
+  batchSize?: number
+}
+
+/**
+ * Hourly sweep that deletes github_webhook_deliveries rows past the retention
+ * window (see GITHUB_WEBHOOK_RETENTION_DAYS). The table grows one row per routed
+ * webhook and is bounded nowhere else, so it needs a reaper.
+ *
+ * Scheduling is delegated to the shared `Ticker` (maxConcurrency 1 → a tick is
+ * skipped while the previous sweep is still running; `stop()` + `drain()` give a
+ * clean shutdown). No DB lease: the control plane runs single-instance, and the
+ * deletes are batched and idempotent, so a second instance sweeping concurrently
+ * is harmless — each `DELETE ... WHERE id IN (SELECT ... LIMIT n)` just removes
+ * whatever rows it wins.
+ */
+export class GithubWebhookRetentionSweeper {
+  private readonly pool: Pool
+  private readonly retentionDays: number
+  private readonly batchSize: number
+  private readonly ticker: Ticker
+
+  constructor({ pool, retentionDays, batchSize }: Dependencies) {
+    this.pool = pool
+    this.retentionDays = retentionDays ?? GITHUB_WEBHOOK_RETENTION_DAYS
+    this.batchSize = batchSize ?? GITHUB_WEBHOOK_SWEEP_BATCH_SIZE
+    this.ticker = new Ticker({
+      name: "github-webhook-retention",
+      intervalMs: GITHUB_WEBHOOK_SWEEP_INTERVAL_MS,
+      maxConcurrency: 1,
+    })
+  }
+
+  start(): void {
+    this.ticker.start(() => this.sweep().then(() => {}))
+  }
+
+  /** Stops scheduling new sweeps and waits for the in-flight one to finish. */
+  async stop(): Promise<void> {
+    this.ticker.stop()
+    await this.ticker.drain()
+  }
+
+  /**
+   * Delete every row older than the cutoff in bounded batches, looping until a
+   * batch comes back short of the batch size (backlog drained). Returns the
+   * total deleted. Runs on demand for tests and the scheduled loop alike.
+   */
+  async sweep(): Promise<number> {
+    const cutoff = new Date(Date.now() - this.retentionDays * 24 * 60 * 60 * 1000)
+    let total = 0
+    for (;;) {
+      const deleted = await GithubWebhookDeliveryRepository.deleteOlderThanBatch(this.pool, cutoff, this.batchSize)
+      total += deleted
+      if (deleted < this.batchSize) break
+    }
+    if (total > 0) {
+      logger.info({ deleted: total, retentionDays: this.retentionDays }, "Swept expired GitHub webhook deliveries")
+    }
+    return total
+  }
+}

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -56,6 +56,7 @@ import {
 } from "./features/platform-admin"
 import {
   GithubWebhookDispatchService,
+  GithubWebhookRetentionSweeper,
   OUTBOX_GITHUB_WEBHOOK_DISPATCH,
   type GithubWebhookDispatchPayload,
 } from "./features/github-webhooks"
@@ -124,6 +125,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   const authzFanOut = new RegionalAuthzFanOut({ pool, regionalClient })
   const featureFlagService = new ControlPlaneFeatureFlagService({ pool, regionalClient })
   const githubWebhookDispatch = new GithubWebhookDispatchService({ pool, regionalClient })
+  const githubWebhookRetention = new GithubWebhookRetentionSweeper({ pool })
 
   const processEvents = async () => {
     await cursorLock.run(async (cursor, processedIds) => {
@@ -180,6 +182,8 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     await ensureListenerFromLatest(pool, LISTENER_ID)
     outboxDispatcher.register(outboxHandler)
     await outboxDispatcher.start()
+
+    githubWebhookRetention.start()
 
     const workosEventLock = new WorkosEventPollerLock({
       pool,
@@ -259,6 +263,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     })
   } catch (err) {
     await authzPoller?.stop().catch(() => {})
+    await githubWebhookRetention.stop().catch(() => {})
     await outboxDispatcher.stop().catch(() => {})
     await listenPool.end().catch(() => {})
     await pool.end().catch(() => {})
@@ -275,6 +280,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       logger.info("Fast shutdown - skipping graceful shutdown")
       startedServer.close()
       await startedPoller.stop()
+      await githubWebhookRetention.stop()
       await outboxDispatcher.stop()
       await listenPool.end()
       await pool.end()
@@ -288,6 +294,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       })
     }
     await startedPoller.stop()
+    await githubWebhookRetention.stop()
     await outboxDispatcher.stop()
     await listenPool.end()
     await pool.end()

--- a/apps/control-plane/tests/integration/github-webhooks-retention.test.ts
+++ b/apps/control-plane/tests/integration/github-webhooks-retention.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { GITHUB_WEBHOOK_RETENTION_DAYS, GithubWebhookRetentionSweeper } from "../../src/features/github-webhooks"
+import { setupTestDatabase } from "./setup"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+async function insertDelivery(pool: Pool, guid: string, ageDays: number): Promise<void> {
+  const createdAt = new Date(Date.now() - ageDays * DAY_MS)
+  await pool.query(
+    `INSERT INTO github_webhook_deliveries
+       (id, delivery_guid, event_type, action, installation_id, repository_full_name, payload, matched_regions, status, created_at)
+     VALUES ($1, $2, 'pull_request', 'synchronize', '1', 'acme/widgets', '{}'::jsonb, '{}', 'no_routes', $3)`,
+    [`ghwd_${guid}`, guid, createdAt]
+  )
+}
+
+async function guids(pool: Pool): Promise<string[]> {
+  const result = await pool.query<{ delivery_guid: string }>(
+    "SELECT delivery_guid FROM github_webhook_deliveries ORDER BY delivery_guid"
+  )
+  return result.rows.map((r) => r.delivery_guid)
+}
+
+describe("GithubWebhookRetentionSweeper.sweep", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("TRUNCATE github_webhook_deliveries")
+  })
+
+  test("deletes rows past the retention window and keeps recent rows", async () => {
+    await insertDelivery(pool, "old-40d", GITHUB_WEBHOOK_RETENTION_DAYS + 10)
+    await insertDelivery(pool, "old-31d", GITHUB_WEBHOOK_RETENTION_DAYS + 1)
+    await insertDelivery(pool, "fresh-1d", 1)
+    await insertDelivery(pool, "fresh-29d", GITHUB_WEBHOOK_RETENTION_DAYS - 1)
+
+    const sweeper = new GithubWebhookRetentionSweeper({ pool })
+    const deleted = await sweeper.sweep()
+
+    expect(deleted).toBe(2)
+    expect(await guids(pool)).toEqual(["fresh-1d", "fresh-29d"])
+  })
+
+  test("respects the cutoff boundary — a row just inside the window survives, just outside is swept", async () => {
+    // retentionDays=10 keeps the arithmetic clear; both rows straddle the cutoff
+    // by a few hours so millisecond drift in Date.now() can't flip the result.
+    await insertDelivery(pool, "inside", 10 - 0.25)
+    await insertDelivery(pool, "outside", 10 + 0.25)
+
+    const sweeper = new GithubWebhookRetentionSweeper({ pool, retentionDays: 10 })
+    const deleted = await sweeper.sweep()
+
+    expect(deleted).toBe(1)
+    expect(await guids(pool)).toEqual(["inside"])
+  })
+
+  test("drains a backlog larger than the batch size across multiple deletes", async () => {
+    const expired = 23
+    for (let i = 0; i < expired; i++) {
+      await insertDelivery(pool, `expired-${String(i).padStart(3, "0")}`, 40)
+    }
+    await insertDelivery(pool, "keep", 1)
+
+    // batchSize < backlog forces the loop to iterate; a single-batch delete would
+    // leave (expired - batchSize) rows behind.
+    const sweeper = new GithubWebhookRetentionSweeper({ pool, retentionDays: 30, batchSize: 5 })
+    const deleted = await sweeper.sweep()
+
+    expect(deleted).toBe(expired)
+    expect(await guids(pool)).toEqual(["keep"])
+  })
+
+  test("is a clean no-op when nothing is expired", async () => {
+    await insertDelivery(pool, "fresh-a", 2)
+    await insertDelivery(pool, "fresh-b", 5)
+
+    const sweeper = new GithubWebhookRetentionSweeper({ pool })
+    const deleted = await sweeper.sweep()
+
+    expect(deleted).toBe(0)
+    expect(await guids(pool)).toEqual(["fresh-a", "fresh-b"])
+  })
+})


### PR DESCRIPTION
Stacked on #1389 (layer 3 of stack #1392).

## Problem

`github_webhook_deliveries` grows one full-payload row per routed webhook — `pull_request.synchronize` fires on every push to every PR branch of an installed org — and is bounded nowhere. #1374 named a retention sweep as a prerequisite for registering the App on any large org.

## Solution

An hourly sweeper on the control plane deletes delivery rows older than **30 days** in bounded **500-row** batches (oldest-first id-subquery `DELETE`, loops until a short batch) so a backlog can never hold long locks. Scheduling rides the shared `Ticker` from `@threa/backend-common` (`maxConcurrency: 1` skips a tick while a sweep runs; `stop()` + `drain()` for clean shutdown) — same shape as backend's `SyncLogRetentionWorker`; the first hand-rolled loop was collapsed into `Ticker` by the verify pass (INV-35). New `created_at` index makes the cutoff a range scan.

Why 30 days: delivery rows are an idempotency window + operator forensic trail, not an archive — GitHub's own Recent Deliveries UI covers roughly the same span. Sweeping an ancient GUID technically reopens CP-side dedupe for it, but redeliveries that old are effectively nonexistent and the regional queue PK (`ghwh_<guid>`) dedupes independently. No DB lease: the CP runs single-instance, and batched idempotent deletes are harmless even if two instances swept concurrently.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/control-plane/src/db/migrations/014_github_webhook_deliveries_created_at_index.sql` | `created_at` index for the sweep |
| `apps/control-plane/src/features/github-webhooks/{constants,repository,retention,index}.ts` | retention/interval/batch constants with rationale; `deleteOlderThanBatch`; `GithubWebhookRetentionSweeper` (Ticker-based) |
| `apps/control-plane/src/server.ts` | start after the outbox dispatcher; stop in all three teardown paths |
| `apps/control-plane/tests/integration/github-webhooks-retention.test.ts` | old-deleted/recent-retained, cutoff boundary, >batch-size drain, clean no-op |

## Test plan

- [x] Retention suite — 4 pass (real Postgres)
- [x] Full CP `bun run test` — 226 pass
- [x] CP typecheck clean; `check:migrations` 219 clean
- [x] Opus-medium implement → Opus-xhigh 2-lens adversarial verify → fix (verify collapsed the bespoke loop into `Ticker`)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
