### PR TITLE
feat(access-log): socket subscribe/unsubscribe intervals + delivered-set reconstruction (stack 3/5)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/socket-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/socket-handler.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./socket-handler"
 import type { BotRuntimeWriteOps } from "./runtime-write-ops"
 import { BotSocketRegistry } from "./bot-socket-registry"
+import type { AccessLogService } from "../access-log"
 
 // Minimal fakes that exercise the public surface of the namespace handler
 // without spinning up Socket.IO: a `namespace` that captures the connection
@@ -113,6 +114,8 @@ function setup(overrides?: {
 
   const botSocketRegistry = new BotSocketRegistry()
 
+  const accessLogService = { record: mock(() => {}) } as unknown as AccessLogService
+
   let connectionHandler: ((socket: FakeSocket) => void) | undefined
   const namespace = {
     use: mock(() => {}),
@@ -128,6 +131,7 @@ function setup(overrides?: {
     botRuntimeWriteOps,
     botApiKeyService,
     botSocketRegistry,
+    accessLogService,
     // Disable revalidation timer in tests — the periodic ticker is covered
     // elsewhere and would otherwise leak between tests.
     keyRevalidationIntervalMs: 60_000_000,
@@ -136,7 +140,7 @@ function setup(overrides?: {
   const socket = makeFakeSocket()
   connectionHandler!(socket)
 
-  return { socket, botRuntimeService, botRuntimeWriteOps, botApiKeyService, botSocketRegistry }
+  return { socket, botRuntimeService, botRuntimeWriteOps, botApiKeyService, botSocketRegistry, accessLogService }
 }
 
 const VALID_HELLO = {
@@ -235,6 +239,65 @@ describe("attachBotNamespace bot:hello", () => {
     await socket.trigger("bot:hello", { ...VALID_HELLO, runtimeSessionId: "sess_1" }, ack)
 
     expect(socket.rooms.has("bot:ws_1:bot:bot_alice:session:sess_1")).toBe(true)
+  })
+
+  it("records audit subscribe rows for the workspace room at connect and the bot rooms at hello", async () => {
+    const { socket, accessLogService } = setup()
+    const record = (accessLogService as unknown as { record: ReturnType<typeof mock> }).record
+
+    // Connect-time subscribe for the workspace-wide bot room. The per-connection
+    // sconn id is the auth_ref that pairs this subscribe with its unsubscribe.
+    const connectRow = record.mock.calls[0]?.[0] as { authRef: string }
+    expect(connectRow).toMatchObject({
+      workspaceId: "ws_1",
+      actorType: "bot",
+      actorId: "bot_alice",
+      operation: "socket.subscribe",
+      accessKind: "subscribe",
+      outcome: "success",
+      subjects: [{ type: "workspace", id: "ws_1" }],
+    })
+    const sconn = connectRow.authRef
+    expect(sconn).toMatch(/^sconn_/)
+
+    await socket.trigger(
+      "bot:hello",
+      VALID_HELLO,
+      mock((_r: BotHelloResponse) => {})
+    )
+
+    const helloRow = record.mock.calls[1]?.[0]
+    expect(helloRow).toMatchObject({
+      actorType: "bot",
+      actorId: "bot_alice",
+      operation: "socket.subscribe",
+      accessKind: "subscribe",
+      authRef: sconn,
+      subjects: [{ type: "bot", id: "bot_alice" }],
+    })
+
+    await socket.trigger("disconnect")
+    // Both intervals close on disconnect: the workspace-room row and the bot-room
+    // row, each reusing this connection's sconn so subscribe/unsubscribe pair.
+    const unsubscribeRows = record.mock.calls.slice(2).map((c: unknown[]) => c[0])
+    expect(unsubscribeRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: "socket.unsubscribe",
+          accessKind: "unsubscribe",
+          actorId: "bot_alice",
+          authRef: sconn,
+          subjects: [{ type: "workspace", id: "ws_1" }],
+        }),
+        expect.objectContaining({
+          operation: "socket.unsubscribe",
+          accessKind: "unsubscribe",
+          actorId: "bot_alice",
+          authRef: sconn,
+          subjects: [{ type: "bot", id: "bot_alice" }],
+        }),
+      ])
+    )
   })
 
   it("rejects a second bot:hello on the same connection", async () => {

--- a/apps/backend/src/features/bot-runtimes/socket-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/socket-handler.ts
@@ -6,7 +6,10 @@ import type { BotRuntimeService } from "./service"
 import type { BotInvocation, BotRuntimeSessionLink, StreamActiveActor } from "./repository"
 import type { BotRuntimeWriteOps } from "./runtime-write-ops"
 import type { BotApiKeyService } from "../public-api"
+import type { AccessLogService, AuditSubjectRef } from "../access-log"
 import { botIdentityKeyFields, bothOrNeitherBotIdentityKey } from "../../lib/schemas"
+import { socketConnectionId } from "../../lib/id"
+import { socketHandshakeIp } from "../../lib/socket-ip"
 import { createBotSocketAuthMiddleware, readSocketToken, type BotSocketData } from "./socket-auth"
 import { BotSocketRegistry } from "./bot-socket-registry"
 import { logger } from "../../lib/logger"
@@ -166,6 +169,7 @@ interface BotSocketHandlerDeps {
   botRuntimeWriteOps: BotRuntimeWriteOps
   botApiKeyService: BotApiKeyService
   botSocketRegistry: BotSocketRegistry
+  accessLogService: AccessLogService
   /**
    * How often (ms) to re-check that the connecting key is still valid.
    * `BotApiKeyService.validateKey` has no cache, so HTTP revocation is
@@ -192,7 +196,7 @@ interface JoinedRoomState {
  * `BroadcastHandler` to the rooms joined here.
  */
 export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
-  const { io, botRuntimeService, botRuntimeWriteOps, botApiKeyService, botSocketRegistry } = deps
+  const { io, botRuntimeService, botRuntimeWriteOps, botApiKeyService, botSocketRegistry, accessLogService } = deps
   const keyRevalidationIntervalMs = deps.keyRevalidationIntervalMs ?? 60_000
   const namespace = io.of("/bot")
 
@@ -209,10 +213,71 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
     }
     const { workspaceId, botId } = auth
 
+    const ip = socketHandshakeIp(socket.handshake)
+    const userAgent = socket.handshake.headers["user-agent"] ?? null
+    // Per-connection id correlating this socket's subscribe/unsubscribe rows
+    // (design §4). Distinct from `auth.keyId`, which a multi-instance runtime
+    // shares across concurrent connections — the connection id disambiguates them.
+    const sconnId = socketConnectionId()
+    // Subject refs for each subscribe row this socket wrote, replayed as
+    // unsubscribe rows on disconnect so the intervals pair (design §3).
+    const auditSubscriptions: AuditSubjectRef[][] = []
+    const recordBotSubscribe = (subjects: AuditSubjectRef[]): void => {
+      auditSubscriptions.push(subjects)
+      accessLogService.record({
+        workspaceId,
+        actorType: "bot",
+        actorId: botId,
+        authRef: sconnId,
+        operation: "socket.subscribe",
+        accessKind: "subscribe",
+        outcome: "success",
+        subjects,
+        // The bak_ credential: auth_ref carries the per-connection sconn for
+        // interval pairing, so the key a leaked-key investigation needs lives
+        // in detail (a bot may rotate keys between connections).
+        detail: { keyId: auth.keyId },
+        // Stamped at the join instant, not at insert time — insert lag must not
+        // shrink the interval (under-approximation is the wrong direction).
+        occurredAt: new Date(),
+        ip,
+        userAgent,
+      })
+    }
+
+    // The bot WS verbs are socket-borne twins of annotated REST routes
+    // (INV-35: same write ops) — without these rows a stolen key's invocation
+    // reads/writes over the socket would be invisible to the access log.
+    const recordBotVerb = (params: {
+      operation: Parameters<typeof accessLogService.record>[0]["operation"]
+      accessKind: "read" | "write"
+      outcome: "success" | "denied" | "error"
+      subjects: AuditSubjectRef[]
+    }): void => {
+      accessLogService.record({
+        workspaceId,
+        actorType: "bot",
+        actorId: botId,
+        authRef: sconnId,
+        operation: params.operation,
+        accessKind: params.accessKind,
+        outcome: params.outcome,
+        subjects: params.subjects,
+        detail: { keyId: auth.keyId },
+        occurredAt: new Date(),
+        ip,
+        userAgent,
+      })
+    }
+
+    const verbOutcome = (err: unknown): "denied" | "error" =>
+      err instanceof HttpError && err.status < 500 ? "denied" : "error"
+
     // Workspace-wide room is always safe — `bot:resync` with no botId fans
     // out to every bot socket in the workspace. The per-bot/instance rooms
     // are joined after `bot:hello` registers the instance identity.
     socket.join(`bot:${workspaceId}`)
+    recordBotSubscribe([{ type: "workspace", id: workspaceId }])
 
     let joined: JoinedRoomState | null = null
     // Synchronous guard against a runtime that sends two `bot:hello` frames
@@ -333,6 +398,7 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
           runtimeKind: data.runtimeKind,
           runtimeSessionId,
         }
+        recordBotSubscribe([{ type: "bot", id: botId }])
 
         const response: BotHelloResponse = {
           ok: true,
@@ -342,6 +408,15 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
           activeActorByStream: bootstrap.activeActorByStream.map(serializeActiveActor),
           activeSessionLinks: bootstrap.activeSessionLinks.map(serializeSessionLink),
         }
+        recordBotVerb({
+          operation: "bot.hello_bootstrap",
+          accessKind: "read",
+          outcome: "success",
+          subjects: [...bootstrap.available, ...bootstrap.ownedClaims].map((inv) => ({
+            type: "bot_invocation",
+            id: inv.id,
+          })),
+        })
         ack?.(response)
       } catch (err) {
         socket.leave(botRoom)
@@ -393,8 +468,20 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
           publicKey: data.publicKey,
           publicKeyId: data.publicKeyId,
         })
+        recordBotVerb({
+          operation: "bot.presence_update",
+          accessKind: "write",
+          outcome: "success",
+          subjects: [{ type: "bot", id: botId }],
+        })
         ack?.({ ok: true })
       } catch (err) {
+        recordBotVerb({
+          operation: "bot.presence_update",
+          accessKind: "write",
+          outcome: verbOutcome(err),
+          subjects: [{ type: "bot", id: botId }],
+        })
         ack?.(toWriteErrorAck(err, { workspaceId, botId, event: "bot:presence:update" }))
       }
     })
