### PR TITLE
fix(channel): route permission verdicts arriving as /steer text to the pending prompt

### DIFF
--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -3,10 +3,17 @@ import type { BotRuntimeTransport } from "@threa/bot-runtime-client"
 import {
   ThreaClient,
   type ClaimedDelegation,
+  type ClaimedInvocation,
   type DelegationClient,
   type RemoteSessionConfig,
 } from "@threa/remote-session"
-import { ChannelServer, buildInstructions, formatDelegationContent, parsePermissionVerdict } from "./channel-server"
+import {
+  ChannelServer,
+  buildInstructions,
+  formatDelegationContent,
+  parsePermissionVerdict,
+  verdictCandidateText,
+} from "./channel-server"
 
 describe("parsePermissionVerdict", () => {
   test("parses allow/deny in long and short forms", () => {
@@ -193,6 +200,151 @@ describe("ChannelServer delegations", () => {
     const result = await server.handleToolCall("reply", "dlg_1", "Done.")
     expect(result.ok).toBe(false)
     expect(sessionReply).toHaveBeenCalled()
+  })
+})
+
+function makeInvocation(partial: Partial<ClaimedInvocation>): ClaimedInvocation {
+  return {
+    id: "binv_1",
+    workspaceId: "ws_1",
+    rootStreamId: "stream_root",
+    activeStreamId: "stream_root",
+    sourceMessageId: "src",
+    responseStreamId: "stream_root",
+    actor: { type: "bot", id: "bot_1", slug: "claude" },
+    trigger: "active-scratchpad",
+    requiredCapability: "active-scratchpad",
+    promptMarkdown: "Do the thing",
+    authorUserId: "user_1",
+    mentionedActorSlugs: [],
+    claimToken: "tok",
+    claimExpiresAt: "2026-07-18T00:00:00.000Z",
+    runtimeSessionId: "rts_1",
+    metadata: {},
+    ...partial,
+  }
+}
+
+function makeSteerInvocation(args: string): ClaimedInvocation {
+  return makeInvocation({
+    id: "binv_steer",
+    trigger: "session-control",
+    promptMarkdown: args ? `/steer ${args}` : "/steer",
+    metadata: { command: { executionKind: "bot-runtime", id: "cmd_1", name: "steer", args } },
+  })
+}
+
+describe("verdictCandidateText", () => {
+  test("an ordinary message's prompt is the candidate", () => {
+    expect(verdictCandidateText(makeInvocation({ promptMarkdown: "yes abcde" }))).toBe("yes abcde")
+  })
+
+  test("a /steer's folded text is the candidate (busy-session replies arrive as steer args)", () => {
+    expect(verdictCandidateText(makeSteerInvocation("no abcde"))).toBe("no abcde")
+  })
+
+  test("other session-control commands never carry a verdict", () => {
+    const model = makeInvocation({
+      trigger: "session-control",
+      promptMarkdown: "/model opus",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_2", name: "model", args: "opus" } },
+    })
+    expect(verdictCandidateText(model)).toBeNull()
+  })
+})
+
+/** A relay-enabled server with the MCP wire and Threa session stubbed for direct permission-path calls. */
+function permissionServer() {
+  const config = { ...makeConfig(), permissionRelay: true }
+  const server = new ChannelServer(config, new ThreaClient(config), makeFakeTransport())
+  const internals = server as unknown as {
+    mcp: { notification: (msg: { method: string; params: Record<string, unknown> }) => Promise<void> }
+    handlePermissionRequest: (params: {
+      request_id: string
+      tool_name: string
+      description: string
+      input_preview: string
+    }) => Promise<void>
+    interceptVerdict: (invocation: ClaimedInvocation) => Promise<boolean>
+  }
+  const notifications: Array<{ method: string; params: Record<string, unknown> }> = []
+  spyOn(internals.mcp, "notification").mockImplementation(async (msg) => void notifications.push(msg))
+  const posts: Array<{ streamId: string; body: { content: string; metadata?: Record<string, unknown> } }> = []
+  spyOn(server.session, "postToStream").mockImplementation(
+    async (streamId: string, body: { content: string; metadata?: Record<string, unknown> }) =>
+      void posts.push({ streamId, body })
+  )
+  spyOn(server.session, "keepAlive").mockImplementation(() => {})
+  ;(server.session as unknown as { activeTurnStream?: string }).activeTurnStream = "stream_turn"
+  return { server, internals, notifications, posts }
+}
+
+describe("ChannelServer permission verdict routing", () => {
+  test("posts the approval prompt, then a plain 'yes <id>' reply routes to it and releases the claim hold", async () => {
+    const { server, internals, notifications, posts } = permissionServer()
+    await internals.handlePermissionRequest({
+      request_id: "krjtt",
+      tool_name: "Bash",
+      description: "Run a command",
+      input_preview: "bun run test",
+    })
+    expect(posts[0]?.streamId).toBe("stream_turn")
+    expect(posts[0]?.body.content).toContain("yes krjtt")
+    expect(posts[0]?.body.metadata?.["cc.channel.permissionRequest"]).toBe("krjtt")
+    expect(server.session.interceptHoldsClaims).toBe(true)
+
+    expect(await internals.interceptVerdict(makeInvocation({ promptMarkdown: "yes krjtt" }))).toBe(true)
+    expect(notifications).toEqual([
+      { method: "notifications/claude/channel/permission", params: { request_id: "krjtt", behavior: "allow" } },
+    ])
+    expect(server.session.interceptHoldsClaims).toBe(false)
+    await server.shutdown()
+  })
+
+  test("a verdict folded into /steer args still reaches the prompt instead of steering the session", async () => {
+    const { server, internals, notifications } = permissionServer()
+    await internals.handlePermissionRequest({
+      request_id: "krjtt",
+      tool_name: "Bash",
+      description: "Run a command",
+      input_preview: "",
+    })
+    expect(await internals.interceptVerdict(makeSteerInvocation("no krjtt"))).toBe(true)
+    expect(notifications).toEqual([
+      { method: "notifications/claude/channel/permission", params: { request_id: "krjtt", behavior: "deny" } },
+    ])
+    await server.shutdown()
+  })
+
+  test("non-verdict steers and other control commands pass through untouched", async () => {
+    const { server, internals, notifications } = permissionServer()
+    await internals.handlePermissionRequest({
+      request_id: "krjtt",
+      tool_name: "Bash",
+      description: "Run a command",
+      input_preview: "",
+    })
+    expect(await internals.interceptVerdict(makeSteerInvocation("focus on the failing test"))).toBe(false)
+    expect(
+      await internals.interceptVerdict(
+        makeInvocation({
+          trigger: "session-control",
+          promptMarkdown: "/model opus",
+          metadata: { command: { executionKind: "bot-runtime", id: "cmd_2", name: "model", args: "opus" } },
+        })
+      )
+    ).toBe(false)
+    expect(notifications).toEqual([])
+    // The request is still pending, so the claim hold stays up.
+    expect(server.session.interceptHoldsClaims).toBe(true)
+    await server.shutdown()
+  })
+
+  test("a verdict with no matching open request falls through to the normal turn path", async () => {
+    const { server, internals, notifications } = permissionServer()
+    expect(await internals.interceptVerdict(makeInvocation({ promptMarkdown: "yes krjtt" }))).toBe(false)
+    expect(notifications).toEqual([])
+    await server.shutdown()
   })
 })
 

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -7,6 +7,7 @@ import {
   DelegationRunner,
   RemoteSession,
   ThreaClient,
+  parseSessionControlCommand,
   type ClaimedDelegation,
   type ClaimedInvocation,
   type DelegationExecutorContext,
@@ -87,6 +88,18 @@ export function parsePermissionVerdict(text: string): PermissionVerdict | null {
     behavior: match[1]!.toLowerCase().startsWith("y") ? "allow" : "deny",
     requestId: match[2]!.toLowerCase(),
   }
+}
+
+/**
+ * The text of a claimed invocation that could carry a permission verdict: an
+ * ordinary message's prompt, or a /steer's folded text — the busy-session
+ * composer routes replies through /steer, so "yes abcde" often arrives as
+ * steer args. Other session-control commands never carry a verdict.
+ */
+export function verdictCandidateText(invocation: ClaimedInvocation): string | null {
+  const command = parseSessionControlCommand(invocation)
+  if (!command) return invocation.promptMarkdown
+  return command.name === "steer" ? command.args : null
 }
 
 export function buildInstructions(permissionRelay: boolean, channelActive = true): string {
@@ -529,12 +542,15 @@ export class ChannelServer {
   // --- Permission relay -----------------------------------------------------
 
   /**
-   * A relayed permission verdict ("yes abcde") arrives as an ordinary message,
-   * hence as a claimed invocation. Recognize it and route it to Claude Code as
-   * a verdict instead of pushing it into the session as a fresh prompt.
+   * A relayed permission verdict ("yes abcde") arrives as a claimed invocation
+   * — an ordinary message, or /steer args when the session was busy. Recognize
+   * it and route it to Claude Code as a verdict instead of pushing it into the
+   * session as a fresh prompt or steering text.
    */
   private async interceptVerdict(invocation: ClaimedInvocation): Promise<boolean> {
-    const verdict = parsePermissionVerdict(invocation.promptMarkdown)
+    const text = verdictCandidateText(invocation)
+    if (text === null) return false
+    const verdict = parsePermissionVerdict(text)
     if (!verdict) return false
     const open = this.openPermissions.get(verdict.requestId)
     if (!open) return false

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -869,6 +869,83 @@ describe("steer into the running turn (native steer support)", () => {
     ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
   })
 
+  test("a swept message the intercept consumes is routed, not folded into the steer text", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const intercepted: string[] = []
+    const queued = [
+      makeInvocation({ id: "binv_verdict", promptMarkdown: "yes abcde" }),
+      makeInvocation({ id: "binv_q1", promptMarkdown: "also bump the deps" }),
+    ]
+    const session = makeSession(client, transport, {
+      interceptClaimed: async (invocation) => {
+        if (invocation.promptMarkdown !== "yes abcde") return false
+        intercepted.push(invocation.id)
+        return true
+      },
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () =>
+      queued.shift() ?? null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation("the steer text"))
+
+    expect(intercepted).toEqual(["binv_verdict"])
+    expect(steered).toHaveLength(1)
+    expect(steered[0]).toContain("also bump the deps")
+    expect(steered[0]).toContain("the steer text")
+    expect(steered[0]).not.toContain("yes abcde")
+    const verdictClose = calls.complete.find((entry) => entry.id === "binv_verdict")
+    expect(verdictClose?.body.noResponse).toBe(true)
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
+  test("an empty steer whose sweep only intercepts a reply acks the routing, not 'nothing to steer'", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const queued = [makeInvocation({ id: "binv_verdict", promptMarkdown: "yes abcde" })]
+    const session = makeSession(client, transport, {
+      interceptClaimed: async (invocation) => invocation.promptMarkdown === "yes abcde",
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () =>
+      queued.shift() ?? null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation(""))
+
+    expect(steered).toEqual([])
+    const verdictClose = calls.complete.find((entry) => entry.id === "binv_verdict")
+    expect(verdictClose?.body.noResponse).toBe(true)
+    const ack = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(ack?.body.finalMessageMarkdown).toContain("Routed your reply")
+    expect(ack?.body.finalMessageMarkdown).not.toContain("Nothing to steer with")
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
   test("failed actuation leaves the running turn alone and reports the failure", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()
@@ -936,6 +1013,70 @@ describe("steer into the running turn (native steer support)", () => {
     expect(interrupted).toBe(true)
     expect(delivered).toEqual(["start with the readme"])
     ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_steer")
+  })
+})
+
+describe("claimDrain intercept routing", () => {
+  test("an intercepted steer invocation closes silently — never actuated as steering text", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const intercepted: string[] = []
+    const queue = [
+      makeInvocation({
+        id: "binv_verdict",
+        trigger: "session-control",
+        promptMarkdown: "/steer yes abcde",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd_v", name: "steer", args: "yes abcde" } },
+      }),
+    ]
+    const session = makeSession(client, transport, {
+      interceptClaimed: async (invocation) => {
+        intercepted.push(invocation.id)
+        return true
+      },
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () => queue.shift() ?? null
+
+    await (session as unknown as { claimDrain: () => Promise<boolean> }).claimDrain()
+
+    expect(intercepted).toEqual(["binv_verdict"])
+    expect(steered).toEqual([])
+    const close = calls.complete.find((entry) => entry.id === "binv_verdict")
+    expect(close?.body.noResponse).toBe(true)
+  })
+
+  test("an intercepted ordinary message closes silently instead of becoming a turn", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const delivered: string[] = []
+    const queue = [
+      makeInvocation({ id: "binv_verdict", promptMarkdown: "yes abcde" }),
+      makeInvocation({ id: "binv_normal", promptMarkdown: "hello there" }),
+    ]
+    const session = makeSession(client, transport, {
+      deliverTurn: async (turn) => {
+        delivered.push(turn.invocationId)
+      },
+      interceptClaimed: async (invocation) => invocation.promptMarkdown === "yes abcde",
+    })
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () => queue.shift() ?? null
+
+    await (session as unknown as { claimDrain: () => Promise<boolean> }).claimDrain()
+
+    expect(delivered).toEqual(["binv_normal"])
+    const verdictClose = calls.complete.find((entry) => entry.id === "binv_verdict")
+    expect(verdictClose?.body.noResponse).toBe(true)
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_normal")
   })
 })
 

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -137,9 +137,13 @@ export interface RemoteSessionDelegate {
   /** Push a turn into the runtime. Resolve when handed off (not when answered). */
   deliverTurn(turn: DeliveredTurn): Promise<void>
   /**
-   * Inspect a claimed invocation before it becomes a turn (e.g. a relayed
-   * tool-approval verdict). Return true when consumed; the SDK then closes it
-   * silently and moves on.
+   * Inspect a claimed invocation before it is routed (e.g. a relayed
+   * tool-approval verdict). Runs for EVERY claim — ordinary messages,
+   * session-control commands, and messages swept into a /steer — because a
+   * verdict can arrive as /steer text (the busy-session composer routes replies
+   * through /steer) and treating it as steering would inject it into the
+   * runtime instead of answering the pending prompt. Return true when
+   * consumed; the SDK then closes it silently and moves on.
    */
   interceptClaimed?(invocation: ClaimedInvocation): Promise<boolean>
   /** Present iff the connector can drive the runtime. Gates advertising session control (fail-safe). */
@@ -615,6 +619,10 @@ export class RemoteSession {
         const invocation = await this.claimNext(busy)
         if (!invocation) break
         claimedAny = true
+        // Intercept before command routing: a relayed verdict can ride in as
+        // /steer text, and the steer path would inject it into the runtime
+        // instead of answering the prompt it belongs to.
+        if (await this.interceptInvocation(invocation)) continue
         if (isSessionControlInvocation(invocation)) {
           const isStop = parseSessionControlCommand(invocation)?.name === "stop"
           await this.handleSessionControl(invocation)
@@ -694,14 +702,17 @@ export class RemoteSession {
     }
   }
 
-  private async handleClaimed(invocation: ClaimedInvocation): Promise<void> {
-    if (this.delegate.interceptClaimed && (await this.delegate.interceptClaimed(invocation))) {
-      await this.completeTurn(invocation, { noResponse: true }).catch((error) =>
-        this.log(`intercepted-claim ack failed: ${this.summarize(error)}`)
-      )
-      return
-    }
+  /** Consult the connector's intercept. True = the delegate consumed the invocation and it was closed silently. */
+  private async interceptInvocation(invocation: ClaimedInvocation): Promise<boolean> {
+    if (!this.delegate.interceptClaimed) return false
+    if (!(await this.delegate.interceptClaimed(invocation))) return false
+    await this.completeTurn(invocation, { noResponse: true }).catch((error) =>
+      this.log(`intercepted-claim ack failed: ${this.summarize(error)}`)
+    )
+    return true
+  }
 
+  private async handleClaimed(invocation: ClaimedInvocation): Promise<void> {
     const content = await this.buildTurnContent(invocation)
     await this.deliverTurn(invocation, content)
   }
@@ -860,12 +871,20 @@ export class RemoteSession {
     steer: (text: string) => Promise<boolean> | boolean,
     text: string
   ): Promise<void> {
-    const { parts, swept } = await this.sweepQueuedForSteer(text)
+    const { parts, swept, interceptedCount } = await this.sweepQueuedForSteer(text)
     if (parts.length === 0) {
       // The sweep can still have claimed foldless invocations (a queued control
       // command in the double-command race) — close them or they hang to TTL.
       await Promise.all(swept.map((item) => this.completeNoResponse(item)))
-      await this.completeAck(invocation, "Nothing to steer with (no text, no queued messages); the turn continues.")
+      // A sweep that only consumed intercepted replies did real work (a verdict
+      // reached its pending prompt) — "nothing to steer with" would misread as
+      // the reply having been lost.
+      await this.completeAck(
+        invocation,
+        interceptedCount > 0
+          ? "Routed your reply to the session's pending request; the turn continues."
+          : "Nothing to steer with (no text, no queued messages); the turn continues."
+      )
       return
     }
     const combined = buildSteerContent(parts)
@@ -922,14 +941,19 @@ export class RemoteSession {
       { alwaysNote: true }
     )
 
-    const { parts, swept } = await this.sweepQueuedForSteer(text)
+    const { parts, swept, interceptedCount } = await this.sweepQueuedForSteer(text)
 
     // Close every swept message with no response — its content is folded into the
     // single combined turn the primary (this steer invocation) will answer.
     await Promise.all(swept.map((item) => this.completeNoResponse(item)))
 
     if (parts.length === 0) {
-      await this.completeAck(invocation, "Interrupted the session; nothing pending to steer with.")
+      await this.completeAck(
+        invocation,
+        interceptedCount > 0
+          ? "Interrupted the session; your reply was routed to its pending request."
+          : "Interrupted the session; nothing pending to steer with."
+      )
       await this.syncPresence()
       return
     }
@@ -938,12 +962,22 @@ export class RemoteSession {
   }
 
   /** Claim messages queued while the runtime was busy and fold their text in (steer text last). */
-  private async sweepQueuedForSteer(text: string): Promise<{ parts: string[]; swept: ClaimedInvocation[] }> {
+  private async sweepQueuedForSteer(
+    text: string
+  ): Promise<{ parts: string[]; swept: ClaimedInvocation[]; interceptedCount: number }> {
     const parts: string[] = []
     const swept: ClaimedInvocation[] = []
+    let interceptedCount = 0
     for (let i = 0; i < STEER_DRAIN_LIMIT; i++) {
       const extra = await this.claimNext(false).catch(() => null)
       if (!extra) break
+      // A swept message the connector intercepts (e.g. a permission verdict) is
+      // consumed and closed here, never folded into the steer text — and never
+      // failed by the caller's could-not-steer path, since it was delivered.
+      if (await this.interceptInvocation(extra)) {
+        interceptedCount++
+        continue
+      }
       swept.push(extra)
       if (isSessionControlInvocation(extra)) {
         // Fold a queued /steer's text in; other control commands in the sweep are
@@ -955,7 +989,7 @@ export class RemoteSession {
       }
     }
     if (text) parts.push(text)
-    return { parts, swept }
+    return { parts, swept, interceptedCount }
   }
 
   /**


### PR DESCRIPTION
## Problem

A relayed Claude Code permission request ("Reply `yes krjtt` to allow…", posted by `ChannelServer.handlePermissionRequest` with `cc.channel.permissionRequest` metadata) could only be answered by a reply that arrived as an **ordinary** invocation: the intercept hook (`interceptClaimed` → `ChannelServer.interceptVerdict`) lived inside `RemoteSession.handleClaimed`, which session-control invocations never reach.

While the session is busy — which is exactly when a permission prompt is open — the scratchpad UI routes replies through `/steer` (the session card's redirect affordance prefills `/steer ` in the composer, #1201). The verdict then rode in as steer args and hit `steerRunningTurn`/`sweepQueuedForSteer` instead of the intercept: injected into the TUI as steering text (typed into a blocked permission dialog), or — when it arrived as a message swept by a bare `/steer` — folded into steer content, with the empty-sweep case acking the misleading `Nothing to steer with (no text, no queued messages); the turn continues.` Observed live in the `seer.support-multiple-users` worktree: a `/workflows` subagent's Bash approval never received its `yes krjtt` reply.

## Solution

Move the intercept to the single claim chokepoint, and teach the connector to read a verdict out of `/steer` text.

### How it works

1. `RemoteSession.claimDrain` now consults `delegate.interceptClaimed` for **every** claimed invocation — ordinary, session-control, and steer-swept — before command routing (`interceptInvocation`, extracted from the old `handleClaimed` block). A consumed invocation closes silently (`completeTurn` noResponse, sealed-safe) and the drain continues.
2. `sweepQueuedForSteer` runs the same intercept on each swept claim. A consumed message is closed in the sweep and **never** folded into the combined steer text — and never hit by the could-not-steer failure path's "resend" fail, since it was already delivered. The sweep reports `interceptedCount`.
3. When a steer's sweep produced no foldable parts but did route intercepted replies, the ack says `Routed your reply to the session's pending request; the turn continues.` instead of `Nothing to steer with…` (same differentiation on the `steerByInterrupt` fallback path).
4. `ChannelServer.interceptVerdict` derives its candidate text via the new `verdictCandidateText`: an ordinary message's `promptMarkdown`, a `/steer`'s args (via the SDK's `parseSessionControlCommand`), and `null` for every other session-control command — `/stop`, `/model` etc. can never be swallowed.

### Key design decisions

**1. Verdict parsing stays in the connector.** The SDK knows nothing about permission verdicts; it only widens *when* the connector's intercept runs. `verdictCandidateText` + `parsePermissionVerdict` (the `PERMISSION_REPLY_RE` gate against `openPermissions`) remain Claude-channel code, so Pi and future connectors are untouched — no other connector implements `interceptClaimed`.

**2. Intercept before `isSessionControlInvocation`, not inside `runSteer`.** Routing at the claim chokepoint covers all three arrival shapes (plain message, `/steer <verdict>`, bare `/steer` sweeping a queued verdict) with one code path, and an unmatched verdict (expired/unknown id) falls through to the exact previous behavior.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/remote-session/src/session.ts` | `interceptInvocation` chokepoint in `claimDrain`; sweep-level intercept + `interceptedCount`; differentiated empty-sweep acks; `interceptClaimed` contract doc |
| `extensions/remote-session/src/session.test.ts` | claimDrain intercept routing (steer + ordinary), sweep interception, interception-only-ack tests |
| `extensions/claude-code-remote/src/channel-server.ts` | `verdictCandidateText`; `interceptVerdict` accepts steer-args verdicts |
| `extensions/claude-code-remote/src/channel-server.test.ts` | `verdictCandidateText` unit tests; full permission-relay round-trip (prompt post + metadata, claim hold up/down, allow/deny notification, non-verdict/non-match fallthrough) |

## Out of scope (deliberate)

- The companion recurring misconfiguration — `spawn.sh` registering the channel without `THREA_CHANNEL_SERVER_KEY` (loaded-but-plain MCP mode) — is fixed in `pi-extensions` (commit `a00fc27`), which lives outside this repo. This repo's `README.md`/`docs/claude-code-channel.md` already document the key correctly; no doc change needed.
- No end-to-end live-session run: reproducing needs a tmux Claude session with a subagent permission prompt. The routing seams are unit-covered; dogfood follows on the next spawned channel session.

## Test plan

- [x] `extensions/remote-session`: `bun test` — 114 pass (5 new)
- [x] `extensions/claude-code-remote`: `bun test` — 101 pass (8 new)
- [x] `tsc --noEmit` clean in both packages; repo-wide pre-commit typecheck/lint green
- [x] Bridge boot smoke test: `bun src/index.ts` outside a channel launch still serves plain and shuts down cleanly on stdin close
- [ ] Live dogfood (subagent permission prompt → `yes <id>` via busy-session steer) — needs a spawned channel session; queued for the next worktree spawn

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787001346&installation_id=129946197&pr_number=1397&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1397&signature=228ade93b95eaf822f41b36a2e826e0e7a3835a8a7d289147b4e6262dc939b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->