### PR TITLE
feat(access-log): HTTP capture — audit middleware, full route annotation, coverage guard (stack 2/5)

### DIFF
--- a/apps/backend/src/features/access-log/index.ts
+++ b/apps/backend/src/features/access-log/index.ts
@@ -27,3 +27,5 @@ export type {
   PublicApiOperation,
   AiOperation,
 } from "./operations"
+export { createAuditMiddleware, assertAuditCoverage } from "./middleware"
+export type { AuditFactory, AuditAnnotation } from "./middleware"

--- a/apps/backend/src/features/access-log/middleware.test.ts
+++ b/apps/backend/src/features/access-log/middleware.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test"
+import express from "express"
+import { assertAuditCoverage, createAuditMiddleware } from "./middleware"
+import type { AccessLogService } from "./service"
+
+const noopService = { record() {} } as unknown as AccessLogService
+
+describe("assertAuditCoverage", () => {
+  it("passes when every /api route carries an audit annotation", () => {
+    const audit = createAuditMiddleware(noopService)
+    const app = express()
+    app.get("/api/thing", audit("streams.get", "read"), (_req, res) => res.end())
+    app.post("/api/other", audit("streams.create", "write"), (_req, res) => res.end())
+    app.get("/api/avatar/:file", audit.none("unauthenticated avatar serve"), (_req, res) => res.end())
+    // Non-/api routes are exempt from the guard.
+    app.get("/readyz", (_req, res) => res.end())
+
+    expect(() => assertAuditCoverage(app)).not.toThrow()
+  })
+
+  it("throws listing method+path for an unannotated /api route", () => {
+    const audit = createAuditMiddleware(noopService)
+    const app = express()
+    app.get("/api/thing", audit("streams.get", "read"), (_req, res) => res.end())
+    app.post("/api/unlogged", (_req, res) => res.end())
+
+    expect(() => assertAuditCoverage(app)).toThrow(/POST \/api\/unlogged/)
+  })
+
+  it("throws on any mounted sub-router (its routes are invisible to the walk)", () => {
+    const app = express()
+    const sub = express.Router()
+    sub.get("/hidden", (_req, res) => res.end())
+    app.use("/api/v2", sub)
+
+    expect(() => assertAuditCoverage(app)).toThrow(/mounted sub-router/)
+  })
+
+  it("throws on a router mounted outside /api too — Express 5 hides mount paths, strictness is deliberate", () => {
+    const app = express()
+    app.use("/apiary", express.Router())
+
+    expect(() => assertAuditCoverage(app)).toThrow(/mounted sub-router/)
+  })
+})

--- a/apps/backend/src/features/access-log/middleware.ts
+++ b/apps/backend/src/features/access-log/middleware.ts
@@ -1,0 +1,213 @@
+import type { Express, Request, RequestHandler, Response } from "express"
+import type { AccessLogService } from "./service"
+import type { AccessKind, AccessLogOperation, AccessOutcome, ActorType } from "./operations"
+import { readAuditSubjects } from "./subjects"
+
+/**
+ * The marker a route's audit middleware carries so the boot-time coverage guard
+ * can read it off the router stack. A real annotation names an `operation` and
+ * `kind`; a `kind: "none"` annotation exempts a route with a justification.
+ */
+export type AuditAnnotation = { operation: AccessLogOperation; kind: AccessKind } | { kind: "none"; reason: string }
+
+interface AnnotatedHandler extends RequestHandler {
+  auditAnnotation?: AuditAnnotation
+}
+
+/** The `audit(operation, kind)` factory with a `.none(reason)` exemption path. */
+export interface AuditFactory {
+  (operation: AccessLogOperation, kind: AccessKind): RequestHandler
+  none(reason: string): RequestHandler
+  /**
+   * Denial backstop mounted BEFORE later auth/permission middleware (inside
+   * `authed`, ahead of `workspaceUser`; in the public-API chain ahead of key
+   * auth). Middleware that short-circuits with `res.status().json()` never
+   * reaches the route's `audit(...)` handler, so without this a cross-workspace
+   * probe or bad-API-key attempt would leave no forensic trace. Records only
+   * denials, and only when no route-level audit hook ran.
+   */
+  boundary: RequestHandler
+}
+
+interface Identity {
+  actorType: ActorType
+  actorId: string
+  authRef: string | null
+}
+
+function resolveIdentity(req: Request): Identity | null {
+  if (req.botApiKey) {
+    return { actorType: "bot", actorId: req.botApiKey.botId, authRef: req.botApiKey.id }
+  }
+  if (req.userApiKey) {
+    return { actorType: "user", actorId: req.userApiKey.userId, authRef: req.userApiKey.id }
+  }
+  if (req.user) {
+    return { actorType: "user", actorId: req.user.id, authRef: null }
+  }
+  // Workspace-less auth surface (/api/auth/me, /api/workspaces list/create, push
+  // cleanup, integration callbacks) mounts `auth` alone — no workspaceUser, so
+  // `req.user` is absent. Attribute to the WorkOS user id (workspace_id stays null).
+  if (req.authUser) {
+    return { actorType: "user", actorId: req.authUser.id, authRef: null }
+  }
+  return null
+}
+
+function outcomeFromStatus(status: number): AccessOutcome {
+  if (status >= 500) return "error"
+  // Every non-2xx/3xx below 500 is treated as `denied`: 401/403 and the
+  // access-hiding 404 are the denial statuses this design targets, and
+  // over-approximating other 4xx (400/409/429) as denied is the safe direction
+  // for breach scoping (design §7.1 makes the same call for 404).
+  if (status >= 400) return "denied"
+  return "success"
+}
+
+/**
+ * Fire `cb` exactly once when the response is done: 'finish' for a fully
+ * written response, 'close' for an aborted one (client gone or stream torn
+ * down mid-write). Data may already have egressed either way, so an aborted
+ * response still gets a row rather than silently vanishing.
+ */
+function onResponseDone(res: Response, cb: (aborted: boolean) => void): void {
+  let fired = false
+  const fire = (aborted: boolean) => {
+    if (fired) return
+    fired = true
+    cb(aborted)
+  }
+  res.on("finish", () => fire(false))
+  res.on("close", () => fire(!res.writableFinished))
+}
+
+export function createAuditMiddleware(accessLogService: AccessLogService): AuditFactory {
+  const audit = ((operation: AccessLogOperation, kind: AccessKind): RequestHandler => {
+    const handler: AnnotatedHandler = (req, res, next) => {
+      res.locals.auditHandled = true
+      // Captured synchronously: Express restores `req.params` as the routing
+      // stack unwinds, so it is not reliable inside the deferred hook.
+      const routeWorkspaceId = req.params.workspaceId ?? null
+      onResponseDone(res, (aborted) => {
+        const identity = resolveIdentity(req)
+        const outcome = aborted && !res.headersSent ? "error" : outcomeFromStatus(res.statusCode)
+
+        // No identity at all: only denials are worth a row (attempted access to
+        // an authed surface); successful unauthenticated hits are skipped.
+        if (!identity && outcome !== "denied") return
+
+        const workspaceId = req.workspaceId ?? routeWorkspaceId
+        accessLogService.record({
+          workspaceId,
+          actorType: identity?.actorType ?? "user",
+          actorId: identity?.actorId ?? "unknown",
+          authRef: identity?.authRef ?? null,
+          operation,
+          accessKind: kind,
+          outcome,
+          subjects: readAuditSubjects(res) ?? null,
+          detail: aborted ? { aborted: true } : null,
+          ip: req.ip ?? null,
+          userAgent: req.headers["user-agent"] ?? null,
+          requestId: (req as Request & { id?: string }).id ?? null,
+        })
+      })
+      next()
+    }
+    handler.auditAnnotation = { operation, kind }
+    return handler
+  }) as AuditFactory
+
+  audit.none = (reason: string): RequestHandler => {
+    const handler: AnnotatedHandler = (_req, res, next) => {
+      res.locals.auditHandled = true
+      next()
+    }
+    handler.auditAnnotation = { kind: "none", reason }
+    return handler
+  }
+
+  audit.boundary = (req, res, next) => {
+    const routeWorkspaceId = req.params.workspaceId ?? null
+    onResponseDone(res, (aborted) => {
+      // A route-level audit(...) ran — it owns the row.
+      if (res.locals.auditHandled) return
+      const outcome = aborted && !res.headersSent ? "error" : outcomeFromStatus(res.statusCode)
+      if (outcome !== "denied") return
+
+      const identity = resolveIdentity(req)
+      const workspaceId = req.workspaceId ?? routeWorkspaceId
+      accessLogService.record({
+        workspaceId,
+        actorType: identity?.actorType ?? "user",
+        actorId: identity?.actorId ?? "unknown",
+        authRef: identity?.authRef ?? null,
+        operation: "auth.boundary_denied",
+        accessKind: req.method === "GET" ? "read" : "write",
+        outcome,
+        subjects: workspaceId ? [{ type: "workspace", id: workspaceId }] : null,
+        detail: aborted ? { aborted: true } : null,
+        ip: req.ip ?? null,
+        userAgent: req.headers["user-agent"] ?? null,
+        requestId: (req as Request & { id?: string }).id ?? null,
+      })
+    })
+    next()
+  }
+
+  return audit
+}
+
+interface RouteLayer {
+  route?: {
+    path: string
+    methods: Record<string, boolean>
+    stack: { handle?: AnnotatedHandler }[]
+  }
+}
+
+/**
+ * Boot-time guard: every `/api` route must carry an audit annotation somewhere
+ * in its handler chain (a real `audit(...)` or an `audit.none(...)` exemption).
+ * Walks the Express 5 router stack (`app.router.stack`) and throws listing any
+ * offending method+path, so a new route can't silently skip access logging.
+ */
+export function assertAuditCoverage(app: Express): void {
+  const router = (app as unknown as { router?: { stack: RouteLayer[] } }).router
+  if (!router) throw new Error("assertAuditCoverage: Express router stack not found (app.router missing)")
+
+  const missing: string[] = []
+  for (const layer of router.stack) {
+    const route = layer.route
+    if (!route) {
+      // A sub-router mounted under /api would carry routes this walk cannot
+      // see — the exact silent-decay path the guard exists to prevent. No
+      // sub-router exists today; mounting one requires extending this guard
+      // to recurse into it first.
+      const l = layer as unknown as { name?: string }
+      // Express 5 exposes a mounted router's path only as matcher closures, so
+      // the guard cannot tell an /api mount from any other — and a router's
+      // routes are invisible to this walk either way. No router mounts exist
+      // today; any future one must extend this guard to recurse before it can
+      // boot. Strictness is the point: routes must never silently escape audit.
+      if (l.name === "router") {
+        missing.push("(mounted sub-router — guard cannot see its routes; extend assertAuditCoverage to recurse)")
+      }
+      continue
+    }
+    if (!route.path.startsWith("/api")) continue
+    const annotated = route.stack.some((s) => s.handle?.auditAnnotation != null)
+    if (annotated) continue
+    const methods = Object.keys(route.methods)
+      .filter((m) => route.methods[m])
+      .map((m) => m.toUpperCase())
+      .join(",")
+    missing.push(`${methods || "?"} ${route.path}`)
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `access-log coverage: ${missing.length} /api route(s) missing an audit annotation:\n  ${missing.join("\n  ")}`
+    )
+  }
+}

