### PR TITLE
fix(pi-remote): isolate child session lifecycle events

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
-import { __testing } from "./threa-remote"
+import threaRemote, { __testing } from "./threa-remote"
 
 describe("Pi remote trace safety", () => {
   test("omits sensitive bash command arguments from tool_call traces", () => {
@@ -852,20 +852,73 @@ describe("buildPersistedConfig", () => {
 
 describe("session-scoped lifecycle isolation", () => {
   afterEach(() => {
+    __testing.clearPendingForTesting()
     __testing.setConfigForTesting(undefined)
   })
 
-  test("ignores in-process child events while the parent session is linked", () => {
+  test("child shutdown preserves the parent claim while parent shutdown clears it", async () => {
+    const shutdownHandlers: Array<(event: unknown, ctx: unknown) => Promise<void>> = []
+    threaRemote({
+      registerCommand: () => {},
+      on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<void>) => {
+        if (event === "session_shutdown") shutdownHandlers.push(handler)
+      },
+    } as never)
+    const shutdown = shutdownHandlers[0]
+    expect(shutdown).toBeDefined()
+
     __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
       linkedSessions: {
         parent: {
           enabled: true,
+          instanceId: "pi-parent",
+          runtimeSessionId: "parent",
+          activeStreamId: "stream_a",
         },
       },
     })
+    __testing.beginPendingInvocation({
+      id: "binv_parent",
+      activeStreamId: "stream_a",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "run workflow",
+      claimToken: "claim_1",
+      claimedInstanceId: "pi-parent",
+      claimExpiresAt: null,
+    } as never)
 
-    expect(__testing.shouldHandleSessionEvents("parent")).toBe(true)
-    expect(__testing.shouldHandleSessionEvents("workflow-child")).toBe(false)
+    const requests: string[] = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      requests.push(String(input))
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+    const context = (sessionId: string) =>
+      ({
+        sessionManager: { getSessionId: () => sessionId },
+        ui: { setStatus: () => {}, notify: () => {} },
+      }) as never
+
+    try {
+      await shutdown({ reason: "quit" }, context("workflow-child"))
+      expect({ claimActive: __testing.claimRenewTimerActive(), requestCount: requests.length }).toEqual({
+        claimActive: true,
+        requestCount: 0,
+      })
+
+      await shutdown({ reason: "quit" }, context("parent"))
+      expect({ claimActive: __testing.claimRenewTimerActive(), madeRequests: requests.length > 0 }).toEqual({
+        claimActive: false,
+        madeRequests: true,
+      })
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 })
 

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -850,6 +850,25 @@ describe("buildPersistedConfig", () => {
   })
 })
 
+describe("session-scoped lifecycle isolation", () => {
+  afterEach(() => {
+    __testing.setConfigForTesting(undefined)
+  })
+
+  test("ignores in-process child events while the parent session is linked", () => {
+    __testing.setConfigForTesting({
+      linkedSessions: {
+        parent: {
+          enabled: true,
+        },
+      },
+    })
+
+    expect(__testing.shouldHandleSessionEvents("parent")).toBe(true)
+    expect(__testing.shouldHandleSessionEvents("workflow-child")).toBe(false)
+  })
+})
+
 describe("claim renewal during a turn", () => {
   const invocation = {
     id: "binv_renew_1",

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -3249,8 +3249,6 @@ export const __testing = {
   setConfigForTesting: (value: unknown) => {
     config = value as Config | undefined
   },
-  shouldHandleSessionEvents: (sessionId: string) =>
-    shouldHandleSessionEvents({ sessionManager: { getSessionId: () => sessionId } } as ExtensionContext),
   buildClaimInvocationPayload,
   buildPersistedConfig,
   buildRuntimeCapabilities,

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -1365,6 +1365,10 @@ function isEnabled(ctx: ExtensionContext): boolean {
   return isCurrentSessionEnabled(ctx)
 }
 
+function shouldHandleSessionEvents(ctx: ExtensionContext): boolean {
+  return isEnabled(ctx)
+}
+
 function stopPolling(): void {
   pollingRunId += 1
   if (timer) clearTimeout(timer)
@@ -1531,6 +1535,10 @@ function botTraitDiagnostics(principal: BotPrincipal | null): string[] {
 async function disableRemote(ctx: ExtensionContext): Promise<void> {
   if (!config) return
   const link = setCurrentSessionEnabled(ctx, false)
+  if (!link) {
+    ctx.ui.notify("No Threa remote session is linked here.", "warning")
+    return
+  }
   stopPolling()
   teardownTransport()
   await failPending("Threa remote disabled", ctx)
@@ -3241,6 +3249,8 @@ export const __testing = {
   setConfigForTesting: (value: unknown) => {
     config = value as Config | undefined
   },
+  shouldHandleSessionEvents: (sessionId: string) =>
+    shouldHandleSessionEvents({ sessionManager: { getSessionId: () => sessionId } } as ExtensionContext),
   buildClaimInvocationPayload,
   buildPersistedConfig,
   buildRuntimeCapabilities,
@@ -3299,6 +3309,7 @@ export default function (pi: ExtensionAPI): void {
     description:
       "Link this Pi session to a Threa scratchpad: configure | status | open | rename <name> | on | off | debug | debug-polls [on|off]",
     handler: async (args, ctx) => {
+      if (ctx.mode === "print" || ctx.mode === "json") return
       const trimmedArgs = args.trim()
       const commandMatch = trimmedArgs.match(/^(\S+)(?:\s+([\s\S]*))?$/)
       const command = commandMatch?.[1]?.toLowerCase() ?? ""
@@ -3432,22 +3443,23 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("agent_start", async (_event, ctx) => {
-    if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…", ctx).catch(() => undefined)
+    if (!config || !shouldHandleSessionEvents(ctx)) return
+    await heartbeatBusyIfStale("Thinking…", ctx).catch(() => undefined)
     // Just a live status heartbeat — no `thinking` trace step. The model's
     // real narration lands as `thinking` trace steps from `message_end` below,
     // so a placeholder "Thinking…" row here would only add noise to the trace.
     await traceHeartbeat("Thinking…", ctx)
   })
 
-  pi.on("tool_call", async (event) => {
-    if (!pending) return
+  pi.on("tool_call", async (event, ctx) => {
+    if (!pending || !shouldHandleSessionEvents(ctx)) return
     const description = describeToolCall(event)
     pendingToolCalls.set(event.toolCallId, { headline: description.replace(/…$/, "") })
     await recordTraceStep("tool_call", formatToolCallTrace(event, shouldEmitFullTrace(pending)), description)
   })
 
-  pi.on("tool_result", async (event) => {
-    if (!pending) return
+  pi.on("tool_result", async (event, ctx) => {
+    if (!pending || !shouldHandleSessionEvents(ctx)) return
     await recordTraceStep(
       event.isError ? "tool_error" : "tool_call",
       formatToolResultTrace(event, shouldEmitFullTrace(pending)),
@@ -3457,18 +3469,18 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("tool_execution_end", async (event, ctx) => {
-    if (!event.isError || !pendingToolCalls.has(event.toolCallId)) return
+    if (!shouldHandleSessionEvents(ctx) || !event.isError || !pendingToolCalls.has(event.toolCallId)) return
     await traceHeartbeat(`${event.toolName} failed`, ctx, "tool_error")
     pendingToolCalls.delete(event.toolCallId)
   })
 
   pi.on("message_start", async (event, ctx) => {
-    if (!pending || event.message.role !== "assistant") return
+    if (!pending || !shouldHandleSessionEvents(ctx) || event.message.role !== "assistant") return
     await traceHeartbeat("Composing response…", ctx)
   })
 
-  pi.on("message_end", async (event) => {
-    if (!pending) return
+  pi.on("message_end", async (event, ctx) => {
+    if (!pending || !shouldHandleSessionEvents(ctx)) return
     const modelError = extractModelError(event.message)
     if (modelError) {
       pendingModelError = modelError
@@ -3494,8 +3506,8 @@ export default function (pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("after_provider_response", async (event) => {
-    if (!pending) return
+  pi.on("after_provider_response", async (event, ctx) => {
+    if (!pending || !shouldHandleSessionEvents(ctx)) return
     const raw = event as { status?: unknown; headers?: unknown }
     const status = typeof raw.status === "number" ? raw.status : 0
     if (status < 400) return
@@ -3506,6 +3518,7 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("agent_end", async (event, ctx) => {
+    if (!shouldHandleSessionEvents(ctx)) return
     if (!pending) {
       if (config && isEnabled(ctx)) {
         lastBusyHeartbeatAt = 0
@@ -3550,6 +3563,9 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("session_shutdown", async (event, ctx) => {
+    // In-process Pi child sessions can discover this global extension. Never
+    // let an unlinked child tear down or complete the linked parent's claim.
+    if (!shouldHandleSessionEvents(ctx)) return
     stopPolling()
     stopClaimRenewTimer()
     teardownTransport()


### PR DESCRIPTION
## Problem

`extensions/pi-remote` stores the active invocation and transport in module-level state. In-process Pi workflow/subagent sessions can emit lifecycle events through another extension context in the same process. Handlers previously checked only `pending`, so a child `agent_end` could complete the parent's invocation with child output; child `session_shutdown` could stop polling and tear down the parent's transport.

Observed failure: a two-agent workflow posted the first child's `BreadBot` response under the parent invocation ID, then discarded the parent's completed workflow response.

## Solution

Scope remote lifecycle handling to the linked runtime session.

### How it works

- `shouldHandleSessionEvents` resolves the event context through `linkedSessions` and accepts only the enabled linked session.
- Agent, tool, message, provider-response, and shutdown handlers return before touching module-level invocation or transport state for unlinked child contexts.
- `/remote-control` ignores print/JSON child contexts; `disableRemote` also refuses global cleanup when its session has no link.
- The regression test verifies the linked parent is accepted while an in-process workflow child is rejected.

### Design decisions

**Use the persisted runtime-session link as ownership.** `linkedSessions` already identifies which Pi session owns the scratchpad. Reusing it avoids parallel ownership state that could drift from remote configuration.

**Guard every module-global mutation surface.** Filtering only `agent_end` would stop the premature reply but still allow child tool traces, provider errors, or shutdown to corrupt the parent turn.

## Modified files

| File | Change |
| --- | --- |
| `extensions/pi-remote/src/threa-remote.ts` | Gate lifecycle handlers and destructive commands by linked session ownership. |
| `extensions/pi-remote/src/threa-remote.test.ts` | Cover parent acceptance and workflow-child rejection. |

## Test plan

- [x] `bun test ./src/threa-remote.test.ts ./src/threa-remote.sealed.test.ts` — 100 pass
- [x] Commit hooks — repository lint, workspace typechecks, Dockerfile/migration checks, and generated API docs check passed
- [x] Manual Threa test — two DeepSeek workflow children completed; Threa received the full parent response instead of the first child response
- [x] Pre-PR review (1 Claude reviewer) — found unguarded headless command/disable paths; fixed before commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787028743&installation_id=129946197&pr_number=1399&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1399&signature=11116ef7cb21f9245b813b287934eadb858bc05522d36176a7fb42530fcaec99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->