### PR TITLE
fix: decode HTML entities in <title> fallback for link previews

### DIFF
--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -217,6 +217,27 @@ describe("parseHtmlMeta", () => {
     expect(result.title).toBe('Tom & Jerry\'s "Show"')
   })
 
+  test("decodes named entities in <title> fallback including em dash and apostrophe", async () => {
+    const html = `
+      <html><head>
+        <title>Voice &amp; Video &mdash; Plan</title>
+      </head></html>
+    `
+    const result = await parseHtmlMeta(html, baseUrl)
+    expect(result.title).toBe("Voice & Video — Plan")
+  })
+
+  test("og:title takes priority over <title> when both exist", async () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="OG Wins">
+        <title>Page Title - Should Not Appear</title>
+      </head></html>
+    `
+    const result = await parseHtmlMeta(html, baseUrl)
+    expect(result.title).toBe("OG Wins")
+  })
+
   test("truncates long titles", async () => {
     const longTitle = "A".repeat(500)
     const html = `

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -415,7 +415,7 @@ export async function parseHtmlMeta(html: string, url: string): Promise<UpdateLi
   // HTMLRewriter requires consuming the transformed response to trigger handlers
   await rewriter.transform(new Response(html)).text()
 
-  const title = decode(meta["og:title"]) ?? decode(meta["twitter:title"]) ?? (titleText.trim() || null)
+  const title = decode(meta["og:title"]) ?? decode(meta["twitter:title"]) ?? decode(titleText.trim() || undefined)
   const description =
     decode(meta["og:description"]) ?? decode(meta["twitter:description"]) ?? decode(meta["description"]) ?? null
   const imageUrl = decode(meta["og:image"]) ?? decode(meta["twitter:image"]) ?? null
@@ -479,6 +479,13 @@ function decode(value: string | undefined): string | null {
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
     .replace(/&nbsp;/g, "\u00A0")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&rsquo;/g, "’")
+    .replace(/&lsquo;/g, "‘")
+    .replace(/&hellip;/g, "…")
+    .replace(/&ldquo;/g, "“")
+    .replace(/&rdquo;/g, "”")
 }
 
 /**


### PR DESCRIPTION
## Problem

Link preview titles show raw HTML entities for pages that lack OpenGraph or Twitter meta tags. The `<title>` element text goes through `decode()`, so entities like `&amp;`, `&mdash;`, `&rsquo;` appear literally — e.g. `Voice &amp; Video &mdash; Plan` instead of `Voice & Video — Plan`.

The `og:title` and `twitter:title` branches already call `decode()`, which is why most big sites look fine. Only the `<title>` fallback is affected.

## Solution

Wrap the `<title>` fallback in `decode()` and extend `decode()` with common named HTML entities that real pages use in their `<title>` tags.

### How it works

- `worker.ts:418` — changed `(titleText.trim() || null)` to `decode(titleText.trim() || undefined)`, so all three title sources (`og:title`, `twitter:title`, `<title>`) go through the same decoder
- `worker.ts:471-488` — added 7 named entity replacements to `decode()` that were missing: `&mdash;` `&ndash;` `&rsquo;` `&lsquo;` `&hellip;` `&ldquo;` `&rdquo;`
- `worker.test.ts` — two new tests covering `<title>` entity decoding with `&amp;`/`&mdash;` and `og:title` priority over `<title>`

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/link-previews/worker.ts` | Wrap `<title>` fallback in `decode()`; extend `decode()` with 7 named entities |
| `apps/backend/src/features/link-previews/worker.test.ts` | Add tests for `<title>` entity decoding and `og:title` priority |

## Test plan

- [x] `bun test apps/backend/src/features/link-previews/worker.test.ts` — 44 pass (67 expect calls)
- [x] `bun run --cwd apps/backend typecheck` — clean
- [x] Full repo lint + typecheck — clean

---

🤖 _PR by pi_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786993504&installation_id=129946197&pr_number=1394&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1394&signature=27765bd8ee154b7b62fa3458b124cecf16616eec781c7f4c8da456a46b9e8a51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->