### PR TITLE
feat: installations list UI for multi-install GitHub settings

### DIFF
--- a/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
@@ -108,6 +108,50 @@ describe("IntegrationsTab GitHub installations", () => {
     expect(await screen.findByRole("link", { name: /add organization or account/i })).toBeInTheDocument()
   })
 
+  it("renders a failed disconnect inside the row that was acted on", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [
+        githubInstall({ id: "wsint_org", accountLogin: "acme" }),
+        githubInstall({ id: "wsint_user", accountLogin: "kris", accountType: "User" }),
+      ],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+    vi.spyOn(integrationsApi, "disconnectGithub").mockRejectedValue(new Error("GitHub said no"))
+    const user = userEvent.setup()
+
+    renderTab(queryClient)
+
+    const secondRow = (await screen.findByText("kris")).closest("div.rounded-md") as HTMLElement
+    await user.click(within(secondRow).getByRole("button", { name: /disconnect/i }))
+
+    await waitFor(() => expect(within(secondRow).getByText("GitHub said no")).toBeInTheDocument())
+    const firstRow = screen.getByText("acme").closest("div.rounded-md") as HTMLElement
+    expect(within(firstRow).queryByText("GitHub said no")).not.toBeInTheDocument()
+  })
+
+  it("offers Reconnect on an errored installation", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [
+        githubInstall({ id: "wsint_ok", accountLogin: "acme" }),
+        githubInstall({ id: "wsint_broken", accountLogin: "kris", accountType: "User", status: "error" }),
+      ],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    const brokenRow = (await screen.findByText("kris")).closest("div.rounded-md") as HTMLElement
+    expect(within(brokenRow).getByRole("link", { name: /reconnect/i })).toBeInTheDocument()
+    const healthyRow = screen.getByText("acme").closest("div.rounded-md") as HTMLElement
+    expect(within(healthyRow).queryByRole("link", { name: /reconnect/i })).not.toBeInTheDocument()
+  })
+
   it("keeps a single Connect button in the empty state", async () => {
     const queryClient = new QueryClient()
     seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  WORKSPACE_PERMISSION_SCOPES,
+  type GitHubWorkspaceIntegration,
+  type WorkspaceBootstrap,
+  type WorkspacePermissionSlug,
+} from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { integrationsApi } from "@/api/integrations"
+import { IntegrationsTab } from "./integrations-tab"
+
+function seedBootstrap(queryClient: QueryClient, viewerPermissions: WorkspacePermissionSlug[]) {
+  queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+    viewerPermissions,
+  } as unknown as WorkspaceBootstrap)
+}
+
+function githubInstall(overrides: Partial<GitHubWorkspaceIntegration>): GitHubWorkspaceIntegration {
+  return {
+    id: "wsint_1",
+    workspaceId: "ws_1",
+    provider: "github",
+    status: "active",
+    installedBy: "usr_1",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    accountLogin: "acme",
+    installationId: "111",
+    accountType: "Organization",
+    repositorySelection: "all",
+    permissions: {},
+    repositories: [],
+    rateLimit: { remaining: null, resetAt: null },
+    ...overrides,
+  }
+}
+
+function renderTab(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntegrationsTab workspaceId="ws_1" />
+    </QueryClientProvider>
+  )
+}
+
+describe("IntegrationsTab GitHub installations", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders one row per installation", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [
+        githubInstall({ id: "wsint_org", accountLogin: "acme", accountType: "Organization" }),
+        githubInstall({ id: "wsint_user", accountLogin: "kris", accountType: "User" }),
+      ],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    expect(await screen.findByText("acme")).toBeInTheDocument()
+    expect(screen.getByText("kris")).toBeInTheDocument()
+    expect(screen.getByText("Personal")).toBeInTheDocument()
+    expect(screen.getByText("Organization")).toBeInTheDocument()
+  })
+
+  it("disconnects the row whose button was clicked, by its own id", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [
+        githubInstall({ id: "wsint_org", accountLogin: "acme" }),
+        githubInstall({ id: "wsint_user", accountLogin: "kris", accountType: "User" }),
+      ],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+    const disconnect = vi.spyOn(integrationsApi, "disconnectGithub").mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    renderTab(queryClient)
+
+    const secondRow = (await screen.findByText("kris")).closest("div.rounded-md") as HTMLElement
+    await user.click(within(secondRow).getByRole("button", { name: /disconnect/i }))
+
+    await waitFor(() => expect(disconnect).toHaveBeenCalledWith("ws_1", "wsint_user"))
+    expect(disconnect).not.toHaveBeenCalledWith("ws_1", "wsint_org")
+  })
+
+  it("shows the add-installation button when installs already exist", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [githubInstall({ id: "wsint_org", accountLogin: "acme" })],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    expect(await screen.findByRole("link", { name: /add organization or account/i })).toBeInTheDocument()
+  })
+
+  it("keeps a single Connect button in the empty state", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({ configured: true, integrations: [] })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    expect(await screen.findByRole("link", { name: /connect github/i })).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /add organization or account/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Github, ExternalLink, RefreshCw, Plus } from "lucide-react"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
@@ -39,17 +40,36 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
     enabled: canManage,
   })
 
