### PR TITLE
feat(access-log): CP auth_log + WorkOS Events ingestion + backoffice audit + db-read-proxy logging (stack 5/5)

### DIFF
--- a/apps/control-plane/src/db/migrations/015_auth_log.sql
+++ b/apps/control-plane/src/db/migrations/015_auth_log.sql
@@ -1,0 +1,48 @@
+-- Control-plane auth_log — a durable, queryable record of authentication-surface
+-- access events. Global scope (no workspace sharding — INV-8's global infra/auth
+-- exception), primarily fed by the WorkOS Events API (see
+-- apps/control-plane/src/features/auth-log/), with a few own-handler rows for
+-- failures WorkOS structurally cannot see (callback-exchange / magic-auth verify).
+--
+-- Plain (non-partitioned) table, deliberately: idempotent re-ingestion of the
+-- replayable Events API relies on a pure `ON CONFLICT (workos_event_id)` upsert.
+-- A declarative-partitioned table cannot carry a unique index that omits the
+-- partition key, so partitioning would force the conflict target to
+-- (occurred_at, workos_event_id) and break event-id idempotency. Auth-event
+-- volume is tiny (logins, sessions, membership changes), so a plain table with a
+-- batched-DELETE retention worker (13 months) is the honest, simple shape.
+--
+-- No FKs, no enums (INV-1/3): outcome/event_type are TEXT validated in code.
+-- No content ever: IDs, emails (forensic, per §10 decision 5), and content-free
+-- detail only — never tokens, codes, or secrets.
+
+CREATE TABLE IF NOT EXISTS auth_log (
+    id                  TEXT NOT NULL PRIMARY KEY,          -- alog_<ulid>
+    occurred_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    workos_event_id     TEXT,                               -- NULL for own-handler rows
+    event_type          TEXT NOT NULL,                      -- WorkOS event type verbatim, or cp.* for own rows
+    workos_user_id      TEXT,
+    email               TEXT,
+    organization_id     TEXT,
+    impersonator_email  TEXT,
+    ip                  INET,
+    user_agent          TEXT,
+    outcome             TEXT NOT NULL,                      -- 'success' | 'denied'
+    detail              JSONB,
+    -- Ingestion time; occurred_at is the event time at WorkOS. The gap between
+    -- the two is the ingestion lag — forensically relevant when establishing
+    -- what we knew when.
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotent re-ingestion: WorkOS event ids are globally unique and the Events
+-- API is replayable, so a partial unique index (own-handler rows carry no event
+-- id) backs the poller's `ON CONFLICT (workos_event_id) DO NOTHING`.
+CREATE UNIQUE INDEX IF NOT EXISTS auth_log_workos_event_id_key
+    ON auth_log (workos_event_id)
+    WHERE workos_event_id IS NOT NULL;
+
+-- Retention sweeps by occurred_at; forensic lookups filter by actor.
+CREATE INDEX IF NOT EXISTS auth_log_occurred_at_idx ON auth_log (occurred_at);
+CREATE INDEX IF NOT EXISTS auth_log_workos_user_id_idx ON auth_log (workos_user_id, occurred_at);
+CREATE INDEX IF NOT EXISTS auth_log_email_idx ON auth_log (email, occurred_at);

--- a/apps/control-plane/src/features/auth-log/backoffice-audit.ts
+++ b/apps/control-plane/src/features/auth-log/backoffice-audit.ts
@@ -1,0 +1,26 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express"
+import type { AuthLogService } from "./service"
+
+/**
+ * Audit middleware for the platform-admin backoffice surface, mounted as
+ * `app.use("/api/backoffice", ...)` ahead of the per-route auth chain. The
+ * finish hook reads identity off `req` at response time (the `auth` middleware
+ * has run by then on success paths), so one mount line covers every backoffice
+ * route — including denials, which fire before any handler.
+ */
+export function createBackofficeAuditMiddleware(authLogService: AuthLogService): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const path = req.path
+    res.on("finish", () => {
+      void authLogService.recordBackofficeRequest({
+        workosUserId: req.workosUserId ?? null,
+        email: req.authUser?.email ?? null,
+        ip: req.ip ?? null,
+        userAgent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+        outcome: res.statusCode >= 400 ? "denied" : "success",
+        detail: { method: req.method, path, status: res.statusCode },
+      })
+    })
+    next()
+  }
+}

--- a/apps/control-plane/src/features/auth-log/backoffice-audit.ts
+++ b/apps/control-plane/src/features/auth-log/backoffice-audit.ts
@@ -11,16 +11,26 @@ import type { AuthLogService } from "./service"
 export function createBackofficeAuditMiddleware(authLogService: AuthLogService): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
     const path = req.path
-    res.on("finish", () => {
+    // Fire once on 'finish' OR 'close': an aborted response may already have
+    // streamed customer data to the admin's client, so it still records (same
+    // rule as the backend audit middleware's onResponseDone).
+    let fired = false
+    const record = (aborted: boolean) => {
+      if (fired) return
+      fired = true
       void authLogService.recordBackofficeRequest({
         workosUserId: req.workosUserId ?? null,
         email: req.authUser?.email ?? null,
         ip: req.ip ?? null,
         userAgent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
         outcome: res.statusCode >= 400 ? "denied" : "success",
-        detail: { method: req.method, path, status: res.statusCode },
+        detail: aborted
+          ? { method: req.method, path, status: res.statusCode, aborted: true }
+          : { method: req.method, path, status: res.statusCode },
       })
-    })
+    }
+    res.on("finish", () => record(false))
+    res.on("close", () => record(!res.writableFinished))
     next()
   }
 }

--- a/apps/control-plane/src/features/auth-log/constants.ts
+++ b/apps/control-plane/src/features/auth-log/constants.ts
@@ -1,0 +1,55 @@
+import type { WorkosEventName } from "@threa/backend-common"
+
+/** Lease identifier for the singleton auth_log WorkOS event poller. */
+export const AUTH_LOG_EVENT_POLLER_NAME = "auth-log-events"
+
+/**
+ * WorkOS event types ingested into `auth_log` (design §7.5). Every name is
+ * verified against the SDK 7.82.0 `EventName` union. Excluded until relevant:
+ * `connection.*`/`dsync.*` (no SSO/SCIM orgs yet), `flag.*`, role/permission
+ * template events, and the deprecated `organization_membership.added/removed`
+ * aliases (superseded by created/deleted).
+ */
+export const AUTH_LOG_EVENT_TYPES = [
+  "authentication.email_verification_succeeded",
+  "authentication.magic_auth_failed",
+  "authentication.magic_auth_succeeded",
+  "authentication.mfa_succeeded",
+  "authentication.oauth_failed",
+  "authentication.oauth_succeeded",
+  "authentication.passkey_failed",
+  "authentication.passkey_succeeded",
+  "authentication.password_failed",
+  "authentication.password_succeeded",
+  "authentication.sso_failed",
+  "authentication.sso_succeeded",
+  "authentication.radar_risk_detected",
+  "session.created",
+  "session.revoked",
+  "user.created",
+  "user.updated",
+  "user.deleted",
+  "organization_membership.created",
+  "organization_membership.updated",
+  "organization_membership.deleted",
+  "invitation.created",
+  "invitation.accepted",
+  "invitation.revoked",
+  "invitation.resent",
+  "password_reset.created",
+  "password_reset.succeeded",
+  "magic_auth.created",
+  "email_verification.created",
+  "api_key.created",
+  "api_key.deleted",
+] as const satisfies readonly WorkosEventName[]
+
+export type AuthLogEventType = (typeof AUTH_LOG_EVENT_TYPES)[number]
+
+export const AUTH_LOG_OUTCOMES = ["success", "denied"] as const
+export type AuthLogOutcome = (typeof AUTH_LOG_OUTCOMES)[number]
+
+/** Own-handler event types for failures WorkOS structurally cannot see. */
+export const AUTH_LOG_CP_CALLBACK_FAILED = "cp.callback_failed"
+export const AUTH_LOG_CP_MAGIC_AUTH_VERIFY_FAILED = "cp.magic_auth_verify_failed"
+export const AUTH_LOG_CP_BACKOFFICE_REQUEST = "cp.backoffice_request"