@@ -418,8 +505,20 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
             claimToken: data.claimToken,
             claimTtlSeconds: data.claimTtlSeconds,
           })
+          recordBotVerb({
+            operation: "bot.invocation_renew",
+            accessKind: "write",
+            outcome: "success",
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.({ ok: true, data: { ...renewed } })
         } catch (err) {
+          recordBotVerb({
+            operation: "bot.invocation_renew",
+            accessKind: "write",
+            outcome: verbOutcome(err),
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.(toWriteErrorAck(err, { workspaceId, botId, event: "bot:invocation:renew" }))
         }
       }
@@ -445,11 +544,23 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
             steps: data.steps,
             statusText: data.statusText,
           })
+          recordBotVerb({
+            operation: "bot.invocation_steps",
+            accessKind: "write",
+            outcome: "success",
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.({
             ok: true,
             data: { invocationId: result.invocationId, sessionId: result.sessionId, steps: result.steps },
           })
         } catch (err) {
+          recordBotVerb({
+            operation: "bot.invocation_steps",
+            accessKind: "write",
+            outcome: verbOutcome(err),
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.(toWriteErrorAck(err, { workspaceId, botId, event: "bot:invocation:steps" }))
         }
       }
@@ -473,11 +584,23 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
             callbackToken: data.callbackToken,
             steps: data.steps,
           })
+          recordBotVerb({
+            operation: "bot.invocation_sealed_steps",
+            accessKind: "write",
+            outcome: "success",
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.({
             ok: true,
             data: { invocationId: result.invocationId, sessionId: result.sessionId, steps: result.steps },
           })
         } catch (err) {
+          recordBotVerb({
+            operation: "bot.invocation_sealed_steps",
+            accessKind: "write",
+            outcome: verbOutcome(err),
+            subjects: [{ type: "bot_invocation", id: data.invocationId }],
+          })
           ack?.(toWriteErrorAck(err, { workspaceId, botId, event: "bot:invocation:sealed-steps" }))
         }
       }
@@ -488,6 +611,24 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
       if (joined) {
         botSocketRegistry.unregister({ workspaceId, botId, instanceId: joined.instanceId }, socket)
       }
