### PR TITLE
feat(calls): Cloudflare proxy, /calls gateway, roster versioning (stack 2/8)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -27,6 +27,12 @@ S3_ENDPOINT=http://localhost:9099
 # VAPID_PRIVATE_KEY=
 # VAPID_SUBJECT=mailto:you@example.com
 
+# Voice/Video Calls (Cloudflare Realtime SFU) - optional, must be set as a pair
+# One CF Realtime app PER ENVIRONMENT (dev/staging/prod); the secret is the
+# media-plane credential — never shipped to clients. Absent ⇒ calls surfaces 503.
+# CLOUDFLARE_REALTIME_APP_ID=
+# CLOUDFLARE_REALTIME_APP_SECRET=
+
 # Langfuse (AI Observability) - optional
 # Run: docker compose -f docker-compose.langfuse.yml up -d
 # Then create account at http://localhost:3100 and copy keys

--- a/apps/backend/src/db/migrations/20260719130000_calls_media_session.sql
+++ b/apps/backend/src/db/migrations/20260719130000_calls_media_session.sql
@@ -1,0 +1,25 @@
+-- Voice/video calls (M0 PR 0.2) — the media-plane columns the CF Realtime SFU
+-- proxy and the `/calls` control gateway write. Append-only (INV-17), all TEXT
+-- statuses/kinds validated in code (INV-3), workspace-scoped rows unchanged
+-- (INV-8). No new tables: these extend the 0.1 tracking tables.
+--
+-- roster_version is the monotonic snapshot version every membership/media-state
+-- change bumps (INV-66); clients drop a roster delta whose version is not newer
+-- than what they hold, so a reordered socket fan-out can't regress state.
+--
+-- The endpoint gains its media identity here: cf_session_id (the CF Realtime
+-- session, minted outside any DB transaction and CAS-written onto the row —
+-- nullable until it exists), media_incarnation (client-minted per CallManager
+-- lifetime, the fencing token for proxy calls so a reload's stale session can't
+-- act on the new one), media_state (server-owned mute/camera claims mirrored to
+-- clients), and published_tracks (the track registry CF pushes no notification
+-- for, so it rides our roster).
+
+ALTER TABLE calls
+  ADD COLUMN IF NOT EXISTS roster_version INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE call_endpoints
+  ADD COLUMN IF NOT EXISTS cf_session_id TEXT,
+  ADD COLUMN IF NOT EXISTS media_incarnation TEXT,
+  ADD COLUMN IF NOT EXISTS media_state JSONB NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS published_tracks JSONB NOT NULL DEFAULT '[]';

--- a/apps/backend/src/db/migrations/20260719140000_call_endpoint_connection_seq.sql
+++ b/apps/backend/src/db/migrations/20260719140000_call_endpoint_connection_seq.sql
@@ -1,0 +1,13 @@
+-- Voice/video calls (M0 PR 0.2, review round) — per-endpoint connection sequence.
+-- Append-only (INV-17), workspace-scoped rows unchanged (INV-8), no new table.
+--
+-- connection_seq is a monotonic fencing counter (INV-66) bumped on every (re)bind
+-- of an endpoint. epoch alone cannot fence a socket disconnect against a fast
+-- same-incarnation reconnect: a reload rebinds the endpoint back to `connected`
+-- at the SAME epoch before the old socket's fire-and-forget demotion commits, so
+-- the demotion's (epoch, status='connected') fence still matches and wedges the
+-- live endpoint at `reconnecting`. rebind bumps connection_seq, and the disconnect
+-- demotion is fenced on the seq the socket bound at, so a stale demotion no-ops.
+
+ALTER TABLE call_endpoints
+  ADD COLUMN IF NOT EXISTS connection_seq INTEGER NOT NULL DEFAULT 0;

--- a/apps/backend/src/features/access-log/operations.ts
+++ b/apps/backend/src/features/access-log/operations.ts
@@ -251,6 +251,17 @@ export const ACCESS_LOG_OPERATIONS = [
   // Voice
   "voice.create_session",
   "voice.abort_session",
+  // Calls (voice/video)
+  "calls.start",
+  "calls.bootstrap",
+  "calls.leave",
+  "calls.decline_invitation",
+  "calls.cancel_invitation",
+  "calls.cf_session",
+  "calls.cf_renegotiate",
+  "calls.cf_publish_tracks",
+  "calls.cf_pull_tracks",
+  "calls.cf_close_tracks",
   // Bots
   "bot.hello_bootstrap",
   "bot.presence_update",

--- a/apps/backend/src/features/calls/CLOUDFLARE_API.md
+++ b/apps/backend/src/features/calls/CLOUDFLARE_API.md
@@ -1,0 +1,55 @@
+# Cloudflare Realtime API — encoded understanding & 0.3 spike open questions
+
+`cloudflare.ts` is our adapter to Cloudflare Realtime (the SFU, formerly "Calls").
+It was written against the **documented** HTTPS API without a live dev account.
+This note records exactly what we encoded and what the **PR 0.3 hostile-matrix
+spike must confirm against the real API** before any M1 client work. This is the
+one sanctioned doc artifact for 0.2 (per the brief).
+
+## What we encoded (documented, believed correct)
+
+- **Base URL**: `https://rtc.live.cloudflare.com/v1/apps/{appId}` (overridable via
+  `CLOUDFLARE_REALTIME_API_BASE`).
+- **Auth**: `Authorization: Bearer {appSecret}` on every request. The secret is
+  the media-plane credential and never leaves the backend.
+- **Create session** — `POST /sessions/new` → `{ sessionId, sessionDescription?: {type, sdp}, errorCode?, errorDescription? }`.
+- **Add local tracks (publish)** — `POST /sessions/{sessionId}/tracks/new` with
+  `{ sessionDescription: {type:"offer", sdp}, tracks: [{location:"local", trackName, mid}] }`
+  → `{ requiresImmediateRenegotiation, tracks:[{mid, trackName, errorCode?, ...}], sessionDescription?: {type:"answer", sdp} }`.
+- **Pull remote tracks** — same `POST /sessions/{sessionId}/tracks/new`, body
+  `{ tracks: [{location:"remote", sessionId: <publisherSession>, trackName}] }`
+  → `{ requiresImmediateRenegotiation, tracks, sessionDescription?: {type:"offer", sdp} }`.
+- **Renegotiate** — `PUT /sessions/{sessionId}/renegotiate` with `{ sessionDescription: {type:"answer", sdp} }`.
+- **Close tracks** — `PUT /sessions/{sessionId}/tracks/close` with `{ tracks:[{mid}], force, sessionDescription? }`.
+- Timeout: 8s per request; non-2xx and network/timeout errors surface as typed
+  `CloudflareRealtimeError` (`CF_HTTP_ERROR` / `CF_NETWORK_ERROR` / `CF_TIMEOUT` /
+  `CF_SESSION_CREATE_FAILED`), mapped to `HttpError` 502/504 at the service boundary.
+
+## Open questions the 0.3 spike MUST confirm
+
+1. **Session teardown.** CF exposes **no documented session-delete verb** — sessions
+   are said to reap on their own inactivity timeout. `closeSession()` currently
+   force-closes all tracks (`PUT .../tracks/close` with `force:true`, empty mids)
+   as the closest available teardown, treated as best-effort. **Confirm** whether
+   (a) a real session-delete endpoint exists, (b) `tracks/close` with force is the
+   right teardown, and (c) the exact inactivity-timeout duration (it bounds how
+   long a reaped-but-not-closed session lingers on the bill).
+2. **Publish/pull response contract.** Confirm `requiresImmediateRenegotiation`
+   semantics, whether the answer SDP is always present on publish, and the exact
+   per-track error fields (`errorCode`/`errorDescription`) and their values.
+3. **`mid` vs `trackName` ownership.** We treat `trackName` as client-minted and
+   `mid` as the offer's m-line id. Confirm CF requires both on publish and that
+   peers pull purely by `{sessionId, trackName}`.
+4. **Simulcast / layered forwarding.** The plan flags this as decisive for free
+   per-receiver adaptation. Pin the exact encodings/layers request shape and what
+   the SFU forwards per receiver — NOT modeled here yet.
+5. **`bidirectionalMediaStream` / `autoDiscover`.** Documented optional fields we do
+   not send. Confirm whether any flow needs them.
+6. **STUN/TURN + reachability.** Confirm the anycast STUN (`stun.cloudflare.com:3478`)
+   and integrated TURN behavior on the enterprise TLS-443 fallback path.
+7. **Error/status codes.** Confirm CF's HTTP status codes and body error codes so
+   the `CloudflareRealtimeError` → `HttpError` mapping is accurate (e.g. distinguish
+   auth failure, unknown session, quota).
+
+Findings feed back into `cloudflare.ts` (shapes), `service.ts` (teardown), and the
+handlers before M1 starts.

--- a/apps/backend/src/features/calls/access.test.ts
+++ b/apps/backend/src/features/calls/access.test.ts
@@ -18,6 +18,7 @@ function fakeCall(overrides: Partial<Call> = {}): Call {
     mediaTransport: "sfu",
     chatStreamId: null,
     sharingEndpointId: null,
+    rosterVersion: 0,
     graceDeadline: null,
     endedReason: null,
     startedAt: NOW,

--- a/apps/backend/src/features/calls/cloudflare.test.ts
+++ b/apps/backend/src/features/calls/cloudflare.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { CloudflareRealtimeApi, CloudflareRealtimeError } from "./cloudflare"
+
+const CONFIG = { appId: "app_1", appSecret: "secret_1", enabled: true }
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } })
+}
+
+function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  return spyOn(globalThis, "fetch").mockImplementation(((url: string, init: RequestInit) =>
+    impl(url, init)) as typeof fetch)
+}
+
+function lastCall(f: ReturnType<typeof stubFetch>) {
+  const [url, init] = f.mock.calls[f.mock.calls.length - 1] as [string, RequestInit]
+  return { url, init, body: init.body ? JSON.parse(init.body as string) : undefined }
+}
+
+describe("CloudflareRealtimeApi.createSession", () => {
+  afterEach(() => mock.restore())
+
+  it("POSTs to sessions/new with the bearer secret and returns the session", async () => {
+    const f = stubFetch(async () =>
+      jsonResponse({ sessionId: "sess_1", sessionDescription: { type: "answer", sdp: "s" } })
+    )
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const result = await api.createSession()
+
+    const { url, init } = lastCall(f)
+    expect(url).toBe("https://rtc.live.cloudflare.com/v1/apps/app_1/sessions/new")
+    expect(init.method).toBe("POST")
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret_1")
+    expect(result).toEqual({ sessionId: "sess_1", sessionDescription: { type: "answer", sdp: "s" } })
+  })
+
+  it("honors the apiBase override", async () => {
+    const f = stubFetch(async () => jsonResponse({ sessionId: "sess_1" }))
+    const api = new CloudflareRealtimeApi({ ...CONFIG, apiBase: "https://cf.test/v1/apps" })
+
+    await api.createSession()
+
+    expect(lastCall(f).url).toBe("https://cf.test/v1/apps/app_1/sessions/new")
+  })
+
+  it("throws a typed error when CF returns no sessionId", async () => {
+    stubFetch(async () => jsonResponse({ errorCode: "boom", errorDescription: "no session" }))
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const promise = api.createSession()
+    await expect(promise).rejects.toBeInstanceOf(CloudflareRealtimeError)
+    await expect(promise).rejects.toMatchObject({ code: "CF_SESSION_CREATE_FAILED", cfErrorCode: "boom" })
+  })
+})
+
+describe("CloudflareRealtimeApi tracks", () => {
+  afterEach(() => mock.restore())
+
+  it("addLocalTracks posts sdp + local tracks to tracks/new", async () => {
+    const f = stubFetch(async () =>
+      jsonResponse({ requiresImmediateRenegotiation: true, tracks: [{ mid: "0", trackName: "mic" }] })
+    )
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const result = await api.addLocalTracks("sess_1", {
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ location: "local", trackName: "mic", mid: "0" }],
+    })
+
+    const { url, body } = lastCall(f)
+    expect(url).toBe("https://rtc.live.cloudflare.com/v1/apps/app_1/sessions/sess_1/tracks/new")
+    expect(body).toEqual({
+      sessionDescription: { type: "offer", sdp: "o" },
+      tracks: [{ location: "local", trackName: "mic", mid: "0" }],
+    })
+    expect(result.requiresImmediateRenegotiation).toBe(true)
+  })
+
+  it("pullRemoteTracks posts only remote tracks (no sdp)", async () => {
+    const f = stubFetch(async () =>
+      jsonResponse({
+        requiresImmediateRenegotiation: true,
+        sessionDescription: { type: "offer", sdp: "o" },
+        tracks: [],
+      })
+    )
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    await api.pullRemoteTracks("sess_1", {
+      tracks: [{ location: "remote", sessionId: "sess_peer", trackName: "cam" }],
+    })
+
+    expect(lastCall(f).body).toEqual({ tracks: [{ location: "remote", sessionId: "sess_peer", trackName: "cam" }] })
+  })
+
+  it("renegotiateSession PUTs the sdp", async () => {
+    const f = stubFetch(async () => jsonResponse({}))
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    await api.renegotiateSession("sess_1", { type: "answer", sdp: "a" })
+
+    const { url, init, body } = lastCall(f)
+    expect(url).toBe("https://rtc.live.cloudflare.com/v1/apps/app_1/sessions/sess_1/renegotiate")
+    expect(init.method).toBe("PUT")
+    expect(body).toEqual({ sessionDescription: { type: "answer", sdp: "a" } })
+  })
+
+  it("closeTracks PUTs the mids to tracks/close", async () => {
+    const f = stubFetch(async () => jsonResponse({ tracks: [] }))
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    await api.closeTracks("sess_1", { mids: ["0", "1"], force: true })
+
+    const { url, init, body } = lastCall(f)
+    expect(url).toBe("https://rtc.live.cloudflare.com/v1/apps/app_1/sessions/sess_1/tracks/close")
+    expect(init.method).toBe("PUT")
+    expect(body).toEqual({ tracks: [{ mid: "0" }, { mid: "1" }], force: true })
+  })
+})
+
+describe("CloudflareRealtimeApi error handling", () => {
+  afterEach(() => mock.restore())
+
+  it("maps a non-2xx response to a typed CF_HTTP_ERROR", async () => {
+    stubFetch(async () => new Response("upstream boom", { status: 500 }))
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const promise = api.createSession()
+    await expect(promise).rejects.toBeInstanceOf(CloudflareRealtimeError)
+    await expect(promise).rejects.toMatchObject({ code: "CF_HTTP_ERROR", status: 502 })
+  })
+
+  it("maps an aborted fetch to a typed CF_TIMEOUT", async () => {
+    stubFetch(async () => {
+      const err = new Error("aborted")
+      err.name = "AbortError"
+      throw err
+    })
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const promise = api.createSession()
+    await expect(promise).rejects.toMatchObject({ code: "CF_TIMEOUT", status: 0 })
+  })
+
+  it("maps a network failure to a typed CF_NETWORK_ERROR", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNREFUSED")
+    })
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    await expect(api.createSession()).rejects.toMatchObject({ code: "CF_NETWORK_ERROR", status: 0 })
+  })
+})

