### PR TITLE
feat: viewport-nudged conditional (ETag) refresh for GitHub link previews

### DIFF
--- a/apps/backend/src/db/migrations/20260718150000_link_preview_refresh_etag.sql
+++ b/apps/backend/src/db/migrations/20260718150000_link_preview_refresh_etag.sql
@@ -1,0 +1,6 @@
+-- Cache validator for conditional provider refreshes (viewport-nudge path).
+-- Holds the ETag of the preview's PRIMARY provider resource (e.g. the pulls
+-- endpoint for a PR card); a conditional refresh sends it as If-None-Match and
+-- a 304 answer skips the full fetch without burning GitHub rate limit.
+ALTER TABLE link_previews
+  ADD COLUMN IF NOT EXISTS refresh_etag TEXT;

--- a/apps/backend/src/features/github-webhooks/preview-refresh.test.ts
+++ b/apps/backend/src/features/github-webhooks/preview-refresh.test.ts
@@ -35,6 +35,7 @@ function makeRow(overrides: Partial<LinkPreview> = {}): LinkPreview {
     targetDelegationId: null,
     fetchedAt: null,
     refreshVersion: 0,
+    refreshEtag: null,
     expiresAt: null,
     createdAt: new Date(),
     ...overrides,

--- a/apps/backend/src/features/github-webhooks/preview-refresh.ts
+++ b/apps/backend/src/features/github-webhooks/preview-refresh.ts
@@ -99,6 +99,9 @@ export async function refreshGithubPreviewWithTrailing(
   const { workspaceId, previewId } = params
   const result = await refreshLinkPreview(deps, { workspaceId, previewId })
   if (result.refreshed || result.reason === "not_found") return
+  // Conditional-mode-only outcome; this path never passes `conditional`, the
+  // check just narrows the union for the branches below.
+  if (result.reason === "not_modified") return
 
   if (result.reason === "debounced" || result.reason === "conflict") {
     // Coalesce on the row's current fetch time. A debounced result carries the

--- a/apps/backend/src/features/github-webhooks/worker.test.ts
+++ b/apps/backend/src/features/github-webhooks/worker.test.ts
@@ -45,6 +45,7 @@ function makeRow(overrides: Partial<LinkPreview> = {}): LinkPreview {
     targetDelegationId: null,
     fetchedAt: null,
     refreshVersion: 0,
+    refreshEtag: null,
     expiresAt: null,
     createdAt: new Date(),
     ...overrides,

--- a/apps/backend/src/features/link-previews/ai-context.test.ts
+++ b/apps/backend/src/features/link-previews/ai-context.test.ts
@@ -25,6 +25,7 @@ function preview(overrides: Partial<LinkPreview> = {}): LinkPreview {
     targetDelegationId: null,
     fetchedAt: new Date(),
     refreshVersion: 0,
+    refreshEtag: null,
     expiresAt: null,
     createdAt: new Date(),
     ...overrides,

--- a/apps/backend/src/features/link-previews/github-preview.ts
+++ b/apps/backend/src/features/link-previews/github-preview.ts
@@ -68,6 +68,78 @@ export async function fetchGitHubPreview(
   }
 }
 
+export type GitHubRefreshGateResult =
+  | { outcome: "not_modified" }
+  | { outcome: "modified"; etag: string | null }
+  | { outcome: "unavailable" }
+
+/**
+ * Cheap change detector for the conditional (viewport-nudge) refresh path: ONE
+ * conditional GET against the preview's primary resource. `not_modified` means
+ * the rendered card cannot have changed; `modified` hands back the fresh
+ * validator to store alongside the follow-up full fetch. An authorized 304 does
+ * not count against the installation's primary rate limit, so a nudge that
+ * finds nothing new is free. `unavailable` (no client, unparseable URL, request
+ * error) tells the caller to skip quietly — the nudge is best-effort and the
+ * next viewport pass retries.
+ */
+export async function checkGitHubRefreshGate(
+  workspaceId: string,
+  url: string,
+  ifNoneMatch: string | null,
+  workspaceIntegrationService: WorkspaceIntegrationService
+): Promise<GitHubRefreshGateResult> {
+  const parsed = parseGitHubUrl(url)
+  if (!parsed) return { outcome: "unavailable" }
+
+  const client = await workspaceIntegrationService.getGithubClient(workspaceId)
+  if (!client) return { outcome: "unavailable" }
+
+  const gate = gateRequestFor(parsed)
+  try {
+    const response = await client.requestConditional(gate.route, gate.parameters, ifNoneMatch)
+    if (response.status === 304) return { outcome: "not_modified" }
+    return { outcome: "modified", etag: response.etag }
+  } catch (error) {
+    log.debug({ err: error, workspaceId, url }, "GitHub refresh gate errored; skipping conditional refresh")
+    return { outcome: "unavailable" }
+  }
+}
+
+/**
+ * The single endpoint whose ETag moves whenever the rendered card could have:
+ * PR and diff cards render from the pull object (reviews and new pushes bump
+ * its `updated_at`), issue/comment/commit cards from their own resource, and
+ * file cards only change after a push, which bumps the repository object's
+ * `pushed_at`. Commits are immutable, so their gate correctly answers 304
+ * forever.
+ */
+function gateRequestFor(parsed: GitHubUrlMatch): { route: string; parameters: Record<string, unknown> } {
+  const { owner, repo } = parsed
+  switch (parsed.type) {
+    case "github_pr":
+    case "github_diff":
+      return {
+        route: "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+        parameters: { owner, repo, pull_number: parsed.number },
+      }
+    case "github_issue":
+      return {
+        route: "GET /repos/{owner}/{repo}/issues/{issue_number}",
+        parameters: { owner, repo, issue_number: parsed.number },
+      }
+    case "github_commit":
+      return { route: "GET /repos/{owner}/{repo}/commits/{ref}", parameters: { owner, repo, ref: parsed.sha } }
+    case "github_file":
+      return { route: "GET /repos/{owner}/{repo}", parameters: { owner, repo } }
+    case "github_comment":
+      return {
+        route: "GET /repos/{owner}/{repo}/issues/comments/{comment_id}",
+        parameters: { owner, repo, comment_id: parsed.commentId },
+      }
+  }
+}
+
 async function fetchPullRequestPreview(
   client: { request<T>(route: string, parameters?: Record<string, unknown>): Promise<T> },
   url: string,

--- a/apps/backend/src/features/link-previews/index.ts
+++ b/apps/backend/src/features/link-previews/index.ts
@@ -16,6 +16,15 @@ export type { InAppLinkRef, GitHubUrlMatch } from "./url-utils"
 export { refreshLinkPreview, findGithubPreviewMatches, DEFAULT_REFRESH_DEBOUNCE_MS } from "./refresh"
 export type { RefreshLinkPreviewDeps, RefreshLinkPreviewResult } from "./refresh"
 
+export {
+  createLinkPreviewVisibleRefreshWorker,
+  enqueueVisiblePreviewRefreshes,
+  visibleRefreshQueueId,
+  VISIBLE_REFRESH_DEBOUNCE_MS,
+  VISIBLE_REFRESH_MAX_IDS,
+  VISIBLE_REPORT_MIN_INTERVAL_MS,
+} from "./visible-refresh"
+
 export { MAX_PREVIEWS_PER_MESSAGE, getAppOrigins } from "./config"
 
 export {

--- a/apps/backend/src/features/link-previews/refresh.test.ts
+++ b/apps/backend/src/features/link-previews/refresh.test.ts
@@ -34,6 +34,7 @@ function makeRow(overrides: Partial<LinkPreview> = {}): LinkPreview {
     targetDelegationId: null,
     fetchedAt: null,
     refreshVersion: 0,
+    refreshEtag: null,
     expiresAt: null,
     createdAt: new Date(),
     ...overrides,
@@ -141,9 +142,11 @@ describe("refreshLinkPreview", () => {
     return {
       getPreviewById: mock(async () => preview),
       applyRefreshedMetadata: mock(async () => applyResult),
+      recordRefreshCheck: mock(async () => true),
     } as unknown as LinkPreviewService & {
       getPreviewById: ReturnType<typeof mock>
       applyRefreshedMetadata: ReturnType<typeof mock>
+      recordRefreshCheck: ReturnType<typeof mock>
     }
   }
 
@@ -255,5 +258,128 @@ describe("refreshLinkPreview", () => {
     expect(service.applyRefreshedMetadata).toHaveBeenCalledWith(WORKSPACE_ID, "lp_pr", REFRESHED_METADATA, {
       expectedRefreshVersion: 0,
     })
+  })
+
+  test("unconditional (webhook) callers never run the ETag gate and preserve the stored validator", async () => {
+    const service = fakeService(makeRow({ fetchedAt: new Date(Date.now() - 60_000), refreshEtag: '"stored"' }))
+    const gateSpy = spyOn(githubPreview, "checkGitHubRefreshGate")
+    spyOn(githubPreview, "fetchGitHubPreview").mockResolvedValue(REFRESHED_METADATA)
+
+    const result = await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr" }
+    )
+
+    expect(result).toEqual({ refreshed: true })
+    expect(gateSpy).not.toHaveBeenCalled()
+    // No `refreshEtag` key: the repository preserves the stored validator.
+    expect(service.applyRefreshedMetadata).toHaveBeenCalledWith(WORKSPACE_ID, "lp_pr", REFRESHED_METADATA, {
+      expectedRefreshVersion: 0,
+    })
+  })
+})
+
+describe("refreshLinkPreview conditional (viewport nudge)", () => {
+  function fakeService(preview: LinkPreview | null) {
+    return {
+      getPreviewById: mock(async () => preview),
+      applyRefreshedMetadata: mock(async () => ({ applied: true })),
+      recordRefreshCheck: mock(async () => true),
+    } as unknown as LinkPreviewService & {
+      getPreviewById: ReturnType<typeof mock>
+      applyRefreshedMetadata: ReturnType<typeof mock>
+      recordRefreshCheck: ReturnType<typeof mock>
+    }
+  }
+
+  const wis = {} as unknown as WorkspaceIntegrationService
+  const stale = () => new Date(Date.now() - 60_000)
+
+  test("a 304 gate answer touches fetched_at and skips the full fetch", async () => {
+    const service = fakeService(makeRow({ fetchedAt: stale(), refreshVersion: 7, refreshEtag: '"v7"' }))
+    const gateSpy = spyOn(githubPreview, "checkGitHubRefreshGate").mockResolvedValue({ outcome: "not_modified" })
+    const fetchSpy = spyOn(githubPreview, "fetchGitHubPreview")
+
+    const result = await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr", conditional: true }
+    )
+
+    expect(result).toEqual({ refreshed: false, reason: "not_modified" })
+    expect(gateSpy).toHaveBeenCalledWith(WORKSPACE_ID, "https://github.com/acme/widgets/pull/42", '"v7"', wis)
+    expect(service.recordRefreshCheck).toHaveBeenCalledWith(WORKSPACE_ID, "lp_pr", 7)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(service.applyRefreshedMetadata).not.toHaveBeenCalled()
+  })
+
+  test("a modified gate answer runs the full fetch and stores the fresh validator", async () => {
+    const service = fakeService(makeRow({ fetchedAt: stale(), refreshVersion: 2, refreshEtag: '"old"' }))
+    spyOn(githubPreview, "checkGitHubRefreshGate").mockResolvedValue({ outcome: "modified", etag: '"fresh"' })
+    spyOn(githubPreview, "fetchGitHubPreview").mockResolvedValue(REFRESHED_METADATA)
+
+    const result = await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr", conditional: true }
+    )
+
+    expect(result).toEqual({ refreshed: true })
+    expect(service.applyRefreshedMetadata).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "lp_pr",
+      { ...REFRESHED_METADATA, refreshEtag: '"fresh"' },
+      { expectedRefreshVersion: 2 }
+    )
+  })
+
+  test("a row with no stored validator gates with null and harvests one", async () => {
+    const service = fakeService(makeRow({ fetchedAt: stale(), refreshEtag: null }))
+    const gateSpy = spyOn(githubPreview, "checkGitHubRefreshGate").mockResolvedValue({
+      outcome: "modified",
+      etag: '"harvested"',
+    })
+    spyOn(githubPreview, "fetchGitHubPreview").mockResolvedValue(REFRESHED_METADATA)
+
+    await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr", conditional: true }
+    )
+
+    expect(gateSpy).toHaveBeenCalledWith(WORKSPACE_ID, "https://github.com/acme/widgets/pull/42", null, wis)
+    expect(service.applyRefreshedMetadata).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "lp_pr",
+      { ...REFRESHED_METADATA, refreshEtag: '"harvested"' },
+      { expectedRefreshVersion: 0 }
+    )
+  })
+
+  test("an unavailable gate skips everything without downgrading", async () => {
+    const service = fakeService(makeRow({ fetchedAt: stale(), refreshVersion: 3 }))
+    spyOn(githubPreview, "checkGitHubRefreshGate").mockResolvedValue({ outcome: "unavailable" })
+    const fetchSpy = spyOn(githubPreview, "fetchGitHubPreview")
+
+    const result = await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr", conditional: true }
+    )
+
+    expect(result).toEqual({ refreshed: false, reason: "fetch_empty", refreshVersion: 3 })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(service.applyRefreshedMetadata).not.toHaveBeenCalled()
+    expect(service.recordRefreshCheck).not.toHaveBeenCalled()
+  })
+
+  test("the debounce gate still runs before the ETag gate", async () => {
+    const service = fakeService(makeRow({ fetchedAt: new Date(Date.now() - 2_000) }))
+    const gateSpy = spyOn(githubPreview, "checkGitHubRefreshGate")
+
+    const result = await refreshLinkPreview(
+      { linkPreviewService: service, workspaceIntegrationService: wis },
+      { workspaceId: WORKSPACE_ID, previewId: "lp_pr", debounceMs: 15_000, conditional: true }
+    )
+
+    expect(result.refreshed).toBe(false)
+    if (result.refreshed || result.reason !== "debounced") throw new Error("expected debounced")
+    expect(gateSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/link-previews/refresh.ts
+++ b/apps/backend/src/features/link-previews/refresh.ts
@@ -43,6 +43,12 @@ export type RefreshLinkPreviewResult =
    * the debounce-timing math.
    */
   | { refreshed: false; reason: "conflict"; refreshVersion: number; fetchedAt: Date | null }
+  /**
+   * Conditional mode only: the gate request answered 304, so the provider
+   * content is unchanged. `fetched_at` was touched to re-arm the debounce; no
+   * metadata was written and nothing was broadcast.
+   */
+  | { refreshed: false; reason: "not_modified" }
 
 /**
  * Force-refresh one already-rendered GitHub link preview from an external
@@ -55,10 +61,17 @@ export type RefreshLinkPreviewResult =
  * Skips (never downgrades) when: the row is gone, it was fetched within
  * `debounceMs`, or the fetch comes back empty (rate-limited/null client) — an
  * empty fetch must not blank a rich card.
+ *
+ * `conditional` mode (the viewport-nudge path, where nothing is KNOWN to have
+ * changed) prepends a one-request ETag gate against the preview's primary
+ * resource: a 304 answer costs no rate limit and short-circuits to a
+ * `fetched_at` touch; a 200 harvests the fresh validator, runs the full fetch,
+ * and stores the validator with the write. Webhook callers stay unconditional —
+ * their signal already proves something changed.
  */
 export async function refreshLinkPreview(
   deps: RefreshLinkPreviewDeps,
-  params: { workspaceId: string; previewId: string; debounceMs?: number }
+  params: { workspaceId: string; previewId: string; debounceMs?: number; conditional?: boolean }
 ): Promise<RefreshLinkPreviewResult> {
   const debounceMs = params.debounceMs ?? DEFAULT_REFRESH_DEBOUNCE_MS
   const preview = await deps.linkPreviewService.getPreviewById(params.workspaceId, params.previewId)
@@ -87,6 +100,28 @@ export async function refreshLinkPreview(
     }
   }
 
+  // In conditional mode the write must carry a `refreshEtag` key even when the
+  // gate returned no validator (storing null), so the field tracks exactly what
+  // the gate last observed; unconditional (webhook) writes omit the key and
+  // preserve whatever validator is stored.
+  let etagOverride: { refreshEtag: string | null } | null = null
+  if (params.conditional) {
+    const gate = await githubPreview.checkGitHubRefreshGate(
+      params.workspaceId,
+      preview.url,
+      preview.refreshEtag,
+      deps.workspaceIntegrationService
+    )
+    if (gate.outcome === "not_modified") {
+      await deps.linkPreviewService.recordRefreshCheck(params.workspaceId, params.previewId, expectedRefreshVersion)
+      return { refreshed: false, reason: "not_modified" }
+    }
+    if (gate.outcome === "unavailable") {
+      return { refreshed: false, reason: "fetch_empty", refreshVersion: expectedRefreshVersion }
+    }
+    etagOverride = { refreshEtag: gate.etag }
+  }
+
   const metadata = await githubPreview.fetchGitHubPreview(
     params.workspaceId,
     preview.url,
@@ -100,9 +135,14 @@ export async function refreshLinkPreview(
     return { refreshed: false, reason: "fetch_empty", refreshVersion: expectedRefreshVersion }
   }
 
-  const outcome = await deps.linkPreviewService.applyRefreshedMetadata(params.workspaceId, params.previewId, metadata, {
-    expectedRefreshVersion,
-  })
+  const outcome = await deps.linkPreviewService.applyRefreshedMetadata(
+    params.workspaceId,
+    params.previewId,
+    etagOverride ? { ...metadata, ...etagOverride } : metadata,
+    {
+      expectedRefreshVersion,
+    }
+  )
   if (!outcome.applied) {
     log.debug(
       { workspaceId: params.workspaceId, previewId: params.previewId },

--- a/apps/backend/src/features/link-previews/repository.ts
+++ b/apps/backend/src/features/link-previews/repository.ts
@@ -45,6 +45,13 @@ export interface LinkPreview {
    * TIMESTAMPTZ-vs-Date precision mismatch broke.
    */
   refreshVersion: number
+  /**
+   * ETag of the preview's primary provider resource, sent as `If-None-Match` by
+   * the conditional (viewport-nudge) refresh path. Null until the first
+   * conditional refresh harvests one; a stale value only costs one counted 200
+   * that re-harvests, so unconditional writers may leave it untouched.
+   */
+  refreshEtag: string | null
   expiresAt: Date | null
   createdAt: Date
 }
@@ -74,6 +81,8 @@ export interface UpdateLinkPreviewParams {
   previewData?: RichPreview | null
   status: LinkPreviewStatus
   expiresAt?: Date | null
+  /** When present, overwrites `refresh_etag`; when absent, the stored value is preserved. */
+  refreshEtag?: string | null
 }
 
 export interface MessageLinkPreview {
@@ -105,6 +114,7 @@ function mapRow(row: Record<string, unknown>): LinkPreview {
     targetDelegationId: (row.target_delegation_id as string | null) ?? null,
     fetchedAt: row.fetched_at ? new Date(row.fetched_at as string) : null,
     refreshVersion: (row.refresh_version as number | null) ?? 0,
+    refreshEtag: (row.refresh_etag as string | null) ?? null,
     expiresAt: row.expires_at ? new Date(row.expires_at as string) : null,
     createdAt: new Date(row.created_at as string),
   }
@@ -230,11 +240,13 @@ export const LinkPreviewRepository = {
     // when CAS is off, `$13` is true and the guard is a no-op; when CAS is on,
     // `$13` is false and the write requires `refresh_version` to equal `$14`.
     const cas = options !== undefined && "expectedRefreshVersion" in options
+    const hasEtag = "refreshEtag" in params
     const result = await querier.query(
       sql`UPDATE link_previews
           SET title = $3, description = $4, image_url = $5, favicon_url = $6,
               site_name = $7, content_type = $8, preview_type = $9, preview_data = $10::jsonb,
-              status = $11, fetched_at = NOW(), refresh_version = refresh_version + 1, expires_at = $12
+              status = $11, fetched_at = NOW(), refresh_version = refresh_version + 1, expires_at = $12,
+              refresh_etag = CASE WHEN $15::boolean THEN $16 ELSE refresh_etag END
           WHERE workspace_id = $1 AND id = $2
             AND ($13::boolean OR refresh_version = $14)
           RETURNING *`,
@@ -253,9 +265,33 @@ export const LinkPreviewRepository = {
         params.expiresAt ?? null,
         !cas,
         cas ? (options!.expectedRefreshVersion ?? 0) : null,
+        hasEtag,
+        hasEtag ? (params.refreshEtag ?? null) : null,
       ]
     )
     return result.rows.length > 0 ? mapRow(result.rows[0]) : null
+  },
+
+  /**
+   * Record that a conditional refresh confirmed the provider content unchanged
+   * (a 304 answer): advance `fetched_at` so the debounce gate re-arms, without
+   * touching the rendered metadata or broadcasting anything. Compare-and-set on
+   * `refresh_version` — losing the CAS to a concurrent real refresh is fine, the
+   * winner's write already advanced `fetched_at`.
+   */
+  async touchRefreshCheck(
+    querier: Querier,
+    workspaceId: string,
+    id: string,
+    expectedRefreshVersion: number
+  ): Promise<boolean> {
+    const result = await querier.query(
+      sql`UPDATE link_previews
+          SET fetched_at = NOW(), refresh_version = refresh_version + 1
+          WHERE workspace_id = $1 AND id = $2 AND refresh_version = $3`,
+      [workspaceId, id, expectedRefreshVersion]
+    )
+    return (result.rowCount ?? 0) > 0
   },
 
   async unlinkAllFromMessage(querier: Querier, workspaceId: string, messageId: string): Promise<void> {

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -40,6 +40,7 @@ function makePreview(overrides: Partial<LinkPreview>): LinkPreview {
     targetDelegationId: null,
     fetchedAt: null,
     refreshVersion: 0,
+    refreshEtag: null,
     expiresAt: null,
     createdAt: new Date(),
     ...overrides,

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -341,6 +341,16 @@ export class LinkPreviewService {
     })
   }
 
+  /**
+   * Record a conditional refresh that confirmed the provider content unchanged
+   * (a 304 gate answer): re-arm the debounce gate without rewriting metadata or
+   * broadcasting. Compare-and-set — losing to a concurrent real refresh is fine,
+   * the winner's write already advanced `fetched_at`.
+   */
+  async recordRefreshCheck(workspaceId: string, previewId: string, expectedRefreshVersion: number): Promise<boolean> {
+    return LinkPreviewRepository.touchRefreshCheck(this.deps.pool, workspaceId, previewId, expectedRefreshVersion)
+  }
+
   /** Filters out failed/pending previews. */
   async getPreviewsForMessage(workspaceId: string, messageId: string): Promise<LinkPreviewSummary[]> {
     const previews = await LinkPreviewRepository.findByMessageId(this.deps.pool, workspaceId, messageId)

--- a/apps/backend/src/features/link-previews/visible-refresh.test.ts
+++ b/apps/backend/src/features/link-previews/visible-refresh.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import type { LinkPreview } from "./repository"
+import type { LinkPreviewService } from "./service"
+import type { WorkspaceIntegrationService } from "../workspace-integrations"
+import * as githubPreviewModule from "./github-preview"
+import {
+  createLinkPreviewVisibleRefreshWorker,
+  enqueueVisiblePreviewRefreshes,
+  visibleRefreshQueueId,
+  VISIBLE_REFRESH_DEBOUNCE_MS,
+} from "./visible-refresh"
+import type { Job } from "../../lib/queue"
+import { JobQueues } from "../../lib/queue"
+import type { LinkPreviewVisibleRefreshJobData } from "../../lib/queue/job-queue"
+
+const WORKSPACE_ID = "ws_1"
+
+function makePreview(overrides: Partial<LinkPreview> = {}): LinkPreview {
+  return {
+    id: "lp_pr",
+    workspaceId: WORKSPACE_ID,
+    url: "https://github.com/acme/widgets/pull/42",
+    normalizedUrl: "https://github.com/acme/widgets/pull/42",
+    title: "PR #42",
+    description: null,
+    imageUrl: null,
+    faviconUrl: null,
+    siteName: "GitHub",
+    contentType: "website",
+    status: "completed",
+    previewType: "github_pr",
+    previewData: null,
+    targetWorkspaceId: null,
+    targetStreamId: null,
+    targetMessageId: null,
+    targetMemoId: null,
+    targetConversationId: null,
+    targetDelegationId: null,
+    fetchedAt: new Date(Date.now() - 60_000),
+    refreshVersion: 1,
+    refreshEtag: null,
+    expiresAt: null,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+function makeJob(data: LinkPreviewVisibleRefreshJobData): Job<LinkPreviewVisibleRefreshJobData> {
+  return { id: "job_1", data } as Job<LinkPreviewVisibleRefreshJobData>
+}
+
+function fakeDeps(preview: LinkPreview | null) {
+  return {
+    linkPreviewService: {
+      getPreviewById: mock(async () => preview),
+      applyRefreshedMetadata: mock(async () => ({ applied: true })),
+      recordRefreshCheck: mock(async () => true),
+    } as unknown as LinkPreviewService,
+    workspaceIntegrationService: {} as unknown as WorkspaceIntegrationService,
+  }
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("visibleRefreshQueueId", () => {
+  test("same debounce-window bucket collapses, next window gets a fresh id", () => {
+    // Aligned to a bucket boundary so "+ window - 1" provably stays inside it.
+    const t0 = Math.floor(1_000_000_000_000 / VISIBLE_REFRESH_DEBOUNCE_MS) * VISIBLE_REFRESH_DEBOUNCE_MS
+    const sameWindow = t0 + VISIBLE_REFRESH_DEBOUNCE_MS - 1
+    const nextWindow = t0 + VISIBLE_REFRESH_DEBOUNCE_MS
+
+    expect(visibleRefreshQueueId("lp_a", t0)).toBe(visibleRefreshQueueId("lp_a", sameWindow))
+    expect(visibleRefreshQueueId("lp_a", t0)).not.toBe(visibleRefreshQueueId("lp_a", nextWindow))
+    expect(visibleRefreshQueueId("lp_a", t0)).not.toBe(visibleRefreshQueueId("lp_b", t0))
+  })
+})
+
+describe("enqueueVisiblePreviewRefreshes", () => {
+  test("sends one bucketed job per preview id", async () => {
+    const send = mock(async () => "queued")
+    await enqueueVisiblePreviewRefreshes({ send } as never, WORKSPACE_ID, ["lp_a", "lp_b"])
+
+    expect(send).toHaveBeenCalledTimes(2)
+    const [queueName, data, options] = send.mock.calls[0] as unknown as [
+      string,
+      LinkPreviewVisibleRefreshJobData,
+      { messageId: string },
+    ]
+    expect(queueName).toBe(JobQueues.LINK_PREVIEW_VISIBLE_REFRESH)
+    expect(data).toEqual({ workspaceId: WORKSPACE_ID, previewId: "lp_a" })
+    expect(options.messageId.startsWith("queue_lpviz_lp_a_b")).toBe(true)
+  })
+
+  test("a failing send (dedupe collision) is swallowed and other ids still enqueue", async () => {
+    const send = mock(async (_q: unknown, data: { previewId: string }) => {
+      if (data.previewId === "lp_a") throw new Error("duplicate key")
+      return "queued"
+    })
+    await enqueueVisiblePreviewRefreshes({ send } as never, WORKSPACE_ID, ["lp_a", "lp_b"])
+
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("createLinkPreviewVisibleRefreshWorker", () => {
+  test("runs the refresh in conditional mode: a 304 gate answer touches the row and skips the full fetch", async () => {
+    const deps = fakeDeps(makePreview({ refreshEtag: '"v1"' }))
+    const gateSpy = spyOn(githubPreviewModule, "checkGitHubRefreshGate").mockResolvedValue({
+      outcome: "not_modified",
+    })
+    const fetchSpy = spyOn(githubPreviewModule, "fetchGitHubPreview")
+
+    await createLinkPreviewVisibleRefreshWorker(deps)(makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_pr" }))
+
+    expect(gateSpy).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "https://github.com/acme/widgets/pull/42",
+      '"v1"',
+      deps.workspaceIntegrationService
+    )
+    expect(deps.linkPreviewService.recordRefreshCheck).toHaveBeenCalledWith(WORKSPACE_ID, "lp_pr", 1)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test("uses the visible-refresh debounce, wider than the webhook default", async () => {
+    // 12s old: past the webhook path's 10s window but inside this path's 15s
+    // window, so a correctly-configured worker must debounce (no gate call).
+    const deps = fakeDeps(makePreview({ fetchedAt: new Date(Date.now() - 12_000) }))
+    const gateSpy = spyOn(githubPreviewModule, "checkGitHubRefreshGate")
+
+    await createLinkPreviewVisibleRefreshWorker(deps)(makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_pr" }))
+
+    expect(gateSpy).not.toHaveBeenCalled()
+  })
+
+  test("drops non-GitHub preview types (opt-in list)", async () => {
+    const deps = fakeDeps(makePreview({ previewType: "linear_issue" }))
+    const gateSpy = spyOn(githubPreviewModule, "checkGitHubRefreshGate")
+    const fetchSpy = spyOn(githubPreviewModule, "fetchGitHubPreview")
+
+    await createLinkPreviewVisibleRefreshWorker(deps)(makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_pr" }))
+
+    expect(gateSpy).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test("drops rows without a provider preview type, pending rows, and vanished rows", async () => {
+    const gateSpy = spyOn(githubPreviewModule, "checkGitHubRefreshGate")
+    const fetchSpy = spyOn(githubPreviewModule, "fetchGitHubPreview")
+
+    await createLinkPreviewVisibleRefreshWorker(fakeDeps(makePreview({ previewType: null })))(
+      makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_pr" })
+    )
+    await createLinkPreviewVisibleRefreshWorker(fakeDeps(makePreview({ status: "pending" })))(
+      makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_pr" })
+    )
+    await createLinkPreviewVisibleRefreshWorker(fakeDeps(null))(
+      makeJob({ workspaceId: WORKSPACE_ID, previewId: "lp_gone" })
+    )
+
+    expect(gateSpy).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/link-previews/visible-refresh.ts
+++ b/apps/backend/src/features/link-previews/visible-refresh.ts
@@ -44,10 +44,9 @@ export function visibleRefreshQueueId(previewId: string, nowMs: number): string 
 }
 
 /**
- * Fan a client's visible-preview report into per-preview refresh jobs. Fire and
- * forget from the socket path: dedupe collisions are the normal case during a
- * scroll storm and enqueue failures are only logged — the next viewport pass
- * re-nudges.
+ * Fan a client's visible-preview report into per-preview refresh jobs.
+ * Same-window duplicates collapse inside `send` (idempotent message-id insert);
+ * any other enqueue failure is only logged — the next viewport pass re-nudges.
  */
 export async function enqueueVisiblePreviewRefreshes(
   jobQueue: Pick<QueueManager, "send">,

--- a/apps/backend/src/features/link-previews/visible-refresh.ts
+++ b/apps/backend/src/features/link-previews/visible-refresh.ts
@@ -1,0 +1,100 @@
+import { logger } from "@threa/backend-common"
+import { GITHUB_PREVIEW_TYPES } from "@threa/types"
+import type { Job, JobHandler, QueueManager } from "../../lib/queue"
+import { JobQueues } from "../../lib/queue"
+import type { LinkPreviewVisibleRefreshJobData } from "../../lib/queue/job-queue"
+import { refreshLinkPreview, type RefreshLinkPreviewDeps } from "./refresh"
+
+const log = logger.child({ module: "link-preview-visible-refresh" })
+
+/**
+ * Debounce for viewport-nudged refreshes. Deliberately longer than the webhook
+ * path's 10s: a webhook KNOWS something changed, a visible card is speculative.
+ * With the ETag gate a nudge that passes this window and finds nothing new
+ * costs no rate limit (304), so the window prices only the gate round-trip.
+ */
+export const VISIBLE_REFRESH_DEBOUNCE_MS = 15_000
+
+/** Per-frame id cap: one viewport of preview cards, with headroom. */
+export const VISIBLE_REFRESH_MAX_IDS = 50
+
+/**
+ * Per-connection floor between accepted `previews:visible` frames. Clients
+ * flush on a slower cadence, so a compliant client never trips this; it only
+ * bounds how fast a hostile socket can make us enqueue.
+ */
+export const VISIBLE_REPORT_MIN_INTERVAL_MS = 5_000
+
+/**
+ * Provider preview types the viewport nudge may refresh. Opt-in by design: a
+ * type belongs here only when its refresh path is conditional-fetch aware, so
+ * a nudge for anything else is dropped instead of burning provider quota.
+ */
+const VISIBLE_REFRESHABLE_PREVIEW_TYPES: ReadonlySet<string> = new Set(GITHUB_PREVIEW_TYPES)
+
+/**
+ * Deterministic queue-message id, keyed on the debounce-window time bucket so
+ * every nudge for one preview within one window — across sockets, users, and
+ * replicas — collapses into a single job via `send`'s messageId dedupe. The
+ * next window gets a fresh bucket, so a persisted completed row never blocks a
+ * later nudge.
+ */
+export function visibleRefreshQueueId(previewId: string, nowMs: number): string {
+  return `queue_lpviz_${previewId}_b${Math.floor(nowMs / VISIBLE_REFRESH_DEBOUNCE_MS)}`
+}
+
+/**
+ * Fan a client's visible-preview report into per-preview refresh jobs. Fire and
+ * forget from the socket path: dedupe collisions are the normal case during a
+ * scroll storm and enqueue failures are only logged — the next viewport pass
+ * re-nudges.
+ */
+export async function enqueueVisiblePreviewRefreshes(
+  jobQueue: Pick<QueueManager, "send">,
+  workspaceId: string,
+  previewIds: string[]
+): Promise<void> {
+  const now = Date.now()
+  await Promise.all(
+    previewIds.map(async (previewId) => {
+      try {
+        await jobQueue.send(
+          JobQueues.LINK_PREVIEW_VISIBLE_REFRESH,
+          { workspaceId, previewId },
+          { messageId: visibleRefreshQueueId(previewId, now) }
+        )
+      } catch (error) {
+        log.debug({ err: error, workspaceId, previewId }, "Failed to enqueue visible preview refresh; dropping")
+      }
+    })
+  )
+}
+
+/**
+ * Worker for viewport-nudged refreshes: conditional (ETag-gated) refresh of one
+ * preview. Every non-refreshed outcome is terminal — `not_modified` and
+ * `debounced` are the expected steady states, and transient failures are not
+ * retried because the nudge source (a user looking at the card) re-fires.
+ */
+export function createLinkPreviewVisibleRefreshWorker(
+  deps: RefreshLinkPreviewDeps
+): JobHandler<LinkPreviewVisibleRefreshJobData> {
+  return async (job: Job<LinkPreviewVisibleRefreshJobData>) => {
+    const { workspaceId, previewId } = job.data
+
+    const preview = await deps.linkPreviewService.getPreviewById(workspaceId, previewId)
+    if (!preview || preview.status !== "completed") return
+    if (!preview.previewType || !VISIBLE_REFRESHABLE_PREVIEW_TYPES.has(preview.previewType)) return
+
+    const result = await refreshLinkPreview(deps, {
+      workspaceId,
+      previewId,
+      debounceMs: VISIBLE_REFRESH_DEBOUNCE_MS,
+      conditional: true,
+    })
+    log.debug(
+      { workspaceId, previewId, refreshed: result.refreshed },
+      `Visible preview refresh ${result.refreshed ? "applied" : `skipped (${result.reason})`}`
+    )
+  }
+}

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -188,6 +188,67 @@ describe("GitHubClient captureRateLimit is best-effort", () => {
   })
 })
 
+describe("GitHubClient requestConditional", () => {
+  function makeClient(requestImpl: (route: string, parameters?: Record<string, unknown>) => Promise<unknown>) {
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubEnabled,
+      linear: linearDisabled,
+    })
+    // Anonymous client: no record/credentials, so captureRateLimit no-ops and
+    // the exploding pool proves nothing touches the DB.
+    const client = GitHubClient.anonymous(service, "ws_1")
+    ;(client as unknown as { octokit: { request: typeof requestImpl } }).octokit = { request: requestImpl }
+    return client
+  }
+
+  it("passes If-None-Match and maps octokit's 304 throw to { status: 304 }", async () => {
+    let seenHeaders: Record<string, unknown> | undefined
+    const client = makeClient(async (_route, parameters) => {
+      seenHeaders = parameters?.headers as Record<string, unknown>
+      throw Object.assign(new Error("Not modified"), { status: 304, response: { headers: {} } })
+    })
+
+    const result = await client.requestConditional("GET /repos/{owner}/{repo}/pulls/{pull_number}", {}, '"v1"')
+
+    expect(result).toEqual({ status: 304 })
+    expect(seenHeaders?.["if-none-match"]).toBe('"v1"')
+  })
+
+  it("returns data plus the fresh validator on 200", async () => {
+    const client = makeClient(async () => ({
+      data: { title: "PR" },
+      headers: { etag: 'W/"fresh"' },
+    }))
+
+    const result = await client.requestConditional("GET /x", {}, '"stale"')
+
+    expect(result).toEqual({ status: 200, data: { title: "PR" }, etag: 'W/"fresh"' })
+  })
+
+  it("sends no validator header when none is stored (harvest call)", async () => {
+    let seenParameters: Record<string, unknown> | undefined
+    const client = makeClient(async (_route, parameters) => {
+      seenParameters = parameters
+      return { data: {}, headers: {} }
+    })
+
+    const result = await client.requestConditional("GET /x", {}, null)
+
+    expect(seenParameters?.headers).toBeUndefined()
+    expect(result).toEqual({ status: 200, data: {}, etag: null })
+  })
+
+  it("rethrows non-304 errors", async () => {
+    const failure = Object.assign(new Error("Server error"), { status: 502, response: { headers: {} } })
+    const client = makeClient(async () => {
+      throw failure
+    })
+
+    await expect(client.requestConditional("GET /x", {}, '"v1"')).rejects.toBe(failure)
+  })
+})
+
 describe("LinearClient captureRateLimit is best-effort", () => {
   const credentials: LinearIntegrationCredentials = {
     accessToken: "at",

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -109,14 +109,46 @@ export class GitHubClient {
   }
 
   async request<T>(route: string, parameters: Record<string, unknown> = {}): Promise<T> {
-    return this.requestInternal<T>(route, parameters, false)
+    return (await this.requestInternal(route, parameters, false)).data as T
   }
 
-  private async requestInternal<T>(route: string, parameters: Record<string, unknown>, retried: boolean): Promise<T> {
+  /**
+   * GET with `If-None-Match` support for cache-validator refreshes. A matching
+   * validator surfaces as `{ status: 304 }` instead of the RequestError octokit
+   * throws for it; an authorized 304 does not count against the primary rate
+   * limit, which is the whole point of the conditional refresh path.
+   */
+  async requestConditional<T>(
+    route: string,
+    parameters: Record<string, unknown>,
+    ifNoneMatch: string | null
+  ): Promise<{ status: 200; data: T; etag: string | null } | { status: 304 }> {
+    const withValidator = ifNoneMatch
+      ? {
+          ...parameters,
+          headers: { ...(parameters.headers as Record<string, unknown> | undefined), "if-none-match": ifNoneMatch },
+        }
+      : parameters
+    try {
+      const response = await this.requestInternal(route, withValidator, false)
+      const etag = response.headers["etag"]
+      return { status: 200, data: response.data as T, etag: typeof etag === "string" ? etag : null }
+    } catch (error) {
+      if (getErrorStatus(error) === 304) return { status: 304 }
+      throw error
+    }
+  }
+
+  private async requestInternal(
+    route: string,
+    parameters: Record<string, unknown>,
+    retried: boolean
+  ): Promise<{ data: unknown; headers: GitHubApiHeaders }> {
     try {
       const response = await this.octokit.request(route, parameters)
-      await this.captureRateLimit(response.headers as GitHubApiHeaders)
-      return response.data as T
+      const headers = response.headers as GitHubApiHeaders
+      await this.captureRateLimit(headers)
+      return { data: response.data, headers }
     } catch (error) {
       const status = getErrorStatus(error)
       const headers = getErrorHeaders(error)
@@ -133,7 +165,7 @@ export class GitHubClient {
         this.credentials = refreshed.credentials
         this.metadata = refreshed.metadata
         this.octokit = new Octokit({ auth: refreshed.credentials.accessToken })
-        return this.requestInternal<T>(route, parameters, true)
+        return this.requestInternal(route, parameters, true)
       }
 
       throw error

--- a/apps/backend/src/lib/queue/job-queue.ts
+++ b/apps/backend/src/lib/queue/job-queue.ts
@@ -50,6 +50,7 @@ export const JobQueues = {
   BACKFILL_CHUNK: "backfill.chunk",
   GITHUB_WEBHOOK_PROCESS: "github_webhook.process",
   GITHUB_PREVIEW_REFRESH: "github_preview.refresh",
+  LINK_PREVIEW_VISIBLE_REFRESH: "link_preview.visible-refresh",
 } as const
 
 export type JobQueueName = (typeof JobQueues)[keyof typeof JobQueues]
@@ -392,6 +393,17 @@ export interface GithubPreviewRefreshJobData {
   hop?: number
 }
 
+/**
+ * Best-effort conditional refresh of one link preview because a client reported
+ * its card in the viewport. No retries or trailing chains — the next viewport
+ * pass re-nudges. Senders key the queue-message id on a debounce-window time
+ * bucket so a scroll-storm across replicas collapses into one job per window.
+ */
+export interface LinkPreviewVisibleRefreshJobData {
+  workspaceId: string
+  previewId: string
+}
+
 export interface JobDataMap {
   [JobQueues.PERSONA_AGENT]: PersonaAgentJobData
   [JobQueues.NAMING_GENERATE]: NamingJobData
@@ -425,6 +437,7 @@ export interface JobDataMap {
   [JobQueues.BACKFILL_CHUNK]: BackfillChunkJobData
   [JobQueues.GITHUB_WEBHOOK_PROCESS]: GithubWebhookProcessJobData
   [JobQueues.GITHUB_PREVIEW_REFRESH]: GithubPreviewRefreshJobData
+  [JobQueues.LINK_PREVIEW_VISIBLE_REFRESH]: LinkPreviewVisibleRefreshJobData
 }
 
 /** Returns void on success, throws on error. */

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -26,7 +26,12 @@ import {
   EnclaveClaimNudge,
   EnclaveDispatchHandler,
 } from "./features/enclave-runtimes"
-import { LinkPreviewService, LinkPreviewOutboxHandler, createLinkPreviewWorker } from "./features/link-previews"
+import {
+  LinkPreviewService,
+  LinkPreviewOutboxHandler,
+  createLinkPreviewWorker,
+  createLinkPreviewVisibleRefreshWorker,
+} from "./features/link-previews"
 import { createGithubWebhookWorker, createGithubPreviewRefreshWorker } from "./features/github-webhooks"
 import { GiphyService } from "./features/giphy"
 import {
@@ -771,6 +776,7 @@ export async function startServer(): Promise<ServerInstance> {
     workspaceService,
     userSocketRegistry,
     sessionAbortRegistry,
+    jobQueue,
   })
 
   // Dedicated voice relay on its own namespace so audio frames don't share the
@@ -1257,6 +1263,17 @@ export async function startServer(): Promise<ServerInstance> {
     jobQueue,
   })
   jobQueue.registerHandler(JobQueues.GITHUB_PREVIEW_REFRESH, githubPreviewRefreshWorker, {
+    tier: QueueTiers.LIGHT,
+    fairness: QueueFairness.NONE,
+  })
+
+  // Viewport-nudged preview refresh — conditional (ETag-gated) GitHub fetch,
+  // best-effort with no retry chain (the visible card re-nudges)
+  const linkPreviewVisibleRefreshWorker = createLinkPreviewVisibleRefreshWorker({
+    linkPreviewService,
+    workspaceIntegrationService,
+  })
+  jobQueue.registerHandler(JobQueues.LINK_PREVIEW_VISIBLE_REFRESH, linkPreviewVisibleRefreshWorker, {
     tier: QueueTiers.LIGHT,
     fairness: QueueFairness.NONE,
   })

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -9,6 +9,12 @@ import type { UserSocketRegistry } from "./lib/user-socket-registry"
 import { AgentSessionRepository, PersonaRepository } from "./features/agents"
 import type { SessionAbortRegistry } from "./features/agents"
 import { UserRepository, type WorkspaceService } from "./features/workspaces"
+import {
+  enqueueVisiblePreviewRefreshes,
+  VISIBLE_REFRESH_MAX_IDS,
+  VISIBLE_REPORT_MIN_INTERVAL_MS,
+} from "./features/link-previews"
+import type { QueueManager } from "./lib/queue"
 import { groupToRoom, permissionGroupsForRole } from "./lib/outbox"
 import { isValidIanaTimezone } from "./lib/temporal"
 import { HttpError } from "./lib/errors"
@@ -54,6 +60,8 @@ interface Dependencies {
   userSocketRegistry: UserSocketRegistry
   /** Registry for graceful tool cancellation (e.g. workspace_research) — in-process sessions. */
   sessionAbortRegistry: SessionAbortRegistry
+  /** For fanning viewport-nudge frames into visible-refresh jobs. */
+  jobQueue: Pick<QueueManager, "send">
 }
 
 /**
@@ -67,8 +75,16 @@ function deriveDeviceKey(userAgent: string | undefined): string {
 }
 
 export function registerSocketHandlers(io: Server, deps: Dependencies) {
-  const { pool, authService, streamService, pushService, workspaceService, userSocketRegistry, sessionAbortRegistry } =
-    deps
+  const {
+    pool,
+    authService,
+    streamService,
+    pushService,
+    workspaceService,
+    userSocketRegistry,
+    sessionAbortRegistry,
+    jobQueue,
+  } = deps
 
   // Auth middleware is shared with the voice namespace — see lib/socket-auth
   io.use(createSocketAuthMiddleware(authService))
@@ -406,6 +422,32 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
       if (entries.length === 0) return
       pushService.upsertSessionsBatch(entries, { focused, interacted }).catch((err) => {
         logger.warn({ err }, "Failed to upsert sessions on heartbeat")
+      })
+    })
+
+    // Viewport nudge: the client reports which provider preview cards are on
+    // screen so the worker can run a conditional (ETag-gated) refresh for repos
+    // no webhook covers. Best-effort by design — invalid or throttled frames
+    // are dropped silently, the client re-reports on its next flush. Membership
+    // check is the userRooms entry: it only exists after a successful
+    // permission-checked workspace room join.
+    let lastVisibleReportAt = 0
+    socket.on("previews:visible", (payload?: { workspaceId?: string; previewIds?: string[] }) => {
+      const workspaceId = payload?.workspaceId
+      if (typeof workspaceId !== "string" || !userRooms.has(workspaceId)) return
+      if (!Array.isArray(payload?.previewIds) || payload.previewIds.length === 0) return
+
+      const now = Date.now()
+      if (now - lastVisibleReportAt < VISIBLE_REPORT_MIN_INTERVAL_MS) return
+      lastVisibleReportAt = now
+
+      const previewIds = payload.previewIds
+        .filter((id): id is string => typeof id === "string" && id.length > 0)
+        .slice(0, VISIBLE_REFRESH_MAX_IDS)
+      if (previewIds.length === 0) return
+
+      enqueueVisiblePreviewRefreshes(jobQueue, workspaceId, previewIds).catch((err) => {
+        logger.warn({ err, workspaceId }, "Failed to enqueue visible preview refreshes")
       })
     })
 

--- a/apps/backend/tests/integration/link-preview-refresh-etag.test.ts
+++ b/apps/backend/tests/integration/link-preview-refresh-etag.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTestTransaction } from "./setup"
+import { LinkPreviewRepository } from "../../src/features/link-previews/repository"
+
+/**
+ * Real-Postgres coverage for the conditional-refresh persistence pieces
+ * (INV-66 rule: the compared version must be produced by the repository's own
+ * NOW()-writing path and read back through the repository, never hand-crafted).
+ */
+describe("touchRefreshCheck (304 gate answer)", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("round-trip: touches fetched_at and bumps the version read back from the repo's own write", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await LinkPreviewRepository.insert(client, {
+        id: "lp_touch",
+        workspaceId: "ws_etag",
+        url: "https://github.com/a/b/pull/1",
+        normalizedUrl: "https://github.com/a/b/pull/1",
+        contentType: "website",
+      })
+      await LinkPreviewRepository.updateMetadata(client, "ws_etag", "lp_touch", {
+        status: "completed",
+        title: "initial",
+      })
+      const before = await LinkPreviewRepository.findById(client, "ws_etag", "lp_touch")
+
+      const touched = await LinkPreviewRepository.touchRefreshCheck(
+        client,
+        "ws_etag",
+        "lp_touch",
+        before!.refreshVersion
+      )
+      expect(touched).toBe(true)
+
+      const after = await LinkPreviewRepository.findById(client, "ws_etag", "lp_touch")
+      expect(after!.refreshVersion).toBe(before!.refreshVersion + 1)
+      expect(after!.fetchedAt!.getTime()).toBeGreaterThanOrEqual(before!.fetchedAt!.getTime())
+      // Touch must not disturb the rendered metadata.
+      expect(after!.title).toBe("initial")
+    })
+  })
+
+  test("loses the CAS against a concurrent write without touching the row", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO link_previews (id, workspace_id, url, normalized_url, status, content_type, refresh_version, fetched_at, created_at)
+         VALUES ('lp_touch_lose', 'ws_etag', 'https://github.com/a/b/pull/2',
+                 'https://github.com/a/b/pull/2', 'completed', 'website', 9, NOW(), NOW())`
+      )
+
+      const touched = await LinkPreviewRepository.touchRefreshCheck(client, "ws_etag", "lp_touch_lose", 5)
+
+      expect(touched).toBe(false)
+      const { rows } = await client.query(`SELECT refresh_version FROM link_previews WHERE id = 'lp_touch_lose'`)
+      expect(rows[0].refresh_version).toBe(9)
+    })
+  })
+})
+
+describe("refresh_etag write semantics on overwriteMetadata", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("a params key present overwrites, absent preserves, explicit null clears", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await LinkPreviewRepository.insert(client, {
+        id: "lp_etag",
+        workspaceId: "ws_etag",
+        url: "https://github.com/a/b/pull/3",
+        normalizedUrl: "https://github.com/a/b/pull/3",
+        contentType: "website",
+      })
+
+      const withEtag = await LinkPreviewRepository.overwriteMetadata(client, "ws_etag", "lp_etag", {
+        status: "completed",
+        title: "v1",
+        refreshEtag: '"abc"',
+      })
+      expect(withEtag!.refreshEtag).toBe('"abc"')
+
+      // Key absent (the unconditional webhook path): stored validator survives.
+      const preserved = await LinkPreviewRepository.overwriteMetadata(client, "ws_etag", "lp_etag", {
+        status: "completed",
+        title: "v2",
+      })
+      expect(preserved!.refreshEtag).toBe('"abc"')
+      expect(preserved!.title).toBe("v2")
+
+      // Explicit null (a gate answer that carried no validator): cleared.
+      const cleared = await LinkPreviewRepository.overwriteMetadata(client, "ws_etag", "lp_etag", {
+        status: "completed",
+        title: "v3",
+        refreshEtag: null,
+      })
+      expect(cleared!.refreshEtag).toBeNull()
+    })
+  })
+})

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -27,6 +27,7 @@ import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { linkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
 import { isVideoPreview, videoPlaybackSrc } from "@/components/gallery/video-embed"
 import { LinkPreviewBody } from "./link-preview-body"
+import { useReportPreviewVisible } from "@/hooks/use-report-preview-visible"
 import { AccentGlow, colorWithAlpha, Field, FieldGrid, LabelChip, MonoTag, StatePill } from "./link-preview-primitives"
 import type {
   GitHubFilePreviewData,
@@ -130,6 +131,14 @@ export function LinkPreviewCard({
     providerPreview && !isLinearPreview(providerPreview) && !isVideoPreview(providerPreview) ? providerPreview : null
   const linearPreview = isLinearPreview(providerPreview) ? providerPreview : null
 
+  // GitHub cards only: feeds the viewport-nudge conditional refresh, which is
+  // how previews from repos without webhook coverage stay fresh while watched.
+  const visibilityRef = useReportPreviewVisible({
+    workspaceId,
+    previewId: preview.id,
+    enabled: githubPreview !== null,
+  })
+
   const handleDismiss = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
@@ -206,6 +215,7 @@ export function LinkPreviewCard({
   // menu (via the inner <a>) instead of the message drawer.
   return (
     <div
+      ref={visibilityRef}
       data-native-context="true"
       className={cn(
         "group/preview reveal-host relative overflow-hidden rounded-lg border bg-card transition-all max-w-md",

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -3,6 +3,7 @@ import { io, Socket } from "socket.io-client"
 import { HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
 import { api } from "@/api/client"
 import { getCachedWsConfig, setCachedWsConfig } from "@/lib/cached-ws-config"
+import { setPreviewVisibilityEmitter } from "@/lib/preview-visibility"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
 import { useSwPresence } from "@/hooks/use-sw-presence"
@@ -215,6 +216,16 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
   const previousPageActivityRef = useRef(pageActivity)
   const pageFocusedRef = useRef(pageActivity.isFocused)
   pageFocusedRef.current = pageActivity.isFocused
+
+  // Viewport-nudge transport: while connected, the preview-visibility batcher
+  // can flush `previews:visible` frames; while disconnected it just accumulates.
+  useEffect(() => {
+    if (!socket || status !== "connected") return
+    setPreviewVisibilityEmitter((wsId, previewIds) => {
+      socket.emit("previews:visible", { workspaceId: wsId, previewIds })
+    })
+    return () => setPreviewVisibilityEmitter(null)
+  }, [socket, status])
 
   useEffect(() => {
     if (!socket || status !== "connected") return

--- a/apps/frontend/src/hooks/use-report-preview-visible.ts
+++ b/apps/frontend/src/hooks/use-report-preview-visible.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react"
+import { reportPreviewHidden, reportPreviewVisible } from "@/lib/preview-visibility"
+
+/**
+ * Report a provider preview card's viewport presence to the visibility batcher
+ * (which feeds the backend's conditional-refresh nudge). Returns a ref for the
+ * card's root element. No-ops when disabled, when ids are missing (transient
+ * previews without a workspace), or where IntersectionObserver doesn't exist
+ * (jsdom).
+ */
+export function useReportPreviewVisible(params: {
+  workspaceId: string | undefined
+  previewId: string
+  enabled: boolean
+}): React.RefObject<HTMLDivElement | null> {
+  const { workspaceId, previewId, enabled } = params
+  const elementRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const element = elementRef.current
+    if (!enabled || !workspaceId || !element || typeof IntersectionObserver === "undefined") return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) reportPreviewVisible(workspaceId, previewId)
+          else reportPreviewHidden(workspaceId, previewId)
+        }
+      },
+      // A sliver of a card peeking in shouldn't count as "looking at it".
+      { threshold: 0.5 }
+    )
+    observer.observe(element)
+
+    return () => {
+      observer.disconnect()
+      reportPreviewHidden(workspaceId, previewId)
+    }
+  }, [enabled, workspaceId, previewId])
+
+  return elementRef
+}

--- a/apps/frontend/src/lib/preview-visibility.test.ts
+++ b/apps/frontend/src/lib/preview-visibility.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import {
+  flushPreviewVisibilityForTest,
+  reportPreviewHidden,
+  reportPreviewVisible,
+  resetPreviewVisibility,
+  setPreviewVisibilityEmitter,
+} from "./preview-visibility"
+
+afterEach(() => {
+  resetPreviewVisibility()
+})
+
+describe("preview visibility batcher", () => {
+  test("a flush emits one frame per workspace with the currently visible ids", () => {
+    const emitter = vi.fn()
+    setPreviewVisibilityEmitter(emitter)
+
+    reportPreviewVisible("ws_a", "lp_1")
+    reportPreviewVisible("ws_a", "lp_2")
+    reportPreviewVisible("ws_b", "lp_3")
+    flushPreviewVisibilityForTest()
+
+    expect(emitter).toHaveBeenCalledTimes(2)
+    expect(emitter).toHaveBeenCalledWith("ws_a", ["lp_1", "lp_2"])
+    expect(emitter).toHaveBeenCalledWith("ws_b", ["lp_3"])
+  })
+
+  test("a hidden card leaves the next flush; re-reporting the same id does not duplicate", () => {
+    const emitter = vi.fn()
+    setPreviewVisibilityEmitter(emitter)
+
+    reportPreviewVisible("ws_a", "lp_1")
+    reportPreviewVisible("ws_a", "lp_1")
+    reportPreviewVisible("ws_a", "lp_2")
+    reportPreviewHidden("ws_a", "lp_1")
+    flushPreviewVisibilityForTest()
+
+    expect(emitter).toHaveBeenCalledTimes(1)
+    expect(emitter).toHaveBeenCalledWith("ws_a", ["lp_2"])
+  })
+
+  test("nothing is emitted while every card is hidden or no emitter is wired", () => {
+    const emitter = vi.fn()
+
+    // No emitter yet: reports accumulate silently.
+    reportPreviewVisible("ws_a", "lp_1")
+    flushPreviewVisibilityForTest()
+    expect(emitter).not.toHaveBeenCalled()
+
+    // Emitter wired but the only card left: no frame.
+    setPreviewVisibilityEmitter(emitter)
+    reportPreviewHidden("ws_a", "lp_1")
+    flushPreviewVisibilityForTest()
+    expect(emitter).not.toHaveBeenCalled()
+  })
+
+  test("accumulated reports survive an emitter swap (reconnect)", () => {
+    reportPreviewVisible("ws_a", "lp_1")
+
+    const emitter = vi.fn()
+    setPreviewVisibilityEmitter(emitter)
+    flushPreviewVisibilityForTest()
+
+    expect(emitter).toHaveBeenCalledWith("ws_a", ["lp_1"])
+  })
+})

--- a/apps/frontend/src/lib/preview-visibility.ts
+++ b/apps/frontend/src/lib/preview-visibility.ts
@@ -1,0 +1,85 @@
+/**
+ * Batches "these provider preview cards are on screen" reports into periodic
+ * `previews:visible` socket frames. The backend uses them to run conditional
+ * (ETag-gated) refreshes for repos webhooks can't reach, so cadence here is
+ * deliberately lazy: one frame per flush interval covering everything visible,
+ * nothing while the tab is hidden, and the server debounces per preview anyway.
+ */
+
+export const PREVIEW_VISIBILITY_FLUSH_MS = 10_000
+/** First flush after the viewport goes from empty to occupied — batches the initial mount burst. */
+const LEADING_FLUSH_MS = 1_000
+
+type Emitter = (workspaceId: string, previewIds: string[]) => void
+
+const visibleByWorkspace = new Map<string, Set<string>>()
+let emitter: Emitter | null = null
+let intervalId: ReturnType<typeof setInterval> | null = null
+let leadingId: ReturnType<typeof setTimeout> | null = null
+
+/** Wired by the socket provider; null while disconnected (reports keep accumulating). */
+export function setPreviewVisibilityEmitter(next: Emitter | null): void {
+  emitter = next
+  syncTimer()
+}
+
+export function reportPreviewVisible(workspaceId: string, previewId: string): void {
+  const hadAny = visibleByWorkspace.size > 0
+  let set = visibleByWorkspace.get(workspaceId)
+  if (!set) {
+    set = new Set()
+    visibleByWorkspace.set(workspaceId, set)
+  }
+  set.add(previewId)
+  if (!hadAny && leadingId === null) {
+    leadingId = setTimeout(() => {
+      leadingId = null
+      flush()
+    }, LEADING_FLUSH_MS)
+  }
+  syncTimer()
+}
+
+export function reportPreviewHidden(workspaceId: string, previewId: string): void {
+  const set = visibleByWorkspace.get(workspaceId)
+  if (!set) return
+  set.delete(previewId)
+  if (set.size === 0) visibleByWorkspace.delete(workspaceId)
+  syncTimer()
+}
+
+/** Test-only: runs one flush synchronously instead of waiting out the interval. */
+export function flushPreviewVisibilityForTest(): void {
+  flush()
+}
+
+/** Test-only: clears accumulated state and timers between cases. */
+export function resetPreviewVisibility(): void {
+  visibleByWorkspace.clear()
+  emitter = null
+  if (leadingId !== null) {
+    clearTimeout(leadingId)
+    leadingId = null
+  }
+  syncTimer()
+}
+
+function syncTimer(): void {
+  const shouldRun = emitter !== null && visibleByWorkspace.size > 0
+  if (shouldRun && intervalId === null) {
+    intervalId = setInterval(flush, PREVIEW_VISIBILITY_FLUSH_MS)
+  } else if (!shouldRun && intervalId !== null) {
+    clearInterval(intervalId)
+    intervalId = null
+  }
+}
+
+function flush(): void {
+  if (!emitter) return
+  // A hidden tab keeps observing (sets stay warm for the return) but must not
+  // nudge the server about cards nobody is looking at.
+  if (typeof document !== "undefined" && document.visibilityState !== "visible") return
+  for (const [workspaceId, ids] of visibleByWorkspace) {
+    if (ids.size > 0) emitter(workspaceId, [...ids])
+  }
+}


### PR DESCRIPTION
## Problem

GitHub preview cards only refresh when a webhook fires, and webhooks only fire for repos the Threa GitHub App is installed on (#1374). A PR card from any other repo — `kristofferremback/seer`, any OSS link — renders rich once and then never updates. Polling would close the gap but burns installation rate limit for repos that mostly aren't changing.

## Solution

Refresh previews when someone is actually looking at them, and make the "nothing changed" case free: an IntersectionObserver on GitHub cards feeds a batched `previews:visible` socket frame, and the backend answers each nudge with a single conditional (`If-None-Match`) request against the preview's primary GitHub resource. Per GitHub's documented behavior, an authorized conditional request answered `304` does not count against the primary rate limit — so a watched-but-unchanged card re-checks every ~15s at zero quota cost, and spends real quota only when the card actually changed.

### How it works

1. **Client** — `useReportPreviewVisible` (IntersectionObserver, 0.5 threshold so a sliver peeking in doesn't count) reports GitHub cards into a module-level batcher (`lib/preview-visibility.ts`). The batcher flushes one `previews:visible` frame per workspace every 10s while the tab is visible, with a 1s leading flush when the viewport goes from empty to occupied; while disconnected it accumulates silently. The emitter is wired in `socket-context.tsx` on connect.
2. **Socket handler** (`socket.ts`) — validates shape, checks workspace membership via the `userRooms` entry (which only exists after a permission-checked room join), applies a 5s per-connection floor and a 50-id cap, then fans into `link_preview.visible-refresh` jobs. Message ids are time-bucketed (`queue_lpviz_<previewId>_b<floor(now/15s)>`), so a scroll storm across sockets, users, and replicas collapses into one job per preview per window via `send`'s idempotent message-id insert.
3. **Worker** (`visible-refresh.ts`) — drops anything that isn't a completed GitHub-type preview (opt-in set; Linear joins by adding a fetcher), then calls `refreshLinkPreview` with `conditional: true` and a 15s debounce.
4. **Conditional refresh** (`refresh.ts`) — after the existing debounce gate, `checkGitHubRefreshGate` makes ONE conditional request against the preview's primary resource: PR/diff → `pulls/{n}`, issue → `issues/{n}`, comment → `issues/comments/{id}`, commit → `commits/{sha}` (immutable, so it 304s forever — correct), file → the repo object (`pushed_at` moves on any push). On `304`: `touchRefreshCheck` advances `fetched_at` under a `refresh_version` CAS with no broadcast — the debounce re-arms, nothing else moves. On `200`: the fresh validator is harvested, the existing full fetch runs, and the validator is stored with the write (`refresh_etag`).
5. **Client plumbing** — `GitHubClient.requestConditional` sends `If-None-Match` and maps octokit's 304-as-throw into a typed `{ status: 304 }`, sharing the 401-token-refresh retry path with `request` via the reshaped `requestInternal`.

### Key design decisions

**1. One ETag per preview, gated on the primary resource** — not per-endpoint ETag maps. A preview's fetch makes 2–3 API calls (repo + pull + reviews for a PR), but everything the card renders moves the primary resource's validator: reviews and pushes bump the pull's `updated_at`, issue comments bump the issue. The alternative (per-endpoint map + cached bodies to rebuild from partial 304s) buys nothing the card can display and complicates every write. Cost of the simple design: one extra counted call when content actually changed (the gate 200 + the full fetch re-requests the primary endpoint) — paid exactly when spending is justified.

**2. Webhook path stays unconditional and preserves the stored validator** — a webhook already proves something changed; a gate request would be pure overhead. `refresh_etag` in `UpdateLinkPreviewParams` is key-present-overwrites / key-absent-preserves, so webhook writes leave the validator stale. A stale validator self-heals: the next nudge's gate answers 200 and re-harvests (one counted call).

**3. Initial fetches store no validator** — threading response headers through every type-specific fetcher for the etag would reshape `fetchGitHubPreview` for marginal gain; the first nudge harvests one. Until a card has been looked at once post-fetch, there's nothing to keep fresh anyway.

**4. 304 "touch" bumps `refresh_version` (INV-66) with no broadcast** — every write increments the version; a touch that didn't would let a stale in-flight full fetch CAS over it. No outbox event because nothing observable changed (INV-4 covers deliveries of real changes, and INV-63's spirit applies: silence when there's nothing to show). If a concurrent real refresh wins the CAS instead, the touch is dropped — the winner already advanced `fetched_at`.

**5. Viewport debounce 15s vs the webhook's 10s** — a webhook KNOWS something changed; a visible card is speculative. With 304s free, 15s prices only the gate round-trip. Both constants are per-call `debounceMs` arguments to the shared `refreshLinkPreview`.

**6. No trailing/retry machinery for nudges** — the webhook path's trailing-refresh chain exists because a dropped invalidation is lost forever. A nudge's signal source is a human looking at the card; the next flush re-nudges. `debounced`, `conflict`, `not_modified`, and `fetch_empty` are all terminal for the visible-refresh worker.

**7. Workspace-membership check only, no per-preview stream ACL on nudges** — a nudge returns no data to the sender; the refreshed row broadcasts through stream rooms that carry their own access gating (INV-62 enforced at delivery). The only abuse surface is making the server spend fetches, bounded by the 5s per-connection throttle, the 50-id cap, the 15s server debounce, and the rate-limit breaker underneath.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260718150000_link_preview_refresh_etag.sql` | `refresh_etag TEXT` on `link_previews` |
| `apps/backend/src/features/link-previews/visible-refresh.ts` | Debounce/bucket constants, queue-id helper, socket-side enqueue, worker |
| `apps/backend/src/features/link-previews/visible-refresh.test.ts` | Bucket collapse, enqueue dedupe, worker routing + conditional-mode coverage |
| `apps/backend/tests/integration/link-preview-refresh-etag.test.ts` | Real-PG: touch CAS round-trip via the repo's own `NOW()` path (INV-66 rule), etag write/preserve/clear semantics |
| `apps/frontend/src/lib/preview-visibility.ts` | Module-level visibility batcher (flush cadence, tab-visibility gate, emitter wiring point) |
| `apps/frontend/src/lib/preview-visibility.test.ts` | Batcher semantics under vitest |
| `apps/frontend/src/hooks/use-report-preview-visible.ts` | IntersectionObserver hook, jsdom-safe |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/link-previews/repository.ts` | `refreshEtag` on row type + `UpdateLinkPreviewParams` (present-overwrites/absent-preserves), `touchRefreshCheck` CAS |
| `apps/backend/src/features/link-previews/refresh.ts` | `conditional` mode: gate → touch / harvest-then-fetch; new `not_modified` result |
| `apps/backend/src/features/link-previews/github-preview.ts` | `checkGitHubRefreshGate` + per-type primary-endpoint mapping |
| `apps/backend/src/features/link-previews/service.ts` | `recordRefreshCheck` passthrough (INV-30: single query on `pool`) |
| `apps/backend/src/features/workspace-integrations/service.ts` | `GitHubClient.requestConditional`; `requestInternal` returns `{ data, headers }` |
| `apps/backend/src/lib/queue/job-queue.ts` | `link_preview.visible-refresh` job type |
| `apps/backend/src/socket.ts` | `previews:visible` inbound handler + `jobQueue` dep |
| `apps/backend/src/server.ts` | Worker registration + socket dep wiring |
| `apps/backend/src/features/github-webhooks/preview-refresh.ts` | Union narrowing for `not_modified` (unreachable on the unconditional path, typed out explicitly) |
| `apps/frontend/src/components/timeline/link-preview-card.tsx` | Visibility ref on GitHub cards only |
| `apps/frontend/src/contexts/socket-context.tsx` | Emitter wiring on connect/disconnect |
| test fixtures (5 files) | `refreshEtag: null` on `LinkPreview` defaults |

## Out of scope (deliberate)

- **Multi-installation support** (app on N orgs / personal accounts) — the durable fix for owned external repos; separate design pass, discussed with Kris in the scratchpad.
- **ETags on the webhook refresh path** — see decision 2.
- **Linear/other providers** — the opt-in set and the generic frame are ready; each provider needs its own gate mapping.

## Test plan

- [x] Backend unit + e2e: 3214 + 367 pass (includes 20 refresh tests, 7 visible-refresh tests, 18 workspace-integrations tests)
- [x] Real-Postgres integration: 3 pass (`link-preview-refresh-etag.test.ts` — touch CAS round-trip per the INV-66 fixture rule, etag write semantics; migration applied by the run)
- [x] Frontend full vitest suite: 4485 pass, 0 fail
- [x] `tsc --noEmit` across the monorepo (pre-commit gauntlet) + eslint + `check:migrations` (220 clean) + API-docs check
- [x] Pre-PR review (3 Sonnet reviewer agents — spec compliance, correctness+security, design+history): 0 findings ≥ threshold. One sub-threshold note accepted as-is: a "modified" conditional refresh resolves the GitHub client twice (gate + full fetch, one extra DB read + decrypt) — only on the rare content-changed path, not worth threading the client through `fetchGitHubPreview`'s signature
- [ ] Live dogfood (post a seer PR link, watch the card refresh while visible) — needs a deployed backend; recipe in the scratchpad thread

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787001593&installation_id=129946197&pr_number=1398&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1398&signature=fbb06d1cc6f06c1d0df5ae04496a7c139b9923cafb5b5bc5e4c0b326710dac5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->