### PR TITLE
feat: N GitHub installations per workspace — multi-install model, service, and API

### DIFF
--- a/apps/backend/src/db/migrations/20260719120000_workspace_integrations_multi_install.sql
+++ b/apps/backend/src/db/migrations/20260719120000_workspace_integrations_multi_install.sql
@@ -1,0 +1,35 @@
+-- Multi-installation support for GitHub: N rows per (workspace, provider), one
+-- per installation. The old single-row unique index (workspace_id, provider) is
+-- replaced by two partial indexes:
+--   1. (workspace_id, provider, installation_id) WHERE installation_id IS NOT NULL
+--      lets a workspace hold many GitHub installs (org + personal + more), each a
+--      distinct row keyed by its installation id, while still rejecting a
+--      duplicate row for the same installation.
+--   2. (workspace_id, provider) WHERE installation_id IS NULL keeps at most one
+--      NULL-installation row per (workspace, provider) — legacy GitHub rows that
+--      predate the installation_id backfill, and any provider that never sets an
+--      installation id.
+-- Linear is single-row but NOT covered by index #2: it stores its org id in
+-- installation_id (non-null), so its rows fall under index #1. Index #1 alone
+-- would permit a second Linear row per distinct org id, so Linear's single-row
+-- guarantee is enforced at the app layer by an id-keyed upsert (ON CONFLICT (id))
+-- that rewrites the one row on an org switch — see persistLinearCredentials.
+-- Partial indexes are used rather than NULLS NOT DISTINCT because that clause is
+-- unavailable on older PostgreSQL and partial indexes work everywhere.
+--
+-- Deploy-window note: the new indexes are created BEFORE the old one is dropped,
+-- so uniqueness is never unenforced. Between this migration and the code cutover
+-- an old replica still runs `ON CONFLICT (workspace_id, provider)`, which errors
+-- once the backing index is gone; the blast radius is an admin connecting a new
+-- install mid-deploy (a retryable 500). Token refreshes are UPDATEs and are
+-- unaffected.
+
+CREATE UNIQUE INDEX IF NOT EXISTS workspace_integrations_workspace_provider_installation
+    ON workspace_integrations (workspace_id, provider, installation_id)
+    WHERE installation_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS workspace_integrations_workspace_provider_no_installation
+    ON workspace_integrations (workspace_id, provider)
+    WHERE installation_id IS NULL;
+
+DROP INDEX IF EXISTS workspace_integrations_workspace_provider;

--- a/apps/backend/src/features/workspace-integrations/handlers.test.ts
+++ b/apps/backend/src/features/workspace-integrations/handlers.test.ts
@@ -1,5 +1,97 @@
 import { describe, expect, test } from "bun:test"