--- a/apps/backend/src/features/calls/cloudflare.ts
+++ b/apps/backend/src/features/calls/cloudflare.ts
@@ -1,0 +1,258 @@
+import type { CloudflareRealtimeConfig } from "../../lib/env"
+
+/**
+ * Cloudflare Realtime (SFU) HTTPS client — the media plane's one adapter behind
+ * the `RealtimeMediaApi` seam (the `MediaTransport` boundary of the plan: a
+ * future >50-participant provider or the Later P2P direct mode slots in here
+ * without touching product code). The app secret is a Bearer credential that
+ * NEVER ships to a browser: every session/track operation proxies through the
+ * backend under `checkCallAccess`.
+ *
+ * NEVER call any of these inside a DB transaction (INV-41): the service pattern
+ * is CF-call-first, then the DB write, so a failed CF call fails the operation
+ * before any row claims a session that was never created.
+ *
+ * The exact request/response shapes are pinned to CF's documented Realtime API
+ * (see CLOUDFLARE_API.md) and are the throwaway-spike's job (PR 0.3) to confirm
+ * against the live dev account before M1.
+ */
+
+export interface SessionDescription {
+  type: "offer" | "answer"
+  sdp: string
+}
+
+/** A track this endpoint publishes (offer carries it). */
+export interface LocalTrackRequest {
+  location: "local"
+  /** CF track name peers pull by; we mint it from the endpoint + kind. */
+  trackName: string
+  /** The m-line id in the endpoint's offer this track maps to. */
+  mid: string
+}
+
+/** A peer's track this endpoint pulls (CF answers with the SDP to add it). */
+export interface RemoteTrackRequest {
+  location: "remote"
+  /** The publisher's CF session. */
+  sessionId: string
+  /** The publisher's track name (from the roster's published_tracks). */
+  trackName: string
+}
+
+export interface TrackResult {
+  mid?: string
+  trackName?: string
+  location?: "local" | "remote"
+  sessionId?: string
+  errorCode?: string
+  errorDescription?: string
+}
+
+export interface CreateSessionResult {
+  sessionId: string
+  sessionDescription?: SessionDescription
+}
+
+export interface TracksResult {
+  requiresImmediateRenegotiation: boolean
+  tracks: TrackResult[]
+  sessionDescription?: SessionDescription
+}
+
+export interface RenegotiateResult {
+  sessionDescription?: SessionDescription
+}
+
+export interface CloseTracksResult {
+  tracks: TrackResult[]
+}
+
+/**
+ * The media-transport seam. One production implementation
+ * ({@link CloudflareRealtimeApi}); the interface is the fake seam tests stub, so
+ * no test ever reaches the network.
+ */
+export interface RealtimeMediaApi {
+  createSession(): Promise<CreateSessionResult>
+  renegotiateSession(sessionId: string, sdp: SessionDescription): Promise<RenegotiateResult>
+  addLocalTracks(
+    sessionId: string,
+    params: { sdp: SessionDescription; tracks: LocalTrackRequest[] }
+  ): Promise<TracksResult>
+  pullRemoteTracks(sessionId: string, params: { tracks: RemoteTrackRequest[] }): Promise<TracksResult>
+  closeTracks(
+    sessionId: string,
+    params: { mids: string[]; force?: boolean; sdp?: SessionDescription }
+  ): Promise<CloseTracksResult>
+  /** Best-effort teardown; CF sessions also die on their own inactivity timeout. */
+  closeSession(sessionId: string): Promise<void>
+}
+
+/**
+ * A typed CF failure. `status` is the HTTP status (0 on a timeout/network
+ * error); `code` is our stable machine code; `cfErrorCode`/`cfErrorDescription`
+ * carry CF's own error fields when the transport succeeded but CF reported a
+ * body-level error. Callers map this to an `HttpError` at the surface.
+ */
+export class CloudflareRealtimeError extends Error {
+  readonly status: number
+  readonly code: string
+  readonly cfErrorCode?: string
+  readonly cfErrorDescription?: string
+
+  constructor(
+    message: string,
+    params: { status: number; code: string; cfErrorCode?: string; cfErrorDescription?: string }
+  ) {
+    super(message)
+    this.name = "CloudflareRealtimeError"
+    this.status = params.status
+    this.code = params.code
+    this.cfErrorCode = params.cfErrorCode
+    this.cfErrorDescription = params.cfErrorDescription
+  }
+}
+
+const DEFAULT_API_BASE = "https://rtc.live.cloudflare.com/v1/apps"
+const REQUEST_TIMEOUT_MS = 8_000
+
+export class CloudflareRealtimeApi implements RealtimeMediaApi {
+  private readonly appId: string
+  private readonly appSecret: string
+  private readonly apiBase: string
+
+  constructor(config: CloudflareRealtimeConfig) {
+    if (!config.appId || !config.appSecret) {
+      throw new Error("CloudflareRealtimeApi requires a CF Realtime app id and secret")
+    }
+    this.appId = config.appId
+    this.appSecret = config.appSecret
+    this.apiBase = (config.apiBase ?? DEFAULT_API_BASE).replace(/\/$/, "")
+  }
+
+  async createSession(): Promise<CreateSessionResult> {
+    const body = await this.request<{
+      sessionId?: string
+      sessionDescription?: SessionDescription
+      errorCode?: string
+      errorDescription?: string
+    }>("POST", `/${this.appId}/sessions/new`, {})
+    if (!body.sessionId) {
+      throw new CloudflareRealtimeError("CF session create returned no sessionId", {
+        status: 502,
+        code: "CF_SESSION_CREATE_FAILED",
+        cfErrorCode: body.errorCode,
+        cfErrorDescription: body.errorDescription,
+      })
+    }
+    return { sessionId: body.sessionId, sessionDescription: body.sessionDescription }
+  }
+
+  async renegotiateSession(sessionId: string, sdp: SessionDescription): Promise<RenegotiateResult> {
+    const body = await this.request<{ sessionDescription?: SessionDescription }>(
+      "PUT",
+      `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/renegotiate`,
+      { sessionDescription: sdp }
+    )
+    return { sessionDescription: body.sessionDescription }
+  }
+
+  async addLocalTracks(
+    sessionId: string,
+    params: { sdp: SessionDescription; tracks: LocalTrackRequest[] }
+  ): Promise<TracksResult> {
+    const body = await this.request<{
+      requiresImmediateRenegotiation?: boolean
+      tracks?: TrackResult[]
+      sessionDescription?: SessionDescription
+    }>("POST", `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/tracks/new`, {
+      sessionDescription: params.sdp,
+      tracks: params.tracks,
+    })
+    return {
+      requiresImmediateRenegotiation: body.requiresImmediateRenegotiation ?? false,
+      tracks: body.tracks ?? [],
+      sessionDescription: body.sessionDescription,
+    }
+  }
+
+  async pullRemoteTracks(sessionId: string, params: { tracks: RemoteTrackRequest[] }): Promise<TracksResult> {
+    const body = await this.request<{
+      requiresImmediateRenegotiation?: boolean
+      tracks?: TrackResult[]
+      sessionDescription?: SessionDescription
+    }>("POST", `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/tracks/new`, {
+      tracks: params.tracks,
+    })
+    return {
+      requiresImmediateRenegotiation: body.requiresImmediateRenegotiation ?? false,
+      tracks: body.tracks ?? [],
+      sessionDescription: body.sessionDescription,
+    }
+  }
+
+  async closeTracks(
+    sessionId: string,
+    params: { mids: string[]; force?: boolean; sdp?: SessionDescription }
+  ): Promise<CloseTracksResult> {
+    const body = await this.request<{ tracks?: TrackResult[] }>(
+      "PUT",
+      `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/tracks/close`,
+      {
+        tracks: params.mids.map((mid) => ({ mid })),
+        force: params.force ?? false,
+        ...(params.sdp ? { sessionDescription: params.sdp } : {}),
+      }
+    )
+    return { tracks: body.tracks ?? [] }
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    // CF exposes no documented session-delete verb; sessions reap on their own
+    // inactivity timeout. We force-close all of a session's tracks as the
+    // closest available teardown so media stops promptly rather than lingering
+    // to the timeout. Confirming the exact teardown is a CLOUDFLARE_API.md open
+    // question for the 0.3 spike; callers treat this as best-effort.
+    await this.request("PUT", `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/tracks/close`, {
+      tracks: [],
+      force: true,
+    })
+  }
+
+  private async request<T>(method: string, path: string, body: unknown): Promise<T> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await fetch(`${this.apiBase}${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.appSecret}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+    } catch (err) {
+      const timedOut = err instanceof Error && err.name === "AbortError"
+      throw new CloudflareRealtimeError(timedOut ? "CF request timed out" : "CF request failed", {
+        status: 0,
+        code: timedOut ? "CF_TIMEOUT" : "CF_NETWORK_ERROR",
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      throw new CloudflareRealtimeError(`CF request failed with ${response.status}`, {
+        status: 502,
+        code: "CF_HTTP_ERROR",
+        cfErrorDescription: text.slice(0, 500) || undefined,
+      })
+    }
+
+    return (await response.json()) as T
+  }
+}

--- a/apps/backend/src/features/calls/config.ts
+++ b/apps/backend/src/features/calls/config.ts
@@ -34,6 +34,31 @@ export type CallParticipantStatus = (typeof CALL_PARTICIPANT_STATUSES)[number]
 export const CALL_ENDPOINT_STATUSES = ["connected", "reconnecting", "closed"] as const
 export type CallEndpointStatus = (typeof CALL_ENDPOINT_STATUSES)[number]
 
+/**
+ * The kinds of media an endpoint can publish. CF Realtime pushes no remote-track
+ * notification, so the published-track registry rides our versioned roster and
+ * clients pull peers' tracks on roster changes. `trackName` is the CF track name
+ * the peer pulls by.
+ */
+export const PUBLISHED_TRACK_KINDS = ["mic", "camera", "share_video", "share_audio"] as const
+export type PublishedTrackKind = (typeof PUBLISHED_TRACK_KINDS)[number]
+
+export interface PublishedTrack {
+  kind: PublishedTrackKind
+  trackName: string
+}
+
+/**
+ * Server-owned mute/camera claims mirrored to every client through the roster —
+ * the authority the UI derives badges from (a client's local `track.enabled` is
+ * cosmetic; this is the truth peers see). Sparse: an absent field means "no
+ * claim yet" (client defaults apply).
+ */
+export interface MediaState {
+  muted?: boolean
+  cameraOn?: boolean
+}
+
 /** How long a call sits in `empty_grace` after the last participant leaves before it ends. */
 export const EMPTY_GRACE_MS = 45_000
 
@@ -51,3 +76,12 @@ export const INVITATION_TTL_MS = 45_000
 
 /** Product comfort cap on concurrent joined participants (the SFU has no hard cliff). */
 export const CALL_PRODUCT_CAP = 50
+
+/**
+ * Per-socket control/proxy event budget on the `/calls` namespace: a simple
+ * token bucket (INV — abuse hardening). Renegotiation churn and roster catch-up
+ * on a bad network burst, so the ceiling is generous; it only trips a runaway
+ * client. Refills continuously at `CALL_SOCKET_RATE_REFILL_PER_SEC`.
+ */
+export const CALL_SOCKET_RATE_BURST = 40
+export const CALL_SOCKET_RATE_REFILL_PER_SEC = 10

--- a/apps/backend/src/features/calls/handlers.test.ts
+++ b/apps/backend/src/features/calls/handlers.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import type { Server } from "socket.io"
+import type { Pool } from "pg"
+import { createCallHandlers } from "./handlers"
+import { HttpError } from "../../lib/errors"
+import * as accessModule from "./access"
+import * as gatewayModule from "./signaling-gateway"
+
+function fakeRes() {
+  const res: Partial<Response> = {}
+  res.status = mock(() => res as Response)
+  res.json = mock(() => res as Response)
+  res.send = mock(() => res as Response)
+  return res as Response
+}
+
+function fakeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    user: { id: "usr_1" },
+    workspaceId: "ws_1",
+    params: {},
+    body: {},
+    query: {},
+    ...overrides,
+  } as unknown as Request
+}
+
+function makeHandlers(opts: {
+  cloudflareEnabled?: boolean
+  callsEnabled?: boolean
+  callService?: Record<string, unknown>
+}) {
+  const workspaceSettingsService = {
+    getSettings: mock(async () => ({ callsEnabled: opts.callsEnabled ?? true })),
+  }
+  return createCallHandlers({
+    pool: {} as Pool,
+    io: {} as Server,
+    callService: (opts.callService ?? {}) as never,
+    workspaceSettingsService: workspaceSettingsService as never,
+    cloudflareEnabled: opts.cloudflareEnabled ?? true,
+  })
+}
+
+describe("createCallHandlers.start — gating", () => {
+  afterEach(() => mock.restore())
+
+  it("503 CALLS_UNAVAILABLE when the CF media plane is unconfigured", async () => {
+    const handlers = makeHandlers({ cloudflareEnabled: false })
+    const promise = handlers.start(fakeReq({ body: { streamId: "stream_1", mode: "video" } }), fakeRes())
+    await expect(promise).rejects.toMatchObject({ status: 503, code: "CALLS_UNAVAILABLE" })
+  })
+
+  it("404 CALLS_DISABLED when the workspace flag is off", async () => {
+    const handlers = makeHandlers({ callsEnabled: false })
+    const promise = handlers.start(fakeReq({ body: { streamId: "stream_1", mode: "video" } }), fakeRes())
+    await expect(promise).rejects.toMatchObject({ status: 404, code: "CALLS_DISABLED" })
+  })
+
+  it("400 VALIDATION_ERROR on a bad body", async () => {
+    const handlers = makeHandlers({})
+    const promise = handlers.start(fakeReq({ body: { streamId: "stream_1", mode: "telepathy" } }), fakeRes())
+    await expect(promise).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" })
+  })
+
+  it("starts the call and returns the roster snapshot", async () => {
+    const startCall = mock(async (_p: unknown) => ({
+      call: { id: "call_1" },
+      created: true,
+      participant: { id: "callp_1" },
+      endpoint: { id: "callep_1" },
+    }))
+    const getRosterSnapshot = mock(async () => ({ rosterVersion: 1, roster: [{ userId: "usr_1" }] }))
+    const handlers = makeHandlers({ callService: { startCall, getRosterSnapshot } })
+    const res = fakeRes()
+
+    await handlers.start(fakeReq({ body: { streamId: "stream_1", mode: "video", mediaIncarnation: "inc_1" } }), res)
+
+    expect(startCall.mock.calls[0][0]).toMatchObject({
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_1",
+      mode: "video",
+      mediaIncarnation: "inc_1",
+    })
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ call: { id: "call_1" }, rosterVersion: 1, roster: [{ userId: "usr_1" }] })
+    )
+  })
+})
+
+describe("createCallHandlers.bootstrap", () => {
+  afterEach(() => mock.restore())
+
+  it("404 CALL_NOT_FOUND when checkCallAccess denies", async () => {
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue(null)
+    const handlers = makeHandlers({ callService: { getRosterSnapshot: mock(async () => ({})) } })
+    const promise = handlers.bootstrap(fakeReq({ params: { callId: "call_1" } }), fakeRes())
+    await expect(promise).rejects.toMatchObject({ status: 404, code: "CALL_NOT_FOUND" })
+  })
+
+  it("returns the roster and the caller's own entry", async () => {
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: { id: "call_1" } } as never)
+    const getRosterSnapshot = mock(async () => ({
+      rosterVersion: 3,
+      roster: [
+        { userId: "usr_1", endpointId: "callep_1" },
+        { userId: "usr_2", endpointId: "callep_2" },
+      ],
+    }))
+    const handlers = makeHandlers({ callService: { getRosterSnapshot } })
+    const res = fakeRes()
+
+    await handlers.bootstrap(fakeReq({ params: { callId: "call_1" } }), res)
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ rosterVersion: 3, self: { userId: "usr_1", endpointId: "callep_1" } })
+    )
+  })
+})
+
+describe("createCallHandlers.createCfSession", () => {
+  afterEach(() => mock.restore())
+
+  it("propagates a stale-incarnation 409 from the service", async () => {
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: { id: "call_1" } } as never)
+    const createEndpointCfSession = mock(async (_p: unknown) => {
+      throw new HttpError("stale", { status: 409, code: "CALL_STALE_INCARNATION" })
+    })
+    const handlers = makeHandlers({ callService: { createEndpointCfSession } })
+
+    const promise = handlers.createCfSession(
+      fakeReq({ params: { callId: "call_1", endpointId: "callep_1" }, body: { mediaIncarnation: "inc_1" } }),
+      fakeRes()
+    )
+    await expect(promise).rejects.toMatchObject({ status: 409, code: "CALL_STALE_INCARNATION" })
+    expect(createEndpointCfSession.mock.calls[0][0]).toMatchObject({
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+    })
+  })
+
+  it("returns the CF session result on success", async () => {
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: { id: "call_1" } } as never)
+    const createEndpointCfSession = mock(async () => ({ cfSessionId: "sess_1", idempotent: false }))
+    const handlers = makeHandlers({ callService: { createEndpointCfSession } })
+    const res = fakeRes()
+
+    await handlers.createCfSession(
+      fakeReq({ params: { callId: "call_1", endpointId: "callep_1" }, body: { mediaIncarnation: "inc_1" } }),
+      res
+    )
+    expect(res.json).toHaveBeenCalledWith({ cfSessionId: "sess_1", idempotent: false })
+  })
+})
+
+describe("createCallHandlers.publishTracks", () => {
+  afterEach(() => mock.restore())
+
+  it("fans the bumped roster to the call room and returns the version", async () => {
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: { id: "call_1" } } as never)
+    const broadcast = spyOn(gatewayModule, "broadcastRoster").mockImplementation(() => {})
+    const snapshot = { rosterVersion: 5, roster: [] }
+    const publishTracks = mock(async () => ({ cf: { requiresImmediateRenegotiation: false, tracks: [] }, snapshot }))
+    const handlers = makeHandlers({ callService: { publishTracks } })
+    const res = fakeRes()
+
+    await handlers.publishTracks(
+      fakeReq({
+        params: { callId: "call_1", endpointId: "callep_1" },
+        body: {
+          mediaIncarnation: "inc_1",
+          sdp: { type: "offer", sdp: "o" },
+          tracks: [{ kind: "mic", mid: "0", trackName: "mic0" }],
+        },
+      }),
+      res
+    )
+
+    expect(broadcast).toHaveBeenCalledWith(expect.anything(), "call_1", snapshot)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ rosterVersion: 5 }))
+  })
+})

--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -1,0 +1,263 @@
+import { z } from "zod"
+import type { Request, Response } from "express"
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import { HttpError } from "../../lib/errors"
+import type { WorkspaceSettingsService } from "../workspace-settings"
+import { checkCallAccess } from "./access"
+import type { CallService } from "./service"
+import { broadcastRoster } from "./signaling-gateway"
+import { CALL_MODES, PUBLISHED_TRACK_KINDS } from "./config"
+
+const sessionDescriptionSchema = z.object({
+  type: z.enum(["offer", "answer"]),
+  sdp: z.string().min(1).max(200_000),
+})
+
+const mediaIncarnationSchema = z.string().min(1).max(128)
+
+const startSchema = z.object({
+  streamId: z.string().min(1),
+  mode: z.enum(CALL_MODES),
+  mediaIncarnation: mediaIncarnationSchema.optional(),
+})
+
+const cfSessionSchema = z.object({
+  mediaIncarnation: mediaIncarnationSchema,
+})
+
+const renegotiateSchema = z.object({
+  mediaIncarnation: mediaIncarnationSchema,
+  sdp: sessionDescriptionSchema,
+})
+
+const publishSchema = z.object({
+  mediaIncarnation: mediaIncarnationSchema,
+  sdp: sessionDescriptionSchema,
+  tracks: z
+    .array(
+      z.object({
+        kind: z.enum(PUBLISHED_TRACK_KINDS),
+        mid: z.string().min(1).max(64),
+        trackName: z.string().min(1).max(128),
+      })
+    )
+    .min(1)
+    .max(8),
+})
+
+const pullSchema = z.object({
+  mediaIncarnation: mediaIncarnationSchema,
+  tracks: z
+    .array(z.object({ sessionId: z.string().min(1).max(128), trackName: z.string().min(1).max(128) }))
+    .min(1)
+    .max(64),
+})
+
+const closeTracksSchema = z.object({
+  mediaIncarnation: mediaIncarnationSchema,
+  mids: z.array(z.string().min(1).max(64)).min(1).max(16),
+  unpublishKinds: z.array(z.enum(PUBLISHED_TRACK_KINDS)).max(4).optional(),
+  sdp: sessionDescriptionSchema.optional(),
+})
+
+interface Dependencies {
+  pool: Pool
+  io: Server
+  callService: CallService
+  workspaceSettingsService: WorkspaceSettingsService
+  /** False when the CF media plane is unconfigured — every calls surface 503s. */
+  cloudflareEnabled: boolean
+}
+
+function parseOrThrow<T>(schema: z.ZodType<T>, body: unknown): T {
+  const result = schema.safeParse(body)
+  if (!result.success) {
+    throw new HttpError("Invalid calls request", {
+      status: 400,
+      code: "VALIDATION_ERROR",
+      details: result.error.flatten(),
+    })
+  }
+  return result.data
+}
+
+/**
+ * REST + CF-proxy surface for calls. Every endpoint is gated in the same order:
+ * CF-config-absent ⇒ 503 CALLS_UNAVAILABLE (the whole feature is off), then the
+ * per-workspace flag ⇒ 404-style CALLS_DISABLED (dark feature), then
+ * `checkCallAccess` authorization. The proxy endpoints are thin, incarnation-fenced
+ * pass-throughs to CF holding the app secret; publish/close additionally update the
+ * roster and fan `call:roster` to the `/calls` namespace room.
+ */
+export function createCallHandlers({
+  pool,
+  io,
+  callService,
+  workspaceSettingsService,
+  cloudflareEnabled,
+}: Dependencies) {
+  async function assertAvailable(workspaceId: string): Promise<void> {
+    if (!cloudflareEnabled) {
+      throw new HttpError("Calls media is not configured", { status: 503, code: "CALLS_UNAVAILABLE" })
+    }
+    const settings = await workspaceSettingsService.getSettings(workspaceId)
+    if (!settings.callsEnabled) {
+      throw new HttpError("Calls are not enabled for this workspace", { status: 404, code: "CALLS_DISABLED" })
+    }
+  }
+
+  async function assertCallAccess(workspaceId: string, userId: string, callId: string): Promise<void> {
+    const access = await checkCallAccess(pool, { workspaceId, userId, callId })
+    if (!access) {
+      throw new HttpError("Call not found", { status: 404, code: "CALL_NOT_FOUND" })
+    }
+  }
+
+  return {
+    async start(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      await assertAvailable(workspaceId)
+      const body = parseOrThrow(startSchema, req.body)
+
+      const result = await callService.startCall({
+        workspaceId,
+        streamId: body.streamId,
+        userId,
+        mode: body.mode,
+        mediaIncarnation: body.mediaIncarnation,
+      })
+      const snapshot = await callService.getRosterSnapshot(workspaceId, result.call.id)
+
+      res.status(result.created ? 201 : 200).json({
+        call: result.call,
+        created: result.created,
+        participant: result.participant,
+        endpoint: result.endpoint,
+        rosterVersion: snapshot.rosterVersion,
+        roster: snapshot.roster,
+      })
+    },
+
+    async bootstrap(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+
+      const snapshot = await callService.getRosterSnapshot(workspaceId, callId)
+      const self = snapshot.roster.find((entry) => entry.userId === userId) ?? null
+      res.json({
+        callId,
+        rosterVersion: snapshot.rosterVersion,
+        roster: snapshot.roster,
+        self,
+      })
+    },
+
+    async createCfSession(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId, endpointId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+      const body = parseOrThrow(cfSessionSchema, req.body)
+
+      const result = await callService.createEndpointCfSession({
+        workspaceId,
+        callId,
+        userId,
+        endpointId,
+        mediaIncarnation: body.mediaIncarnation,
+      })
+      res.json(result)
+    },
+
+    async renegotiate(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId, endpointId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+      const body = parseOrThrow(renegotiateSchema, req.body)
+
+      const result = await callService.renegotiate({
+        workspaceId,
+        callId,
+        userId,
+        endpointId,
+        mediaIncarnation: body.mediaIncarnation,
+        sdp: body.sdp,
+      })
+      res.json(result.cf)
+    },
+
+    async publishTracks(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId, endpointId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+      const body = parseOrThrow(publishSchema, req.body)
+
+      const result = await callService.publishTracks({
+        workspaceId,
+        callId,
+        userId,
+        endpointId,
+        mediaIncarnation: body.mediaIncarnation,
+        sdp: body.sdp,
+        tracks: body.tracks,
+      })
+      broadcastRoster(io, callId, result.snapshot)
+      res.json({ ...result.cf, rosterVersion: result.snapshot.rosterVersion })
+    },
+
+    async pullTracks(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId, endpointId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+      const body = parseOrThrow(pullSchema, req.body)
+
+      const result = await callService.pullTracks({
+        workspaceId,
+        callId,
+        userId,
+        endpointId,
+        mediaIncarnation: body.mediaIncarnation,
+        tracks: body.tracks.map((t) => ({
+          location: "remote" as const,
+          sessionId: t.sessionId,
+          trackName: t.trackName,
+        })),
+      })
+      res.json(result.cf)
+    },
+
+    async closeTracks(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { callId, endpointId } = req.params
+      await assertAvailable(workspaceId)
+      await assertCallAccess(workspaceId, userId, callId)
+      const body = parseOrThrow(closeTracksSchema, req.body)
+
+      const result = await callService.closeTracks({
+        workspaceId,
+        callId,
+        userId,
+        endpointId,
+        mediaIncarnation: body.mediaIncarnation,
+        mids: body.mids,
+        unpublishKinds: body.unpublishKinds,
+        sdp: body.sdp,
+      })
+      if (result.snapshot) broadcastRoster(io, callId, result.snapshot)
+      res.json(result.cf)
+    },
+  }
+}

--- a/apps/backend/src/features/calls/index.ts
+++ b/apps/backend/src/features/calls/index.ts
@@ -1,16 +1,20 @@
 export { CallService } from "./service"
-export type { StartCallResult, JoinCallResult } from "./service"
+export type { StartCallResult, JoinCallResult, CallRosterSnapshot } from "./service"
 export {
   CallRepository,
   CallInvitationRepository,
   CallParticipantRepository,
   CallEndpointRepository,
 } from "./repository"
-export type { Call, CallInvitation, CallParticipant, CallEndpoint } from "./repository"
+export type { Call, CallInvitation, CallParticipant, CallEndpoint, CallRosterEntry } from "./repository"
 export { checkCallAccess } from "./access"
 export type { CallAccessResult } from "./access"
 export { createCallSweeper } from "./sweeper"
 export type { CallSweeper } from "./sweeper"
+export { CloudflareRealtimeApi, CloudflareRealtimeError } from "./cloudflare"
+export type { RealtimeMediaApi } from "./cloudflare"
+export { createCallHandlers } from "./handlers"
+export { registerCallGateway } from "./signaling-gateway"
 export {
   CALL_STATUSES,
   CALL_MODES,
@@ -24,6 +28,9 @@ export {
   ENDPOINT_LEASE_RENEW_MS,
   INVITATION_TTL_MS,
   CALL_PRODUCT_CAP,
+  PUBLISHED_TRACK_KINDS,
+  CALL_SOCKET_RATE_BURST,
+  CALL_SOCKET_RATE_REFILL_PER_SEC,
 } from "./config"
 export type {
   CallStatus,
@@ -33,4 +40,7 @@ export type {
   CallInvitationStatus,
   CallParticipantStatus,
   CallEndpointStatus,
+  PublishedTrackKind,
+  PublishedTrack,
+  MediaState,
 } from "./config"

--- a/apps/backend/src/features/calls/repository.test.ts
+++ b/apps/backend/src/features/calls/repository.test.ts
@@ -114,6 +114,54 @@ describe("CallParticipantRepository — actor-conditional admission", () => {
   })
 })
 
+describe("CallEndpointRepository — rebind clears stale media + bumps the connection seq", () => {
+  it("clears cf_session_id + published_tracks only when the incarnation changes, keeping them otherwise", async () => {
+    const captured: Captured = { text: "" }
+    await CallEndpointRepository.rebind(createQuerier(captured, [{}]), {
+      workspaceId: "ws_1",
+      id: "callep_1",
+      mediaIncarnation: "inc_new",
+      leaseExpiresAt: NOW,
+    })
+    const sql = normalize(captured.text)
+    // A reload's new incarnation drops the previous incarnation's dead CF session
+    // and track registry; a same-incarnation reconnect keeps both (the ELSE arm).
+    expect(sql).toMatch(
+      /cf_session_id = CASE WHEN media_incarnation IS DISTINCT FROM \$\d+ THEN NULL ELSE cf_session_id END/
+    )
+    expect(sql).toMatch(
+      /published_tracks = CASE WHEN media_incarnation IS DISTINCT FROM \$\d+ THEN '\[\]'::jsonb ELSE published_tracks END/
+    )
+  })
+
+  it("bumps connection_seq on every bind so a stale disconnect demotion no-ops", async () => {
+    const captured: Captured = { text: "" }
+    await CallEndpointRepository.rebind(createQuerier(captured, [{}]), {
+      workspaceId: "ws_1",
+      id: "callep_1",
+      mediaIncarnation: "inc_1",
+      leaseExpiresAt: NOW,
+    })
+    const sql = normalize(captured.text)
+    expect(sql).toContain("connection_seq = connection_seq + 1")
+  })
+
+  it("markReconnecting fences the demotion on (id, epoch, connection_seq, live status)", async () => {
+    const captured: Captured = { text: "" }
+    await CallEndpointRepository.markReconnecting(createQuerier(captured), {
+      workspaceId: "ws_1",
+      id: "callep_1",
+      epoch: 3,
+      connectionSeq: 5,
+    })
+    const sql = normalize(captured.text)
+    expect(sql).toContain("SET status = 'reconnecting'")
+    expect(sql).toContain("epoch =")
+    expect(sql).toContain("connection_seq =")
+    expect(sql).toContain("status = 'connected'")
+  })
+})
+
 describe("CallEndpointRepository — lease fencing + lapse-only reap", () => {
   it("renewLease is fenced on (id, epoch, live status)", async () => {
     const captured: Captured = { text: "" }

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -8,6 +8,8 @@ import {
   type CallInvitationStatus,
   type CallParticipantStatus,
   type CallEndpointStatus,
+  type MediaState,
+  type PublishedTrack,
 } from "./config"
 
 // ── calls ────────────────────────────────────────────────────────────────────
@@ -22,6 +24,7 @@ interface CallRow {
   media_transport: string
   chat_stream_id: string | null
   sharing_endpoint_id: string | null
+  roster_version: number
   grace_deadline: Date | null
   ended_reason: string | null
   started_at: Date
@@ -41,6 +44,7 @@ export interface Call {
   mediaTransport: CallMediaTransport
   chatStreamId: string | null
   sharingEndpointId: string | null
+  rosterVersion: number
   graceDeadline: Date | null
   endedReason: CallEndedReason | null
   startedAt: Date
@@ -52,7 +56,7 @@ export interface Call {
 
 const CALL_COLUMNS = `
   id, workspace_id, stream_id, started_by, status, mode, media_transport,
-  chat_stream_id, sharing_endpoint_id, grace_deadline, ended_reason,
+  chat_stream_id, sharing_endpoint_id, roster_version, grace_deadline, ended_reason,
   started_at, ended_at, status_changed_at, created_at, updated_at
 `
 
@@ -67,6 +71,7 @@ function mapCall(row: CallRow): Call {
     mediaTransport: row.media_transport as CallMediaTransport,
     chatStreamId: row.chat_stream_id,
     sharingEndpointId: row.sharing_endpoint_id,
+    rosterVersion: row.roster_version,
     graceDeadline: row.grace_deadline,
     endedReason: row.ended_reason as CallEndedReason | null,
     startedAt: row.started_at,
@@ -240,6 +245,35 @@ export const CallRepository = {
       RETURNING ${sql.raw(CALL_COLUMNS)}
     `)
     return result.rows.map(mapCall)
+  },
+
+  /**
+   * Monotonically bump the roster version (INV-66). Every membership/media-state
+   * change bumps it so clients drop a stale snapshot by version. Single atomic
+   * increment — no read-modify-write. Returns the new version (`null` if the
+   * call vanished).
+   */
+  async bumpRosterVersion(db: Querier, workspaceId: string, id: string): Promise<number | null> {
+    const result = await db.query<{ roster_version: number }>(sql`
+      UPDATE calls SET roster_version = roster_version + 1, updated_at = NOW()
+      WHERE workspace_id = ${workspaceId} AND id = ${id}
+      RETURNING roster_version
+    `)
+    return result.rows[0]?.roster_version ?? null
+  },
+
+  /**
+   * Batch roster-version bump for the reaper cascade (INV-56, INV-66): one atomic
+   * increment across every call whose membership the sweep just changed. Locked by
+   * global id (the sweeper already holds these call rows FOR UPDATE and runs
+   * workspace-agnostic), matching {@link lockForUpdateInOrder}.
+   */
+  async bumpRosterVersionBatch(db: Querier, callIds: readonly string[]): Promise<void> {
+    if (callIds.length === 0) return
+    await db.query(sql`
+      UPDATE calls SET roster_version = roster_version + 1, updated_at = NOW()
+      WHERE id = ANY(${callIds as string[]})
+    `)
   },
 }
 