+  // Sync/disconnect failures render inside the row that was acted on — with N
+  // installation rows, a section-level error can sit off-screen and a failed
+  // disconnect would read as a silent no-op.
+  const [actionError, setActionError] = useState<{ integrationId: string; message: string } | null>(null)
+
   const disconnectMutation = useMutation({
     mutationFn: (integrationId: string) => integrationsApi.disconnectGithub(workspaceId, integrationId),
+    onMutate: () => setActionError(null),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workspace-integrations", workspaceId, "github"] })
+    },
+    onError: (error, integrationId) => {
+      setActionError({
+        integrationId,
+        message: error instanceof Error ? error.message : "Failed to disconnect GitHub.",
+      })
     },
   })
 
   const syncMutation = useMutation({
     mutationFn: (integrationId: string) => integrationsApi.syncGithub(workspaceId, integrationId),
+    onMutate: () => setActionError(null),
     onSuccess: (data) => {
       queryClient.setQueryData(["workspace-integrations", workspaceId, "github"], data)
+    },
+    onError: (error, integrationId) => {
+      setActionError({
+        integrationId,
+        message: error instanceof Error ? error.message : "Failed to sync GitHub repositories.",
+      })
     },
   })
 
@@ -129,8 +149,10 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
 
               return (
                 <div key={installation.id} className="rounded-md border border-border p-3 space-y-3">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium">{installation.accountLogin ?? "GitHub installation"}</span>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="min-w-0 max-w-full truncate text-sm font-medium">
+                      {installation.accountLogin ?? "GitHub installation"}
+                    </span>
                     <Badge variant="secondary">
                       {installation.accountType === "User" ? "Personal" : "Organization"}
                     </Badge>
@@ -187,6 +209,14 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
                         {syncPending ? "Syncing\u2026" : "Sync repos"}
                       </Button>
                     )}
+                    {installation.status === "error" && (
+                      <Button variant="outline" size="sm" asChild>
+                        <a href={`/api/workspaces/${workspaceId}/integrations/github/connect`}>
+                          <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                          Reconnect
+                        </a>
+                      </Button>
+                    )}
                     <Button
                       variant="ghost"
                       size="sm"
@@ -196,6 +226,10 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
                       {disconnectPending ? "Disconnecting\u2026" : "Disconnect"}
                     </Button>
                   </div>
+
+                  {actionError?.integrationId === installation.id && (
+                    <p className="text-sm text-destructive">{actionError.message}</p>
+                  )}
                 </div>
               )
             })}
@@ -209,23 +243,9 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
           </div>
         )}
 
-        {syncMutation.error && (
-          <p className="mt-2 text-sm text-destructive">
-            {syncMutation.error instanceof Error ? syncMutation.error.message : "Failed to sync GitHub repositories."}
-          </p>
-        )}
-
         {query.error && (
           <p className="mt-2 text-sm text-destructive">
             {query.error instanceof Error ? query.error.message : "Failed to load integration status."}
-          </p>
-        )}
-
-        {disconnectMutation.error && (
-          <p className="mt-2 text-sm text-destructive">
-            {disconnectMutation.error instanceof Error
-              ? disconnectMutation.error.message
-              : "Failed to disconnect GitHub."}
           </p>
         )}
       </section>

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Github, ExternalLink, RefreshCw } from "lucide-react"
+import { Github, ExternalLink, RefreshCw, Plus } from "lucide-react"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { integrationsApi } from "@/api/integrations"
 import { Button } from "@/components/ui/button"
@@ -79,9 +79,7 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   }
 
   const configured = query.data?.configured ?? false
-  const integration = query.data?.integrations?.[0] ?? null
-  const repositories = integration?.repositories ?? []
-  const isActive = integration?.status === "active"
+  const installations = query.data?.integrations ?? []
 
   const linearConfigured = linearQuery.data?.configured ?? false
   const linearIntegration = linearQuery.data?.integration ?? null
@@ -93,16 +91,6 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
         <div className="flex items-center gap-2 mb-1">
           <Github className="h-4 w-4 text-foreground" />
           <h3 className="text-sm font-medium">GitHub</h3>