-import { buildProviderCallbackRedirectUrl } from "./handlers"
+import type { Request, Response } from "express"
+import { buildProviderCallbackRedirectUrl, createWorkspaceIntegrationHandlers } from "./handlers"
+import type { WorkspaceIntegrationService } from "./service"
+
+interface CapturedResponse {
+  statusCode: number | null
+  body: unknown
+  sent: boolean
+}
+
+function fakeRes(): { res: Response; captured: CapturedResponse } {
+  const captured: CapturedResponse = { statusCode: null, body: undefined, sent: false }
+  const res = {
+    json(body: unknown) {
+      captured.body = body
+      return this
+    },
+    status(code: number) {
+      captured.statusCode = code
+      return this
+    },
+    send() {
+      captured.sent = true
+      return this
+    },
+  } as unknown as Response
+  return { res, captured }
+}
+
+function makeHandlers(service: Partial<WorkspaceIntegrationService>) {
+  return createWorkspaceIntegrationHandlers({
+    workspaceIntegrationService: service as WorkspaceIntegrationService,
+    allowedFrontendOrigins: [],
+  })
+}
+
+describe("github integration handlers", () => {
+  test("getGithub responds with { configured, integrations }", async () => {
+    const integrations = [{ id: "wsi_1" }]
+    const handlers = makeHandlers({
+      isGitHubEnabled: () => true,
+      listGithubInstallations: async () => integrations as never,
+    })
+    const { res, captured } = fakeRes()
+    await handlers.getGithub({ workspaceId: "ws_1" } as unknown as Request, res)
+    expect(captured.body).toEqual({ configured: true, integrations })
+  })
+
+  test("disconnectGithub validates integrationId param and delegates to the per-install service", async () => {
+    let received: { workspaceId?: string; integrationId?: string } = {}
+    const handlers = makeHandlers({
+      disconnectGithubInstallation: async (workspaceId: string, integrationId: string) => {
+        received = { workspaceId, integrationId }
+      },
+    })
+    const { res, captured } = fakeRes()
+    await handlers.disconnectGithub(
+      { workspaceId: "ws_1", params: { integrationId: "wsi_9" } } as unknown as Request,
+      res
+    )
+    expect(received).toEqual({ workspaceId: "ws_1", integrationId: "wsi_9" })
+    expect(captured.statusCode).toBe(204)
+    expect(captured.sent).toBe(true)
+  })
+
+  test("disconnectGithub rejects a missing integrationId param", async () => {
+    const handlers = makeHandlers({ disconnectGithubInstallation: async () => {} })
+    const { res } = fakeRes()
+    await expect(
+      handlers.disconnectGithub({ workspaceId: "ws_1", params: {} } as unknown as Request, res)
+    ).rejects.toThrow()
+  })
+
+  test("syncGithub re-lists installations after syncing the addressed one", async () => {
+    const calls: string[] = []
+    const integrations = [{ id: "wsi_1" }]
+    const handlers = makeHandlers({
+      isGitHubEnabled: () => true,
+      syncGithubRepositories: async (_ws: string, integrationId: string) => {
+        calls.push(`sync:${integrationId}`)
+        return {} as never
+      },
+      listGithubInstallations: async () => {
+        calls.push("list")
+        return integrations as never
+      },
+    })
+    const { res, captured } = fakeRes()
+    await handlers.syncGithub({ workspaceId: "ws_1", params: { integrationId: "wsi_1" } } as unknown as Request, res)
+    expect(calls).toEqual(["sync:wsi_1", "list"])
+    expect(captured.body).toEqual({ configured: true, integrations })
+  })
+})
 
 describe("buildProviderCallbackRedirectUrl (github)", () => {
   const allowedOrigins = ["http://localhost:3000", "https://app.threa.io"]

--- a/apps/backend/src/features/workspace-integrations/handlers.ts
+++ b/apps/backend/src/features/workspace-integrations/handlers.ts
@@ -9,6 +9,10 @@ const githubCallbackSchema = z.object({
   state: z.string().min(1, "state is required"),
 })
 
+const githubInstallationParamsSchema = z.object({
+  integrationId: z.string().min(1, "integrationId is required"),
+})
+
 const linearCallbackSchema = z.object({
   code: z.string().min(1, "code is required"),
   state: z.string().min(1, "state is required"),
@@ -54,10 +58,10 @@ export function createWorkspaceIntegrationHandlers({
   return {
     async getGithub(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
-      const integration = await workspaceIntegrationService.getGithubIntegration(workspaceId)
+      const integrations = await workspaceIntegrationService.listGithubInstallations(workspaceId)
       res.json({
         configured: workspaceIntegrationService.isGitHubEnabled(),
-        integration,
+        integrations,
       })
     },
 
@@ -69,16 +73,19 @@ export function createWorkspaceIntegrationHandlers({
 
     async disconnectGithub(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
-      await workspaceIntegrationService.disconnectGithubIntegration(workspaceId)
+      const { integrationId } = validateRequest(githubInstallationParamsSchema, req.params)
+      await workspaceIntegrationService.disconnectGithubInstallation(workspaceId, integrationId)
       res.status(204).send()
     },
 
     async syncGithub(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
-      const integration = await workspaceIntegrationService.syncGithubRepositories(workspaceId)
+      const { integrationId } = validateRequest(githubInstallationParamsSchema, req.params)
+      await workspaceIntegrationService.syncGithubRepositories(workspaceId, integrationId)
+      const integrations = await workspaceIntegrationService.listGithubInstallations(workspaceId)
       res.json({
         configured: workspaceIntegrationService.isGitHubEnabled(),
-        integration,
+        integrations,
       })
     },
 

--- a/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
+++ b/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, mock, spyOn } from "bun:test"
 import type { Pool } from "pg"
-import { WorkspaceIntegrationService } from "./service"
+import { GitHubClient, WorkspaceIntegrationService } from "./service"
 import {
   WorkspaceIntegrationRepository,
   type UpsertWorkspaceIntegrationParams,
@@ -101,6 +101,197 @@ afterEach(() => {
   mock.restore()
 })
 
+const FUTURE_ISO = new Date(Date.now() + 3_600_000).toISOString()
+
+function encryptedGithubCredentials(installationId: number): Record<string, unknown> {
+  return encryptJson(
+    SECRET,
+    { installationId, accessToken: "tok", tokenExpiresAt: FUTURE_ISO },
+    { workspaceId: "ws_1", provider: "github" }
+  )
+}
+
+/** An active install row with decryptable, non-expiring credentials and metadata. */
+function activeGithubInstall(installationId: string, metadata: Record<string, unknown> = {}): Record<string, unknown> {
+  return githubRow({
+    id: `wsi_${installationId}`,
+    installation_id: installationId,
+    credentials: encryptedGithubCredentials(Number(installationId)),
+    metadata,
+    version: 1,
+  })
+}
+
+const NEAR_LIMIT = { rateLimitRemaining: 5, rateLimitResetAt: FUTURE_ISO }
+
+describe("getGithubClient owner-aware resolution", () => {
+  function serviceWithInstalls(rows: Array<Record<string, unknown>>): WorkspaceIntegrationService {
+    // recordingPool returns the same rows for the listByWorkspaceAndProvider SELECT.
+    return new WorkspaceIntegrationService({
+      pool: recordingPool(rows).pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+  }
+
+  it("uses the install whose account login matches repoOwner (case-insensitive)", async () => {
+    const service = serviceWithInstalls([
+      activeGithubInstall("100", { organizationName: "Acme" }),
+      activeGithubInstall("200", { organizationName: "other" }),
+    ])
+    const client = await service.getGithubClient("ws_1", { repoOwner: "acme" })
+    expect(client).toBeInstanceOf(GitHubClient)
+  })
+
+  it("returns null (hard breaker) when the owner-matched install is throttled, never borrowing a sibling", async () => {
+    const service = serviceWithInstalls([
+      activeGithubInstall("100", { organizationName: "acme", ...NEAR_LIMIT }),
+      activeGithubInstall("200", { organizationName: "other" }),
+    ])
+    const client = await service.getGithubClient("ws_1", {
+      repoOwner: "acme",
+      allowUnauthenticatedFallback: true,
+    })
+    expect(client).toBeNull()
+  })
+
+  it("falls through to any non-throttled install when no login matches", async () => {
+    const service = serviceWithInstalls([
+      activeGithubInstall("100", { organizationName: "acme" }),
+      activeGithubInstall("200", { organizationName: "other" }),
+    ])
+    const client = await service.getGithubClient("ws_1", { repoOwner: "nobody" })
+    expect(client).toBeInstanceOf(GitHubClient)
+  })
+
+  it("returns null when every active install is throttled (breaker), even with fallback allowed", async () => {
+    const service = serviceWithInstalls([
+      activeGithubInstall("100", { organizationName: "acme", ...NEAR_LIMIT }),
+      activeGithubInstall("200", { organizationName: "other", ...NEAR_LIMIT }),
+    ])
+    const client = await service.getGithubClient("ws_1", { allowUnauthenticatedFallback: true })
+    expect(client).toBeNull()
+  })
+
+  it("falls back to anonymous when no install yields a client and fallback is allowed", async () => {
+    // Undecryptable credentials → no client parsed; not throttled → fallback path.
+    const service = serviceWithInstalls([githubRow({ installation_id: "100", credentials: { garbage: true } })])
+    const client = await service.getGithubClient("ws_1", { allowUnauthenticatedFallback: true })
+    expect(client).toBeInstanceOf(GitHubClient)
+  })
+
+  it("returns null (no fallback flag) when there are no active installs", async () => {
+    const service = serviceWithInstalls([githubRow({ status: "inactive" })])
+    expect(await service.getGithubClient("ws_1", { repoOwner: "acme" })).toBeNull()
+  })
+})
+
+describe("completeGithubInstallation account types", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  function stubInstallationNetwork(service: WorkspaceIntegrationService, accountType: string, login: string): void {
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async (route: string) => {
+        if (route.startsWith("GET /app/installations")) {
+          return {
+            data: {
+              account: { type: accountType, login },
+              repository_selection: "all",
+              permissions: {},
+            },
+          }
+        }
+        return { data: { token: "tok", expires_at: FUTURE_ISO, permissions: {} } }
+      },
+    })
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ repositories: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
+  }
+
+  function completeInstall(service: WorkspaceIntegrationService, rawId: string): Promise<void> {
+    return (
+      service as unknown as {
+        completeGithubInstallation(workspaceId: string, userId: string, rawId: string): Promise<void>
+      }
+    ).completeGithubInstallation("ws_1", "user_1", rawId)
+  }
+
+  it("accepts a personal (User) account and persists accountType into metadata", async () => {
+    const { pool } = recordingPool([])
+    spyOn(WorkspaceIntegrationRepository, "lockWorkspace").mockResolvedValue(undefined)
+    spyOn(WorkspaceIntegrationRepository, "listByWorkspaceAndProvider").mockResolvedValue([])
+    const upsertSpy = spyOn(WorkspaceIntegrationRepository, "upsert").mockImplementation(async (_c, params) => ({
+      id: params.id,
+      workspaceId: params.workspaceId,
+      provider: params.provider,
+      status: params.status,
+      credentials: params.credentials,
+      metadata: params.metadata,
+      installedBy: params.installedBy,
+      installationId: params.installationId ?? null,
+      version: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }))
+    outboxSpy()
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+    stubInstallationNetwork(service, "User", "kristofferremback")
+
+    await completeInstall(service, "555")
+
+    const params = upsertSpy.mock.calls[0][1]
+    expect(params.status).toBe("active")
+    expect(params.installationId).toBe("555")
+    expect((params.metadata as { accountType?: unknown }).accountType).toBe("User")
+    expect((params.metadata as { organizationName?: unknown }).organizationName).toBe("kristofferremback")
+  })
+
+  it("accepts an Organization account (no org-required throw)", async () => {
+    const { pool } = recordingPool([])
+    spyOn(WorkspaceIntegrationRepository, "lockWorkspace").mockResolvedValue(undefined)
+    spyOn(WorkspaceIntegrationRepository, "listByWorkspaceAndProvider").mockResolvedValue([])
+    const upsertSpy = spyOn(WorkspaceIntegrationRepository, "upsert").mockImplementation(async (_c, params) => ({
+      id: params.id,
+      workspaceId: params.workspaceId,
+      provider: params.provider,
+      status: params.status,
+      credentials: params.credentials,
+      metadata: params.metadata,
+      installedBy: params.installedBy,
+      installationId: params.installationId ?? null,
+      version: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }))
+    outboxSpy()
+    const service = new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+    stubInstallationNetwork(service, "Organization", "acme")
+
+    await completeInstall(service, "777")
+
+    const params = upsertSpy.mock.calls[0][1]
+    expect((params.metadata as { accountType?: unknown }).accountType).toBe("Organization")
+  })
+})
+
 describe("disconnectGithubIntegration route unregistration", () => {
   it("emits a github_route:unregister event with the plaintext installation id", async () => {
     const { pool } = recordingPool([githubRow()])
@@ -112,7 +303,7 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: "eu-north-1",
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     expect(routeEvents(spy)).toEqual([
       {
@@ -137,7 +328,7 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: "eu-north-1",
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     expect(routeEvents(spy)).toEqual([
       {
@@ -166,7 +357,7 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: "eu-north-1",
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update).toBeDefined()
@@ -199,7 +390,7 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: "eu-north-1",
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     const update = calls.find((call) => call.text.includes("UPDATE workspace_integrations"))
     expect(update?.values).toContain("42")
@@ -207,8 +398,8 @@ describe("disconnectGithubIntegration route unregistration", () => {
   })
 
   it("does NOT version-CAS, so a concurrent background version bump can't no-op the disconnect (asymmetry)", async () => {
-    // Lifecycle writes express absolute user intent: the guarded UPDATE carries an
-    // installation-id guard but leaves the version guard ($12) NULL, so a
+    // Lifecycle writes express absolute user intent: the guarded UPDATE is scoped
+    // to the installation id but leaves the version guard ($10) NULL, so a
     // concurrent rate-limit/refresh version bump does not make the disconnect miss.
     const { pool, calls } = recordingPool([githubRow({ installation_id: "42", version: 9 })])
     const spy = outboxSpy()
@@ -219,12 +410,12 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: "eu-north-1",
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update?.values).toContain("inactive")
-    // $12 (expectedVersion) is null → no version CAS on the lifecycle write.
-    expect(update?.values[11]).toBeNull()
+    // $10 (expectedVersion) is null → no version CAS on the lifecycle write.
+    expect(update?.values[9]).toBeNull()
     expect(routeEvents(spy)).toEqual([
       {
         eventType: "github_route:unregister",
@@ -243,30 +434,19 @@ describe("disconnectGithubIntegration route unregistration", () => {
       region: null,
     })
 
-    await service.disconnectGithubIntegration("ws_1")
+    await service.disconnectGithubInstallation("ws_1", "wsi_1")
 
     expect(spy).not.toHaveBeenCalled()
   })
 })
 
-describe("GitHub installation replacement route lifecycle", () => {
-  it("serializes replacement and unregisters the previous route before registering the new one", async () => {
+describe("GitHub installation route lifecycle (additive)", () => {
+  it("serializes on the workspace lock and registers the new install WITHOUT unregistering siblings", async () => {
+    // Installs are additive (N rows per workspace): connecting installation 77
+    // must not unregister an existing installation 42. Only a register event fires.
     const { pool } = recordingPool([])
-    const previous: WorkspaceIntegrationRecord = {
-      id: "wsi_1",
-      workspaceId: "ws_1",
-      provider: "github",
-      status: "active",
-      credentials: {},
-      metadata: {},
-      installedBy: "user_1",
-      installationId: "42",
-      version: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }
-    const replacement: UpsertWorkspaceIntegrationParams = {
-      id: "wsi_1",
+    const install: UpsertWorkspaceIntegrationParams = {
+      id: "wsi_2",
       workspaceId: "ws_1",
       provider: "github",
       status: "active",
@@ -276,8 +456,20 @@ describe("GitHub installation replacement route lifecycle", () => {
       installationId: "77",
     }
     const lockSpy = spyOn(WorkspaceIntegrationRepository, "lockWorkspace").mockResolvedValue(undefined)
-    spyOn(WorkspaceIntegrationRepository, "findByWorkspaceAndProvider").mockResolvedValue(previous)
-    spyOn(WorkspaceIntegrationRepository, "upsert").mockResolvedValue({ ...previous, installationId: "77" })
+    const findSpy = spyOn(WorkspaceIntegrationRepository, "findByWorkspaceAndProvider")
+    spyOn(WorkspaceIntegrationRepository, "upsert").mockResolvedValue({
+      id: "wsi_2",
+      workspaceId: "ws_1",
+      provider: "github",
+      status: "active",
+      credentials: {},
+      metadata: {},
+      installedBy: "user_1",
+      installationId: "77",
+      version: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
     const spy = outboxSpy()
     const service = new WorkspaceIntegrationService({
       pool,
@@ -290,17 +482,16 @@ describe("GitHub installation replacement route lifecycle", () => {
       service as unknown as {
         persistGithubIntegration(
           params: UpsertWorkspaceIntegrationParams,
+          installationScope: string | null,
           routeInstallationId: string
         ): Promise<WorkspaceIntegrationRecord>
       }
-    ).persistGithubIntegration(replacement, "77")
+    ).persistGithubIntegration(install, null, "77")
 
     expect(lockSpy).toHaveBeenCalledWith(pool, "ws_1")
+    // The lifecycle branch no longer looks up the previous row to unregister it.
+    expect(findSpy).not.toHaveBeenCalled()
     expect(routeEvents(spy)).toEqual([
-      {
-        eventType: "github_route:unregister",
-        payload: { workspaceId: "ws_1", installationId: "42", region: "eu-north-1" },
-      },
       {
         eventType: "github_route:register",
         payload: { workspaceId: "ws_1", installationId: "77", region: "eu-north-1" },
@@ -496,7 +687,7 @@ describe("syncGithubRepositories version-CAS retry (INV-66)", () => {
 
     let caught: unknown
     try {
-      await service.syncGithubRepositories("ws_1")
+      await service.syncGithubRepositories("ws_1", "wsi_1")
     } catch (error) {
       caught = error
     }
@@ -532,7 +723,7 @@ describe("syncGithubRepositories version-CAS retry (INV-66)", () => {
     })
     stubGithubNetwork(service)
 
-    const result = await service.syncGithubRepositories("ws_1")
+    const result = await service.syncGithubRepositories("ws_1", "wsi_1")
 
     expect(result.status).toBe("active")
     expect(updateCount).toBe(2)
@@ -640,6 +831,7 @@ describe("deactivateInstallation", () => {
 describe("GitHub metadata write guards", () => {
   const metadata = {
     organizationName: "acme",
+    accountType: "Organization" as const,
     repositorySelection: "all" as const,
     permissions: {},
     repositories: [],
@@ -664,11 +856,11 @@ describe("GitHub metadata write guards", () => {
     expect(result.version).toBe(8)
     const update = calls.find((call) => call.text.includes("UPDATE workspace_integrations"))
     expect(update?.text).toContain("version = version + 1")
-    expect(update?.text).toContain("version = $12")
+    expect(update?.text).toContain("version = $10")
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("42")
-    // Version-CAS: the observed generation is the last positional param ($12).
-    expect(update?.values[11]).toBe(7)
+    // Version-CAS: the observed generation is the last positional param ($10).
+    expect(update?.values[9]).toBe(7)
   })
 
   it("keeps the client's prior metadata when a replacement wins the guard", async () => {
@@ -704,7 +896,7 @@ describe("GitHub metadata write guards", () => {
     expect(result.metadata).toBe(metadata)
     expect(result.version).toBeNull()
     const update = calls.find((call) => call.text.includes("UPDATE workspace_integrations"))
-    expect(update?.values[11]).toBe(3)
+    expect(update?.values[9]).toBe(3)
   })
 })
 
@@ -730,11 +922,12 @@ describe("persistGithubIntegration token-refresh path (non-route)", () => {
       service as unknown as {
         persistGithubIntegration(
           p: UpsertWorkspaceIntegrationParams,
+          scope: string | null,
           r?: string,
           v?: number
         ): Promise<WorkspaceIntegrationRecord | null>
       }
-    ).persistGithubIntegration(params, routeInstallationId, expectedVersion)
+    ).persistGithubIntegration(params, params.installationId ?? null, routeInstallationId, expectedVersion)
   }
 
   it("uses the guarded UPDATE (not a blind upsert) and persists a normal refresh", async () => {
@@ -753,7 +946,7 @@ describe("persistGithubIntegration token-refresh path (non-route)", () => {
     expect(result).not.toBeNull()
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update).toBeDefined()
-    // Guard values: expectedStatus 'active' and expectedInstallationId '42'.
+    // Guard values: expectedStatus 'active' and installationScope '42'.
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("42")
     // The non-route path never locks the workspace, upserts, or emits a route event.
@@ -838,8 +1031,8 @@ describe("persistGithubIntegration token-refresh path (non-route)", () => {
 
     expect(result).toBeNull()
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
-    expect(update?.text).toContain("version = $12")
-    expect(update?.values[11]).toBe(4)
+    expect(update?.text).toContain("version = $10")
+    expect(update?.values[9]).toBe(4)
     expect(calls.find((c) => c.text.includes("INSERT INTO workspace_integrations"))).toBeUndefined()
   })
 })

--- a/apps/backend/src/features/workspace-integrations/linear-client.ts
+++ b/apps/backend/src/features/workspace-integrations/linear-client.ts
@@ -176,6 +176,7 @@ export class LinearClient {
     const result = await this.service.updateLinearRateLimitMetadata(
       this.workspaceId,
       this.metadata,
+      this.record.installationId,
       {
         requestsRemaining,
         requestsResetAt,

--- a/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
+++ b/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
@@ -139,8 +139,8 @@ describe("persistLinearCredentials refresh path (isInstall:false)", () => {
     expect(update?.values).toContain("active")
     expect(update?.values).toContain("org_123")
     // Credential write → version-CAS on the record's observed generation (1).
-    expect(update?.text).toContain("version = $12")
-    expect(update?.values[11]).toBe(1)
+    expect(update?.text).toContain("version = $10")
+    expect(update?.values[9]).toBe(1)
     expect(calls.find((c) => c.text.includes("INSERT INTO workspace_integrations"))).toBeUndefined()
   })
 
@@ -197,14 +197,16 @@ describe("updateLinearRateLimitMetadata guards", () => {
     expect(update?.values).toContain("org_123")
   })
 
-  it("pins missing legacy org identity to NULL/empty instead of falling back to status-only", async () => {
+  it("scopes a missing legacy org identity to NULL instead of falling back to status-only", async () => {
     const { pool, calls } = recordingPool([{ ...linearRecordRow(), installation_id: null }])
     const service = makeService(pool)
 
     await service.updateLinearRateLimitMetadata("ws_1", linearMetadata(null), rateLimit)
 
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
-    expect(update?.values).toContain("")
+    // installationScope ($3) is NULL — matches only the NULL-column row, never a
+    // row that reconnected to a populated org id.
+    expect(update?.values[2]).toBeNull()
   })
 
   it("keeps the prior metadata when the write lands on a cleared row (guard no-op)", async () => {
@@ -228,18 +230,16 @@ describe("updateLinearRateLimitMetadata guards", () => {
     expect(result.version).toBeNull()
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update?.text).toContain("version = version + 1")
-    expect(update?.text).toContain("version = $12")
-    // $12 (expectedVersion) is the last positional param.
-    expect(update?.values[11]).toBe(12)
+    expect(update?.text).toContain("version = $10")
+    // $10 (expectedVersion) is the last positional param.
+    expect(update?.values[9]).toBe(12)
   })
 })
 
 describe("disconnectLinearIntegration guard", () => {
-  it("pins the org id so a disconnect for org A cannot clobber a reconnected org B", async () => {
+  it("scopes to the org id column so a disconnect can't clobber a row reconnected to a different org", async () => {
     // credentials {} → parseLinearCredentials throws → revoke skipped (no network).
-    const { pool, calls } = recordingPool([
-      { ...linearRecordRow(), installation_id: null, metadata: { organizationId: "org_A" } },
-    ])
+    const { pool, calls } = recordingPool([{ ...linearRecordRow(), installation_id: "org_A" }])
     const service = makeService(pool)
 
     await service.disconnectLinearIntegration("ws_1")
@@ -247,7 +247,9 @@ describe("disconnectLinearIntegration guard", () => {
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     expect(update).toBeDefined()
     expect(update?.values).toContain("inactive")
-    expect(update?.values).toContain("org_A")
+    // installationScope ($3) is the column value read before the clear; a reconnect
+    // to org B shifts the column and this write matches 0 rows.
+    expect(update?.values[2]).toBe("org_A")
   })
 })
 

--- a/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
+++ b/apps/backend/src/features/workspace-integrations/linear-write-guards.test.ts
@@ -186,7 +186,7 @@ describe("updateLinearRateLimitMetadata guards", () => {
     const service = makeService(pool)
     const metadata = linearMetadata("org_123")
 
-    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit)
+    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, "org_123", rateLimit)
 
     expect(result.metadata.rateLimit.requestsRemaining).toBe(42)
     // A win returns the row's new version so a reused client advances its cached
@@ -201,7 +201,7 @@ describe("updateLinearRateLimitMetadata guards", () => {
     const { pool, calls } = recordingPool([{ ...linearRecordRow(), installation_id: null }])
     const service = makeService(pool)
 
-    await service.updateLinearRateLimitMetadata("ws_1", linearMetadata(null), rateLimit)
+    await service.updateLinearRateLimitMetadata("ws_1", linearMetadata(null), null, rateLimit)
 
     const update = calls.find((c) => c.text.includes("UPDATE workspace_integrations"))
     // installationScope ($3) is NULL — matches only the NULL-column row, never a
@@ -214,7 +214,7 @@ describe("updateLinearRateLimitMetadata guards", () => {
     const service = makeService(pool)
     const metadata = linearMetadata("org_123")
 
-    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit)
+    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, "org_123", rateLimit)
     expect(result.metadata).toBe(metadata)
     expect(result.version).toBeNull()
   })
@@ -224,7 +224,7 @@ describe("updateLinearRateLimitMetadata guards", () => {
     const service = makeService(pool)
     const metadata = linearMetadata("org_123")
 
-    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, rateLimit, 12)
+    const result = await service.updateLinearRateLimitMetadata("ws_1", metadata, "org_123", rateLimit, 12)
 
     expect(result.metadata).toBe(metadata)
     expect(result.version).toBeNull()

--- a/apps/backend/src/features/workspace-integrations/repository.ts
+++ b/apps/backend/src/features/workspace-integrations/repository.ts
@@ -34,6 +34,14 @@ export interface UpsertWorkspaceIntegrationParams {
   installationId?: string | null
 }
 
+/**
+ * Which unique index the upsert arbitrates on. Multi-install providers (GitHub)
+ * key on the (workspace, provider, installation) partial index; single-row
+ * providers (Linear) key on the row's ULID so a reconnect to a different org
+ * replaces the existing row rather than inserting a second one.
+ */
+export type WorkspaceIntegrationUpsertConflict = "provider-installation" | "id"
+
 export interface UpdateWorkspaceIntegrationParams {
   status?: WorkspaceIntegrationStatus
   credentials?: Record<string, unknown>
@@ -45,24 +53,37 @@ export interface UpdateWorkspaceIntegrationParams {
 export interface UpdateWorkspaceIntegrationOptions {
   expectedStatus?: WorkspaceIntegrationStatus
   /**
-   * Optimistic guard on the current `installation_id`, so a write can't clobber a
-   * row that disconnected + reconnected to a DIFFERENT installation in between.
-   * `allowNull: true` also matches a pre-backfill NULL column (the backfill path
-   * fills the column, so its own value or NULL is the legitimate "before"); the
-   * deactivation path passes `allowNull: false` to require an EXACT match on the
-   * installation it listed.
-   */
-  expectedInstallationId?: { value: string; allowNull: boolean }
-  /**
    * Optimistic generation guard (INV-66). When set, the write only lands if the
    * row's `version` still equals the value read before the out-of-transaction
    * network work — so a stale full-object write (rate-limit/credential/metadata)
-   * can't clobber a newer concurrent write to the SAME installation. A miss
-   * matches 0 rows and returns null. Lifecycle writes (disconnect, deactivate,
-   * install/replace) deliberately OMIT this: they express absolute user/webhook
-   * intent and must not be no-op'd by a background refresh's version bump.
+   * can't clobber a newer concurrent write to the SAME row. A miss matches 0 rows
+   * and returns null. Lifecycle writes (disconnect, deactivate, install/replace)
+   * deliberately OMIT this: they express absolute user/webhook intent and must not
+   * be no-op'd by a background refresh's version bump.
    */
   expectedVersion?: number
+}
+
+/**
+ * Choose the upsert's conflict arbiter. GitHub is multi-install, so it keys on
+ * the partial unique index that fits the row: (workspace, provider, installation)
+ * for a real install, or (workspace, provider) for a legacy NULL-installation
+ * row. Single-row providers (Linear) key on the row's own ULID so a reconnect to
+ * a different external org replaces the row in place instead of colliding on the
+ * primary key — Linear stores its org id in installation_id (non-null), which
+ * would otherwise route it to the multi-install index and permit a second row
+ * per distinct org id. The arbiter pins installation_id / keeps NULL, so
+ * DO UPDATE writes it plainly.
+ */
+function upsertConflictClause(
+  conflictTarget: WorkspaceIntegrationUpsertConflict,
+  installationId: string | null
+): string {
+  if (conflictTarget === "id") return "ON CONFLICT (id)"
+  if (installationId != null) {
+    return "ON CONFLICT (workspace_id, provider, installation_id) WHERE installation_id IS NOT NULL"
+  }
+  return "ON CONFLICT (workspace_id, provider) WHERE installation_id IS NULL"
 }
 
 function mapRow(row: Record<string, unknown>): WorkspaceIntegrationRecord {
@@ -87,6 +108,11 @@ export const WorkspaceIntegrationRepository = {
     await querier.query(sql`SELECT id FROM workspaces WHERE id = $1 FOR UPDATE`, [workspaceId])
   },
 
+  /**
+   * Single-row providers only (Linear); GitHub reads go through
+   * listByWorkspaceAndProvider (one grandfathered exception: the inert
+   * backfillGithubRoute, whose row set predates multi-install).
+   */
   async findByWorkspaceAndProvider(
     querier: Querier,
     workspaceId: string,
@@ -97,6 +123,34 @@ export const WorkspaceIntegrationRepository = {
       [workspaceId, provider]
     )
     return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /** Address one integration row by its ULID (per-install handlers, any provider). */
+  async findByWorkspaceAndId(
+    querier: Querier,
+    workspaceId: string,
+    id: string
+  ): Promise<WorkspaceIntegrationRecord | null> {
+    const result = await querier.query(sql`SELECT * FROM workspace_integrations WHERE workspace_id = $1 AND id = $2`, [
+      workspaceId,
+      id,
+    ])
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /** Every integration row for a provider (GitHub is multi-install), oldest first. */
+  async listByWorkspaceAndProvider(
+    querier: Querier,
+    workspaceId: string,
+    provider: WorkspaceIntegrationProvider
+  ): Promise<WorkspaceIntegrationRecord[]> {
+    const result = await querier.query(
+      sql`SELECT * FROM workspace_integrations
+          WHERE workspace_id = $1 AND provider = $2
+          ORDER BY created_at ASC, id ASC`,
+      [workspaceId, provider]
+    )
+    return result.rows.map(mapRow)
   },
 
   /**
@@ -117,18 +171,23 @@ export const WorkspaceIntegrationRepository = {
     return result.rows.map(mapRow)
   },
 
-  async upsert(querier: Querier, params: UpsertWorkspaceIntegrationParams): Promise<WorkspaceIntegrationRecord> {
+  async upsert(
+    querier: Querier,
+    params: UpsertWorkspaceIntegrationParams,
+    conflictTarget: WorkspaceIntegrationUpsertConflict = "provider-installation"
+  ): Promise<WorkspaceIntegrationRecord> {
+    const conflict = upsertConflictClause(conflictTarget, params.installationId ?? null)
     const result = await querier.query(
-      sql`INSERT INTO workspace_integrations (
+      `INSERT INTO workspace_integrations (
               id, workspace_id, provider, status, credentials, metadata, installed_by, installation_id
           )
           VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8)
-          ON CONFLICT (workspace_id, provider) DO UPDATE SET
+          ${conflict} DO UPDATE SET
               status = EXCLUDED.status,
               credentials = EXCLUDED.credentials,
               metadata = EXCLUDED.metadata,
               installed_by = EXCLUDED.installed_by,
-              installation_id = COALESCE(EXCLUDED.installation_id, workspace_integrations.installation_id),
+              installation_id = EXCLUDED.installation_id,
               version = workspace_integrations.version + 1,
               updated_at = NOW()
           RETURNING *`,
@@ -147,45 +206,48 @@ export const WorkspaceIntegrationRepository = {
     return mapRow(result.rows[0])
   },
 
+  /**
+   * Guarded partial update, scoped to a SINGLE row by its installation id.
+   * `installationScope` is the row's `installation_id` COLUMN value read before
+   * the write (`IS NOT DISTINCT FROM` matches NULL to NULL), so with GitHub's N
+   * rows per (workspace, provider) the write touches exactly the intended
+   * installation — never a sibling. Pass the value observed at read (identity
+   * pinned at read, INV-20); a reconnect to a different installation shifts the
+   * column and the write correctly matches 0 rows.
+   */
   async update(
     querier: Querier,
     workspaceId: string,
     provider: WorkspaceIntegrationProvider,
+    installationScope: string | null,
     params: UpdateWorkspaceIntegrationParams,
     options?: UpdateWorkspaceIntegrationOptions
   ): Promise<WorkspaceIntegrationRecord | null> {
-    const installationGuard = options?.expectedInstallationId
     const result = await querier.query(
       sql`UPDATE workspace_integrations
           SET
-            status = COALESCE($3, status),
-            credentials = COALESCE($4::jsonb, credentials),
-            metadata = COALESCE($5::jsonb, metadata),
-            installed_by = COALESCE($6, installed_by),
+            status = COALESCE($4, status),
+            credentials = COALESCE($5::jsonb, credentials),
+            metadata = COALESCE($6::jsonb, metadata),
+            installed_by = COALESCE($7, installed_by),
             installation_id = COALESCE($8, installation_id),
             version = version + 1,
             updated_at = NOW()
           WHERE workspace_id = $1 AND provider = $2
-            AND ($7::text IS NULL OR status = $7)
-            AND (
-              $9::boolean
-              OR ($11::boolean AND (installation_id IS NULL OR installation_id = $10))
-              OR ((NOT $11::boolean) AND installation_id IS NOT DISTINCT FROM $10)
-            )
-            AND ($12::int IS NULL OR version = $12)
+            AND installation_id IS NOT DISTINCT FROM $3
+            AND ($9::text IS NULL OR status = $9)
+            AND ($10::int IS NULL OR version = $10)
           RETURNING *`,
       [
         workspaceId,
         provider,
+        installationScope,
         params.status ?? null,
         params.credentials ? JSON.stringify(params.credentials) : null,
         params.metadata ? JSON.stringify(params.metadata) : null,
         params.installedBy ?? null,
-        options?.expectedStatus ?? null,
         params.installationId ?? null,
-        installationGuard ? false : true,
-        installationGuard?.value ?? null,
-        installationGuard?.allowNull ?? false,
+        options?.expectedStatus ?? null,
         options?.expectedVersion ?? null,
       ]
     )

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -103,6 +103,7 @@ describe("GitHubClient captureRateLimit is best-effort", () => {
   }
   const metadata = {
     organizationName: "acme",
+    accountType: "Organization" as const,
     repositorySelection: "all" as const,
     permissions: {},
     repositories: [],
@@ -395,9 +396,9 @@ describe("getAvailableToolCategories", () => {
       github: githubEnabled,
       linear: linearEnabled,
     })
-    spyOn(service, "getGithubIntegration").mockResolvedValue({
-      status: "active",
-    } as Awaited<ReturnType<WorkspaceIntegrationService["getGithubIntegration"]>>)
+    spyOn(service, "listGithubInstallations").mockResolvedValue([{ status: "active" }] as Awaited<
+      ReturnType<WorkspaceIntegrationService["listGithubInstallations"]>
+    >)
     spyOn(service, "getLinearIntegration").mockResolvedValue({
       status: "active",
     } as Awaited<ReturnType<WorkspaceIntegrationService["getLinearIntegration"]>>)

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -344,9 +344,9 @@ describe("LinearClient captureRateLimit is best-effort", () => {
     remaining = 100
     await client.request("query { b }")
 
-    // expectedVersion is the 4th positional arg (index 3).
-    expect(captureSpy.mock.calls[0][3]).toBe(1)
-    expect(captureSpy.mock.calls[1][3]).toBe(2)
+    // expectedVersion is the 5th positional arg (index 4).
+    expect(captureSpy.mock.calls[0][4]).toBe(1)
+    expect(captureSpy.mock.calls[1][4]).toBe(2)
   })
 })
 

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -1164,22 +1164,25 @@ export class WorkspaceIntegrationService {
   async updateLinearRateLimitMetadata(
     workspaceId: string,
     metadata: LinearIntegrationMetadata,
+    installationScope: string | null,
     rateLimit: LinearRateLimit,
     expectedVersion?: number
   ): Promise<{ metadata: LinearIntegrationMetadata; version: number | null }> {
     const nextMetadata: LinearIntegrationMetadata = { ...metadata, rateLimit }
 
     // CACHE WRITE — version-CAS. This replaces the whole metadata object, so
-    // guard on active status + the client's observed org (INV-20) AND the version
-    // read at the client's read (INV-66): a stale rate-limit write can't land on a
-    // row a concurrent disconnect cleared, a row reconnected to a different org, or
-    // a row a newer same-org write already advanced. A lost race matches 0 rows;
-    // keep the client's prior metadata rather than pretending the write stuck.
+    // guard on active status + the installation_id COLUMN value the client read
+    // with its record (INV-20 — NULL for a legacy pre-population row, which
+    // metadata.organizationId would miss) AND the version read at the same point
+    // (INV-66): a stale rate-limit write can't land on a row a concurrent
+    // disconnect cleared, a row reconnected to a different org, or a row a newer
+    // same-org write already advanced. A lost race matches 0 rows; keep the
+    // client's prior metadata rather than pretending the write stuck.
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR,
-      metadata.organizationId,
+      installationScope,
       { metadata: nextMetadata },
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -63,7 +63,9 @@ interface GitHubIntegrationCredentials {
 }
 
 interface GitHubIntegrationMetadata extends Record<string, unknown> {
+  // Account login (org or user); the JSONB key predates personal-account support.
   organizationName: string | null
+  accountType: "Organization" | "User" | null
   repositorySelection: "all" | "selected" | null
   permissions: Record<string, string>
   repositories: GitHubInstalledRepository[]
@@ -192,7 +194,7 @@ export class GitHubClient {
       const result = await this.service.updateGithubRateLimitMetadata(
         this.workspaceId,
         this.metadata,
-        String(this.credentials.installationId),
+        record.installationId,
         remaining,
         resetAt,
         record.version
@@ -251,24 +253,35 @@ export class WorkspaceIntegrationService {
     // GitHub and Linear are independent lookups — fan them out so they don't
     // serialize on the bootstrap path. Each short-circuits (no query) when its
     // integration is disabled for the deployment.
-    const [github, linear] = await Promise.all([
-      this.isGitHubEnabled() ? this.getGithubIntegration(workspaceId) : Promise.resolve(null),
+    const [githubInstalls, linear] = await Promise.all([
+      this.isGitHubEnabled() ? this.listGithubInstallations(workspaceId) : Promise.resolve([]),
       this.isLinearEnabled() ? this.getLinearIntegration(workspaceId) : Promise.resolve(null),
     ])
     const categories: ToolPrivacyCategory[] = ["web", "workspace"]
-    if (github?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("github")
+    if (githubInstalls.some((install) => install.status === WorkspaceIntegrationStatuses.ACTIVE)) {
+      categories.push("github")
+    }
     if (linear?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("linear")
     return categories
   }
 
-  async getGithubIntegration(workspaceId: string): Promise<GitHubWorkspaceIntegration | null> {
-    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
+  /**
+   * Every GitHub installation the workspace has connected (multi-install). Rows
+   * disconnected to INACTIVE are historical junk and filtered out; active and
+   * error rows render. Oldest install first (list ordering is deterministic).
+   */
+  async listGithubInstallations(workspaceId: string): Promise<GitHubWorkspaceIntegration[]> {
+    const records = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.GITHUB
     )
-    if (!record) return null
+    return records
+      .filter((record) => record.status !== WorkspaceIntegrationStatuses.INACTIVE)
+      .map((record) => this.mapGithubIntegration(record))
+  }
 
+  private mapGithubIntegration(record: WorkspaceIntegrationRecord): GitHubWorkspaceIntegration {
     const metadata = this.parseMetadata(record.metadata)
     return {
       id: record.id,
@@ -276,7 +289,9 @@ export class WorkspaceIntegrationService {
       provider: "github",
       status: record.status,
       installedBy: record.installedBy,
-      organizationName: metadata.organizationName,
+      accountLogin: metadata.organizationName,
+      installationId: record.installationId,
+      accountType: metadata.accountType,
       repositorySelection: metadata.repositorySelection,
       permissions: metadata.permissions,
       repositories: metadata.repositories,
@@ -295,34 +310,27 @@ export class WorkspaceIntegrationService {
     return `https://github.com/apps/${this.deps.github.appSlug}/installations/new?state=${encodeURIComponent(state)}`
   }
 
-  async disconnectGithubIntegration(workspaceId: string): Promise<void> {
-    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
-      this.deps.pool,
-      workspaceId,
-      WorkspaceIntegrationProviders.GITHUB
-    )
+  async disconnectGithubInstallation(workspaceId: string, integrationId: string): Promise<void> {
+    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndId(this.deps.pool, workspaceId, integrationId)
+    // Idempotent 204 semantics: an unknown id or a non-GitHub row is a no-op.
+    if (!record || record.provider !== WorkspaceIntegrationProviders.GITHUB) return
+
     // Resolve the installation id from the pre-clear row so the unregister event
     // carries it even for a pre-backfill row whose only copy lives in the
     // credentials this update wipes. Committing the event in the same transaction
     // makes the order the clear runs in irrelevant — the id is already captured.
-    const installationId = record ? this.resolveInstallationId(workspaceId, record) : null
-
-    if (!record) return
+    const installationId = this.resolveInstallationId(workspaceId, record)
 
     await withTransaction(this.deps.pool, async (client) => {
       const updated = await WorkspaceIntegrationRepository.update(
         client,
         workspaceId,
         WorkspaceIntegrationProviders.GITHUB,
+        record.installationId,
         {
           status: WorkspaceIntegrationStatuses.INACTIVE,
           credentials: {},
           metadata: {},
-        },
-        {
-          expectedInstallationId: installationId
-            ? { value: installationId, allowNull: record.installationId === null }
-            : { value: "", allowNull: true },
         }
       )
       if (!updated) {
@@ -379,11 +387,9 @@ export class WorkspaceIntegrationService {
           client,
           record.workspaceId,
           WorkspaceIntegrationProviders.GITHUB,
+          installationId,
           { status: WorkspaceIntegrationStatuses.INACTIVE },
-          {
-            expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-            expectedInstallationId: { value: installationId, allowNull: false },
-          }
+          { expectedStatus: WorkspaceIntegrationStatuses.ACTIVE }
         )
         if (result) {
           await this.emitRouteUnregister(client, record.workspaceId, installationId)
@@ -423,21 +429,20 @@ export class WorkspaceIntegrationService {
 
     // One transaction persists the plaintext id and commits the register event.
     // The update is guarded on status='active' (a concurrent disconnect flips it
-    // inactive) AND on the installation id being NULL-or-this-value (a reconnect
-    // to a DIFFERENT installation B leaves installation_id = B, which must not be
-    // clobbered back to A). Because the register event is ordered in the outbox,
-    // a disconnect that lands after this commit emits its unregister event after
-    // ours — the control plane converges without a post-register re-check.
+    // inactive) AND scoped to the installation id column read at the top (NULL for a
+    // pre-backfill row); a reconnect to a DIFFERENT installation B shifts the column
+    // to B, so this NULL-scoped write matches 0 rows rather than clobbering B back
+    // to A. Because the register event is ordered in the outbox, a disconnect that
+    // lands after this commit emits its unregister event after ours — the control
+    // plane converges without a post-register re-check.
     const updated = await withTransaction(this.deps.pool, async (client) => {
       const result = await WorkspaceIntegrationRepository.update(
         client,
         workspaceId,
         WorkspaceIntegrationProviders.GITHUB,
+        record.installationId,
         { installationId },
-        {
-          expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-          expectedInstallationId: { value: installationId, allowNull: true },
-        }
+        { expectedStatus: WorkspaceIntegrationStatuses.ACTIVE }
       )
       if (result) {
         await this.emitRouteRegister(client, workspaceId, installationId)
@@ -462,15 +467,15 @@ export class WorkspaceIntegrationService {
     }
   }
 
-  async syncGithubRepositories(workspaceId: string): Promise<GitHubWorkspaceIntegration> {
+  async syncGithubRepositories(workspaceId: string, integrationId: string): Promise<GitHubWorkspaceIntegration> {
     this.requireGitHubEnabled()
 
-    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
-      this.deps.pool,
-      workspaceId,
-      WorkspaceIntegrationProviders.GITHUB
-    )
-    if (!record || record.status !== WorkspaceIntegrationStatuses.ACTIVE) {
+    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndId(this.deps.pool, workspaceId, integrationId)
+    if (
+      !record ||
+      record.provider !== WorkspaceIntegrationProviders.GITHUB ||
+      record.status !== WorkspaceIntegrationStatuses.ACTIVE
+    ) {
       throw new HttpError("GitHub integration is not active for this workspace", {
         status: 404,
         code: "GITHUB_INTEGRATION_NOT_ACTIVE",
@@ -535,10 +540,10 @@ export class WorkspaceIntegrationService {
         this.deps.pool,
         workspaceId,
         WorkspaceIntegrationProviders.GITHUB,
+        base.installationId,
         { credentials: encryptedCredentials, metadata: nextMetadata },
         {
           expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-          expectedInstallationId: { value: String(credentials.installationId), allowNull: true },
           expectedVersion: base.version,
         }
       )
@@ -546,10 +551,10 @@ export class WorkspaceIntegrationService {
 
     let updated = await persistSync(record)
     if (!updated) {
-      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
+      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndId(
         this.deps.pool,
         workspaceId,
-        WorkspaceIntegrationProviders.GITHUB
+        integrationId
       )
       if (reread && reread.status === WorkspaceIntegrationStatuses.ACTIVE) {
         updated = await persistSync(reread)
@@ -562,14 +567,7 @@ export class WorkspaceIntegrationService {
       })
     }
 
-    const integration = await this.getGithubIntegration(workspaceId)
-    if (!integration) {
-      throw new HttpError("GitHub integration not found after sync", {
-        status: 500,
-        code: "GITHUB_INTEGRATION_NOT_FOUND",
-      })
-    }
-    return integration
+    return this.mapGithubIntegration(updated)
   }
 
   async handleGithubCallback(params: {
@@ -607,64 +605,95 @@ export class WorkspaceIntegrationService {
   }
 
   /**
-   * Resolve a GitHub client for a workspace.
+   * Resolve a GitHub client for a workspace across its N installations.
    *
-   * When `allowUnauthenticatedFallback` is set, the paths where the workspace
-   * has no usable installation (no app configured, no active integration,
-   * undecryptable or unrefreshable credentials) return an anonymous client that
-   * can still read public/open-source repositories instead of `null`. Callers
-   * that only want authenticated access (e.g. link-preview enrichment) omit the
-   * flag and keep the original null-on-missing behavior.
+   * `repoOwner` (a repository's owner login) prefers the installation whose
+   * account login matches it: that install is the ONLY candidate — its quota is
+   * never borrowed by a sibling. A near-limit owner-matched install returns
+   * `null` (hard breaker) regardless of the fallback flag, because handing back a
+   * sibling or anonymous client would silently downgrade a heavy user to the
+   * shared per-IP quota and mask the rate-limit state (surfaced as
+   * GITHUB_NOT_CONNECTED).
    *
-   * The near-rate-limit branch deliberately does NOT fall back: it is a
-   * back-off circuit-breaker for an installation that exists but is throttled.
-   * Handing back an anonymous client there would silently downgrade a heavy
-   * GitHub user to the shared per-IP anonymous quota and mask the rate-limit
-   * state, so it keeps returning `null` (surfaced as GITHUB_NOT_CONNECTED).
+   * With no `repoOwner` (or no matching install), any active non-throttled
+   * install serves the request — installation tokens read public repos too. When
+   * every active install is throttled the breaker returns `null`; when none
+   * yields a usable client (undecryptable/unrefreshable) it falls back.
+   *
+   * When `allowUnauthenticatedFallback` is set, the fallback paths (no app, no
+   * active install, nothing usable) return an anonymous client that still reads
+   * public/open-source repos instead of `null`. Callers wanting only
+   * authenticated access (link-preview enrichment) omit the flag.
    */
   async getGithubClient(
     workspaceId: string,
-    options: { allowUnauthenticatedFallback?: boolean } = {}
+    options: { repoOwner?: string; allowUnauthenticatedFallback?: boolean } = {}
   ): Promise<GitHubClient | null> {
     const fallback = () => (options.allowUnauthenticatedFallback ? GitHubClient.anonymous(this, workspaceId) : null)
 
     if (!this.app) return fallback()
 
-    const record = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
-      this.deps.pool,
-      workspaceId,
-      WorkspaceIntegrationProviders.GITHUB
-    )
-    if (!record || record.status !== WorkspaceIntegrationStatuses.ACTIVE) {
-      return fallback()
+    const activeRecords = (
+      await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+        this.deps.pool,
+        workspaceId,
+        WorkspaceIntegrationProviders.GITHUB
+      )
+    ).filter((record) => record.status === WorkspaceIntegrationStatuses.ACTIVE)
+    if (activeRecords.length === 0) return fallback()
+
+    if (options.repoOwner) {
+      const owner = options.repoOwner.toLowerCase()
+      const matched = activeRecords.find(
+        (record) => this.parseMetadata(record.metadata).organizationName?.toLowerCase() === owner
+      )
+      if (matched) {
+        if (this.isNearGithubRateLimit(this.parseMetadata(matched.metadata))) return null
+        return (await this.buildGithubClientFromRecord(workspaceId, matched)) ?? fallback()
+      }
     }
 
-    const metadata = this.parseMetadata(record.metadata)
-    if (this.isNearGithubRateLimit(metadata)) {
-      return null
+    let allThrottled = true
+    for (const record of activeRecords) {
+      if (this.isNearGithubRateLimit(this.parseMetadata(record.metadata))) continue
+      allThrottled = false
+      const client = await this.buildGithubClientFromRecord(workspaceId, record)
+      if (client) return client
     }
+    if (allThrottled) return null
+    return fallback()
+  }
 
+  /**
+   * Build a client for one active install: parse credentials (undecryptable →
+   * null), proactively refresh a near-expiry token (refresh failure → null), else
+   * a client bound to this record so its 401-refresh/rate-limit CAS hit the right row.
+   */
+  private async buildGithubClientFromRecord(
+    workspaceId: string,
+    record: WorkspaceIntegrationRecord
+  ): Promise<GitHubClient | null> {
     let credentials: GitHubIntegrationCredentials
     try {
       credentials = this.parseCredentials(workspaceId, record.credentials)
     } catch (error) {
       log.warn({ err: error, workspaceId }, "GitHub integration credentials could not be decrypted")
-      return fallback()
+      return null
     }
 
     if (this.shouldRefreshToken(credentials.tokenExpiresAt)) {
       const refreshed = await this.refreshGithubCredentialsForClient(workspaceId, record)
-      if (!refreshed) return fallback()
+      if (!refreshed) return null
       return new GitHubClient(this, workspaceId, refreshed.record, refreshed.credentials, refreshed.metadata)
     }
 
-    return new GitHubClient(this, workspaceId, record, credentials, metadata)
+    return new GitHubClient(this, workspaceId, record, credentials, this.parseMetadata(record.metadata))
   }
 
   async updateGithubRateLimitMetadata(
     workspaceId: string,
     metadata: GitHubIntegrationMetadata,
-    installationId: string,
+    installationScope: string | null,
     remaining: number | null,
     resetAt: string | null,
     expectedVersion?: number
@@ -677,16 +706,18 @@ export class WorkspaceIntegrationService {
 
     // CACHE WRITE — version-CAS. This replaces the WHOLE metadata object, so a
     // stale rate-limit write must not erase a newer concurrent write (e.g. a
-    // repo-sync that just refreshed `repositories`). A lost race matches 0 rows;
-    // keep the client's prior metadata rather than pretending the write stuck.
+    // repo-sync that just refreshed `repositories`). Scoped to the client's
+    // observed installation so it lands on the right row of an N-install
+    // workspace. A lost race matches 0 rows; keep the client's prior metadata
+    // rather than pretending the write stuck.
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.GITHUB,
+      installationScope,
       { metadata: nextMetadata },
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-        expectedInstallationId: { value: installationId, allowNull: true },
         expectedVersion,
       }
     )
@@ -732,36 +763,40 @@ export class WorkspaceIntegrationService {
       installation_id: installationId,
     })
 
-    const accountType = getInstallationAccountType(installation.data.account) ?? installation.data.target_type ?? null
-    if (accountType !== "Organization") {
-      throw new HttpError("GitHub App must be installed on an organization", {
-        status: 400,
-        code: "GITHUB_ORGANIZATION_REQUIRED",
-      })
+    // Both organizations and personal accounts are accepted; the account type is
+    // captured into metadata so the settings UI can badge each install.
+    const accountType = normalizeGithubAccountType(
+      getInstallationAccountType(installation.data.account) ?? installation.data.target_type ?? null
+    )
+
+    // Base the write on the existing row for THIS installation (multi-install: a
+    // workspace can hold several), else a fresh default record for a first install.
+    const existingInstalls = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+      this.deps.pool,
+      workspaceId,
+      WorkspaceIntegrationProviders.GITHUB
+    )
+    const baseRecord = existingInstalls.find((record) => record.installationId === String(installationId)) ?? {
+      id: workspaceIntegrationId(),
+      workspaceId,
+      provider: WorkspaceIntegrationProviders.GITHUB,
+      status: WorkspaceIntegrationStatuses.INACTIVE,
+      credentials: {},
+      metadata: {},
+      installedBy: installedByUserId,
+      installationId: null,
+      version: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
     }
 
     const refreshed = await this.refreshGithubCredentials(
       workspaceId,
-      (await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
-        this.deps.pool,
-        workspaceId,
-        WorkspaceIntegrationProviders.GITHUB
-      )) ?? {
-        id: workspaceIntegrationId(),
-        workspaceId,
-        provider: WorkspaceIntegrationProviders.GITHUB,
-        status: WorkspaceIntegrationStatuses.INACTIVE,
-        credentials: {},
-        metadata: {},
-        installedBy: installedByUserId,
-        installationId: null,
-        version: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
+      baseRecord,
       installationId,
       {
         organizationName: getInstallationAccountLogin(installation.data.account),
+        accountType,
         repositorySelection: normalizeRepositorySelection(installation.data.repository_selection),
         permissions: normalizePermissions(installation.data.permissions),
         repositories: [],
@@ -854,7 +889,12 @@ export class WorkspaceIntegrationService {
         installationId: String(installationId),
       }
 
-      const updated = await this.persistGithubIntegration(upsertParams, routeInstallationId, record.version)
+      const updated = await this.persistGithubIntegration(
+        upsertParams,
+        record.installationId,
+        routeInstallationId,
+        record.version
+      )
       if (!updated) {
         return null
       }
@@ -874,9 +914,10 @@ export class WorkspaceIntegrationService {
     }
   }
 
-  /** Persist after all network work; replacement route events commit with the row. */
+  /** Persist after all network work; install route events commit with the row. */
   private async persistGithubIntegration(
     params: UpsertWorkspaceIntegrationParams,
+    installationScope: string | null,
     routeInstallationId?: string,
     expectedVersion?: number
   ): Promise<WorkspaceIntegrationRecord | null> {
@@ -884,15 +925,16 @@ export class WorkspaceIntegrationService {
       // CREDENTIAL WRITE (token refresh, no route change) — version-CAS. A blind
       // upsert here would resurrect a row a concurrent disconnect just cleared,
       // or clobber a row that reconnected to a DIFFERENT installation B back to A.
-      // Guard on status ACTIVE, installation_id == this install (or NULL for a
-      // pre-backfill row), AND the version read before the token round-trip so a
-      // stale refresh can't overwrite a newer same-installation write (INV-66).
-      // A lost race matches 0 rows and surfaces as a refresh failure the callers
-      // (401 retry, proactive refresh) already handle by returning null.
+      // Scoped to the base record's installation_id column read before the token
+      // round-trip (NULL for a pre-backfill row), guarded on status ACTIVE AND the
+      // version read at the same point so a stale refresh can't overwrite a newer
+      // same-row write (INV-66). A lost race matches 0 rows and surfaces as a
+      // refresh failure the callers (401 retry, proactive refresh) already handle.
       return WorkspaceIntegrationRepository.update(
         this.deps.pool,
         params.workspaceId,
         WorkspaceIntegrationProviders.GITHUB,
+        installationScope,
         {
           credentials: params.credentials,
           metadata: params.metadata,
@@ -901,32 +943,21 @@ export class WorkspaceIntegrationService {
         },
         {
           expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-          expectedInstallationId: params.installationId
-            ? { value: params.installationId, allowNull: true }
-            : { value: "", allowNull: true },
           expectedVersion,
         }
       )
     }
 
-    // LIFECYCLE WRITE (install / replace) — NO version-CAS. This upsert expresses
-    // an absolute install intent and serializes on the workspace lock; a
-    // concurrent background refresh's version bump must not make it lose.
+    // LIFECYCLE WRITE (install) — NO version-CAS. This upsert expresses an absolute
+    // install intent and serializes on the workspace lock; a concurrent background
+    // refresh's version bump must not make it lose. Installs are additive: N rows
+    // per (workspace, provider), so a new installation never unregisters a sibling.
 
     // Lock the workspace rather than the provider row: two first-time installs
     // must serialize even when no workspace_integrations row exists yet.
     return withTransaction(this.deps.pool, async (client) => {
       await WorkspaceIntegrationRepository.lockWorkspace(client, params.workspaceId)
-      const previous = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
-        client,
-        params.workspaceId,
-        WorkspaceIntegrationProviders.GITHUB
-      )
-      const previousInstallationId = previous ? this.resolveInstallationId(params.workspaceId, previous) : null
       const updated = await WorkspaceIntegrationRepository.upsert(client, params)
-      if (previousInstallationId && previousInstallationId !== routeInstallationId) {
-        await this.emitRouteUnregister(client, params.workspaceId, previousInstallationId)
-      }
       await this.emitRouteRegister(client, params.workspaceId, routeInstallationId)
       return updated
     })
@@ -951,6 +982,7 @@ export class WorkspaceIntegrationService {
   private parseMetadata(payload: Record<string, unknown>): GitHubIntegrationMetadata {
     return {
       organizationName: typeof payload.organizationName === "string" ? payload.organizationName : null,
+      accountType: normalizeGithubAccountType(payload.accountType),
       repositorySelection: normalizeRepositorySelection(payload.repositorySelection),
       permissions: normalizePermissions(payload.permissions),
       repositories: normalizeRepositories(payload.repositories),
@@ -1039,36 +1071,29 @@ export class WorkspaceIntegrationService {
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR
     )
-    // Resolve the org id from the pre-clear row so the guard survives the wipe.
-    const organizationId = record ? this.resolveLinearOrganizationId(record) : null
+    if (!record) return
 
-    if (record) {
-      try {
-        const credentials = this.parseLinearCredentials(workspaceId, record.credentials)
-        await revokeLinearToken({ accessToken: credentials.accessToken })
-      } catch (error) {
-        log.warn({ err: error, workspaceId }, "Linear token revocation failed; continuing with local disconnect")
-      }
+    try {
+      const credentials = this.parseLinearCredentials(workspaceId, record.credentials)
+      await revokeLinearToken({ accessToken: credentials.accessToken })
+    } catch (error) {
+      log.warn({ err: error, workspaceId }, "Linear token revocation failed; continuing with local disconnect")
     }
 
-    // Pin the Linear organization observed before the network call so a disconnect
-    // for org A can't clobber a row that reconnected to a DIFFERENT org B in
-    // between (INV-20). Not guarded on status — a disconnect must clear a row in
-    // any status (active/error). `{value:"", allowNull:true}` covers a pre-column
-    // row whose org id can't be resolved (its installation_id is still NULL).
+    // Scope to the installation_id column observed before the network call so a
+    // disconnect for org A can't clobber a row that reconnected to a DIFFERENT org
+    // B in between (INV-20). Not guarded on status — a disconnect must clear a row
+    // in any status (active/error). A NULL scope covers a pre-column row whose
+    // installation_id is still NULL.
     await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR,
+      record.installationId,
       {
         status: WorkspaceIntegrationStatuses.INACTIVE,
         credentials: {},
         metadata: {},
-      },
-      {
-        expectedInstallationId: organizationId
-          ? { value: organizationId, allowNull: record?.installationId == null }
-          : { value: "", allowNull: true },
       }
     )
   }
@@ -1150,15 +1175,14 @@ export class WorkspaceIntegrationService {
     // row a concurrent disconnect cleared, a row reconnected to a different org, or
     // a row a newer same-org write already advanced. A lost race matches 0 rows;
     // keep the client's prior metadata rather than pretending the write stuck.
-    const organizationId = metadata.organizationId
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR,
+      metadata.organizationId,
       { metadata: nextMetadata },
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-        expectedInstallationId: { value: organizationId ?? "", allowNull: true },
         expectedVersion,
       }
     )
@@ -1214,27 +1238,17 @@ export class WorkspaceIntegrationService {
    * no-op (nothing to surface).
    */
   private async markLinearIntegrationError(workspaceId: string, record: WorkspaceIntegrationRecord): Promise<void> {
-    const organizationId = this.resolveLinearOrganizationId(record)
     await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR,
+      record.installationId,
       { status: WorkspaceIntegrationStatuses.ERROR },
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-        expectedInstallationId: { value: organizationId ?? "", allowNull: true },
         expectedVersion: record.version,
       }
     )
-  }
-
-  /**
-   * The plaintext `installation_id` column carries the Linear organization id for
-   * newer rows; fall back to the id embedded in metadata for pre-population rows.
-   */
-  private resolveLinearOrganizationId(record: WorkspaceIntegrationRecord): string | null {
-    if (record.installationId) return record.installationId
-    return this.parseLinearMetadata(record.metadata).organizationId
   }
 
   private async completeLinearInstallation(
@@ -1308,13 +1322,15 @@ export class WorkspaceIntegrationService {
    * Persist Linear credentials after the OAuth round-trip.
    *
    * `isInstall` (first-time authorize / re-authorize) creates or replaces the row
-   * via upsert. The refresh path instead runs a guarded UPDATE: a blind upsert
-   * there would resurrect a row a concurrent disconnect just cleared, or clobber a
-   * row reconnected to a different Linear org back to this one (INV-20). A lost
-   * race matches 0 rows and returns null, which callers (401 retry, proactive
-   * refresh) already handle as a refresh failure. The Linear organization id is
-   * the stable external identity — persisted lazily into `installation_id` on
-   * every write; the guard's `allowNull` covers pre-population rows.
+   * via an id-keyed upsert (ON CONFLICT (id)) so a reconnect to a different Linear
+   * org rewrites the single Linear row in place rather than colliding on the
+   * primary key — Linear stores its org id in `installation_id`, so an
+   * installation-keyed arbiter would miss on an org switch and hit the PK. The
+   * refresh path instead runs a guarded UPDATE scoped to the installation_id read
+   * with the record: a blind upsert there would resurrect a row a concurrent
+   * disconnect just cleared, or clobber a row reconnected to a different Linear org
+   * back to this one (INV-20). A lost race matches 0 rows and returns null, which
+   * callers (401 retry, proactive refresh) already handle as a refresh failure.
    */
   private async persistLinearCredentials(
     workspaceId: string,
@@ -1338,29 +1354,48 @@ export class WorkspaceIntegrationService {
     const organizationId = metadata.organizationId
 
     if (options.isInstall) {
-      const updated = await WorkspaceIntegrationRepository.upsert(this.deps.pool, {
-        id: record.id,
-        workspaceId,
-        provider: WorkspaceIntegrationProviders.LINEAR,
-        status: WorkspaceIntegrationStatuses.ACTIVE,
-        credentials: encryptedCredentials,
-        metadata,
-        installedBy: options.installedByOverride ?? record.installedBy,
-        installationId: organizationId,
+      // Serialize on the workspace lock and re-read the row inside it: the id
+      // arbiter cannot dedupe two concurrent FIRST-TIME connects (two fresh ULIDs
+      // both insert cleanly), so without the lock a workspace could end up with
+      // two Linear rows for different orgs. Mirrors persistGithubIntegration's
+      // lifecycle branch.
+      const updated = await withTransaction(this.deps.pool, async (client) => {
+        await WorkspaceIntegrationRepository.lockWorkspace(client, workspaceId)
+        const existing = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
+          client,
+          workspaceId,
+          WorkspaceIntegrationProviders.LINEAR
+        )
+        return WorkspaceIntegrationRepository.upsert(
+          client,
+          {
+            id: existing?.id ?? record.id,
+            workspaceId,
+            provider: WorkspaceIntegrationProviders.LINEAR,
+            status: WorkspaceIntegrationStatuses.ACTIVE,
+            credentials: encryptedCredentials,
+            metadata,
+            installedBy: options.installedByOverride ?? record.installedBy,
+            installationId: organizationId,
+          },
+          "id"
+        )
       })
       return { record: updated, credentials, metadata }
     }
 
-    // Refresh path — CREDENTIAL WRITE, version-CAS. A missing org id is pinned to
-    // a NULL/empty installation id rather than falling back to status-only, so even
-    // a malformed legacy client cannot overwrite a concurrently reconnected row
-    // with a populated org id. The version read with the record (INV-66) additionally
-    // stops a stale refresh clobbering a newer same-org write. A 0-row miss returns
-    // null, which callers (401 retry, proactive refresh) handle as a refresh failure.
+    // Refresh path — CREDENTIAL WRITE, version-CAS. Scoped to the installation_id
+    // column read with the record (NULL for a pre-population row), so even a
+    // malformed legacy client cannot overwrite a concurrently reconnected row that
+    // shifted the column to a populated org id. The version read with the record
+    // (INV-66) additionally stops a stale refresh clobbering a newer same-org write.
+    // A 0-row miss returns null, which callers (401 retry, proactive refresh) handle
+    // as a refresh failure.
     const updated = await WorkspaceIntegrationRepository.update(
       this.deps.pool,
       workspaceId,
       WorkspaceIntegrationProviders.LINEAR,
+      record.installationId,
       {
         status: WorkspaceIntegrationStatuses.ACTIVE,
         credentials: encryptedCredentials,
@@ -1370,7 +1405,6 @@ export class WorkspaceIntegrationService {
       },
       {
         expectedStatus: WorkspaceIntegrationStatuses.ACTIVE,
-        expectedInstallationId: { value: organizationId ?? "", allowNull: true },
         expectedVersion: record.version,
       }
     )
@@ -1513,6 +1547,10 @@ function getInstallationAccountType(account: unknown): string | null {
   if (!account || typeof account !== "object") return null
   const type = (account as { type?: unknown }).type
   return typeof type === "string" ? type : null
+}
+
+function normalizeGithubAccountType(value: unknown): "Organization" | "User" | null {
+  return value === "Organization" || value === "User" ? value : null
 }
 
 function getInstallationAccountLogin(account: unknown): string | null {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -826,13 +826,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workspaceIntegration.connectGithub
   )
   app.delete(
-    "/api/workspaces/:workspaceId/integrations/github",
+    "/api/workspaces/:workspaceId/integrations/github/:integrationId",
     ...authed,
     requireWorkspaceAdmin,
     workspaceIntegration.disconnectGithub
   )
   app.post(
-    "/api/workspaces/:workspaceId/integrations/github/sync",
+    "/api/workspaces/:workspaceId/integrations/github/:integrationId/sync",
     ...authed,
     requireWorkspaceAdmin,
     workspaceIntegration.syncGithub

--- a/apps/backend/tests/integration/github-installation-backfill-migration.test.ts
+++ b/apps/backend/tests/integration/github-installation-backfill-migration.test.ts
@@ -104,133 +104,6 @@ describe("enqueue github installation backfill migration", () => {
 })
 
 /**
- * A stale lifecycle write must pin the installation it observed at read (INV-20):
- * a status-only guard would let a backfill/deactivation holding installation A
- * clobber a row that has since reconnected to installation B.
- * `expectedInstallationId: {value, allowNull}` encodes that pin; exercised
- * against real Postgres because a mock can't prove the WHERE actually gates.
- */
-describe("workspace_integrations installation_id guard", () => {
-  let pool: Pool
-
-  beforeAll(async () => {
-    pool = await setupTestDatabase()
-  })
-
-  afterAll(async () => {
-    await pool.end()
-  })
-
-  async function seed(client: Pool | import("pg").PoolClient, installationId: string | null): Promise<void> {
-    await client.query(
-      `INSERT INTO workspace_integrations (id, workspace_id, provider, status, installed_by, installation_id)
-       VALUES ('wsi_guard', 'ws_guard', 'github', 'active', 'usr_test', $1)`,
-      [installationId]
-    )
-  }
-
-  test("allowNull=true (backfill) matches a NULL column and fills it", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, null)
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { installationId: "A" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: true } }
-      )
-
-      expect(updated?.installationId).toBe("A")
-    })
-  })
-
-  test("allowNull=true (backfill) matches when the column already equals the value", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, "A")
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { installationId: "A" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: true } }
-      )
-
-      expect(updated?.installationId).toBe("A")
-    })
-  })
-
-  test("allowNull=true (backfill) does NOT match a row reinstalled to B — no clobber to A", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, "B")
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { installationId: "A" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: true } }
-      )
-
-      expect(updated).toBeNull()
-      const { rows } = await client.query(`SELECT installation_id FROM workspace_integrations WHERE id = 'wsi_guard'`)
-      expect(rows[0].installation_id).toBe("B")
-    })
-  })
-
-  test("allowNull=false (deactivate) matches only the exact installation id", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, "A")
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { status: "inactive" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: false } }
-      )
-
-      expect(updated?.status).toBe("inactive")
-    })
-  })
-
-  test("allowNull=false (deactivate) does NOT deactivate a row now on B", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, "B")
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { status: "inactive" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: false } }
-      )
-
-      expect(updated).toBeNull()
-      const { rows } = await client.query(`SELECT status FROM workspace_integrations WHERE id = 'wsi_guard'`)
-      expect(rows[0].status).toBe("active")
-    })
-  })
-
-  test("allowNull=false (deactivate) does NOT match a NULL column", async () => {
-    await withTestTransaction(pool, async (client) => {
-      await seed(client, null)
-
-      const updated = await WorkspaceIntegrationRepository.update(
-        client,
-        "ws_guard",
-        "github",
-        { status: "inactive" },
-        { expectedStatus: "active", expectedInstallationId: { value: "A", allowNull: false } }
-      )
-
-      expect(updated).toBeNull()
-    })
-  })
-})
-
-/**
  * INV-66 discipline: the compared version is produced by the repository's own
  * NOW()-writing update path and read back through the repository — never a
  * hand-crafted fixture — so the CAS is exercised against a value that actually
@@ -266,6 +139,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { repositories: [{ fullName: "org/repo", private: false }] } },
         { expectedVersion: before!.version }
       )
@@ -284,6 +158,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { winner: true } },
         { expectedVersion: before!.version }
       )
@@ -294,6 +169,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { loser: true } },
         { expectedVersion: before!.version }
       )
@@ -313,6 +189,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { a: 1 } },
         {
           expectedVersion: before!.version,
@@ -323,6 +200,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { b: 2 } },
         {
           expectedVersion: before!.version,
@@ -335,6 +213,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
         client,
         "ws_ver",
         "github",
+        "A",
         { metadata: { b: 2 } },
         {
           expectedVersion: reread!.version,
@@ -347,7 +226,7 @@ describe("workspace_integrations version CAS (INV-66)", () => {
   test("an update without expectedVersion still bumps the version (every update increments)", async () => {
     await withTestTransaction(pool, async (client) => {
       await seed(client)
-      const updated = await WorkspaceIntegrationRepository.update(client, "ws_ver", "github", {
+      const updated = await WorkspaceIntegrationRepository.update(client, "ws_ver", "github", "A", {
         metadata: { touched: true },
       })
       expect(updated?.version).toBe(2)

--- a/apps/backend/tests/integration/workspace-integrations-multi-install.test.ts
+++ b/apps/backend/tests/integration/workspace-integrations-multi-install.test.ts
@@ -1,0 +1,223 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { WorkspaceIntegrationProviders } from "@threa/types"
+import { setupTestDatabase, withTestTransaction } from "./setup"
+import {
+  WorkspaceIntegrationRepository,
+  type UpsertWorkspaceIntegrationParams,
+} from "../../src/features/workspace-integrations/repository"
+import { workspaceIntegrationId } from "../../src/lib/id"
+
+/**
+ * Real-Postgres coverage for the multi-install schema (two partial unique
+ * indexes) and the row-scoped `update`. The headline risk is a write matching
+ * more than one of a workspace's N GitHub installations; these tests exercise
+ * the ON CONFLICT targets and `installation_id IS NOT DISTINCT FROM $scope`
+ * against the actual indexes, not by eyeballing SQL.
+ */
+const WS = "ws_multi_install"
+
+function githubUpsert(overrides: Partial<UpsertWorkspaceIntegrationParams> = {}): UpsertWorkspaceIntegrationParams {
+  return {
+    id: workspaceIntegrationId(),
+    workspaceId: WS,
+    provider: WorkspaceIntegrationProviders.GITHUB,
+    status: "active",
+    credentials: {},
+    metadata: {},
+    installedBy: "user_1",
+    installationId: null,
+    ...overrides,
+  }
+}
+
+describe("workspace_integrations multi-install", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("two GitHub installs coexist for one workspace", async () => {
+    await withTestTransaction(pool, async (client) => {
+      await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: "100" }))
+      await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: "200" }))
+
+      const installs = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.GITHUB
+      )
+      expect(installs.map((i) => i.installationId).sort()).toEqual(["100", "200"])
+    })
+  })
+
+  test("re-upsert of the same (workspace, provider, installation) updates in place (no second row)", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const first = await WorkspaceIntegrationRepository.upsert(
+        client,
+        githubUpsert({ installationId: "300", metadata: { organizationName: "before" } })
+      )
+      const second = await WorkspaceIntegrationRepository.upsert(
+        client,
+        githubUpsert({ installationId: "300", metadata: { organizationName: "after" } })
+      )
+
+      const installs = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.GITHUB
+      )
+      expect(installs).toHaveLength(1)
+      // Conflict keeps the original row id and bumps the version.
+      expect(second.id).toBe(first.id)
+      expect(second.version).toBe(first.version + 1)
+      expect(second.metadata.organizationName).toBe("after")
+    })
+  })
+
+  test("a second NULL-installation row for the same (workspace, provider) is rejected", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const insertNull = (id: string) =>
+        client.query(
+          `INSERT INTO workspace_integrations
+             (id, workspace_id, provider, status, credentials, metadata, installed_by, installation_id)
+           VALUES ($1, $2, 'linear', 'active', '{}'::jsonb, '{}'::jsonb, 'user_1', NULL)`,
+          [id, WS]
+        )
+
+      await insertNull(workspaceIntegrationId())
+      await expect(insertNull(workspaceIntegrationId())).rejects.toThrow(/duplicate key|unique/i)
+    })
+  })
+
+  test("scoped update touches EXACTLY ONE of two installs", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const a = await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: "100" }))
+      const b = await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: "200" }))
+
+      const updated = await WorkspaceIntegrationRepository.update(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.GITHUB,
+        "100",
+        { status: "inactive" }
+      )
+      expect(updated?.id).toBe(a.id)
+
+      const afterA = await WorkspaceIntegrationRepository.findByWorkspaceAndId(client, WS, a.id)
+      const afterB = await WorkspaceIntegrationRepository.findByWorkspaceAndId(client, WS, b.id)
+      expect(afterA?.status).toBe("inactive")
+      expect(afterB?.status).toBe("active")
+    })
+  })
+
+  test("scoped update with scope NULL touches only the NULL-installation row when an id row coexists", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const legacy = await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: null }))
+      const withId = await WorkspaceIntegrationRepository.upsert(client, githubUpsert({ installationId: "100" }))
+
+      const updated = await WorkspaceIntegrationRepository.update(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.GITHUB,
+        null,
+        { metadata: { organizationName: "legacy-touched" } }
+      )
+      expect(updated?.id).toBe(legacy.id)
+
+      const afterLegacy = await WorkspaceIntegrationRepository.findByWorkspaceAndId(client, WS, legacy.id)
+      const afterWithId = await WorkspaceIntegrationRepository.findByWorkspaceAndId(client, WS, withId.id)
+      expect(afterLegacy?.metadata.organizationName).toBe("legacy-touched")
+      expect(afterWithId?.metadata.organizationName).toBeUndefined()
+    })
+  })
+
+  // Linear stores its org id in installation_id, so it lands on the multi-install
+  // index (#1), not the NULL index. Its single-row guarantee is upheld by the
+  // id-keyed upsert: reconnecting the same row to a different org must REPLACE it
+  // (rewrite installation_id on the reused ULID), never insert a second row or
+  // collide on the primary key.
+  test("Linear org switch replaces the single row via id-keyed upsert (no PK collision, no second row)", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const linearRow = (id: string, installationId: string): UpsertWorkspaceIntegrationParams => ({
+        id,
+        workspaceId: WS,
+        provider: WorkspaceIntegrationProviders.LINEAR,
+        status: "active",
+        credentials: {},
+        metadata: { organizationId: installationId },
+        installedBy: "user_1",
+        installationId,
+      })
+
+      const orgA = await WorkspaceIntegrationRepository.upsert(
+        client,
+        linearRow(workspaceIntegrationId(), "orgA"),
+        "id"
+      )
+      // Reconnect the SAME row (reused ULID) to a different org — the failure mode
+      // was an installation-keyed arbiter missing on the org switch and raising a
+      // duplicate-key error on the reused id.
+      const switched = await WorkspaceIntegrationRepository.upsert(client, linearRow(orgA.id, "orgB"), "id")
+
+      const rows = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.LINEAR
+      )
+      expect(rows).toHaveLength(1)
+      expect(switched.id).toBe(orgA.id)
+      expect(rows[0].installationId).toBe("orgB")
+    })
+  })
+
+  // Connecting a wrong org while an active Linear row exists is the same
+  // reuse-existing-row path (completeLinearInstallation reuses the found row's id):
+  // it must replace, not add.
+  test("Linear connect-different-org while active replaces in place", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const active = await WorkspaceIntegrationRepository.upsert(
+        client,
+        {
+          id: workspaceIntegrationId(),
+          workspaceId: WS,
+          provider: WorkspaceIntegrationProviders.LINEAR,
+          status: "active",
+          credentials: {},
+          metadata: { organizationId: "orgA" },
+          installedBy: "user_1",
+          installationId: "orgA",
+        },
+        "id"
+      )
+
+      const replaced = await WorkspaceIntegrationRepository.upsert(
+        client,
+        {
+          id: active.id,
+          workspaceId: WS,
+          provider: WorkspaceIntegrationProviders.LINEAR,
+          status: "active",
+          credentials: {},
+          metadata: { organizationId: "orgB" },
+          installedBy: "user_1",
+          installationId: "orgB",
+        },
+        "id"
+      )
+
+      const rows = await WorkspaceIntegrationRepository.listByWorkspaceAndProvider(
+        client,
+        WS,
+        WorkspaceIntegrationProviders.LINEAR
+      )
+      expect(rows).toHaveLength(1)
+      expect(replaced.installationId).toBe("orgB")
+    })
+  })
+})

--- a/apps/frontend/src/api/integrations.ts
+++ b/apps/frontend/src/api/integrations.ts
@@ -3,7 +3,7 @@ import type { GitHubWorkspaceIntegration, LinearWorkspaceIntegration } from "@th
 
 export interface GitHubIntegrationResponse {
   configured: boolean
-  integration: GitHubWorkspaceIntegration | null
+  integrations: GitHubWorkspaceIntegration[]
 }
 
 export interface LinearIntegrationResponse {
@@ -16,12 +16,14 @@ export const integrationsApi = {
     return api.get<GitHubIntegrationResponse>(`/api/workspaces/${workspaceId}/integrations/github`)
   },
 
-  async disconnectGithub(workspaceId: string): Promise<void> {
-    await api.delete(`/api/workspaces/${workspaceId}/integrations/github`)
+  async disconnectGithub(workspaceId: string, integrationId: string): Promise<void> {
+    await api.delete(`/api/workspaces/${workspaceId}/integrations/github/${integrationId}`)
   },
 
-  async syncGithub(workspaceId: string): Promise<GitHubIntegrationResponse> {
-    return api.post<GitHubIntegrationResponse>(`/api/workspaces/${workspaceId}/integrations/github/sync`)
+  async syncGithub(workspaceId: string, integrationId: string): Promise<GitHubIntegrationResponse> {
+    return api.post<GitHubIntegrationResponse>(
+      `/api/workspaces/${workspaceId}/integrations/github/${integrationId}/sync`
+    )
   },
 
   async getLinear(workspaceId: string): Promise<LinearIntegrationResponse> {

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -40,14 +40,14 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   })
 
   const disconnectMutation = useMutation({
-    mutationFn: () => integrationsApi.disconnectGithub(workspaceId),
+    mutationFn: (integrationId: string) => integrationsApi.disconnectGithub(workspaceId, integrationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workspace-integrations", workspaceId, "github"] })
     },
   })
 
   const syncMutation = useMutation({
-    mutationFn: () => integrationsApi.syncGithub(workspaceId),
+    mutationFn: (integrationId: string) => integrationsApi.syncGithub(workspaceId, integrationId),
     onSuccess: (data) => {
       queryClient.setQueryData(["workspace-integrations", workspaceId, "github"], data)
     },
@@ -79,7 +79,7 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   }
 
   const configured = query.data?.configured ?? false
-  const integration = query.data?.integration ?? null
+  const integration = query.data?.integrations?.[0] ?? null
   const repositories = integration?.repositories ?? []
   const isActive = integration?.status === "active"
 
@@ -116,10 +116,10 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
 
         {configured && isActive && (
           <div className="mt-3 space-y-3">
-            {integration.organizationName && (
+            {integration.accountLogin && (
               <div>
                 <h4 className="text-xs font-medium text-muted-foreground">Organization</h4>
-                <p className="text-sm">{integration.organizationName}</p>
+                <p className="text-sm">{integration.accountLogin}</p>
               </div>
             )}
 
@@ -166,7 +166,7 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => syncMutation.mutate()}
+                onClick={() => integration && syncMutation.mutate(integration.id)}
                 disabled={syncMutation.isPending}
               >
                 <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${syncMutation.isPending ? "animate-spin" : ""}`} />
@@ -177,7 +177,7 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => disconnectMutation.mutate()}
+                onClick={() => integration && disconnectMutation.mutate(integration.id)}
                 disabled={disconnectMutation.isPending}
               >
                 {disconnectMutation.isPending ? "Disconnecting\u2026" : "Disconnect"}

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -118,7 +118,9 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
           <div className="mt-3 space-y-3">
             {integration.accountLogin && (
               <div>
-                <h4 className="text-xs font-medium text-muted-foreground">Organization</h4>
+                <h4 className="text-xs font-medium text-muted-foreground">
+                  {integration.accountType === "User" ? "Account" : "Organization"}
+                </h4>
                 <p className="text-sm">{integration.accountLogin}</p>
               </div>
             )}

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1248,7 +1248,10 @@ export interface GitHubInstalledRepository {
 
 export interface GitHubWorkspaceIntegration extends WorkspaceIntegration {
   provider: "github"
-  organizationName: string | null
+  /** Account login the app is installed on — an org OR a personal user (INV-10). */
+  accountLogin: string | null
+  installationId: string | null
+  accountType: "Organization" | "User" | null
   repositorySelection: "all" | "selected" | null
   permissions: Record<string, string>
   repositories: GitHubInstalledRepository[]


### PR DESCRIPTION
## Problem

A workspace could hold exactly one GitHub App installation. `workspace_integrations` enforced that with a single unique index `(workspace_id, provider)`, and the install path treated a new installation id as a *replacement* — connecting a second org silently unregistered the first. That blocks the real cases the deepen-GitHub work is aimed at: webhook coverage for a personal account (`kristofferremback/seer`) alongside an org, a friend's org joining an existing workspace, and a multi-org company linking every org. It also rejected personal accounts outright — `completeGithubInstallation` threw `GITHUB_ORGANIZATION_REQUIRED` for any non-`Organization` account.

## Solution

N rows in `workspace_integrations`, one per `(workspace, provider, installation)`, with no child table. GitHub installs live independently and additively; disconnect and sync are per-install and address the row's ULID, not the GitHub installation id. Linear stays single-row. This is Step A of a three-PR stack (model + service + API); owner-aware consumers and the settings list UI are the stacked follow-ups (see Out of scope).

### How it works

1. **Two partial unique indexes** (`20260719120000_workspace_integrations_multi_install.sql`) replace the single-row index: `workspace_integrations_workspace_provider_installation` on `(workspace_id, provider, installation_id) WHERE installation_id IS NOT NULL` lets a workspace hold many GitHub installs; `workspace_integrations_workspace_provider_no_installation` on `(workspace_id, provider) WHERE installation_id IS NULL` keeps at most one NULL-installation row (legacy pre-backfill GitHub rows, and providers that never set an id). Partial indexes rather than `NULLS NOT DISTINCT` because that clause is unavailable on older PostgreSQL. New indexes are created **before** the old one is dropped so uniqueness is never unenforced.

2. **`repository.update()` is scoped to a single row.** The old `expectedInstallationId {value, allowNull}` guard machinery ($9/$10/$11) is gone; the WHERE now carries `installation_id IS NOT DISTINCT FROM $3` (`installationScope`), keeping only `expectedStatus` and `expectedVersion`. Callers pass the row's `installation_id` **column value read before the write** (identity pinned at read, INV-20); with N rows per `(workspace, provider)` the write touches exactly the intended install, and a reconnect to a different installation shifts the column so a stale write matches 0 rows.

3. **`repository.upsert()` arbitrates on the matching index.** `upsertConflictClause(conflictTarget, installationId)` picks `ON CONFLICT (workspace_id, provider, installation_id) WHERE installation_id IS NOT NULL` for a real install, `ON CONFLICT (workspace_id, provider) WHERE installation_id IS NULL` for a NULL row, or `ON CONFLICT (id)` for single-row providers. `DO UPDATE` writes `installation_id = EXCLUDED.installation_id` plainly (the conflict key pins it), replacing the old `COALESCE`.

4. **Installs are additive.** `persistGithubIntegration`'s lifecycle branch keeps the workspace lock and `emitRouteRegister`, but the previous-installation `emitRouteUnregister` branch is deleted — a second install never unregisters a sibling. Per-install disconnect (`disconnectGithubInstallation(workspaceId, integrationId)`) and sync (`syncGithubRepositories(workspaceId, integrationId)`) resolve the row via `findByWorkspaceAndId`, and disconnect emits exactly its own unregister.

5. **Owner-aware client resolution, no quota borrowing.** `getGithubClient(workspaceId, { repoOwner?, allowUnauthenticatedFallback? })` loads active rows via `listByWorkspaceAndProvider`. A `repoOwner` that matches an install's account login (case-insensitive) selects *that install only*; if it is near its rate limit it returns `null` — a hard breaker that never hands back a sibling's or anonymous token. With no owner match it iterates active rows in list order, skipping near-limit ones, and takes the first that yields a client (`buildGithubClientFromRecord`); if every active row is throttled it returns `null`, otherwise it falls back per the flag. The chosen record threads into `GitHubClient` so 401-refresh and `captureRateLimit` CAS hit the right row.

6. **Personal accounts accepted.** The `GITHUB_ORGANIZATION_REQUIRED` throw is deleted. `normalizeGithubAccountType` maps the installation's account to `"Organization" | "User" | null`, captured into metadata at install time. `GitHubIntegrationMetadata` gains `accountType`; the JSONB key stays `organizationName` (renaming it would force row rewrites) and is mapped to the wire field `accountLogin` at the service boundary.

7. **Wire shape.** `GET /api/workspaces/:workspaceId/integrations/github` returns `{ configured, integrations: GitHubWorkspaceIntegration[] }` — the singular `integration` field is gone. `GitHubWorkspaceIntegration` renames `organizationName` → `accountLogin` and adds `installationId: string | null` and `accountType: "Organization" | "User" | null`. Per-install routes: `DELETE .../github/:integrationId` and `POST .../github/:integrationId/sync`, both `requireWorkspaceAdmin`, `integrationId` validated with a Zod params schema (INV-55).

### Key design decisions

**1. N rows, no child table.** Each installation is a full `workspace_integrations` row keyed by its installation id. A child table would split credential/metadata/rate-limit state across two tables for no gain — the row already carries all of it, and the reverse index (`listActiveByInstallationId`) for webhook fan-out keeps working unchanged.

**2. No transitional wire compat.** The stack merges together, so `GET` drops the singular field, the old disconnect-all `DELETE .../github` and sync `POST .../github/sync` routes die, and there is no temporary shim (Kris's explicit ruling). Step A still ships a minimal mechanical frontend adaptation (`integrations[0]`) so the monorepo typechecks and single-install behavior is preserved; the real list UI is Step B.

**3. Partial indexes, not `NULLS NOT DISTINCT`.** The prod PostgreSQL version is unverifiable from this session; partial indexes work everywhere. Accepted deploy-window note (in the migration): between the migration and the code cutover, an old replica still runs `ON CONFLICT (workspace_id, provider)`, which errors once the backing index is gone — blast radius is an admin connecting a new install mid-deploy (a retryable 500); token refreshes are UPDATEs and unaffected.

**4. Per-install routes address the ROW ULID, not the GitHub installation id.** The ULID is always present (even on legacy NULL-installation rows), workspace-scoped, and requires no client-supplied external-id trust.

**5. Row-scoped writes pin identity at read (INV-20).** The scope is the column value observed at read, not a status flag. `updateGithubRateLimitMetadata` takes `installationScope` (from `record.installationId`) so a stale cache write lands on the right row of an N-install workspace or matches 0 rows. Lifecycle writes still omit `expectedVersion` deliberately: they express absolute user/webhook intent and must not be no-op'd by a background refresh's version bump.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260719120000_workspace_integrations_multi_install.sql` | Two partial unique indexes replace the single-row `(workspace_id, provider)` index; drop the old index after creating the new ones |
| `apps/backend/tests/integration/workspace-integrations-multi-install.test.ts` | Real-Postgres coverage of the ON CONFLICT targets and `installation_id IS NOT DISTINCT FROM $scope` against the actual indexes |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/workspace-integrations/repository.ts` | `update()` gains `installationScope`, drops `expectedInstallationId`; `upsertConflictClause` + `WorkspaceIntegrationUpsertConflict` type; new `findByWorkspaceAndId`, `listByWorkspaceAndProvider`; `upsert` writes `installation_id = EXCLUDED.installation_id` |
| `apps/backend/src/features/workspace-integrations/service.ts` | `getGithubIntegration` → `listGithubInstallations` (+ `mapGithubIntegration`); `disconnectGithubInstallation` / per-install `syncGithubRepositories`; `getGithubClient` owner-aware + `buildGithubClientFromRecord`; additive `persistGithubIntegration` (scope arg, no sibling unregister); `GITHUB_ORGANIZATION_REQUIRED` deleted + `normalizeGithubAccountType`; Linear install path workspace-locked + id-keyed upsert; `resolveLinearOrganizationId` removed |
| `apps/backend/src/features/workspace-integrations/handlers.ts` | `getGithub`/`syncGithub` return `{ configured, integrations }`; `disconnectGithub`/`syncGithub` validate `integrationId` params (INV-55) and delegate per-install |
| `apps/backend/src/routes.ts` | `DELETE`/`POST` GitHub routes take `:integrationId` |
| `packages/types/src/domain.ts` | `GitHubWorkspaceIntegration`: `organizationName` → `accountLogin`; add `installationId`, `accountType` |
| `apps/frontend/src/api/integrations.ts` | Response envelope `{ configured, integrations }`; `disconnectGithub`/`syncGithub` take `integrationId` |
| `apps/frontend/src/components/workspace-settings/integrations-tab.tsx` | Mechanical single-install adaptation (`integrations[0]`, thread `integration.id`, `accountLogin`) — real list UI is Step B |
| `apps/backend/tests/integration/github-installation-backfill-migration.test.ts` | Remove the orphaned `expectedInstallationId` guard test block; version-CAS tests pass the new `installationScope` arg |
| `apps/backend/src/features/workspace-integrations/{installation-routes,handlers,service,linear-write-guards}.test.ts` | Owner-matrix + account-type + additive-lifecycle + scoped-guard coverage; renamed disconnect calls; `accountType` in fixtures |

## Out of scope (deliberate)

- **Owner-aware consumers** — the link-preview fetch/gate and agent tools passing `{ repoOwner }` into `getGithubClient`. The parameter exists and is tested here; wiring the call sites is the next stacked PR (`feat/github-multi-install-owner-routing`).
- **Settings installations UI** — the per-row list (account badge, repo summary, per-row Sync/Disconnect, "Add organization or account"). This PR only does the mechanical `integrations[0]` adaptation to stay compile-green; the real UI is the top stacked PR (`feat/github-multi-install-ui`).
- **Webhook worker, control plane, route-sync outbox handler, `installation-backfill.ts`** — untouched. None of the 14 files touch them; the new repo signatures thread through the exact installation id those paths already hold.

## Design evolution (self-review)

Two adversarial reviewers (xhigh) and the coordinator's own pass turned up four issues, all fixed and re-verified:

- **Linear regression (must-fix).** Linear stores its org id in `installation_id` (non-null), so its rows fall under the multi-install index #1 — not the NULL index. Dropping the covering `(workspace_id, provider)` index would have let a Linear org-switch throw a PK violation on the reused ULID and permitted two active Linear rows. Fixed with an **id-keyed upsert arbiter** (`ON CONFLICT (id)` via `WorkspaceIntegrationUpsertConflict = "id"`) so a reconnect rewrites the one row in place. Proven against real PG (`Linear org switch replaces the single row`, `Linear connect-different-org while active replaces in place`).
- **Orphaned integration test (must-fix).** A test block still exercised the deleted `expectedInstallationId` guard — 7 deterministic failures invisible to `tsc` because `tests/` is outside `tsconfig`. Removed.
- **Concurrent Linear first-connect (coordinator).** Two first-time connects with different org ids could both insert (the id arbiter can't dedupe two fresh ULIDs). Added the **workspace lock + re-read** to the Linear install path, mirroring `persistGithubIntegration`.
- **INV-47 (coordinator).** Factored the upsert conflict selection into `upsertConflictClause` after a nested-ternary lint error; the clause is derived from a controlled enum, not user input.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] Backend unit — 3226 pass (96 in `workspace-integrations`: second-install-ADD, disconnect scoping, deactivate-A-leaves-B, `getGithubClient` owner matrix, User/Org account types)
- [x] Backend `test:e2e` — 367 pass
- [x] Real-Postgres integration — `workspace-integrations-multi-install.test.ts` (5 schema/scope tests + 2 Linear-regression tests added in self-review) and the rewritten `github-installation-backfill-migration.test.ts`: 14 pass across the two files
- [x] Frontend `tsc --noEmit` clean; full vitest — 4487 pass
- [x] `check:migrations` — 221 clean; lint clean (pre-commit gauntlet)
- [ ] Full `test:integration` — 2 pre-existing sync-log retention tests fail under cross-file DB contention (pass in isolation; zero file overlap with this diff). Noted, not caused by this change.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** N GitHub App installations per workspace (orgs AND personal accounts) so webhook coverage extends to personal repos, a friend's org can join an existing workspace, and multi-org companies can link every org. Workspace-level, admin-gated (gating already exists). Stack: Step A (this PR — model + service + API), Step C (owner-aware consumers), Step B (settings UI).

**What was built.**
- Migration: two partial unique indexes (`..._workspace_provider_installation` WHERE installation_id IS NOT NULL, `..._workspace_provider_no_installation` WHERE installation_id IS NULL), drop the old single-row index after creating them.
- Repository: `update()` scoped by `installation_id IS NOT DISTINCT FROM $scope`; `expectedInstallationId` guard removed; `upsertConflictClause` selects the partial index or `ON CONFLICT (id)`; `findByWorkspaceAndId`, `listByWorkspaceAndProvider` added.
- Service: `listGithubInstallations`, per-install `disconnectGithubInstallation`/`syncGithubRepositories`, owner-aware `getGithubClient` with a hard per-install rate-limit breaker (no quota borrowing), additive `persistGithubIntegration`, `GITHUB_ORGANIZATION_REQUIRED` removed, `accountType` capture, Linear install path workspace-locked + id-keyed.
- Types/handlers/routes/frontend: `{ configured, integrations }` envelope; `organizationName` → `accountLogin` + `installationId` + `accountType`; per-install `:integrationId` routes with Zod validation; mechanical frontend adaptation.

**Design decisions.** N rows over a child table; no transitional wire compat (Kris's ruling); partial indexes over NULLS NOT DISTINCT (older PG); routes address the row ULID; identity pinned at read for row-scoped writes (INV-20); no quota borrowing across installs.

**Design evolution.** Linear PK-collision regression fixed via id-keyed upsert arbiter; orphaned `expectedInstallationId` test removed; workspace lock added to the Linear install path; conflict clause extracted for INV-47.

**Schema changes.** `20260719120000_workspace_integrations_multi_install.sql` — index-only (no column changes); `installation_id` already existed. Append-only (INV-17).

**What's NOT included.** Owner-aware call sites (Step C), settings installations list UI (Step B). Webhook worker / CP / route-sync / installation-backfill unchanged.

**Status.** Backend + frontend typecheck clean; backend unit 3226, e2e 367, integration 14 across the two multi-install files; frontend vitest 4487; migrations 221. Two pre-existing sync-log retention integration tests fail only under cross-file contention (unrelated).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