@@ -551,6 +585,57 @@ export const CallParticipantRepository = {
     `)
     return result.rows[0] ? mapParticipant(result.rows[0]) : null
   },
+
+  /**
+   * The versioned roster's per-participant rows: every currently-joined
+   * participant with their single live endpoint's connection status, server-owned
+   * media state, and published-track registry (LEFT JOIN — a participant momentarily
+   * without a live endpoint still appears). CF pushes no track notifications, so this
+   * registry is how peers learn what to pull. Read alongside `calls.roster_version`
+   * for the snapshot version.
+   */
+  async listRoster(db: Querier, workspaceId: string, callId: string): Promise<CallRosterEntry[]> {
+    const result = await db.query<{
+      user_id: string
+      participant_status: string
+      endpoint_id: string | null
+      connection_status: string | null
+      media_state: MediaState | null
+      published_tracks: PublishedTrack[] | null
+    }>(sql`
+      SELECT
+        p.user_id,
+        p.status AS participant_status,
+        e.id AS endpoint_id,
+        e.status AS connection_status,
+        e.media_state,
+        e.published_tracks
+      FROM call_participants p
+      LEFT JOIN call_endpoints e
+        ON e.workspace_id = p.workspace_id AND e.participant_id = p.id
+        AND e.status IN ('connected', 'reconnecting')
+      WHERE p.workspace_id = ${workspaceId} AND p.call_id = ${callId} AND p.status = 'joined'
+      ORDER BY p.joined_at ASC
+    `)
+    return result.rows.map((row) => ({
+      userId: row.user_id,
+      participantStatus: row.participant_status as CallParticipantStatus,
+      endpointId: row.endpoint_id,
+      connectionStatus: row.connection_status as CallEndpointStatus | null,
+      mediaState: row.media_state ?? {},
+      publishedTracks: row.published_tracks ?? [],
+    }))
+  },
+}
+
+/** One participant's row in the versioned roster snapshot (see `listRoster`). */
+export interface CallRosterEntry {
+  userId: string
+  participantStatus: CallParticipantStatus
+  endpointId: string | null
+  connectionStatus: CallEndpointStatus | null
+  mediaState: MediaState
+  publishedTracks: PublishedTrack[]
 }
 
 // ── call_endpoints ────────────────────────────────────────────────────────────
@@ -562,6 +647,10 @@ interface CallEndpointRow {
   participant_id: string
   epoch: number
   status: string
+  cf_session_id: string | null
+  media_incarnation: string | null
+  media_state: MediaState
+  published_tracks: PublishedTrack[]
   lease_expires_at: Date
   created_at: Date
   status_changed_at: Date
@@ -574,6 +663,10 @@ export interface CallEndpoint {
   participantId: string
   epoch: number
   status: CallEndpointStatus
+  cfSessionId: string | null
+  mediaIncarnation: string | null
+  mediaState: MediaState
+  publishedTracks: PublishedTrack[]
   leaseExpiresAt: Date
   createdAt: Date
   statusChangedAt: Date
@@ -581,6 +674,7 @@ export interface CallEndpoint {
 
 const ENDPOINT_COLUMNS = `
   id, workspace_id, call_id, participant_id, epoch, status,
+  cf_session_id, media_incarnation, media_state, published_tracks,
   lease_expires_at, created_at, status_changed_at
 `
 
@@ -592,6 +686,10 @@ function mapEndpoint(row: CallEndpointRow): CallEndpoint {
     participantId: row.participant_id,
     epoch: row.epoch,
     status: row.status as CallEndpointStatus,
+    cfSessionId: row.cf_session_id,
+    mediaIncarnation: row.media_incarnation,
+    mediaState: row.media_state ?? {},
+    publishedTracks: row.published_tracks ?? [],
     leaseExpiresAt: row.lease_expires_at,
     createdAt: row.created_at,
     statusChangedAt: row.status_changed_at,
@@ -607,16 +705,110 @@ export const CallEndpointRepository = {
       callId: string
       participantId: string
       epoch: number
+      mediaIncarnation: string | null
       leaseExpiresAt: Date
     }
   ): Promise<CallEndpoint> {
     const result = await db.query<CallEndpointRow>(sql`
-      INSERT INTO call_endpoints (id, workspace_id, call_id, participant_id, epoch, status, lease_expires_at)
+      INSERT INTO call_endpoints (
+        id, workspace_id, call_id, participant_id, epoch, status, media_incarnation, lease_expires_at
+      )
       VALUES (${params.id}, ${params.workspaceId}, ${params.callId}, ${params.participantId},
-              ${params.epoch}, 'connected', ${params.leaseExpiresAt})
+              ${params.epoch}, 'connected', ${params.mediaIncarnation}, ${params.leaseExpiresAt})
       RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
     `)
     return mapEndpoint(result.rows[0])
+  },
+
+  /**
+   * Re-bind a participant's existing live endpoint to a (possibly new)
+   * incarnation on a reconnect/reload: CAS a live endpoint back to `connected`,
+   * set the incoming incarnation, and renew the lease — keeping the same row and
+   * epoch (the lease is the authority, INV — a transient socket drop or a reload
+   * within the lease returns to the same endpoint). `null` when the endpoint is
+   * no longer live.
+   */
+  async rebind(
+    db: Querier,
+    params: { workspaceId: string; id: string; mediaIncarnation: string | null; leaseExpiresAt: Date }
+  ): Promise<CallEndpoint | null> {
+    const result = await db.query<CallEndpointRow>(sql`
+      UPDATE call_endpoints SET
+        status = 'connected', media_incarnation = ${params.mediaIncarnation},
+        lease_expires_at = ${params.leaseExpiresAt}, status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.id}
+        AND status IN ('connected', 'reconnecting')
+      RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapEndpoint(result.rows[0]) : null
+  },
+
+  /**
+   * Fenced `connected → reconnecting` on a socket disconnect (INV-66): the lease
+   * still holds the slot, so a reconnect within it re-binds. Guarded on the epoch
+   * so a superseded instance's disconnect can't demote the live endpoint. `null`
+   * when nothing matched.
+   */
+  async markReconnecting(
+    db: Querier,
+    params: { workspaceId: string; id: string; epoch: number }
+  ): Promise<CallEndpoint | null> {
+    const result = await db.query<CallEndpointRow>(sql`
+      UPDATE call_endpoints SET status = 'reconnecting', status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.id} AND epoch = ${params.epoch}
+        AND status = 'connected'
+      RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapEndpoint(result.rows[0]) : null
+  },
+
+  /**
+   * CAS the CF session id onto a live endpoint, fenced on the incarnation
+   * (INV-66) and only when none is set yet — so a committed row can never claim
+   * a `cf_session_id` for a superseded incarnation. `null` when the endpoint is
+   * gone, the incarnation no longer matches, or a session was already set (the
+   * caller re-reads to distinguish idempotency from a stale fence).
+   */
+  async setCfSessionIfUnset(
+    db: Querier,
+    params: { workspaceId: string; id: string; mediaIncarnation: string; cfSessionId: string }
+  ): Promise<CallEndpoint | null> {
+    const result = await db.query<CallEndpointRow>(sql`
+      UPDATE call_endpoints SET cf_session_id = ${params.cfSessionId}, status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.id}
+        AND media_incarnation = ${params.mediaIncarnation}
+        AND status IN ('connected', 'reconnecting') AND cf_session_id IS NULL
+      RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapEndpoint(result.rows[0]) : null
+  },
+
+  /** Overwrite the server-owned media state (mute/camera claims). `null` when the endpoint is gone. */
+  async setMediaState(
+    db: Querier,
+    params: { workspaceId: string; id: string; mediaState: MediaState }
+  ): Promise<CallEndpoint | null> {
+    const result = await db.query<CallEndpointRow>(sql`
+      UPDATE call_endpoints SET media_state = ${JSON.stringify(params.mediaState)}::jsonb, status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.id}
+        AND status IN ('connected', 'reconnecting')
+      RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapEndpoint(result.rows[0]) : null
+  },
+
+  /** Overwrite the published-track registry. `null` when the endpoint is gone. */
+  async setPublishedTracks(
+    db: Querier,
+    params: { workspaceId: string; id: string; publishedTracks: PublishedTrack[] }
+  ): Promise<CallEndpoint | null> {
+    const result = await db.query<CallEndpointRow>(sql`
+      UPDATE call_endpoints SET published_tracks = ${JSON.stringify(params.publishedTracks)}::jsonb, status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.id}
+        AND status IN ('connected', 'reconnecting')
+      RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapEndpoint(result.rows[0]) : null
   },
 
   /** Read an endpoint by id, workspace-scoped (INV-8). Used to verify leave ownership. */

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -646,6 +646,7 @@ interface CallEndpointRow {
   call_id: string
   participant_id: string
   epoch: number
+  connection_seq: number
   status: string
   cf_session_id: string | null
   media_incarnation: string | null
@@ -662,6 +663,7 @@ export interface CallEndpoint {
   callId: string
   participantId: string
   epoch: number
+  connectionSeq: number
   status: CallEndpointStatus
   cfSessionId: string | null
   mediaIncarnation: string | null
@@ -673,7 +675,7 @@ export interface CallEndpoint {
 }
 
 const ENDPOINT_COLUMNS = `
-  id, workspace_id, call_id, participant_id, epoch, status,
+  id, workspace_id, call_id, participant_id, epoch, connection_seq, status,
   cf_session_id, media_incarnation, media_state, published_tracks,
   lease_expires_at, created_at, status_changed_at
 `
@@ -685,6 +687,7 @@ function mapEndpoint(row: CallEndpointRow): CallEndpoint {
     callId: row.call_id,
     participantId: row.participant_id,
     epoch: row.epoch,
+    connectionSeq: row.connection_seq,
     status: row.status as CallEndpointStatus,
     cfSessionId: row.cf_session_id,
     mediaIncarnation: row.media_incarnation,
@@ -727,6 +730,21 @@ export const CallEndpointRepository = {
    * epoch (the lease is the authority, INV — a transient socket drop or a reload
    * within the lease returns to the same endpoint). `null` when the endpoint is
    * no longer live.
+   *
+   * A reload mints a NEW incarnation, so its old `cf_session_id`/`published_tracks`
+   * belong to a dead peer connection the reloaded page can no longer drive; clear
+   * both when the incoming incarnation differs from the stored one so
+   * `createEndpointCfSession` mints a fresh session instead of short-circuiting on
+   * the stale id. A same-incarnation transient reconnect keeps both. `IS DISTINCT
+   * FROM` reads the pre-update `media_incarnation` (Postgres evaluates SET
+   * expressions against the old row).
+   *
+   * `connection_seq` bumps on every bind (INV-66): a fast same-incarnation
+   * reconnect rebinds to `connected` at the same epoch before the old socket's
+   * fire-and-forget demotion commits; the demotion's (epoch, status) fence would
+   * still match and wedge the endpoint at `reconnecting`, so `markReconnecting`
+   * additionally fences on the seq the socket bound at — advancing it here makes
+   * the stale demotion a no-op.
    */
   async rebind(
     db: Querier,
@@ -734,8 +752,17 @@ export const CallEndpointRepository = {
   ): Promise<CallEndpoint | null> {
     const result = await db.query<CallEndpointRow>(sql`
       UPDATE call_endpoints SET
-        status = 'connected', media_incarnation = ${params.mediaIncarnation},
-        lease_expires_at = ${params.leaseExpiresAt}, status_changed_at = NOW()
+        status = 'connected',
+        media_incarnation = ${params.mediaIncarnation},
+        cf_session_id = CASE
+          WHEN media_incarnation IS DISTINCT FROM ${params.mediaIncarnation} THEN NULL
+          ELSE cf_session_id END,
+        published_tracks = CASE
+          WHEN media_incarnation IS DISTINCT FROM ${params.mediaIncarnation} THEN '[]'::jsonb
+          ELSE published_tracks END,
+        connection_seq = connection_seq + 1,
+        lease_expires_at = ${params.leaseExpiresAt},
+        status_changed_at = NOW()
       WHERE workspace_id = ${params.workspaceId} AND id = ${params.id}
         AND status IN ('connected', 'reconnecting')
       RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
@@ -745,18 +772,21 @@ export const CallEndpointRepository = {
 
   /**
    * Fenced `connected → reconnecting` on a socket disconnect (INV-66): the lease
-   * still holds the slot, so a reconnect within it re-binds. Guarded on the epoch
-   * so a superseded instance's disconnect can't demote the live endpoint. `null`
-   * when nothing matched.
+   * still holds the slot, so a reconnect within it re-binds. Fenced on the
+   * `connection_seq` the disconnecting socket bound at — a faster same-incarnation
+   * reconnect bumps the seq via {@link rebind}, so this stale demotion matches
+   * nothing and cannot wedge the freshly re-bound endpoint at `reconnecting`. The
+   * epoch fence is retained as belt for the superseded-instance case. `null` when
+   * nothing matched.
    */
   async markReconnecting(
     db: Querier,
-    params: { workspaceId: string; id: string; epoch: number }
+    params: { workspaceId: string; id: string; epoch: number; connectionSeq: number }
   ): Promise<CallEndpoint | null> {
     const result = await db.query<CallEndpointRow>(sql`
       UPDATE call_endpoints SET status = 'reconnecting', status_changed_at = NOW()
       WHERE workspace_id = ${params.workspaceId} AND id = ${params.id} AND epoch = ${params.epoch}
-        AND status = 'connected'
+        AND connection_seq = ${params.connectionSeq} AND status = 'connected'
       RETURNING ${sql.raw(ENDPOINT_COLUMNS)}
     `)
     return result.rows[0] ? mapEndpoint(result.rows[0]) : null

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -65,6 +65,7 @@ function fakeEndpoint(overrides: Partial<CallEndpoint> = {}): CallEndpoint {
     callId: "call_1",
     participantId: "callp_1",
     epoch: 1,
+    connectionSeq: 0,
     status: "connected",
     cfSessionId: null,
     mediaIncarnation: null,
@@ -816,8 +817,18 @@ describe("CallService.joinCall — incarnation rebind", () => {
     spyOn(CallEndpointRepository, "findLiveByParticipant").mockResolvedValue(
       fakeEndpoint({ id: "callep_old", epoch: 5, status: "reconnecting", mediaIncarnation: "inc_old" })
     )
+    // A reload mints a new incarnation, so rebind drops the previous incarnation's
+    // dead CF session (cfSessionId null) — createEndpointCfSession then mints fresh
+    // instead of short-circuiting on the stale id (INV-41).
     const rebind = spyOn(CallEndpointRepository, "rebind").mockResolvedValue(
-      fakeEndpoint({ id: "callep_old", epoch: 5, status: "connected", mediaIncarnation: "inc_new" })
+      fakeEndpoint({
+        id: "callep_old",
+        epoch: 5,
+        connectionSeq: 6,
+        status: "connected",
+        mediaIncarnation: "inc_new",
+        cfSessionId: null,
+      })
     )
     const insert = spyOn(CallEndpointRepository, "insert").mockResolvedValue(fakeEndpoint())
     spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
@@ -834,7 +845,45 @@ describe("CallService.joinCall — incarnation rebind", () => {
       expect.objectContaining({ id: "callep_old", mediaIncarnation: "inc_new" })
     )
     expect(insert).not.toHaveBeenCalled()
-    expect(result.endpoint.id).toBe("callep_old")
-    expect(result.endpoint.epoch).toBe(5)
+    expect(result.endpoint).toMatchObject({ id: "callep_old", epoch: 5, cfSessionId: null })
+  })
+})
+
+describe("CallService.markEndpointReconnecting", () => {
+  afterEach(() => mock.restore())
+
+  it("demotes and bumps the roster version in the same tx", async () => {
+    stubTransaction()
+    spyOn(CallEndpointRepository, "markReconnecting").mockResolvedValue(
+      fakeEndpoint({ id: "callep_1", status: "reconnecting" })
+    )
+    const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(3)
+
+    const result = await makeService().markEndpointReconnecting({
+      workspaceId: "ws_1",
+      endpointId: "callep_1",
+      epoch: 2,
+      connectionSeq: 0,
+    })
+
+    expect(result?.status).toBe("reconnecting")
+    // The disconnect broadcast must be newer than what peers hold (INV-66).
+    expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
+  })
+
+  it("skips the bump on a stale fence (a fast reconnect already re-bound the endpoint)", async () => {
+    stubTransaction()
+    spyOn(CallEndpointRepository, "markReconnecting").mockResolvedValue(null)
+    const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(3)
+
+    const result = await makeService().markEndpointReconnecting({
+      workspaceId: "ws_1",
+      endpointId: "callep_1",
+      epoch: 2,
+      connectionSeq: 0,
+    })
+
+    expect(result).toBeNull()
+    expect(bump).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -28,6 +28,7 @@ function fakeCall(overrides: Partial<Call> = {}): Call {
     mediaTransport: "sfu",
     chatStreamId: null,
     sharingEndpointId: null,
+    rosterVersion: 0,
     graceDeadline: null,
     endedReason: null,
     startedAt: NOW,
@@ -65,6 +66,10 @@ function fakeEndpoint(overrides: Partial<CallEndpoint> = {}): CallEndpoint {
     participantId: "callp_1",
     epoch: 1,
     status: "connected",
+    cfSessionId: null,
+    mediaIncarnation: null,
+    mediaState: {},
+    publishedTracks: [],
     leaseExpiresAt: NOW,
     createdAt: NOW,
     statusChangedAt: NOW,
@@ -73,7 +78,11 @@ function fakeEndpoint(overrides: Partial<CallEndpoint> = {}): CallEndpoint {
 }
 
 function stubTransaction() {
-  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+  // The client carries a no-op `query` so unspied same-tx statements (the roster
+  // bumps every membership/connection transition now runs) don't throw; each test
+  // that cares spies CallRepository.bumpRosterVersion(Batch) directly and asserts.
+  const client = { query: async () => ({ rows: [] }) } as unknown as PoolClient
+  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn(client))
 }
 
 function makeService() {
@@ -245,11 +254,14 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
     spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
     stubCleanEndpointAdmission()
     const accept = spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+    const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
 
     const result = await makeService().joinCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_b" })
 
     expect(revive).toHaveBeenCalledTimes(1)
     expect(accept).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ inviteeUserId: "usr_b" }))
+    // A join bumps the roster version in the same tx (INV-66) so peers don't drop the arrival.
+    expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
     expect(result.endpoint.id).toBe("callep_1")
   })
 
@@ -374,6 +386,7 @@ describe("CallService.leaveCall", () => {
     )
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
     const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
     spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "empty_grace" }))
 
     const result = await makeService().leaveCall({
@@ -386,6 +399,8 @@ describe("CallService.leaveCall", () => {
     expect(close).toHaveBeenCalledWith(expect.anything(), "ws_1", "callep_1")
     expect(markLeft).toHaveBeenCalledTimes(1)
     expect(grace).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ reason: "completed" }))
+    // A leave bumps the roster version in the same tx (INV-66) so the departed tile isn't a ghost.
+    expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
     expect(result.call.status).toBe("empty_grace")
   })
 
@@ -464,6 +479,7 @@ describe("CallService.removeParticipant", () => {
     )
     const closeEp = spyOn(CallEndpointRepository, "closeByParticipant").mockResolvedValue([])
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
+    const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
 
     const result = await makeService().removeParticipant({
       workspaceId: "ws_1",
@@ -477,6 +493,8 @@ describe("CallService.removeParticipant", () => {
       expect.objectContaining({ targetUserId: "usr_target", removedBy: "usr_remover" })
     )
     expect(closeEp).toHaveBeenCalledWith(expect.anything(), "ws_1", "callp_target")
+    // Removal bumps the roster version in the same tx (INV-66).
+    expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
     expect(result.status).toBe("removed")
   })
 
@@ -545,6 +563,7 @@ describe("CallService sweeps", () => {
     const grace = spyOn(CallRepository, "enterGraceIfEmptyBatch").mockResolvedValue([
       fakeCall({ status: "empty_grace" }),
     ])
+    const bumpBatch = spyOn(CallRepository, "bumpRosterVersionBatch").mockResolvedValue(undefined)
 
     const result = await makeService().reapLapsedEndpoints(NOW)
 
@@ -554,6 +573,8 @@ describe("CallService sweeps", () => {
     expect(lock).toHaveBeenCalledWith(expect.anything(), ["call_1"])
     expect(markLeft).toHaveBeenCalledWith(expect.anything(), ["callp_a", "callp_b"])
     expect(grace).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ callIds: ["call_1"] }))
+    // The reap cascade bumps the roster version of every touched call in the same tx (INV-66).
+    expect(bumpBatch).toHaveBeenCalledWith(expect.anything(), ["call_1"])
   })
 
   it("reapLapsedEndpoints short-circuits before locking when nothing lapsed", async () => {
@@ -578,5 +599,242 @@ describe("CallService sweeps", () => {
 
     expect(await makeService().expireStaleRings(NOW)).toEqual({ expired: 1 })
     expect(await makeService().endGraceExpiredCalls(NOW)).toEqual({ ended: 1 })
+  })
+
+  it("reapLapsedEndpoints closes the CF sessions of reaped endpoints AFTER commit", async () => {
+    stubTransaction()
+    spyOn(CallEndpointRepository, "findLapsedCallIds").mockResolvedValue(["call_1"])
+    spyOn(CallRepository, "lockForUpdateInOrder").mockResolvedValue(undefined)
+    spyOn(CallEndpointRepository, "reapLapsed").mockResolvedValue([
+      fakeEndpoint({ id: "callep_a", cfSessionId: "sess_a", status: "closed" }),
+      fakeEndpoint({ id: "callep_b", cfSessionId: null, status: "closed" }),
+    ])
+    spyOn(CallParticipantRepository, "markLeftWhereNoLiveEndpoint").mockResolvedValue([])
+    spyOn(CallRepository, "enterGraceIfEmptyBatch").mockResolvedValue([])
+    const closeSession = mock(async () => {})
+
+    await makeServiceWithCf({ closeSession }).reapLapsedEndpoints(NOW)
+
+    // Only the endpoint that carried a CF session is torn down.
+    expect(closeSession).toHaveBeenCalledTimes(1)
+    expect(closeSession).toHaveBeenCalledWith("sess_a")
+  })
+})
+
+function fakeCloudflare(overrides: Record<string, unknown> = {}) {
+  return {
+    createSession: mock(async () => ({ sessionId: "sess_new", sessionDescription: { type: "answer", sdp: "a" } })),
+    renegotiateSession: mock(async () => ({})),
+    addLocalTracks: mock(async () => ({ requiresImmediateRenegotiation: true, tracks: [] })),
+    pullRemoteTracks: mock(async () => ({ requiresImmediateRenegotiation: false, tracks: [] })),
+    closeTracks: mock(async () => ({ tracks: [] })),
+    closeSession: mock(async () => {}),
+    ...overrides,
+  }
+}
+
+function makeServiceWithCf(cloudflare: Record<string, unknown>) {
+  return new CallService({ pool: {} as Pool, cloudflare: cloudflare as never })
+}
+
+function stubWithClient() {
+  spyOn(dbModule, "withClient").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+}
+
+/** Stub the fence reads (call, endpoint, participant) for a live, owned, incarnation-matched endpoint. */
+function stubFence(endpoint: CallEndpoint, call = fakeCall()) {
+  spyOn(CallRepository, "findById").mockResolvedValue(call)
+  spyOn(CallEndpointRepository, "findById").mockResolvedValue(endpoint)
+  spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant({ id: endpoint.participantId }))
+}
+
+describe("CallService.createEndpointCfSession", () => {
+  afterEach(() => mock.restore())
+
+  it("is idempotent per incarnation — an endpoint with a CF session returns it without a CF call", async () => {
+    stubWithClient()
+    stubFence(fakeEndpoint({ id: "callep_1", cfSessionId: "sess_existing", mediaIncarnation: "inc_1" }))
+    const cf = fakeCloudflare()
+
+    const result = await makeServiceWithCf(cf).createEndpointCfSession({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+    })
+
+    expect(result).toEqual({ cfSessionId: "sess_existing", idempotent: true })
+    expect(cf.createSession).not.toHaveBeenCalled()
+  })
+
+  it("creates the CF session first, then CAS-binds it onto the endpoint", async () => {
+    stubWithClient()
+    stubFence(fakeEndpoint({ id: "callep_1", cfSessionId: null, mediaIncarnation: "inc_1" }))
+    spyOn(CallEndpointRepository, "setCfSessionIfUnset").mockResolvedValue(
+      fakeEndpoint({ id: "callep_1", cfSessionId: "sess_new", mediaIncarnation: "inc_1" })
+    )
+    const cf = fakeCloudflare()
+
+    const result = await makeServiceWithCf(cf).createEndpointCfSession({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+    })
+
+    expect(cf.createSession).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ cfSessionId: "sess_new", idempotent: false })
+  })
+
+  it("closes the just-created CF session and 409s when the CAS loses to a stale incarnation", async () => {
+    stubWithClient()
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
+    spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant({ id: "callp_1" }))
+    // First findById is the fence read (live, matching incarnation); the second
+    // is the post-CAS re-read, by which point a different incarnation owns the row.
+    spyOn(CallEndpointRepository, "findById")
+      .mockResolvedValueOnce(
+        fakeEndpoint({ id: "callep_1", participantId: "callp_1", cfSessionId: null, mediaIncarnation: "inc_1" })
+      )
+      .mockResolvedValueOnce(
+        fakeEndpoint({ id: "callep_1", participantId: "callp_1", cfSessionId: "sess_other", mediaIncarnation: "inc_2" })
+      )
+    spyOn(CallEndpointRepository, "setCfSessionIfUnset").mockResolvedValue(null)
+    const cf = fakeCloudflare()
+
+    const promise = makeServiceWithCf(cf).createEndpointCfSession({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+    })
+
+    await expect(promise).rejects.toMatchObject({ status: 409, code: "CALL_STALE_INCARNATION" })
+    expect(cf.closeSession).toHaveBeenCalledWith("sess_new")
+  })
+})
+
+describe("CallService.setEndpointMediaState", () => {
+  afterEach(() => mock.restore())
+
+  it("bumps the roster version and returns the fresh snapshot", async () => {
+    stubTransaction()
+    stubFence(fakeEndpoint({ id: "callep_1", mediaIncarnation: "inc_1" }))
+    const setState = spyOn(CallEndpointRepository, "setMediaState").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(9)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+
+    const snapshot = await makeService().setEndpointMediaState({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mediaState: { muted: true },
+    })
+
+    expect(snapshot.rosterVersion).toBe(9)
+    expect(setState).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ mediaState: { muted: true } }))
+  })
+
+  it("rejects camera-on on an audio-only call", async () => {
+    stubTransaction()
+    stubFence(fakeEndpoint({ id: "callep_1", mediaIncarnation: "inc_1" }), fakeCall({ mode: "audio_only" }))
+
+    const promise = makeService().setEndpointMediaState({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mediaState: { cameraOn: true },
+    })
+
+    await expect(promise).rejects.toMatchObject({ status: 409, code: "CALL_CAMERA_NOT_ALLOWED" })
+  })
+})
+
+describe("CallService.publishTracks", () => {
+  afterEach(() => mock.restore())
+
+  it("publishes to CF, sets the registry, and bumps the roster version", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(fakeEndpoint({ id: "callep_1", cfSessionId: "sess_1", mediaIncarnation: "inc_1" }))
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(4)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+    const cf = fakeCloudflare()
+
+    const result = await makeServiceWithCf(cf).publishTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ kind: "mic", mid: "0", trackName: "mic0" }],
+    })
+
+    expect(cf.addLocalTracks).toHaveBeenCalledWith("sess_1", {
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ location: "local", trackName: "mic0", mid: "0" }],
+    })
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
+    )
+    expect(result.snapshot.rosterVersion).toBe(4)
+  })
+
+  it("503s when the media plane is unconfigured", async () => {
+    const promise = makeService().publishTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ kind: "mic", mid: "0", trackName: "mic0" }],
+    })
+    await expect(promise).rejects.toMatchObject({ status: 503, code: "CALLS_UNAVAILABLE" })
+  })
+})
+
+describe("CallService.joinCall — incarnation rebind", () => {
+  afterEach(() => mock.restore())
+
+  it("re-binds a reconnecting endpoint to the same epoch on a reload (new incarnation)", async () => {
+    stubTransaction()
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
+    spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
+    spyOn(CallEndpointRepository, "findLiveByParticipant").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 5, status: "reconnecting", mediaIncarnation: "inc_old" })
+    )
+    const rebind = spyOn(CallEndpointRepository, "rebind").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 5, status: "connected", mediaIncarnation: "inc_new" })
+    )
+    const insert = spyOn(CallEndpointRepository, "insert").mockResolvedValue(fakeEndpoint())
+    spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+
+    const result = await makeService().joinCall({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_a",
+      mediaIncarnation: "inc_new",
+    })
+
+    expect(rebind).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: "callep_old", mediaIncarnation: "inc_new" })
+    )
+    expect(insert).not.toHaveBeenCalled()
+    expect(result.endpoint.id).toBe("callep_old")
+    expect(result.endpoint.epoch).toBe(5)
   })
 })

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -1,7 +1,8 @@
 import type { Pool, PoolClient } from "pg"
 import { StreamTypes } from "@threa/types"
-import { withTransaction } from "../../db"
+import { withTransaction, withClient } from "../../db"
 import { HttpError } from "../../lib/errors"
+import { logger } from "../../lib/logger"
 import { callId, callInvitationId, callParticipantId, callEndpointId } from "../../lib/id"
 import { checkStreamAccess, StreamMemberRepository } from "../streams"
 import { checkCallAccess } from "./access"
@@ -14,8 +15,27 @@ import {
   type CallInvitation,
   type CallParticipant,
   type CallEndpoint,
+  type CallRosterEntry,
 } from "./repository"
-import { EMPTY_GRACE_MS, ENDPOINT_LEASE_TTL_MS, INVITATION_TTL_MS, CALL_PRODUCT_CAP, type CallMode } from "./config"
+import {
+  EMPTY_GRACE_MS,
+  ENDPOINT_LEASE_TTL_MS,
+  INVITATION_TTL_MS,
+  CALL_PRODUCT_CAP,
+  type CallMode,
+  type MediaState,
+  type PublishedTrack,
+} from "./config"
+import {
+  CloudflareRealtimeError,
+  type RealtimeMediaApi,
+  type SessionDescription,
+  type LocalTrackRequest,
+  type RemoteTrackRequest,
+  type TracksResult,
+  type RenegotiateResult,
+  type CloseTracksResult,
+} from "./cloudflare"
 
 export interface StartCallResult {
   call: Call
@@ -30,10 +50,19 @@ export interface JoinCallResult {
   endpoint: CallEndpoint
 }
 
+/** A versioned roster snapshot: the per-participant rows plus the version they were read at. */
+export interface CallRosterSnapshot {
+  rosterVersion: number
+  roster: CallRosterEntry[]
+}
+
 /**
- * Lifecycle owner for calls (M0 PR 0.1) — transport-independent state machines
- * only: no sockets, no Cloudflare, no outbox emission yet. A call is a set of
- * rows in call-scoped tracking tables (INV-57) attached to an existing stream.
+ * Lifecycle owner for calls — the transport-independent state machines (0.1) plus
+ * the Cloudflare media-plane proxy (0.2): CF session/track operations run
+ * CF-first, then the DB write (INV-41), so no committed row ever claims a
+ * `cf_session_id` that was never created. No outbox/timeline emission yet (1.3/1.4).
+ * A call is a set of rows in call-scoped tracking tables (INV-57) attached to an
+ * existing stream.
  *
  * The service owns every transaction (INV-6) and every transition is CAS +
  * row-lock (INV-20): product glare resolves via `INSERT ... ON CONFLICT DO
@@ -47,9 +76,19 @@ export interface JoinCallResult {
  */
 export class CallService {
   private readonly pool: Pool
+  private readonly cloudflare: RealtimeMediaApi | null
 
-  constructor(deps: { pool: Pool }) {
+  constructor(deps: { pool: Pool; cloudflare?: RealtimeMediaApi | null }) {
     this.pool = deps.pool
+    this.cloudflare = deps.cloudflare ?? null
+  }
+
+  /** Fail loudly (503) when the CF media plane is not configured (INV-11). */
+  private requireCloudflare(): RealtimeMediaApi {
+    if (!this.cloudflare) {
+      throw new HttpError("Calls media is not configured", { status: 503, code: "CALLS_UNAVAILABLE" })
+    }
+    return this.cloudflare
   }
 
   /**
@@ -62,7 +101,7 @@ export class CallService {
    * participant with no lease the sweeper can reap. A DM start rings the peer.
    */
   async startCall(
-    params: { workspaceId: string; streamId: string; userId: string; mode: CallMode },
+    params: { workspaceId: string; streamId: string; userId: string; mode: CallMode; mediaIncarnation?: string },
     tx?: PoolClient
   ): Promise<StartCallResult> {
     return withTransaction(tx ?? this.pool, async (client) => {
@@ -98,6 +137,7 @@ export class CallService {
         workspaceId: params.workspaceId,
         callId: targetCallId,
         userId: params.userId,
+        mediaIncarnation: params.mediaIncarnation,
       })
 
       if (created && stream.type === StreamTypes.DM) {
@@ -128,7 +168,7 @@ export class CallService {
    * is accepted.
    */
   async joinCall(
-    params: { workspaceId: string; callId: string; userId: string; takeover?: boolean },
+    params: { workspaceId: string; callId: string; userId: string; takeover?: boolean; mediaIncarnation?: string },
     tx?: PoolClient
   ): Promise<JoinCallResult> {
     return withTransaction(tx ?? this.pool, async (client) => {
@@ -156,7 +196,7 @@ export class CallService {
    */
   private async joinLockedCall(
     client: PoolClient,
-    params: { workspaceId: string; callId: string; userId: string; takeover?: boolean }
+    params: { workspaceId: string; callId: string; userId: string; takeover?: boolean; mediaIncarnation?: string }
   ): Promise<JoinCallResult> {
     let call = await CallRepository.findByIdForUpdate(client, params.workspaceId, params.callId)
     if (!call) {
@@ -178,26 +218,9 @@ export class CallService {
 
     const participant = await this.admitParticipant(client, { call, userId: params.userId, invitedBy: null })
 
+    const incarnation = params.mediaIncarnation ?? null
     const live = await CallEndpointRepository.findLiveByParticipant(client, params.workspaceId, participant.id)
-    if (live) {
-      if (!params.takeover) {
-        throw new HttpError("An active endpoint already exists for this user", {
-          status: 409,
-          code: "CALL_ENDPOINT_ACTIVE",
-        })
-      }
-      await CallEndpointRepository.close(client, params.workspaceId, live.id)
-    }
-
-    const maxEpoch = await CallEndpointRepository.maxEpochForParticipant(client, params.workspaceId, participant.id)
-    const endpoint = await CallEndpointRepository.insert(client, {
-      id: callEndpointId(),
-      workspaceId: params.workspaceId,
-      callId: params.callId,
-      participantId: participant.id,
-      epoch: maxEpoch + 1,
-      leaseExpiresAt: new Date(Date.now() + ENDPOINT_LEASE_TTL_MS),
-    })
+    const endpoint = await this.admitEndpoint(client, { params, participant, live, incarnation })
 
     await CallInvitationRepository.acceptRingingForUser(client, {
       workspaceId: params.workspaceId,
@@ -205,7 +228,75 @@ export class CallService {
       inviteeUserId: params.userId,
     })
 
+    // A join is a membership change: bump the roster version in the same tx as
+    // the membership/endpoint writes so the snapshot the gateway reads after
+    // commit is strictly newer than what peers hold (INV-66).
+    await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
+
     return { call, participant, endpoint }
+  }
+
+  /**
+   * Admit exactly one live endpoint for a participant, resolving the
+   * device/tab/reload arbitration. The lease is the authority (INV — a lapsed
+   * lease is the only durable "gone" signal), so:
+   * - No live endpoint ⇒ mint a fresh one (epoch = prior max + 1).
+   * - A live endpoint that is `reconnecting`, carries no incarnation yet (a REST
+   *   start not yet socket-bound), or carries THIS incarnation ⇒ re-bind that
+   *   same row + epoch to the incoming incarnation (a transient socket drop or a
+   *   reload within the lease returns to the same endpoint, fresh CF session).
+   * - A genuinely live (`connected`) endpoint on a DIFFERENT incarnation ⇒ a
+   *   second concurrent device: rejected unless `takeover`, which closes the
+   *   prior one and mints a higher epoch.
+   */
+  private async admitEndpoint(
+    client: PoolClient,
+    args: {
+      params: { workspaceId: string; callId: string; takeover?: boolean }
+      participant: CallParticipant
+      live: CallEndpoint | null
+      incarnation: string | null
+    }
+  ): Promise<CallEndpoint> {
+    const { params, participant, live, incarnation } = args
+    const leaseExpiresAt = new Date(Date.now() + ENDPOINT_LEASE_TTL_MS)
+
+    if (live) {
+      // Rebind only applies to the incarnation-aware socket-join path. A caller
+      // that supplies no incarnation keeps the transport-independent rule:
+      // a live endpoint blocks a second one unless takeover.
+      const rebindable =
+        incarnation !== null &&
+        (live.status === "reconnecting" || live.mediaIncarnation === null || live.mediaIncarnation === incarnation)
+      if (rebindable) {
+        const rebound = await CallEndpointRepository.rebind(client, {
+          workspaceId: params.workspaceId,
+          id: live.id,
+          mediaIncarnation: incarnation,
+          leaseExpiresAt,
+        })
+        if (rebound) return rebound
+        // Lost the row to a concurrent close between read and CAS; fall through to a fresh mint.
+      } else if (!params.takeover) {
+        throw new HttpError("An active endpoint already exists for this user", {
+          status: 409,
+          code: "CALL_ENDPOINT_ACTIVE",
+        })
+      } else {
+        await CallEndpointRepository.close(client, params.workspaceId, live.id)
+      }
+    }
+
+    const maxEpoch = await CallEndpointRepository.maxEpochForParticipant(client, params.workspaceId, participant.id)
+    return CallEndpointRepository.insert(client, {
+      id: callEndpointId(),
+      workspaceId: params.workspaceId,
+      callId: params.callId,
+      participantId: participant.id,
+      epoch: maxEpoch + 1,
+      mediaIncarnation: incarnation,
+      leaseExpiresAt,
+    })
   }
 
   /**
@@ -256,6 +347,10 @@ export class CallService {
           reason: "completed",
         })
       }
+
+      // A leave is a membership change: bump the roster version in the same tx as
+      // the endpoint-close/participant-left writes (INV-66).
+      await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
 
       const updated = (await CallRepository.findById(client, params.workspaceId, params.callId)) ?? call
       return { call: updated }
@@ -317,6 +412,334 @@ export class CallService {
   }
 
   /**
+   * Mark a disconnected endpoint `reconnecting` (fenced on epoch). The lease
+   * still holds the slot, so a reconnect within it re-binds — a socket drop is
+   * NOT a leave. `null` when the epoch is stale (a superseded instance's
+   * disconnect must not demote the live endpoint).
+   */
+  async markEndpointReconnecting(params: {
+    workspaceId: string
+    endpointId: string
+    epoch: number
+  }): Promise<CallEndpoint | null> {
+    return withTransaction(this.pool, async (client) => {
+      const endpoint = await CallEndpointRepository.markReconnecting(client, {
+        workspaceId: params.workspaceId,
+        id: params.endpointId,
+        epoch: params.epoch,
+      })
+      // A connection transition (connected → reconnecting) changes the roster:
+      // bump the version in the same tx so the disconnect broadcast is newer than
+      // what peers hold (INV-66). Skip the bump when nothing was demoted (stale epoch).
+      if (endpoint) {
+        await CallRepository.bumpRosterVersion(client, params.workspaceId, endpoint.callId)
+      }
+      return endpoint
+    })
+  }
+
+  /** Read the versioned roster snapshot (call.roster_version + per-participant rows) on one connection. */
+  async getRosterSnapshot(workspaceId: string, targetCallId: string): Promise<CallRosterSnapshot> {
+    return withClient(this.pool, async (client) => {
+      const call = await CallRepository.findById(client, workspaceId, targetCallId)
+      if (!call) {
+        throw new HttpError("Call not found", { status: 404, code: "CALL_NOT_FOUND" })
+      }
+      const roster = await CallParticipantRepository.listRoster(client, workspaceId, targetCallId)
+      return { rosterVersion: call.rosterVersion, roster }
+    })
+  }
+
+  /**
+   * Update the server-owned media state (mute/camera claims) for an endpoint,
+   * bump the roster version, and return the fresh snapshot. Camera-enable is
+   * rejected on an audio-only call (the mode is immutable and caps the media).
+   */
+  async setEndpointMediaState(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+    mediaState: MediaState
+  }): Promise<CallRosterSnapshot> {
+    return withTransaction(this.pool, async (client) => {
+      const { endpoint, call } = await this.loadFencedEndpoint(client, params)
+      if (params.mediaState.cameraOn === true && call.mode === "audio_only") {
+        throw new HttpError("Camera is not allowed on an audio-only call", {
+          status: 409,
+          code: "CALL_CAMERA_NOT_ALLOWED",
+        })
+      }
+      const merged: MediaState = { ...endpoint.mediaState, ...params.mediaState }
+      await CallEndpointRepository.setMediaState(client, {
+        workspaceId: params.workspaceId,
+        id: endpoint.id,
+        mediaState: merged,
+      })
+      const rosterVersion = await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
+      const roster = await CallParticipantRepository.listRoster(client, params.workspaceId, params.callId)
+      return { rosterVersion: rosterVersion ?? call.rosterVersion, roster }
+    })
+  }
+
+  /**
+   * Create the endpoint's CF session (INV-41: CF call BEFORE the DB write, never
+   * inside a transaction). Fenced on `(endpointId, media_incarnation)`. Idempotent
+   * per incarnation: an endpoint that already carries a `cf_session_id` returns it
+   * without a second CF call. On the CAS losing to a concurrent writer or a stale
+   * incarnation, the just-created CF session is closed best-effort so nothing
+   * strands.
+   */
+  async createEndpointCfSession(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+  }): Promise<{ cfSessionId: string; sessionDescription?: SessionDescription; idempotent: boolean }> {
+    const cf = this.requireCloudflare()
+    const { endpoint } = await this.fenceEndpoint(params)
+    if (endpoint.cfSessionId) {
+      return { cfSessionId: endpoint.cfSessionId, idempotent: true }
+    }
+
+    const created = await this.cfCall(() => cf.createSession())
+
+    let bound: CallEndpoint | null
+    try {
+      bound = await CallEndpointRepository.setCfSessionIfUnset(this.pool, {
+        workspaceId: params.workspaceId,
+        id: params.endpointId,
+        mediaIncarnation: params.mediaIncarnation,
+        cfSessionId: created.sessionId,
+      })
+    } catch (err) {
+      // The CAS write failed (e.g. a transient DB drop) after the CF session was
+      // minted — no row captured it, so close it best-effort before rethrowing so
+      // nothing strands until CF's inactivity timeout.
+      await this.bestEffortCloseSession(created.sessionId)
+      throw err
+    }
+    if (bound) {
+      return { cfSessionId: created.sessionId, sessionDescription: created.sessionDescription, idempotent: false }
+    }
+
+    // CAS failed: either another call bound a session for this incarnation
+    // (idempotent winner) or the endpoint/incarnation is no longer live. Either
+    // way the session we just minted is orphaned — close it best-effort.
+    await this.bestEffortCloseSession(created.sessionId)
+    const current = await CallEndpointRepository.findById(this.pool, params.workspaceId, params.endpointId)
+    if (current && current.cfSessionId && current.mediaIncarnation === params.mediaIncarnation) {
+      return { cfSessionId: current.cfSessionId, idempotent: true }
+    }
+    throw new HttpError("Endpoint incarnation is stale", { status: 409, code: "CALL_STALE_INCARNATION" })
+  }
+
+  /**
+   * Publish local tracks: CF `addLocalTracks` (outside any tx), then overwrite the
+   * endpoint's published-track registry to the declared set, bump the roster
+   * version, and return the CF answer plus the fresh snapshot. Peers pull these
+   * tracks on the roster change (CF pushes no notification).
+   */
+  async publishTracks(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+    sdp: SessionDescription
+    tracks: Array<{ kind: PublishedTrack["kind"]; mid: string; trackName: string }>
+  }): Promise<{ cf: TracksResult; snapshot: CallRosterSnapshot }> {
+    const cf = this.requireCloudflare()
+    const { endpoint } = await this.fenceEndpoint(params)
+    const cfSessionId = this.requireCfSession(endpoint)
+
+    const localTracks: LocalTrackRequest[] = params.tracks.map((t) => ({
+      location: "local",
+      trackName: t.trackName,
+      mid: t.mid,
+    }))
+    const cfResult = await this.cfCall(() => cf.addLocalTracks(cfSessionId, { sdp: params.sdp, tracks: localTracks }))
+
+    const registry: PublishedTrack[] = params.tracks.map((t) => ({ kind: t.kind, trackName: t.trackName }))
+    const snapshot = await withTransaction(this.pool, async (client) => {
+      const updated = await CallEndpointRepository.setPublishedTracks(client, {
+        workspaceId: params.workspaceId,
+        id: params.endpointId,
+        publishedTracks: registry,
+      })
+      if (!updated) {
+        // The endpoint was closed (concurrent takeover/reap) between the fence read
+        // and this write — don't bump the roster for a registry that wasn't persisted.
+        throw new HttpError("Endpoint is no longer live", { status: 409, code: "CALL_ENDPOINT_NOT_LIVE" })
+      }
+      const rosterVersion = await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
+      const roster = await CallParticipantRepository.listRoster(client, params.workspaceId, params.callId)
+      return { rosterVersion: rosterVersion ?? 0, roster }
+    })
+    return { cf: cfResult, snapshot }
+  }
+
+  /** Pull peer tracks: a thin CF `tracks/new` (remote) pass-through, incarnation-fenced. No DB write. */
+  async pullTracks(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+    tracks: RemoteTrackRequest[]
+  }): Promise<{ cf: TracksResult }> {
+    const cf = this.requireCloudflare()
+    const { endpoint } = await this.fenceEndpoint(params)
+    const cfSessionId = this.requireCfSession(endpoint)
+    const cfResult = await this.cfCall(() => cf.pullRemoteTracks(cfSessionId, { tracks: params.tracks }))
+    return { cf: cfResult }
+  }
+
+  /** Renegotiate the CF session: a thin pass-through, incarnation-fenced. No DB write. */
+  async renegotiate(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+    sdp: SessionDescription
+  }): Promise<{ cf: RenegotiateResult }> {
+    const cf = this.requireCloudflare()
+    const { endpoint } = await this.fenceEndpoint(params)
+    const cfSessionId = this.requireCfSession(endpoint)
+    const cfResult = await this.cfCall(() => cf.renegotiateSession(cfSessionId, params.sdp))
+    return { cf: cfResult }
+  }
+
+  /**
+   * Close published tracks: CF `tracks/close` (outside any tx). When the caller
+   * names the kinds it is unpublishing, prune them from the registry, bump the
+   * roster, and return the fresh snapshot so peers stop pulling dead tracks.
+   */
+  async closeTracks(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+    mids: string[]
+    unpublishKinds?: Array<PublishedTrack["kind"]>
+    sdp?: SessionDescription
+  }): Promise<{ cf: CloseTracksResult; snapshot?: CallRosterSnapshot }> {
+    const cf = this.requireCloudflare()
+    const { endpoint } = await this.fenceEndpoint(params)
+    const cfSessionId = this.requireCfSession(endpoint)
+    const cfResult = await this.cfCall(() =>
+      cf.closeTracks(cfSessionId, { mids: params.mids, force: false, sdp: params.sdp })
+    )
+
+    if (!params.unpublishKinds || params.unpublishKinds.length === 0) {
+      return { cf: cfResult }
+    }
+    const remove = new Set(params.unpublishKinds)
+    const registry = endpoint.publishedTracks.filter((t) => !remove.has(t.kind))
+    const snapshot = await withTransaction(this.pool, async (client) => {
+      const updated = await CallEndpointRepository.setPublishedTracks(client, {
+        workspaceId: params.workspaceId,
+        id: params.endpointId,
+        publishedTracks: registry,
+      })
+      if (!updated) {
+        // The endpoint was closed concurrently — skip the bump for an unpersisted registry.
+        throw new HttpError("Endpoint is no longer live", { status: 409, code: "CALL_ENDPOINT_NOT_LIVE" })
+      }
+      const rosterVersion = await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
+      const roster = await CallParticipantRepository.listRoster(client, params.workspaceId, params.callId)
+      return { rosterVersion: rosterVersion ?? 0, roster }
+    })
+    return { cf: cfResult, snapshot }
+  }
+
+  /** Run a CF call, translating a transport/CF error into a surfaced HttpError (502/504). */
+  private async cfCall<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn()
+    } catch (err) {
+      if (err instanceof CloudflareRealtimeError) {
+        const status = err.code === "CF_TIMEOUT" ? 504 : 502
+        throw new HttpError("Calls media provider error", {
+          status,
+          code: "CALL_MEDIA_PROVIDER_ERROR",
+          details: { cfCode: err.code, cfErrorCode: err.cfErrorCode },
+        })
+      }
+      throw err
+    }
+  }
+
+  private requireCfSession(endpoint: CallEndpoint): string {
+    if (!endpoint.cfSessionId) {
+      throw new HttpError("Endpoint has no CF session yet", { status: 409, code: "CALL_NO_CF_SESSION" })
+    }
+    return endpoint.cfSessionId
+  }
+
+  private async bestEffortCloseSession(sessionId: string): Promise<void> {
+    if (!this.cloudflare) return
+    try {
+      await this.cloudflare.closeSession(sessionId)
+    } catch (err) {
+      logger.warn({ err, sessionId }, "Best-effort CF session close failed")
+    }
+  }
+
+  /**
+   * Ownership + incarnation fence for a proxy call, run on the pool WITHOUT a
+   * transaction (the CF call that follows must not hold a DB connection, INV-41).
+   * Verifies the endpoint is on this call, belongs to this user, is live, and
+   * carries the claimed incarnation; a mismatch is a stale incarnation (409).
+   */
+  private async fenceEndpoint(params: {
+    workspaceId: string
+    callId: string
+    userId: string
+    endpointId: string
+    mediaIncarnation: string
+  }): Promise<{ endpoint: CallEndpoint; call: Call }> {
+    return withClient(this.pool, (client) => this.loadFencedEndpoint(client, params))
+  }
+
+  private async loadFencedEndpoint(
+    client: PoolClient,
+    params: { workspaceId: string; callId: string; userId: string; endpointId: string; mediaIncarnation: string }
+  ): Promise<{ endpoint: CallEndpoint; call: Call }> {
+    const call = await CallRepository.findById(client, params.workspaceId, params.callId)
+    if (!call) {
+      throw new HttpError("Call not found", { status: 404, code: "CALL_NOT_FOUND" })
+    }
+    const endpoint = await CallEndpointRepository.findById(client, params.workspaceId, params.endpointId)
+    if (!endpoint || endpoint.callId !== params.callId) {
+      throw new HttpError("Endpoint not found on this call", { status: 404, code: "CALL_ENDPOINT_NOT_FOUND" })
+    }
+    const participant = await CallParticipantRepository.findByUser(
+      client,
+      params.workspaceId,
+      params.callId,
+      params.userId
+    )
+    if (!participant || endpoint.participantId !== participant.id) {
+      throw new HttpError("Endpoint does not belong to this participant", {
+        status: 403,
+        code: "CALL_NOT_PARTICIPANT",
+      })
+    }
+    if (endpoint.status === "closed") {
+      throw new HttpError("Endpoint is no longer live", { status: 409, code: "CALL_ENDPOINT_NOT_LIVE" })
+    }
+    if (endpoint.mediaIncarnation !== params.mediaIncarnation) {
+      throw new HttpError("Endpoint incarnation is stale", { status: 409, code: "CALL_STALE_INCARNATION" })
+    }
+    return { endpoint, call }
+  }
+
+  /**
    * Remove a participant. The remover must be a joined participant; the target
    * goes `removed` (recording `removed_by`) and their endpoints close. If the
    * call is thereby empty it enters `empty_grace` under the call row lock.
@@ -366,6 +789,10 @@ export class CallService {
         })
       }
 
+      // Removal is a membership change: bump the roster version in the same tx as
+      // the participant-removed/endpoint-close writes (INV-66).
+      await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
+
       return removed
     })
   }
@@ -382,14 +809,18 @@ export class CallService {
    * Sweep: close endpoints whose lease lapsed, cascade their participants to
    * `left` when no live endpoint remains, and cascade calls to `empty_grace`
    * when no joined participant remains (reason `reaped`). Returns per-stage
-   * counts.
+   * counts. The CF sessions of reaped endpoints are closed AFTER the DB
+   * transition commits (never inside it, INV-41) — media dies with the lease,
+   * not with luck — best-effort, per-session errors logged not thrown.
    */
   async reapLapsedEndpoints(
     now: Date = new Date()
   ): Promise<{ endpoints: number; participants: number; calls: number }> {
-    return withTransaction(this.pool, async (client) => {
+    const { closedSessionIds, result } = await withTransaction(this.pool, async (client) => {
       const lapsedCallIds = await CallEndpointRepository.findLapsedCallIds(client, now)
-      if (lapsedCallIds.length === 0) return { endpoints: 0, participants: 0, calls: 0 }
+      if (lapsedCallIds.length === 0) {
+        return { closedSessionIds: [] as string[], result: { endpoints: 0, participants: 0, calls: 0 } }
+      }
 
       // Take the call-row locks first, in id order, so this sweep acquires the
       // call lock before any endpoint/participant lock — the same
@@ -399,7 +830,9 @@ export class CallService {
       await CallRepository.lockForUpdateInOrder(client, lapsedCallIds)
 
       const closed = await CallEndpointRepository.reapLapsed(client, now, lapsedCallIds)
-      if (closed.length === 0) return { endpoints: 0, participants: 0, calls: 0 }
+      if (closed.length === 0) {
+        return { closedSessionIds: [] as string[], result: { endpoints: 0, participants: 0, calls: 0 } }
+      }
 
       const participantIds = [...new Set(closed.map((e) => e.participantId))]
       const left = await CallParticipantRepository.markLeftWhereNoLiveEndpoint(client, participantIds)
@@ -410,8 +843,22 @@ export class CallService {
         graceDeadline: new Date(now.getTime() + EMPTY_GRACE_MS),
       })
 
-      return { endpoints: closed.length, participants: left.length, calls: graced.length }
+      // The reap changed membership on every call it touched: bump their roster
+      // versions in the same tx (the call rows are already locked FOR UPDATE) so a
+      // later roster fan-out is strictly newer than what peers hold (INV-66).
+      await CallRepository.bumpRosterVersionBatch(client, callIds)
+
+      const closedSessionIds = closed.map((e) => e.cfSessionId).filter((id): id is string => !!id)
+      return {
+        closedSessionIds,
+        result: { endpoints: closed.length, participants: left.length, calls: graced.length },
+      }
     })
+
+    for (const sessionId of closedSessionIds) {
+      await this.bestEffortCloseSession(sessionId)
+    }
+    return result
   }
 
   /**

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -412,21 +412,25 @@ export class CallService {
   }
 
   /**
-   * Mark a disconnected endpoint `reconnecting` (fenced on epoch). The lease
-   * still holds the slot, so a reconnect within it re-binds — a socket drop is
-   * NOT a leave. `null` when the epoch is stale (a superseded instance's
-   * disconnect must not demote the live endpoint).
+   * Mark a disconnected endpoint `reconnecting` (fenced on epoch +
+   * `connection_seq`). The lease still holds the slot, so a reconnect within it
+   * re-binds — a socket drop is NOT a leave. `null` when the fence is stale: a
+   * superseded instance's disconnect, or a fast same-incarnation reconnect that
+   * already re-bound the endpoint (bumping `connection_seq`) before this demotion
+   * lands. Either way the live endpoint must not be demoted.
    */
   async markEndpointReconnecting(params: {
     workspaceId: string
     endpointId: string
     epoch: number
+    connectionSeq: number
   }): Promise<CallEndpoint | null> {
     return withTransaction(this.pool, async (client) => {
       const endpoint = await CallEndpointRepository.markReconnecting(client, {
         workspaceId: params.workspaceId,
         id: params.endpointId,
         epoch: params.epoch,
+        connectionSeq: params.connectionSeq,
       })
       // A connection transition (connected → reconnecting) changes the roster:
       // bump the version in the same tx so the disconnect broadcast is newer than

--- a/apps/backend/src/features/calls/signaling-gateway.test.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Server } from "socket.io"
+import { registerCallGateway } from "./signaling-gateway"
+import { HttpError } from "../../lib/errors"
+import * as workspacesModule from "../workspaces"
+
+type Ack = (result: { ok: boolean; error?: string; code?: string; data?: unknown }) => void
+
+function fakeSocket(workosUserId = "workos_1") {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  const joined = new Set<string>()
+  const left = new Set<string>()
+  return {
+    data: { workosUserId },
+    on(event: string, cb: (...args: unknown[]) => unknown) {
+      handlers.set(event, cb)
+    },
+    join: mock(async (room: string) => {
+      joined.add(room)
+    }),
+    leave: mock(async (room: string) => {
+      left.add(room)
+    }),
+    joined,
+    left,
+    trigger(event: string, ...args: unknown[]) {
+      return handlers.get(event)?.(...args)
+    },
+  }
+}
+
+function setup(overrides?: { callService?: Record<string, unknown>; cloudflareEnabled?: boolean; user?: unknown }) {
+  const emit = mock(() => {})
+  const to = mock(() => ({ emit }))
+  let connectionHandler: ((socket: unknown) => void) | undefined
+  const namespace = {
+    use: mock(() => {}),
+    to,
+    on: (event: string, cb: (socket: unknown) => void) => {
+      if (event === "connection") connectionHandler = cb
+    },
+  }
+  const io = { of: mock(() => namespace) } as unknown as Server
+
+  spyOn(workspacesModule.UserRepository, "findByWorkosUserIdInWorkspace").mockResolvedValue(
+    (overrides?.user === undefined ? { id: "usr_1" } : overrides.user) as never
+  )
+
+  const callService = {
+    joinCall: mock(async () => ({
+      call: { id: "call_1" },
+      participant: { id: "callp_1" },
+      endpoint: { id: "callep_1", epoch: 2 },
+    })),
+    leaveCall: mock(async () => ({ call: { id: "call_1" } })),
+    getRosterSnapshot: mock(async () => ({ rosterVersion: 7, roster: [{ userId: "usr_1" }] })),
+    setEndpointMediaState: mock(async () => ({
+      rosterVersion: 8,
+      roster: [{ userId: "usr_1", mediaState: { muted: true } }],
+    })),
+    renewEndpointLease: mock(async () => ({ leaseExpiresAt: new Date("2026-07-19T12:00:45.000Z") })),
+    markEndpointReconnecting: mock(async () => ({ id: "callep_1", status: "reconnecting" })),
+    ...overrides?.callService,
+  }
+
+  registerCallGateway(io, {
+    authService: {} as never,
+    callService: callService as never,
+    pool: {} as never,
+    cloudflareEnabled: overrides?.cloudflareEnabled ?? true,
+  })
+
+  const socket = fakeSocket()
+  connectionHandler!(socket)
+
+  return { socket, callService, emit, to, namespace }
+}
+
+const JOIN = { workspaceId: "ws_1", callId: "call_1", mediaIncarnation: "inc_1" }
+
+describe("registerCallGateway call:join", () => {
+  afterEach(() => mock.restore())
+
+  it("joins the call + endpoint rooms and acks the endpoint id, epoch, versioned roster, and lease ttl", async () => {
+    const { socket, callService } = setup()
+    const ack = mock(() => {})
+
+    await socket.trigger("call:join", JOIN, ack)
+
+    expect(callService.joinCall).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws_1", callId: "call_1", userId: "usr_1", mediaIncarnation: "inc_1" })
+    )
+    expect(socket.joined.has("call:call_1")).toBe(true)
+    expect(socket.joined.has("call:call_1:ep:callep_1")).toBe(true)
+    const arg = (ack as ReturnType<typeof mock>).mock.calls[0][0] as { ok: boolean; data: Record<string, unknown> }
+    expect(arg.ok).toBe(true)
+    expect(arg.data).toMatchObject({ endpointId: "callep_1", epoch: 2, rosterVersion: 7, leaseTtlMs: 45_000 })
+  })
+
+  it("passes takeover through to joinCall", async () => {
+    const { socket, callService } = setup()
+    await socket.trigger(
+      "call:join",
+      { ...JOIN, takeover: true },
+      mock(() => {})
+    )
+    expect(callService.joinCall).toHaveBeenCalledWith(expect.objectContaining({ takeover: true }))
+  })
+
+  it("acks CALLS_UNAVAILABLE when the media plane is unconfigured", async () => {
+    const { socket, callService } = setup({ cloudflareEnabled: false })
+    const ack = mock(() => {})
+    await socket.trigger("call:join", JOIN, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALLS_UNAVAILABLE" }))
+    expect(callService.joinCall).not.toHaveBeenCalled()
+  })
+
+  it("rejects a removed participant with the service's HttpError code", async () => {
+    const { socket } = setup({
+      callService: {
+        joinCall: mock(async () => {
+          throw new HttpError("removed", { status: 403, code: "CALL_PARTICIPANT_REMOVED" })
+        }),
+      },
+    })
+    const ack = mock(() => {})
+    await socket.trigger("call:join", JOIN, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALL_PARTICIPANT_REMOVED" }))
+  })
+
+  it("rejects an invalid payload", async () => {
+    const { socket, callService } = setup()
+    const ack = mock(() => {})
+    await socket.trigger("call:join", { workspaceId: "ws_1" }, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "VALIDATION_ERROR" }))
+    expect(callService.joinCall).not.toHaveBeenCalled()
+  })
+})
+
+describe("registerCallGateway call:state", () => {
+  afterEach(() => mock.restore())
+
+  it("bumps the roster version and fans call:roster to the call room", async () => {
+    const { socket, callService, to, emit } = setup()
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    const ack = mock(() => {})
+    await socket.trigger("call:state", { muted: true }, ack)
+
+    expect(callService.setEndpointMediaState).toHaveBeenCalledWith(
+      expect.objectContaining({ endpointId: "callep_1", mediaIncarnation: "inc_1", mediaState: { muted: true } })
+    )
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: true, data: { rosterVersion: 8 } }))
+    expect(to).toHaveBeenCalledWith("call:call_1")
+    expect(emit).toHaveBeenLastCalledWith("call:roster", expect.objectContaining({ rosterVersion: 8 }))
+  })
+
+  it("rejects call:state before a join", async () => {
+    const { socket } = setup()
+    const ack = mock(() => {})
+    await socket.trigger("call:state", { muted: true }, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALL_NOT_JOINED" }))
+  })
+})
+
+describe("registerCallGateway call:lease:renew", () => {
+  afterEach(() => mock.restore())
+
+  it("renews via the bound endpoint + epoch", async () => {
+    const { socket, callService } = setup()
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    const ack = mock(() => {})
+    await socket.trigger("call:lease:renew", {}, ack)
+
+    expect(callService.renewEndpointLease).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws_1", endpointId: "callep_1", epoch: 2 })
+    )
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: true }))
+  })
+
+  it("acks CALL_LEASE_SUPERSEDED when the fenced renew returns null", async () => {
+    const { socket } = setup({ callService: { renewEndpointLease: mock(async () => null) } })
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    const ack = mock(() => {})
+    await socket.trigger("call:lease:renew", {}, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALL_LEASE_SUPERSEDED" }))
+  })
+})
+
+describe("registerCallGateway disconnect", () => {
+  afterEach(() => mock.restore())
+
+  it("demotes the endpoint to reconnecting (not closed) fenced on the bound epoch", async () => {
+    const { socket, callService } = setup()
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    await socket.trigger("disconnect")
+    await Promise.resolve()
+
+    expect(callService.markEndpointReconnecting).toHaveBeenCalledWith({
+      workspaceId: "ws_1",
+      endpointId: "callep_1",
+      epoch: 2,
+    })
+    expect(callService.leaveCall).not.toHaveBeenCalled()
+  })
+})
+
+describe("registerCallGateway call:leave", () => {
+  afterEach(() => mock.restore())
+
+  it("leaves the rooms and fans the updated roster", async () => {
+    const { socket, callService } = setup()
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    const ack = mock(() => {})
+    await socket.trigger("call:leave", {}, ack)
+
+    expect(callService.leaveCall).toHaveBeenCalledWith(
+      expect.objectContaining({ endpointId: "callep_1", userId: "usr_1", callId: "call_1" })
+    )
+    expect(socket.left.has("call:call_1")).toBe(true)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: true }))
+  })
+})

--- a/apps/backend/src/features/calls/signaling-gateway.test.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.test.ts
@@ -29,7 +29,12 @@ function fakeSocket(workosUserId = "workos_1") {
   }
 }
 
-function setup(overrides?: { callService?: Record<string, unknown>; cloudflareEnabled?: boolean; user?: unknown }) {
+function setup(overrides?: {
+  callService?: Record<string, unknown>
+  cloudflareEnabled?: boolean
+  callsEnabled?: boolean
+  user?: unknown
+}) {
   const emit = mock(() => {})
   const to = mock(() => ({ emit }))
   let connectionHandler: ((socket: unknown) => void) | undefined
@@ -50,7 +55,7 @@ function setup(overrides?: { callService?: Record<string, unknown>; cloudflareEn
     joinCall: mock(async () => ({
       call: { id: "call_1" },
       participant: { id: "callp_1" },
-      endpoint: { id: "callep_1", epoch: 2 },
+      endpoint: { id: "callep_1", epoch: 2, connectionSeq: 4 },
     })),
     leaveCall: mock(async () => ({ call: { id: "call_1" } })),
     getRosterSnapshot: mock(async () => ({ rosterVersion: 7, roster: [{ userId: "usr_1" }] })),
@@ -63,9 +68,14 @@ function setup(overrides?: { callService?: Record<string, unknown>; cloudflareEn
     ...overrides?.callService,
   }
 
+  const workspaceSettingsService = {
+    getSettings: mock(async () => ({ callsEnabled: overrides?.callsEnabled ?? true })),
+  }
+
   registerCallGateway(io, {
     authService: {} as never,
     callService: callService as never,
+    workspaceSettingsService: workspaceSettingsService as never,
     pool: {} as never,
     cloudflareEnabled: overrides?.cloudflareEnabled ?? true,
   })
@@ -73,7 +83,7 @@ function setup(overrides?: { callService?: Record<string, unknown>; cloudflareEn
   const socket = fakeSocket()
   connectionHandler!(socket)
 
-  return { socket, callService, emit, to, namespace }
+  return { socket, callService, workspaceSettingsService, emit, to, namespace }
 }
 
 const JOIN = { workspaceId: "ws_1", callId: "call_1", mediaIncarnation: "inc_1" }
@@ -112,6 +122,14 @@ describe("registerCallGateway call:join", () => {
     const ack = mock(() => {})
     await socket.trigger("call:join", JOIN, ack)
     expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALLS_UNAVAILABLE" }))
+    expect(callService.joinCall).not.toHaveBeenCalled()
+  })
+
+  it("rejects the join with CALLS_DISABLED when the workspace kill-switch is off", async () => {
+    const { socket, callService } = setup({ callsEnabled: false })
+    const ack = mock(() => {})
+    await socket.trigger("call:join", JOIN, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALLS_DISABLED" }))
     expect(callService.joinCall).not.toHaveBeenCalled()
   })
 
@@ -199,6 +217,21 @@ describe("registerCallGateway call:lease:renew", () => {
     await socket.trigger("call:lease:renew", {}, ack)
     expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALL_LEASE_SUPERSEDED" }))
   })
+
+  it("rejects the renew with CALLS_DISABLED once the kill-switch is flipped off (drains live calls in one TTL)", async () => {
+    const { socket, callService, workspaceSettingsService } = setup()
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+    workspaceSettingsService.getSettings.mockResolvedValue({ callsEnabled: false } as never)
+
+    const ack = mock(() => {})
+    await socket.trigger("call:lease:renew", {}, ack)
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: false, code: "CALLS_DISABLED" }))
+    expect(callService.renewEndpointLease).not.toHaveBeenCalled()
+  })
 })
 
 describe("registerCallGateway disconnect", () => {
@@ -219,6 +252,7 @@ describe("registerCallGateway disconnect", () => {
       workspaceId: "ws_1",
       endpointId: "callep_1",
       epoch: 2,
+      connectionSeq: 4,
     })
     expect(callService.leaveCall).not.toHaveBeenCalled()
   })

--- a/apps/backend/src/features/calls/signaling-gateway.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.ts
@@ -6,6 +6,7 @@ import { createSocketAuthMiddleware } from "../../lib/socket-auth"
 import { logger } from "../../lib/logger"
 import { HttpError } from "../../lib/errors"
 import { UserRepository } from "../workspaces"
+import type { WorkspaceSettingsService } from "../workspace-settings"
 import type { CallService, CallRosterSnapshot } from "./service"
 import { ENDPOINT_LEASE_TTL_MS, CALL_SOCKET_RATE_BURST, CALL_SOCKET_RATE_REFILL_PER_SEC } from "./config"
 
@@ -51,6 +52,7 @@ const stateSchema = z.object({
 interface Dependencies {
   authService: AuthService
   callService: CallService
+  workspaceSettingsService: WorkspaceSettingsService
   pool: Pool
   /** False when the CF media plane is unconfigured — every join then acks CALLS_UNAVAILABLE. */
   cloudflareEnabled: boolean
@@ -63,6 +65,7 @@ interface SocketBinding {
   participantId: string
   endpointId: string
   epoch: number
+  connectionSeq: number
   mediaIncarnation: string
 }
 
@@ -98,10 +101,21 @@ function createTokenBucket() {
  * reordered update is dropped by version check, not trusted.
  */
 export function registerCallGateway(io: Server, deps: Dependencies) {
-  const { authService, callService, pool, cloudflareEnabled } = deps
+  const { authService, callService, workspaceSettingsService, pool, cloudflareEnabled } = deps
   const namespace = io.of(CALLS_NAMESPACE)
 
   namespace.use(createSocketAuthMiddleware(authService))
+
+  // The per-workspace kill-switch (404-style CALLS_DISABLED, mirroring the REST
+  // `assertAvailable`). Gated on both `call:join` (reject new joins) and
+  // `call:lease:renew` — renewing on the flag lets a live call outlive the switch,
+  // so flipping calls off starves every live call within one lease TTL.
+  const assertWorkspaceCallsEnabled = async (workspaceId: string): Promise<void> => {
+    const settings = await workspaceSettingsService.getSettings(workspaceId)
+    if (!settings.callsEnabled) {
+      throw new HttpError("Calls are not enabled for this workspace", { status: 404, code: "CALLS_DISABLED" })
+    }
+  }
 
   namespace.on("connection", (socket) => {
     const workosUserId = socket.data.workosUserId as string
@@ -116,17 +130,21 @@ export function registerCallGateway(io: Server, deps: Dependencies) {
 
     socket.on("call:join", async (payload: unknown, ack?: Ack) => {
       if (rateLimited(ack)) return
+      // Availability before Zod (mirrors the REST gate order): the whole-feature
+      // switch needs no payload, so it precedes decoding; the per-workspace flag
+      // needs workspaceId, so it runs right after the parse and before access.
+      if (!cloudflareEnabled) {
+        ack?.({ ok: false, error: "Calls media is not configured", code: "CALLS_UNAVAILABLE" })
+        return
+      }
       const parsed = joinSchema.safeParse(payload)
       if (!parsed.success) {
         ack?.({ ok: false, error: "Invalid call:join payload", code: "VALIDATION_ERROR" })
         return
       }
-      if (!cloudflareEnabled) {
-        ack?.({ ok: false, error: "Calls media is not configured", code: "CALLS_UNAVAILABLE" })
-        return
-      }
       const { workspaceId, callId, mediaIncarnation, takeover } = parsed.data
       try {
+        await assertWorkspaceCallsEnabled(workspaceId)
         const user = await UserRepository.findByWorkosUserIdInWorkspace(pool, workspaceId, workosUserId)
         if (!user) {
           ack?.({ ok: false, error: "No workspace access", code: "CALL_NOT_PARTICIPANT" })
@@ -147,6 +165,7 @@ export function registerCallGateway(io: Server, deps: Dependencies) {
           participantId: result.participant.id,
           endpointId: result.endpoint.id,
           epoch: result.endpoint.epoch,
+          connectionSeq: result.endpoint.connectionSeq,
           mediaIncarnation,
         }
         await socket.join(callRoom(callId))
@@ -231,6 +250,9 @@ export function registerCallGateway(io: Server, deps: Dependencies) {
       }
       const bound = binding
       try {
+        // Gate the renew on the kill-switch so flipping calls off drains live
+        // calls within one lease TTL rather than letting them run indefinitely.
+        await assertWorkspaceCallsEnabled(bound.workspaceId)
         const endpoint = await callService.renewEndpointLease({
           workspaceId: bound.workspaceId,
           endpointId: bound.endpointId,
@@ -258,6 +280,7 @@ export function registerCallGateway(io: Server, deps: Dependencies) {
           workspaceId: bound.workspaceId,
           endpointId: bound.endpointId,
           epoch: bound.epoch,
+          connectionSeq: bound.connectionSeq,
         })
         .then((endpoint) => {
           if (endpoint) return callService.getRosterSnapshot(bound.workspaceId, bound.callId)

--- a/apps/backend/src/features/calls/signaling-gateway.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.ts
@@ -1,0 +1,283 @@
+import type { Server } from "socket.io"
+import { z } from "zod"
+import type { AuthService } from "@threa/backend-common"
+import type { Pool } from "pg"
+import { createSocketAuthMiddleware } from "../../lib/socket-auth"
+import { logger } from "../../lib/logger"
+import { HttpError } from "../../lib/errors"
+import { UserRepository } from "../workspaces"
+import type { CallService, CallRosterSnapshot } from "./service"
+import { ENDPOINT_LEASE_TTL_MS, CALL_SOCKET_RATE_BURST, CALL_SOCKET_RATE_REFILL_PER_SEC } from "./config"
+
+export const CALLS_NAMESPACE = "/calls"
+
+/** Room every call member joins — roster/state fan-out target. */
+export function callRoom(callId: string): string {
+  return `call:${callId}`
+}
+
+/** Per-endpoint room — control events are addressed here, never a user room (one device, one command). */
+export function endpointRoom(callId: string, endpointId: string): string {
+  return `call:${callId}:ep:${endpointId}`
+}
+
+/**
+ * Fan a versioned roster snapshot to a call's room. Shared by the gateway and
+ * the REST proxy handlers (a publish/close over HTTP must reach the sockets), so
+ * both fan through the identical `call:roster` shape. Every roster emit carries
+ * `rosterVersion` so a reordered delivery is dropped by the client's version
+ * check, not trusted.
+ */
+export function broadcastRoster(io: Server, callId: string, snapshot: CallRosterSnapshot): void {
+  io.of(CALLS_NAMESPACE).to(callRoom(callId)).emit("call:roster", {
+    callId,
+    rosterVersion: snapshot.rosterVersion,
+    roster: snapshot.roster,
+  })
+}
+
+const joinSchema = z.object({
+  workspaceId: z.string().min(1),
+  callId: z.string().min(1),
+  mediaIncarnation: z.string().min(1).max(128),
+  takeover: z.boolean().optional(),
+})
+
+const stateSchema = z.object({
+  muted: z.boolean().optional(),
+  cameraOn: z.boolean().optional(),
+})
+
+interface Dependencies {
+  authService: AuthService
+  callService: CallService
+  pool: Pool
+  /** False when the CF media plane is unconfigured — every join then acks CALLS_UNAVAILABLE. */
+  cloudflareEnabled: boolean
+}
+
+interface SocketBinding {
+  workspaceId: string
+  callId: string
+  userId: string
+  participantId: string
+  endpointId: string
+  epoch: number
+  mediaIncarnation: string
+}
+
+type Ack = (result: { ok: boolean; error?: string; code?: string; data?: unknown }) => void
+
+/** Continuous-refill token bucket, one per socket (INV — signaling abuse hardening). */
+function createTokenBucket() {
+  let tokens = CALL_SOCKET_RATE_BURST
+  let last = Date.now()
+  return {
+    take(): boolean {
+      const now = Date.now()
+      tokens = Math.min(CALL_SOCKET_RATE_BURST, tokens + ((now - last) / 1000) * CALL_SOCKET_RATE_REFILL_PER_SEC)
+      last = now
+      if (tokens < 1) return false
+      tokens -= 1
+      return true
+    },
+  }
+}
+
+/**
+ * The `/calls` control namespace. Mirrors {@link registerVoiceGateway}: own
+ * namespace, the same `createSocketAuthMiddleware`, registered in `server.ts`.
+ * Media negotiation does NOT ride this socket — it goes over HTTPS to the CF
+ * proxy endpoints, so SDP never touches Socket.io fan-out. This carries only
+ * small control events.
+ *
+ * INV-4 carve-out: `call:join`/`call:leave`/`call:state`/`call:lease:renew` and
+ * the `call:roster` fan-out are ephemeral, per-connection control — no durable
+ * read model to reconstruct, so they are delivered directly over the socket
+ * rather than through the outbox. Roster/state carries a monotonic version so a
+ * reordered update is dropped by version check, not trusted.
+ */
+export function registerCallGateway(io: Server, deps: Dependencies) {
+  const { authService, callService, pool, cloudflareEnabled } = deps
+  const namespace = io.of(CALLS_NAMESPACE)
+
+  namespace.use(createSocketAuthMiddleware(authService))
+
+  namespace.on("connection", (socket) => {
+    const workosUserId = socket.data.workosUserId as string
+    let binding: SocketBinding | null = null
+    const bucket = createTokenBucket()
+
+    const rateLimited = (ack?: Ack): boolean => {
+      if (bucket.take()) return false
+      ack?.({ ok: false, error: "Too many call events", code: "CALL_RATE_LIMITED" })
+      return true
+    }
+
+    socket.on("call:join", async (payload: unknown, ack?: Ack) => {
+      if (rateLimited(ack)) return
+      const parsed = joinSchema.safeParse(payload)
+      if (!parsed.success) {
+        ack?.({ ok: false, error: "Invalid call:join payload", code: "VALIDATION_ERROR" })
+        return
+      }
+      if (!cloudflareEnabled) {
+        ack?.({ ok: false, error: "Calls media is not configured", code: "CALLS_UNAVAILABLE" })
+        return
+      }
+      const { workspaceId, callId, mediaIncarnation, takeover } = parsed.data
+      try {
+        const user = await UserRepository.findByWorkosUserIdInWorkspace(pool, workspaceId, workosUserId)
+        if (!user) {
+          ack?.({ ok: false, error: "No workspace access", code: "CALL_NOT_PARTICIPANT" })
+          return
+        }
+        const result = await callService.joinCall({
+          workspaceId,
+          callId,
+          userId: user.id,
+          takeover,
+          mediaIncarnation,
+        })
+
+        binding = {
+          workspaceId,
+          callId,
+          userId: user.id,
+          participantId: result.participant.id,
+          endpointId: result.endpoint.id,
+          epoch: result.endpoint.epoch,
+          mediaIncarnation,
+        }
+        await socket.join(callRoom(callId))
+        await socket.join(endpointRoom(callId, result.endpoint.id))
+
+        const snapshot = await callService.getRosterSnapshot(workspaceId, callId)
+        ack?.({
+          ok: true,
+          data: {
+            endpointId: result.endpoint.id,
+            epoch: result.endpoint.epoch,
+            rosterVersion: snapshot.rosterVersion,
+            roster: snapshot.roster,
+            leaseTtlMs: ENDPOINT_LEASE_TTL_MS,
+          },
+        })
+        // Let existing members observe the new arrival.
+        broadcastRoster(io, callId, snapshot)
+      } catch (err) {
+        respondError(err, ack, "call:join", { workspaceId, callId })
+      }
+    })
+
+    socket.on("call:leave", async (_payload: unknown, ack?: Ack) => {
+      if (rateLimited(ack)) return
+      if (!binding) {
+        ack?.({ ok: false, error: "Not joined", code: "CALL_NOT_JOINED" })
+        return
+      }
+      const bound = binding
+      try {
+        await callService.leaveCall({
+          workspaceId: bound.workspaceId,
+          callId: bound.callId,
+          userId: bound.userId,
+          endpointId: bound.endpointId,
+        })
+        await socket.leave(callRoom(bound.callId))
+        await socket.leave(endpointRoom(bound.callId, bound.endpointId))
+        binding = null
+        const snapshot = await callService.getRosterSnapshot(bound.workspaceId, bound.callId)
+        ack?.({ ok: true })
+        broadcastRoster(io, bound.callId, snapshot)
+      } catch (err) {
+        respondError(err, ack, "call:leave", { callId: bound.callId })
+      }
+    })
+
+    socket.on("call:state", async (payload: unknown, ack?: Ack) => {
+      if (rateLimited(ack)) return
+      if (!binding) {
+        ack?.({ ok: false, error: "Not joined", code: "CALL_NOT_JOINED" })
+        return
+      }
+      const parsed = stateSchema.safeParse(payload)
+      if (!parsed.success) {
+        ack?.({ ok: false, error: "Invalid call:state payload", code: "VALIDATION_ERROR" })
+        return
+      }
+      const bound = binding
+      try {
+        const snapshot = await callService.setEndpointMediaState({
+          workspaceId: bound.workspaceId,
+          callId: bound.callId,
+          userId: bound.userId,
+          endpointId: bound.endpointId,
+          mediaIncarnation: bound.mediaIncarnation,
+          mediaState: parsed.data,
+        })
+        ack?.({ ok: true, data: { rosterVersion: snapshot.rosterVersion } })
+        broadcastRoster(io, bound.callId, snapshot)
+      } catch (err) {
+        respondError(err, ack, "call:state", { callId: bound.callId })
+      }
+    })
+
+    socket.on("call:lease:renew", async (_payload: unknown, ack?: Ack) => {
+      if (rateLimited(ack)) return
+      if (!binding) {
+        ack?.({ ok: false, error: "Not joined", code: "CALL_NOT_JOINED" })
+        return
+      }
+      const bound = binding
+      try {
+        const endpoint = await callService.renewEndpointLease({
+          workspaceId: bound.workspaceId,
+          endpointId: bound.endpointId,
+          epoch: bound.epoch,
+        })
+        if (!endpoint) {
+          ack?.({ ok: false, error: "Lease superseded", code: "CALL_LEASE_SUPERSEDED" })
+          return
+        }
+        ack?.({ ok: true, data: { leaseExpiresAt: endpoint.leaseExpiresAt.toISOString() } })
+      } catch (err) {
+        respondError(err, ack, "call:lease:renew", { callId: bound.callId })
+      }
+    })
+
+    socket.on("disconnect", () => {
+      if (!binding) return
+      const bound = binding
+      binding = null
+      // A socket drop is NOT a leave — the lease is the authority. Demote the
+      // endpoint to `reconnecting` (fenced on epoch) so a reconnect within the
+      // lease re-binds; the sweeper reaps it only if the lease lapses.
+      callService
+        .markEndpointReconnecting({
+          workspaceId: bound.workspaceId,
+          endpointId: bound.endpointId,
+          epoch: bound.epoch,
+        })
+        .then((endpoint) => {
+          if (endpoint) return callService.getRosterSnapshot(bound.workspaceId, bound.callId)
+          return null
+        })
+        .then((snapshot) => {
+          if (snapshot) broadcastRoster(io, bound.callId, snapshot)
+        })
+        .catch((err) => {
+          logger.warn({ err, callId: bound.callId, endpointId: bound.endpointId }, "call disconnect cleanup failed")
+        })
+    })
+  })
+}
+
+function respondError(err: unknown, ack: Ack | undefined, event: string, ctx: Record<string, unknown>): void {
+  if (err instanceof HttpError) {
+    ack?.({ ok: false, error: err.message, code: err.code })
+    return
+  }
+  logger.error({ err, event, ...ctx }, "Call gateway event failed")
+  ack?.({ ok: false, error: "Call event failed", code: "INTERNAL_ERROR" })
+}

--- a/apps/backend/src/features/workspace-settings/handlers.ts
+++ b/apps/backend/src/features/workspace-settings/handlers.ts
@@ -33,6 +33,9 @@ const updateWorkspaceSettingsSchema = z.object({
     .string()
     .refine(isValidIanaTimezone, { message: "must be a valid IANA timezone identifier" })
     .optional(),
+  // Voice/video calls feature flag (dark feature, default off). Admin-flipped per
+  // workspace during rollout; gated on the Cloudflare processor-register entry in prod.
+  callsEnabled: z.boolean().optional(),
 })
 
 export { updateWorkspaceSettingsSchema }

--- a/apps/backend/src/features/workspace-settings/service.ts
+++ b/apps/backend/src/features/workspace-settings/service.ts
@@ -37,6 +37,7 @@ function flattenUpdates(updates: UpdateWorkspaceSettingsInput): Array<{ key: str
     "maxPendingFollowUps",
     "defaultCompanionPersonaId",
     "billingTimezone",
+    "callsEnabled",
   ] as const
   for (const key of simpleKeys) {
     if (updates[key] !== undefined) {

--- a/apps/backend/src/lib/env.test.ts
+++ b/apps/backend/src/lib/env.test.ts
@@ -21,6 +21,9 @@ function setBaseEnv() {
   delete process.env.ENCLAVE_INTERNAL_API_KEY
   delete process.env.CONTROL_PLANE_URL
   delete process.env.REGION
+  delete process.env.CLOUDFLARE_REALTIME_APP_ID
+  delete process.env.CLOUDFLARE_REALTIME_APP_SECRET
+  delete process.env.CLOUDFLARE_REALTIME_API_BASE
 }
 
 afterEach(() => {
@@ -322,6 +325,64 @@ describe("loadConfig MediaConvert configuration", () => {
     const config = loadConfig()
     expect(config.mediaConvert.enabled).toBe(true)
     expect(config.mediaConvert.roleArn).toBe("arn:aws:iam::123456789012:role/threa-mediaconvert-dev")
+  })
+})
+
+describe("loadConfig Cloudflare Realtime configuration", () => {
+  test("disables calls media when no CF Realtime env vars are set", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+
+    const config = loadConfig()
+    expect(config.cloudflareRealtime.enabled).toBe(false)
+  })
+
+  test("throws when only the app id is set", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.CLOUDFLARE_REALTIME_APP_ID = "app_123"
+
+    expect(() => loadConfig()).toThrow(
+      "CLOUDFLARE_REALTIME_APP_ID and CLOUDFLARE_REALTIME_APP_SECRET must both be set together"
+    )
+  })
+
+  test("throws when only the app secret is set", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.CLOUDFLARE_REALTIME_APP_SECRET = "secret_123"
+
+    expect(() => loadConfig()).toThrow(
+      "CLOUDFLARE_REALTIME_APP_ID and CLOUDFLARE_REALTIME_APP_SECRET must both be set together"
+    )
+  })
+
+  test("enables calls media when both the app id and secret are set", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.CLOUDFLARE_REALTIME_APP_ID = "app_123"
+    process.env.CLOUDFLARE_REALTIME_APP_SECRET = "secret_123"
+
+    const config = loadConfig()
+    expect(config.cloudflareRealtime.enabled).toBe(true)
+    expect(config.cloudflareRealtime.appId).toBe("app_123")
+    expect(config.cloudflareRealtime.appSecret).toBe("secret_123")
+  })
+
+  test("reads the optional API base override", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.CLOUDFLARE_REALTIME_APP_ID = "app_123"
+    process.env.CLOUDFLARE_REALTIME_APP_SECRET = "secret_123"
+    process.env.CLOUDFLARE_REALTIME_API_BASE = "https://cf.test/v1/apps"
+
+    const config = loadConfig()
+    expect(config.cloudflareRealtime.apiBase).toBe("https://cf.test/v1/apps")
   })
 })
 

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -64,6 +64,22 @@ export interface GiphyConfig {
   apiKey: string
 }
 
+export interface CloudflareRealtimeConfig {
+  /** CF Realtime (Calls) app id — the SFU application the media plane runs on. */
+  appId: string
+  /** CF Realtime app secret — the media-plane credential, never shipped to clients. */
+  appSecret: string
+  /** API base override, for tests/staging. Defaults to CF's production base. */
+  apiBase?: string
+  /**
+   * Whether calls media can be served — true only when the app id + secret pair
+   * is present. Absent ⇒ the calls feature responds 503 CALLS_UNAVAILABLE at its
+   * HTTP/socket surfaces (deploying without the pair disables calls, breaks
+   * nothing).
+   */
+  enabled: boolean
+}
+
 export interface MediaConvertConfig {
   /** IAM role ARN that MediaConvert assumes to access S3 */
   roleArn: string
@@ -99,6 +115,7 @@ export interface Config {
   github: GitHubAppConfig
   linear: LinearOAuthConfig
   mediaConvert: MediaConvertConfig
+  cloudflareRealtime: CloudflareRealtimeConfig
   /** Control-plane URL for inter-service communication (optional — only needed in multi-region) */
   controlPlaneUrl: string | null
   /** Shared secret for authenticating internal API calls from the control-plane */
@@ -232,6 +249,12 @@ export function loadConfig(): Config {
       endpoint: process.env.MEDIACONVERT_ENDPOINT || undefined,
       enabled: process.env.MEDIACONVERT_ENABLED === "true",
     },
+    cloudflareRealtime: {
+      appId: process.env.CLOUDFLARE_REALTIME_APP_ID || "",
+      appSecret: process.env.CLOUDFLARE_REALTIME_APP_SECRET || "",
+      apiBase: process.env.CLOUDFLARE_REALTIME_API_BASE || undefined,
+      enabled: !!(process.env.CLOUDFLARE_REALTIME_APP_ID && process.env.CLOUDFLARE_REALTIME_APP_SECRET),
+    },
     controlPlaneUrl: process.env.CONTROL_PLANE_URL || null,
     internalApiKey: process.env.INTERNAL_API_KEY || null,
     enclaveInternalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY || null,
@@ -275,6 +298,18 @@ export function loadConfig(): Config {
   }
   if (linearSetCount === linearProviderVars.length && !process.env.WORKSPACE_INTEGRATIONS_SECRET) {
     throw new Error("WORKSPACE_INTEGRATIONS_SECRET is required when Linear OAuth credentials are configured")
+  }
+
+  // Validate co-presence: the CF Realtime app id + secret must both be set or
+  // both be absent (INV-11). The secret is the media-plane credential; one
+  // without the other is a misconfiguration that would silently half-enable
+  // calls. Absent pair ⇒ calls surfaces answer 503 CALLS_UNAVAILABLE.
+  const cfRealtimeVars = [process.env.CLOUDFLARE_REALTIME_APP_ID, process.env.CLOUDFLARE_REALTIME_APP_SECRET]
+  const cfRealtimeSetCount = cfRealtimeVars.filter(Boolean).length
+  if (cfRealtimeSetCount > 0 && cfRealtimeSetCount < cfRealtimeVars.length) {
+    throw new Error(
+      "CLOUDFLARE_REALTIME_APP_ID and CLOUDFLARE_REALTIME_APP_SECRET must both be set together — the calls media plane needs the app id and its secret"
+    )
   }
 
   if (config.mediaConvert.enabled && !config.mediaConvert.roleArn) {

--- a/apps/backend/src/middleware/rate-limit.ts
+++ b/apps/backend/src/middleware/rate-limit.ts
@@ -10,6 +10,7 @@ export interface RateLimiterSet {
   messageCreate: RequestHandler
   commandDispatch: RequestHandler
   pushTest: RequestHandler
+  calls: RequestHandler
   publicApiWorkspace: RequestHandler
   publicApiKey: RequestHandler
 }
@@ -74,6 +75,15 @@ export function createRateLimiters(config: RateLimiterConfig): RateLimiterSet {
       name: "push-test",
       windowMs: 60_000,
       max: 6,
+      key: userScopeKey,
+    }),
+
+    // CF media-proxy pass-throughs: renegotiation + track pulls churn on a bad
+    // network, so the ceiling is generous; it only trips a runaway client.
+    calls: createRateLimit({
+      name: "calls",
+      windowMs: 60_000,
+      max: 240,
       key: userScopeKey,
     }),
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -65,6 +65,7 @@ import {
 import { BotRuntimeService, type BotRuntimeWriteOps } from "./features/bot-runtimes"
 import { createUserApiKeyHandlers, type UserApiKeyService } from "./features/user-api-keys"
 import { createVoiceTranscriptionHandlers, type VoiceTranscriptionService } from "./features/voice-transcription"
+import { createCallHandlers, type CallService } from "./features/calls"
 import {
   createEnclaveRuntimesHandlers,
   createEnclaveSessionHandlers,
@@ -177,6 +178,9 @@ interface Dependencies {
   workosOrgService: WorkosOrgService
   userApiKeyService: UserApiKeyService
   voiceTranscriptionService: VoiceTranscriptionService
+  callService: CallService
+  /** True when the CF Realtime media plane is configured; when false, calls surfaces 503. */
+  callsCloudflareEnabled: boolean
   enclaveRuntimesService: EnclaveRuntimesService
   enclaveClaimService: EnclaveClaimService
   enclaveClaimNudge: EnclaveClaimWaiter | null
@@ -241,6 +245,8 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workosOrgService,
     userApiKeyService,
     voiceTranscriptionService,
+    callService,
+    callsCloudflareEnabled,
     enclaveRuntimesService,
     enclaveClaimService,
     enclaveClaimNudge,
@@ -1609,6 +1615,49 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     audit("voice.abort_session", "write"),
     voice.abortSession
+  )
+
+  // Calls (voice/video, flag-gated). HTTP starts/bootstraps a call and proxies
+  // the CF Realtime session/track operations (the app secret never reaches the
+  // client); the dedicated /calls socket namespace owns the control plane.
+  const calls = createCallHandlers({
+    pool,
+    io: deps.io,
+    callService,
+    workspaceSettingsService,
+    cloudflareEnabled: callsCloudflareEnabled,
+  })
+  app.post("/api/workspaces/:workspaceId/calls", ...authed, rateLimits.calls, calls.start)
+  app.get("/api/workspaces/:workspaceId/calls/:callId", ...authed, calls.bootstrap)
+  app.post(
+    "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/session",
+    ...authed,
+    rateLimits.calls,
+    calls.createCfSession
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/renegotiate",
+    ...authed,
+    rateLimits.calls,
+    calls.renegotiate
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/publish",
+    ...authed,
+    rateLimits.calls,
+    calls.publishTracks
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/pull",
+    ...authed,
+    rateLimits.calls,
+    calls.pullTracks
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/close",
+    ...authed,
+    rateLimits.calls,
+    calls.closeTracks
   )
 
   // Bot management. Management routes (update, archive, keys, avatar, grants)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1628,7 +1628,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     cloudflareEnabled: callsCloudflareEnabled,
   })
   app.post("/api/workspaces/:workspaceId/calls", ...authed, rateLimits.calls, calls.start)
-  app.get("/api/workspaces/:workspaceId/calls/:callId", ...authed, calls.bootstrap)
+  app.get("/api/workspaces/:workspaceId/calls/:callId", ...authed, rateLimits.calls, calls.bootstrap)
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/session",
     ...authed,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1627,35 +1627,52 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workspaceSettingsService,
     cloudflareEnabled: callsCloudflareEnabled,
   })
-  app.post("/api/workspaces/:workspaceId/calls", ...authed, rateLimits.calls, calls.start)
-  app.get("/api/workspaces/:workspaceId/calls/:callId", ...authed, rateLimits.calls, calls.bootstrap)
+  app.post(
+    "/api/workspaces/:workspaceId/calls",
+    ...authed,
+    audit("calls.start", "write"),
+    rateLimits.calls,
+    calls.start
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/calls/:callId",
+    ...authed,
+    audit("calls.bootstrap", "read"),
+    rateLimits.calls,
+    calls.bootstrap
+  )
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/session",
     ...authed,
+    audit("calls.cf_session", "write"),
     rateLimits.calls,
     calls.createCfSession
   )
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/renegotiate",
     ...authed,
+    audit("calls.cf_renegotiate", "write"),
     rateLimits.calls,
     calls.renegotiate
   )
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/publish",
     ...authed,
+    audit("calls.cf_publish_tracks", "write"),
     rateLimits.calls,
     calls.publishTracks
   )
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/pull",
     ...authed,
+    audit("calls.cf_pull_tracks", "write"),
     rateLimits.calls,
     calls.pullTracks
   )
   app.post(
     "/api/workspaces/:workspaceId/calls/:callId/endpoints/:endpointId/cf/tracks/close",
     ...authed,
+    audit("calls.cf_close_tracks", "write"),
     rateLimits.calls,
     calls.closeTracks
   )

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -19,6 +19,13 @@ import {
   registerVoiceGateway,
   createPolishTranscript,
 } from "./features/voice-transcription"
+import {
+  CallService,
+  CloudflareRealtimeApi,
+  createCallSweeper,
+  registerCallGateway,
+  type RealtimeMediaApi,
+} from "./features/calls"
 import { BotApiKeyService, createBotRuntimeWriteOps } from "./features/public-api"
 import {
   EnclaveRuntimesService,
@@ -622,6 +629,17 @@ export async function startServer(): Promise<ServerInstance> {
     modelRegistry,
   })
 
+  // Calls media plane — the CF Realtime SFU adapter (constructed only when the
+  // app id + secret pair is configured; absent ⇒ calls surfaces answer 503
+  // CALLS_UNAVAILABLE) and the transaction-owning CallService that proxies to it
+  // CF-call-first, DB-write-second (INV-41). One instance shared by the HTTP
+  // proxy routes, the /calls gateway, and the lease sweeper (INV-13).
+  const cloudflareRealtime: RealtimeMediaApi | null = config.cloudflareRealtime.enabled
+    ? new CloudflareRealtimeApi(config.cloudflareRealtime)
+    : null
+  const callService = new CallService({ pool, cloudflare: cloudflareRealtime })
+  const callSweeper = createCallSweeper(callService)
+
   const botApiKeyService = new BotApiKeyService(pool)
 
   // Enclave runtime registry — register/heartbeat/revoke of enclave instance
@@ -737,6 +755,8 @@ export async function startServer(): Promise<ServerInstance> {
     workosOrgService,
     userApiKeyService,
     voiceTranscriptionService,
+    callService,
+    callsCloudflareEnabled: config.cloudflareRealtime.enabled,
     enclaveRuntimesService,
     enclaveClaimService,
     enclaveClaimNudge,
@@ -803,6 +823,16 @@ export async function startServer(): Promise<ServerInstance> {
     userPreferencesService,
     workspaceSettingsService,
     polishTranscript,
+  })
+
+  // Dedicated /calls control namespace (mirrors the /voice gateway shape). Media
+  // negotiation rides the HTTPS CF proxy, not this socket; this carries only
+  // small control events (join/leave/state/lease renew) and the roster fan-out.
+  registerCallGateway(io, {
+    authService,
+    callService,
+    pool,
+    cloudflareEnabled: config.cloudflareRealtime.enabled,
   })
 
   const serverId = `server_${ulid()}`
@@ -1359,6 +1389,12 @@ export async function startServer(): Promise<ServerInstance> {
   scheduleManager.start()
   cleanupWorker.start()
   agentSessionMetrics.start()
+  // Reaps lapsed endpoint leases (→ left/empty_grace), expires stale rings, ends
+  // graced calls, and closes the CF sessions of reaped endpoints — every 15s
+  // (the lease-reap heartbeat vs the 45s TTL). In-process interval per instance
+  // (matching the sweepers above) so every instance reaps; each stage is
+  // idempotent CAS, so concurrent instance sweeps don't double-act.
+  callSweeper.start()
 
   // payload workspaceId "system" = system-wide check; schedule workspaceId null = global schedule
   if (!config.useStubAI) {
@@ -1560,6 +1596,7 @@ export async function startServer(): Promise<ServerInstance> {
     delegationExpirySweep.stop()
     pushSessionCleanup.stop()
     voiceSessionSweeper.stop()
+    callSweeper.stop()
     agentSessionMetrics.stop()
     await scheduleManager.stop()
     await cleanupWorker.stop()

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -831,6 +831,7 @@ export async function startServer(): Promise<ServerInstance> {
   registerCallGateway(io, {
     authService,
     callService,
+    workspaceSettingsService,
     pool,
     cloudflareEnabled: config.cloudflareRealtime.enabled,
   })

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -289,6 +289,31 @@ See `.env.example` at the repo root for the full list with descriptions. The cri
 | `CONTROL_PLANE_URL`                                                  | `http://control-plane.railway.internal:8080`            |
 | `INTERNAL_API_KEY`                                                   | Shared inter-service secret                             |
 | `REGION`                                                             | `eu-north-1`                                            |
+| `CLOUDFLARE_REALTIME_APP_ID`                                         | CF Realtime (SFU) app id for calls — see below          |
+| `CLOUDFLARE_REALTIME_APP_SECRET`                                     | CF Realtime app secret (media-plane credential)         |
+
+#### Cloudflare Realtime app (voice/video calls)
+
+Calls media routes through a **Cloudflare Realtime (SFU) app**, one **per environment** (dev / staging / prod). Never share an app across environments — the app secret is the media-plane credential, and a shared secret couples the environments' media planes.
+
+- **Provisioning** (once per environment). Create the app with an account API token carrying the `Cloudflare Calls: Edit` permission:
+
+  ```sh
+  curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/calls/apps" \
+    -H "Authorization: Bearer {account_token}" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"threa-calls-prod"}'
+  ```
+
+  The response carries the app **id** and **secret**. The **secret is shown once** — capture it immediately.
+
+- **Where the vars go**: set `CLOUDFLARE_REALTIME_APP_ID` and `CLOUDFLARE_REALTIME_APP_SECRET` as **Railway variables on the backend service** (`Dockerfile.backend` → backend service), per environment. They are backend-only — no other service reads them.
+
+- **Boot behavior**: the pair is co-presence-validated at startup (both set or both absent, INV-11). When absent, the backend boots normally but every calls HTTP/socket surface answers **503 `CALLS_UNAVAILABLE`** — deploying without them **disables calls and breaks nothing** else. A single one of the two set fails boot loudly.
+
+- **Per-workspace flag**: even with the app configured, calls stay dark until the `callsEnabled` workspace setting is turned on (default off).
+
+- **M1 exit gate**: the SFU is a content-level media processor from the first shipped call. Do **not** flip `callsEnabled` on in prod until Cloudflare's DPA / processor-register entry is in place — see the plan's `GDPR (v1)` section (`docs/plans/voice-video-calls.md`).
 
 ### Control-Plane
 

--- a/packages/types/src/workspace-settings.ts
+++ b/packages/types/src/workspace-settings.ts
@@ -75,6 +75,14 @@ export interface WorkspaceSettings {
    * shared money boundary has to be a deliberate choice, not one member's laptop.
    */
   billingTimezone: string
+  /**
+   * Feature flag for voice/video calls (dark feature, default OFF). Off ⇒ the
+   * calls HTTP/socket surfaces answer as if the feature does not exist
+   * (`CALLS_DISABLED`, 404-style) per the house convention for gated features.
+   * Flipped on per-workspace during rollout; the M1 exit gate requires the
+   * Cloudflare DPA/processor-register entry before enabling it in prod.
+   */
+  callsEnabled: boolean
   createdAt: string
   updatedAt: string
 }
@@ -88,6 +96,7 @@ export const DEFAULT_WORKSPACE_SETTINGS: Omit<WorkspaceSettings, "workspaceId" |
   maxPendingFollowUps: DEFAULT_MAX_PENDING_FOLLOW_UPS,
   defaultCompanionPersonaId: null,
   billingTimezone: "UTC",
+  callsEnabled: false,
 }
 
 /** Partial update — only provided fields are changed. */
@@ -99,6 +108,7 @@ export interface UpdateWorkspaceSettingsInput {
   maxPendingFollowUps?: number
   defaultCompanionPersonaId?: string | null
   billingTimezone?: string
+  callsEnabled?: boolean
 }
 
 /** Valid top-level settings keys that can be overridden. */


### PR DESCRIPTION
**Stack:** PR 2 of the calls build, on #1410 (schema + `CallService`). Spec: `docs/plans/voice-video-calls.md` §Topology/§Signaling/§Connectivity. PR 0.3 (spike harness) stacks on this.

## Problem

PR 0.1's state machines have no media plane and no wire surface. The plan's SFU-first design needs three things this PR adds: a backend-held Cloudflare Realtime API client (the app secret can never ship to a client), a control-plane socket namespace, and the roster/track registry clients converge on — plus the ops path for provisioning the per-environment Cloudflare app.

## Solution

Everything media-negotiation rides HTTPS through our proxy; everything control-plane rides the `/calls` namespace; every state change bumps one integer version clients key on.

### How it works

- **`cloudflare.ts`**: `RealtimeMediaApi` interface (the test seam) + `CloudflareRealtimeApi` (bearer `appSecret`, 8s timeouts, typed `CloudflareRealtimeError`). Known-unknowns about CF's evolving API are pinned in `CLOUDFLARE_API.md` as 7 questions the 0.3 spike must answer — encoded best-understanding, not guessed silently.
- **Proxy endpoints** under `/api/workspaces/:id/calls/:callId/endpoints/:endpointId/cf/…`: session create is **CF-first, then CAS** (`setCfSessionIfUnset` fenced on endpoint + `media_incarnation`); idempotent per incarnation; *any* failure after `createSession` best-effort closes the just-minted session — a committed row never claims a session that wasn't created, and no session leaks on the CAS-throw path (INV-41: no CF call ever runs inside a DB transaction — verified path-by-path in review).
- **`/calls` gateway** (`registerCallGateway`, the `/voice` shape): `call:join` handshake acks endpoint id + epoch + versioned roster snapshot; sockets bind their endpoint in `socket.data`; `disconnect` demotes to `reconnecting` (the lease is the authority, not the socket); per-socket token-bucket rate limits; INV-4 carve-out documented.
- **`roster_version`** (INV-66): bumped atomically in the same transaction as **every** membership/connection/media-state write — join, leave, reconnecting demotion, remove, reap (batched under the already-held call locks), media-state, publish/close tracks. Every roster-carrying emit sends the post-commit version; clients drop stale snapshots by comparison.
- **Sweeper**: reaped endpoints' CF sessions are closed after commit, best-effort — media dies with the lease.
- **Gating**: `CloudflareRealtimeConfig` (VAPID-style co-presence validation at boot, INV-11); absent ⇒ 503 `CALLS_UNAVAILABLE`. `callsEnabled` workspace setting (default OFF) ⇒ 404 `CALLS_DISABLED`. Both checked at every surface.

### Key design decisions

**1. In-process sweeper interval, not `jobQueue.schedule`** — deliberate brief deviation (flagged, reviewed, accepted): matches the three neighboring in-process sweepers, every instance reaps (the hostile matrix's crash-safety requirement), and each stage is idempotent CAS so concurrent sweeps can't double-act.

**2. `publishTracks`/`closeTracks` treat a null registry write as `409 CALL_ENDPOint_NOT_LIVE`** rather than false success — the TOCTOU where a takeover/reap closes the endpoint between fence-read and write surfaces honestly instead of bumping the version for an unpersisted registry.

**3. Graceful-path CF teardown deferred**: only the sweeper closes CF sessions; a leave's session dies via CF's inactivity timeout. Low-risk follow-up flagged in `CLOUDFLARE_API.md`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260719130000_calls_media_session.sql` | `roster_version` + endpoint media columns (`cf_session_id`, `media_incarnation`, `media_state`, `published_tracks`) |
| `apps/backend/src/features/calls/cloudflare.ts` (+ test) | CF Realtime client behind the `RealtimeMediaApi` seam |
| `apps/backend/src/features/calls/handlers.ts` (+ test) | REST + CF proxy surface, gate order CF-absent → flag → access → Zod |
| `apps/backend/src/features/calls/signaling-gateway.ts` (+ test) | `/calls` namespace control plane |
| `apps/backend/src/features/calls/CLOUDFLARE_API.md` | Encoded CF API shapes + the 7 spike questions |

## Modified files

| File | Change |
| ---- | ------ |
| `features/calls/{service,repository,config}.ts` (+ tests) | Incarnation-aware endpoint admission/rebind, CF session lifecycle, roster versioning, media state, publish registry |
| `lib/env.ts` (+ test) | `CloudflareRealtimeConfig` with co-presence validation |
| `features/workspace-settings/*`, `packages/types` | `callsEnabled` flag (default OFF) |
| `middleware/rate-limit.ts`, `routes.ts`, `server.ts` | Limiter, route mounting, one-time construction + gateway/sweeper wiring |
| `.env.example`, `docs/deployment.md` | Per-environment Realtime app provisioning (exact API call, Railway placement, 503-safe boot, M1 DPA gate) |

## Out of scope (deliberate)

Frontend (M1), ring/push (1.3), timeline/outbox registration (1.4), live CF validation (0.3 spike — needs the dev app credentials). Nothing plan-deferred is built.

## Test plan

- [x] Implement → xhigh adversarial verify → fix → re-verify loop: **1 blocker + 3 minors found and resolved** (roster_version silent on membership transitions — now atomic with every write and pinned by `toHaveBeenCalledWith` tests; CAS-throw orphaning a CF session; false-success on dead-endpoint publish; sweeper-scheduling deviation accepted with rationale)
- [x] `bun test src/features/calls/` — 84 pass / 0 fail (7 files; re-run by me post-loop)
- [x] `bun run test:unit` — 3303 pass / 0 fail; typecheck (backend, types, frontend) clean; `check:migrations` 222 clean; full pre-commit green
- [ ] No live Cloudflare exercise yet — the client is fetch-stub tested; the real API contract is 0.3's spike (blocked on the dev app token)
- [ ] `markEndpointReconnecting`'s version bump is implemented but not unit-pinned (residual from re-verify; noted for the 0.3/1.1 rounds)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