-          {isActive && (
-            <Badge variant="default" className="hover:bg-primary">
-              Connected
-            </Badge>
-          )}
-          {configured && !isActive && integration?.status === "error" && (
-            <Badge variant="destructive" className="hover:bg-destructive">
-              Error
-            </Badge>
-          )}
         </div>
         <p className="text-xs text-muted-foreground">
           Rich previews for pull requests, issues, commits, files, and comments.
@@ -114,77 +102,110 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
           </p>
         )}
 
-        {configured && isActive && (
-          <div className="mt-3 space-y-3">
-            {integration.accountLogin && (
-              <div>
-                <h4 className="text-xs font-medium text-muted-foreground">
-                  {integration.accountType === "User" ? "Account" : "Organization"}
-                </h4>
-                <p className="text-sm">{integration.accountLogin}</p>
-              </div>
-            )}
-
-            <div>
-              <h4 className="text-xs font-medium text-muted-foreground">Repository access</h4>
-              <p className="text-sm">
-                {integration.repositorySelection === "all" ? "All repositories" : "Selected repositories"}
-              </p>
+        {configured && installations.length === 0 && (
+          <>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Connect the Threa GitHub App to enable authenticated workspace previews.
+            </p>
+            <div className="mt-4">
+              <Button size="sm" asChild>
+                <a href={`/api/workspaces/${workspaceId}/integrations/github/connect`}>
+                  <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                  Connect GitHub
+                </a>
+              </Button>
             </div>
+          </>
+        )}
 
-            {repositories.length > 0 && (
-              <div>
-                <h4 className="text-xs font-medium text-muted-foreground">Repositories</h4>
-                <div className="mt-1 flex flex-wrap gap-1.5">
-                  {repositories.slice(0, 12).map((repository) => (
-                    <Badge key={repository.fullName} variant="outline" className="text-xs font-normal">
-                      {repository.fullName}
+        {configured && installations.length > 0 && (
+          <div className="mt-3 space-y-3">
+            {installations.map((installation) => {
+              const isActive = installation.status === "active"
+              const repositories = installation.repositories ?? []
+              const syncPending = syncMutation.isPending && syncMutation.variables === installation.id
+              const disconnectPending = disconnectMutation.isPending && disconnectMutation.variables === installation.id
+              const rateLimit = installation.rateLimit
+
+              return (
+                <div key={installation.id} className="rounded-md border border-border p-3 space-y-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{installation.accountLogin ?? "GitHub installation"}</span>
+                    <Badge variant="secondary">
+                      {installation.accountType === "User" ? "Personal" : "Organization"}
                     </Badge>
-                  ))}
-                  {repositories.length > 12 && (
-                    <span className="text-xs text-muted-foreground self-center">+{repositories.length - 12} more</span>
+                    {isActive && (
+                      <Badge variant="default" className="hover:bg-primary">
+                        Connected
+                      </Badge>
+                    )}
+                    {installation.status === "error" && (
+                      <Badge variant="destructive" className="hover:bg-destructive">
+                        Error
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div>
+                    <h4 className="text-xs font-medium text-muted-foreground">Repository access</h4>
+                    <p className="text-sm">
+                      {installation.repositorySelection === "all" ? "All repositories" : "Selected repositories"}
+                    </p>
+                  </div>
+
+                  {repositories.length > 0 && (
+                    <div>
+                      <h4 className="text-xs font-medium text-muted-foreground">Repositories</h4>
+                      <div className="mt-1 flex flex-wrap gap-1.5">
+                        {repositories.slice(0, 12).map((repository) => (
+                          <Badge key={repository.fullName} variant="outline" className="text-xs font-normal">
+                            {repository.fullName}
+                          </Badge>
+                        ))}
+                        {repositories.length > 12 && (
+                          <span className="text-xs text-muted-foreground self-center">
+                            +{repositories.length - 12} more
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   )}
+
+                  {rateLimit.remaining !== null && (
+                    <p className="text-xs text-muted-foreground">{rateLimit.remaining} API requests remaining</p>
+                  )}
+
+                  <div className="flex items-center gap-2">
+                    {isActive && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => syncMutation.mutate(installation.id)}
+                        disabled={syncPending}
+                      >
+                        <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${syncPending ? "animate-spin" : ""}`} />
+                        {syncPending ? "Syncing\u2026" : "Sync repos"}
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => disconnectMutation.mutate(installation.id)}
+                      disabled={disconnectPending}
+                    >
+                      {disconnectPending ? "Disconnecting\u2026" : "Disconnect"}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
+              )
+            })}
 
-        {configured && !isActive && (
-          <p className="mt-3 text-sm text-muted-foreground">
-            Connect the Threa GitHub App to enable authenticated workspace previews.
-          </p>
-        )}
-
-        {configured && (
-          <div className="mt-4 flex items-center gap-2">
-            <Button size="sm" asChild>
+            <Button size="sm" variant="outline" asChild>
               <a href={`/api/workspaces/${workspaceId}/integrations/github/connect`}>
-                <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
-                {isActive ? "Reconnect" : "Connect GitHub"}
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Add organization or account
               </a>
             </Button>
-            {isActive && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => integration && syncMutation.mutate(integration.id)}
-                disabled={syncMutation.isPending}
-              >
-                <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${syncMutation.isPending ? "animate-spin" : ""}`} />
-                {syncMutation.isPending ? "Syncing\u2026" : "Sync repos"}
-              </Button>
-            )}
-            {isActive && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => integration && disconnectMutation.mutate(integration.id)}
-                disabled={disconnectMutation.isPending}
-              >
-                {disconnectMutation.isPending ? "Disconnecting\u2026" : "Disconnect"}
-              </Button>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
Stacked on #1401 (owner-aware GitHub client routing) → #1400 (multi-install backend model). **Merge those first.** Top of the multi-install GitHub stack.

## Problem

`GET /integrations/github` now returns `{ configured, integrations: [...] }` — N rows, one per (workspace, provider, installation) after #1400. The settings GitHub section still rendered a single card off `integrations?.[0]`, the mechanical compile-green adaptation STEP A left in place. A workspace with a personal account plus an org (or two orgs) showed only the first install and could not sync or disconnect the rest.

## Solution

The GitHub section in `integrations-tab.tsx` becomes a per-installation list. Each row renders `accountLogin`, a `Personal`/`Organization` badge (`accountType === "User" ? "Personal" : "Organization"`), a `Connected`/`Error` status badge, the repository-access summary + repo chips (first 12, `+N more`), a rate-limit line when `rateLimit.remaining` is present, and per-row `Sync repos` / `Disconnect` buttons wired to the per-install endpoints via the row's own `installation.id`. An "Add organization or account" button (`Button asChild` → the connect redirect) stays visible alongside existing installs; the empty state keeps a single `Connect GitHub` button. Linear section untouched.

### How it works

- **Per-row pending, no extra state.** `syncPending`/`disconnectPending` derive from react-query's `mutation.isPending && mutation.variables === installation.id`, so only the acting row's button spins. Trade-off (accepted): two same-type mutations racing would drop the first row's spinner mid-flight — an edge case for admin-gated single actions.
- **Disconnected rows vanish** because the backend filters `INACTIVE` out of `listGithubInstallations`; the disconnect mutation invalidates the same query key (`["workspace-integrations", workspaceId, "github"]`) and the row is simply absent from the re-list. No client-side removal.
- **INV-63** — no `toast.success` on sync/disconnect; the list reflects the result. **INV-40** — connect/add are anchor links (`Button asChild`), sync/disconnect are `<button>`s. **INV-14** — `Badge` from `components/ui`. **INV-18** — the row is an inline `.map` closure, not a nested component definition. **INV-21** — badges/status render at fixed footprint, no layout shift.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/workspace-settings/integrations-tab.tsx` | GitHub section rewritten from single-card `integrations[0]` to an installations list: per-row account/badges/repos/rate-limit + per-install Sync/Disconnect keyed by `mutation.variables`; persistent "Add organization or account" button; empty-state Connect preserved. |
| `apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx` (new) | vitest component test mounting the real `IntegrationsTab` with `integrationsApi` scoped-spied (INV-48): two-install render (Personal/Organization badges), per-row disconnect targets its own id (`"wsint_user"`, not the org row), add button present with installs, empty state shows Connect and no add button. |

## Test plan

- [x] `bunx tsc --noEmit` (frontend) — clean
- [x] eslint — clean on both files
- [x] `integrations-tab.test.tsx` — 4 pass; suite `components/workspace-settings/` — 31 pass
- [x] Full frontend vitest — 4490 pass + 4 new. One pre-existing flake (`billing-timezone-section.test.tsx`) failed the first pass, passed on replay and 5/5 in isolation — cross-file contention, unrelated to this diff.

Pre-PR review (Opus implementer + 2 Opus xhigh verifiers): zero must-fix/should-fix. Three nits accepted as-is — pending keyed on `mutation.variables` (racing same-type mutations drop the first spinner); the connect URL string appears in two `<a href>`s (matches the file's existing precedent); the test scopes rows via `.closest("div.rounded-md")` (fails loudly if restyled).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
