### PR TITLE
feat(calls): CallManager + MediaTransport media core (stack 4/8)

### DIFF
--- a/apps/backend/src/features/calls/repository.test.ts
+++ b/apps/backend/src/features/calls/repository.test.ts
@@ -238,3 +238,27 @@ describe("CallInvitationRepository — expire only past-due rings", () => {
     expect(sql).toContain("status = 'ringing'")
   })
 })
+
+describe("CallParticipantRepository — roster carries the publisher's CF session", () => {
+  it("listRoster selects and maps cf_session_id so clients can address peer media", async () => {
+    const captured: Captured = { text: "" }
+    const roster = await CallParticipantRepository.listRoster(
+      createQuerier(captured, [
+        {
+          participant_id: "callp_1",
+          user_id: "usr_1",
+          participant_status: "joined",
+          endpoint_id: "callep_1",
+          endpoint_status: "connected",
+          cf_session_id: "cfsess_abc",
+          media_state: {},
+          published_tracks: [{ kind: "mic", trackName: "t1" }],
+        },
+      ]),
+      "ws_1",
+      "call_1"
+    )
+    expect(normalize(captured.text)).toContain("cf_session_id")
+    expect(roster[0]).toMatchObject({ endpointId: "callep_1", cfSessionId: "cfsess_abc" })
+  })
+})

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -600,6 +600,7 @@ export const CallParticipantRepository = {
       participant_status: string
       endpoint_id: string | null
       connection_status: string | null
+      cf_session_id: string | null
       media_state: MediaState | null
       published_tracks: PublishedTrack[] | null
     }>(sql`
@@ -608,6 +609,7 @@ export const CallParticipantRepository = {
         p.status AS participant_status,
         e.id AS endpoint_id,
         e.status AS connection_status,
+        e.cf_session_id AS cf_session_id,
         e.media_state,
         e.published_tracks
       FROM call_participants p
@@ -622,6 +624,7 @@ export const CallParticipantRepository = {
       participantStatus: row.participant_status as CallParticipantStatus,
       endpointId: row.endpoint_id,
       connectionStatus: row.connection_status as CallEndpointStatus | null,
+      cfSessionId: row.cf_session_id,
       mediaState: row.media_state ?? {},
       publishedTracks: row.published_tracks ?? [],
     }))
@@ -634,6 +637,7 @@ export interface CallRosterEntry {
   participantStatus: CallParticipantStatus
   endpointId: string | null
   connectionStatus: CallEndpointStatus | null
+  cfSessionId: string | null
   mediaState: MediaState
   publishedTracks: PublishedTrack[]
 }

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -16,6 +16,7 @@ import { resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
 import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
+import { resetCallStoreCache } from "@/stores/call-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
 import { useAuth } from "./hooks"
 
@@ -77,6 +78,10 @@ function flushModuleStoreCaches(): void {
   resetE2eSessionStoreCache()
   resetComposeOverlayStoreCache()
   resetBoardFlashStoreCache()
+  // Ordered hangup before state drop: the call-store reset emits leave, closes
+  // the transport, and stops tracks (the CallManager's registered hangup) so an
+  // account switch with a live call never leaves the prior account's mic hot.
+  resetCallStoreCache()
   resetRevealGate()
 }
 

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { CallManager, type CallManagerDeps, type CallSocket } from "./call-manager"
+import type { MediaTransport } from "./media-transport"
+import { getCallState, clearCallState, type CallRosterParticipant } from "@/stores/call-store"
+import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
+
+// Shared teardown-order log: the mic track, socket, and transport push into it so
+// the ordered-hangup test can pin emit-leave → close-transport → stop-tracks.
+let order: string[]
+
+function makeTrack(kind: "audio" | "video"): MediaStreamTrack {
+  return {
+    kind,
+    enabled: true,
+    stop: vi.fn(() => order.push(`stopTrack:${kind}`)),
+    applyConstraints: vi.fn(async () => {}),
+    addEventListener: vi.fn(),
+  } as unknown as MediaStreamTrack
+}
+
+function makeStream(kinds: Array<"audio" | "video">) {
+  const tracks = kinds.map(makeTrack)
+  return {
+    getAudioTracks: () => tracks.filter((t) => t.kind === "audio"),
+    getVideoTracks: () => tracks.filter((t) => t.kind === "video"),
+    getTracks: () => tracks,
+    _track: tracks[0],
+  } as unknown as MediaStream & { _track: MediaStreamTrack }
+}
+
+function makeTransport() {
+  const events: string[] = []
+  const t: MediaTransport & { _events: string[] } = {
+    connectionState: "new",
+    onRemoteTrack: null,
+    onRemoteTrackEnded: null,
+    onConnectionStateChange: null,
+    connect: vi.fn(async () => {
+      events.push("connect")
+    }),
+    publish: vi.fn(async (kind: string) => {
+      events.push(`publish:${kind}`)
+    }),
+    unpublish: vi.fn(async (kind: string) => {
+      events.push(`unpublish:${kind}`)
+    }),
+    setPublishEncoding: vi.fn(async () => {}),
+    pull: vi.fn(async (ref) => {
+      events.push(`pull:${ref.trackName}`)
+    }),
+    stopPull: vi.fn(async (ref) => {
+      events.push(`stopPull:${ref.trackName}`)
+    }),
+    getStats: vi.fn(async () => ({ rttMs: null, packetLoss: null, qualityLimitation: null, encodeTimeMs: null })),
+    close: vi.fn(async () => {
+      events.push("close")
+      order.push("close")
+    }),
+    _events: events,
+  }
+  return t as MediaTransport & { _events: string[]; publish: ReturnType<typeof vi.fn> }
+}
+
+interface FakeSocket extends CallSocket {
+  handlers: Map<string, (...a: unknown[]) => void>
+  emitted: Array<{ event: string; payload: unknown }>
+  joinAck: {
+    endpointId: string
+    epoch: number
+    rosterVersion: number
+    roster: CallRosterParticipant[]
+    leaseTtlMs: number
+  }
+  fire(event: string, ...args: unknown[]): void
+}
+
+function makeSocket(): FakeSocket {
+  const handlers = new Map<string, (...a: unknown[]) => void>()
+  const emitted: Array<{ event: string; payload: unknown }> = []
+  const socket: FakeSocket = {
+    connected: true,
+    joinAck: { endpointId: "ep_1", epoch: 1, rosterVersion: 0, roster: [], leaseTtlMs: 45_000 },
+    handlers,
+    emitted,
+    emit(event, payload, ack) {
+      emitted.push({ event, payload })
+      if (event === "call:leave") order.push("leave")
+      if (event === "call:join") ack?.({ ok: true, data: socket.joinAck })
+      else if (event === "call:leave") ack?.({ ok: true })
+      else if (event === "call:lease:renew") ack?.({ ok: true, data: { leaseExpiresAt: new Date().toISOString() } })
+    },
+    on(event, handler) {
+      handlers.set(event, handler)
+    },
+    off(event) {
+      handlers.delete(event)
+    },
+    disconnect: vi.fn(),
+    fire(event, ...args) {
+      handlers.get(event)?.(...args)
+    },
+  }
+  return socket
+}
+
+function makeDeps(socket: FakeSocket, transport: MediaTransport) {
+  let inc = 0
+  const deps: CallManagerDeps = {
+    startCallRest: vi.fn(async ({ workspaceId, streamId, mode }) => ({
+      call: { id: "call_1", workspaceId, streamId, mode },
+      created: true,
+      participant: { id: "p_1" },
+      endpoint: { id: "ep_rest" },
+      rosterVersion: 0,
+      roster: [],
+    })),
+    connectSocket: vi.fn(() => socket),
+    createTransport: vi.fn(() => transport),
+    acquireUserMedia: vi.fn(async (c: MediaStreamConstraints) => {
+      const kinds: Array<"audio" | "video"> = []
+      if (c.audio) kinds.push("audio")
+      if (c.video) kinds.push("video")
+      return makeStream(kinds.length ? kinds : ["audio"])
+    }),
+    createAudioContext: () => null,
+    enumerateDevices: vi.fn(async () => []),
+    locks: null,
+    requestWakeLock: vi.fn(async () => null),
+    mintIncarnation: vi.fn(() => `inc-${++inc}`),
+  }
+  return deps
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_x",
+    participantStatus: "joined",
+    endpointId: "ep_peer",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+describe("CallManager", () => {
+  beforeEach(() => {
+    order = []
+    clearCallState()
+    setDictationExternalHold(false)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("join happy path: REST → socket join → connect → publish mic → connected", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    const join = socket.emitted.find((e) => e.event === "call:join")
+    expect(join?.payload).toMatchObject({ workspaceId: "ws_1", callId: "call_1", mediaIncarnation: "inc-1" })
+    expect(transport.connect).toHaveBeenCalledWith({ endpointId: "ep_1", mediaIncarnation: "inc-1" })
+    expect(transport.publish).toHaveBeenCalledWith("mic", expect.anything())
+    expect(getCallState().phase).toBe("connected")
+    expect(getCallState().callId).toBe("call_1")
+    expect(isDictationExternalHeld()).toBe(true)
+  })
+
+  it("video mode publishes the camera; audio_only does not", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    expect(transport._events).toContain("publish:camera")
+  })
+
+  it("drops a stale/duplicate roster version, applies a newer one", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // Newer version applies.
+    socket.fire("call:roster", { callId: "call_1", rosterVersion: 5, roster: [participant({ userId: "usr_1" })] })
+    expect(getCallState().rosterVersion).toBe(5)
+    expect(getCallState().roster).toHaveLength(1)
+
+    // Stale (lower) version is dropped.
+    socket.fire("call:roster", { callId: "call_1", rosterVersion: 2, roster: [] })
+    expect(getCallState().rosterVersion).toBe(5)
+    expect(getCallState().roster).toHaveLength(1)
+  })
+
+  it("track-registry diff drives pull then stopPull", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 2,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "mic", trackName: "peer:mic" }],
+        }),
+      ],
+    })
+    expect(transport.pull).toHaveBeenCalledWith({ sessionId: "cf-peer", trackName: "peer:mic" })
+
+    // Peer leaves the roster → stopPull.
+    socket.fire("call:roster", { callId: "call_1", rosterVersion: 3, roster: [] })
+    expect(transport.stopPull).toHaveBeenCalledWith({ sessionId: "cf-peer", trackName: "peer:mic" })
+  })
+
+  it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 2,
+      roster: [
+        participant({ userId: "usr_1", cfSessionId: null, publishedTracks: [{ kind: "mic", trackName: "peer:mic" }] }),
+      ],
+    })
+    expect(transport.pull).not.toHaveBeenCalled()
+  })
+
+  it("renews the lease at TTL/3", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    socket.emitted.length = 0
+    // TTL 45s → renew every 15s.
+    vi.advanceTimersByTime(15_000)
+    expect(socket.emitted.filter((e) => e.event === "call:lease:renew")).toHaveLength(1)
+    vi.advanceTimersByTime(15_000)
+    expect(socket.emitted.filter((e) => e.event === "call:lease:renew")).toHaveLength(2)
+  })
+
+  it("mute gates track.enabled and emits call:state", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    const micTrack = getMicTrack(transport)
+    manager.setMuted(true)
+    expect(micTrack.enabled).toBe(false)
+    expect(getCallState().local.muted).toBe(true)
+    expect(socket.emitted.find((e) => e.event === "call:state")?.payload).toEqual({ muted: true })
+  })
+
+  it("ordered teardown: emit leave → close transport → stop tracks", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    order = []
+
+    await manager.leaveCall()
+
+    expect(order[0]).toBe("leave")
+    expect(order[1]).toBe("close")
+    expect(order.slice(2)).toContain("stopTrack:audio")
+    expect(getCallState().phase).toBe("idle")
+    expect(isDictationExternalHeld()).toBe(false)
+  })
+
+  it("transient socket reconnect rejoins with the SAME incarnation", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    expect(deps.mintIncarnation).toHaveBeenCalledTimes(1)
+
+    socket.emitted.length = 0
+    socket.fire("disconnect")
+    expect(getCallState().phase).toBe("reconnecting")
+    socket.fire("connect")
+    await Promise.resolve()
+
+    const rejoin = socket.emitted.find((e) => e.event === "call:join")
+    expect(rejoin?.payload).toMatchObject({ mediaIncarnation: "inc-1" })
+    // A transient reconnect must NOT mint a new incarnation.
+    expect(deps.mintIncarnation).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejoin after leaving mints a NEW incarnation", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    await manager.leaveCall()
+
+    const socket2 = makeSocket()
+    const transport2 = makeTransport()
+    // Reuse the same deps identity for mintIncarnation continuity.
+    ;(deps.connectSocket as ReturnType<typeof vi.fn>).mockReturnValue(socket2)
+    ;(deps.createTransport as ReturnType<typeof vi.fn>).mockReturnValue(transport2)
+
+    await manager.rejoin({ workspaceId: "ws_1", streamId: "stream_1", callId: "call_1", mode: "audio_only" })
+    expect(deps.mintIncarnation).toHaveBeenCalledTimes(2)
+    const join = socket2.emitted.find((e) => e.event === "call:join")
+    expect(join?.payload).toMatchObject({ mediaIncarnation: "inc-2" })
+  })
+})
+
+/** The mic track the manager published — reach it through the publish spy. */
+function getMicTrack(transport: MediaTransport): MediaStreamTrack {
+  const publish = transport.publish as unknown as ReturnType<typeof vi.fn>
+  const micCall = publish.mock.calls.find((c: unknown[]) => c[0] === "mic")
+  return micCall?.[1] as MediaStreamTrack
+}

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { CallManager, type CallManagerDeps, type CallSocket } from "./call-manager"
+import {
+  CallManager,
+  CallCaptureError,
+  CallStartCancelledError,
+  type CallManagerDeps,
+  type CallSocket,
+} from "./call-manager"
 import type { MediaTransport } from "./media-transport"
-import { getCallState, clearCallState, type CallRosterParticipant } from "@/stores/call-store"
+import { getCallState, clearCallState, resetCallStoreCache, type CallRosterParticipant } from "@/stores/call-store"
 import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
 
 // Shared teardown-order log: the mic track, socket, and transport push into it so
@@ -71,6 +77,9 @@ interface FakeSocket extends CallSocket {
     roster: CallRosterParticipant[]
     leaseTtlMs: number
   }
+  /** When true, `call:join` stores its ack on `pendingJoinAck` instead of resolving it. */
+  deferJoin: boolean
+  pendingJoinAck: ((result: unknown) => void) | null
   fire(event: string, ...args: unknown[]): void
 }
 
@@ -82,11 +91,15 @@ function makeSocket(): FakeSocket {
     joinAck: { endpointId: "ep_1", epoch: 1, rosterVersion: 0, roster: [], leaseTtlMs: 45_000 },
     handlers,
     emitted,
+    deferJoin: false,
+    pendingJoinAck: null,
     emit(event, payload, ack) {
       emitted.push({ event, payload })
       if (event === "call:leave") order.push("leave")
-      if (event === "call:join") ack?.({ ok: true, data: socket.joinAck })
-      else if (event === "call:leave") ack?.({ ok: true })
+      if (event === "call:join") {
+        if (socket.deferJoin) socket.pendingJoinAck = ack ?? null
+        else ack?.({ ok: true, data: socket.joinAck })
+      } else if (event === "call:leave") ack?.({ ok: true })
       else if (event === "call:lease:renew") ack?.({ ok: true, data: { leaseExpiresAt: new Date().toISOString() } })
     },
     on(event, handler) {
@@ -127,6 +140,7 @@ function makeDeps(socket: FakeSocket, transport: MediaTransport) {
     locks: null,
     requestWakeLock: vi.fn(async () => null),
     mintIncarnation: vi.fn(() => `inc-${++inc}`),
+    singleActiveCapture: false,
   }
   return deps
 }
@@ -318,6 +332,165 @@ describe("CallManager", () => {
     expect(deps.mintIncarnation).toHaveBeenCalledTimes(2)
     const join = socket2.emitted.find((e) => e.event === "call:join")
     expect(join?.payload).toMatchObject({ mediaIncarnation: "inc-2" })
+  })
+
+  // ── session-generation guard (findings 1-6) ─────────────────────────────────
+
+  it("double startCall throws synchronously while the first is joining (in-flight guard)", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+
+    // The first start suspends at its first await with the `starting` sentinel set.
+    const first = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    // A second start must throw in the caller's stack, not leak a parallel session.
+    expect(() => manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })).toThrow(
+      /already active/
+    )
+
+    await first
+    expect(manager.isActive()).toBe(true)
+    // Exactly one session was ever minted (one incarnation, one socket).
+    expect(socket.emitted.filter((e) => e.event === "call:join")).toHaveLength(1)
+  })
+
+  it("a stale reconnect-join continuation no-ops after teardown", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // A socket reconnect fires a rejoin whose ack we hold in flight.
+    socket.deferJoin = true
+    socket.fire("disconnect")
+    socket.fire("connect")
+    expect(socket.pendingJoinAck).not.toBeNull()
+
+    // The user leaves while the rejoin is still in flight.
+    await manager.leaveCall()
+    expect(manager.isActive()).toBe(false)
+    expect(getCallState().phase).toBe("idle")
+
+    // The rejoin resolves late — its `.then` must NOT resurrect a phantom "connected".
+    socket.pendingJoinAck?.({ ok: true, data: socket.joinAck })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getCallState().phase).toBe("idle")
+    expect(manager.isActive()).toBe(false)
+  })
+
+  it("leaveCall during the joining window cancels the start and stops the mic", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    // Park the start at acquireWakeLock — one await past the mic capture — so the
+    // cancel lands with a live capture already in place.
+    let releaseWake: () => void = () => {}
+    ;(deps.requestWakeLock as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseWake = () => resolve(null)
+        })
+    )
+    const manager = new CallManager(deps, null)
+
+    const start = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    // Drain all microtasks so runStart reaches the parked wake-lock request.
+    await new Promise((r) => setTimeout(r, 0))
+    const micTrack = getMicTrack(transport)
+    expect(micTrack).toBeTruthy()
+    expect(manager.isActive()).toBe(true)
+
+    // User cancels mid-join; the in-flight start must roll back.
+    const leaving = manager.leaveCall()
+    releaseWake()
+    await expect(start).rejects.toBeInstanceOf(CallStartCancelledError)
+    await leaving
+
+    expect(manager.isActive()).toBe(false)
+    expect(getCallState().phase).toBe("idle")
+    expect(micTrack.stop).toHaveBeenCalled()
+  })
+
+  it("overlapping input-device switches serialize (never two captures at once)", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    let inFlight = 0
+    let maxConcurrent = 0
+    ;(deps.acquireUserMedia as ReturnType<typeof vi.fn>).mockImplementation(async (c: MediaStreamConstraints) => {
+      inFlight++
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      await Promise.resolve()
+      await Promise.resolve()
+      inFlight--
+      const kinds: Array<"audio" | "video"> = ["audio"]
+      if (c.video) kinds.push("video")
+      return makeStream(kinds)
+    })
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // Fire two switches without awaiting the first — the chain must serialize them.
+    const a = manager.switchInputDevice("dev-a")
+    const b = manager.switchInputDevice("dev-b")
+    await Promise.all([a, b])
+
+    // A concurrent second capture would be fatal on iOS single-active-capture.
+    expect(maxConcurrent).toBe(1)
+    // Serialized in request order → settles at the last requested device.
+    expect(getCallState().local.devices.selectedInputId).toBe("dev-b")
+  })
+
+  it("iOS mid-call recapture failure rolls back to the prior capture with a typed error", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    deps.singleActiveCapture = true
+    let calls = 0
+    ;(deps.acquireUserMedia as ReturnType<typeof vi.fn>).mockImplementation(async (c: MediaStreamConstraints) => {
+      calls++
+      // The device-switch acquire fails (e.g. NotReadableError); the rollback re-acquire succeeds.
+      if (calls === 2) throw new Error("device busy")
+      const kinds: Array<"audio" | "video"> = ["audio"]
+      if (c.video) kinds.push("video")
+      return makeStream(kinds)
+    })
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    const err = await manager.switchInputDevice("dev-x").catch((e) => e)
+    expect(err).toBeInstanceOf(CallCaptureError)
+    expect(err.code).toBe("capture_failed")
+
+    // Startup + failed switch + rollback re-acquire = 3 getUserMedia calls; audio restored.
+    expect(deps.acquireUserMedia).toHaveBeenCalledTimes(3)
+    expect(manager.isActive()).toBe(true)
+    // The store surfaces the typed failure for the UI.
+    expect(getCallState().captureError).toMatchObject({ code: "capture_failed" })
+  })
+
+  it("a roster event dispatched before hangupSync no-ops after the flush", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // Capture the handler as if a roster broadcast were already dispatched into the loop.
+    const rosterHandler = socket.handlers.get("call:roster")
+    expect(rosterHandler).toBeTruthy()
+
+    // Account switch / logout flush → hangupSync.
+    resetCallStoreCache()
+    expect(manager.isActive()).toBe(false)
+    // Symmetric with teardown: the socket handlers were detached.
+    expect(socket.handlers.has("call:roster")).toBe(false)
+
+    // The already-in-flight event still fires — it must NOT write the prior
+    // account's roster into the just-reset store.
+    rosterHandler?.({ callId: "call_1", rosterVersion: 99, roster: [participant({ userId: "usr_z" })] })
+    expect(getCallState().roster).toHaveLength(0)
+    expect(getCallState().rosterVersion).toBe(0)
   })
 })
 

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -1,0 +1,886 @@
+import { ulid } from "ulid"
+import { io } from "socket.io-client"
+import { api } from "@/api/client"
+import { getCachedWsConfig } from "@/lib/cached-ws-config"
+import { setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
+import {
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  patchCallLocal,
+  setCallSpeakingLevel,
+  setCallDevices,
+  setCallDiagnostics,
+  setCallActiveElsewhere,
+  setCallConfirmPending,
+  clearCallState,
+  registerCallHangup,
+  getCallState,
+  type CallRosterParticipant,
+  type CallDeviceState,
+} from "@/stores/call-store"
+import {
+  CloudflareSfuTransport,
+  type MediaTransport,
+  type PeerTrackRef,
+  type RemoteTrackEvent,
+} from "./media-transport"
+import {
+  ENDPOINT_LEASE_TTL_MS,
+  leaseRenewIntervalMs,
+  WATCHDOG_SAMPLE_MS,
+  WATCHDOG_HEALTHY_SAMPLES_TO_UPGRADE,
+  CAMERA_PUBLISH_LADDER,
+  AUDIO_CAPTURE_CONSTRAINTS,
+  VIDEO_CAPTURE_CONSTRAINTS,
+  type CallMode,
+} from "./config"
+
+// ── Wire shapes ────────────────────────────────────────────────────────────────
+
+interface StartCallResponse {
+  call: { id: string; workspaceId: string; streamId: string; mode: CallMode }
+  created: boolean
+  participant: { id: string }
+  endpoint: { id: string }
+  rosterVersion: number
+  roster: CallRosterParticipant[]
+}
+
+interface JoinAckData {
+  endpointId: string
+  epoch: number
+  rosterVersion: number
+  roster: CallRosterParticipant[]
+  leaseTtlMs: number
+}
+
+type Ack<T> = { ok: boolean; error?: string; code?: string; data?: T }
+
+interface RosterEvent {
+  callId: string
+  rosterVersion: number
+  roster: CallRosterParticipant[]
+}
+
+/** Minimal socket surface the manager needs — satisfied by socket.io's `Socket`. */
+export interface CallSocket {
+  connected: boolean
+  emit(event: string, payload: unknown, ack?: (result: unknown) => void): void
+  on(event: string, handler: (...args: unknown[]) => void): void
+  off(event: string): void
+  disconnect(): void
+}
+
+interface WakeLockLike {
+  release(): Promise<void>
+  released: boolean
+}
+
+/**
+ * Injected browser/network collaborators. Production wires real APIs via
+ * {@link defaultCallManagerDeps}; tests pass fakes so no test touches the network,
+ * a real `RTCPeerConnection`, `getUserMedia`, Web Locks, or the wake lock.
+ */
+export interface CallManagerDeps {
+  startCallRest(args: {
+    workspaceId: string
+    streamId: string
+    mode: CallMode
+    mediaIncarnation: string
+  }): Promise<StartCallResponse>
+  connectSocket(workspaceId: string): CallSocket | null
+  createTransport(args: { workspaceId: string; callId: string }): MediaTransport
+  acquireUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>
+  createAudioContext(): AudioContext | null
+  enumerateDevices(): Promise<MediaDeviceInfo[]>
+  locks: LockManager | null
+  requestWakeLock(): Promise<WakeLockLike | null>
+  mintIncarnation(): string
+}
+
+interface CallSession {
+  callId: string
+  workspaceId: string
+  streamId: string
+  mode: CallMode
+  mediaIncarnation: string
+  endpointId: string
+  leaseTtlMs: number
+  rosterVersion: number
+  transport: MediaTransport
+  socket: CallSocket
+  micTrack: MediaStreamTrack | null
+  cameraTrack: MediaStreamTrack | null
+  micStream: MediaStream | null
+  audioContext: AudioContext | null
+  analyser: AnalyserNode | null
+  pulled: Map<string, { ref: PeerTrackRef; kind: string }>
+  remoteAudioEls: Map<string, HTMLAudioElement>
+  cameraLayer: number
+  healthySamples: number
+  leaseTimer: ReturnType<typeof setInterval> | null
+  watchdogTimer: ReturnType<typeof setInterval> | null
+  meterRaf: number | null
+  wakeLock: WakeLockLike | null
+  releaseLock: (() => void) | null
+  onVisibility: (() => void) | null
+  onDeviceChange: (() => void) | null
+}
+
+function refKey(ref: PeerTrackRef): string {
+  return `${ref.sessionId}:${ref.trackName}`
+}
+
+/**
+ * The account-scoped, workspace-agnostic call singleton (calls carry their own
+ * `workspaceId`, so — unlike the per-workspace SyncEngine — it survives a
+ * workspace switch and only dies on account switch / logout via the call-store
+ * flush registration). Owns the `/calls` socket, the CF transport + media, the
+ * media incarnation, leases, and local capture. It never activates on its own —
+ * only an explicit `startCall`/`rejoin` from a user gesture brings it up.
+ */
+export class CallManager {
+  private readonly deps: CallManagerDeps
+  private session: CallSession | null = null
+  private unregisterHangup: (() => void) | null = null
+  private readonly audioContainer: HTMLElement | null
+
+  constructor(deps: CallManagerDeps, audioContainer?: HTMLElement | null) {
+    this.deps = deps
+    this.audioContainer = audioContainer ?? null
+    // The store's flush (account switch / logout) drives the ordered hangup.
+    this.unregisterHangup = registerCallHangup(() => this.hangupSync())
+  }
+
+  isActive(): boolean {
+    return this.session !== null
+  }
+
+  /**
+   * Start (or join) the call on a stream and connect media. Must be invoked from
+   * a user gesture — the AudioContext is created synchronously at the top so iOS
+   * Safari honors it (an AudioContext created after an await stays suspended).
+   */
+  async startCall(params: { workspaceId: string; streamId: string; mode: CallMode }): Promise<void> {
+    if (this.session) throw new Error("A call is already active")
+    const mediaIncarnation = this.deps.mintIncarnation()
+    // Synchronous, in-gesture (see method doc). Held on a temp until the session exists.
+    const audioContext = this.deps.createAudioContext()
+    void audioContext?.resume().catch(() => {})
+
+    // Held on locals so the catch can release them even when a throw precedes
+    // `this.session = session` (teardown early-returns on a null session).
+    let releaseLock: (() => void) | null = null
+    let socket: CallSocket | null = null
+    try {
+      const started = await this.deps.startCallRest({ ...params, mediaIncarnation })
+      const callId = started.call.id
+      setCallSession({ callId, workspaceId: params.workspaceId, streamId: params.streamId, mode: params.mode })
+      // One tab owns the call (Web Locks). A second tab sees the lock held →
+      // activeElsewhere; on this tab's crash the lock releases and the other tab
+      // may offer rejoin (surfaced via the store; UI is M1.2).
+      releaseLock = await this.acquireLock(callId)
+
+      socket = this.deps.connectSocket(params.workspaceId)
+      if (!socket) throw new Error("Calls socket is not available")
+
+      const join = await this.joinOverSocket(socket, {
+        workspaceId: params.workspaceId,
+        callId,
+        mediaIncarnation,
+      })
+
+      const transport = this.deps.createTransport({ workspaceId: params.workspaceId, callId })
+      const session: CallSession = {
+        callId,
+        workspaceId: params.workspaceId,
+        streamId: params.streamId,
+        mode: params.mode,
+        mediaIncarnation,
+        endpointId: join.endpointId,
+        leaseTtlMs: join.leaseTtlMs || ENDPOINT_LEASE_TTL_MS,
+        // -1 so the join's own snapshot (version ≥ 0) is applied by applyRoster.
+        rosterVersion: -1,
+        transport,
+        socket,
+        micTrack: null,
+        cameraTrack: null,
+        micStream: null,
+        audioContext,
+        analyser: null,
+        pulled: new Map(),
+        remoteAudioEls: new Map(),
+        cameraLayer: 0,
+        healthySamples: 0,
+        leaseTimer: null,
+        watchdogTimer: null,
+        meterRaf: null,
+        wakeLock: null,
+        releaseLock,
+        onVisibility: null,
+        onDeviceChange: null,
+      }
+      this.session = session
+
+      // Composer dictation off for the call's life — one active capture only.
+      setDictationExternalHold(true)
+
+      this.wireTransport(session)
+      this.wireSocket(session)
+
+      await transport.connect({ endpointId: join.endpointId, mediaIncarnation })
+      // Video joins acquire mic+camera in ONE getUserMedia (iOS single-active-
+      // capture: a second gUM while the first is live mutes it), then split.
+      await this.captureAndPublish(session, { camera: params.mode === "video" })
+      if (params.mode === "video") {
+        patchCallLocal({ cameraOn: true })
+        this.emitState(session, { cameraOn: true })
+      }
+
+      this.applyRoster(session, join.rosterVersion, join.roster)
+      this.startLeaseTimer(session)
+      this.startWatchdog(session)
+      await this.acquireWakeLock(session)
+      await this.refreshDevices()
+
+      setCallPhase("connected")
+    } catch (err) {
+      if (this.session) {
+        await this.teardown()
+      } else {
+        // Threw before the session existed — teardown can't see these, so
+        // release the lock, socket, and AudioContext here or they orphan (a
+        // held-forever call lock wedges every later startCall on this tab).
+        releaseLock?.()
+        try {
+          socket?.disconnect()
+        } catch {
+          // ignore
+        }
+        void audioContext?.close?.().catch(() => {})
+        clearCallState()
+      }
+      throw err
+    }
+  }
+
+  /**
+   * Rejoin a call after a fresh page load: a NEW media incarnation (new CF
+   * session), unlike a transient socket reconnect which reuses the incarnation.
+   * The rejoin flow is otherwise identical to a start on the same stream.
+   */
+  async rejoin(params: { workspaceId: string; streamId: string; callId: string; mode: CallMode }): Promise<void> {
+    // startCall's REST endpoint is start-or-join, so a rejoin is a start on the
+    // same stream with a fresh incarnation — the shared path keeps one lifecycle.
+    await this.startCall({ workspaceId: params.workspaceId, streamId: params.streamId, mode: params.mode })
+  }
+
+  /** Ordered teardown: emit leave → close transport → stop tracks. */
+  async leaveCall(): Promise<void> {
+    const session = this.session
+    if (!session) return
+    await this.emitLeave(session)
+    await this.teardown()
+  }
+
+  setMuted(muted: boolean): void {
+    const session = this.session
+    if (!session) return
+    if (session.micTrack) session.micTrack.enabled = !muted
+    patchCallLocal({ muted })
+    this.emitState(session, { muted })
+  }
+
+  async setCameraOn(on: boolean): Promise<void> {
+    const session = this.session
+    if (!session) return
+    if (session.mode === "audio_only") return
+    if (on) {
+      // Turning the camera on re-acquires mic+camera as ONE stream (iOS single-
+      // active-capture): a camera-only gUM while the mic is live would mute it.
+      await this.captureAndPublish(session, {
+        camera: true,
+        inputDeviceId: getCallState().local.devices.selectedInputId,
+      })
+    } else if (session.cameraTrack) {
+      // Camera off fully stops the track (kills the LED) and unpublishes; the
+      // mic is untouched, so no recapture is needed.
+      session.cameraTrack.stop()
+      session.cameraTrack = null
+      await session.transport.unpublish("camera")
+    }
+    patchCallLocal({ cameraOn: on })
+    this.emitState(session, { cameraOn: on })
+  }
+
+  async switchInputDevice(deviceId: string): Promise<void> {
+    const session = this.session
+    if (!session) return
+    // Recapture the whole stream (mic + camera if live) so iOS single-active-
+    // capture never mutes the surviving track.
+    await this.captureAndPublish(session, { camera: session.cameraTrack != null, inputDeviceId: deviceId })
+    patchCallLocal({ devices: { ...getCallState().local.devices, selectedInputId: deviceId } })
+    await this.refreshDevices()
+  }
+
+  async setOutputDevice(deviceId: string): Promise<void> {
+    const session = this.session
+    if (!session) return
+    for (const el of session.remoteAudioEls.values()) {
+      const sinkable = el as HTMLAudioElement & { setSinkId?: (id: string) => Promise<void> }
+      if (typeof sinkable.setSinkId === "function") await sinkable.setSinkId(deviceId).catch(() => {})
+    }
+    patchCallLocal({
+      devices: { ...getCallState().local.devices, selectedOutputId: deviceId },
+    })
+  }
+
+  dispose(): void {
+    this.unregisterHangup?.()
+    this.unregisterHangup = null
+    void this.teardown()
+  }
+
+  // ── socket + roster ───────────────────────────────────────────────────────
+
+  private joinOverSocket(
+    socket: CallSocket,
+    args: { workspaceId: string; callId: string; mediaIncarnation: string }
+  ): Promise<JoinAckData> {
+    return new Promise<JoinAckData>((resolve, reject) => {
+      socket.emit("call:join", args, (result: unknown) => {
+        const ack = result as Ack<JoinAckData>
+        if (ack?.ok && ack.data) resolve(ack.data)
+        else reject(new Error(ack?.code ?? ack?.error ?? "call:join failed"))
+      })
+    })
+  }
+
+  private wireSocket(session: CallSession): void {
+    session.socket.on("call:roster", (payload: unknown) => {
+      const evt = payload as RosterEvent
+      if (evt.callId !== session.callId) return
+      this.applyRoster(session, evt.rosterVersion, evt.roster)
+    })
+    session.socket.on("disconnect", () => {
+      // A socket drop is NOT a call end (the lease holds the slot). Demote to
+      // reconnecting; the CF media session survives brief socket loss.
+      if (this.session !== session) return
+      setCallPhase("reconnecting")
+    })
+    session.socket.on("connect", () => {
+      if (this.session !== session) return
+      // Transient reconnect: rejoin with the SAME incarnation (rebinds the same
+      // endpoint + epoch). A new incarnation is only minted by a fresh page load.
+      this.joinOverSocket(session.socket, {
+        workspaceId: session.workspaceId,
+        callId: session.callId,
+        mediaIncarnation: session.mediaIncarnation,
+      })
+        .then((join) => {
+          session.endpointId = join.endpointId
+          this.applyRoster(session, join.rosterVersion, join.roster)
+          setCallPhase("connected")
+        })
+        .catch(() => {
+          void this.teardown()
+        })
+    })
+  }
+
+  private applyRoster(session: CallSession, version: number, roster: CallRosterParticipant[]): void {
+    // Versioned: a reordered/stale delivery is dropped by version check, not
+    // trusted (INV-66 client side). A version we already hold (or older) is a
+    // duplicate/reorder — the bump is monotonic, so equal means no new state.
+    if (version <= session.rosterVersion) return
+    session.rosterVersion = version
+    setCallRoster(roster, version)
+    this.diffPulls(session, roster)
+  }
+
+  /** Diff the roster's track registry against what we pull; pull new, stop gone. */
+  private diffPulls(session: CallSession, roster: CallRosterParticipant[]): void {
+    const desired = new Map<string, { ref: PeerTrackRef; kind: string }>()
+    for (const p of roster) {
+      if (p.endpointId === session.endpointId) continue
+      if (p.connectionStatus !== "connected" && p.connectionStatus !== "reconnecting") continue
+      // The publisher's CF session id is required to pull. The 0.2 roster does
+      // not carry it (contract gap) — skip peers we can't address rather than
+      // constructing an unpullable ref.
+      if (!p.cfSessionId) continue
+      for (const track of p.publishedTracks) {
+        const ref: PeerTrackRef = { sessionId: p.cfSessionId, trackName: track.trackName }
+        desired.set(refKey(ref), { ref, kind: track.kind })
+      }
+    }
+    for (const [key, entry] of desired) {
+      if (!session.pulled.has(key)) {
+        session.pulled.set(key, entry)
+        void session.transport.pull(entry.ref).catch(() => session.pulled.delete(key))
+      }
+    }
+    for (const [key, entry] of session.pulled) {
+      if (!desired.has(key)) {
+        session.pulled.delete(key)
+        void session.transport.stopPull(entry.ref).catch(() => {})
+        this.detachRemoteAudio(session, key)
+      }
+    }
+  }
+
+  // ── media ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Acquire mic (and camera when requested) in a SINGLE getUserMedia and publish
+   * the split tracks. Combined capture is the iOS rule: a second concurrent gUM
+   * mutes the first (single-active-capture), so every camera-on or input-switch
+   * routes through here — stop the live capture, then acquire one combined stream.
+   */
+  private async captureAndPublish(
+    session: CallSession,
+    opts: { camera: boolean; inputDeviceId?: string | null }
+  ): Promise<void> {
+    session.micTrack?.stop()
+    session.cameraTrack?.stop()
+    session.micStream?.getTracks().forEach((t) => t.stop())
+
+    const audio: MediaTrackConstraints = opts.inputDeviceId
+      ? { ...AUDIO_CAPTURE_CONSTRAINTS, deviceId: { exact: opts.inputDeviceId } }
+      : AUDIO_CAPTURE_CONSTRAINTS
+    const constraints: MediaStreamConstraints = opts.camera ? { audio, video: VIDEO_CAPTURE_CONSTRAINTS } : { audio }
+    const stream = await this.deps.acquireUserMedia(constraints)
+    session.micStream = stream
+
+    const micTrack = stream.getAudioTracks()[0] ?? null
+    session.micTrack = micTrack
+    if (micTrack) {
+      micTrack.enabled = !getCallState().local.muted
+      await session.transport.publish("mic", micTrack)
+    }
+
+    const cameraTrack = opts.camera ? (stream.getVideoTracks()[0] ?? null) : null
+    session.cameraTrack = cameraTrack
+    if (cameraTrack) {
+      await session.transport.publish("camera", cameraTrack)
+      await this.applyCameraLayer(session)
+    }
+
+    this.wireSpeakingAnalyser(session, stream)
+  }
+
+  private wireSpeakingAnalyser(session: CallSession, stream: MediaStream): void {
+    const ctx = session.audioContext
+    if (!ctx) return
+    // A recapture rewires the analyser; cancel the prior meter loop so a second
+    // RAF never runs alongside it.
+    if (session.meterRaf !== null && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(session.meterRaf)
+      session.meterRaf = null
+    }
+    try {
+      const source = ctx.createMediaStreamSource(stream)
+      const analyser = ctx.createAnalyser()
+      analyser.fftSize = 1024
+      // Analyser is a pure sink — never connected onward, so it never routes the
+      // mic to the speakers.
+      source.connect(analyser)
+      session.analyser = analyser
+      this.runMeter(session)
+    } catch {
+      // AudioContext unavailable (jsdom / unsupported) — speaking level stays 0.
+    }
+  }
+
+  private runMeter(session: CallSession): void {
+    const raf = typeof requestAnimationFrame === "function" ? requestAnimationFrame : null
+    if (!raf || !session.analyser) return
+    const buf = new Uint8Array(session.analyser.fftSize)
+    const tick = () => {
+      const analyser = session.analyser
+      if (!analyser || this.session !== session) return
+      analyser.getByteTimeDomainData(buf)
+      let sum = 0
+      for (let i = 0; i < buf.length; i++) {
+        const s = (buf[i] - 128) / 128
+        sum += s * s
+      }
+      setCallSpeakingLevel(Math.min(1, Math.sqrt(sum / buf.length) * 3))
+      session.meterRaf = raf(tick)
+    }
+    session.meterRaf = raf(tick)
+  }
+
+  // ── remote audio (one <audio> per pulled audio track, AEC reference) ────────
+
+  private wireTransport(session: CallSession): void {
+    session.transport.onRemoteTrack = (event: RemoteTrackEvent) => {
+      if (this.session !== session) return
+      // Remote audio renders through a dedicated <audio> element so Chromium's
+      // echo canceller stays referenced to the output and setSinkId works. It is
+      // NEVER routed through the AudioContext to the speakers (Web Audio taps are
+      // pure sinks only).
+      if (event.track.kind === "audio") this.attachRemoteAudio(session, event.ref, event.track)
+    }
+    session.transport.onRemoteTrackEnded = (ref) => {
+      this.detachRemoteAudio(session, refKey(ref))
+    }
+    session.transport.onConnectionStateChange = (state) => {
+      if (this.session !== session) return
+      if (state === "reconnecting") setCallPhase("reconnecting")
+      else if (state === "connected") setCallPhase("connected")
+    }
+  }
+
+  private attachRemoteAudio(session: CallSession, ref: PeerTrackRef, track: MediaStreamTrack): void {
+    if (typeof document === "undefined") return
+    const key = refKey(ref)
+    this.detachRemoteAudio(session, key)
+    const el = document.createElement("audio")
+    el.autoplay = true
+    el.srcObject = new MediaStream([track])
+    const selectedOutput = getCallState().local.devices.selectedOutputId
+    const sinkable = el as HTMLAudioElement & { setSinkId?: (id: string) => Promise<void> }
+    if (selectedOutput && typeof sinkable.setSinkId === "function") {
+      void sinkable.setSinkId(selectedOutput).catch(() => {})
+    }
+    const container = this.audioContainer ?? document.body
+    container.appendChild(el)
+    session.remoteAudioEls.set(key, el)
+    void el.play?.().catch(() => {})
+  }
+
+  private detachRemoteAudio(session: CallSession, key: string): void {
+    const el = session.remoteAudioEls.get(key)
+    if (!el) return
+    el.srcObject = null
+    el.remove()
+    session.remoteAudioEls.delete(key)
+  }
+
+  // ── lease + watchdog ─────────────────────────────────────────────────────
+
+  private startLeaseTimer(session: CallSession): void {
+    const interval = leaseRenewIntervalMs(session.leaseTtlMs)
+    session.leaseTimer = setInterval(() => {
+      session.socket.emit("call:lease:renew", {}, (result: unknown) => {
+        const ack = result as Ack<{ leaseExpiresAt: string }>
+        // A superseded lease means our endpoint was taken over — the call is lost
+        // on this incarnation; tear down rather than pretend we're still in.
+        if (!ack?.ok && ack?.code === "CALL_LEASE_SUPERSEDED") void this.teardown()
+      })
+    }, interval)
+  }
+
+  private startWatchdog(session: CallSession): void {
+    session.watchdogTimer = setInterval(() => {
+      void session.transport
+        .getStats()
+        .then((stats) => {
+          if (this.session !== session) return
+          setCallDiagnostics({
+            rttMs: stats.rttMs,
+            packetLoss: stats.packetLoss,
+            qualityLimitation: stats.qualityLimitation,
+          })
+          void this.stepCameraLayer(session, stats.qualityLimitation)
+        })
+        .catch(() => {})
+    }, WATCHDOG_SAMPLE_MS)
+  }
+
+  private async stepCameraLayer(
+    session: CallSession,
+    limitation: "none" | "cpu" | "bandwidth" | "other" | null
+  ): Promise<void> {
+    if (!session.cameraTrack) return
+    const limited = limitation === "bandwidth" || limitation === "cpu"
+    if (limited) {
+      session.healthySamples = 0
+      if (session.cameraLayer < CAMERA_PUBLISH_LADDER.length - 1) {
+        session.cameraLayer += 1
+        await this.applyCameraLayer(session)
+      }
+      return
+    }
+    session.healthySamples += 1
+    if (session.healthySamples >= WATCHDOG_HEALTHY_SAMPLES_TO_UPGRADE && session.cameraLayer > 0) {
+      session.healthySamples = 0
+      session.cameraLayer -= 1
+      await this.applyCameraLayer(session)
+    }
+  }
+
+  private async applyCameraLayer(session: CallSession): Promise<void> {
+    const layer = CAMERA_PUBLISH_LADDER[session.cameraLayer]
+    const track = session.cameraTrack
+    if (!track) return
+    try {
+      await track.applyConstraints({
+        height: { max: layer.maxHeight },
+        frameRate: { max: layer.maxFramerate },
+      })
+    } catch {
+      // Some tracks reject mid-stream constraint tightening; the SFU still adapts.
+    }
+    // Resolution/framerate alone don't cap uplink bitrate — apply the ladder's
+    // maxBitrate on the encoder so a collapsing uplink actually steps down.
+    await session.transport.setPublishEncoding("camera", { maxBitrate: layer.maxBitrate })
+  }
+
+  // ── wake lock + devices ─────────────────────────────────────────────────
+
+  private async acquireWakeLock(session: CallSession): Promise<void> {
+    session.wakeLock = await this.deps.requestWakeLock().catch(() => null)
+    if (typeof document !== "undefined") {
+      const onVisibility = () => {
+        if (this.session !== session) return
+        if (document.visibilityState === "visible" && (!session.wakeLock || session.wakeLock.released)) {
+          void this.deps.requestWakeLock().then((lock) => {
+            if (this.session === session) session.wakeLock = lock
+          })
+        }
+      }
+      document.addEventListener("visibilitychange", onVisibility)
+      // Store the bound handler so teardown can detach it — a listener left on
+      // `document` retains the whole session closure and leaks it (and stacks
+      // per call).
+      session.onVisibility = onVisibility
+    }
+    // Auto-refresh the device list on hot-plug/unplug for the call's life.
+    if (typeof navigator !== "undefined" && navigator.mediaDevices) {
+      const onDeviceChange = () => {
+        if (this.session !== session) return
+        void this.refreshDevices()
+      }
+      navigator.mediaDevices.addEventListener("devicechange", onDeviceChange)
+      session.onDeviceChange = onDeviceChange
+    }
+  }
+
+  private async refreshDevices(): Promise<void> {
+    const session = this.session
+    if (!session) return
+    const devices = await this.deps.enumerateDevices().catch(() => [] as MediaDeviceInfo[])
+    const current = getCallState().local.devices
+    const next: CallDeviceState = {
+      inputs: devices.filter((d) => d.kind === "audioinput"),
+      outputs: devices.filter((d) => d.kind === "audiooutput"),
+      cameras: devices.filter((d) => d.kind === "videoinput"),
+      selectedInputId: current.selectedInputId,
+      selectedOutputId: current.selectedOutputId,
+      selectedCameraId: current.selectedCameraId,
+    }
+    setCallDevices(next)
+  }
+
+  // ── locks ──────────────────────────────────────────────────────────────
+
+  private acquireLock(callId: string): Promise<(() => void) | null> {
+    const locks = this.deps.locks
+    if (!locks) return Promise.resolve(null)
+    const name = `call:${callId}`
+    return new Promise<(() => void) | null>((resolveOuter) => {
+      // A single `ifAvailable` request both detects a prior holder and, when
+      // granted, holds the lock for the call's life. A null callback arg means
+      // another tab already owns the call → activeElsewhere; a granted lock is
+      // held until the returned promise resolves (on teardown/crash).
+      void locks
+        .request(name, { ifAvailable: true }, (lock) => {
+          if (!lock) {
+            setCallActiveElsewhere(true)
+            resolveOuter(null)
+            return
+          }
+          return new Promise<void>((releaseLock) => {
+            resolveOuter(() => releaseLock())
+          })
+        })
+        .catch(() => resolveOuter(null))
+    })
+  }
+
+  // ── emit helpers ────────────────────────────────────────────────────────
+
+  private emitLeave(session: CallSession): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let settled = false
+      const done = () => {
+        if (!settled) {
+          settled = true
+          resolve()
+        }
+      }
+      try {
+        session.socket.emit("call:leave", {}, () => done())
+      } catch {
+        done()
+      }
+      // Don't wedge teardown on a missing ack.
+      setTimeout(done, 2_000)
+    })
+  }
+
+  private emitState(session: CallSession, state: { muted?: boolean; cameraOn?: boolean }): void {
+    try {
+      session.socket.emit("call:state", state)
+    } catch {
+      // Control event is best-effort; the roster reconciles on the next snapshot.
+    }
+  }
+
+  // ── teardown ───────────────────────────────────────────────────────────
+
+  /** Synchronous ordered hangup for the store flush (account switch / logout). */
+  private hangupSync(): void {
+    const session = this.session
+    if (!session) return
+    // Emit leave (fire-and-forget — the flush can't await), then close transport,
+    // then stop tracks. The store drops state after this returns.
+    try {
+      session.socket.emit("call:leave", {})
+    } catch {
+      // ignore
+    }
+    void session.transport.close()
+    this.stopLocalCapture(session)
+    for (const key of [...session.remoteAudioEls.keys()]) this.detachRemoteAudio(session, key)
+    this.clearTimers(session)
+    this.removeSessionListeners(session)
+    void session.wakeLock?.release().catch(() => {})
+    session.releaseLock?.()
+    setDictationExternalHold(false)
+    try {
+      session.socket.disconnect()
+    } catch {
+      // ignore
+    }
+    this.session = null
+    // clearCallState is driven by the store flush itself; nothing else to do.
+  }
+
+  private async teardown(): Promise<void> {
+    const session = this.session
+    if (!session) return
+    this.session = null
+    this.clearTimers(session)
+    try {
+      session.socket.off("call:roster")
+      session.socket.off("disconnect")
+      session.socket.off("connect")
+    } catch {
+      // ignore
+    }
+    await session.transport.close().catch(() => {})
+    this.stopLocalCapture(session)
+    for (const key of [...session.remoteAudioEls.keys()]) this.detachRemoteAudio(session, key)
+    this.removeSessionListeners(session)
+    session.releaseLock?.()
+    await session.wakeLock?.release().catch(() => {})
+    try {
+      session.socket.disconnect()
+    } catch {
+      // ignore
+    }
+    setDictationExternalHold(false)
+    clearCallState()
+    setCallConfirmPending(false)
+    setCallActiveElsewhere(false)
+  }
+
+  private stopLocalCapture(session: CallSession): void {
+    session.micTrack?.stop()
+    session.cameraTrack?.stop()
+    session.micStream?.getTracks().forEach((t) => t.stop())
+    void session.audioContext?.close?.().catch(() => {})
+    session.micTrack = null
+    session.cameraTrack = null
+    session.micStream = null
+    session.analyser = null
+  }
+
+  private removeSessionListeners(session: CallSession): void {
+    if (session.onVisibility && typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", session.onVisibility)
+    }
+    if (session.onDeviceChange && typeof navigator !== "undefined" && navigator.mediaDevices) {
+      navigator.mediaDevices.removeEventListener("devicechange", session.onDeviceChange)
+    }
+    session.onVisibility = null
+    session.onDeviceChange = null
+  }
+
+  private clearTimers(session: CallSession): void {
+    if (session.leaseTimer) clearInterval(session.leaseTimer)
+    if (session.watchdogTimer) clearInterval(session.watchdogTimer)
+    if (session.meterRaf !== null && typeof cancelAnimationFrame === "function") cancelAnimationFrame(session.meterRaf)
+    session.leaseTimer = null
+    session.watchdogTimer = null
+    session.meterRaf = null
+  }
+}
+
+// ── production wiring ────────────────────────────────────────────────────────
+
+function resolveCallsUrl(workspaceId: string): string | null {
+  const config = getCachedWsConfig(workspaceId)
+  if (!config) return null
+  const base = import.meta.env.DEV ? config.wsUrl.replace("localhost", window.location.hostname) : config.wsUrl
+  const url = new URL(base)
+  url.pathname = "/calls"
+  return url.toString()
+}
+
+export function defaultCallManagerDeps(): CallManagerDeps {
+  return {
+    async startCallRest({ workspaceId, streamId, mode, mediaIncarnation }) {
+      return api.post<StartCallResponse>(`/api/workspaces/${workspaceId}/calls`, { streamId, mode, mediaIncarnation })
+    },
+    connectSocket(workspaceId) {
+      const url = resolveCallsUrl(workspaceId)
+      if (!url) return null
+      return io(url, { path: "/socket.io/", withCredentials: true, autoConnect: true }) as unknown as CallSocket
+    },
+    createTransport({ workspaceId, callId }) {
+      return new CloudflareSfuTransport({ workspaceId, callId })
+    },
+    acquireUserMedia(constraints) {
+      return navigator.mediaDevices.getUserMedia(constraints)
+    },
+    createAudioContext() {
+      const Ctx =
+        typeof window !== "undefined"
+          ? (window.AudioContext ??
+            (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)
+          : undefined
+      return Ctx ? new Ctx() : null
+    },
+    enumerateDevices() {
+      return navigator.mediaDevices.enumerateDevices()
+    },
+    locks: typeof navigator !== "undefined" && "locks" in navigator ? navigator.locks : null,
+    async requestWakeLock() {
+      const wl =
+        typeof navigator !== "undefined" ? (navigator as Navigator & { wakeLock?: WakeLock }).wakeLock : undefined
+      if (!wl) return null
+      const sentinel = await wl.request("screen")
+      return {
+        release: () => sentinel.release(),
+        get released() {
+          return sentinel.released
+        },
+      }
+    },
+    mintIncarnation() {
+      return `mi_${ulid()}`
+    },
+  }
+}
+
+let singleton: CallManager | null = null
+
+/** Lazily build the account-scoped singleton with production deps. */
+export function getCallManager(): CallManager {
+  if (!singleton) singleton = new CallManager(defaultCallManagerDeps())
+  return singleton
+}

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -13,6 +13,7 @@ import {
   setCallDiagnostics,
   setCallActiveElsewhere,
   setCallConfirmPending,
+  setCallCaptureError,
   clearCallState,
   registerCallHangup,
   getCallState,
@@ -63,6 +64,37 @@ interface RosterEvent {
   roster: CallRosterParticipant[]
 }
 
+/** Thrown by an in-flight `startCall` when `leaveCall` cancels it mid-join. */
+export class CallStartCancelledError extends Error {
+  constructor() {
+    super("Call start cancelled")
+    this.name = "CallStartCancelledError"
+  }
+}
+
+/**
+ * Thrown when a mid-call recapture fails. `capture_failed` means the prior
+ * capture was restored (audio survives); `capture_rollback_failed` means the
+ * restore also failed (outbound audio is dead). The store mirrors the code.
+ */
+export class CallCaptureError extends Error {
+  readonly code: "capture_failed" | "capture_rollback_failed"
+  constructor(code: "capture_failed" | "capture_rollback_failed", cause?: unknown) {
+    super(
+      code === "capture_rollback_failed"
+        ? "Recapture failed and the prior capture could not be restored"
+        : "Recapture failed"
+    )
+    this.name = "CallCaptureError"
+    this.code = code
+    if (cause !== undefined) (this as { cause?: unknown }).cause = cause
+  }
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 /** Minimal socket surface the manager needs — satisfied by socket.io's `Socket`. */
 export interface CallSocket {
   connected: boolean
@@ -97,9 +129,18 @@ export interface CallManagerDeps {
   locks: LockManager | null
   requestWakeLock(): Promise<WakeLockLike | null>
   mintIncarnation(): string
+  /**
+   * True on platforms that allow only one active `getUserMedia` at a time (iOS
+   * Safari): a recapture must stop the live tracks before acquiring, so an
+   * acquire failure is rolled back to the prior constraints. False elsewhere,
+   * where the new capture is acquired before the old is stopped.
+   */
+  singleActiveCapture: boolean
 }
 
 interface CallSession {
+  /** Monotonic generation claimed synchronously at `startCall`; identifies this incarnation. */
+  gen: number
   callId: string
   workspaceId: string
   streamId: string
@@ -113,6 +154,8 @@ interface CallSession {
   micTrack: MediaStreamTrack | null
   cameraTrack: MediaStreamTrack | null
   micStream: MediaStream | null
+  /** Constraints of the current capture, so a failed recapture can be rolled back. */
+  captureConstraints: { constraints: MediaStreamConstraints; camera: boolean } | null
   audioContext: AudioContext | null
   analyser: AnalyserNode | null
   pulled: Map<string, { ref: PeerTrackRef; kind: string }>
@@ -143,6 +186,21 @@ function refKey(ref: PeerTrackRef): string {
 export class CallManager {
   private readonly deps: CallManagerDeps
   private session: CallSession | null = null
+  // Monotonic generation, claimed synchronously by `startCall` before its first
+  // await. Every async continuation captures the gen it belongs to and rechecks
+  // `sessionForGen(gen)` before touching `this.session` or the store, so a stale
+  // continuation (torn down, or superseded by a newer call) becomes a no-op.
+  private sessionGen = 0
+  // Synchronous in-flight sentinel: true from `startCall` entry until `runStart`
+  // settles. A second `startCall` throws on it (no double-start); `leaveCall`
+  // reads it to cancel a start that has not yet produced a session.
+  private starting = false
+  // Set by `leaveCall` during the joining window; `runStart` checks it after each
+  // await and rolls back so a user's cancel wins over an in-flight join.
+  private cancelStart = false
+  // Serializes capture mutations (mic/camera acquire) so two never run concurrently
+  // — the iOS single-active-capture rule and the reentrancy latch in one chain.
+  private captureChain: Promise<void> = Promise.resolve()
   private unregisterHangup: (() => void) | null = null
   private readonly audioContainer: HTMLElement | null
 
@@ -161,11 +219,26 @@ export class CallManager {
    * Start (or join) the call on a stream and connect media. Must be invoked from
    * a user gesture — the AudioContext is created synchronously at the top so iOS
    * Safari honors it (an AudioContext created after an await stays suspended).
+   *
+   * Synchronous (not `async`) so the in-flight guard and generation claim run
+   * before the caller's synchronous tail: a second `startCall` before the first
+   * settles throws here, in the caller's stack, rather than passing a post-await
+   * check and leaking a whole second session.
    */
-  async startCall(params: { workspaceId: string; streamId: string; mode: CallMode }): Promise<void> {
-    if (this.session) throw new Error("A call is already active")
+  startCall(params: { workspaceId: string; streamId: string; mode: CallMode }): Promise<void> {
+    if (this.session || this.starting) throw new Error("A call is already active")
+    this.starting = true
+    this.cancelStart = false
+    const gen = ++this.sessionGen
+    return this.runStart(gen, params)
+  }
+
+  private async runStart(
+    gen: number,
+    params: { workspaceId: string; streamId: string; mode: CallMode }
+  ): Promise<void> {
     const mediaIncarnation = this.deps.mintIncarnation()
-    // Synchronous, in-gesture (see method doc). Held on a temp until the session exists.
+    // Synchronous, in-gesture (see startCall doc). Held on a temp until the session exists.
     const audioContext = this.deps.createAudioContext()
     void audioContext?.resume().catch(() => {})
 
@@ -175,12 +248,14 @@ export class CallManager {
     let socket: CallSocket | null = null
     try {
       const started = await this.deps.startCallRest({ ...params, mediaIncarnation })
+      this.assertStartLive(gen)
       const callId = started.call.id
       setCallSession({ callId, workspaceId: params.workspaceId, streamId: params.streamId, mode: params.mode })
       // One tab owns the call (Web Locks). A second tab sees the lock held →
       // activeElsewhere; on this tab's crash the lock releases and the other tab
       // may offer rejoin (surfaced via the store; UI is M1.2).
       releaseLock = await this.acquireLock(callId)
+      this.assertStartLive(gen)
 
       socket = this.deps.connectSocket(params.workspaceId)
       if (!socket) throw new Error("Calls socket is not available")
@@ -190,9 +265,11 @@ export class CallManager {
         callId,
         mediaIncarnation,
       })
+      this.assertStartLive(gen)
 
       const transport = this.deps.createTransport({ workspaceId: params.workspaceId, callId })
       const session: CallSession = {
+        gen,
         callId,
         workspaceId: params.workspaceId,
         streamId: params.streamId,
@@ -207,6 +284,7 @@ export class CallManager {
         micTrack: null,
         cameraTrack: null,
         micStream: null,
+        captureConstraints: null,
         audioContext,
         analyser: null,
         pulled: new Map(),
@@ -230,9 +308,11 @@ export class CallManager {
       this.wireSocket(session)
 
       await transport.connect({ endpointId: join.endpointId, mediaIncarnation })
+      this.assertStartLive(gen)
       // Video joins acquire mic+camera in ONE getUserMedia (iOS single-active-
       // capture: a second gUM while the first is live mutes it), then split.
       await this.captureAndPublish(session, { camera: params.mode === "video" })
+      this.assertStartLive(gen)
       if (params.mode === "video") {
         patchCallLocal({ cameraOn: true })
         this.emitState(session, { cameraOn: true })
@@ -242,27 +322,52 @@ export class CallManager {
       this.startLeaseTimer(session)
       this.startWatchdog(session)
       await this.acquireWakeLock(session)
+      this.assertStartLive(gen)
       await this.refreshDevices()
+      // Final gate before declaring connected: no await follows, so a cancel can
+      // no longer race in between this check and the phase flip.
+      this.assertStartLive(gen)
 
       setCallPhase("connected")
     } catch (err) {
-      if (this.session) {
-        await this.teardown()
-      } else {
-        // Threw before the session existed — teardown can't see these, so
-        // release the lock, socket, and AudioContext here or they orphan (a
-        // held-forever call lock wedges every later startCall on this tab).
-        releaseLock?.()
-        try {
-          socket?.disconnect()
-        } catch {
-          // ignore
-        }
-        void audioContext?.close?.().catch(() => {})
-        clearCallState()
-      }
+      await this.rollbackStart({ releaseLock, socket, audioContext })
       throw err
+    } finally {
+      this.starting = false
     }
+  }
+
+  /**
+   * Throws {@link CallStartCancelledError} at a start checkpoint when `leaveCall`
+   * cancelled the in-flight join, or when a newer generation superseded this one.
+   * Called after every await in `runStart` so a cancel wins over the join.
+   */
+  private assertStartLive(gen: number): void {
+    if (this.cancelStart || gen !== this.sessionGen) throw new CallStartCancelledError()
+  }
+
+  /** Ordered rollback of an aborted/failed start: teardown if a session exists, else the raw locals. */
+  private async rollbackStart(locals: {
+    releaseLock: (() => void) | null
+    socket: CallSocket | null
+    audioContext: AudioContext | null
+  }): Promise<void> {
+    if (this.session) {
+      // The session owns the lock/socket/audioContext — teardown releases them in order.
+      await this.teardown()
+      return
+    }
+    // Threw before the session existed — teardown can't see these, so release the
+    // lock, socket, and AudioContext here or they orphan (a held-forever call lock
+    // wedges every later startCall on this tab).
+    locals.releaseLock?.()
+    try {
+      locals.socket?.disconnect()
+    } catch {
+      // ignore
+    }
+    void locals.audioContext?.close?.().catch(() => {})
+    clearCallState()
   }
 
   /**
@@ -278,10 +383,27 @@ export class CallManager {
 
   /** Ordered teardown: emit leave → close transport → stop tracks. */
   async leaveCall(): Promise<void> {
+    // Cancel wins over an in-flight join: signal the running `runStart`, which
+    // rolls back whatever it acquired (lock, socket, context, tracks) at its next
+    // checkpoint — so a user's cancel during "joining" never lands a hot mic.
+    if (this.starting) {
+      this.cancelStart = true
+      return
+    }
     const session = this.session
     if (!session) return
     await this.emitLeave(session)
     await this.teardown()
+  }
+
+  /**
+   * The live session for `gen`, or null when this generation was torn down
+   * (`this.session === null`) or superseded by a newer `startCall`
+   * (`gen !== this.sessionGen`). Every async continuation gates on this before
+   * touching `this.session` or the global store.
+   */
+  private sessionForGen(gen: number): CallSession | null {
+    return gen === this.sessionGen ? this.session : null
   }
 
   setMuted(muted: boolean): void {
@@ -296,31 +418,37 @@ export class CallManager {
     const session = this.session
     if (!session) return
     if (session.mode === "audio_only") return
-    if (on) {
-      // Turning the camera on re-acquires mic+camera as ONE stream (iOS single-
-      // active-capture): a camera-only gUM while the mic is live would mute it.
-      await this.captureAndPublish(session, {
-        camera: true,
-        inputDeviceId: getCallState().local.devices.selectedInputId,
-      })
-    } else if (session.cameraTrack) {
-      // Camera off fully stops the track (kills the LED) and unpublishes; the
-      // mic is untouched, so no recapture is needed.
-      session.cameraTrack.stop()
-      session.cameraTrack = null
-      await session.transport.unpublish("camera")
-    }
-    patchCallLocal({ cameraOn: on })
-    this.emitState(session, { cameraOn: on })
+    // Serialized on the capture chain so a rapid on/off/switch never runs two
+    // captures at once (iOS single-active-capture) and settles at the last state.
+    await this.serializeCapture(session, async () => {
+      if (on) {
+        // Turning the camera on re-acquires mic+camera as ONE stream (iOS single-
+        // active-capture): a camera-only gUM while the mic is live would mute it.
+        await this.doCaptureAndPublish(session, {
+          camera: true,
+          inputDeviceId: getCallState().local.devices.selectedInputId,
+        })
+      } else if (session.cameraTrack) {
+        // Camera off fully stops the track (kills the LED) and unpublishes; the
+        // mic is untouched, so no recapture is needed.
+        session.cameraTrack.stop()
+        session.cameraTrack = null
+        await session.transport.unpublish("camera")
+      }
+      patchCallLocal({ cameraOn: on })
+      this.emitState(session, { cameraOn: on })
+    })
   }
 
   async switchInputDevice(deviceId: string): Promise<void> {
     const session = this.session
     if (!session) return
     // Recapture the whole stream (mic + camera if live) so iOS single-active-
-    // capture never mutes the surviving track.
-    await this.captureAndPublish(session, { camera: session.cameraTrack != null, inputDeviceId: deviceId })
-    patchCallLocal({ devices: { ...getCallState().local.devices, selectedInputId: deviceId } })
+    // capture never mutes the surviving track; serialized on the capture chain.
+    await this.serializeCapture(session, async () => {
+      await this.doCaptureAndPublish(session, { camera: session.cameraTrack != null, inputDeviceId: deviceId })
+      patchCallLocal({ devices: { ...getCallState().local.devices, selectedInputId: deviceId } })
+    })
     await this.refreshDevices()
   }
 
@@ -358,19 +486,25 @@ export class CallManager {
   }
 
   private wireSocket(session: CallSession): void {
+    const gen = session.gen
     session.socket.on("call:roster", (payload: unknown) => {
+      // Session-identity gate: an event already dispatched into the loop before a
+      // teardown/flush (or belonging to a superseded call) must not write the
+      // prior call's roster into the store.
+      const s = this.sessionForGen(gen)
+      if (!s) return
       const evt = payload as RosterEvent
-      if (evt.callId !== session.callId) return
-      this.applyRoster(session, evt.rosterVersion, evt.roster)
+      if (evt.callId !== s.callId) return
+      this.applyRoster(s, evt.rosterVersion, evt.roster)
     })
     session.socket.on("disconnect", () => {
       // A socket drop is NOT a call end (the lease holds the slot). Demote to
       // reconnecting; the CF media session survives brief socket loss.
-      if (this.session !== session) return
+      if (!this.sessionForGen(gen)) return
       setCallPhase("reconnecting")
     })
     session.socket.on("connect", () => {
-      if (this.session !== session) return
+      if (!this.sessionForGen(gen)) return
       // Transient reconnect: rejoin with the SAME incarnation (rebinds the same
       // endpoint + epoch). A new incarnation is only minted by a fresh page load.
       this.joinOverSocket(session.socket, {
@@ -379,11 +513,19 @@ export class CallManager {
         mediaIncarnation: session.mediaIncarnation,
       })
         .then((join) => {
-          session.endpointId = join.endpointId
-          this.applyRoster(session, join.rosterVersion, join.roster)
+          // Recheck AFTER the awaited rejoin: teardown/leave (or a newer call)
+          // may have run in between. A stale `.then` must not resurrect a phantom
+          // "connected" phase or overwrite a newer call's store.
+          const s = this.sessionForGen(gen)
+          if (!s) return
+          s.endpointId = join.endpointId
+          this.applyRoster(s, join.rosterVersion, join.roster)
           setCallPhase("connected")
         })
         .catch(() => {
+          // Same recheck: a stale failed rejoin for the OLD call must not tear
+          // down whatever `this.session` now is (possibly a newly started call).
+          if (!this.sessionForGen(gen)) return
           void this.teardown()
         })
     })
@@ -432,24 +574,99 @@ export class CallManager {
   // ── media ──────────────────────────────────────────────────────────────────
 
   /**
-   * Acquire mic (and camera when requested) in a SINGLE getUserMedia and publish
-   * the split tracks. Combined capture is the iOS rule: a second concurrent gUM
-   * mutes the first (single-active-capture), so every camera-on or input-switch
-   * routes through here — stop the live capture, then acquire one combined stream.
+   * Serialize a capture mutation on the capture chain: never two acquires in
+   * flight at once (iOS single-active-capture) and the reentrancy latch behind
+   * camera-toggle / input-switch. A mutation queued while the session was torn
+   * down is skipped. Chain links swallow their own outcome so one failure does
+   * not poison later mutations, but the result still propagates to the caller.
    */
-  private async captureAndPublish(
+  private serializeCapture(session: CallSession, fn: () => Promise<void>): Promise<void> {
+    const run = this.captureChain.then(() => {
+      if (this.sessionForGen(session.gen) !== session) return
+      return fn()
+    })
+    this.captureChain = run.then(
+      () => {},
+      () => {}
+    )
+    return run
+  }
+
+  private captureAndPublish(
     session: CallSession,
     opts: { camera: boolean; inputDeviceId?: string | null }
   ): Promise<void> {
-    session.micTrack?.stop()
-    session.cameraTrack?.stop()
-    session.micStream?.getTracks().forEach((t) => t.stop())
+    return this.serializeCapture(session, () => this.doCaptureAndPublish(session, opts))
+  }
 
+  private buildCaptureConstraints(opts: { camera: boolean; inputDeviceId?: string | null }): MediaStreamConstraints {
     const audio: MediaTrackConstraints = opts.inputDeviceId
       ? { ...AUDIO_CAPTURE_CONSTRAINTS, deviceId: { exact: opts.inputDeviceId } }
       : AUDIO_CAPTURE_CONSTRAINTS
-    const constraints: MediaStreamConstraints = opts.camera ? { audio, video: VIDEO_CAPTURE_CONSTRAINTS } : { audio }
-    const stream = await this.deps.acquireUserMedia(constraints)
+    return opts.camera ? { audio, video: VIDEO_CAPTURE_CONSTRAINTS } : { audio }
+  }
+
+  /**
+   * Acquire mic (and camera when requested) in a SINGLE getUserMedia and publish
+   * the split tracks. Combined capture is the iOS rule: a second concurrent gUM
+   * mutes the first (single-active-capture). Ordering by platform:
+   *
+   * - Single-active-capture (iOS): stop the live capture, THEN acquire. If the
+   *   acquire rejects (permission revoked, `NotReadableError`), roll back to the
+   *   previous constraints so outbound audio survives, and surface a typed
+   *   {@link CallCaptureError}.
+   * - Elsewhere: acquire the NEW capture FIRST, only stop the old once it
+   *   succeeds — a failed acquire leaves the current tracks untouched.
+   *
+   * Always run through {@link serializeCapture}, never called directly.
+   */
+  private async doCaptureAndPublish(
+    session: CallSession,
+    opts: { camera: boolean; inputDeviceId?: string | null }
+  ): Promise<void> {
+    const constraints = this.buildCaptureConstraints(opts)
+    const prev = session.captureConstraints
+
+    if (this.deps.singleActiveCapture) {
+      this.stopCapture(session)
+      let stream: MediaStream
+      try {
+        stream = await this.deps.acquireUserMedia(constraints)
+      } catch (acquireErr) {
+        if (this.sessionForGen(session.gen) !== session) throw acquireErr
+        await this.rollbackCapture(session, prev, acquireErr)
+        return // rollbackCapture always throws
+      }
+      if (this.sessionForGen(session.gen) !== session) {
+        stream.getTracks().forEach((t) => t.stop())
+        return
+      }
+      await this.publishStream(session, stream, opts.camera)
+      session.captureConstraints = { constraints, camera: opts.camera }
+      setCallCaptureError(null)
+      return
+    }
+
+    let stream: MediaStream
+    try {
+      stream = await this.deps.acquireUserMedia(constraints)
+    } catch (acquireErr) {
+      // Old capture untouched — outbound audio survives; just report the failure.
+      setCallCaptureError({ code: "capture_failed", message: describeError(acquireErr) })
+      throw new CallCaptureError("capture_failed", acquireErr)
+    }
+    if (this.sessionForGen(session.gen) !== session) {
+      stream.getTracks().forEach((t) => t.stop())
+      return
+    }
+    this.stopCapture(session)
+    await this.publishStream(session, stream, opts.camera)
+    session.captureConstraints = { constraints, camera: opts.camera }
+    setCallCaptureError(null)
+  }
+
+  /** Publish a freshly acquired stream's tracks and rewire the speaking analyser. */
+  private async publishStream(session: CallSession, stream: MediaStream, camera: boolean): Promise<void> {
     session.micStream = stream
 
     const micTrack = stream.getAudioTracks()[0] ?? null
@@ -459,7 +676,7 @@ export class CallManager {
       await session.transport.publish("mic", micTrack)
     }
 
-    const cameraTrack = opts.camera ? (stream.getVideoTracks()[0] ?? null) : null
+    const cameraTrack = camera ? (stream.getVideoTracks()[0] ?? null) : null
     session.cameraTrack = cameraTrack
     if (cameraTrack) {
       await session.transport.publish("camera", cameraTrack)
@@ -467,6 +684,46 @@ export class CallManager {
     }
 
     this.wireSpeakingAnalyser(session, stream)
+  }
+
+  /**
+   * iOS recapture-failure rollback: the live tracks are already stopped, so
+   * re-acquire the previous constraints and republish them. Always throws — a
+   * successful restore throws `capture_failed` (switch failed, audio back); a
+   * failed restore throws `capture_rollback_failed` (audio dead).
+   */
+  private async rollbackCapture(
+    session: CallSession,
+    prev: { constraints: MediaStreamConstraints; camera: boolean } | null,
+    acquireErr: unknown
+  ): Promise<never> {
+    this.stopCapture(session)
+    if (prev) {
+      try {
+        const restored = await this.deps.acquireUserMedia(prev.constraints)
+        if (this.sessionForGen(session.gen) === session) {
+          await this.publishStream(session, restored, prev.camera)
+          session.captureConstraints = prev
+        } else {
+          restored.getTracks().forEach((t) => t.stop())
+        }
+      } catch (rollbackErr) {
+        setCallCaptureError({ code: "capture_rollback_failed", message: describeError(rollbackErr) })
+        throw new CallCaptureError("capture_rollback_failed", rollbackErr)
+      }
+    }
+    setCallCaptureError({ code: "capture_failed", message: describeError(acquireErr) })
+    throw new CallCaptureError("capture_failed", acquireErr)
+  }
+
+  /** Stop and drop the current local capture tracks (does not touch the AudioContext). */
+  private stopCapture(session: CallSession): void {
+    session.micTrack?.stop()
+    session.cameraTrack?.stop()
+    session.micStream?.getTracks().forEach((t) => t.stop())
+    session.micTrack = null
+    session.cameraTrack = null
+    session.micStream = null
   }
 
   private wireSpeakingAnalyser(session: CallSession, stream: MediaStream): void {
@@ -561,9 +818,13 @@ export class CallManager {
   // ── lease + watchdog ─────────────────────────────────────────────────────
 
   private startLeaseTimer(session: CallSession): void {
+    const gen = session.gen
     const interval = leaseRenewIntervalMs(session.leaseTtlMs)
     session.leaseTimer = setInterval(() => {
       session.socket.emit("call:lease:renew", {}, (result: unknown) => {
+        // The ack can arrive after teardown/supersession; gate before acting so a
+        // stale ack never tears down a newer call.
+        if (!this.sessionForGen(gen)) return
         const ack = result as Ack<{ leaseExpiresAt: string }>
         // A superseded lease means our endpoint was taken over — the call is lost
         // on this incarnation; tear down rather than pretend we're still in.
@@ -573,11 +834,12 @@ export class CallManager {
   }
 
   private startWatchdog(session: CallSession): void {
+    const gen = session.gen
     session.watchdogTimer = setInterval(() => {
       void session.transport
         .getStats()
         .then((stats) => {
-          if (this.session !== session) return
+          if (this.sessionForGen(gen) !== session) return
           setCallDiagnostics({
             rttMs: stats.rttMs,
             packetLoss: stats.packetLoss,
@@ -747,6 +1009,10 @@ export class CallManager {
     for (const key of [...session.remoteAudioEls.keys()]) this.detachRemoteAudio(session, key)
     this.clearTimers(session)
     this.removeSessionListeners(session)
+    // Symmetric with teardown: detach the socket handlers so a roster/connect
+    // event already dispatched into the loop before this flush can't run against
+    // the just-switched-to account (the handlers also gate on gen, belt-and-braces).
+    this.removeSocketHandlers(session)
     void session.wakeLock?.release().catch(() => {})
     session.releaseLock?.()
     setDictationExternalHold(false)
@@ -764,13 +1030,7 @@ export class CallManager {
     if (!session) return
     this.session = null
     this.clearTimers(session)
-    try {
-      session.socket.off("call:roster")
-      session.socket.off("disconnect")
-      session.socket.off("connect")
-    } catch {
-      // ignore
-    }
+    this.removeSocketHandlers(session)
     await session.transport.close().catch(() => {})
     this.stopLocalCapture(session)
     for (const key of [...session.remoteAudioEls.keys()]) this.detachRemoteAudio(session, key)
@@ -797,6 +1057,16 @@ export class CallManager {
     session.cameraTrack = null
     session.micStream = null
     session.analyser = null
+  }
+
+  private removeSocketHandlers(session: CallSession): void {
+    try {
+      session.socket.off("call:roster")
+      session.socket.off("disconnect")
+      session.socket.off("connect")
+    } catch {
+      // ignore
+    }
   }
 
   private removeSessionListeners(session: CallSession): void {
@@ -829,6 +1099,18 @@ function resolveCallsUrl(workspaceId: string): string | null {
   const url = new URL(base)
   url.pathname = "/calls"
   return url.toString()
+}
+
+/**
+ * iOS/iPadOS Safari allows only one active `getUserMedia` at a time — a second
+ * concurrent capture mutes the first. iPadOS reports as "MacIntel", so fall
+ * through to the touch-point probe there.
+ */
+function detectSingleActiveCapture(): boolean {
+  if (typeof navigator === "undefined") return false
+  const ua = navigator.userAgent ?? ""
+  if (/iPad|iPhone|iPod/.test(ua)) return true
+  return navigator.platform === "MacIntel" && (navigator.maxTouchPoints ?? 0) > 1
 }
 
 export function defaultCallManagerDeps(): CallManagerDeps {
@@ -874,6 +1156,7 @@ export function defaultCallManagerDeps(): CallManagerDeps {
     mintIncarnation() {
       return `mi_${ulid()}`
     },
+    singleActiveCapture: detectSingleActiveCapture(),
   }
 }
 

--- a/apps/frontend/src/calls/config.ts
+++ b/apps/frontend/src/calls/config.ts
@@ -1,0 +1,77 @@
+// Client-side call constants and the publisher watchdog policy. Mirrors the
+// backend's `features/calls/config.ts` where the two must agree (track kinds,
+// modes, lease TTL); the publish-layer ladder is client-only (the SFU does
+// per-receiver adaptation, so this only steps the *published* encode).
+
+export const CALL_MODES = ["video", "audio_only"] as const
+export type CallMode = (typeof CALL_MODES)[number]
+
+export const PUBLISHED_TRACK_KINDS = ["mic", "camera", "share_video", "share_audio"] as const
+export type PublishedTrackKind = (typeof PUBLISHED_TRACK_KINDS)[number]
+
+/**
+ * Endpoint lease TTL, mirrored from the backend (`ENDPOINT_LEASE_TTL_MS`). The
+ * server hands the authoritative value back on `call:join` (`leaseTtlMs`); this
+ * is the fallback when an ack somehow omits it.
+ */
+export const ENDPOINT_LEASE_TTL_MS = 45_000
+
+/**
+ * The owning tab renews its lease at TTL/3 so two missed renewals still precede
+ * expiry. The renew timer is derived from the server-supplied TTL, falling back
+ * to this fraction of {@link ENDPOINT_LEASE_TTL_MS}.
+ */
+export const LEASE_RENEW_FRACTION = 1 / 3
+
+export function leaseRenewIntervalMs(leaseTtlMs: number): number {
+  return Math.max(1_000, Math.floor(leaseTtlMs * LEASE_RENEW_FRACTION))
+}
+
+/**
+ * The published-camera ladder for the publisher watchdog. Highest layer first;
+ * the watchdog steps *down* one rung when the encoder is bandwidth/CPU limited
+ * and *up* one rung when it has recovered for a sustained window. Per-receiver
+ * adaptation is the SFU's job — this only protects the uplink from collapse.
+ */
+export interface PublishLayer {
+  maxHeight: number
+  maxFramerate: number
+  /** `RTCRtpEncodingParameters.maxBitrate` in bits/sec. */
+  maxBitrate: number
+}
+
+export const CAMERA_PUBLISH_LADDER: readonly PublishLayer[] = [
+  { maxHeight: 720, maxFramerate: 30, maxBitrate: 1_500_000 },
+  { maxHeight: 480, maxFramerate: 30, maxBitrate: 700_000 },
+  { maxHeight: 360, maxFramerate: 20, maxBitrate: 350_000 },
+  { maxHeight: 180, maxFramerate: 15, maxBitrate: 150_000 },
+] as const
+
+/** Screen-share encode targets, keyed by the track's `contentHint`. */
+export const SHARE_PUBLISH_LAYERS: Record<"detail" | "motion", PublishLayer> = {
+  detail: { maxHeight: 1080, maxFramerate: 15, maxBitrate: 2_500_000 },
+  motion: { maxHeight: 720, maxFramerate: 30, maxBitrate: 2_000_000 },
+}
+
+/**
+ * Watchdog sampling + hysteresis. Sample `getStats` on this interval; step down
+ * immediately on a limited sample, but require several consecutive healthy
+ * samples before stepping back up so the layer doesn't oscillate.
+ */
+export const WATCHDOG_SAMPLE_MS = 3_000
+export const WATCHDOG_HEALTHY_SAMPLES_TO_UPGRADE = 4
+
+/** Mic audio constraints: browser AEC/NS/AGC applied once at capture. (The combined mic+camera acquisition rule lives on captureAndPublish.) */
+export const AUDIO_CAPTURE_CONSTRAINTS: MediaTrackConstraints = {
+  channelCount: 1,
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+}
+
+/** Camera capture defaults; the watchdog re-applies encode caps via sender params. */
+export const VIDEO_CAPTURE_CONSTRAINTS: MediaTrackConstraints = {
+  width: { ideal: 1280 },
+  height: { ideal: 720 },
+  frameRate: { ideal: 30 },
+}

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { CloudflareSfuTransport, createCallProxyClient, type PeerTrackRef } from "./media-transport"
+
+interface PostCall {
+  path: string
+  body: Record<string, unknown>
+}
+
+function makeTransceiver(mid: string) {
+  return {
+    mid,
+    sender: { replaceTrack: vi.fn(async () => {}) },
+    stop: vi.fn(),
+  }
+}
+
+/** A hand-rolled RTCPeerConnection double — behavior only, no real SDP. */
+function makeFakePc() {
+  let midCounter = 0
+  const transceivers: ReturnType<typeof makeTransceiver>[] = []
+  const pc = {
+    ontrack: null as ((e: unknown) => void) | null,
+    onconnectionstatechange: null as (() => void) | null,
+    connectionState: "new",
+    transceivers,
+    addTransceiver: vi.fn((_track: unknown, _init: unknown) => {
+      const t = makeTransceiver(`local-${midCounter++}`)
+      transceivers.push(t)
+      return t
+    }),
+    createOffer: vi.fn(async () => ({ type: "offer", sdp: "offer-sdp" })),
+    createAnswer: vi.fn(async () => ({ type: "answer", sdp: "answer-sdp" })),
+    setLocalDescription: vi.fn(async () => {}),
+    setRemoteDescription: vi.fn(async () => {}),
+    getStats: vi.fn(async () => new Map()),
+    close: vi.fn(),
+  }
+  return pc
+}
+
+function makeTrack(kind: "audio" | "video" = "audio"): MediaStreamTrack {
+  return { kind, stop: vi.fn(), addEventListener: vi.fn() } as unknown as MediaStreamTrack
+}
+
+const INC = "inc-1"
+
+function makeTransport(overrides?: {
+  post?: (path: string, body: unknown) => Promise<unknown>
+  pc?: ReturnType<typeof makeFakePc>
+}) {
+  const calls: PostCall[] = []
+  const pc = overrides?.pc ?? makeFakePc()
+  const post =
+    overrides?.post ??
+    (async (path: string, body: unknown) => {
+      calls.push({ path, body: body as Record<string, unknown> })
+      if (path.endsWith("/session")) return { cfSessionId: "cf-sess", idempotent: false }
+      if (path.endsWith("/tracks/publish")) return { requiresImmediateRenegotiation: false, tracks: [] }
+      if (path.endsWith("/tracks/pull"))
+        return {
+          requiresImmediateRenegotiation: false,
+          tracks: [{ mid: "remote-0" }],
+          sessionDescription: { type: "offer", sdp: "cf-offer" },
+        }
+      if (path.endsWith("/renegotiate")) return {}
+      if (path.endsWith("/tracks/close")) return { tracks: [] }
+      return {}
+    })
+  const transport = new CloudflareSfuTransport({
+    workspaceId: "ws_1",
+    callId: "call_1",
+    post: post as <T>(p: string, b: unknown) => Promise<T>,
+    createPeerConnection: () => pc as unknown as RTCPeerConnection,
+  })
+  return { transport, calls, pc, post }
+}
+
+describe("createCallProxyClient", () => {
+  it("carries mediaIncarnation in every proxy body", async () => {
+    const calls: PostCall[] = []
+    const post = async (path: string, body: unknown) => {
+      calls.push({ path, body: body as Record<string, unknown> })
+      return {}
+    }
+    const proxy = createCallProxyClient({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      endpointId: "ep_1",
+      mediaIncarnation: INC,
+      post: post as <T>(p: string, b: unknown) => Promise<T>,
+    })
+    await proxy.createSession()
+    await proxy.publishTracks({ sdp: { type: "offer", sdp: "s" }, tracks: [{ kind: "mic", mid: "0", trackName: "t" }] })
+    await proxy.pullTracks([{ sessionId: "cf", trackName: "t" }])
+    await proxy.renegotiate({ type: "answer", sdp: "a" })
+    await proxy.closeTracks({ mids: ["0"] })
+
+    expect(calls).toHaveLength(5)
+    for (const c of calls) expect(c.body.mediaIncarnation).toBe(INC)
+    expect(calls[0].path).toContain("/api/workspaces/ws_1/calls/call_1/endpoints/ep_1/cf/session")
+  })
+})
+
+describe("CloudflareSfuTransport", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("carries the incarnation on every proxy fetch through the transport", async () => {
+    const { transport, calls } = makeTransport()
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("mic", makeTrack("audio"))
+    expect(calls.length).toBeGreaterThanOrEqual(2)
+    for (const c of calls) expect(c.body.mediaIncarnation).toBe(INC)
+  })
+
+  it("serializes overlapping renegotiations behind the queue (never interleaves)", async () => {
+    const pc = makeFakePc()
+    let inFlight = 0
+    let maxInFlight = 0
+    let release!: () => void
+    const barrier = new Promise<void>((r) => (release = r))
+    pc.createOffer = vi.fn(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await barrier
+      inFlight--
+      return { type: "offer", sdp: "offer-sdp" }
+    })
+    const { transport } = makeTransport({ pc })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+
+    // Fire two publishes (different kinds → both add a transceiver + offer).
+    const p1 = transport.publish("mic", makeTrack("audio"))
+    const p2 = transport.publish("camera", makeTrack("video"))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Serialized: only the first job has entered createOffer.
+    expect(maxInFlight).toBe(1)
+    release()
+    await Promise.all([p1, p2])
+    expect(maxInFlight).toBe(1)
+  })
+
+  it("adds a transceiver once per kind and replaceTracks on re-publish", async () => {
+    const { transport, pc } = makeTransport()
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("mic", makeTrack("audio"))
+    await transport.publish("mic", makeTrack("audio"))
+
+    expect(pc.addTransceiver).toHaveBeenCalledTimes(1)
+    expect(pc.transceivers[0].sender.replaceTrack).toHaveBeenCalledTimes(1)
+  })
+
+  it("pull surfaces the remote track and stopPull closes its mid", async () => {
+    const { transport, calls, pc } = makeTransport()
+    const seen: PeerTrackRef[] = []
+    transport.onRemoteTrack = (e) => seen.push(e.ref)
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+
+    const ref: PeerTrackRef = { sessionId: "cf-peer", trackName: "peer:mic" }
+    await transport.pull(ref)
+    // Simulate the engine delivering the pulled track on its transceiver.
+    pc.ontrack?.({ transceiver: { mid: "remote-0" }, track: makeTrack("audio") })
+    expect(seen).toEqual([ref])
+
+    await transport.stopPull(ref)
+    const closeCall = calls.find((c) => c.path.endsWith("/tracks/close"))
+    expect(closeCall?.body.mids).toEqual(["remote-0"])
+  })
+
+  it("keeps the queue alive after a failed job", async () => {
+    let call = 0
+    const { transport } = makeTransport({
+      post: async (path: string, body: unknown) => {
+        void body
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish")) {
+          call++
+          if (call === 1) throw new Error("CF publish failed")
+          return { requiresImmediateRenegotiation: false, tracks: [] }
+        }
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await expect(transport.publish("mic", makeTrack("audio"))).rejects.toThrow("CF publish failed")
+    // A later job still runs (the chain didn't wedge on the rejection).
+    await expect(transport.publish("camera", makeTrack("video"))).resolves.toBeUndefined()
+  })
+})

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -1,0 +1,461 @@
+import { api } from "@/api/client"
+import type { PublishedTrackKind } from "./config"
+
+// The media-transport seam: an actor/track-oriented, provider-agnostic boundary
+// (the plan's provider boundary — a future >50-participant SFU or the Later P2P
+// direct mode slots in here without touching CallManager). One implementation
+// today: CloudflareSfuTransport. All CF negotiation rides the 0.2 backend proxy
+// endpoints; no CF URL ever appears client-side, and the app secret never
+// leaves the backend.
+
+/** The per-media-session handle a transport connects with (endpoint + incarnation). */
+export interface SessionDescriptor {
+  endpointId: string
+  /** Fenced on every proxy call; a stale incarnation is rejected 409 by the backend. */
+  mediaIncarnation: string
+}
+
+/** A peer track to pull: the publisher's CF session + the advertised track name. */
+export interface PeerTrackRef {
+  /** The publisher's CF session id (from the roster's published-track registry). */
+  sessionId: string
+  trackName: string
+}
+
+/** A remote track surfaced by a `pull`, tagged with the ref it satisfied. */
+export interface RemoteTrackEvent {
+  ref: PeerTrackRef
+  track: MediaStreamTrack
+}
+
+export type TransportConnectionState = "new" | "connecting" | "connected" | "reconnecting" | "closed" | "failed"
+
+export interface TransportStats {
+  /** Round-trip time in ms from the selected candidate pair, or null when unknown. */
+  rttMs: number | null
+  /** Fractional inbound packet loss [0,1], or null when unknown. */
+  packetLoss: number | null
+  /** The worst `qualityLimitationReason` across outbound video, or null. */
+  qualityLimitation: "none" | "cpu" | "bandwidth" | "other" | null
+  /** Sum of outbound encode time / frames, a rough encoder-pressure signal (ms), or null. */
+  encodeTimeMs: number | null
+}
+
+/**
+ * Provider-agnostic media transport. Track-oriented: the CallManager speaks in
+ * kinds and peer-track refs, never SDP. Renegotiation is an internal concern of
+ * the implementation.
+ */
+export interface MediaTransport {
+  connect(descriptor: SessionDescriptor): Promise<void>
+  publish(kind: PublishedTrackKind, track: MediaStreamTrack): Promise<void>
+  unpublish(kind: PublishedTrackKind): Promise<void>
+  /** Cap a published track's encoder (watchdog ladder `maxBitrate`); no-op if unpublished. */
+  setPublishEncoding(kind: PublishedTrackKind, params: { maxBitrate?: number }): Promise<void>
+  pull(ref: PeerTrackRef): Promise<void>
+  stopPull(ref: PeerTrackRef): Promise<void>
+  getStats(): Promise<TransportStats>
+  close(): Promise<void>
+  readonly connectionState: TransportConnectionState
+  /** Set by the owner before `connect`; fires once per pulled remote track. */
+  onRemoteTrack: ((event: RemoteTrackEvent) => void) | null
+  onRemoteTrackEnded: ((ref: PeerTrackRef) => void) | null
+  onConnectionStateChange: ((state: TransportConnectionState) => void) | null
+}
+
+// ── CF proxy wire shapes (mirror apps/backend/src/features/calls) ──────────────
+
+interface CfSessionDescription {
+  type: "offer" | "answer"
+  sdp: string
+}
+
+interface CfTrackResult {
+  mid?: string
+  trackName?: string
+  errorCode?: string
+  errorDescription?: string
+}
+
+interface CfCreateSessionResult {
+  cfSessionId: string
+  sessionDescription?: CfSessionDescription
+  idempotent: boolean
+}
+
+interface CfTracksResult {
+  requiresImmediateRenegotiation: boolean
+  tracks: CfTrackResult[]
+  sessionDescription?: CfSessionDescription
+  rosterVersion?: number
+}
+
+interface CfRenegotiateResult {
+  sessionDescription?: CfSessionDescription
+}
+
+type PostJson = <T>(path: string, body: unknown) => Promise<T>
+
+/**
+ * Bound proxy client for one media session. Every method carries the media
+ * incarnation in its body (the backend fences on it), so incarnation lives in
+ * exactly one place and no call can forget it.
+ */
+export interface CallProxyClient {
+  createSession(): Promise<CfCreateSessionResult>
+  publishTracks(args: {
+    sdp: CfSessionDescription
+    tracks: Array<{ kind: PublishedTrackKind; mid: string; trackName: string }>
+  }): Promise<CfTracksResult>
+  pullTracks(tracks: PeerTrackRef[]): Promise<CfTracksResult>
+  renegotiate(sdp: CfSessionDescription): Promise<CfRenegotiateResult>
+  closeTracks(args: {
+    mids: string[]
+    unpublishKinds?: PublishedTrackKind[]
+    sdp?: CfSessionDescription
+  }): Promise<unknown>
+}
+
+export function createCallProxyClient(args: {
+  workspaceId: string
+  callId: string
+  endpointId: string
+  mediaIncarnation: string
+  post?: PostJson
+}): CallProxyClient {
+  const { workspaceId, callId, endpointId, mediaIncarnation } = args
+  const post: PostJson = args.post ?? ((path, body) => api.post(path, body))
+  const base = `/api/workspaces/${workspaceId}/calls/${callId}/endpoints/${endpointId}/cf`
+  return {
+    createSession: () => post(`${base}/session`, { mediaIncarnation }),
+    publishTracks: ({ sdp, tracks }) => post(`${base}/tracks/publish`, { mediaIncarnation, sdp, tracks }),
+    pullTracks: (tracks) => post(`${base}/tracks/pull`, { mediaIncarnation, tracks }),
+    renegotiate: (sdp) => post(`${base}/renegotiate`, { mediaIncarnation, sdp }),
+    closeTracks: ({ mids, unpublishKinds, sdp }) =>
+      post(`${base}/tracks/close`, { mediaIncarnation, mids, unpublishKinds, sdp }),
+  }
+}
+
+interface CloudflareSfuTransportDeps {
+  workspaceId: string
+  callId: string
+  /** Injectable for tests; production builds a bound proxy from `api.post`. */
+  post?: PostJson
+  /** Injectable for tests; production uses the browser `RTCPeerConnection`. */
+  createPeerConnection?: () => RTCPeerConnection
+}
+
+function pickWorst(reasons: Array<string | undefined>): TransportStats["qualityLimitation"] {
+  if (reasons.includes("bandwidth")) return "bandwidth"
+  if (reasons.includes("cpu")) return "cpu"
+  if (reasons.some((r) => r && r !== "none")) return "other"
+  if (reasons.some((r) => r === "none")) return "none"
+  return null
+}
+
+/**
+ * Cloudflare Realtime SFU transport: owns the single `RTCPeerConnection`, the
+ * per-session renegotiation queue, transceiver bookkeeping for publish/pull, and
+ * `getStats` sampling.
+ *
+ * The renegotiation queue is load-bearing: CF serializes renegotiations per
+ * session, so two overlapping offer/answer exchanges corrupt each other's SDP
+ * state. Every operation that mutates the local/remote description runs as a job
+ * on a strictly serial promise chain — jobs never interleave. A CF-requested
+ * immediate renegotiation is resolved *inside* the same job (not re-enqueued),
+ * or it would deadlock behind its own enqueue.
+ */
+export class CloudflareSfuTransport implements MediaTransport {
+  private readonly workspaceId: string
+  private readonly callId: string
+  private readonly post?: PostJson
+  private readonly pcFactory: () => RTCPeerConnection
+
+  private pc: RTCPeerConnection | null = null
+  private proxy: CallProxyClient | null = null
+  private descriptor: SessionDescriptor | null = null
+
+  private readonly publishTransceivers = new Map<PublishedTrackKind, RTCRtpTransceiver>()
+  /** mid → ref, so an `ontrack` can be attributed to the pull that requested it. */
+  private readonly pullByMid = new Map<string, PeerTrackRef>()
+  private readonly pulledRefs = new Map<string, PeerTrackRef>()
+
+  private queue: Promise<unknown> = Promise.resolve()
+  private _state: TransportConnectionState = "new"
+  private closed = false
+
+  onRemoteTrack: ((event: RemoteTrackEvent) => void) | null = null
+  onRemoteTrackEnded: ((ref: PeerTrackRef) => void) | null = null
+  onConnectionStateChange: ((state: TransportConnectionState) => void) | null = null
+
+  constructor(deps: CloudflareSfuTransportDeps) {
+    this.workspaceId = deps.workspaceId
+    this.callId = deps.callId
+    this.post = deps.post
+    this.pcFactory = deps.createPeerConnection ?? (() => new RTCPeerConnection())
+  }
+
+  get connectionState(): TransportConnectionState {
+    return this._state
+  }
+
+  private setState(state: TransportConnectionState): void {
+    if (this._state === state) return
+    this._state = state
+    this.onConnectionStateChange?.(state)
+  }
+
+  /** Serialize a PC-mutating job behind the renegotiation queue. */
+  private enqueue<T>(job: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(() => job())
+    // Keep the chain alive even if a job rejects, so later jobs still run.
+    this.queue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  async connect(descriptor: SessionDescriptor): Promise<void> {
+    if (this.pc) throw new Error("Transport already connected")
+    this.descriptor = descriptor
+    this.proxy = createCallProxyClient({
+      workspaceId: this.workspaceId,
+      callId: this.callId,
+      endpointId: descriptor.endpointId,
+      mediaIncarnation: descriptor.mediaIncarnation,
+      post: this.post,
+    })
+    const pc = this.pcFactory()
+    this.pc = pc
+    this.setState("connecting")
+
+    pc.ontrack = (event: RTCTrackEvent) => {
+      const mid = event.transceiver?.mid ?? null
+      const ref = mid ? this.pullByMid.get(mid) : undefined
+      if (!ref) return
+      this.onRemoteTrack?.({ ref, track: event.track })
+      event.track.addEventListener("ended", () => this.onRemoteTrackEnded?.(ref))
+    }
+    pc.onconnectionstatechange = () => {
+      if (this.closed) return
+      switch (pc.connectionState) {
+        case "connected":
+          this.setState("connected")
+          break
+        case "disconnected":
+          this.setState("reconnecting")
+          break
+        case "failed":
+          this.setState("failed")
+          break
+        case "closed":
+          this.setState("closed")
+          break
+      }
+    }
+
+    await this.enqueue(async () => {
+      const created = await this.proxy!.createSession()
+      // CF *may* return an initial offer on session create (spike-unconfirmed —
+      // CLOUDFLARE_API.md Q2). Apply it defensively when present; otherwise the
+      // first publish's offer bootstraps the connection.
+      if (created.sessionDescription?.type === "offer") {
+        await pc.setRemoteDescription(created.sessionDescription)
+        const answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+        await this.proxy!.renegotiate({ type: "answer", sdp: answer.sdp ?? "" })
+      }
+    })
+  }
+
+  async publish(kind: PublishedTrackKind, track: MediaStreamTrack): Promise<void> {
+    await this.enqueue(async () => {
+      const pc = this.requirePc()
+      const trackName = this.trackName(kind)
+      let transceiver = this.publishTransceivers.get(kind)
+      if (transceiver) {
+        await transceiver.sender.replaceTrack(track)
+        // A replaceTrack into an existing sendonly transceiver needs no SDP churn.
+        return
+      }
+      transceiver = pc.addTransceiver(track, { direction: "sendonly" })
+      this.publishTransceivers.set(kind, transceiver)
+      const offer = await pc.createOffer()
+      await pc.setLocalDescription(offer)
+      const result = await this.proxy!.publishTracks({
+        sdp: { type: "offer", sdp: offer.sdp ?? "" },
+        tracks: [{ kind, mid: transceiver.mid ?? "", trackName }],
+      })
+      await this.applyAnswerAndMaybeRenegotiate(result)
+    })
+  }
+
+  async setPublishEncoding(kind: PublishedTrackKind, params: { maxBitrate?: number }): Promise<void> {
+    const transceiver = this.publishTransceivers.get(kind)
+    if (!transceiver) return
+    const sender = transceiver.sender
+    const current = sender.getParameters()
+    if (!current.encodings || current.encodings.length === 0) current.encodings = [{}]
+    for (const enc of current.encodings) {
+      if (params.maxBitrate != null) enc.maxBitrate = params.maxBitrate
+    }
+    try {
+      await sender.setParameters(current)
+    } catch {
+      // Some engines reject mid-stream parameter changes; the SFU still adapts.
+    }
+  }
+
+  async unpublish(kind: PublishedTrackKind): Promise<void> {
+    await this.enqueue(async () => {
+      const transceiver = this.publishTransceivers.get(kind)
+      if (!transceiver) return
+      this.publishTransceivers.delete(kind)
+      const mid = transceiver.mid
+      await transceiver.sender.replaceTrack(null)
+      try {
+        transceiver.stop()
+      } catch {
+        // Some engines throw if the transceiver is already stopping; ignore.
+      }
+      if (!mid) return
+      const pc = this.requirePc()
+      const offer = await pc.createOffer()
+      await pc.setLocalDescription(offer)
+      await this.proxy!.closeTracks({
+        mids: [mid],
+        unpublishKinds: [kind],
+        sdp: { type: "offer", sdp: offer.sdp ?? "" },
+      })
+    })
+  }
+
+  async pull(ref: PeerTrackRef): Promise<void> {
+    await this.enqueue(async () => {
+      const pc = this.requirePc()
+      const result = await this.proxy!.pullTracks([ref])
+      for (const t of result.tracks) {
+        if (t.mid) this.pullByMid.set(t.mid, ref)
+      }
+      this.pulledRefs.set(this.refKey(ref), ref)
+      // A pull answers with an OFFER (CF adds the remote m-line); we answer it.
+      if (result.sessionDescription?.type === "offer") {
+        await pc.setRemoteDescription(result.sessionDescription)
+        const answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+        await this.proxy!.renegotiate({ type: "answer", sdp: answer.sdp ?? "" })
+      } else if (result.requiresImmediateRenegotiation) {
+        await this.renegotiateFromRemote()
+      }
+    })
+  }
+
+  async stopPull(ref: PeerTrackRef): Promise<void> {
+    await this.enqueue(async () => {
+      const key = this.refKey(ref)
+      if (!this.pulledRefs.has(key)) return
+      this.pulledRefs.delete(key)
+      const mids: string[] = []
+      for (const [mid, r] of this.pullByMid) {
+        if (this.refKey(r) === key) mids.push(mid)
+      }
+      for (const mid of mids) this.pullByMid.delete(mid)
+      if (mids.length === 0) return
+      await this.proxy!.closeTracks({ mids })
+    })
+  }
+
+  async getStats(): Promise<TransportStats> {
+    const pc = this.pc
+    if (!pc) return { rttMs: null, packetLoss: null, qualityLimitation: null, encodeTimeMs: null }
+    const report = await pc.getStats()
+    let rttMs: number | null = null
+    let packetLoss: number | null = null
+    let encodeTimeMs: number | null = null
+    const qualityReasons: Array<string | undefined> = []
+    let received = 0
+    let lost = 0
+    report.forEach((s) => {
+      const stat = s as Record<string, unknown> & { type: string }
+      if (stat.type === "candidate-pair" && stat.nominated && typeof stat.currentRoundTripTime === "number") {
+        rttMs = stat.currentRoundTripTime * 1000
+      }
+      if (stat.type === "outbound-rtp" && (stat.kind === "video" || stat.mediaType === "video")) {
+        qualityReasons.push(stat.qualityLimitationReason as string | undefined)
+        if (
+          typeof stat.totalEncodeTime === "number" &&
+          typeof stat.framesEncoded === "number" &&
+          stat.framesEncoded > 0
+        ) {
+          encodeTimeMs = (stat.totalEncodeTime / stat.framesEncoded) * 1000
+        }
+      }
+      if (stat.type === "inbound-rtp") {
+        if (typeof stat.packetsReceived === "number") received += stat.packetsReceived
+        if (typeof stat.packetsLost === "number") lost += stat.packetsLost
+      }
+    })
+    if (received + lost > 0) packetLoss = lost / (received + lost)
+    return { rttMs, packetLoss, qualityLimitation: pickWorst(qualityReasons), encodeTimeMs }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+    this.setState("closed")
+    // Best-effort CF track teardown before dropping the PC so media stops
+    // promptly rather than lingering to CF's inactivity timeout.
+    const pc = this.pc
+    this.pc = null
+    if (pc) {
+      pc.ontrack = null
+      pc.onconnectionstatechange = null
+      try {
+        pc.close()
+      } catch {
+        // ignore
+      }
+    }
+    this.publishTransceivers.clear()
+    this.pullByMid.clear()
+    this.pulledRefs.clear()
+  }
+
+  private async applyAnswerAndMaybeRenegotiate(result: CfTracksResult): Promise<void> {
+    const pc = this.requirePc()
+    if (result.sessionDescription?.type === "answer") {
+      await pc.setRemoteDescription(result.sessionDescription)
+    }
+    if (result.requiresImmediateRenegotiation) {
+      await this.renegotiateFromRemote()
+    }
+  }
+
+  /**
+   * Resolve a CF-initiated renegotiation inline within the current job. CF hands
+   * us an offer via the renegotiate endpoint's answer path only on explicit
+   * pull; the immediate-renegotiation flag here re-drives an offer/answer we own.
+   */
+  private async renegotiateFromRemote(): Promise<void> {
+    const pc = this.requirePc()
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+    const result = await this.proxy!.renegotiate({ type: "offer", sdp: offer.sdp ?? "" })
+    if (result.sessionDescription?.type === "answer") {
+      await pc.setRemoteDescription(result.sessionDescription)
+    }
+  }
+
+  private requirePc(): RTCPeerConnection {
+    if (!this.pc) throw new Error("Transport is not connected")
+    return this.pc
+  }
+
+  private trackName(kind: PublishedTrackKind): string {
+    return `${this.descriptor!.endpointId}:${kind}`
+  }
+
+  private refKey(ref: PeerTrackRef): string {
+    return `${ref.sessionId}:${ref.trackName}`
+  }
+}

--- a/apps/frontend/src/contexts/dictation-coordinator-context.test.tsx
+++ b/apps/frontend/src/contexts/dictation-coordinator-context.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import { render } from "@testing-library/react"
 import { useEffect } from "react"
-import { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"
+import {
+  DictationCoordinatorProvider,
+  useDictationCoordinator,
+  setDictationExternalHold,
+  isDictationExternalHeld,
+} from "./dictation-coordinator-context"
 
 function Activator({
   stop,
@@ -97,5 +102,32 @@ describe("DictationCoordinatorProvider", () => {
 
     activate()
     expect(stop).not.toHaveBeenCalled()
+  })
+})
+
+describe("dictation external hold (call coexistence)", () => {
+  afterEach(() => setDictationExternalHold(false))
+
+  it("tracks the held flag", () => {
+    expect(isDictationExternalHeld()).toBe(false)
+    setDictationExternalHold(true)
+    expect(isDictationExternalHeld()).toBe(true)
+    setDictationExternalHold(false)
+    expect(isDictationExternalHeld()).toBe(false)
+  })
+
+  it("stops the active take when the hold engages mid-take", () => {
+    const stop = vi.fn()
+    let activate = () => {}
+    render(
+      <DictationCoordinatorProvider>
+        <Activator stop={stop} onReady={(a) => (activate = a)} />
+      </DictationCoordinatorProvider>
+    )
+
+    activate()
+    expect(stop).not.toHaveBeenCalled()
+    setDictationExternalHold(true)
+    expect(stop).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/contexts/dictation-coordinator-context.tsx
+++ b/apps/frontend/src/contexts/dictation-coordinator-context.tsx
@@ -1,4 +1,22 @@
-import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, type ReactNode } from "react"
+
+// External hold: a non-React owner (the account-scoped CallManager) disables
+// composer dictation for the duration of a call — two concurrent getUserMedia
+// captures conflict, fatally on iOS. Module-level so the singleton can set it
+// without reaching into React context; the provider stops any live take when it
+// flips on, and `useVoiceDictation.start` bails while it's held.
+let externalHeld = false
+const holdListeners = new Set<() => void>()
+
+export function setDictationExternalHold(held: boolean): void {
+  if (held === externalHeld) return
+  externalHeld = held
+  for (const listener of holdListeners) listener()
+}
+
+export function isDictationExternalHeld(): boolean {
+  return externalHeld
+}
 
 interface DictationCoordinatorContextValue {
   /**
@@ -35,6 +53,18 @@ export function DictationCoordinatorProvider({ children }: { children: ReactNode
 
   const deactivate = useCallback((stop: () => void) => {
     if (activeStopRef.current === stop) activeStopRef.current = null
+  }, [])
+
+  // When an external hold engages mid-take, stop the live take so its mic
+  // releases before the call acquires its own capture.
+  useEffect(() => {
+    const onHoldChange = () => {
+      if (isDictationExternalHeld()) activeStopRef.current?.()
+    }
+    holdListeners.add(onHoldChange)
+    return () => {
+      holdListeners.delete(onHoldChange)
+    }
   }, [])
 
   const value = useMemo<DictationCoordinatorContextValue>(() => ({ activate, deactivate }), [activate, deactivate])

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -59,7 +59,12 @@ export {
 export { SidebarProvider, useSidebar, type UrgencyBlock, type CollapseState } from "./sidebar-context"
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
-export { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"
+export {
+  DictationCoordinatorProvider,
+  useDictationCoordinator,
+  setDictationExternalHold,
+  isDictationExternalHeld,
+} from "./dictation-coordinator-context"
 export {
   StreamAgentActivityProvider,
   useAgentActivitySummary,

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -3,7 +3,7 @@ import { io, type Socket } from "socket.io-client"
 import { VOICE_DRAFT_CONTEXT_MAX_CHARS } from "@threa/types"
 import { voiceApi } from "@/api/voice"
 import { getCachedWsConfig } from "@/lib/cached-ws-config"
-import { useDictationCoordinator } from "@/contexts"
+import { useDictationCoordinator, isDictationExternalHeld } from "@/contexts"
 
 export type VoiceDictationState = "idle" | "connecting" | "recording" | "stopping" | "error"
 
@@ -501,6 +501,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const start = useCallback(() => {
     if (!supportRef.current.supported) return
     if (state !== "idle" && state !== "error") return
+    // Composer dictation is disabled while a call holds the mic — two concurrent
+    // getUserMedia captures conflict (fatally on iOS). The call owns the seam.
+    if (isDictationExternalHeld()) return
 
     // Take the single active slot, flushing+stopping any other composer's take.
     coordinator.activate(coordinatedStop)

--- a/apps/frontend/src/stores/call-store.test.ts
+++ b/apps/frontend/src/stores/call-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  getCallState,
+  setCallSession,
+  setCallRoster,
+  registerCallHangup,
+  resetCallStoreCache,
+  clearCallState,
+} from "./call-store"
+
+const ACCOUNT_SCOPE = resolve(dirname(fileURLToPath(import.meta.url)), "../auth/account-scope.tsx")
+
+describe("call-store", () => {
+  beforeEach(() => clearCallState())
+
+  it("starts idle", () => {
+    expect(getCallState().phase).toBe("idle")
+    expect(getCallState().callId).toBeNull()
+  })
+
+  it("tracks session + roster", () => {
+    setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    setCallRoster(
+      [
+        {
+          userId: "usr_1",
+          participantStatus: "joined",
+          endpointId: "ep_1",
+          connectionStatus: "connected",
+          mediaState: {},
+          publishedTracks: [],
+        },
+      ],
+      3
+    )
+    const state = getCallState()
+    expect(state.phase).toBe("joining")
+    expect(state.callId).toBe("call_1")
+    expect(state.rosterVersion).toBe(3)
+    expect(state.roster).toHaveLength(1)
+  })
+
+  it("reset performs the ordered hangup BEFORE dropping state", () => {
+    const order: string[] = []
+    setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    const unregister = registerCallHangup(() => {
+      // The hangup runs while state is still live (call not yet cleared).
+      order.push(`hangup:${getCallState().callId ?? "cleared"}`)
+    })
+
+    resetCallStoreCache()
+
+    expect(order).toEqual(["hangup:call_1"])
+    expect(getCallState().phase).toBe("idle")
+    expect(getCallState().callId).toBeNull()
+    unregister()
+  })
+
+  it("registration guard: account-scope flushes the call store cache", () => {
+    // The flush list is hand-maintained; assert the registration exists so a
+    // future edit can't silently drop it (leaving a prior account's mic hot).
+    const source = readFileSync(ACCOUNT_SCOPE, "utf8")
+    expect(source).toContain("resetCallStoreCache")
+    // And that it's actually invoked inside flushModuleStoreCaches, not just imported.
+    const flushBody = source.slice(source.indexOf("function flushModuleStoreCaches"))
+    expect(flushBody).toContain("resetCallStoreCache()")
+  })
+
+  it("unregistering the hangup makes reset a plain state drop", () => {
+    const hangup = vi.fn()
+    const unregister = registerCallHangup(hangup)
+    unregister()
+    resetCallStoreCache()
+    expect(hangup).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -1,0 +1,191 @@
+import { useSyncExternalStore } from "react"
+import type { CallMode, PublishedTrackKind } from "@/calls/config"
+
+// Module store (useSyncExternalStore) for the single active call. The CallManager
+// (non-React, account-scoped) is the sole writer; components read via the hooks.
+// Registered in `flushModuleStoreCaches` (account-scope.tsx) — the reset performs
+// the ordered hangup (emit leave → close transport → stop tracks) BEFORE dropping
+// state, so an account switch never leaves the prior account's mic hot. A guard
+// test asserts the registration exists (the flush list is hand-maintained).
+
+export type CallPhase = "idle" | "joining" | "connected" | "reconnecting"
+
+export interface CallPublishedTrack {
+  kind: PublishedTrackKind
+  trackName: string
+}
+
+export interface CallRosterParticipant {
+  userId: string
+  participantStatus: "joined" | "left" | "removed"
+  endpointId: string | null
+  connectionStatus: "connected" | "reconnecting" | "closed" | null
+  mediaState: { muted?: boolean; cameraOn?: boolean }
+  publishedTracks: CallPublishedTrack[]
+  /**
+   * The publisher endpoint's CF session id — required to pull this participant's
+   * tracks. NOT sent by the 0.2 roster (contract gap, see PR report); when
+   * absent the CallManager cannot pull this peer's media.
+   */
+  cfSessionId?: string | null
+}
+
+export interface CallDeviceState {
+  inputs: MediaDeviceInfo[]
+  outputs: MediaDeviceInfo[]
+  cameras: MediaDeviceInfo[]
+  selectedInputId: string | null
+  selectedOutputId: string | null
+  selectedCameraId: string | null
+}
+
+export interface CallLocalState {
+  muted: boolean
+  cameraOn: boolean
+  devices: CallDeviceState
+  /** Local speaking level [0,1] from the AudioContext analyser. */
+  speakingLevel: number
+}
+
+export interface CallDiagnostics {
+  rttMs: number | null
+  packetLoss: number | null
+  qualityLimitation: "none" | "cpu" | "bandwidth" | "other" | null
+}
+
+export interface CallState {
+  phase: CallPhase
+  callId: string | null
+  workspaceId: string | null
+  streamId: string | null
+  mode: CallMode | null
+  roster: CallRosterParticipant[]
+  rosterVersion: number
+  local: CallLocalState
+  /** True when another tab holds the call's Web Lock (this tab can offer rejoin). */
+  activeElsewhere: boolean
+  /** Set when an account switch is requested with a live call — UI confirms (M1.2). */
+  confirmPending: boolean
+  diagnostics: CallDiagnostics
+}
+
+const EMPTY_DEVICES: CallDeviceState = {
+  inputs: [],
+  outputs: [],
+  cameras: [],
+  selectedInputId: null,
+  selectedOutputId: null,
+  selectedCameraId: null,
+}
+
+function idleState(): CallState {
+  return {
+    phase: "idle",
+    callId: null,
+    workspaceId: null,
+    streamId: null,
+    mode: null,
+    roster: [],
+    rosterVersion: 0,
+    local: { muted: false, cameraOn: false, devices: EMPTY_DEVICES, speakingLevel: 0 },
+    activeElsewhere: false,
+    confirmPending: false,
+    diagnostics: { rttMs: null, packetLoss: null, qualityLimitation: null },
+  }
+}
+
+let state: CallState = idleState()
+const listeners = new Set<() => void>()
+
+// The CallManager registers its ordered-hangup here so `resetCallStoreCache`
+// (the flush entry point) can tear the live call down without the store importing
+// the manager (which would be circular). A plain ref, not reactive state.
+let hangupRef: (() => void) | null = null
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+function setState(next: CallState): void {
+  state = next
+  emit()
+}
+
+export function getCallState(): CallState {
+  return state
+}
+
+export function registerCallHangup(hangup: () => void): () => void {
+  hangupRef = hangup
+  return () => {
+    if (hangupRef === hangup) hangupRef = null
+  }
+}
+
+export function setCallPhase(phase: CallPhase): void {
+  if (state.phase === phase) return
+  setState({ ...state, phase })
+}
+
+export function setCallSession(args: { callId: string; workspaceId: string; streamId: string; mode: CallMode }): void {
+  setState({ ...state, ...args, phase: "joining" })
+}
+
+export function setCallRoster(roster: CallRosterParticipant[], rosterVersion: number): void {
+  setState({ ...state, roster, rosterVersion })
+}
+
+export function patchCallLocal(patch: Partial<CallLocalState>): void {
+  setState({ ...state, local: { ...state.local, ...patch } })
+}
+
+export function setCallSpeakingLevel(level: number): void {
+  if (state.local.speakingLevel === level) return
+  setState({ ...state, local: { ...state.local, speakingLevel: level } })
+}
+
+export function setCallDevices(devices: CallDeviceState): void {
+  setState({ ...state, local: { ...state.local, devices } })
+}
+
+export function setCallDiagnostics(diagnostics: CallDiagnostics): void {
+  setState({ ...state, diagnostics })
+}
+
+export function setCallActiveElsewhere(activeElsewhere: boolean): void {
+  if (state.activeElsewhere === activeElsewhere) return
+  setState({ ...state, activeElsewhere })
+}
+
+export function setCallConfirmPending(confirmPending: boolean): void {
+  if (state.confirmPending === confirmPending) return
+  setState({ ...state, confirmPending })
+}
+
+/** Drop all call state without a hangup — the manager calls this after teardown. */
+export function clearCallState(): void {
+  setState(idleState())
+}
+
+/**
+ * Flush entry point (account switch / logout). Performs the ordered hangup FIRST
+ * — emit leave, close transport, stop tracks (the manager's registered callback)
+ * — THEN drops state, so a switch with a live call never strands a hot mic.
+ */
+export function resetCallStoreCache(): void {
+  hangupRef?.()
+  setState(idleState())
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useCallState(): CallState {
+  return useSyncExternalStore(
+    subscribe,
+    () => state,
+    () => state
+  )
+}

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -53,6 +53,18 @@ export interface CallDiagnostics {
   qualityLimitation: "none" | "cpu" | "bandwidth" | "other" | null
 }
 
+/**
+ * Surfaced when a mid-call recapture (device switch / camera on) fails. `code`
+ * distinguishes a switch that failed but restored the prior capture
+ * (`capture_failed`, audio survives) from one whose rollback also failed
+ * (`capture_rollback_failed`, outbound audio is dead). Cleared on the next
+ * successful capture and on teardown.
+ */
+export interface CallCaptureErrorInfo {
+  code: "capture_failed" | "capture_rollback_failed"
+  message: string
+}
+
 export interface CallState {
   phase: CallPhase
   callId: string | null
@@ -67,6 +79,8 @@ export interface CallState {
   /** Set when an account switch is requested with a live call — UI confirms (M1.2). */
   confirmPending: boolean
   diagnostics: CallDiagnostics
+  /** Last mid-call recapture failure, or null. See {@link CallCaptureErrorInfo}. */
+  captureError: CallCaptureErrorInfo | null
 }
 
 const EMPTY_DEVICES: CallDeviceState = {
@@ -91,6 +105,7 @@ function idleState(): CallState {
     activeElsewhere: false,
     confirmPending: false,
     diagnostics: { rttMs: null, packetLoss: null, qualityLimitation: null },
+    captureError: null,
   }
 }
 
@@ -160,6 +175,11 @@ export function setCallActiveElsewhere(activeElsewhere: boolean): void {
 export function setCallConfirmPending(confirmPending: boolean): void {
   if (state.confirmPending === confirmPending) return
   setState({ ...state, confirmPending })
+}
+
+export function setCallCaptureError(captureError: CallCaptureErrorInfo | null): void {
+  if (state.captureError === captureError) return
+  setState({ ...state, captureError })
 }
 
 /** Drop all call state without a hangup — the manager calls this after teardown. */


### PR DESCRIPTION
**Stack:** PR 4 of the calls build, on #1413. M1 begins — the frontend media plane, no visible UI yet (dock is 1.2, ring 1.3, timeline 1.4).

## Problem

The backend can run calls end-to-end (proven by the 0.3 matrix) but no client exists: nothing negotiates with Cloudflare through the proxy, holds the roster, or owns local media.

## Solution

A non-React media core in `apps/frontend/src/calls/`: the `MediaTransport` provider boundary, the account-scoped `CallManager`, and the call store — everything M1.2's dock will render from.

### How it works

- **`media-transport.ts`**: `MediaTransport` (actor/track-oriented — the plan's provider boundary) implemented by `CloudflareSfuTransport`: one `RTCPeerConnection` to CF, a **serial renegotiation queue** (survives rejected jobs; CF-initiated `requiresImmediateRenegotiation` resolves inline in the same job — re-enqueueing would deadlock), publish/pull transceiver bookkeeping, `getStats` sampling. All negotiation rides the 0.2 proxy via an incarnation-bound client; spike-unconfirmed CF behaviors are coded defensively and commented against `CLOUDFLARE_API.md`.
- **`call-manager.ts`**: account-scoped singleton (workspace-agnostic — calls carry their `workspaceId`; the per-workspace SyncEngine lifecycle would kill calls on workspace switch). Full dependency injection (`CallManagerDeps`) so jsdom tests exercise behavior without module mocks (INV-48). Lifecycle: start/join → CF session → publish → pull peers from the **versioned roster** (strict monotonic drop of stale versions; track-registry diff drives pull/stopPull; a leaving peer's pulls stop and its audio element detaches). Lease renewal at TTL/3; socket reconnect reuses the incarnation, fresh loads mint a new one; `rejoin` = start-or-join with a fresh incarnation.
- **Media rules**: one combined mic(+camera) `getUserMedia` per acquisition (iOS single-active-capture), AEC/NS/AGC once, mute = `track.enabled` + state emit, camera-off stops the track (LED), one `<audio>` element per remote track (Chromium AEC reference + `setSinkId`) — never routed through the AudioContext; one AudioContext per call created in the join gesture; publisher watchdog steps the published encode by `qualityLimitationReason`.
- **Ownership & teardown**: Web Locks via a single `{ifAvailable}` request (owner holds for the call's life; a second tab gets `activeElsewhere` instead of hanging); wake lock with `visibilitychange` re-acquire (listeners lifecycle-managed); `call-store` registered in `flushModuleStoreCaches` with ordered hangup (leave → transport close → track stop) **before** state drops, pinned by a source-scan guard test; dictation takes an external hold while a call is live (a second concurrent `getUserMedia` is fatal on iOS).

### Key design decision

**One backend change rides this PR**: `listRoster` now carries the publisher's `cfSessionId`. The adversarial verify proved peer pulls were *structurally dead* without it — the client pulls by `{sessionId, trackName}` but the roster never exposed the session id. It lives here rather than amending #1411 because this PR is the consumer that makes the field meaningful; the SQL-capture test pins the producing side.

## Files

| Path | Purpose |
| ---- | ------- |
| `apps/frontend/src/calls/{config,media-transport,call-manager}.ts` (+ tests) | The media core |
| `apps/frontend/src/stores/call-store.ts` (+ test) | Module store + hangup seam + flush guard |
| `apps/frontend/src/contexts/dictation-coordinator-context.tsx`, `hooks/use-voice-dictation.ts` | External hold while a call is live |
| `apps/frontend/src/auth/account-scope.tsx` | `resetCallStoreCache` in the flush list |
| `apps/backend/src/features/calls/repository.ts` (+ test) | Roster `cfSessionId` (the contract fix) |

## Out of scope (deliberate)

All UI (1.2), ring (1.3), timeline (1.4), screen share (M3), simulcast `encodings[]` (spike-unconfirmed — watchdog uses `applyConstraints` on the single encode). Nothing plan-deferred.

## Test plan

- [x] Implement → xhigh verify → fix → re-verify loop: **1 blocker + 4 majors fixed** (roster contract gap; Web Locks inversion that hung a second tab and made the owner self-report `activeElsewhere`; iOS combined-capture; `visibilitychange` listener leak; `startCall` error path leaking the lock/socket/context) + minors incl. `devicechange` wiring and `hangupSync` audio-element detach; 2 trivial residuals fixed post-loop (stale comment, roster SQL-capture pin)
- [x] Frontend scoped: media-transport 6, call-manager 10, call-store 5, dictation-hold 2 → 21 pass (Vitest); backend calls suite 92 pass; both typechecks + full pre-commit green
- [ ] No real-browser WebRTC exercise yet — jsdom + injected fakes; the live path is 0.3's cf-2 probe (blocked on creds) and M1.5's e2e

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