+      const leftAt = new Date()
+      for (const subjects of auditSubscriptions) {
+        accessLogService.record({
+          workspaceId,
+          actorType: "bot",
+          actorId: botId,
+          authRef: sconnId,
+          operation: "socket.unsubscribe",
+          accessKind: "unsubscribe",
+          outcome: "success",
+          subjects,
+          detail: { keyId: auth.keyId },
+          occurredAt: leftAt,
+          ip,
+          userAgent,
+        })
+      }
+      auditSubscriptions.length = 0
     })
   })
 }

--- a/apps/backend/src/lib/socket-ip.ts
+++ b/apps/backend/src/lib/socket-ip.ts
@@ -1,0 +1,15 @@
+/**
+ * Real client IP for a socket.io handshake. `trust proxy` only rewrites
+ * `req.ip` for HTTP requests; the handshake object is not run through it, so
+ * the workspace-router's `X-Forwarded-For` (rewritten from `CF-Connecting-IP`)
+ * is read explicitly, falling back to the transport's remote address.
+ */
+export function socketHandshakeIp(handshake: {
+  headers: Record<string, string | string[] | undefined>
+  address: string
+}): string {
+  const forwarded = handshake.headers["x-forwarded-for"]
+  const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded
+  if (typeof raw === "string" && raw.length > 0) return raw.split(",")[0]!.trim()
+  return handshake.address
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -770,7 +770,14 @@ export async function startServer(): Promise<ServerInstance> {
   // Bot runtime namespace — runtimes authenticate with a `threa_bk_*` key and
   // get invocation pushes over WebSocket so they no longer poll the HTTP
   // claim endpoint every second.
-  attachBotNamespace({ io, botRuntimeService, botRuntimeWriteOps, botApiKeyService, botSocketRegistry })
+  attachBotNamespace({
+    io,
+    botRuntimeService,
+    botRuntimeWriteOps,
+    botApiKeyService,
+    botSocketRegistry,
+    accessLogService,
+  })
 
   registerSocketHandlers(io, {
     pool,
@@ -781,6 +788,7 @@ export async function startServer(): Promise<ServerInstance> {
     userSocketRegistry,
     sessionAbortRegistry,
     jobQueue,
+    accessLogService,
   })
 
   // Dedicated voice relay on its own namespace so audio frames don't share the

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -1,7 +1,10 @@
-import type { Server, Socket } from "socket.io"
+import type { Server, Socket, DefaultEventsMap } from "socket.io"
 import crypto from "crypto"
 import type { AuthService } from "@threa/backend-common"
 import { createSocketAuthMiddleware } from "./lib/socket-auth"
+import { socketConnectionId } from "./lib/id"
+import { socketHandshakeIp } from "./lib/socket-ip"
+import type { AccessLogService, AuditSubjectRef } from "./features/access-log"
 import { DEVICE_KEY_LENGTH, HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
 import type { StreamService } from "./features/streams"
 import type { PushService } from "./features/push"
@@ -46,9 +49,33 @@ function isJoinAccessError(error: unknown): boolean {
   return error instanceof HttpError && (error.status === 403 || error.status === 404)
 }
 
+/**
+ * Typed `socket.data` for the main namespace. `workosUserId` is stamped by the
+ * shared auth middleware (`lib/socket-auth`); `sconnId` is minted at connect and
+ * is the access-log `auth_ref` correlating a connection's subscribe/unsubscribe
+ * rows; `userId` (`usr_`) is stamped at the first room join that resolves the
+ * workspace user.
+ */
+export interface MainSocketData {
+  workosUserId: string
+  userId?: string
+  sconnId: string
+}
+
+type MainSocket = Socket<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, MainSocketData>
+
+interface JoinedRoomAudit {
+  workspaceId: string
+  roomPattern: string
+  /** Actor for the paired unsubscribe row — the workspace user resolved at join. */
+  actorUserId: string
+  /** Subject refs recorded on subscribe; the unsubscribe row reuses them so the interval pairs. */
+  subjects: AuditSubjectRef[]
+}
+
 interface SocketMetricsState {
   connectTime: bigint
-  joinedRooms: Map<string, { workspaceId: string; roomPattern: string }>
+  joinedRooms: Map<string, JoinedRoomAudit>
 }
 
 interface Dependencies {
@@ -62,6 +89,7 @@ interface Dependencies {
   sessionAbortRegistry: SessionAbortRegistry
   /** For fanning viewport-nudge frames into visible-refresh jobs. */
   jobQueue: Pick<QueueManager, "send">
+  accessLogService: AccessLogService
 }
 
 /**
@@ -84,15 +112,76 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
     userSocketRegistry,
     sessionAbortRegistry,
     jobQueue,
+    accessLogService,
   } = deps
 
   // Auth middleware is shared with the voice namespace — see lib/socket-auth
   io.use(createSocketAuthMiddleware(authService))
 
-  io.on("connection", (socket) => {
+  io.on("connection", (socket: MainSocket) => {
     const workosUserId = socket.data.workosUserId
+    const sconnId = socketConnectionId()
+    socket.data.sconnId = sconnId
+    const ip = socketHandshakeIp(socket.handshake)
+    const userAgent = socket.handshake.headers["user-agent"] ?? null
     userSocketRegistry.register(workosUserId, socket)
     logger.debug({ workosUserId, socketId: socket.id }, "Socket connected")
+
+    const recordSubscribe = (params: {
+      workspaceId: string
+      actorUserId: string
+      subjects: AuditSubjectRef[]
+      outcome: "success" | "denied" | "error"
+    }): void => {
+      accessLogService.record({
+        workspaceId: params.workspaceId,
+        actorType: "user",
+        actorId: params.actorUserId,
+        authRef: sconnId,
+        operation: "socket.subscribe",
+        accessKind: "subscribe",
+        outcome: params.outcome,
+        subjects: params.subjects,
+        // Stamped at the join instant, not at insert time — the fire-and-forget
+        // insert lag would otherwise shrink the interval and exclude events
+        // delivered while the row was in flight (under-approximation is the
+        // wrong direction for breach scoping).
+        occurredAt: new Date(),
+        ip,
+        userAgent,
+      })
+    }
+
+    const recordUnsubscribe = (entry: JoinedRoomAudit): void => {
+      accessLogService.record({
+        workspaceId: entry.workspaceId,
+        actorType: "user",
+        actorId: entry.actorUserId,
+        authRef: sconnId,
+        operation: "socket.unsubscribe",
+        accessKind: "unsubscribe",
+        outcome: "success",
+        subjects: entry.subjects,
+        occurredAt: new Date(),
+        ip,
+        userAgent,
+      })
+    }
+
+    // Re-joining an already-open room (permission heal, redundant client join)
+    // must not open a second interval — the original subscribe row still pairs
+    // with the eventual unsubscribe.
+    const trackJoin = (room: string, entry: JoinedRoomAudit): void => {
+      const rejoin = metricsState.joinedRooms.has(room)
+      metricsState.joinedRooms.set(room, entry)
+      if (rejoin) return
+      recordSubscribe({
+        workspaceId: entry.workspaceId,
+        actorUserId: entry.actorUserId,
+        subjects: entry.subjects,
+        outcome: "success",
+      })
+    }
 
     const metricsState: SocketMetricsState = {
       connectTime: process.hrtime.bigint(),
@@ -123,6 +212,14 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
     }
 
     socket.on("join", async (room: string, callback?: (result: { ok: boolean; error?: string }) => void) => {
+      // Room names must be id-shaped: their segments land in audit subjects,
+      // the workspace_id column, and metrics labels. An attacker-controlled
+      // free-text segment must never reach the content-free access log
+      // (design §5), so garbage rooms are rejected before anything records.
+      if (typeof room !== "string" || !/^[A-Za-z0-9:_-]{1,256}$/.test(room)) {
+        callback?.({ ok: false, error: "Invalid room" })
+        return
+      }
       const workspaceId = extractWorkspaceId(room)
       const roomPattern = normalizeRoomPattern(room)
       wsMessagesTotal.inc({
@@ -138,6 +235,16 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         const wsId = workspaceMatch[1]
         const workspaceUser = await UserRepository.findByWorkosUserIdInWorkspace(pool, wsId, workosUserId)
         if (!workspaceUser) {
+          // Authenticated non-member: a cross-workspace probe. Log the denial
+          // (attempted access is a first-class event, design §2) with the WorkOS
+          // user id as actor — no workspace user resolves here, mirroring the HTTP
+          // boundary's authUser fallback.
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workosUserId,
+            subjects: [{ type: "workspace", id: wsId }],
+            outcome: "denied",
+          })
           socket.emit("error", { message: "Not authorized to join this workspace" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Not authorized to join this workspace" })
@@ -165,6 +272,7 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         for (const permissionRoom of permissionRooms) {
           socket.join(permissionRoom)
         }
+        socket.data.userId ??= workspaceUser.id
         const roomEntry = { userId: workspaceUser.id, userRoom, permissionRooms, appliedTimezone: null }
         userRooms.set(wsId, roomEntry)
         syncDeviceTimezone(wsId, roomEntry)
@@ -180,7 +288,13 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         }
 
         wsConnectionsActive.inc({ workspace_id: wsId, room_pattern: roomPattern })
-        metricsState.joinedRooms.set(room, { workspaceId: wsId, roomPattern })
+        const wsSubjects: AuditSubjectRef[] = [{ type: "workspace", id: wsId }]
+        trackJoin(room, {
+          workspaceId: wsId,
+          roomPattern,
+          actorUserId: workspaceUser.id,
+          subjects: wsSubjects,
+        })
 
         logger.debug({ workosUserId, room, userRoom }, "Joined workspace room")
         callback?.({ ok: true })
@@ -193,17 +307,34 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         const [, wsId, streamId] = streamMatch
         const workspaceUser = await UserRepository.findByWorkosUserIdInWorkspace(pool, wsId, workosUserId)
         if (!workspaceUser) {
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workosUserId,
+            subjects: [{ type: "stream", id: streamId }],
+            outcome: "denied",
+          })
           socket.emit("error", { message: "Not authorized to join this stream" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Not authorized to join this stream" })
           return
         }
+        socket.data.userId ??= workspaceUser.id
+        const streamSubjects: AuditSubjectRef[] = [{ type: "stream", id: streamId }]
         try {
           await streamService.validateStreamAccess(streamId, wsId, workspaceUser.id)
         } catch (error) {
-          if (!isJoinAccessError(error)) {
+          // An access denial (403/404) is `denied`; any other throw is an
+          // unexpected service failure — record it as `error`, not a false denial.
+          const accessDenied = isJoinAccessError(error)
+          if (!accessDenied) {
             logger.error({ error, workosUserId, room, wsId, streamId }, "Unexpected error during stream room join")
           }
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workspaceUser.id,
+            subjects: streamSubjects,
+            outcome: accessDenied ? "denied" : "error",
+          })
           socket.emit("error", { message: "Not authorized to join this stream" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Not authorized to join this stream" })
@@ -212,7 +343,12 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         socket.join(room)
 
         wsConnectionsActive.inc({ workspace_id: wsId, room_pattern: roomPattern })
-        metricsState.joinedRooms.set(room, { workspaceId: wsId, roomPattern })
+        trackJoin(room, {
+          workspaceId: wsId,
+          roomPattern,
+          actorUserId: workspaceUser.id,
+          subjects: streamSubjects,
+        })
 
         logger.debug({ workosUserId, room }, "Joined stream room")
         callback?.({ ok: true })
@@ -240,6 +376,12 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         const [, wsId, agentSessionId] = sessionMatch
         const session = await AgentSessionRepository.findById(pool, agentSessionId)
         if (!session) {
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workosUserId,
+            subjects: [{ type: "agent_session", id: agentSessionId }],
+            outcome: "denied",
+          })
           socket.emit("error", { message: "Session not found" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Session not found" })
@@ -247,20 +389,40 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         }
         const workspaceUser = await UserRepository.findByWorkosUserIdInWorkspace(pool, wsId, workosUserId)
         if (!workspaceUser) {
+          // The session was fetched globally by id and its workspace is
+          // unproven here — recording its streamId would leak a foreign
+          // workspace's identifier into the probed workspace's audit rows.
+          // Denied rows carry only the session id the prober supplied.
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workosUserId,
+            subjects: [{ type: "agent_session", id: agentSessionId }],
+            outcome: "denied",
+          })
           socket.emit("error", { message: "Not authorized to join this session" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Not authorized to join this session" })
           return
         }
+        socket.data.userId ??= workspaceUser.id
         try {
           await streamService.validateStreamAccess(session.streamId, wsId, workspaceUser.id)
         } catch (error) {
-          if (!isJoinAccessError(error)) {
+          const accessDenied = isJoinAccessError(error)
+          if (!accessDenied) {
             logger.error(
               { error, workosUserId, room, wsId, streamId: session.streamId },
               "Unexpected error during agent session room join"
             )
           }
+          // Same rule as above: validation failed, so the session's stream is
+          // not proven to belong to wsId — no stream ref on the denial row.
+          recordSubscribe({
+            workspaceId: wsId,
+            actorUserId: workspaceUser.id,
+            subjects: [{ type: "agent_session", id: agentSessionId }],
+            outcome: accessDenied ? "denied" : "error",
+          })
           socket.emit("error", { message: "Not authorized to join this session" })
           wsMessagesTotal.inc({ workspace_id: wsId, direction: "sent", event_type: "error", room_pattern: roomPattern })
           callback?.({ ok: false, error: "Not authorized to join this session" })
@@ -268,7 +430,17 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         }
         socket.join(room)
         wsConnectionsActive.inc({ workspace_id: wsId, room_pattern: roomPattern })
-        metricsState.joinedRooms.set(room, { workspaceId: wsId, roomPattern })
+        // Validation proved the session's stream belongs to wsId — the stream
+        // ref is safe to record from here on.
+        trackJoin(room, {
+          workspaceId: wsId,
+          roomPattern,
+          actorUserId: workspaceUser.id,
+          subjects: [
+            { type: "agent_session", id: agentSessionId },
+            { type: "stream", id: session.streamId },
+          ],
+        })
         logger.debug({ workosUserId, room }, "Joined agent session room")
         callback?.({ ok: true })
         return
@@ -314,6 +486,7 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
       const roomInfo = metricsState.joinedRooms.get(room)
       if (roomInfo) {
         wsConnectionsActive.dec({ workspace_id: roomInfo.workspaceId, room_pattern: roomInfo.roomPattern })
+        recordUnsubscribe(roomInfo)
         metricsState.joinedRooms.delete(room)
       }
 
@@ -466,6 +639,7 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
 
       for (const [, roomInfo] of metricsState.joinedRooms) {
         wsConnectionsActive.dec({ workspace_id: roomInfo.workspaceId, room_pattern: roomInfo.roomPattern })
+        recordUnsubscribe(roomInfo)
         workspaceIds.add(roomInfo.workspaceId)
       }
 

--- a/apps/backend/tests/integration/access-log-socket.test.ts
+++ b/apps/backend/tests/integration/access-log-socket.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Socket capture integration (step 3): subscribe/unsubscribe rows on room
+ * join/leave/disconnect, denial capture, and delivered-set reconstruction.
+ * Boots the real server (setup.ts preload) and reads rows back from threa_test.
+ * Socket audit rows are fire-and-forget, so assertions poll for the row to land.
+ *
+ * Run: bun test --preload ./tests/setup.ts tests/integration/access-log-socket.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { io, Socket } from "socket.io-client"
+import { Pool } from "pg"
+import {
+  TestClient,
+  loginAs,
+  createWorkspace,
+  createChannel,
+  createScratchpad,
+  sendMessage,
+  getUserId,
+  joinRoom,
+} from "../client"
+import { AccessLogRepository } from "../../src/features/access-log"
+
+function getBaseUrl(): string {
+  return process.env.TEST_BASE_URL || "http://localhost:3001"
+}
+
+interface SubjectRef {
+  type: string
+  id?: string
+}
+
+interface AccessLogDbRow {
+  workspace_id: string | null
+  actor_type: string
+  actor_id: string
+  auth_ref: string | null
+  operation: string
+  access_kind: string
+  outcome: string
+  subjects: SubjectRef[] | null
+}
+
+function cookieHeader(client: TestClient): string {
+  const cookies = (client as unknown as { cookies?: Map<string, string> }).cookies
+  if (!cookies) return ""
+  return Array.from(cookies.entries())
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ")
+}
+
+function createSocket(client: TestClient): Socket {
+  return io(getBaseUrl(), {
+    extraHeaders: { Cookie: cookieHeader(client) },
+    transports: ["websocket"],
+    autoConnect: false,
+  })
+}
+
+function connectSocket(socket: Socket, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Socket connection timeout")), timeoutMs)
+    socket.on("connect", () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    socket.on("connect_error", (err) => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+    socket.connect()
+  })
+}
+
+const testRunId = Math.random().toString(36).slice(2, 8)
+const email = (name: string) => `${name}-${testRunId}@test.com`
+
+function hasStreamSubject(row: AccessLogDbRow, streamId: string): boolean {
+  return (row.subjects ?? []).some((s) => s.type === "stream" && s.id === streamId)
+}
+
+describe("access-log socket capture", () => {
+  let pool: Pool
+
+  beforeAll(() => {
+    pool = new Pool({
+      connectionString: process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test",
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function pollRows(
+    where: string,
+    params: unknown[],
+    predicate: (rows: AccessLogDbRow[]) => boolean = (rows) => rows.length > 0
+  ): Promise<AccessLogDbRow[]> {
+    for (let attempt = 0; attempt < 60; attempt++) {
+      const { rows } = await pool.query<AccessLogDbRow>(
+        `SELECT workspace_id, actor_type, actor_id, auth_ref, operation, access_kind, outcome, subjects
+         FROM access_log WHERE ${where} ORDER BY occurred_at DESC`,
+        params
+      )
+      if (predicate(rows)) return rows
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    return []
+  }
+
+  test("stream-room join records a subscribe row: sconn auth_ref, stream subject, usr_ actor", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("sub"), "Subscriber")
+    const ws = await createWorkspace(client, "Sub WS")
+    const stream = await createChannel(client, ws.id, `sub-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+
+    const socket = createSocket(client)
+    await connectSocket(socket)
+    await joinRoom(socket, `ws:${ws.id}:stream:${stream.id}`)
+
+    const rows = await pollRows(
+      "workspace_id = $1 AND operation = 'socket.subscribe' AND access_kind = 'subscribe' AND actor_id = $2 AND outcome = 'success'",
+      [ws.id, userId],
+      (rs) => rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+    const row = rows.find((r) => hasStreamSubject(r, stream.id))
+    expect(row).toBeDefined()
+    expect(row).toMatchObject({
+      workspace_id: ws.id,
+      actor_type: "user",
+      actor_id: userId,
+      operation: "socket.subscribe",
+      access_kind: "subscribe",
+      outcome: "success",
+    })
+    expect(row!.auth_ref?.startsWith("sconn_")).toBe(true)
+
+    socket.disconnect()
+  })
+
+  test("leaving a stream room records an unsubscribe row with the same sconn + subject", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("leave"), "Leaver")
+    const ws = await createWorkspace(client, "Leave WS")
+    const stream = await createChannel(client, ws.id, `leave-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+    const room = `ws:${ws.id}:stream:${stream.id}`
+
+    const socket = createSocket(client)
+    await connectSocket(socket)
+    await joinRoom(socket, room)
+
+    const subRows = await pollRows("operation = 'socket.subscribe' AND actor_id = $1", [userId], (rs) =>
+      rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+    const sconn = subRows.find((r) => hasStreamSubject(r, stream.id))!.auth_ref
+    expect(sconn?.startsWith("sconn_")).toBe(true)
+
+    socket.emit("leave", room)
+
+    const unsubRows = await pollRows(
+      "operation = 'socket.unsubscribe' AND actor_id = $1 AND auth_ref = $2",
+      [userId, sconn],
+      (rs) => rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+    const unsub = unsubRows.find((r) => hasStreamSubject(r, stream.id))
+    expect(unsub).toBeDefined()
+    expect(unsub).toMatchObject({
+      actor_id: userId,
+      access_kind: "unsubscribe",
+      outcome: "success",
+      auth_ref: sconn,
+    })
+
+    socket.disconnect()
+  })
+
+  test("disconnect records unsubscribe rows for still-joined rooms", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("disc"), "Disconnector")
+    const ws = await createWorkspace(client, "Disc WS")
+    const stream = await createChannel(client, ws.id, `disc-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+
+    const socket = createSocket(client)
+    await connectSocket(socket)
+    await joinRoom(socket, `ws:${ws.id}`)
+    await joinRoom(socket, `ws:${ws.id}:stream:${stream.id}`)
+
+    const subRows = await pollRows("operation = 'socket.subscribe' AND actor_id = $1", [userId], (rs) =>
+      rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+    const sconn = subRows.find((r) => hasStreamSubject(r, stream.id))!.auth_ref
+
+    socket.disconnect()
+
+    // One unsubscribe per joined room (workspace + stream) for this connection.
+    const unsubRows = await pollRows(
+      "operation = 'socket.unsubscribe' AND auth_ref = $1",
+      [sconn],
+      (rs) => rs.length >= 2
+    )
+    expect(unsubRows.some((r) => hasStreamSubject(r, stream.id))).toBe(true)
+    expect(unsubRows.some((r) => (r.subjects ?? []).some((s) => s.type === "workspace" && s.id === ws.id))).toBe(true)
+  })
+
+  test("denied join (stream in another workspace) records a denied subscribe row", async () => {
+    const clientA = new TestClient()
+    const userA = await loginAs(clientA, email("owner"), "Owner A")
+    const wsA = await createWorkspace(clientA, "Owner A WS")
+    const privateStream = await createScratchpad(clientA, wsA.id)
+
+    const clientB = new TestClient()
+    const userB = await loginAs(clientB, email("intruder"), "Intruder B")
+    const wsB = await createWorkspace(clientB, "Intruder B WS")
+    const userBId = await getUserId(clientB, wsB.id, userB.id)
+
+    const socket = createSocket(clientB)
+    await connectSocket(socket)
+    // B tries to join A's private stream under B's own workspace id → the
+    // handler resolves B in wsB, then validateStreamAccess 404s (stream not in
+    // wsB) → a denied subscribe row with the attempted stream subject.
+    await joinRoom(socket, `ws:${wsB.id}:stream:${privateStream.id}`).catch(() => {})
+
+    const rows = await pollRows(
+      "operation = 'socket.subscribe' AND access_kind = 'subscribe' AND outcome = 'denied' AND actor_id = $1",
+      [userBId],
+      (rs) => rs.some((r) => hasStreamSubject(r, privateStream.id))
+    )
+    const denied = rows.find((r) => hasStreamSubject(r, privateStream.id))
+    expect(denied).toBeDefined()
+    expect(denied).toMatchObject({
+      workspace_id: wsB.id,
+      actor_type: "user",
+      actor_id: userBId,
+      access_kind: "subscribe",
+      outcome: "denied",
+    })
+    expect(denied!.auth_ref?.startsWith("sconn_")).toBe(true)
+
+    void userA
+    socket.disconnect()
+  })
+
+  test("joining a workspace room you are not a member of records a denied subscribe row", async () => {
+    const clientA = new TestClient()
+    await loginAs(clientA, email("member-a"), "Member A")
+    const wsA = await createWorkspace(clientA, "Member A WS")
+
+    const clientB = new TestClient()
+    const userB = await loginAs(clientB, email("nonmember"), "Non Member")
+    await createWorkspace(clientB, "Non Member WS")
+
+    const socket = createSocket(clientB)
+    await connectSocket(socket)
+    // B is authenticated but not a member of wsA → the workspace-room join is a
+    // cross-workspace probe. Actor is B's WorkOS user id (no wsA user resolves).
+    await joinRoom(socket, `ws:${wsA.id}`).catch(() => {})
+
+    const rows = await pollRows(
+      "workspace_id = $1 AND operation = 'socket.subscribe' AND outcome = 'denied' AND actor_id = $2",
+      [wsA.id, userB.id],
+      (rs) => rs.some((r) => (r.subjects ?? []).some((s) => s.type === "workspace" && s.id === wsA.id))
+    )
+    const denied = rows.find((r) => (r.subjects ?? []).some((s) => s.type === "workspace" && s.id === wsA.id))
+    expect(denied).toBeDefined()
+    expect(denied).toMatchObject({
+      actor_type: "user",
+      actor_id: userB.id,
+      access_kind: "subscribe",
+      outcome: "denied",
+    })
+    expect(denied!.auth_ref?.startsWith("sconn_")).toBe(true)
+
+    socket.disconnect()
+  })
+
+  test("reconstructDeliveredEvents returns exactly the in-interval events for the subscriber", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("recon"), "Reconstructor")
+    const ws = await createWorkspace(client, "Recon WS")
+    const stream = await createChannel(client, ws.id, `recon-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+    const room = `ws:${ws.id}:stream:${stream.id}`
+
+    const socket = createSocket(client)
+    await connectSocket(socket)
+    await joinRoom(socket, room)
+
+    // Wait for the subscribe row so its occurred_at precedes the in-window
+    // messages (record() is fire-and-forget after the join ack).
+    await pollRows("operation = 'socket.subscribe' AND actor_id = $1", [userId], (rs) =>
+      rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+
+    const inWindow = 3
+    for (let i = 0; i < inWindow; i++) {
+      await sendMessage(client, ws.id, stream.id, `in-window ${i}`)
+    }
+
+    socket.emit("leave", room)
+    // Wait for the unsubscribe row to close the interval before sending the
+    // out-of-window messages, so their created_at is strictly after it.
+    await pollRows("operation = 'socket.unsubscribe' AND actor_id = $1", [userId], (rs) =>
+      rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+
+    for (let i = 0; i < 2; i++) {
+      await sendMessage(client, ws.id, stream.id, `out-of-window ${i}`)
+    }
+    socket.disconnect()
+
+    const delivered = await AccessLogRepository.reconstructDeliveredEvents(pool, {
+      // Pad disabled: these tests assert exact interval semantics; the skew pad
+      // has its own dedicated test below.
+      clockSkewToleranceMs: 0,
+      workspaceId: ws.id,
+      streamId: stream.id,
+      from: new Date(0),
+      to: new Date(Date.now() + 60_000),
+    })
+
+    const messageEvents = delivered.filter((e) => e.eventType === "message_created")
+    expect(messageEvents.length).toBe(inWindow)
+    expect(messageEvents.every((e) => e.actorId === userId)).toBe(true)
+    expect(messageEvents.every((e) => e.authRef?.startsWith("sconn_"))).toBe(true)
+    expect(messageEvents.every((e) => typeof e.sequence === "number")).toBe(true)
+  })
+
+  test("reconstructDeliveredEvents keeps one row per connection for the same user (two devices = two deliveries)", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("multitab"), "MultiTab")
+    const ws = await createWorkspace(client, "MultiTab WS")
+    const stream = await createChannel(client, ws.id, `multitab-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+    const room = `ws:${ws.id}:stream:${stream.id}`
+
+    const socketA = createSocket(client)
+    const socketB = createSocket(client)
+    await connectSocket(socketA)
+    await connectSocket(socketB)
+    await joinRoom(socketA, room)
+    await joinRoom(socketB, room)
+    await pollRows("operation = 'socket.subscribe' AND actor_id = $1", [userId], (rs) => {
+      const refs = rs.filter((r) => hasStreamSubject(r, stream.id))
+      return new Set(refs.map((r) => r.auth_ref)).size >= 2
+    })
+
+    await sendMessage(client, ws.id, stream.id, "delivered to both connections")
+    socketA.disconnect()
+    socketB.disconnect()
+
+    const delivered = await AccessLogRepository.reconstructDeliveredEvents(pool, {
+      // Pad disabled: these tests assert exact interval semantics; the skew pad
+      // has its own dedicated test below.
+      clockSkewToleranceMs: 0,
+      workspaceId: ws.id,
+      streamId: stream.id,
+      from: new Date(0),
+      to: new Date(Date.now() + 60_000),
+    })
+
+    const messageEvents = delivered.filter((e) => e.eventType === "message_created")
+    // "From where" matters: both connections received the event, so both
+    // appear — deduped per connection, never collapsed per actor.
+    expect(messageEvents.length).toBe(2)
+    expect(new Set(messageEvents.map((e) => e.authRef)).size).toBe(2)
+    expect(messageEvents.every((e) => e.actorId === userId)).toBe(true)
+  })
+
+  test("clock-skew pad widens interval edges (default) and can be disabled for exact semantics", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("skew"), "Skewed")
+    const ws = await createWorkspace(client, "Skew WS")
+    const stream = await createChannel(client, ws.id, `skew-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+
+    await sendMessage(client, ws.id, stream.id, "sent just before a late-stamped subscribe")
+
+    // A subscribe row app-clock stamped ~2s AFTER the message landed — the
+    // shape a slightly-ahead app clock produces at a real join.
+    const lateStart = new Date(Date.now() + 2_000)
+    await AccessLogRepository.insert(pool, {
+      id: `acc_skew_${testRunId}`,
+      workspaceId: ws.id,
+      occurredAt: lateStart,
+      actorType: "user",
+      actorId: userId,
+      authRef: `sconn_skew_${testRunId}`,
+      operation: "socket.subscribe",
+      accessKind: "subscribe",
+      outcome: "success",
+      subjects: [{ type: "stream", id: stream.id }],
+    })
+
+    const base = {
+      workspaceId: ws.id,
+      streamId: stream.id,
+      from: new Date(0),
+      to: new Date(Date.now() + 60_000),
+    }
+    const padded = await AccessLogRepository.reconstructDeliveredEvents(pool, base)
+    const exact = await AccessLogRepository.reconstructDeliveredEvents(pool, { ...base, clockSkewToleranceMs: 0 })
+
+    const paddedForConn = padded.filter((e) => e.authRef === `sconn_skew_${testRunId}`)
+    const exactForConn = exact.filter((e) => e.authRef === `sconn_skew_${testRunId}`)
+    expect(paddedForConn.some((e) => e.eventType === "message_created")).toBe(true)
+    expect(exactForConn.some((e) => e.eventType === "message_created")).toBe(false)
+  })
+
+  test("reconstructDeliveredEvents ignores an agent-session unsubscribe on the same connection", async () => {
+    // An agent-session-room subscription carries both {agent_session} and
+    // {stream} subjects (socket.ts join site). Leaving the agent-session room
+    // while staying in the stream room must NOT close the stream-room interval:
+    // events delivered after that leave were still received (§3 "never claim
+    // less"). Rows are seeded directly — an agent_session room join needs a live
+    // session; the SQL pairing is what this exercises.
+    const wsId = `workspace_recon_${testRunId}`
+    const streamId = `stream_recon_${testRunId}`
+    const sconn = `sconn_recon_${testRunId}`
+    const userId = `usr_recon_${testRunId}`
+    const sessionId = `agsess_recon_${testRunId}`
+    // Anchor mid-current-UTC-month so the seeded rows always land in a live
+    // partition (the migration seeds current + next month); a fixed calendar
+    // date would fail once retention drops that month's partition.
+    const nowUtc = new Date()
+    const base = Date.UTC(nowUtc.getUTCFullYear(), nowUtc.getUTCMonth(), 15, 10, 0, 0)
+    const at = (offsetMs: number) => new Date(base + offsetMs).toISOString()
+
+    await pool.query(`DELETE FROM access_log WHERE workspace_id = $1`, [wsId])
+    await pool.query(`DELETE FROM stream_events WHERE stream_id = $1`, [streamId])
+
+    const insertAccess = (kind: string, subjects: unknown[], occurredAt: string) =>
+      pool.query(
+        `INSERT INTO access_log (id, workspace_id, occurred_at, actor_type, actor_id, auth_ref, operation, access_kind, outcome, subjects)
+         VALUES ($1,$2,$3,'user',$4,$5,$6,$7,'success',$8::jsonb)`,
+        [
+          `acc_${Math.random().toString(36).slice(2)}`,
+          wsId,
+          occurredAt,
+          userId,
+          sconn,
+          kind === "subscribe" ? "socket.subscribe" : "socket.unsubscribe",
+          kind,
+          JSON.stringify(subjects),
+        ]
+      )
+    const insertEvent = (seq: number, createdAt: string) =>
+      pool.query(
+        `INSERT INTO stream_events (id, stream_id, sequence, event_type, actor_id, actor_type, payload, created_at)
+         VALUES ($1,$2,$3,'message_created',$4,'user','{}'::jsonb,$5)`,
+        [`evt_${Math.random().toString(36).slice(2)}`, streamId, seq, userId, createdAt]
+      )
+
+    await insertAccess("subscribe", [{ type: "stream", id: streamId }], at(0))
+    await insertAccess(
+      "subscribe",
+      [
+        { type: "agent_session", id: sessionId },
+        { type: "stream", id: streamId },
+      ],
+      at(1000)
+    )
+    await insertEvent(1, at(1500))
+    await insertAccess(
+      "unsubscribe",
+      [
+        { type: "agent_session", id: sessionId },
+        { type: "stream", id: streamId },
+      ],
+      at(2000)
+    )
+    await insertEvent(2, at(3000))
+    await insertAccess("unsubscribe", [{ type: "stream", id: streamId }], at(4000))
+
+    const delivered = await AccessLogRepository.reconstructDeliveredEvents(pool, {
+      // Pad disabled: these tests assert exact interval semantics; the skew pad
+      // has its own dedicated test below.
+      clockSkewToleranceMs: 0,
+      workspaceId: wsId,
+      streamId,
+      from: new Date(base - 60_000),
+      to: new Date(base + 60_000),
+    })
+
+    const seqs = delivered
+      .filter((e) => e.eventType === "message_created")
+      .map((e) => e.sequence)
+      .sort((a, b) => a - b)
+    expect(seqs).toEqual([1, 2])
+
+    await pool.query(`DELETE FROM access_log WHERE workspace_id = $1`, [wsId])
+    await pool.query(`DELETE FROM stream_events WHERE stream_id = $1`, [streamId])
+  })
+
+  test("reconstructDeliveredEvents treats an unclosed interval as open-ended", async () => {
+    const client = new TestClient()
+    const user = await loginAs(client, email("open"), "Open Interval")
+    const ws = await createWorkspace(client, "Open WS")
+    const stream = await createChannel(client, ws.id, `open-${testRunId}`, "private")
+    const userId = await getUserId(client, ws.id, user.id)
+
+    const socket = createSocket(client)
+    await connectSocket(socket)
+    await joinRoom(socket, `ws:${ws.id}:stream:${stream.id}`)
+
+    await pollRows("operation = 'socket.subscribe' AND actor_id = $1", [userId], (rs) =>
+      rs.some((r) => hasStreamSubject(r, stream.id))
+    )
+
+    // No leave/disconnect: the interval stays open, so a later event is still
+    // attributed as delivered (over-approximation is the safe direction).
+    await sendMessage(client, ws.id, stream.id, "after open subscribe")
+
+    const delivered = await AccessLogRepository.reconstructDeliveredEvents(pool, {
+      // Pad disabled: these tests assert exact interval semantics; the skew pad
+      // has its own dedicated test below.
+      clockSkewToleranceMs: 0,
+      workspaceId: ws.id,
+      streamId: stream.id,
+      from: new Date(0),
+      to: new Date(Date.now() + 60_000),
+    })
+    const messageEvents = delivered.filter((e) => e.eventType === "message_created")
+    expect(messageEvents.length).toBe(1)
+    expect(messageEvents[0]!.actorId).toBe(userId)
+
+    socket.disconnect()
+  })
+})


### PR DESCRIPTION
Layer 3 of the read/access-logging stack (base: access-log-2-http). Socket delivery is derived, not materialized: subscription intervals x stream_events metadata instead of a row per event per member.

- sconn_ connection id minted at connect (the auth_ref pairing subscribe/unsubscribe rows); typed MainSocketData; usr_ stamped at first join; occurredAt stamped at the join instant so insert lag cannot shrink intervals; re-join of an open room does not open a duplicate interval
- subscribe rows on workspace/stream/agent-session joins; denied and early-rejected joins recorded (denied agent-session rows carry only the session ref — the session is fetched globally before workspace validation, so its streamId must not leak a foreign workspace id); unsubscribe rows on leave + disconnect via the joinedRooms map; room names id-shape-guarded so they cannot smuggle free text into the content-free log
- Bot /bot namespace: per-connection sconn_, detail.keyId (leaked-key forensics across rotations), room subscribe/unsubscribe rows AND the WS verb surface (bot:hello bootstrap read with invocation subjects, presence/renew/steps/sealed-steps writes with denied-vs-error outcomes) — the socket-borne twins of the annotated REST routes
- shared socketHandshakeIp helper (trust proxy does not cover handshakes)
- Layer 1 reconstructDeliveredEvents gets its tests here: per-connection DISTINCT ON (two devices = two deliveries), open-interval over-approximation, agent-session two-subject exclusion, clock-skew pad (default 5s edge widening; a 2s-late-stamped subscribe still captures)

Tests: bot socket-handler unit (21), socket capture integration (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787036621&installation_id=129946197&pr_number=1405&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1405&signature=1a85a5bf32f9406e31ee013ab8094e5cc0ba87d2b9b9eb7138638e9d661e016f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->