--- a/apps/backend/src/features/attachments/handlers.test.ts
+++ b/apps/backend/src/features/attachments/handlers.test.ts
@@ -10,7 +10,7 @@ import { AttachmentRepository, type AttachmentSearchRow } from "./repository"
 import { VideoTranscodeJobRepository } from "./video"
 
 function createResponse() {
-  const res: any = {}
+  const res: any = { locals: {} }
   res.status = mock((code: number) => {
     res.statusCode = code
     return res
@@ -767,6 +767,7 @@ function createStreamingResponse() {
   })
   res.statusCode = 200
   res.headersSent = false
+  res.locals = {}
   res.headers = {} as Record<string, string>
   res.set = mock((name: string, value: string) => {
     res.headers[name.toLowerCase()] = value

--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -13,6 +13,7 @@ import {
 import { AttachmentUploadRepository } from "./upload-repository"
 import { AttachmentExtractionRepository } from "./extraction-repository"
 import type { StreamService } from "../streams"
+import { setAuditSubjects } from "../access-log"
 import { VideoTranscodeJobRepository } from "./video"
 import { isImageAttachment } from "./image-caption"
 import type { StorageProvider } from "../../lib/storage/s3-client"
@@ -223,6 +224,7 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { attachmentId } = req.params
+      setAuditSubjects(res, [{ type: "attachment", id: attachmentId }])
 
       const attachment = await attachmentService.getById(attachmentId)
       if (!attachment || attachment.workspaceId !== workspaceId) {
@@ -292,6 +294,7 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { attachmentId } = req.params
+      setAuditSubjects(res, [{ type: "attachment", id: attachmentId }])
 
       const attachment = await attachmentService.getById(attachmentId)
       if (!attachment || attachment.workspaceId !== workspaceId) {
@@ -404,6 +407,7 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { attachmentId } = req.params
+      setAuditSubjects(res, [{ type: "attachment", id: attachmentId }])
 
       const attachment = await attachmentService.getById(attachmentId)
       if (!attachment || attachment.workspaceId !== workspaceId) {
@@ -481,6 +485,11 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       const items = hasMore ? rows.slice(0, limit) : rows
       const last = items[items.length - 1]
       const nextCursor = hasMore && last ? encodeCursor({ createdAt: last.createdAt, id: last.id }) : null
+
+      setAuditSubjects(
+        res,
+        items.map((i) => ({ type: "attachment", id: i.id }))
+      )
 
       res.json({
         items: items.map(serializeSearchRow),

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -16,6 +16,7 @@ function mockRes() {
   const res = {
     statusCode: 200,
     body: null as unknown,
+    locals: {} as Record<string, unknown>,
     status(code: number) {
       res.statusCode = code
       return res

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -4,6 +4,7 @@ import type { ConversationService } from "./service"
 import type { BoundaryExtractionService } from "./boundary-extraction-service"
 import type { BoardExclusionService } from "./board-exclusion-service"
 import type { StreamService } from "../streams"
+import { setAuditSubjects } from "../access-log"
 import {
   CONVERSATION_STATUSES,
   ConversationStatuses,
@@ -226,6 +227,10 @@ export function createConversationHandlers({
       // validateStreamAccess handles public visibility + thread root membership
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
+      setAuditSubjects(res, [
+        { type: "conversation", id: conversationId },
+        { type: "stream", id: conversation.streamId },
+      ])
       res.json({ conversation })
     },
 
@@ -243,6 +248,10 @@ export function createConversationHandlers({
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const messages = await conversationService.getMessages(conversationId)
+      setAuditSubjects(res, [
+        { type: "conversation", id: conversationId },
+        { type: "stream", id: conversation.streamId },
+      ])
       res.json({ messages })
     },
 
@@ -265,6 +274,10 @@ export function createConversationHandlers({
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const messages = await conversationService.getBoardMessages(workspaceId, conversationId)
+      setAuditSubjects(res, [
+        { type: "conversation", id: conversationId },
+        { type: "stream", id: conversation.streamId },
+      ])
       res.json({ messages })
     },
 
@@ -292,6 +305,10 @@ export function createConversationHandlers({
       if (!post) {
         return res.status(404).json({ error: "Conversation not found" })
       }
+      setAuditSubjects(res, [
+        { type: "conversation", id: conversationId },
+        { type: "stream", id: conversation.streamId },
+      ])
       res.json({ post })
     },
 

--- a/apps/backend/src/features/memos/handlers.ts
+++ b/apps/backend/src/features/memos/handlers.ts
@@ -6,6 +6,7 @@ import { HttpError } from "../../lib/errors"
 import { MEMO_ABSTRACT_MAX_CHARS, MEMO_KEY_POINTS_MAX, MEMO_TAGS_MAX, MEMO_TITLE_MAX_CHARS } from "./config"
 import { resolveUserAccessibleStreamIds, SearchRepository } from "../search"
 import { computeAgentAccessSpec } from "../agents"
+import { setAuditSubjects } from "../access-log"
 import { StreamRepository } from "../streams"
 import type { MemoExplorerDetail, MemoExplorerResult, MemoExplorerService } from "./explorer-service"
 import type { Memo } from "./repository"
@@ -179,6 +180,11 @@ export function createMemoHandlers({ pool, memoExplorerService }: Dependencies) 
         limit,
       })
 
+      setAuditSubjects(
+        res,
+        results.map((r) => ({ type: "memo", id: r.memo.id }))
+      )
+
       res.json({ results: results.map(serializeMemoResult) })
     },
 
@@ -200,6 +206,7 @@ export function createMemoHandlers({ pool, memoExplorerService }: Dependencies) 
         throw new HttpError("Memo not found", { status: 404, code: "NOT_FOUND" })
       }
 
+      setAuditSubjects(res, [{ type: "memo", id: memoId }])
       res.json({ memo: serializeMemoDetail(memo) })
     },
 

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
 import type { SearchFilters, SearchService } from "../search"
+import { setAuditSubjects } from "../access-log"
 import { serializeSearchResult, resolveUserAccessibleStreamIds, SearchRepository } from "../search"
 import { BotChannelAccessRepository, type BotChannelService } from "../api-keys"
 import { MessageRepository, type EventService, type Message } from "../messaging"
@@ -1879,6 +1880,10 @@ export function createPublicApiHandlers({
         skipEmbedding: !semantic,
       })
 
+      setAuditSubjects(
+        res,
+        results.map((r) => ({ type: "message", id: r.id }))
+      )
       const authorNames = await resolveAuthorDisplayNames(pool, workspaceId, results)
       const serialized: WireSearchResult[] = results.map((r) => {
         const name = authorNames.get(r.authorId)
@@ -1936,6 +1941,10 @@ export function createPublicApiHandlers({
         limit,
       })
 
+      setAuditSubjects(
+        res,
+        results.map((r) => ({ type: "memo", id: r.memo.id }))
+      )
       res.json({ data: results.map(serializeMemoSearchResult) })
     },
 
@@ -1954,6 +1963,7 @@ export function createPublicApiHandlers({
         throw new HttpError("Memo not found", { status: 404, code: "NOT_FOUND" })
       }
 
+      setAuditSubjects(res, [{ type: "memo", id: memoId }])
       res.json({ data: serializeMemoDetail(memo) })
     },
 
@@ -1987,6 +1997,10 @@ export function createPublicApiHandlers({
         limit,
       })
 
+      setAuditSubjects(
+        res,
+        attachments.map((a) => ({ type: "attachment", id: a.id }))
+      )
       res.json({ data: attachments.map(serializeAttachmentSearchResult) })
     },
 
@@ -1994,6 +2008,7 @@ export function createPublicApiHandlers({
       const attachment = await resolveAccessibleAttachment(req, req.params.attachmentId)
       const extraction = await AttachmentExtractionRepository.findByAttachmentId(pool, attachment.id)
 
+      setAuditSubjects(res, [{ type: "attachment", id: attachment.id }])
       res.json({ data: serializeAttachmentDetail(attachment, extraction) })
     },
 
@@ -2004,6 +2019,7 @@ export function createPublicApiHandlers({
         expiresIn: 900,
       }
 
+      setAuditSubjects(res, [{ type: "attachment", id: attachment.id }])
       res.json({ data })
     },
 
@@ -2179,6 +2195,19 @@ export function createPublicApiHandlers({
         page = after ? messages.slice(0, limit) : messages.slice(-limit)
       }
 
+      setAuditSubjects(
+        res,
+        page.length > 0
+          ? [
+              {
+                type: "stream",
+                id: streamId,
+                fromSeq: Number(page[0].sequence),
+                toSeq: Number(page[page.length - 1].sequence),
+              },
+            ]
+          : [{ type: "stream", id: streamId }]
+      )
       const pageMessageIds = page.map((m) => m.id)
       const [authorNames, threadMap, attachmentsByMessage] = await Promise.all([
         resolveAuthorDisplayNames(pool, req.workspaceId!, page),
@@ -2346,6 +2375,10 @@ export function createPublicApiHandlers({
 
       const authorNames = await resolveAuthorDisplayNames(pool, workspaceId, messages)
 
+      setAuditSubjects(
+        res,
+        messages.map((m) => ({ type: "message", id: m.id }))
+      )
       res.json({
         data: messages.map((m) => serializeMessage(m, { authorDisplayName: authorNames.get(m.authorId) ?? null })),
       })

--- a/apps/backend/src/features/search/handlers.ts
+++ b/apps/backend/src/features/search/handlers.ts
@@ -5,6 +5,7 @@ import type { SearchService } from "./service"
 import type { SearchResult } from "./repository"
 import { resolveInFilterStreamIds, resolveUserAccessibleStreamIds } from "./access"
 import { validateRequest } from "../../lib/validation"
+import { setAuditSubjects } from "../access-log"
 import { STREAM_TYPES } from "@threa/types"
 
 const ARCHIVE_STATUSES = ["active", "archived"] as const
@@ -88,6 +89,11 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
         exact,
         limit,
       })
+
+      setAuditSubjects(
+        res,
+        results.map((r) => ({ type: "message", id: r.id }))
+      )
 
       res.json({
         results: results.map(serializeSearchResult),

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -8,6 +8,7 @@ import type { LinkPreviewService } from "../link-previews"
 import type { BotRuntimeService } from "../bot-runtimes"
 import type { CommandAvailabilityService } from "../commands"
 import type { WorkspaceIntegrationService } from "../workspace-integrations"
+import { setAuditSubjects, type AuditSubjectRef } from "../access-log"
 import type { StreamEvent } from "./event-repository"
 import type {
   EventType,
@@ -278,6 +279,21 @@ const actorRewrapSchema = z.object({
 
 /** Default number of events returned in bootstrap and event list queries. */
 const EVENTS_DEFAULT_LIMIT = 50
+
+/** Audit ref for a range read: the stream plus the min/max sequence loaded. */
+function streamSequenceRangeRef(streamId: string, events: readonly StreamEvent[]): AuditSubjectRef {
+  const ref: AuditSubjectRef = { type: "stream", id: streamId }
+  if (events.length === 0) return ref
+  let min = events[0].sequence
+  let max = events[0].sequence
+  for (const event of events) {
+    if (event.sequence < min) min = event.sequence
+    if (event.sequence > max) max = event.sequence
+  }
+  ref.fromSeq = Number(min)
+  ref.toSeq = Number(max)
+  return ref
+}
 
 const numericString = z.string().regex(/^\d+$/, "must be a numeric string")
 
@@ -732,6 +748,8 @@ export function createStreamHandlers({
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(linkPreviewService, workspaceId, userId, events)
       const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
+      setAuditSubjects(res, [streamSequenceRangeRef(streamId, events)])
+
       res.json({ events: eventsWithLinkPreviews, sharedMessages })
     },
 
@@ -772,6 +790,11 @@ export function createStreamHandlers({
         enrichedEvents
       )
       const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
+
+      const aroundSubjects: AuditSubjectRef[] = [streamSequenceRangeRef(streamId, result.events)]
+      const anchorId = anchorMessageId ?? messageId ?? eventId
+      if (anchorId) aroundSubjects.push({ type: eventId ? "event" : "message", id: anchorId })
+      setAuditSubjects(res, aroundSubjects)
 
       res.json({
         events: eventsWithLinkPreviews,
@@ -1064,6 +1087,11 @@ export function createStreamHandlers({
       // Resolve the tool-policy reads started up front (parallel with the rest
       // of bootstrap, not serial after enrichment).
       const [allowedToolCategories, configuredToolCategories] = await toolPolicyReads
+
+      const bootstrapRef: AuditSubjectRef = { type: "stream", id: streamId, toSeq: Number(latestSequence ?? 0n) }
+      if (afterSequence !== undefined) bootstrapRef.fromSeq = Number(afterSequence)
+      else if (events.length > 0) bootstrapRef.fromSeq = Number(events[0].sequence)
+      setAuditSubjects(res, [bootstrapRef])
 
       res.json({
         data: {

--- a/apps/backend/src/features/sync/handlers.test.ts
+++ b/apps/backend/src/features/sync/handlers.test.ts
@@ -13,7 +13,7 @@ function makeReqRes(query: Record<string, string>, role: string = "member") {
     query,
   } as unknown as Request
   const json = mock((_body: unknown) => {})
-  const res = { json } as unknown as Response
+  const res = { json, locals: {} } as unknown as Response
   return { req, res, json }
 }
 

--- a/apps/backend/src/features/sync/handlers.ts
+++ b/apps/backend/src/features/sync/handlers.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import type { SyncCatchUpResponse } from "@threa/types"
 import { HttpError } from "../../lib/errors"
 import { permissionGroupsForRole } from "../../lib/outbox"
+import { setAuditSubjects } from "../access-log"
 import type { SyncService } from "./service"
 
 const catchUpQuerySchema = z.object({
@@ -35,6 +36,10 @@ export function createSyncHandlers({ syncService }: Dependencies) {
         after: BigInt(parsed.data.after),
         limit: parsed.data.limit,
       })
+
+      setAuditSubjects(res, [
+        { type: "workspace", id: workspaceId, fromSync: parsed.data.after, toSync: head.toString() },
+      ])
 
       res.json({
         entries: entries.map((entry) => ({

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
+import { setAuditSubjects } from "../access-log"
 import { isValidIanaTimezone } from "../../lib/temporal"
 import type { WorkspaceService } from "./service"
 import type { StreamService } from "../streams"
@@ -150,6 +151,7 @@ export function createWorkspaceHandlers({
     async bootstrap(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
+      setAuditSubjects(res, [{ type: "workspace", id: workspaceId }])
 
       // Read the sync-log head BEFORE the snapshot queries below: every
       // projection then observes a DB state at or after this read, so the

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -116,6 +116,12 @@ import type { GiphyService } from "./features/giphy"
 import type { WorkspaceIntegrationService } from "./features/workspace-integrations"
 import type { WorkosOrgService } from "@threa/backend-common"
 import type { BotApiKeyService } from "./features/public-api"
+import {
+  createAuditMiddleware,
+  assertAuditCoverage,
+  publicApiOperation,
+  type AccessLogService,
+} from "./features/access-log"
 import type { Pool } from "pg"
 import type { PoolMonitor } from "./lib/observability"
 
@@ -181,6 +187,7 @@ interface Dependencies {
   ai: AI
   controlPlaneClient: ControlPlaneClient | null
   costService: AICostServiceLike
+  accessLogService: AccessLogService
 }
 
 export function registerRoutes(app: Express, deps: Dependencies) {
@@ -243,13 +250,18 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     storage,
     ai,
     controlPlaneClient,
+    accessLogService,
   } = deps
 
+  const audit = createAuditMiddleware(accessLogService)
   const auth = createAuthMiddleware({ authService })
   const workspaceUser = createWorkspaceUserMiddleware({ pool, workspaceService, controlPlaneClient })
   const upload = createUploadMiddleware({ s3Config })
   // Express natively chains handlers - spread array at usage sites
-  const authed: RequestHandler[] = [auth, workspaceUser]
+  // audit.boundary sits between auth and workspaceUser: workspaceUser denies
+  // with res.status().json() without next(), so the route-level audit(...)
+  // never runs for cross-workspace probes — the boundary backstop records them.
+  const authed: RequestHandler[] = [auth, audit.boundary, workspaceUser]
 
   const requireWorkspacePermission = createRequireWorkspacePermission()
   const workspaceAuthz = createWorkspaceAuthzHandlers({ workspaceAuthzService })
@@ -419,33 +431,56 @@ export function registerRoutes(app: Express, deps: Dependencies) {
       invitationService,
     })
 
+    const devAudit = audit.none("dev-only stub auth route")
     app.get("/test-auth-login", authStub.getLoginPage)
     app.post("/test-auth-login", authStub.handleLogin)
-    app.post("/api/dev/login", authStub.handleDevLogin)
-    app.post("/api/dev/workspaces/:workspaceId/join", auth, authStub.handleWorkspaceJoin)
-    app.post("/api/dev/workspaces/:workspaceId/streams/:streamId/join", auth, workspaceUser, authStub.handleStreamJoin)
+    app.post("/api/dev/login", devAudit, authStub.handleDevLogin)
+    app.post("/api/dev/workspaces/:workspaceId/join", auth, devAudit, authStub.handleWorkspaceJoin)
+    app.post(
+      "/api/dev/workspaces/:workspaceId/streams/:streamId/join",
+      auth,
+      workspaceUser,
+      devAudit,
+      authStub.handleStreamJoin
+    )
   }
 
-  app.get("/api/auth/me", auth, authHandlers.me)
+  app.get("/api/auth/me", auth, audit("auth.me", "read"), authHandlers.me)
 
   // Workspace list/create are also on the control-plane. The router proxies
   // GET/POST /api/workspaces to the control-plane in production. These stay
   // here for direct backend testing and single-region dev without the router.
-  app.get("/api/workspaces", auth, workspace.list)
-  app.post("/api/workspaces", auth, workspace.create)
-  app.get("/api/workspaces/:workspaceId", ...authed, workspace.get)
-  app.get("/api/workspaces/:workspaceId/bootstrap", ...authed, workspace.bootstrap)
-  app.get("/api/workspaces/:workspaceId/users", ...authed, workspace.getUsers)
-  app.get("/api/workspaces/:workspaceId/emojis", ...authed, emoji.list)
+  app.get("/api/workspaces", auth, audit("workspace.list", "read"), workspace.list)
+  app.post("/api/workspaces", auth, audit("workspace.create", "write"), workspace.create)
+  app.get("/api/workspaces/:workspaceId", ...authed, audit("workspace.get", "read"), workspace.get)
+  app.get(
+    "/api/workspaces/:workspaceId/bootstrap",
+    ...authed,
+    audit("workspace.bootstrap", "read"),
+    workspace.bootstrap
+  )
+  app.get("/api/workspaces/:workspaceId/users", ...authed, audit("workspace.list_users", "read"), workspace.getUsers)
+  app.get("/api/workspaces/:workspaceId/emojis", ...authed, audit("emoji.list", "read"), emoji.list)
 
-  app.get("/api/workspaces/:workspaceId/preferences", ...authed, preferences.get)
-  app.patch("/api/workspaces/:workspaceId/preferences", ...authed, preferences.update)
+  app.get("/api/workspaces/:workspaceId/preferences", ...authed, audit("preferences.get", "read"), preferences.get)
+  app.patch(
+    "/api/workspaces/:workspaceId/preferences",
+    ...authed,
+    audit("preferences.update", "write"),
+    preferences.update
+  )
 
   // Workspace settings (workspace-wide defaults; writes are admin-only)
-  app.get("/api/workspaces/:workspaceId/workspace-settings", ...authed, workspaceSettings.get)
+  app.get(
+    "/api/workspaces/:workspaceId/workspace-settings",
+    ...authed,
+    audit("workspace_settings.get", "read"),
+    workspaceSettings.get
+  )
   app.patch(
     "/api/workspaces/:workspaceId/workspace-settings",
     ...authed,
+    audit("workspace_settings.update", "write"),
     requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN),
     workspaceSettings.update
   )
@@ -456,151 +491,426 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // workspace rows, ownership for personal rows (a non-owner 404s, never sees
   // it). The one exception is the built-in override PUT, which is inherently
   // admin-managed and keeps its route-level admin gate.
-  app.get("/api/workspaces/:workspaceId/personas", ...authed, persona.list)
-  app.get("/api/workspaces/:workspaceId/personas/archived", ...authed, persona.listArchived)
+  app.get("/api/workspaces/:workspaceId/personas", ...authed, audit("personas.list", "read"), persona.list)
+  app.get(
+    "/api/workspaces/:workspaceId/personas/archived",
+    ...authed,
+    audit("personas.list_archived", "read"),
+    persona.listArchived
+  )
   // Fork a source persona into a new workspace custom (admin) or personal
   // persona (any member); the service enforces the scope rule.
-  app.post("/api/workspaces/:workspaceId/personas", ...authed, persona.create)
-  app.get("/api/workspaces/:workspaceId/personas/:personaId/config", ...authed, persona.getConfig)
+  app.post("/api/workspaces/:workspaceId/personas", ...authed, audit("personas.create", "write"), persona.create)
+  app.get(
+    "/api/workspaces/:workspaceId/personas/:personaId/config",
+    ...authed,
+    audit("personas.get_config", "read"),
+    persona.getConfig
+  )
   // Built-in override write stays admin-only at the route layer (built-ins are
   // inherently admin-managed).
   app.put(
     "/api/workspaces/:workspaceId/personas/:personaId/override",
     ...authed,
+    audit("personas.put_override", "write"),
     requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN),
     persona.putOverride
   )
   // Full-field update of a custom/personal persona (customs only — built-ins 400).
-  app.put("/api/workspaces/:workspaceId/personas/:personaId", ...authed, persona.update)
-  app.post("/api/workspaces/:workspaceId/personas/:personaId/archive", ...authed, persona.archive)
-  app.post("/api/workspaces/:workspaceId/personas/:personaId/unarchive", ...authed, persona.unarchive)
+  app.put(
+    "/api/workspaces/:workspaceId/personas/:personaId",
+    ...authed,
+    audit("personas.update", "write"),
+    persona.update
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/archive",
+    ...authed,
+    audit("personas.archive", "write"),
+    persona.archive
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/unarchive",
+    ...authed,
+    audit("personas.unarchive", "write"),
+    persona.unarchive
+  )
   // Revision history (roadmap 7.1): list a persona's committed revisions and
   // restore one (re-commits an old patch as a new revision).
-  app.get("/api/workspaces/:workspaceId/personas/:personaId/revisions", ...authed, persona.listRevisions)
+  app.get(
+    "/api/workspaces/:workspaceId/personas/:personaId/revisions",
+    ...authed,
+    audit("personas.list_revisions", "read"),
+    persona.listRevisions
+  )
   app.post(
     "/api/workspaces/:workspaceId/personas/:personaId/revisions/:revisionId/restore",
     ...authed,
+    audit("personas.restore_revision", "write"),
     persona.restoreRevision
   )
   // Draft lifecycle (test-drive substrate, per caller): upsert own draft,
   // discard (archives the bound test stream), and idempotently create-or-return
   // the bound test scratchpad.
-  app.put("/api/workspaces/:workspaceId/personas/:personaId/draft", ...authed, persona.putDraft)
-  app.delete("/api/workspaces/:workspaceId/personas/:personaId/draft", ...authed, persona.deleteDraft)
-  app.post("/api/workspaces/:workspaceId/personas/:personaId/draft/test-stream", ...authed, persona.createTestStream)
+  app.put(
+    "/api/workspaces/:workspaceId/personas/:personaId/draft",
+    ...authed,
+    audit("personas.put_draft", "write"),
+    persona.putDraft
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/personas/:personaId/draft",
+    ...authed,
+    audit("personas.delete_draft", "write"),
+    persona.deleteDraft
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/draft/test-stream",
+    ...authed,
+    audit("personas.create_test_stream", "write"),
+    persona.createTestStream
+  )
   // Custom/personal persona avatar image (customs only — a built-in id 400s in
   // the service). Upload/remove mirror the bot avatar flow; serving is
   // unauthenticated by path (S3 keys carry unguessable ULIDs).
-  app.post("/api/workspaces/:workspaceId/personas/:personaId/avatar", ...authed, avatarUpload, persona.uploadAvatar)
-  app.delete("/api/workspaces/:workspaceId/personas/:personaId/avatar", ...authed, persona.removeAvatar)
-  app.get("/api/workspaces/:workspaceId/personas/:personaId/avatar/:file", persona.serveAvatarFile)
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/avatar",
+    ...authed,
+    audit("personas.upload_avatar", "write"),
+    avatarUpload,
+    persona.uploadAvatar
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/personas/:personaId/avatar",
+    ...authed,
+    audit("personas.remove_avatar", "write"),
+    persona.removeAvatar
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/personas/:personaId/avatar/:file",
+    audit.none("unauthenticated avatar serve; S3 keys carry unguessable ULIDs"),
+    persona.serveAvatarFile
+  )
   // Custom/personal persona context attachments (persona-context-attachments):
   // the bytes reach S3 through the shared composer upload transport (reserve →
   // content); this JSON POST binds an already-uploaded attachment to the persona,
   // so there is one frontend upload path (INV-35/37). The list rides the config
   // GET — no separate GET route.
-  app.post("/api/workspaces/:workspaceId/personas/:personaId/attachments", ...authed, persona.bindAttachment)
+  app.post(
+    "/api/workspaces/:workspaceId/personas/:personaId/attachments",
+    ...authed,
+    audit("personas.bind_attachment", "write"),
+    persona.bindAttachment
+  )
   // Knowledge-by-reference: copy an existing readable workspace file into a fresh
   // persona-owned attachment (copy-on-attach). The service authorizes + copies.
   app.post(
     "/api/workspaces/:workspaceId/personas/:personaId/attachments/from-existing",
     ...authed,
+    audit("personas.attach_from_existing", "write"),
     persona.attachFromExisting
   )
   app.delete(
     "/api/workspaces/:workspaceId/personas/:personaId/attachments/:attachmentId",
     ...authed,
+    audit("personas.delete_attachment", "write"),
     persona.deleteAttachment
   )
 
   // Sidebar config (per-user, per-workspace layout)
-  app.get("/api/workspaces/:workspaceId/sidebar-config", ...authed, sidebarConfig.get)
-  app.patch("/api/workspaces/:workspaceId/sidebar-config", ...authed, sidebarConfig.update)
+  app.get(
+    "/api/workspaces/:workspaceId/sidebar-config",
+    ...authed,
+    audit("sidebar_config.get", "read"),
+    sidebarConfig.get
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/sidebar-config",
+    ...authed,
+    audit("sidebar_config.update", "write"),
+    sidebarConfig.update
+  )
 
   // End-to-end encryption keys (Phase 0)
   // Server stores only ciphertext + public key. Body is the encrypted private
   // bundle (passphrase-wrapped) plus KDF metadata so any device the user logs
   // into can derive the KEK and unwrap locally.
-  app.get("/api/workspaces/:workspaceId/users/me/e2e-key", ...authed, userE2eKeys.get)
-  app.post("/api/workspaces/:workspaceId/users/me/e2e-key", ...authed, userE2eKeys.set)
-  app.delete("/api/workspaces/:workspaceId/users/me/e2e-key", ...authed, userE2eKeys.revoke)
+  app.get(
+    "/api/workspaces/:workspaceId/users/me/e2e-key",
+    ...authed,
+    audit("user_e2e_keys.get", "read"),
+    userE2eKeys.get
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/users/me/e2e-key",
+    ...authed,
+    audit("user_e2e_keys.set", "write"),
+    userE2eKeys.set
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/users/me/e2e-key",
+    ...authed,
+    audit("user_e2e_keys.revoke", "write"),
+    userE2eKeys.revoke
+  )
 
   // Live enclave instance keys. Workspace-member auth gates the read; the
   // EIK set itself is global. The frontend wraps the per-stream SSK to each
   // live EIK so the dispatcher-picked enclave instance can decrypt.
-  app.get("/api/workspaces/:workspaceId/enclave/active-keys", ...authed, enclave.listActiveKeys)
+  app.get(
+    "/api/workspaces/:workspaceId/enclave/active-keys",
+    ...authed,
+    audit("enclave.list_active_keys", "read"),
+    enclave.listActiveKeys
+  )
 
-  app.get("/api/workspaces/:workspaceId/streams", ...authed, stream.list)
-  app.post("/api/workspaces/:workspaceId/streams", ...authed, stream.create)
-  app.post("/api/workspaces/:workspaceId/streams/read-all", ...authed, workspace.markAllAsRead)
-  app.get("/api/workspaces/:workspaceId/streams/slug-available", ...authed, stream.checkSlugAvailable)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.get)
-  app.patch("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.update)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/bootstrap", ...authed, stream.bootstrap)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/brief", ...authed, streamBrief.get)
-  app.put("/api/workspaces/:workspaceId/streams/:streamId/brief", ...authed, streamBrief.put)
-  app.patch("/api/workspaces/:workspaceId/streams/:streamId/companion", ...authed, stream.updateCompanionMode)
-  app.patch("/api/workspaces/:workspaceId/streams/:streamId/tool-policy", ...authed, stream.updateToolPolicy)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/notification-level", ...authed, stream.setNotificationLevel)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/join", ...authed, stream.join)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/actors", ...authed, stream.inviteActor)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps", ...authed, stream.getE2eKeyWraps)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps", ...authed, stream.storeE2eKeyWrap)
+  app.get("/api/workspaces/:workspaceId/streams", ...authed, audit("streams.list", "read"), stream.list)
+  app.post("/api/workspaces/:workspaceId/streams", ...authed, audit("streams.create", "write"), stream.create)
+  app.post(
+    "/api/workspaces/:workspaceId/streams/read-all",
+    ...authed,
+    audit("streams.read_all", "write"),
+    workspace.markAllAsRead
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/slug-available",
+    ...authed,
+    audit("streams.slug_available", "read"),
+    stream.checkSlugAvailable
+  )
+  app.get("/api/workspaces/:workspaceId/streams/:streamId", ...authed, audit("streams.get", "read"), stream.get)
+  app.patch(
+    "/api/workspaces/:workspaceId/streams/:streamId",
+    ...authed,
+    audit("streams.update", "write"),
+    stream.update
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/bootstrap",
+    ...authed,
+    audit("streams.bootstrap", "read"),
+    stream.bootstrap
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/brief",
+    ...authed,
+    audit("streams.get_brief", "read"),
+    streamBrief.get
+  )
+  app.put(
+    "/api/workspaces/:workspaceId/streams/:streamId/brief",
+    ...authed,
+    audit("streams.put_brief", "write"),
+    streamBrief.put
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/streams/:streamId/companion",
+    ...authed,
+    audit("streams.update_companion", "write"),
+    stream.updateCompanionMode
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/streams/:streamId/tool-policy",
+    ...authed,
+    audit("streams.update_tool_policy", "write"),
+    stream.updateToolPolicy
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/notification-level",
+    ...authed,
+    audit("streams.set_notification_level", "write"),
+    stream.setNotificationLevel
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/join",
+    ...authed,
+    audit("streams.join", "write"),
+    stream.join
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/e2e/actors",
+    ...authed,
+    audit("streams.invite_actor", "write"),
+    stream.inviteActor
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps",
+    ...authed,
+    audit("streams.get_e2e_key_wraps", "read"),
+    stream.getE2eKeyWraps
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps",
+    ...authed,
+    audit("streams.store_e2e_key_wrap", "write"),
+    stream.storeE2eKeyWrap
+  )
   app.post(
     "/api/workspaces/:workspaceId/streams/:streamId/e2e/actor-key-wraps",
     ...authed,
+    audit("streams.revive_e2e_actor_key_wraps", "write"),
     stream.reviveE2eActorKeyWraps
   )
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-generations", ...authed, stream.rollE2eKey)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/read", ...authed, stream.markAsRead)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/unread", ...authed, stream.markUnread)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/archive", ...authed, stream.archive)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/unarchive", ...authed, stream.unarchive)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/members", ...authed, stream.addMember)
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/e2e/key-generations",
+    ...authed,
+    audit("streams.roll_e2e_key", "write"),
+    stream.rollE2eKey
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/read",
+    ...authed,
+    audit("streams.mark_read", "write"),
+    stream.markAsRead
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/unread",
+    ...authed,
+    audit("streams.mark_unread", "write"),
+    stream.markUnread
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/archive",
+    ...authed,
+    audit("streams.archive", "write"),
+    stream.archive
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/unarchive",
+    ...authed,
+    audit("streams.unarchive", "write"),
+    stream.unarchive
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/members",
+    ...authed,
+    audit("streams.add_member", "write"),
+    stream.addMember
+  )
   app.delete(
     "/api/workspaces/:workspaceId/streams/:streamId/members/:memberId",
     ...authed,
+    audit("streams.remove_member", "write"),
     requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE),
     stream.removeMember
   )
 
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/events", ...authed, stream.listEvents)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/events/around", ...authed, stream.listEventsAround)
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/events",
+    ...authed,
+    audit("streams.history", "read"),
+    stream.listEvents
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/events/around",
+    ...authed,
+    audit("streams.around", "read"),
+    stream.listEventsAround
+  )
 
-  app.post("/api/workspaces/:workspaceId/search", ...authed, rateLimits.search, search.search)
-  app.post("/api/workspaces/:workspaceId/memos/search", ...authed, rateLimits.search, memo.search)
-  app.get("/api/workspaces/:workspaceId/memos/:memoId", ...authed, memo.getById)
-  app.patch("/api/workspaces/:workspaceId/memos/:memoId", ...authed, memo.update)
-  app.post("/api/workspaces/:workspaceId/memos/:memoId/archive", ...authed, memo.archive)
-  app.post("/api/workspaces/:workspaceId/memos/:memoId/unarchive", ...authed, memo.unarchive)
-  app.delete("/api/workspaces/:workspaceId/memos/:memoId", ...authed, memo.delete)
+  app.post(
+    "/api/workspaces/:workspaceId/search",
+    ...authed,
+    audit("search.messages", "read"),
+    rateLimits.search,
+    search.search
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/memos/search",
+    ...authed,
+    audit("search.memos", "read"),
+    rateLimits.search,
+    memo.search
+  )
+  app.get("/api/workspaces/:workspaceId/memos/:memoId", ...authed, audit("memos.read", "read"), memo.getById)
+  app.patch("/api/workspaces/:workspaceId/memos/:memoId", ...authed, audit("memos.update", "write"), memo.update)
+  app.post(
+    "/api/workspaces/:workspaceId/memos/:memoId/archive",
+    ...authed,
+    audit("memos.archive", "write"),
+    memo.archive
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/memos/:memoId/unarchive",
+    ...authed,
+    audit("memos.unarchive", "write"),
+    memo.unarchive
+  )
+  app.delete("/api/workspaces/:workspaceId/memos/:memoId", ...authed, audit("memos.delete", "write"), memo.delete)
 
-  app.post("/api/workspaces/:workspaceId/messages", ...authed, rateLimits.messageCreate, message.create)
+  app.post(
+    "/api/workspaces/:workspaceId/messages",
+    ...authed,
+    audit("messages.create", "write"),
+    rateLimits.messageCreate,
+    message.create
+  )
   app.post(
     "/api/workspaces/:workspaceId/messages/move-to-thread/validate",
     ...authed,
+    audit("messages.validate_move_to_thread", "write"),
     rateLimits.messageCreate,
     message.validateMoveToThread
   )
   app.post(
     "/api/workspaces/:workspaceId/messages/move-to-thread",
     ...authed,
+    audit("messages.move_to_thread", "write"),
     rateLimits.messageCreate,
     message.moveToThread
   )
-  app.patch("/api/workspaces/:workspaceId/messages/:messageId", ...authed, message.update)
-  app.delete("/api/workspaces/:workspaceId/messages/:messageId", ...authed, message.delete)
-  app.get("/api/workspaces/:workspaceId/messages/:messageId/versions", ...authed, message.getHistory)
-  app.post("/api/workspaces/:workspaceId/messages/:messageId/reactions", ...authed, message.addReaction)
-  app.delete("/api/workspaces/:workspaceId/messages/:messageId/reactions/:emoji", ...authed, message.removeReaction)
+  app.patch(
+    "/api/workspaces/:workspaceId/messages/:messageId",
+    ...authed,
+    audit("messages.update", "write"),
+    message.update
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/messages/:messageId",
+    ...authed,
+    audit("messages.delete", "write"),
+    message.delete
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/messages/:messageId/versions",
+    ...authed,
+    audit("messages.get_history", "read"),
+    message.getHistory
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/messages/:messageId/reactions",
+    ...authed,
+    audit("messages.add_reaction", "write"),
+    message.addReaction
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/messages/:messageId/reactions/:emoji",
+    ...authed,
+    audit("messages.remove_reaction", "write"),
+    message.removeReaction
+  )
 
   // Attachments (workspace-scoped upload, stream assigned on message creation)
-  app.post("/api/workspaces/:workspaceId/attachments", ...authed, rateLimits.upload, upload, attachment.upload)
+  app.post(
+    "/api/workspaces/:workspaceId/attachments",
+    ...authed,
+    audit("attachments.upload", "write"),
+    rateLimits.upload,
+    upload,
+    attachment.upload
+  )
   // Reserved background uploads: id first, bytes later (send-while-uploading).
-  app.post("/api/workspaces/:workspaceId/attachments/reservations", ...authed, rateLimits.upload, attachment.reserve)
+  app.post(
+    "/api/workspaces/:workspaceId/attachments/reservations",
+    ...authed,
+    audit("attachments.reserve", "write"),
+    rateLimits.upload,
+    attachment.reserve
+  )
   app.post(
     "/api/workspaces/:workspaceId/attachments/:attachmentId/content",
     ...authed,
+    audit("attachments.complete_content", "write"),
     rateLimits.upload,
     // Must run before `upload`: multer-s3 streams bytes to the reserved key,
     // so reservation ownership/state has to be checked before any byte lands.
@@ -611,61 +921,184 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post(
     "/api/workspaces/:workspaceId/attachments/:attachmentId/upload-failure",
     ...authed,
+    audit("attachments.report_upload_failure", "write"),
     attachment.reportUploadFailure
   )
-  app.post("/api/workspaces/:workspaceId/attachments/search", ...authed, rateLimits.search, attachment.search)
-  app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/url", ...authed, attachment.getDownloadUrl)
-  app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/content", ...authed, attachment.getContent)
-  app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/extraction", ...authed, attachment.getExtraction)
-  app.delete("/api/workspaces/:workspaceId/attachments/:attachmentId", ...authed, attachment.delete)
+  app.post(
+    "/api/workspaces/:workspaceId/attachments/search",
+    ...authed,
+    audit("attachments.search", "read"),
+    rateLimits.search,
+    attachment.search
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/attachments/:attachmentId/url",
+    ...authed,
+    audit("attachments.presign", "read"),
+    attachment.getDownloadUrl
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/attachments/:attachmentId/content",
+    ...authed,
+    audit("attachments.content", "read"),
+    attachment.getContent
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/attachments/:attachmentId/extraction",
+    ...authed,
+    audit("attachments.extraction", "read"),
+    attachment.getExtraction
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/attachments/:attachmentId",
+    ...authed,
+    audit("attachments.delete", "write"),
+    attachment.delete
+  )
 
-  app.get("/api/workspaces/:workspaceId/conversations", ...authed, conversation.listByWorkspace)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/conversations", ...authed, conversation.listByStream)
-  app.get("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.getById)
-  app.get("/api/workspaces/:workspaceId/conversations/:conversationId/messages", ...authed, conversation.getMessages)
+  app.get(
+    "/api/workspaces/:workspaceId/conversations",
+    ...authed,
+    audit("conversations.list", "read"),
+    conversation.listByWorkspace
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/conversations",
+    ...authed,
+    audit("conversations.list_by_stream", "read"),
+    conversation.listByStream
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/conversations/:conversationId",
+    ...authed,
+    audit("conversations.get", "read"),
+    conversation.getById
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/messages",
+    ...authed,
+    audit("conversations.get_messages", "read"),
+    conversation.getMessages
+  )
   app.get(
     "/api/workspaces/:workspaceId/conversations/:conversationId/board-messages",
     ...authed,
+    audit("conversations.get_board_messages", "read"),
     conversation.getBoardMessages
   )
-  app.get("/api/workspaces/:workspaceId/conversations/:conversationId/board-post", ...authed, conversation.getBoardPost)
-  app.patch("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.updateConversation)
-  app.get("/api/workspaces/:workspaceId/board/exclusions", ...authed, conversation.getBoardExclusions)
-  app.get("/api/workspaces/:workspaceId/board/views", ...authed, boardView.list)
-  app.post("/api/workspaces/:workspaceId/board/views", ...authed, boardView.create)
-  app.patch("/api/workspaces/:workspaceId/board/views/:boardViewId", ...authed, boardView.update)
-  app.delete("/api/workspaces/:workspaceId/board/views/:boardViewId", ...authed, boardView.remove)
-  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/hide", ...authed, conversation.hideConversation)
+  app.get(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/board-post",
+    ...authed,
+    audit("conversations.get_board_post", "read"),
+    conversation.getBoardPost
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/conversations/:conversationId",
+    ...authed,
+    audit("conversations.update", "write"),
+    conversation.updateConversation
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/board/exclusions",
+    ...authed,
+    audit("board.get_exclusions", "read"),
+    conversation.getBoardExclusions
+  )
+  app.get("/api/workspaces/:workspaceId/board/views", ...authed, audit("board.list_views", "read"), boardView.list)
+  app.post("/api/workspaces/:workspaceId/board/views", ...authed, audit("board.create_view", "write"), boardView.create)
+  app.patch(
+    "/api/workspaces/:workspaceId/board/views/:boardViewId",
+    ...authed,
+    audit("board.update_view", "write"),
+    boardView.update
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/board/views/:boardViewId",
+    ...authed,
+    audit("board.delete_view", "write"),
+    boardView.remove
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/hide",
+    ...authed,
+    audit("conversations.hide", "write"),
+    conversation.hideConversation
+  )
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/unhide",
     ...authed,
+    audit("conversations.unhide", "write"),
     conversation.unhideConversation
   )
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/board-mute", ...authed, conversation.muteStream)
-  app.post("/api/workspaces/:workspaceId/streams/:streamId/board-unmute", ...authed, conversation.unmuteStream)
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/board-mute",
+    ...authed,
+    audit("conversations.mute_stream", "write"),
+    conversation.muteStream
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/streams/:streamId/board-unmute",
+    ...authed,
+    audit("conversations.unmute_stream", "write"),
+    conversation.unmuteStream
+  )
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/reassign",
     ...authed,
+    audit("conversations.reassign_message", "write"),
     conversation.reassignMessage
   )
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/split-thread",
     ...authed,
+    audit("conversations.split_thread", "write"),
     conversation.splitThread
   )
-  app.post("/api/workspaces/:workspaceId/conversations/reassign-messages", ...authed, conversation.reassignMessages)
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/reassign-messages",
+    ...authed,
+    audit("conversations.reassign_messages", "write"),
+    conversation.reassignMessages
+  )
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/split-proposal",
     ...authed,
+    audit("conversations.propose_split", "write"),
     conversation.proposeSplit
   )
-  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/split", ...authed, conversation.applySplit)
-  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/read", ...authed, conversation.markRead)
-  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/unread", ...authed, conversation.markUnread)
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/split",
+    ...authed,
+    audit("conversations.apply_split", "write"),
+    conversation.applySplit
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/read",
+    ...authed,
+    audit("conversations.mark_read", "write"),
+    conversation.markRead
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/unread",
+    ...authed,
+    audit("conversations.mark_unread", "write"),
+    conversation.markUnread
+  )
 
-  app.post("/api/workspaces/:workspaceId/commands/dispatch", ...authed, rateLimits.commandDispatch, command.dispatch)
-  app.get("/api/workspaces/:workspaceId/commands", ...authed, command.list)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/commands", ...authed, command.listForStream)
+  app.post(
+    "/api/workspaces/:workspaceId/commands/dispatch",
+    ...authed,
+    audit("commands.dispatch", "write"),
+    rateLimits.commandDispatch,
+    command.dispatch
+  )
+  app.get("/api/workspaces/:workspaceId/commands", ...authed, audit("commands.list", "read"), command.list)
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/commands",
+    ...authed,
+    audit("commands.list_for_stream", "read"),
+    command.listForStream
+  )
 
   // Invitations and member management — gated on members:write
   const requireMembersWrite = requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)
@@ -674,166 +1107,427 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post(
     "/api/workspaces/:workspaceId/users/:userId/role",
     ...authed,
+    audit("members.change_role", "write"),
     requireMembersWrite,
     memberManagement.changeRole
   )
   app.delete(
     "/api/workspaces/:workspaceId/users/:userId",
     ...authed,
+    audit("members.remove", "write"),
     requireMembersWrite,
     memberManagement.removeMember
   )
 
-  app.get("/api/workspaces/:workspaceId/invitations", ...authed, requireMembersWrite, invitation.list)
-  app.post("/api/workspaces/:workspaceId/invitations", ...authed, requireMembersWrite, invitation.send)
-  app.post("/api/workspaces/:workspaceId/invitations/links", ...authed, requireMembersWrite, invitation.createLink)
+  app.get(
+    "/api/workspaces/:workspaceId/invitations",
+    ...authed,
+    audit("invitations.list", "read"),
+    requireMembersWrite,
+    invitation.list
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/invitations",
+    ...authed,
+    audit("invitations.send", "write"),
+    requireMembersWrite,
+    invitation.send
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/invitations/links",
+    ...authed,
+    audit("invitations.create_link", "write"),
+    requireMembersWrite,
+    invitation.createLink
+  )
   app.post(
     "/api/workspaces/:workspaceId/invitations/:invitationId/revoke",
     ...authed,
+    audit("invitations.revoke", "write"),
     requireMembersWrite,
     invitation.revoke
   )
   app.post(
     "/api/workspaces/:workspaceId/invitations/:invitationId/resend",
     ...authed,
+    audit("invitations.resend", "write"),
     requireMembersWrite,
     invitation.resend
   )
 
   // User setup (any authenticated workspace user)
-  app.get("/api/workspaces/:workspaceId/slug-available", ...authed, workspace.checkSlugAvailability)
-  app.post("/api/workspaces/:workspaceId/setup", ...authed, workspace.completeUserSetup)
+  app.get(
+    "/api/workspaces/:workspaceId/slug-available",
+    ...authed,
+    audit("workspace.slug_available", "read"),
+    workspace.checkSlugAvailability
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/setup",
+    ...authed,
+    audit("workspace.complete_setup", "write"),
+    workspace.completeUserSetup
+  )
 
-  app.patch("/api/workspaces/:workspaceId/profile", ...authed, workspace.updateProfile)
-  app.put("/api/workspaces/:workspaceId/status", ...authed, workspace.setStatus)
-  app.delete("/api/workspaces/:workspaceId/status", ...authed, workspace.clearStatus)
-  app.put("/api/workspaces/:workspaceId/notifications/pause", ...authed, workspace.pauseNotifications)
-  app.delete("/api/workspaces/:workspaceId/notifications/pause", ...authed, workspace.resumeNotifications)
-  app.post("/api/workspaces/:workspaceId/profile/avatar", ...authed, avatarUpload, workspace.uploadAvatar)
-  app.delete("/api/workspaces/:workspaceId/profile/avatar", ...authed, workspace.removeAvatar)
+  app.patch(
+    "/api/workspaces/:workspaceId/profile",
+    ...authed,
+    audit("workspace.update_profile", "write"),
+    workspace.updateProfile
+  )
+  app.put("/api/workspaces/:workspaceId/status", ...authed, audit("workspace.set_status", "write"), workspace.setStatus)
+  app.delete(
+    "/api/workspaces/:workspaceId/status",
+    ...authed,
+    audit("workspace.clear_status", "write"),
+    workspace.clearStatus
+  )
+  app.put(
+    "/api/workspaces/:workspaceId/notifications/pause",
+    ...authed,
+    audit("workspace.pause_notifications", "write"),
+    workspace.pauseNotifications
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/notifications/pause",
+    ...authed,
+    audit("workspace.resume_notifications", "write"),
+    workspace.resumeNotifications
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/profile/avatar",
+    ...authed,
+    audit("workspace.upload_avatar", "write"),
+    avatarUpload,
+    workspace.uploadAvatar
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/profile/avatar",
+    ...authed,
+    audit("workspace.remove_avatar", "write"),
+    workspace.removeAvatar
+  )
 
   // Avatar file serving (unauthenticated — S3 keys contain unguessable ULIDs)
-  app.get("/api/workspaces/:workspaceId/users/:userId/avatar/:file", workspace.serveAvatarFile)
+  app.get(
+    "/api/workspaces/:workspaceId/users/:userId/avatar/:file",
+    audit.none("unauthenticated avatar serve; S3 keys carry unguessable ULIDs"),
+    workspace.serveAvatarFile
+  )
 
-  app.get("/api/workspaces/:workspaceId/ai-usage", ...authed, aiUsage.getUsage)
-  app.get("/api/workspaces/:workspaceId/ai-usage/recent", ...authed, aiUsage.getRecentUsage)
-  app.get("/api/workspaces/:workspaceId/ai-budget", ...authed, aiUsage.getBudget)
+  app.get("/api/workspaces/:workspaceId/ai-usage", ...authed, audit("ai_usage.get", "read"), aiUsage.getUsage)
+  app.get(
+    "/api/workspaces/:workspaceId/ai-usage/recent",
+    ...authed,
+    audit("ai_usage.get_recent", "read"),
+    aiUsage.getRecentUsage
+  )
+  app.get("/api/workspaces/:workspaceId/ai-budget", ...authed, audit("ai_usage.get_budget", "read"), aiUsage.getBudget)
   app.put(
     "/api/workspaces/:workspaceId/ai-budget",
     ...authed,
+    audit("ai_usage.update_budget", "write"),
     requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN),
     aiUsage.updateBudget
   )
 
   // Sync-log catch-up (sync engine v2 step 1): ordered entries after a cursor,
   // ACL-filtered to the requester's delivery groups.
-  app.get("/api/workspaces/:workspaceId/sync", ...authed, sync.catchUp)
+  app.get("/api/workspaces/:workspaceId/sync", ...authed, audit("streams.catchup", "read"), sync.catchUp)
 
-  app.get("/api/workspaces/:workspaceId/activity", ...authed, activity.list)
-  app.post("/api/workspaces/:workspaceId/activity/read", ...authed, activity.markAllAsRead)
-  app.post("/api/workspaces/:workspaceId/activity/:id/read", ...authed, activity.markOneAsRead)
+  app.get("/api/workspaces/:workspaceId/activity", ...authed, audit("activity.list", "read"), activity.list)
+  app.post(
+    "/api/workspaces/:workspaceId/activity/read",
+    ...authed,
+    audit("activity.mark_all_read", "write"),
+    activity.markAllAsRead
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/activity/:id/read",
+    ...authed,
+    audit("activity.mark_one_read", "write"),
+    activity.markOneAsRead
+  )
 
-  app.get("/api/workspaces/:workspaceId/saved", ...authed, savedMessages.list)
-  app.post("/api/workspaces/:workspaceId/saved", ...authed, savedMessages.create)
-  app.patch("/api/workspaces/:workspaceId/saved/:savedId", ...authed, savedMessages.update)
-  app.delete("/api/workspaces/:workspaceId/saved/:savedId", ...authed, savedMessages.delete)
+  app.get("/api/workspaces/:workspaceId/saved", ...authed, audit("saved_messages.list", "read"), savedMessages.list)
+  app.post(
+    "/api/workspaces/:workspaceId/saved",
+    ...authed,
+    audit("saved_messages.create", "write"),
+    savedMessages.create
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/saved/:savedId",
+    ...authed,
+    audit("saved_messages.update", "write"),
+    savedMessages.update
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/saved/:savedId",
+    ...authed,
+    audit("saved_messages.delete", "write"),
+    savedMessages.delete
+  )
 
   // Saved suggestions (passively collected to-do candidates)
-  app.get("/api/workspaces/:workspaceId/saved/suggestions", ...authed, savedSuggestions.list)
-  app.post("/api/workspaces/:workspaceId/saved/suggestions/:suggestionId/accept", ...authed, savedSuggestions.accept)
-  app.post("/api/workspaces/:workspaceId/saved/suggestions/:suggestionId/dismiss", ...authed, savedSuggestions.dismiss)
+  app.get(
+    "/api/workspaces/:workspaceId/saved/suggestions",
+    ...authed,
+    audit("saved_suggestions.list", "read"),
+    savedSuggestions.list
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/saved/suggestions/:suggestionId/accept",
+    ...authed,
+    audit("saved_suggestions.accept", "write"),
+    savedSuggestions.accept
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/saved/suggestions/:suggestionId/dismiss",
+    ...authed,
+    audit("saved_suggestions.dismiss", "write"),
+    savedSuggestions.dismiss
+  )
 
-  app.get("/api/workspaces/:workspaceId/labels", ...authed, label.list)
-  app.get("/api/workspaces/:workspaceId/labels/:labelId/messages", ...authed, label.listMessages)
-  app.post("/api/workspaces/:workspaceId/labels", ...authed, label.create)
-  app.patch("/api/workspaces/:workspaceId/labels/:labelId", ...authed, label.update)
-  app.delete("/api/workspaces/:workspaceId/labels/:labelId", ...authed, label.delete)
-  app.post("/api/workspaces/:workspaceId/labels/:labelId/assignments", ...authed, label.assign)
-  app.delete("/api/workspaces/:workspaceId/labels/:labelId/assignments", ...authed, label.unassign)
+  app.get("/api/workspaces/:workspaceId/labels", ...authed, audit("labels.list", "read"), label.list)
+  app.get(
+    "/api/workspaces/:workspaceId/labels/:labelId/messages",
+    ...authed,
+    audit("labels.list_messages", "read"),
+    label.listMessages
+  )
+  app.post("/api/workspaces/:workspaceId/labels", ...authed, audit("labels.create", "write"), label.create)
+  app.patch("/api/workspaces/:workspaceId/labels/:labelId", ...authed, audit("labels.update", "write"), label.update)
+  app.delete("/api/workspaces/:workspaceId/labels/:labelId", ...authed, audit("labels.delete", "write"), label.delete)
+  app.post(
+    "/api/workspaces/:workspaceId/labels/:labelId/assignments",
+    ...authed,
+    audit("labels.assign", "write"),
+    label.assign
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/labels/:labelId/assignments",
+    ...authed,
+    audit("labels.unassign", "write"),
+    label.unassign
+  )
 
-  app.get("/api/workspaces/:workspaceId/scheduled", ...authed, scheduledMessages.list)
-  app.post("/api/workspaces/:workspaceId/scheduled", ...authed, scheduledMessages.create)
-  app.get("/api/workspaces/:workspaceId/scheduled/:id", ...authed, scheduledMessages.getById)
-  app.patch("/api/workspaces/:workspaceId/scheduled/:id", ...authed, scheduledMessages.update)
-  app.delete("/api/workspaces/:workspaceId/scheduled/:id", ...authed, scheduledMessages.delete)
-  app.post("/api/workspaces/:workspaceId/scheduled/:id/lock", ...authed, scheduledMessages.lockForEdit)
-  app.post("/api/workspaces/:workspaceId/scheduled/:id/unlock", ...authed, scheduledMessages.releaseEditLock)
-  app.post("/api/workspaces/:workspaceId/scheduled/:id/send-now", ...authed, scheduledMessages.sendNow)
+  app.get(
+    "/api/workspaces/:workspaceId/scheduled",
+    ...authed,
+    audit("scheduled_messages.list", "read"),
+    scheduledMessages.list
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/scheduled",
+    ...authed,
+    audit("scheduled_messages.create", "write"),
+    scheduledMessages.create
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/scheduled/:id",
+    ...authed,
+    audit("scheduled_messages.get", "read"),
+    scheduledMessages.getById
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/scheduled/:id",
+    ...authed,
+    audit("scheduled_messages.update", "write"),
+    scheduledMessages.update
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/scheduled/:id",
+    ...authed,
+    audit("scheduled_messages.delete", "write"),
+    scheduledMessages.delete
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/scheduled/:id/lock",
+    ...authed,
+    audit("scheduled_messages.lock", "write"),
+    scheduledMessages.lockForEdit
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/scheduled/:id/unlock",
+    ...authed,
+    audit("scheduled_messages.unlock", "write"),
+    scheduledMessages.releaseEditLock
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/scheduled/:id/send-now",
+    ...authed,
+    audit("scheduled_messages.send_now", "write"),
+    scheduledMessages.sendNow
+  )
 
   // Agent follow-ups — a stream member can cancel a follow-up they can see from
   // its timeline card (roadmap 1.3). Scheduling/listing stay agent-only tools.
-  app.post("/api/workspaces/:workspaceId/agent-follow-ups/:id/cancel", ...authed, agentFollowUps.cancel)
+  app.post(
+    "/api/workspaces/:workspaceId/agent-follow-ups/:id/cancel",
+    ...authed,
+    audit("agent_follow_ups.cancel", "write"),
+    agentFollowUps.cancel
+  )
 
-  app.get("/api/workspaces/:workspaceId/delegations", ...authed, delegations.list)
-  app.get("/api/workspaces/:workspaceId/delegations/:id", ...authed, delegations.get)
-  app.post("/api/workspaces/:workspaceId/delegations/:id/cancel", ...authed, delegations.cancel)
-  app.post("/api/workspaces/:workspaceId/delegations/:id/done", ...authed, delegations.markDone)
+  app.get("/api/workspaces/:workspaceId/delegations", ...authed, audit("delegations.list", "read"), delegations.list)
+  app.get("/api/workspaces/:workspaceId/delegations/:id", ...authed, audit("delegations.get", "read"), delegations.get)
+  app.post(
+    "/api/workspaces/:workspaceId/delegations/:id/cancel",
+    ...authed,
+    audit("delegations.cancel", "write"),
+    delegations.cancel
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/delegations/:id/done",
+    ...authed,
+    audit("delegations.mark_done", "write"),
+    delegations.markDone
+  )
 
   // Bot access requests — a stream member approves or denies a bot's request to
   // access the stream so it can claim a delegation (F3). Approve applies the
   // grant; both are member-gated (stricter than delegation cancel).
-  app.post("/api/workspaces/:workspaceId/bot-access-requests/:id/approve", ...authed, botAccessRequests.approve)
-  app.post("/api/workspaces/:workspaceId/bot-access-requests/:id/deny", ...authed, botAccessRequests.deny)
+  app.post(
+    "/api/workspaces/:workspaceId/bot-access-requests/:id/approve",
+    ...authed,
+    audit("bot_access_requests.approve", "write"),
+    botAccessRequests.approve
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/bot-access-requests/:id/deny",
+    ...authed,
+    audit("bot_access_requests.deny", "write"),
+    botAccessRequests.deny
+  )
 
   // Drafts — centralized, local-first composer payloads that roam across the
   // author's devices. Private to the author; never timeline-broadcast.
-  app.get("/api/workspaces/:workspaceId/drafts", ...authed, drafts.list)
-  app.put("/api/workspaces/:workspaceId/drafts/:id", ...authed, drafts.upsert)
-  app.post("/api/workspaces/:workspaceId/drafts/:id/resolve", ...authed, drafts.resolve)
-  app.delete("/api/workspaces/:workspaceId/drafts/:id", ...authed, drafts.delete)
+  app.get("/api/workspaces/:workspaceId/drafts", ...authed, audit("drafts.list", "read"), drafts.list)
+  app.put("/api/workspaces/:workspaceId/drafts/:id", ...authed, audit("drafts.upsert", "write"), drafts.upsert)
+  app.post(
+    "/api/workspaces/:workspaceId/drafts/:id/resolve",
+    ...authed,
+    audit("drafts.resolve", "write"),
+    drafts.resolve
+  )
+  app.delete("/api/workspaces/:workspaceId/drafts/:id", ...authed, audit("drafts.delete", "write"), drafts.delete)
 
   const push = createPushHandlers({ pushService })
-  app.get("/api/workspaces/:workspaceId/push/vapid-key", ...authed, push.getVapidKey)
-  app.post("/api/workspaces/:workspaceId/push/subscribe", ...authed, push.subscribe)
-  app.post("/api/workspaces/:workspaceId/push/unsubscribe", ...authed, push.unsubscribe)
-  app.post("/api/workspaces/:workspaceId/push/test", ...authed, rateLimits.pushTest, push.sendTest)
+  app.get(
+    "/api/workspaces/:workspaceId/push/vapid-key",
+    ...authed,
+    audit("push.get_vapid_key", "read"),
+    push.getVapidKey
+  )
+  app.post("/api/workspaces/:workspaceId/push/subscribe", ...authed, audit("push.subscribe", "write"), push.subscribe)
+  app.post(
+    "/api/workspaces/:workspaceId/push/unsubscribe",
+    ...authed,
+    audit("push.unsubscribe", "write"),
+    push.unsubscribe
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/push/test",
+    ...authed,
+    audit("push.test", "write"),
+    rateLimits.pushTest,
+    push.sendTest
+  )
   // Non-workspace-scoped: cleans up all push subscriptions for a browser endpoint (used on logout)
-  app.post("/api/push/cleanup-endpoint", auth, push.cleanupEndpoint)
+  app.post("/api/push/cleanup-endpoint", auth, audit("push.cleanup_endpoint", "write"), push.cleanupEndpoint)
 
-  app.get("/api/workspaces/:workspaceId/agent-sessions/:sessionId", ...authed, agentSession.getSession)
+  app.get(
+    "/api/workspaces/:workspaceId/agent-sessions/:sessionId",
+    ...authed,
+    audit("agent_sessions.get", "read"),
+    agentSession.getSession
+  )
 
-  app.post("/api/workspaces/:workspaceId/context-bag/precompute", ...authed, contextBag.precompute)
-  app.get("/api/workspaces/:workspaceId/streams/:streamId/context-bag", ...authed, contextBag.getStreamBag)
+  app.post(
+    "/api/workspaces/:workspaceId/context-bag/precompute",
+    ...authed,
+    audit("context_bag.precompute", "write"),
+    contextBag.precompute
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/context-bag",
+    ...authed,
+    audit("context_bag.get_stream_bag", "read"),
+    contextBag.getStreamBag
+  )
 
-  app.get("/api/workspaces/:workspaceId/messages/:messageId/link-previews", ...authed, linkPreview.getForMessage)
+  app.get(
+    "/api/workspaces/:workspaceId/messages/:messageId/link-previews",
+    ...authed,
+    audit("link_previews.get_for_message", "read"),
+    linkPreview.getForMessage
+  )
   app.post(
     "/api/workspaces/:workspaceId/messages/:messageId/link-previews/:linkPreviewId/dismiss",
     ...authed,
+    audit("link_previews.dismiss", "write"),
     linkPreview.dismiss
   )
-  app.get("/api/workspaces/:workspaceId/link-previews/resolve", ...authed, linkPreview.resolveInAppLinkByUrl)
-  app.get("/api/workspaces/:workspaceId/link-previews/:linkPreviewId/resolve", ...authed, linkPreview.resolveInAppLink)
+  app.get(
+    "/api/workspaces/:workspaceId/link-previews/resolve",
+    ...authed,
+    audit("link_previews.resolve_in_app", "read"),
+    linkPreview.resolveInAppLinkByUrl
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/link-previews/:linkPreviewId/resolve",
+    ...authed,
+    audit("link_previews.resolve_in_app_by_id", "read"),
+    linkPreview.resolveInAppLink
+  )
 
   // Giphy picker — backend proxy keeps the API key server-side. `config` reports
   // whether the feature is enabled; the chosen GIF is embedded by its CDN URL
   // (no byte download), so there's no file-proxy endpoint.
-  app.get("/api/workspaces/:workspaceId/giphy/config", ...authed, giphy.getConfig)
-  app.get("/api/workspaces/:workspaceId/giphy/search", ...authed, rateLimits.search, giphy.search)
-  app.get("/api/workspaces/:workspaceId/giphy/trending", ...authed, rateLimits.search, giphy.trending)
+  app.get("/api/workspaces/:workspaceId/giphy/config", ...authed, audit("giphy.get_config", "read"), giphy.getConfig)
+  app.get(
+    "/api/workspaces/:workspaceId/giphy/search",
+    ...authed,
+    audit("giphy.search", "read"),
+    rateLimits.search,
+    giphy.search
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/giphy/trending",
+    ...authed,
+    audit("giphy.trending", "read"),
+    rateLimits.search,
+    giphy.trending
+  )
 
   // Workspace integrations — gated on workspace:admin
   const requireWorkspaceAdmin = requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN)
   app.get(
     "/api/workspaces/:workspaceId/integrations/github",
     ...authed,
+    audit("integrations.get_github", "read"),
     requireWorkspaceAdmin,
     workspaceIntegration.getGithub
   )
   app.get(
     "/api/workspaces/:workspaceId/integrations/github/connect",
     ...authed,
+    audit("integrations.connect_github", "read"),
     requireWorkspaceAdmin,
     workspaceIntegration.connectGithub
   )
   app.delete(
     "/api/workspaces/:workspaceId/integrations/github/:integrationId",
     ...authed,
+    audit("integrations.disconnect_github", "write"),
     requireWorkspaceAdmin,
     workspaceIntegration.disconnectGithub
   )
   app.post(
     "/api/workspaces/:workspaceId/integrations/github/:integrationId/sync",
     ...authed,
+    audit("integrations.sync_github", "write"),
     requireWorkspaceAdmin,
     workspaceIntegration.syncGithub
   )
@@ -841,38 +1535,81 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get(
     "/api/workspaces/:workspaceId/integrations/linear",
     ...authed,
+    audit("integrations.get_linear", "read"),
     requireWorkspaceAdmin,
     workspaceIntegration.getLinear
   )
   app.get(
     "/api/workspaces/:workspaceId/integrations/linear/connect",
     ...authed,
+    audit("integrations.connect_linear", "read"),
     requireWorkspaceAdmin,
     workspaceIntegration.connectLinear
   )
   app.delete(
     "/api/workspaces/:workspaceId/integrations/linear",
     ...authed,
+    audit("integrations.disconnect_linear", "write"),
     requireWorkspaceAdmin,
     workspaceIntegration.disconnectLinear
   )
 
   // Fixed callback targets for provider installation flows (workspace resolved from signed state)
-  app.get("/api/integrations/github/callback", auth, workspaceIntegration.githubCallback)
-  app.get("/api/integrations/linear/callback", auth, workspaceIntegration.linearCallback)
+  app.get(
+    "/api/integrations/github/callback",
+    auth,
+    audit("integrations.github_callback", "read"),
+    workspaceIntegration.githubCallback
+  )
+  app.get(
+    "/api/integrations/linear/callback",
+    auth,
+    audit("integrations.linear_callback", "read"),
+    workspaceIntegration.linearCallback
+  )
 
   // User API key management (any authenticated user)
   const userApiKeys = createUserApiKeyHandlers({ userApiKeyService })
-  app.get("/api/workspaces/:workspaceId/user-api-keys", ...authed, userApiKeys.list)
-  app.post("/api/workspaces/:workspaceId/user-api-keys", ...authed, userApiKeys.create)
-  app.patch("/api/workspaces/:workspaceId/user-api-keys/:keyId", ...authed, userApiKeys.update)
-  app.post("/api/workspaces/:workspaceId/user-api-keys/:keyId/revoke", ...authed, userApiKeys.revoke)
+  app.get(
+    "/api/workspaces/:workspaceId/user-api-keys",
+    ...authed,
+    audit("user_api_keys.list", "read"),
+    userApiKeys.list
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/user-api-keys",
+    ...authed,
+    audit("user_api_keys.create", "write"),
+    userApiKeys.create
+  )
+  app.patch(
+    "/api/workspaces/:workspaceId/user-api-keys/:keyId",
+    ...authed,
+    audit("user_api_keys.update", "write"),
+    userApiKeys.update
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/user-api-keys/:keyId/revoke",
+    ...authed,
+    audit("user_api_keys.revoke", "write"),
+    userApiKeys.revoke
+  )
 
   // Voice dictation: HTTP creates/aborts the session; the dedicated /voice
   // socket namespace owns the live audio relay and authoritative stop.
   const voice = createVoiceTranscriptionHandlers({ voiceTranscriptionService })
-  app.post("/api/workspaces/:workspaceId/voice/sessions", ...authed, voice.createSession)
-  app.delete("/api/workspaces/:workspaceId/voice/sessions/:sessionId", ...authed, voice.abortSession)
+  app.post(
+    "/api/workspaces/:workspaceId/voice/sessions",
+    ...authed,
+    audit("voice.create_session", "write"),
+    voice.createSession
+  )
+  app.delete(
+    "/api/workspaces/:workspaceId/voice/sessions/:sessionId",
+    ...authed,
+    audit("voice.abort_session", "write"),
+    voice.abortSession
+  )
 
   // Bot management. Management routes (update, archive, keys, avatar, grants)
   // are gated by `requireBotManagement()` middleware that resolves the bot,
@@ -880,29 +1617,62 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // and attaches the bot to req.bot so handlers don't re-fetch it.
   const botHandlers = createBotHandlers({ botApiKeyService, avatarService, streamService, pool })
   const requireBotManagement = createRequireBotManagement(pool)
-  app.get("/api/workspaces/:workspaceId/bots", ...authed, botHandlers.list)
-  app.post("/api/workspaces/:workspaceId/bots", ...authed, botHandlers.create)
-  app.get("/api/workspaces/:workspaceId/bots/:botId", ...authed, botHandlers.get)
-  app.patch("/api/workspaces/:workspaceId/bots/:botId", ...authed, requireBotManagement(), botHandlers.update)
-  app.post("/api/workspaces/:workspaceId/bots/:botId/archive", ...authed, requireBotManagement(), botHandlers.archive)
-  app.post("/api/workspaces/:workspaceId/bots/:botId/restore", ...authed, requireBotManagement(), botHandlers.restore)
-  app.get("/api/workspaces/:workspaceId/bots/:botId/keys", ...authed, requireBotManagement(), botHandlers.listKeys)
-  app.post("/api/workspaces/:workspaceId/bots/:botId/keys", ...authed, requireBotManagement(), botHandlers.createKey)
+  app.get("/api/workspaces/:workspaceId/bots", ...authed, audit("bots.list", "read"), botHandlers.list)
+  app.post("/api/workspaces/:workspaceId/bots", ...authed, audit("bots.create", "write"), botHandlers.create)
+  app.get("/api/workspaces/:workspaceId/bots/:botId", ...authed, audit("bots.get", "read"), botHandlers.get)
+  app.patch(
+    "/api/workspaces/:workspaceId/bots/:botId",
+    ...authed,
+    audit("bots.update", "write"),
+    requireBotManagement(),
+    botHandlers.update
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/bots/:botId/archive",
+    ...authed,
+    audit("bots.archive", "write"),
+    requireBotManagement(),
+    botHandlers.archive
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/bots/:botId/restore",
+    ...authed,
+    audit("bots.restore", "write"),
+    requireBotManagement(),
+    botHandlers.restore
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/bots/:botId/keys",
+    ...authed,
+    audit("bots.list_keys", "read"),
+    requireBotManagement(),
+    botHandlers.listKeys
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/bots/:botId/keys",
+    ...authed,
+    audit("bots.create_key", "write"),
+    requireBotManagement(),
+    botHandlers.createKey
+  )
   app.patch(
     "/api/workspaces/:workspaceId/bots/:botId/keys/:keyId",
     ...authed,
+    audit("bots.update_key", "write"),
     requireBotManagement(),
     botHandlers.updateKey
   )
   app.post(
     "/api/workspaces/:workspaceId/bots/:botId/keys/:keyId/revoke",
     ...authed,
+    audit("bots.revoke_key", "write"),
     requireBotManagement(),
     botHandlers.revokeKey
   )
   app.post(
     "/api/workspaces/:workspaceId/bots/:botId/avatar",
     ...authed,
+    audit("bots.upload_avatar", "write"),
     requireBotManagement(),
     avatarUpload,
     botHandlers.uploadAvatar
@@ -910,27 +1680,35 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.delete(
     "/api/workspaces/:workspaceId/bots/:botId/avatar",
     ...authed,
+    audit("bots.remove_avatar", "write"),
     requireBotManagement(),
     botHandlers.removeAvatar
   )
   // Bot avatar serving (unauthenticated — S3 keys contain unguessable ULIDs)
-  app.get("/api/workspaces/:workspaceId/bots/:botId/avatar/:file", botHandlers.serveAvatarFile)
+  app.get(
+    "/api/workspaces/:workspaceId/bots/:botId/avatar/:file",
+    audit.none("unauthenticated avatar serve; S3 keys carry unguessable ULIDs"),
+    botHandlers.serveAvatarFile
+  )
   // Bot channel access grants
   app.get(
     "/api/workspaces/:workspaceId/bots/:botId/streams",
     ...authed,
+    audit("bots.list_stream_grants", "read"),
     requireBotManagement(),
     botHandlers.listStreamGrants
   )
   app.post(
     "/api/workspaces/:workspaceId/bots/:botId/streams/:streamId/grant",
     ...authed,
+    audit("bots.grant_stream_access", "write"),
     requireBotManagement(),
     botHandlers.grantStreamAccess
   )
   app.delete(
     "/api/workspaces/:workspaceId/bots/:botId/streams/:streamId/grant",
     ...authed,
+    audit("bots.revoke_stream_access", "write"),
     requireBotManagement(),
     botHandlers.revokeStreamAccess
   )
@@ -938,6 +1716,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get(
     "/api/workspaces/:workspaceId/streams/:streamId/bots",
     ...authed,
+    audit("bots.list_stream_bots", "read"),
     requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.BOTS_MANAGE),
     botHandlers.listStreamBots
   )
@@ -967,7 +1746,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     botChannelService,
     botAccessRequestService,
   })
-  const publicMiddleware = [rateLimits.publicApiWorkspace, rateLimits.publicApiKey, publicAuth] as const
+  // Boundary ahead of key auth: a bad/revoked API key 401s inside publicAuth
+  // without reaching the route's audit(...) — key-probing attempts must leave
+  // a trace (actor unknown, ip recorded).
+  const publicMiddleware = [rateLimits.publicApiWorkspace, rateLimits.publicApiKey, audit.boundary, publicAuth] as const
 
   const publicHandlers: Record<OperationId, RequestHandler | RequestHandler[]> = {
     searchMessages: publicApi.searchMessages,
@@ -1024,17 +1806,29 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
   assertHandlerParity(Object.keys(publicHandlers))
 
+  // POST-shaped reads: same §11 decision as the session search routes — a
+  // breach query filtered by access_kind='read' must not miss external-caller
+  // searches, nor should 'write' queries be polluted with them.
+  const publicApiReadPosts = new Set(["searchMessages", "searchMemos", "searchAttachments", "findMessagesByMetadata"])
+
   for (const route of PUBLIC_API_ROUTES) {
     const handler = publicHandlers[route.operationId]
     const scopeGuard = route.scopes.length > 0 ? [requireApiKeyScope(...route.scopes)] : []
+    const kind = route.method === "get" || publicApiReadPosts.has(route.operationId) ? "read" : "write"
     app[route.method](
       toExpressPath(route.path),
       ...publicMiddleware,
+      audit(publicApiOperation(route.operationId), kind),
       createApiVersionGate(route.operationId),
       ...scopeGuard,
       ...(Array.isArray(handler) ? handler : [handler])
     )
   }
+
+  // Boot-time invariant: every /api route declares an audit annotation (design
+  // §7.1). A new endpoint without one fails the server's start, not silently
+  // ships un-logged access.
+  assertAuditCoverage(app)
 
   app.use(errorHandler)
 }

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -745,6 +745,7 @@ export async function startServer(): Promise<ServerInstance> {
     ai,
     controlPlaneClient,
     costService,
+    accessLogService,
   })
 
   app.use(errorHandler)

--- a/apps/backend/tests/integration/access-log-http.test.ts
+++ b/apps/backend/tests/integration/access-log-http.test.ts
@@ -1,0 +1,242 @@
+/**
+ * HTTP capture integration: the audit middleware writes access_log rows on
+ * response finish. Boots the real server (setup.ts preload) and reads rows back
+ * from threa_test. Rows are fire-and-forget on `res.on("finish")`, so every
+ * assertion polls briefly for the row to land.
+ *
+ * Run: bun test --preload ./tests/setup.ts tests/integration/access-log-http.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import {
+  TestClient,
+  loginAs,
+  createWorkspace,
+  createScratchpad,
+  sendMessage,
+  getUserId,
+  joinWorkspace,
+} from "../client"
+
+interface AccessLogDbRow {
+  workspace_id: string | null
+  actor_type: string
+  actor_id: string
+  operation: string
+  access_kind: string
+  outcome: string
+  subjects: { type: string; id?: string }[] | null
+  request_id: string | null
+}
+
+const testRunId = Math.random().toString(36).slice(2, 8)
+const email = (name: string) => `${name}-${testRunId}@test.com`
+
+describe("access-log HTTP capture", () => {
+  let pool: Pool
+
+  beforeAll(() => {
+    pool = new Pool({
+      connectionString: process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test",
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function pollRow(
+    where: string,
+    params: unknown[],
+    predicate: (rows: AccessLogDbRow[]) => boolean = (rows) => rows.length > 0
+  ): Promise<AccessLogDbRow[]> {
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const { rows } = await pool.query<AccessLogDbRow>(
+        `SELECT workspace_id, actor_type, actor_id, operation, access_kind, outcome, subjects, request_id
+         FROM access_log WHERE ${where} ORDER BY occurred_at DESC`,
+        params
+      )
+      if (predicate(rows)) return rows
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    return []
+  }
+
+  test("annotated read (stream bootstrap) records actor/workspace/operation/kind/outcome/subjects", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("reader"), "Reader")
+    const ws = await createWorkspace(client, "Reader WS")
+    const stream = await createScratchpad(client, ws.id)
+    const userId = await getUserId(client, ws.id, user.id)
+
+    const { status } = await client.get(`/api/workspaces/${ws.id}/streams/${stream.id}/bootstrap`)
+    expect(status).toBe(200)
+
+    const rows = await pollRow("workspace_id = $1 AND operation = 'streams.bootstrap' AND actor_id = $2", [
+      ws.id,
+      userId,
+    ])
+    expect(rows.length).toBeGreaterThan(0)
+    const row = rows[0]
+    expect(row).toMatchObject({
+      workspace_id: ws.id,
+      actor_type: "user",
+      actor_id: userId,
+      operation: "streams.bootstrap",
+      access_kind: "read",
+      outcome: "success",
+    })
+    // request_id (pino genReqId) is populated.
+    expect(row.request_id).toBeTruthy()
+    // Subjects carry the stream ref (a range read), never content.
+    expect(row.subjects).toEqual(expect.arrayContaining([expect.objectContaining({ type: "stream", id: stream.id })]))
+  })
+
+  test("access-hiding 404 records outcome 'denied'", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("denied"), "Denied")
+    const ws = await createWorkspace(client, "Denied WS")
+    const userId = await getUserId(client, ws.id, user.id)
+
+    const { status } = await client.get(`/api/workspaces/${ws.id}/streams/stream_does_not_exist/bootstrap`)
+    expect(status).toBe(404)
+
+    const rows = await pollRow(
+      "workspace_id = $1 AND operation = 'streams.bootstrap' AND actor_id = $2 AND outcome = 'denied'",
+      [ws.id, userId]
+    )
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0].access_kind).toBe("read")
+  })
+
+  test("mutation records access_kind 'write'", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("writer"), "Writer")
+    const ws = await createWorkspace(client, "Writer WS")
+    const stream = await createScratchpad(client, ws.id)
+    const userId = await getUserId(client, ws.id, user.id)
+
+    await sendMessage(client, ws.id, stream.id, "hello audit")
+
+    const rows = await pollRow("workspace_id = $1 AND operation = 'messages.create' AND actor_id = $2", [ws.id, userId])
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0]).toMatchObject({ access_kind: "write", outcome: "success", actor_type: "user" })
+  })
+
+  test("workspace-less auth surface (/api/auth/me) records a row with null workspace, WorkOS actor", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("mereader"), "MeReader")
+
+    const { status } = await client.get("/api/auth/me")
+    expect(status).toBe(200)
+
+    const rows = await pollRow("operation = 'auth.me' AND actor_id = $1", [user.id])
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0]).toMatchObject({
+      workspace_id: null,
+      actor_type: "user",
+      actor_id: user.id,
+      operation: "auth.me",
+      access_kind: "read",
+      outcome: "success",
+    })
+  })
+
+  test("unauthenticated hit on an annotated route writes no success row", async () => {
+    const owner = new TestClient()
+    const ownerUser = await loginAs(owner, email("owner"), "Owner")
+    const ws = await createWorkspace(owner, "Unauth WS")
+    const ownerId = await getUserId(owner, ws.id, ownerUser.id)
+
+    const anon = new TestClient()
+    const { status } = await anon.get(`/api/workspaces/${ws.id}/bootstrap`)
+    expect(status).toBe(401)
+
+    // Control: an authed hit on the same operation DOES record — proving the
+    // pipeline works for this op, so the absence below is meaningful rather
+    // than vacuous.
+    const ownerRes = await owner.get(`/api/workspaces/${ws.id}/bootstrap`)
+    expect(ownerRes.status).toBe(200)
+    const ownerRows = await pollRow("workspace_id = $1 AND operation = 'workspace.bootstrap' AND actor_id = $2", [
+      ws.id,
+      ownerId,
+    ])
+    expect(ownerRows.length).toBeGreaterThan(0)
+
+    // `auth` short-circuits before the audit middleware registers its finish
+    // hook, so the unauthenticated hit itself produced no row: every row for
+    // this op belongs to the owner.
+    const { rows } = await pool.query<AccessLogDbRow>(
+      "SELECT actor_id, outcome FROM access_log WHERE workspace_id = $1 AND operation = 'workspace.bootstrap'",
+      [ws.id]
+    )
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((r) => r.actor_id === ownerId && r.outcome === "success")).toBe(true)
+  })
+
+  test("cross-workspace probe (workspaceUser 403) records a boundary denial row", async () => {
+    const owner = new TestClient()
+    await loginAs(owner, email("target-owner"), "Target Owner")
+    const targetWs = await createWorkspace(owner, "Target WS")
+
+    const outsiderClient = new TestClient()
+    const outsider = await loginAs(outsiderClient, email("outsider"), "Outsider")
+    await createWorkspace(outsiderClient, "Outsider WS")
+
+    const { status } = await outsiderClient.get(`/api/workspaces/${targetWs.id}/streams`)
+    expect(status).toBe(403)
+
+    // workspaceUser denied before the route-level audit ran; the boundary
+    // backstop must have recorded the probe, attributed to the WorkOS user.
+    const rows = await pollRow(
+      "workspace_id = $1 AND operation = 'auth.boundary_denied' AND actor_id = $2 AND outcome = 'denied'",
+      [targetWs.id, outsider.id]
+    )
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0].subjects).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "workspace", id: targetWs.id })])
+    )
+  })
+
+  test("bad public-API key records a boundary denial row", async () => {
+    const owner = new TestClient()
+    await loginAs(owner, email("api-owner"), "Api Owner")
+    const ws = await createWorkspace(owner, "Api WS")
+
+    const anon = new TestClient()
+    const { status } = await anon.request("GET", `/api/v1/workspaces/${ws.id}/streams`, undefined, {
+      Authorization: "Bearer threa_uk_bogus_key_value",
+    })
+    expect(status).toBe(401)
+
+    const rows = await pollRow(
+      "workspace_id = $1 AND operation = 'auth.boundary_denied' AND actor_id = 'unknown' AND outcome = 'denied'",
+      [ws.id]
+    )
+    expect(rows.length).toBeGreaterThan(0)
+  })
+
+  test("permission-guard 403 records outcome 'denied' (audit runs before requireX guards)", async () => {
+    const owner = new TestClient()
+    await loginAs(owner, email("guard-owner"), "Guard Owner")
+    const ws = await createWorkspace(owner, "Guard WS")
+
+    const memberClient = new TestClient()
+    const member = await loginAs(memberClient, email("guard-member"), "Guard Member")
+    await joinWorkspace(memberClient, ws.id)
+    const memberId = await getUserId(memberClient, ws.id, member.id)
+
+    const { status } = await memberClient.patch(`/api/workspaces/${ws.id}/workspace-settings`, {
+      defaultCompanionPersonaId: null,
+    })
+    expect(status).toBe(403)
+
+    const rows = await pollRow(
+      "workspace_id = $1 AND operation = 'workspace_settings.update' AND actor_id = $2 AND outcome = 'denied'",
+      [ws.id, memberId]
+    )
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0].access_kind).toBe("write")
+  })
+})


### PR DESCRIPTION
Layer 2 of the read/access-logging stack (base: access-log-1-core). Every HTTP read/write/denial now produces an access_log row.

- audit(operation, kind) marker middleware: one res.on(finish)/(close) hook per request — identity precedence botApiKey→userApiKey→user→authUser, outcome from status (all 4xx→denied, over-approximation is the safe direction; 5xx→error), aborted responses still record with detail.aborted, workspace id captured synchronously (Express 5 restores req.params during unwind)
- audit.boundary backstop between auth and workspaceUser (and ahead of public-API key auth): middleware that denies without next() never reaches the route-level audit — cross-workspace probes and bad-API-key attempts must leave a trace
- Every /api route annotated (~250 sites; public-API registry loop injects public_api.<operationId>, search-shaped POSTs labeled read); assertAuditCoverage walks the Express 5 router at boot and throws on any unannotated /api route or any mounted sub-router (mount paths are matcher closures in Express 5 — strictness forces a conscious guard extension)
- Subjects populated in the content-bearing read handlers: 12 session surfaces (stream sequence ranges, search result refs, coarse workspace refs for bootstrap/catch-up), the 4 conversation reads, and 7 public-API handlers incl. the public presign twin — no query text, ever

Tests: middleware/guard unit (4), HTTP capture integration (8: row shape, access-hiding 404 denial, permission-guard 403 denial, boundary rows for cross-workspace probe + bad key, workspace-less auth surface, unauth no-row control), handler unit suites, public-API e2e (43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787036617&installation_id=129946197&pr_number=1404&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1404&signature=0b7440be1fe197be580dd7ea2d2288e58defb8cc79a93019f47b51920a2e944d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->