### PR TITLE
feat(skills): /build-feature — stacked-PR feature-build workflow

### DIFF
--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: build-feature
+description: Build a planned feature as a stacked PR chain with per-chunk implement → adversarial-verify → fix loops and multi-model reviews. Use when asked to /build-feature, or to build out a ratified plan with the Opus implement + xhigh adversarial verify + code-review pipeline.
+---
+
+# Build a feature as a reviewed stacked-PR chain
+
+The working rhythm: every chunk is implemented by one agent, adversarially verified by a stronger-effort agent, fixed, PR'd, and machine-reviewed — then the whole stack gets a top-model pass and (optionally) a second-model external pass.
+
+## Preconditions
+
+- A ratified plan doc in `docs/plans/<feature>.md` containing a PR-stack breakdown. No plan → write one and get it ratified first; do not start building from a chat message.
+- Deferred items in the plan are binding: do not build them.
+
+## Per chunk (repeat until the stack is done)
+
+1. **Brief**: write the chunk's implementation brief to a scratchpad file — plan sections that bind, deliverables, neighbor files to imitate, enumerated tests, what NOT to build. Agents get the file path, not a pasted wall.
+2. **Implement**: one agent, Opus, effort `medium`, working directly in the branch's working tree (no commits).
+3. **Adversarially verify**: one agent, Opus, effort `xhigh`, structured findings output. It must not trust the implementer's report: it re-derives from the diff, walks the race/edge paths the plan names, and runs typecheck + the relevant test suites itself.
+4. **Fix**: the medium agent fixes blockers/majors; the xhigh agent re-checks the fix list. Loop until clean.
+5. **Stacked PR**: commit (use `/commit`), then `/gh-stack` + `/create-pr` — each chunk's branch based on the previous chunk's (first chunk on `origin/main`). If `gh stack` is unavailable, plain branches + `gh pr create --base <parent-branch>`, rebasing children as parents move.
+6. **Code review**: an Opus agent runs `/code-review` on the PR; confirmed findings get fixed and pushed before the next chunk starts.
+
+## After the last chunk
+
+7. **Whole-stack review**: the top model (Fable) adversarially reviews the entire stack diff (`git diff origin/main...<tip>`) — cross-PR seams, plan conformance, invariant sweep.
+8. **External second model** (optional, ask the user about quota): GPT-5.6 Sol via Pi — `pi --provider openai-codex --model gpt-5.6-sol -p --no-tools --no-session --thinking high "$(cat review-brief-with-diff)"`. Output buffers until the run completes; budget 10-25 min.
+9. Fold surviving findings, push, report per-PR links.
+
+## Gotchas (earned)
+
+- Workflow `args` must be real JSON values, not a stringified blob; briefs go in files.
+- Stacked PRs only run the main CI trio when targeting `main` — run `bun run test:unit` (and friends) locally before merging anything.
+- Merge order: squash-merging a base PR with `--delete-branch` auto-closes its children — rebase children onto `main` (dropping squashed commits with `--onto`) before merging down the stack.
+- Pre-commit runs full monorepo lint+typecheck: give commit commands a generous timeout, and fresh worktrees need `bun install` first.


### PR DESCRIPTION
## Problem

The plan → chunk → implement → adversarially verify → fix → stacked PR → code-review working rhythm has now been dictated by hand for the third time (delegations overnight run, the calls build). It lives in chat messages, so every session re-types it and drifts.

## Solution

One skill file, `.agents/skills/build-feature/SKILL.md`, invocable as `/build-feature`. It encodes the loop: per chunk, an Opus `medium` implementer works from a written brief file, an Opus `xhigh` agent adversarially verifies with structured findings (re-running typecheck + suites itself, never trusting the implementer's report), the medium agent fixes, then `/commit` + `/gh-stack` + `/create-pr` create the stacked PR and an Opus agent runs `/code-review` on it before the next chunk starts. After the last chunk: a whole-stack Fable review over `git diff origin/main...<tip>`, then an optional GPT-5.6 Sol pass via Pi (exact command pinned in the skill).

Gotchas earned in real runs are recorded so they stop recurring: Workflow `args` as real JSON, stacked PRs not triggering the main CI trio, the squash-merge stack-collapse trap, and pre-commit needing `bun install` + generous timeouts in fresh worktrees.

## Files changed

| File | Purpose |
| ---- | ------- |
| `.agents/skills/build-feature/SKILL.md` | The `/build-feature` skill (new; also reachable via the `.claude/skills` symlink) |

## Test plan

- [x] Claims verified against reality: all referenced skills exist in `.agents/skills/` (`commit`, `gh-stack`, `create-pr`, `code-review`); the Pi command form matches the invocation used live this session; the stack-collapse and CI-trio gotchas match the recorded incidents they came from
- [x] Pre-commit hook (full monorepo lint + typecheck + migration checks) green on the commit
- [ ] No runtime surface — nothing to execute; the skill's first real exercise is the calls PR stack currently in flight

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787036667&installation_id=129946197&pr_number=1409&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1409&signature=b35b4afd7407d691e73cdac63289798838bd9ae24b3b50892144de82985c8940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->