--- a/apps/control-plane/src/features/auth-log/index.ts
+++ b/apps/control-plane/src/features/auth-log/index.ts
@@ -1,0 +1,15 @@
+export { AuthLogService } from "./service"
+export { createBackofficeAuditMiddleware } from "./backoffice-audit"
+export type { AuthLogRequestContext } from "./service"
+export { AuthLogPoller } from "./poller"
+export { AuthLogRetentionWorker } from "./retention-worker"
+export { AuthLogRepository } from "./repository"
+export { mapWorkosEventToAuthLogRow } from "./mapper"
+export type { AuthLogRowInput } from "./mapper"
+export {
+  AUTH_LOG_EVENT_POLLER_NAME,
+  AUTH_LOG_EVENT_TYPES,
+  AUTH_LOG_CP_CALLBACK_FAILED,
+  AUTH_LOG_CP_MAGIC_AUTH_VERIFY_FAILED,
+} from "./constants"
+export type { AuthLogEventType, AuthLogOutcome } from "./constants"

--- a/apps/control-plane/src/features/auth-log/mapper.ts
+++ b/apps/control-plane/src/features/auth-log/mapper.ts
@@ -1,0 +1,100 @@
+import type { WorkosEvent } from "@threa/backend-common"
+import type { AuthLogOutcome } from "./constants"
+
+/** A row ready to insert into `auth_log`. `id` is minted by the repository. */
+export interface AuthLogRowInput {
+  occurredAt: Date
+  workosEventId: string | null
+  eventType: string
+  workosUserId: string | null
+  email: string | null
+  organizationId: string | null
+  impersonatorEmail: string | null
+  ip: string | null
+  userAgent: string | null
+  outcome: AuthLogOutcome
+  detail: Record<string, unknown> | null
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+/**
+ * Outcome derives purely from the event type: only WorkOS `*_failed` variants
+ * are denials. `authentication.radar_risk_detected` fires on a sign-in that
+ * *succeeded* but Radar flagged as risky — a successful authentication, not a
+ * denial; the risk signal is the event type itself. Everything else in the
+ * ingested set is a successful lifecycle event.
+ */
+function outcomeFor(eventType: string): AuthLogOutcome {
+  if (eventType.endsWith("_failed")) return "denied"
+  return "success"
+}
+
+/**
+ * Build the content-free `detail` extract. Scalar, non-content metadata only —
+ * never tokens, codes, or free-text (e.g. the impersonator `reason`, which is
+ * operator-authored prose). `authMethod`/`type`/`status`/`errorCode`/`action`
+ * are enum-shaped forensic signal, safe to keep.
+ */
+function detailFor(data: Record<string, unknown>): Record<string, unknown> | null {
+  const detail: Record<string, unknown> = {}
+  const authMethod = str(data.authMethod)
+  if (authMethod) detail.authMethod = authMethod
+  const type = str(data.type)
+  if (type) detail.type = type
+  const status = str(data.status)
+  if (status) detail.status = status
+  const action = str(data.action)
+  if (action) detail.action = action
+  const error = data.error
+  if (error && typeof error === "object") {
+    const code = str((error as Record<string, unknown>).code)
+    if (code) detail.errorCode = code
+  }
+  return Object.keys(detail).length > 0 ? detail : null
+}
+
+/**
+ * Map a raw WorkOS event to an `auth_log` row. Field placement varies by event
+ * category, so extraction is duck-typed against the deserialized (camelCase)
+ * payload:
+ * - `user.*` payloads key the user id under `id` (object==='user'); everything
+ *   else carries it as `userId`.
+ * - `api_key.*` payloads carry the org under `owner.id`; `authentication.sso_*`
+ *   events nest it under `sso.organizationId`; everything else uses
+ *   `organizationId`.
+ * - `session.created` carries `impersonator.email` — the operator-impersonation
+ *   visibility this table exists to capture.
+ */
+export function mapWorkosEventToAuthLogRow(event: WorkosEvent): AuthLogRowInput {
+  const data = (event.data ?? {}) as Record<string, unknown>
+
+  const isUserObject = str(data.object) === "user"
+  const workosUserId = str(data.userId) ?? (isUserObject ? str(data.id) : null)
+
+  const owner = data.owner
+  const ownerId = owner && typeof owner === "object" ? str((owner as Record<string, unknown>).id) : null
+  const sso = data.sso
+  const ssoOrgId = sso && typeof sso === "object" ? str((sso as Record<string, unknown>).organizationId) : null
+  const organizationId = str(data.organizationId) ?? ssoOrgId ?? ownerId
+
+  const impersonator = data.impersonator
+  const impersonatorEmail =
+    impersonator && typeof impersonator === "object" ? str((impersonator as Record<string, unknown>).email) : null
+
+  return {
+    occurredAt: new Date(event.createdAt),
+    workosEventId: event.id,
+    eventType: event.event,
+    workosUserId,
+    email: str(data.email),
+    organizationId,
+    impersonatorEmail,
+    ip: str(data.ipAddress),
+    userAgent: str(data.userAgent),
+    outcome: outcomeFor(event.event),
+    detail: detailFor(data),
+  }
+}

--- a/apps/control-plane/src/features/auth-log/poller.ts
+++ b/apps/control-plane/src/features/auth-log/poller.ts
@@ -1,0 +1,127 @@
+import { logger, type WorkosOrgService } from "@threa/backend-common"
+import type { WorkosEventPollerLock } from "../../lib/workos-event-poller-lock"
+import { AUTH_LOG_EVENT_TYPES } from "./constants"
+import type { AuthLogService } from "./service"
+
+interface Dependencies {
+  workosOrgService: WorkosOrgService
+  authLogService: AuthLogService
+  lock: WorkosEventPollerLock
+  /** Time between ticks when there is no work and we hold no lease. */
+  pollIntervalMs: number
+  /** Per-page event batch size. */
+  batchSize: number
+}
+
+/**
+ * Second WorkOS-event cursor consumer, beside {@link WorkosAuthzPoller}: drains
+ * the authentication-surface event set into `auth_log`. Same lease → page →
+ * process → advance loop and multi-instance safety (one lease holder at a time;
+ * losers no-op) — see `features/workos-authz/poller.ts` for the shared shape.
+ *
+ * Idempotency lives in the repository (`ON CONFLICT (workos_event_id)`), so a
+ * replayed page after a mid-tick crash inserts nothing new.
+ */
+export class AuthLogPoller {
+  private readonly workosOrgService: WorkosOrgService
+  private readonly authLogService: AuthLogService
+  private readonly lock: WorkosEventPollerLock
+  private readonly pollIntervalMs: number
+  private readonly batchSize: number
+
+  private running = false
+  private currentTick: Promise<void> | null = null
+  private tickTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor({ workosOrgService, authLogService, lock, pollIntervalMs, batchSize }: Dependencies) {
+    this.workosOrgService = workosOrgService
+    this.authLogService = authLogService
+    this.lock = lock
+    this.pollIntervalMs = pollIntervalMs
+    this.batchSize = batchSize
+  }
+
+  start(): void {
+    if (this.running) return
+    this.running = true
+    void this.scheduleNext(0)
+  }
+
+  async stop(): Promise<void> {
+    this.running = false
+    if (this.tickTimer) {
+      clearTimeout(this.tickTimer)
+      this.tickTimer = null
+    }
+    if (this.currentTick) {
+      try {
+        await this.currentTick
+      } catch {
+        // already logged
+      }
+    }
+  }
+
+  async tick(): Promise<void> {
+    const claim = await this.lock.tryAcquire()
+    if (!claim) return
+
+    this.lock.startRefreshTimer()
+    try {
+      let cursor: string | null = claim.lastEventId
+      let drained = false
+      while (!drained) {
+        const page = await this.workosOrgService.listEvents({
+          events: [...AUTH_LOG_EVENT_TYPES],
+          ...(cursor ? { after: cursor } : {}),
+          limit: this.batchSize,
+        })
+        if (page.data.length === 0) {
+          drained = true
+          break
+        }
+        for (const event of page.data) {
+          try {
+            await this.authLogService.ingestEvent(event)
+          } catch (err) {
+            // A single un-ingestible event (malformed payload field, etc.) must
+            // not stall the cursor and halt the whole auth trail — the event
+            // stays fetchable from WorkOS for 90 days if a fix wants to
+            // re-ingest it. Log loudly and advance.
+            logger.error({ err, eventId: event.id, eventType: event.event }, "auth_log event ingest failed — skipping")
+          }
+          await this.lock.advance(event.id, new Date(event.createdAt))
+          cursor = event.id
+        }
+        if (page.after === null) {
+          drained = true
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error({ err }, "auth_log event poller tick failed")
+      const { shouldRetry } = await this.lock.recordError(message)
+      if (!shouldRetry) {
+        logger.error({ lastError: message }, "auth_log event poller exhausted retries — manual intervention required")
+      }
+    } finally {
+      this.lock.stopRefreshTimer()
+      await this.lock.release()
+    }
+  }
+
+  private scheduleNext(delayMs: number): void {
+    if (!this.running) return
+    this.tickTimer = setTimeout(() => {
+      this.tickTimer = null
+      this.currentTick = this.tick()
+        .catch((err) => {
+          logger.error({ err }, "auth_log event poller tick raised")
+        })
+        .finally(() => {
+          this.currentTick = null
+          this.scheduleNext(this.pollIntervalMs)
+        })
+    }, delayMs)
+  }
+}

--- a/apps/control-plane/src/features/auth-log/repository.ts
+++ b/apps/control-plane/src/features/auth-log/repository.ts
@@ -1,0 +1,61 @@
+import { authLogId, type Querier } from "@threa/backend-common"
+import type { AuthLogRowInput } from "./mapper"
+
+export const AuthLogRepository = {
+  /**
+   * Idempotent insert (INV-20). The partial unique index on `workos_event_id`
+   * backs `ON CONFLICT DO NOTHING`, so re-ingesting a replayed WorkOS event is
+   * a no-op. Own-handler rows carry a NULL event id (not indexed) and always
+   * insert. Returns true when a row was written.
+   */
+  async insert(db: Querier, row: AuthLogRowInput): Promise<boolean> {
+    const result = await db.query(
+      `INSERT INTO auth_log (
+         id,
+         occurred_at,
+         workos_event_id,
+         event_type,
+         workos_user_id,
+         email,
+         organization_id,
+         impersonator_email,
+         ip,
+         user_agent,
+         outcome,
+         detail
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+       ON CONFLICT (workos_event_id) WHERE workos_event_id IS NOT NULL DO NOTHING`,
+      [
+        authLogId(),
+        row.occurredAt,
+        row.workosEventId,
+        row.eventType,
+        row.workosUserId,
+        row.email,
+        row.organizationId,
+        row.impersonatorEmail,
+        row.ip,
+        row.userAgent,
+        row.outcome,
+        row.detail === null ? null : JSON.stringify(row.detail),
+      ]
+    )
+    return (result.rowCount ?? 0) > 0
+  },
+
+  /**
+   * Delete one batch of rows older than `cutoff` (INV-56 set-based). Returns
+   * the number deleted so the retention worker can loop until a short batch.
+   */
+  async deleteOlderThan(db: Querier, cutoff: Date, limit: number): Promise<number> {
+    const result = await db.query(
+      `DELETE FROM auth_log
+       WHERE id IN (
+         SELECT id FROM auth_log WHERE occurred_at < $1 LIMIT $2
+       )`,
+      [cutoff, limit]
+    )
+    return result.rowCount ?? 0
+  },
+}

--- a/apps/control-plane/src/features/auth-log/retention-worker.ts
+++ b/apps/control-plane/src/features/auth-log/retention-worker.ts
@@ -1,0 +1,94 @@
+import type { Pool } from "pg"
+import { Ticker, logger } from "@threa/backend-common"
+import { AuthLogRepository } from "./repository"
+
+export interface AuthLogRetentionWorkerConfig {
+  intervalMs: number
+  retentionMs: number
+  batchSize: number
+  maxBatchesPerRun: number
+}
+
+const DEFAULT_CONFIG: AuthLogRetentionWorkerConfig = {
+  intervalMs: 6 * 60 * 60 * 1000,
+  // 13 months (confirmed §10 decision 1). Approximated as 396 days.
+  retentionMs: 396 * 24 * 60 * 60 * 1000,
+  batchSize: 1000,
+  maxBatchesPerRun: 10,
+}
+
+/**
+ * Batched-DELETE retention for `auth_log`. The table is plain (not partitioned),
+ * so retention is a bounded `DELETE ... WHERE occurred_at < cutoff` loop rather
+ * than a partition drop. Same Ticker/start/stop shape as
+ * `OutboxRetentionWorker`; runs on every pod (idempotent, no leader election).
+ */
+export class AuthLogRetentionWorker {
+  private readonly ticker: Ticker
+  private readonly config: AuthLogRetentionWorkerConfig
+
+  constructor(
+    private readonly pool: Pool,
+    config: Partial<AuthLogRetentionWorkerConfig> = {}
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+
+    if (this.config.intervalMs <= 0) {
+      throw new Error(`AuthLogRetentionWorker intervalMs must be > 0, got ${this.config.intervalMs}`)
+    }
+    if (this.config.retentionMs <= 0) {
+      throw new Error(`AuthLogRetentionWorker retentionMs must be > 0, got ${this.config.retentionMs}`)
+    }
+    if (this.config.batchSize <= 0) {
+      throw new Error(`AuthLogRetentionWorker batchSize must be > 0, got ${this.config.batchSize}`)
+    }
+    if (this.config.maxBatchesPerRun <= 0) {
+      throw new Error(`AuthLogRetentionWorker maxBatchesPerRun must be > 0, got ${this.config.maxBatchesPerRun}`)
+    }
+
+    this.ticker = new Ticker({ name: "auth-log-retention", intervalMs: this.config.intervalMs, maxConcurrency: 1 })
+  }
+
+  start(): void {
+    this.ticker.start(() => this.cleanup())
+    logger.info(
+      { intervalMs: this.config.intervalMs, retentionMs: this.config.retentionMs },
+      "AuthLogRetentionWorker started"
+    )
+  }
+
+  async stop(): Promise<void> {
+    this.ticker.stop()
+    await this.ticker.drain()
+    logger.info("AuthLogRetentionWorker stopped")
+  }
+
+  isRunning(): boolean {
+    return this.ticker.isRunning()
+  }
+
+  async cleanup(): Promise<void> {
+    try {
+      const cutoff = new Date(Date.now() - this.config.retentionMs)
+      let totalDeleted = 0
+      let batches = 0
+
+      while (batches < this.config.maxBatchesPerRun) {
+        const deleted = await AuthLogRepository.deleteOlderThan(this.pool, cutoff, this.config.batchSize)
+        if (deleted === 0) break
+        totalDeleted += deleted
+        batches += 1
+        if (deleted < this.config.batchSize) break
+      }
+
+      if (totalDeleted > 0) {
+        logger.info(
+          { deleted: totalDeleted, batches, cutoff: cutoff.toISOString() },
+          "auth_log retention cleanup completed"
+        )
+      }
+    } catch (err) {
+      logger.error({ err }, "auth_log retention cleanup failed")
+    }
+  }
+}

--- a/apps/control-plane/src/features/auth-log/service.ts
+++ b/apps/control-plane/src/features/auth-log/service.ts
@@ -1,0 +1,103 @@
+import type { Pool } from "pg"
+import { logger, type WorkosEvent } from "@threa/backend-common"
+import {
+  AUTH_LOG_CP_BACKOFFICE_REQUEST,
+  AUTH_LOG_CP_CALLBACK_FAILED,
+  AUTH_LOG_CP_MAGIC_AUTH_VERIFY_FAILED,
+} from "./constants"
+import { mapWorkosEventToAuthLogRow } from "./mapper"
+import { AuthLogRepository } from "./repository"
+
+interface Dependencies {
+  pool: Pool
+}
+
+/** Client-supplied context for own-handler auth failure rows. */
+export interface AuthLogRequestContext {
+  email: string | null
+  ip: string | null
+  userAgent: string | null
+}
+
+/**
+ * Owns writes to `auth_log`. The poller feeds {@link ingestEvent} the WorkOS
+ * events it can see; the CP auth handlers feed the two failure recorders the
+ * rows WorkOS structurally cannot (AuthKit hosts the login UI, so exchange /
+ * verify failures never reach WorkOS as events).
+ *
+ * Own-handler recorders are best-effort: they never throw, so an audit-insert
+ * failure can't mask the real 401 the handler is about to return.
+ */
+export class AuthLogService {
+  private readonly pool: Pool
+
+  constructor({ pool }: Dependencies) {
+    this.pool = pool
+  }
+
+  /** Ingest one WorkOS event. Idempotent on `workos_event_id`. */
+  async ingestEvent(event: WorkosEvent): Promise<void> {
+    await AuthLogRepository.insert(this.pool, mapWorkosEventToAuthLogRow(event))
+  }
+
+  async recordCallbackFailure(ctx: AuthLogRequestContext): Promise<void> {
+    await this.recordOwnFailure(AUTH_LOG_CP_CALLBACK_FAILED, ctx)
+  }
+
+  /**
+   * One row per backoffice request — platform-admin access to customer data
+   * (workspace lists, member emails, invitations) must be forensically
+   * answerable, and WorkOS events only cover identity lifecycle, not what an
+   * admin actually read or changed. Best-effort: never throws.
+   */
+  async recordBackofficeRequest(params: {
+    workosUserId: string | null
+    email: string | null
+    ip: string | null
+    userAgent: string | null
+    outcome: "success" | "denied"
+    detail: { method: string; path: string; status: number }
+  }): Promise<void> {
+    try {
+      await AuthLogRepository.insert(this.pool, {
+        occurredAt: new Date(),
+        workosEventId: null,
+        eventType: AUTH_LOG_CP_BACKOFFICE_REQUEST,
+        workosUserId: params.workosUserId,
+        email: params.email,
+        organizationId: null,
+        impersonatorEmail: null,
+        ip: params.ip,
+        userAgent: params.userAgent,
+        outcome: params.outcome,
+        detail: params.detail,
+      })
+    } catch (err) {
+      logger.error({ err, path: params.detail.path }, "auth_log backoffice insert failed")
+    }
+  }
+
+  async recordMagicAuthVerifyFailure(ctx: AuthLogRequestContext): Promise<void> {
+    await this.recordOwnFailure(AUTH_LOG_CP_MAGIC_AUTH_VERIFY_FAILED, ctx)
+  }
+
+  private async recordOwnFailure(eventType: string, ctx: AuthLogRequestContext): Promise<void> {
+    try {
+      await AuthLogRepository.insert(this.pool, {
+        occurredAt: new Date(),
+        workosEventId: null,
+        eventType,
+        workosUserId: null,
+        email: ctx.email,
+        organizationId: null,
+        impersonatorEmail: null,
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+        outcome: "denied",
+        detail: null,
+      })
+    } catch (err) {
+      logger.error({ err, eventType }, "auth_log own-handler insert failed")
+    }
+  }
+}

--- a/apps/control-plane/src/features/auth-log/service.ts
+++ b/apps/control-plane/src/features/auth-log/service.ts
@@ -56,7 +56,7 @@ export class AuthLogService {
     ip: string | null
     userAgent: string | null
     outcome: "success" | "denied"
-    detail: { method: string; path: string; status: number }
+    detail: { method: string; path: string; status: number; aborted?: boolean }
   }): Promise<void> {
     try {
       await AuthLogRepository.insert(this.pool, {

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -12,7 +12,18 @@ import {
 } from "@threa/backend-common"
 import { MAGIC_CODE_LENGTH, ORIGINAL_HOST_HEADER, SOCIAL_PROVIDERS } from "@threa/types"
 import type { AccountsService } from "../accounts"
+import type { AuthLogRequestContext, AuthLogService } from "../auth-log"
 import { parseCallbackState, splitInnerState } from "./callback-state"
+
+/** Client ip + user-agent for own-handler auth_log rows. CP sets `trust proxy`. */
+function authLogContext(req: Request, email: string | null): AuthLogRequestContext {
+  const userAgent = req.headers["user-agent"]
+  return {
+    email,
+    ip: req.ip ?? null,
+    userAgent: typeof userAgent === "string" && userAgent.length > 0 ? userAgent : null,
+  }
+}
 
 const callbackSchema = z.object({
   code: z.string().min(1),
@@ -67,6 +78,8 @@ interface Dependencies {
    * e.g. the backoffice at admin.threa.io.
    */
   dedicatedRedirectHosts: string[]
+  /** Records the auth failures WorkOS structurally cannot see (best-effort). */
+  authLogService: AuthLogService
 }
 
 /**
@@ -99,6 +112,7 @@ export function createControlPlaneAuthHandlers({
   frontendUrl,
   allowedRedirectDomain,
   dedicatedRedirectHosts,
+  authLogService,
 }: Dependencies) {
   return {
     async login(req: Request, res: Response) {
@@ -168,6 +182,7 @@ export function createControlPlaneAuthHandlers({
       const result = await authService.authenticateWithCode(code)
 
       if (!result.success || !result.user || !result.sealedSession) {
+        void authLogService.recordCallbackFailure(authLogContext(req, null))
         throw new HttpError("Authentication failed", { status: 401, code: "AUTH_FAILED" })
       }
 
@@ -299,6 +314,7 @@ export function createControlPlaneAuthHandlers({
 
       const result = await authService.authenticateWithMagicAuth(email, code)
       if (!result.success || !result.user || !result.sealedSession) {
+        void authLogService.recordMagicAuthVerifyFailure(authLogContext(req, email))
         throw new HttpError("Invalid or expired code", { status: 401, code: "INVALID_CODE" })
       }
 

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -23,6 +23,7 @@ import {
   createInternalAuthzAdminHandlers,
   type WorkosAuthzAdminService,
 } from "./features/workos-authz"
+import { createBackofficeAuditMiddleware, type AuthLogService } from "./features/auth-log"
 import { createInternalAuthMiddleware } from "./lib/internal-auth"
 import type { RegionConfig } from "./config"
 
@@ -41,6 +42,7 @@ interface Dependencies {
   backofficeService: BackofficeService
   workosAuthzAdminService: WorkosAuthzAdminService
   featureFlagService: ControlPlaneFeatureFlagService
+  authLogService: AuthLogService
   internalApiKey: string
   allowDevAuthRoutes: boolean
   frontendUrl: string
@@ -61,6 +63,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     backofficeService,
     workosAuthzAdminService,
     featureFlagService,
+    authLogService,
     internalApiKey,
     allowDevAuthRoutes,
   } = deps
@@ -114,6 +117,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     frontendUrl: deps.frontendUrl,
     allowedRedirectDomain: deps.allowedRedirectDomain,
     dedicatedRedirectHosts: deps.workosDedicatedRedirectHosts,
+    authLogService,
   })
   const workspace = createWorkspaceHandlers({ workspaceService, shadowService })
   const shadow = createInvitationShadowHandlers({ shadowService })
@@ -199,6 +203,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // Backoffice app surface. `/me` returns both identity and admin status so
   // the frontend can render a friendly "not authorised" screen; every other
   // backoffice route is gated by requirePlatformAdmin.
+  // One mount covers the whole surface: platform-admin access to customer data
+  // is auth_log-audited per request (reads AND denials), since WorkOS events
+  // only cover identity lifecycle.
+  app.use("/api/backoffice", createBackofficeAuditMiddleware(authLogService))
   app.get("/api/backoffice/me", auth, backoffice.me)
   app.get("/api/backoffice/config", auth, requirePlatformAdmin, backoffice.getConfig)
   app.get("/api/backoffice/workspaces", auth, requirePlatformAdmin, backoffice.listWorkspaces)

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -60,6 +60,7 @@ import {
   OUTBOX_GITHUB_WEBHOOK_DISPATCH,
   type GithubWebhookDispatchPayload,
 } from "./features/github-webhooks"
+import { AuthLogService, AuthLogPoller, AuthLogRetentionWorker, AUTH_LOG_EVENT_POLLER_NAME } from "./features/auth-log"
 import { WorkosEventPollerLock } from "./lib/workos-event-poller-lock"
 import { CONTROL_PLANE_LISTENER_ID } from "./lib/outbox-listeners"
 
@@ -105,6 +106,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     : new StubWaitlistEmailSender()
   const waitlistService = new WaitlistService({ pool, emailSender: waitlistEmailSender })
   const workosAuthzAdminService = new WorkosAuthzAdminService({ pool, workosOrgService })
+  const authLogService = new AuthLogService({ pool })
   await seedPlatformAdmins(pool, config.platformAdminWorkosUserIds)
   // Re-emitting the fan-out for every seeded admin on each boot is the
   // self-heal path: idempotent snapshots, tiny N, and it converges regions
@@ -177,6 +179,8 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   // backfill, port bind) tears down the workers and pools we already spun up
   // — otherwise a crashed boot leaks intervals and connections.
   let authzPoller: WorkosAuthzPoller | undefined
+  let authLogPoller: AuthLogPoller | undefined
+  let authLogRetention: AuthLogRetentionWorker | undefined
   let server: Server | undefined
   try {
     await ensureListenerFromLatest(pool, LISTENER_ID)
@@ -228,6 +232,30 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     }
     authzPoller.start()
 
+    // Second WorkOS-event cursor consumer: auth_log ingestion. Own lease row
+    // ('auth-log-events') on the shared workos_event_poller_state table, so it
+    // advances independently of the authz mirror.
+    const authLogLock = new WorkosEventPollerLock({
+      pool,
+      name: AUTH_LOG_EVENT_POLLER_NAME,
+      lockDurationMs: 10_000,
+      refreshIntervalMs: 5_000,
+      maxRetries: 5,
+      baseBackoffMs: 1_000,
+    })
+    await authLogLock.ensureRow()
+    authLogPoller = new AuthLogPoller({
+      workosOrgService,
+      authLogService,
+      lock: authLogLock,
+      pollIntervalMs: 5_000,
+      batchSize: 100,
+    })
+    authLogPoller.start()
+
+    authLogRetention = new AuthLogRetentionWorker(pool)
+    authLogRetention.start()
+
     const isProduction = process.env.NODE_ENV === "production"
     const app = createApp({ corsAllowedOrigins: config.corsAllowedOrigins })
 
@@ -240,6 +268,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       backofficeService,
       workosAuthzAdminService,
       featureFlagService,
+      authLogService,
       internalApiKey: config.internalApiKey,
       allowDevAuthRoutes: config.useStubAuth && !isProduction,
       frontendUrl: config.frontendUrl,
@@ -264,16 +293,20 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   } catch (err) {
     await authzPoller?.stop().catch(() => {})
     await githubWebhookRetention.stop().catch(() => {})
+    await authLogPoller?.stop().catch(() => {})
+    await authLogRetention?.stop().catch(() => {})
     await outboxDispatcher.stop().catch(() => {})
     await listenPool.end().catch(() => {})
     await pool.end().catch(() => {})
     throw err
   }
 
-  // The try/catch above either returned with both set or rethrew, so we can
-  // narrow safely here without runtime checks.
+  // The try/catch above either returned with all four set or rethrew, so we
+  // can narrow safely here without runtime checks.
   const startedServer = server
   const startedPoller = authzPoller
+  const startedAuthLogPoller = authLogPoller
+  const startedAuthLogRetention = authLogRetention
 
   const stop = async () => {
     if (config.fastShutdown) {
@@ -281,6 +314,8 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       startedServer.close()
       await startedPoller.stop()
       await githubWebhookRetention.stop()
+      await startedAuthLogPoller.stop()
+      await startedAuthLogRetention.stop()
       await outboxDispatcher.stop()
       await listenPool.end()
       await pool.end()
@@ -295,6 +330,8 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     }
     await startedPoller.stop()
     await githubWebhookRetention.stop()
+    await startedAuthLogPoller.stop()
+    await startedAuthLogRetention.stop()
     await outboxDispatcher.stop()
     await listenPool.end()
     await pool.end()

--- a/apps/control-plane/tests/integration/auth-log-backoffice.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-backoffice.test.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "events"
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import type { Request, Response } from "express"
+import { AuthLogService, createBackofficeAuditMiddleware } from "../../src/features/auth-log"
+import { setupTestDatabase } from "./setup"
+
+function fakeReqRes(overrides: Partial<Request>): { req: Request; res: Response & EventEmitter } {
+  const req = {
+    method: "GET",
+    path: "/workspaces/ws_1/members",
+    ip: "203.0.113.5",
+    headers: { "user-agent": "backoffice-ua" },
+    ...overrides,
+  } as unknown as Request
+  const res = new EventEmitter() as Response & EventEmitter
+  ;(res as { statusCode: number }).statusCode = 200
+  return { req, res }
+}
+
+describe("backoffice audit middleware", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function pollRow(where: string, params: unknown[]): Promise<Record<string, unknown> | null> {
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const { rows } = await pool.query(
+        `SELECT workos_user_id, email, outcome, detail FROM auth_log
+         WHERE event_type = 'cp.backoffice_request' AND ${where} ORDER BY occurred_at DESC LIMIT 1`,
+        params
+      )
+      if (rows.length > 0) return rows[0]
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    return null
+  }
+
+  test("records an admin read with identity, path detail, and success outcome", async () => {
+    const service = new AuthLogService({ pool })
+    const middleware = createBackofficeAuditMiddleware(service)
+    const { req, res } = fakeReqRes({
+      workosUserId: "user_admin_1",
+      authUser: { id: "user_admin_1", email: "admin@threa.io" },
+    } as Partial<Request>)
+
+    middleware(req, res, () => {})
+    res.emit("finish")
+
+    const row = await pollRow("workos_user_id = $1", ["user_admin_1"])
+    expect(row).toMatchObject({
+      workos_user_id: "user_admin_1",
+      email: "admin@threa.io",
+      outcome: "success",
+      detail: { method: "GET", path: "/workspaces/ws_1/members", status: 200 },
+    })
+  })
+
+  test("records a denied hit without identity", async () => {
+    const service = new AuthLogService({ pool })
+    const middleware = createBackofficeAuditMiddleware(service)
+    const { req, res } = fakeReqRes({ path: "/config", ip: "203.0.113.9" })
+    ;(res as { statusCode: number }).statusCode = 403
+
+    middleware(req, res, () => {})
+    res.emit("finish")
+
+    const row = await pollRow("detail->>'path' = $1 AND outcome = 'denied'", ["/config"])
+    expect(row).toMatchObject({
+      workos_user_id: null,
+      outcome: "denied",
+      detail: { method: "GET", path: "/config", status: 403 },
+    })
+  })
+})

--- a/apps/control-plane/tests/integration/auth-log-callback-failure.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-callback-failure.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { Request, Response } from "express"
+import { HttpError, type AuthService } from "@threa/backend-common"
+import { createControlPlaneAuthHandlers } from "../../src/features/auth"
+import type { AccountsService } from "../../src/features/accounts"
+import type { AuthLogService } from "../../src/features/auth-log"
+
+describe("CP auth callback failure → auth_log own-handler row", () => {
+  function makeHandlers(recordCallbackFailure: ReturnType<typeof mock>) {
+    const authService = {
+      authenticateWithCode: mock(async () => ({ success: false })),
+    } as unknown as AuthService
+    const authLogService = { recordCallbackFailure } as unknown as AuthLogService
+    return createControlPlaneAuthHandlers({
+      authService,
+      accountsService: {} as unknown as AccountsService,
+      frontendUrl: "https://app.example.com",
+      allowedRedirectDomain: "example.com",
+      dedicatedRedirectHosts: [],
+      authLogService,
+    })
+  }
+
+  test("records a denied callback-failure row (ip/user-agent from req) before throwing 401", async () => {
+    const recordCallbackFailure = mock(async () => {})
+    const handlers = makeHandlers(recordCallbackFailure)
+
+    const req = {
+      query: { code: "bad-code" },
+      body: {},
+      headers: { "user-agent": "Mozilla/5.0" },
+      ip: "203.0.113.7",
+      cookies: {},
+    } as unknown as Request
+    const res = { redirect: mock(() => {}), json: mock(() => {}) } as unknown as Response
+
+    await expect(handlers.callback(req, res)).rejects.toMatchObject({
+      status: 401,
+      code: "AUTH_FAILED",
+    } satisfies Partial<HttpError>)
+
+    expect(recordCallbackFailure).toHaveBeenCalledTimes(1)
+    expect(recordCallbackFailure).toHaveBeenCalledWith({
+      email: null,
+      ip: "203.0.113.7",
+      userAgent: "Mozilla/5.0",
+    })
+  })
+
+  test("records a denied magic-auth-verify-failure row with the attempted email before throwing 401", async () => {
+    const recordMagicAuthVerifyFailure = mock(async () => {})
+    const authService = {
+      authenticateWithMagicAuth: mock(async () => ({ success: false })),
+    } as unknown as AuthService
+    const authLogService = { recordMagicAuthVerifyFailure } as unknown as AuthLogService
+    const handlers = createControlPlaneAuthHandlers({
+      authService,
+      accountsService: {} as unknown as AccountsService,
+      frontendUrl: "https://app.example.com",
+      allowedRedirectDomain: "example.com",
+      dedicatedRedirectHosts: [],
+      authLogService,
+    })
+
+    const req = {
+      query: {},
+      body: { email: "probe@example.com", code: "000000", intent: "add" },
+      headers: { "user-agent": "Mozilla/5.0" },
+      ip: "203.0.113.9",
+      cookies: {},
+    } as unknown as Request
+    const res = { redirect: mock(() => {}), json: mock(() => {}) } as unknown as Response
+
+    await expect(handlers.magicVerify(req, res)).rejects.toMatchObject({
+      status: 401,
+      code: "INVALID_CODE",
+    } satisfies Partial<HttpError>)
+
+    expect(recordMagicAuthVerifyFailure).toHaveBeenCalledTimes(1)
+    expect(recordMagicAuthVerifyFailure).toHaveBeenCalledWith({
+      email: "probe@example.com",
+      ip: "203.0.113.9",
+      userAgent: "Mozilla/5.0",
+    })
+  })
+})

--- a/apps/control-plane/tests/integration/auth-log-mapper.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-mapper.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test"
+import type { WorkosEvent } from "@threa/backend-common"
+import { mapWorkosEventToAuthLogRow } from "../../src/features/auth-log"
+
+function event(partial: { id: string; event: string; createdAt?: string; data: Record<string, unknown> }): WorkosEvent {
+  return {
+    id: partial.id,
+    event: partial.event,
+    createdAt: partial.createdAt ?? "2026-07-18T10:00:00.000Z",
+    context: undefined,
+    data: partial.data,
+  } as unknown as WorkosEvent
+}
+
+describe("mapWorkosEventToAuthLogRow", () => {
+  test("authentication.password_failed → denied, extracts identity, content-free detail", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_pw_failed",
+        event: "authentication.password_failed",
+        data: {
+          email: "alice@example.com",
+          userId: "user_alice",
+          ipAddress: "203.0.113.9",
+          userAgent: "Mozilla/5.0",
+          type: "password",
+          status: "failed",
+          error: { code: "invalid_credentials", message: "wrong password for alice" },
+        },
+      })
+    )
+
+    expect(row).toEqual({
+      occurredAt: new Date("2026-07-18T10:00:00.000Z"),
+      workosEventId: "event_pw_failed",
+      eventType: "authentication.password_failed",
+      workosUserId: "user_alice",
+      email: "alice@example.com",
+      organizationId: null,
+      impersonatorEmail: null,
+      ip: "203.0.113.9",
+      userAgent: "Mozilla/5.0",
+      outcome: "denied",
+      detail: { type: "password", status: "failed", errorCode: "invalid_credentials" },
+    })
+    // The free-text error message is content and must never be persisted.
+    expect(JSON.stringify(row.detail)).not.toContain("wrong password")
+  })
+
+  test("authentication.radar_risk_detected → success (a flagged but successful sign-in)", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_radar",
+        event: "authentication.radar_risk_detected",
+        data: { email: "bob@example.com", userId: "user_bob", action: "login", ipAddress: "198.51.100.2" },
+      })
+    )
+    expect(row.outcome).toBe("success")
+    expect(row.detail).toEqual({ action: "login" })
+  })
+
+  test("authentication.sso_succeeded reads organizationId from the nested sso object", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_sso",
+        event: "authentication.sso_succeeded",
+        data: {
+          email: "frank@example.com",
+          userId: "user_frank",
+          sso: { connectionId: "conn_1", organizationId: "org_sso" },
+          ipAddress: "203.0.113.9",
+        },
+      })
+    )
+    expect(row.outcome).toBe("success")
+    expect(row.workosUserId).toBe("user_frank")
+    expect(row.organizationId).toBe("org_sso")
+  })
+
+  test("session.created maps impersonator → impersonatorEmail (success)", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_session",
+        event: "session.created",
+        data: {
+          object: "session",
+          id: "session_1",
+          userId: "user_carol",
+          organizationId: "org_acme",
+          ipAddress: "192.0.2.5",
+          userAgent: "curl/8",
+          authMethod: "impersonation",
+          status: "active",
+          impersonator: { email: "operator@workos.com", reason: "customer requested debugging of billing" },
+        },
+      })
+    )
+    expect(row.outcome).toBe("success")
+    expect(row.workosUserId).toBe("user_carol")
+    expect(row.organizationId).toBe("org_acme")
+    expect(row.impersonatorEmail).toBe("operator@workos.com")
+    expect(row.detail).toEqual({ authMethod: "impersonation", status: "active" })
+    // The impersonation reason is operator free-text — never persisted.
+    expect(JSON.stringify(row)).not.toContain("customer requested")
+  })
+
+  test("user.created reads user id from data.id (object==='user')", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_user",
+        event: "user.created",
+        data: { object: "user", id: "user_dave", email: "dave@example.com" },
+      })
+    )
+    expect(row.outcome).toBe("success")
+    expect(row.workosUserId).toBe("user_dave")
+    expect(row.email).toBe("dave@example.com")
+    expect(row.detail).toBeNull()
+  })
+
+  test("invitation.created carries email + organizationId", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_invite",
+        event: "invitation.created",
+        data: { object: "invitation", id: "inv_1", email: "eve@example.com", organizationId: "org_beta" },
+      })
+    )
+    expect(row.email).toBe("eve@example.com")
+    expect(row.organizationId).toBe("org_beta")
+    expect(row.workosUserId).toBeNull()
+    expect(row.outcome).toBe("success")
+  })
+
+  test("api_key.created reads org from owner.id", () => {
+    const row = mapWorkosEventToAuthLogRow(
+      event({
+        id: "event_apikey",
+        event: "api_key.created",
+        data: { object: "api_key", id: "key_1", owner: { type: "organization", id: "org_gamma" } },
+      })
+    )
+    expect(row.organizationId).toBe("org_gamma")
+    expect(row.outcome).toBe("success")
+  })
+})

--- a/apps/control-plane/tests/integration/auth-log-poller.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-poller.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { StubWorkosOrgService, type WorkosEvent } from "@threa/backend-common"
+import { AuthLogPoller, AuthLogService } from "../../src/features/auth-log"
+import { WorkosEventPollerLock } from "../../src/lib/workos-event-poller-lock"
+import { setupTestDatabase } from "./setup"
+
+describe("AuthLogPoller", () => {
+  let pool: Pool
+  const lockName = "test-auth-log-events-poller"
+  const eventIds = ["event_al_01", "event_al_02", "event_al_03"]
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM workos_event_poller_state WHERE name = $1", [lockName])
+    await pool.query("DELETE FROM auth_log WHERE workos_event_id = ANY($1)", [eventIds])
+  })
+
+  function rawEvent(id: string, type: string, data: Record<string, unknown>): WorkosEvent {
+    return {
+      id,
+      event: type,
+      createdAt: "2026-07-18T10:00:00.000Z",
+      context: undefined,
+      data,
+    } as unknown as WorkosEvent
+  }
+
+  function makeStack({ batchSize = 10 }: { batchSize?: number } = {}) {
+    const stub = new StubWorkosOrgService()
+    const lock = new WorkosEventPollerLock({
+      pool,
+      name: lockName,
+      lockDurationMs: 5_000,
+      refreshIntervalMs: 1_000,
+      maxRetries: 3,
+      baseBackoffMs: 100,
+    })
+    const service = new AuthLogService({ pool })
+    const poller = new AuthLogPoller({
+      workosOrgService: stub,
+      authLogService: service,
+      lock,
+      pollIntervalMs: 50,
+      batchSize,
+    })
+    return { stub, lock, service, poller }
+  }
+
+  async function countRows(): Promise<number> {
+    const res = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM auth_log WHERE workos_event_id = ANY($1)",
+      [eventIds]
+    )
+    return Number(res.rows[0].count)
+  }
+
+  test("processes a page, advances cursor, and re-ingesting the same events inserts nothing new", async () => {
+    const { stub, lock, poller } = makeStack({ batchSize: 2 })
+    await lock.ensureRow()
+
+    stub.pushEvent(rawEvent(eventIds[0], "authentication.password_failed", { email: "a@x.com", userId: "user_a" }))
+    stub.pushEvent(
+      rawEvent(eventIds[1], "session.created", {
+        object: "session",
+        userId: "user_b",
+        impersonator: { email: "op@workos.com", reason: "debug" },
+      })
+    )
+    stub.pushEvent(rawEvent(eventIds[2], "user.created", { object: "user", id: "user_c", email: "c@x.com" }))
+
+    await poller.tick()
+
+    expect(await countRows()).toBe(3)
+
+    const cursor = await pool.query<{ last_event_id: string | null; locked_until: Date | null }>(
+      "SELECT last_event_id, locked_until FROM workos_event_poller_state WHERE name = $1",
+      [lockName]
+    )
+    expect(cursor.rows[0]).toMatchObject({ last_event_id: eventIds[2], locked_until: null })
+
+    const denied = await pool.query<{ outcome: string }>("SELECT outcome FROM auth_log WHERE workos_event_id = $1", [
+      eventIds[0],
+    ])
+    expect(denied.rows[0].outcome).toBe("denied")
+
+    const impersonated = await pool.query<{ impersonator_email: string | null }>(
+      "SELECT impersonator_email FROM auth_log WHERE workos_event_id = $1",
+      [eventIds[1]]
+    )
+    expect(impersonated.rows[0].impersonator_email).toBe("op@workos.com")
+
+    // Second run: cursor already at the tail, but even a full replay is a no-op
+    // because the repository dedupes on workos_event_id.
+    await poller.tick()
+    expect(await countRows()).toBe(3)
+  })
+
+  test("replay from a reset cursor still dedupes on event id", async () => {
+    const { stub, lock, poller } = makeStack()
+    await lock.ensureRow()
+
+    stub.pushEvent(rawEvent(eventIds[0], "session.created", { object: "session", userId: "user_a" }))
+    await poller.tick()
+    expect(await countRows()).toBe(1)
+
+    // Simulate a cursor rewind (operator re-ingestion). The same page returns;
+    // ON CONFLICT DO NOTHING keeps the row count flat.
+    await pool.query("UPDATE workos_event_poller_state SET last_event_id = NULL WHERE name = $1", [lockName])
+    await poller.tick()
+    expect(await countRows()).toBe(1)
+  })
+
+  test("an un-ingestible event is skipped with the cursor advanced, not a stall", async () => {
+    const { stub, lock, poller } = makeStack()
+    await lock.ensureRow()
+
+    // Malformed ipAddress → INET insert throws for this event only.
+    stub.pushEvent(
+      rawEvent(eventIds[0], "authentication.password_failed", { email: "bad@x.com", ipAddress: "not-an-ip" })
+    )
+    stub.pushEvent(rawEvent(eventIds[1], "user.created", { object: "user", id: "user_ok", email: "ok@x.com" }))
+
+    await poller.tick()
+
+    // The bad event produced no row, the good one landed, and the cursor moved
+    // past both — the auth trail keeps flowing.
+    expect(await countRows()).toBe(1)
+    const cursor = await pool.query<{ last_event_id: string | null }>(
+      "SELECT last_event_id FROM workos_event_poller_state WHERE name = $1",
+      [lockName]
+    )
+    expect(cursor.rows[0].last_event_id).toBe(eventIds[1])
+  })
+})

--- a/apps/control-plane/tests/integration/auth-log-repository.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-repository.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { AuthLogRepository } from "../../src/features/auth-log"
+import type { AuthLogRowInput } from "../../src/features/auth-log"
+import { setupTestDatabase } from "./setup"
+
+describe("AuthLogRepository", () => {
+  let pool: Pool
+  const eventId = "event_repo_idempotency"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM auth_log WHERE workos_event_id = $1 OR workos_event_id IS NULL", [eventId])
+  })
+
+  function row(overrides: Partial<AuthLogRowInput> = {}): AuthLogRowInput {
+    return {
+      occurredAt: new Date("2026-07-18T10:00:00.000Z"),
+      workosEventId: eventId,
+      eventType: "session.created",
+      workosUserId: "user_x",
+      email: "x@example.com",
+      organizationId: "org_x",
+      impersonatorEmail: null,
+      ip: "203.0.113.1",
+      userAgent: "agent",
+      outcome: "success",
+      detail: { authMethod: "password" },
+      ...overrides,
+    }
+  }
+
+  test("same workos_event_id inserted twice yields one row (ON CONFLICT DO NOTHING)", async () => {
+    const first = await AuthLogRepository.insert(pool, row())
+    const second = await AuthLogRepository.insert(pool, row({ email: "changed@example.com" }))
+
+    expect(first).toBe(true)
+    expect(second).toBe(false)
+
+    const count = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM auth_log WHERE workos_event_id = $1",
+      [eventId]
+    )
+    expect(Number(count.rows[0].count)).toBe(1)
+
+    const stored = await pool.query<{ email: string; ip: string; detail: unknown }>(
+      "SELECT email, host(ip) AS ip, detail FROM auth_log WHERE workos_event_id = $1",
+      [eventId]
+    )
+    expect(stored.rows[0].email).toBe("x@example.com")
+    expect(stored.rows[0].ip).toBe("203.0.113.1")
+    expect(stored.rows[0].detail).toEqual({ authMethod: "password" })
+  })
+
+  test("own-handler rows (NULL event id) always insert and never dedupe", async () => {
+    const a = await AuthLogRepository.insert(pool, row({ workosEventId: null, eventType: "cp.callback_failed" }))
+    const b = await AuthLogRepository.insert(pool, row({ workosEventId: null, eventType: "cp.callback_failed" }))
+    expect(a).toBe(true)
+    expect(b).toBe(true)
+
+    const count = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM auth_log WHERE workos_event_id IS NULL AND event_type = 'cp.callback_failed'"
+    )
+    expect(Number(count.rows[0].count)).toBe(2)
+  })
+})

--- a/apps/control-plane/tests/integration/auth-log-retention.test.ts
+++ b/apps/control-plane/tests/integration/auth-log-retention.test.ts
@@ -1,0 +1,34 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { authLogId } from "@threa/backend-common"
+import { AuthLogRetentionWorker } from "../../src/features/auth-log"
+import { setupTestDatabase } from "./setup"
+
+describe("AuthLogRetentionWorker", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("cleanup deletes rows past the retention horizon and spares fresh ones", async () => {
+    const oldId = authLogId()
+    const freshId = authLogId()
+    await pool.query(
+      `INSERT INTO auth_log (id, occurred_at, event_type, outcome)
+       VALUES ($1, now() - interval '400 days', 'user.created', 'success'),
+              ($2, now(), 'user.created', 'success')`,
+      [oldId, freshId]
+    )
+
+    const worker = new AuthLogRetentionWorker(pool, { retentionMs: 396 * 24 * 60 * 60 * 1000 })
+    await worker.cleanup()
+
+    const { rows } = await pool.query<{ id: string }>("SELECT id FROM auth_log WHERE id = ANY($1)", [[oldId, freshId]])
+    expect(rows.map((r) => r.id)).toEqual([freshId])
+  })
+})

--- a/apps/db-read-proxy/src/app.ts
+++ b/apps/db-read-proxy/src/app.ts
@@ -74,10 +74,6 @@ export function createApp({ pool, config }: CreateAppOptions): Express {
         statementTimeoutMs: config.statementTimeoutMs,
         maxRows: config.maxRows,
       })
-      logger.info(
-        { rowCount: result.rowCount, truncated: result.truncated, durationMs: result.durationMs },
-        "db-read-proxy query ok"
-      )
       res.json(result)
     } catch (err) {
       if (err instanceof QueryValidationError) {

--- a/apps/db-read-proxy/src/query.ts
+++ b/apps/db-read-proxy/src/query.ts
@@ -185,13 +185,19 @@ export async function executeReadOnly(req: QueryRequest, opts: ExecuteOptions): 
     const allRows = result.rows
     const truncated = WRAPPABLE_KEYWORDS.has(keyword) && allRows.length > opts.maxRows
     const rows = truncated ? allRows.slice(0, opts.maxRows) : allRows
+    const durationMs = Math.round(performance.now() - start)
+
+    // Log every executed query's SQL (§7.6) — the prod pool is BEGIN READ ONLY,
+    // so structured stdout is the only durable record. Both success and failure
+    // logging live in this one function; app.ts does not re-log the success.
+    logger.info({ sql, rowCount: rows.length, truncated, durationMs }, "db-read-proxy query ok")
 
     return {
       columns: result.fields.map((f) => f.name),
       rows,
       rowCount: rows.length,
       truncated,
-      durationMs: Math.round(performance.now() - start),
+      durationMs,
     }
   } catch (err) {
     try {

--- a/apps/db-read-proxy/tests/query-success-log.test.ts
+++ b/apps/db-read-proxy/tests/query-success-log.test.ts
@@ -1,0 +1,34 @@
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test"
+import { Pool } from "pg"
+import { logger } from "@threa/backend-common"
+import { executeReadOnly } from "../src/query"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL ?? "postgresql://threa:threa@localhost:5454/postgres"
+
+describe("executeReadOnly success logging", () => {
+  const pool = new Pool({ connectionString: TEST_DATABASE_URL })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  afterEach(() => {
+    spyOn(logger, "info").mockRestore()
+  })
+
+  test("logs the executed SQL, rowCount, truncated, and duration on success", async () => {
+    const infoSpy = spyOn(logger, "info")
+
+    const result = await executeReadOnly({ sql: "SELECT 1 AS n" }, { pool, statementTimeoutMs: 5_000, maxRows: 100 })
+
+    expect(result.rowCount).toBe(1)
+
+    const okCall = infoSpy.mock.calls.find(([, msg]) => msg === "db-read-proxy query ok")
+    expect(okCall).toBeDefined()
+    const [fields] = okCall as [Record<string, unknown>, string]
+    expect(fields.sql).toBe("SELECT 1 AS n")
+    expect(fields.rowCount).toBe(1)
+    expect(fields.truncated).toBe(false)
+    expect(typeof fields.durationMs).toBe("number")
+  })
+})

--- a/packages/backend-common/src/auth/workos-org-service.stub.ts
+++ b/packages/backend-common/src/auth/workos-org-service.stub.ts
@@ -1,4 +1,5 @@
 import { ulid } from "ulid"
+import type { Event, EventName } from "@workos-inc/node"
 import { logger } from "../logger"
 import type {
   WorkosAppInvitation,
@@ -18,6 +19,12 @@ export class StubWorkosOrgService implements WorkosOrgService {
    * `pushMirrorEvent` and the poller drains via `listMirrorEvents`.
    */
   private mirrorEvents: WorkosMembershipEvent[] = []
+  /**
+   * Test helper: in-memory stack of raw WorkOS events for the `auth_log`
+   * consumer. Tests push with `pushEvent` and the poller drains via
+   * `listEvents`.
+   */
+  private rawEvents: Event[] = []
   /**
    * Test helper: per-org membership listing returned by backfill. Tests seed
    * it via `setOrganizationMemberships`.
@@ -217,6 +224,18 @@ export class StubWorkosOrgService implements WorkosOrgService {
     return { data: slice, after: next }
   }
 
+  async listEvents(params: {
+    events: EventName[]
+    after?: string
+    limit?: number
+  }): Promise<{ data: Event[]; after: string | null }> {
+    const filtered = this.rawEvents.filter((e) => (params.events as readonly string[]).includes(e.event))
+    const startIdx = params.after ? filtered.findIndex((e) => e.id === params.after) + 1 : 0
+    const slice = filtered.slice(startIdx, startIdx + (params.limit ?? 100))
+    const next = startIdx + slice.length < filtered.length ? (slice[slice.length - 1]?.id ?? null) : null
+    return { data: slice, after: next }
+  }
+
   async listOrganizationMemberships(organizationId: string): Promise<WorkosOrganizationMembership[]> {
     return [...(this.membershipsByOrg.get(organizationId) ?? [])]
   }
@@ -224,6 +243,16 @@ export class StubWorkosOrgService implements WorkosOrgService {
   /** Test helper: append a mirror event to the stub queue. */
   pushMirrorEvent(event: WorkosMembershipEvent): void {
     this.mirrorEvents.push(event)
+  }
+
+  /** Test helper: append a raw WorkOS event to the `listEvents` queue. */
+  pushEvent(event: Event): void {
+    this.rawEvents.push(event)
+  }
+
+  /** Test helper: clear all queued raw events. */
+  clearEvents(): void {
+    this.rawEvents = []
   }
 
   /** Test helper: replace the membership listing for an organization. */

--- a/packages/backend-common/src/auth/workos-org-service.ts
+++ b/packages/backend-common/src/auth/workos-org-service.ts
@@ -1,4 +1,4 @@
-import { WorkOS } from "@workos-inc/node"
+import { WorkOS, type Event, type EventName } from "@workos-inc/node"
 import { logger } from "../logger"
 import { WORKOS_REQUEST_TIMEOUT_MS, type WorkosConfig } from "./types"
 
@@ -135,6 +135,17 @@ export interface WorkosOrgService {
     after?: string
     limit?: number
   }): Promise<{ data: WorkosMembershipEvent[]; after: string | null }>
+  /**
+   * List raw WorkOS events for a caller-supplied event set. Unlike
+   * {@link listMirrorEvents} (which decodes membership payloads for the authz
+   * mirror), this returns the SDK events unmodified so a second consumer — the
+   * control-plane `auth_log` ingestion — can extract its own fields.
+   */
+  listEvents(params: {
+    events: EventName[]
+    after?: string
+    limit?: number
+  }): Promise<{ data: Event[]; after: string | null }>
   /**
    * List every membership for an organization, paginated to completion. Used
    * by backfill — low-frequency, run by an explicit operator action.
@@ -406,6 +417,19 @@ export class WorkosOrgServiceImpl implements WorkosOrgService {
       if (decoded) data.push(decoded)
     }
     return { data, after: page.listMetadata.after ?? null }
+  }
+
+  async listEvents(params: {
+    events: EventName[]
+    after?: string
+    limit?: number
+  }): Promise<{ data: Event[]; after: string | null }> {
+    const page = await this.workos.events.listEvents({
+      events: params.events,
+      ...(params.after ? { after: params.after } : {}),
+      ...(params.limit ? { limit: params.limit } : {}),
+    })
+    return { data: page.data, after: page.listMetadata.after ?? null }
   }
 
   async listOrganizationMemberships(organizationId: string): Promise<WorkosOrganizationMembership[]> {


### PR DESCRIPTION
> **Restructured into a 5-PR stack** (stack #1407) for reviewability — this PR is now the **top layer** (control-plane scope only, 23 files, +1,349/−8). The stack, bottom-up:
> 1. #1403 — core: partitioned `access_log`, partition machinery, repo/service
> 2. #1404 — HTTP capture: audit middleware, ~250 route annotations, coverage guard
> 3. #1405 — sockets: `sconn_` intervals, bot WS verbs, delivered-set reconstruction
> 4. #1406 — AI egress: `AccessLogSink` in `createAI`, at-send disclose, subjectRefs
> 5. **this PR** — CP `auth_log` + WorkOS ingestion + backoffice audit + db-read-proxy
>
> The combined tree is **byte-identical** to the previously reviewed monolithic branch — the six-layer review history in this PR's comments (24-agent adversarial review, Opus+CodeRabbit 7/7, Fable gate, GPT-5.6-Sol, Fable round 2) applies to the whole stack. Design + as-built record: [`docs/plans/read-access-logging.md`](https://github.com/threahq/threa/blob/feat/read-access-logging/docs/plans/read-access-logging.md) (§11).

## Problem

Control-plane auth had zero logging: AuthKit hosts the login UI, so authentication *failures* and `session.created`'s **`impersonator`** field (WorkOS dashboard impersonation — an operator-access path nothing in our stack recorded) exist only as WorkOS events, which WorkOS retains for **90 days** vs our 13-month horizon. Platform-admin backoffice reads of customer data and the db-read-proxy's successful prod queries were equally invisible.

## Solution

### How it works

1. **Plain `auth_log` table** (`015_auth_log.sql`) — deliberately non-partitioned: a partitioned table cannot carry a unique index omitting the partition key, which would break pure event-id idempotency, the load-bearing property for replayable ingestion. Partial `UNIQUE INDEX ... WHERE workos_event_id IS NOT NULL` backs `ON CONFLICT DO NOTHING`; batched-DELETE 13-month retention worker (auth volume is tiny).
2. **`AuthLogPoller`** — second cursor consumer beside the authz mirror (own row in the name-keyed `workos_event_poller_state`, no migration needed), via a generic `listEvents` on `WorkosOrgService`. 31-event set validated against the SDK's `EventName` union (`as const satisfies`). Mapping: `*_failed` → `denied`, `radar_risk_detected` → `success` (flagged-but-successful sign-in), `session.created` → `impersonator_email`. `detail` is a curated scalar allowlist — never tokens, codes, or free text (tests assert absence). Un-ingestible events **skip-and-advance** with a loud error: one poisoned payload cannot stall the entire auth trail (the event stays re-fetchable from WorkOS for 90 days).
3. **Own-handler rows** for the two failures WorkOS structurally cannot see: callback-exchange failure and magic-auth verify failure — fire-and-forget `denied` rows with attempted email + IP.
4. **Backoffice audit** — one `app.use("/api/backoffice", ...)` mount records every platform-admin request (reads AND denials) as `cp.backoffice_request` rows with method/path/status detail; WorkOS events cover identity lifecycle, not what an admin actually accessed.
5. **db-read-proxy** — the success path now logs every executed query's SQL + duration + rowCount (previously failures only), colocated in `executeReadOnly`; closes the biggest observability hole in the out-of-band prod-read path (audit G-30).

## Test plan

- [x] CP integration — 140 pass / 0 fail (mapper per event category incl. impersonator + no-token assertions, repository idempotency, poller cursor advance + skip-on-error, retention, both failure recorders, backoffice rows)
- [x] db-read-proxy — 24 pass / 0 fail
- [x] backend-common typecheck + tests (generic `listEvents` + stub)
- [x] Stack-wide: each layer typechecks and passes its suites independently; combined tree verified byte-identical to the reviewed monolith
- [ ] Deploy-day watch (whole stack): first partitioned-table migration + `PartitionMaintenanceWorker` first tick (#1403), `AuthLogPoller` first WorkOS ingestion (this PR)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
