### PR TITLE
feat(calls): call dock, controls, pre-join gate, entry points (stack 5/8)

### DIFF
--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -184,12 +184,28 @@ describe("CallManager", () => {
     expect(isDictationExternalHeld()).toBe(true)
   })
 
-  it("video mode publishes the camera; audio_only does not", async () => {
+  it("join defaults to mic-on / camera-off even in video mode; camera publishes only on setCameraOn", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const manager = new CallManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    // Plan §In-call features: join is mic-on, camera-off — no camera capture yet.
+    expect(transport._events).toContain("publish:mic")
+    expect(transport._events).not.toContain("publish:camera")
+    expect(getCallState().local.cameraOn).toBe(false)
+
+    await manager.setCameraOn(true)
     expect(transport._events).toContain("publish:camera")
+    expect(getCallState().local.cameraOn).toBe(true)
+  })
+
+  it("audio_only mode ignores setCameraOn", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const manager = new CallManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+    await manager.setCameraOn(true)
+    expect(transport._events).not.toContain("publish:camera")
   })
 
   it("drops a stale/duplicate roster version, applies a newer one", async () => {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -14,6 +14,7 @@ import {
   setCallActiveElsewhere,
   setCallConfirmPending,
   setCallCaptureError,
+  bumpCallMediaEpoch,
   clearCallState,
   registerCallHangup,
   getCallState,
@@ -160,6 +161,19 @@ interface CallSession {
   analyser: AnalyserNode | null
   pulled: Map<string, { ref: PeerTrackRef; kind: string }>
   remoteAudioEls: Map<string, HTMLAudioElement>
+  /**
+   * refKey → owning endpoint id, recorded from the roster in `diffPulls` so an
+   * `onRemoteTrack` (which carries only the CF ref) can be attributed to the
+   * roster participant whose tile renders it.
+   */
+  remoteTrackOwner: Map<string, string>
+  /**
+   * endpoint id → the video `MediaStream` a tile attaches to its `<video>`. Kept
+   * on the session (never the store snapshot — see {@link CallState.mediaEpoch}),
+   * carries the local camera under the session's own endpoint and each pulled
+   * peer camera under theirs.
+   */
+  videoStreams: Map<string, MediaStream>
   cameraLayer: number
   healthySamples: number
   leaseTimer: ReturnType<typeof setInterval> | null
@@ -176,6 +190,22 @@ function refKey(ref: PeerTrackRef): string {
 }
 
 /**
+ * The command surface UI components drive (INV-15: components never touch
+ * `MediaTransport` or sockets). `CallManager` implements it; tests inject a fake
+ * through the `CallManagerProvider`. State is read from the call-store, never
+ * from here — this is action-only, plus the video ref-map accessor.
+ */
+export interface CallController {
+  startCall(params: { workspaceId: string; streamId: string; mode: CallMode }): Promise<void>
+  leaveCall(): Promise<void>
+  setMuted(muted: boolean): void
+  setCameraOn(on: boolean): Promise<void>
+  switchInputDevice(deviceId: string): Promise<void>
+  setOutputDevice(deviceId: string): Promise<void>
+  getVideoStream(endpointId: string): MediaStream | null
+}
+
+/**
  * The account-scoped, workspace-agnostic call singleton (calls carry their own
  * `workspaceId`, so — unlike the per-workspace SyncEngine — it survives a
  * workspace switch and only dies on account switch / logout via the call-store
@@ -183,7 +213,7 @@ function refKey(ref: PeerTrackRef): string {
  * media incarnation, leases, and local capture. It never activates on its own —
  * only an explicit `startCall`/`rejoin` from a user gesture brings it up.
  */
-export class CallManager {
+export class CallManager implements CallController {
   private readonly deps: CallManagerDeps
   private session: CallSession | null = null
   // Monotonic generation, claimed synchronously by `startCall` before its first
@@ -289,6 +319,8 @@ export class CallManager {
         analyser: null,
         pulled: new Map(),
         remoteAudioEls: new Map(),
+        remoteTrackOwner: new Map(),
+        videoStreams: new Map(),
         cameraLayer: 0,
         healthySamples: 0,
         leaseTimer: null,
@@ -309,14 +341,12 @@ export class CallManager {
 
       await transport.connect({ endpointId: join.endpointId, mediaIncarnation })
       this.assertStartLive(gen)
-      // Video joins acquire mic+camera in ONE getUserMedia (iOS single-active-
-      // capture: a second gUM while the first is live mutes it), then split.
-      await this.captureAndPublish(session, { camera: params.mode === "video" })
+      // Join default is mic-on / camera-off (plan §In-call features) regardless of
+      // mode — `mode: "video"` is a capability, not "camera on now". Acquiring only
+      // the mic keeps the camera dark on join and lets a camera-less device join a
+      // video call; the camera is acquired later via setCameraOn.
+      await this.captureAndPublish(session, { camera: false })
       this.assertStartLive(gen)
-      if (params.mode === "video") {
-        patchCallLocal({ cameraOn: true })
-        this.emitState(session, { cameraOn: true })
-      }
 
       this.applyRoster(session, join.rosterVersion, join.roster)
       this.startLeaseTimer(session)
@@ -434,6 +464,7 @@ export class CallManager {
         session.cameraTrack.stop()
         session.cameraTrack = null
         await session.transport.unpublish("camera")
+        this.clearVideoStream(session, session.endpointId)
       }
       patchCallLocal({ cameraOn: on })
       this.emitState(session, { cameraOn: on })
@@ -545,7 +576,7 @@ export class CallManager {
   private diffPulls(session: CallSession, roster: CallRosterParticipant[]): void {
     const desired = new Map<string, { ref: PeerTrackRef; kind: string }>()
     for (const p of roster) {
-      if (p.endpointId === session.endpointId) continue
+      if (!p.endpointId || p.endpointId === session.endpointId) continue
       if (p.connectionStatus !== "connected" && p.connectionStatus !== "reconnecting") continue
       // The publisher's CF session id is required to pull. The 0.2 roster does
       // not carry it (contract gap) — skip peers we can't address rather than
@@ -553,7 +584,10 @@ export class CallManager {
       if (!p.cfSessionId) continue
       for (const track of p.publishedTracks) {
         const ref: PeerTrackRef = { sessionId: p.cfSessionId, trackName: track.trackName }
-        desired.set(refKey(ref), { ref, kind: track.kind })
+        const key = refKey(ref)
+        desired.set(key, { ref, kind: track.kind })
+        // Attribute the eventual onRemoteTrack (CF ref only) to this participant's tile.
+        session.remoteTrackOwner.set(key, p.endpointId)
       }
     }
     for (const [key, entry] of desired) {
@@ -567,6 +601,8 @@ export class CallManager {
         session.pulled.delete(key)
         void session.transport.stopPull(entry.ref).catch(() => {})
         this.detachRemoteAudio(session, key)
+        this.detachRemoteVideo(session, key)
+        session.remoteTrackOwner.delete(key)
       }
     }
   }
@@ -681,6 +717,11 @@ export class CallManager {
     if (cameraTrack) {
       await session.transport.publish("camera", cameraTrack)
       await this.applyCameraLayer(session)
+      // Surface the local preview under the session's own endpoint id (self is on
+      // the roster with that endpoint), so the self tile renders it uniformly.
+      this.setVideoStream(session, session.endpointId, cameraTrack)
+    } else {
+      this.clearVideoStream(session, session.endpointId)
     }
 
     this.wireSpeakingAnalyser(session, stream)
@@ -778,9 +819,12 @@ export class CallManager {
       // NEVER routed through the AudioContext to the speakers (Web Audio taps are
       // pure sinks only).
       if (event.track.kind === "audio") this.attachRemoteAudio(session, event.ref, event.track)
+      else if (event.track.kind === "video") this.attachRemoteVideo(session, event.ref, event.track)
     }
     session.transport.onRemoteTrackEnded = (ref) => {
-      this.detachRemoteAudio(session, refKey(ref))
+      const key = refKey(ref)
+      this.detachRemoteAudio(session, key)
+      this.detachRemoteVideo(session, key)
     }
     session.transport.onConnectionStateChange = (state) => {
       if (this.session !== session) return
@@ -813,6 +857,48 @@ export class CallManager {
     el.srcObject = null
     el.remove()
     session.remoteAudioEls.delete(key)
+  }
+
+  // ── video registry (tiles read this via getVideoStream; never the store) ────
+
+  /** Wrap a track in a `MediaStream`, or null where the constructor is unavailable (jsdom). */
+  private makeVideoStream(track: MediaStreamTrack): MediaStream | null {
+    if (typeof MediaStream === "undefined") return null
+    return new MediaStream([track])
+  }
+
+  /** Register/replace an endpoint's video stream and tick the ref-map version. */
+  private setVideoStream(session: CallSession, endpointId: string, track: MediaStreamTrack): void {
+    const stream = this.makeVideoStream(track)
+    if (!stream) return
+    session.videoStreams.set(endpointId, stream)
+    bumpCallMediaEpoch()
+  }
+
+  /** Drop an endpoint's video stream and tick the version, if one was present. */
+  private clearVideoStream(session: CallSession, endpointId: string): void {
+    if (session.videoStreams.delete(endpointId)) bumpCallMediaEpoch()
+  }
+
+  private attachRemoteVideo(session: CallSession, ref: PeerTrackRef, track: MediaStreamTrack): void {
+    const endpointId = session.remoteTrackOwner.get(refKey(ref))
+    if (!endpointId) return
+    this.setVideoStream(session, endpointId, track)
+  }
+
+  private detachRemoteVideo(session: CallSession, key: string): void {
+    const endpointId = session.remoteTrackOwner.get(key)
+    if (endpointId) this.clearVideoStream(session, endpointId)
+  }
+
+  /**
+   * The video `MediaStream` for a roster participant's endpoint (self's own
+   * camera under the session endpoint, or a pulled peer's camera), or null when
+   * that endpoint publishes no video. Tiles attach it to their `<video>` and
+   * re-read on {@link CallState.mediaEpoch} changes.
+   */
+  getVideoStream(endpointId: string): MediaStream | null {
+    return this.session?.videoStreams.get(endpointId) ?? null
   }
 
   // ── lease + watchdog ─────────────────────────────────────────────────────

--- a/apps/frontend/src/components/call/active-elsewhere-chip.tsx
+++ b/apps/frontend/src/components/call/active-elsewhere-chip.tsx
@@ -1,0 +1,15 @@
+import { PhoneCall } from "lucide-react"
+
+/**
+ * Shown when the call's Web Lock is held by another tab (`store.activeElsewhere`):
+ * this tab isn't in the call, so it offers only a compact status marker. Rejoin
+ * lands in a later PR (ring/rejoin bar) — this is the read-only signal.
+ */
+export function ActiveElsewhereChip() {
+  return (
+    <div className="flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-xs text-muted-foreground shadow-lg">
+      <PhoneCall className="h-3.5 w-3.5" aria-hidden />
+      Call active in another tab
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -15,7 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
 import { useCallManager } from "./call-manager-context"
-import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMuted } from "./call-store-hooks"
+import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMode, useCallMuted } from "./call-store-hooks"
 
 // setSinkId (output device selection) is unsupported on Safari/Firefox; hide the
 // speaker picker where the API is absent rather than showing a dead control.
@@ -135,6 +135,7 @@ export function CallControls() {
   const manager = useCallManager()
   const muted = useCallMuted()
   const cameraOn = useCallCameraOn()
+  const mode = useCallMode()
   const devices = useCallDevices()
   const diagnostics = useCallDiagnostics()
   const [leaving, setLeaving] = useState(false)
@@ -163,16 +164,18 @@ export function CallControls() {
       >
         {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
       </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-9 w-9"
-        aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
-        aria-pressed={cameraOn}
-        onClick={toggleCamera}
-      >
-        {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
-      </Button>
+      {mode !== "audio_only" && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9"
+          aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
+          aria-pressed={cameraOn}
+          onClick={toggleCamera}
+        >
+          {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+        </Button>
+      )}
       <DevicePickerMenu devices={devices} />
       <ConnectionDiagnostics diagnostics={diagnostics} />
       <Button

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { Mic, MicOff, Video, VideoOff, PhoneOff, Settings, Signal } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
+import { useCallManager } from "./call-manager-context"
+import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMuted } from "./call-store-hooks"
+
+// setSinkId (output device selection) is unsupported on Safari/Firefox; hide the
+// speaker picker where the API is absent rather than showing a dead control.
+const OUTPUT_SELECTION_SUPPORTED = typeof HTMLMediaElement !== "undefined" && "setSinkId" in HTMLMediaElement.prototype
+
+function deviceLabel(device: MediaDeviceInfo, index: number): string {
+  return device.label || `Device ${index + 1}`
+}
+
+export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
+  const manager = useCallManager()
+  const hasInputs = devices.inputs.length > 0
+  const hasOutputs = OUTPUT_SELECTION_SUPPORTED && devices.outputs.length > 0
+  if (!hasInputs && !hasOutputs) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Devices">
+          <Settings className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" className="max-w-[280px]">
+        {hasInputs && (
+          <>
+            <DropdownMenuLabel>Microphone</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={devices.selectedInputId ?? undefined}
+              onValueChange={(id) =>
+                void manager.switchInputDevice(id).catch(() => toast.error("Couldn't switch microphone"))
+              }
+            >
+              {devices.inputs.map((d, i) => (
+                <DropdownMenuRadioItem key={d.deviceId} value={d.deviceId} className="truncate">
+                  {deviceLabel(d, i)}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+        {hasInputs && hasOutputs && <DropdownMenuSeparator />}
+        {hasOutputs && (
+          <>
+            <DropdownMenuLabel>Speaker</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={devices.selectedOutputId ?? undefined}
+              onValueChange={(id) =>
+                void manager.setOutputDevice(id).catch(() => toast.error("Couldn't switch speaker"))
+              }
+            >
+              {devices.outputs.map((d, i) => (
+                <DropdownMenuRadioItem key={d.deviceId} value={d.deviceId} className="truncate">
+                  {deviceLabel(d, i)}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function formatRtt(rttMs: number | null): string {
+  return rttMs == null ? "—" : `${Math.round(rttMs)} ms`
+}
+
+function formatLoss(loss: number | null): string {
+  return loss == null ? "—" : `${(loss * 100).toFixed(1)}%`
+}
+
+function formatLimitation(limitation: CallDiagnostics["qualityLimitation"]): string {
+  switch (limitation) {
+    case "bandwidth":
+      return "Limited by bandwidth"
+    case "cpu":
+      return "Limited by CPU"
+    case "other":
+      return "Limited"
+    case "none":
+      return "None"
+    default:
+      return "—"
+  }
+}
+
+export function ConnectionDiagnostics({ diagnostics }: { diagnostics: CallDiagnostics }) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Connection diagnostics">
+          <Signal className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="center" className="w-56 text-sm">
+        <p className="mb-2 font-medium">Connection</p>
+        <dl className="space-y-1">
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted-foreground">Round-trip</dt>
+            <dd className="tabular-nums">{formatRtt(diagnostics.rttMs)}</dd>
+          </div>
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted-foreground">Packet loss</dt>
+            <dd className="tabular-nums">{formatLoss(diagnostics.packetLoss)}</dd>
+          </div>
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted-foreground">Quality</dt>
+            <dd>{formatLimitation(diagnostics.qualityLimitation)}</dd>
+          </div>
+        </dl>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function CallControls() {
+  const manager = useCallManager()
+  const muted = useCallMuted()
+  const cameraOn = useCallCameraOn()
+  const devices = useCallDevices()
+  const diagnostics = useCallDiagnostics()
+  const [leaving, setLeaving] = useState(false)
+
+  const toggleCamera = () => {
+    void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))
+  }
+
+  const leave = () => {
+    setLeaving(true)
+    void manager.leaveCall().catch(() => {
+      setLeaving(false)
+      toast.error("Couldn't leave the call")
+    })
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn("h-9 w-9", muted && "text-destructive")}
+        aria-label={muted ? "Unmute" : "Mute"}
+        aria-pressed={muted}
+        onClick={() => manager.setMuted(!muted)}
+      >
+        {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9"
+        aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
+        aria-pressed={cameraOn}
+        onClick={toggleCamera}
+      >
+        {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+      </Button>
+      <DevicePickerMenu devices={devices} />
+      <ConnectionDiagnostics diagnostics={diagnostics} />
+      <Button
+        variant="destructive"
+        size="icon"
+        className="h-9 w-9"
+        aria-label="Leave call"
+        disabled={leaving}
+        onClick={leave}
+      >
+        <PhoneOff className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act } from "@testing-library/react"
+import { render, screen, userEvent } from "@/test"
+import * as authModule from "@/auth"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+import {
+  clearCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  patchCallLocal,
+  setCallActiveElsewhere,
+  setCallCaptureError,
+  bumpCallMediaEpoch,
+  type CallRosterParticipant,
+} from "@/stores/call-store"
+import { CallCaptureError, type CallController } from "@/calls/call-manager"
+import { CallDock } from "./call-dock"
+import { CallManagerProvider } from "./call-manager-context"
+import { CallLaunchProvider, useCallLaunch, type CallLaunchRequest } from "./call-launch-context"
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_x",
+    participantStatus: "joined",
+    endpointId: "callep_x",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function LaunchButton({ request }: { request: CallLaunchRequest }) {
+  const { launch } = useCallLaunch()
+  return (
+    <button type="button" onClick={() => launch(request)}>
+      launch
+    </button>
+  )
+}
+
+function renderDock(manager: CallController) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <CallLaunchProvider>
+        <LaunchButton request={{ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }} />
+        <CallDock />
+      </CallLaunchProvider>
+    </CallManagerProvider>
+  )
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+function enterConnectedCall(roster: CallRosterParticipant[]) {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallRoster(roster, 1)
+  })
+}
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  seedUsers()
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("CallDock — idle", () => {
+  it("renders nothing when idle with no launch or cross-tab call", () => {
+    const { container } = renderDock(makeManager())
+    expect(container.querySelector('[data-testid="call-tile"]')).toBeNull()
+    expect(screen.queryByText(/active in another tab/i)).toBeNull()
+  })
+
+  it("shows the active-elsewhere chip when another tab holds the call", () => {
+    renderDock(makeManager())
+    act(() => setCallActiveElsewhere(true))
+    expect(screen.getByText(/Call active in another tab/i)).toBeInTheDocument()
+  })
+})
+
+describe("CallDock — connected roster", () => {
+  it("renders a tile per joined participant with names, self marker, and mute + reconnecting state", () => {
+    renderDock(makeManager())
+    enterConnectedCall([
+      participant({ userId: "usr_self", endpointId: "callep_self" }),
+      participant({
+        userId: "usr_peer",
+        endpointId: "callep_peer",
+        connectionStatus: "reconnecting",
+        mediaState: { muted: true },
+      }),
+    ])
+    const tiles = screen.getAllByTestId("call-tile")
+    expect(tiles).toHaveLength(2)
+    expect(screen.getByText("Ada (you)")).toBeInTheDocument()
+    expect(screen.getByText("Grace")).toBeInTheDocument()
+    // Peer is muted + reconnecting.
+    expect(screen.getByLabelText("Muted")).toBeInTheDocument()
+    expect(screen.getByText(/Reconnecting/i)).toBeInTheDocument()
+  })
+
+  it("dispatches mute, camera, and leave to the manager (success stays silent — INV-63)", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+
+    await userEvent.click(screen.getByLabelText("Mute"))
+    expect(manager.setMuted).toHaveBeenCalledWith(true)
+
+    await userEvent.click(screen.getByLabelText("Turn camera on"))
+    expect(manager.setCameraOn).toHaveBeenCalledWith(true)
+
+    await userEvent.click(screen.getByLabelText("Leave call"))
+    expect(manager.leaveCall).toHaveBeenCalled()
+  })
+
+  it("surfaces a mid-call capture error as an in-dock banner", () => {
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
+    expect(screen.getByTestId("call-capture-error")).toHaveTextContent(/couldn't be restored/i)
+  })
+
+  it("attaches the manager's per-endpoint video stream to the tile <video> on a media-epoch tick", () => {
+    const fakeStream = { id: "fake" } as unknown as MediaStream
+    const getVideoStream = vi.fn((endpointId: string) => (endpointId === "callep_self" ? fakeStream : null))
+    renderDock(makeManager({ getVideoStream }))
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    act(() => bumpCallMediaEpoch())
+    const video = screen.getByTestId("call-tile-video") as HTMLVideoElement
+    expect(video.srcObject).toBe(fakeStream)
+  })
+
+  it("reflects a local mute toggle in the control label without a toast", () => {
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    act(() => patchCallLocal({ muted: true }))
+    expect(screen.getByLabelText("Unmute")).toBeInTheDocument()
+  })
+})
+
+describe("CallDock — pre-join permission taxonomy", () => {
+  async function launchWithError(name: string, message = "") {
+    // The taxonomy is derived from startCall's own typed capture failure (single
+    // media acquisition in the manager), so the fake manager rejects startCall with
+    // a CallCaptureError wrapping the raw getUserMedia DOMException.
+    const startCall = vi.fn(async () => {
+      throw new CallCaptureError("capture_failed", Object.assign(new Error(message), { name }))
+    })
+    renderDock(makeManager({ startCall }))
+    await userEvent.click(screen.getByText("launch"))
+  }
+
+  it("renders denied copy for a plain permission denial", async () => {
+    await launchWithError("NotAllowedError", "Permission denied")
+    expect(await screen.findByText(/Microphone access denied/i)).toBeInTheDocument()
+  })
+
+  it("renders no-device copy when hardware is missing", async () => {
+    await launchWithError("NotFoundError")
+    expect(await screen.findByText(/No microphone found/i)).toBeInTheDocument()
+  })
+
+  it("renders device-busy copy when the mic is in use", async () => {
+    await launchWithError("NotReadableError")
+    expect(await screen.findByText(/microphone is busy/i)).toBeInTheDocument()
+  })
+
+  it("renders blocked-by-policy copy", async () => {
+    await launchWithError("NotAllowedError", "disallowed by permissions policy")
+    expect(await screen.findByText(/blocked here/i)).toBeInTheDocument()
+  })
+
+  it("starts the call through the manager on launch", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    await userEvent.click(screen.getByText("launch"))
+    expect(manager.startCall).toHaveBeenCalledWith({ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+  })
+})

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "@testing-library/react"
 import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
+import * as useMobileModule from "@/hooks/use-mobile"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
 
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
@@ -251,5 +252,69 @@ describe("CallDock — pre-join permission taxonomy", () => {
     renderDock(manager)
     await userEvent.click(screen.getByText("launch"))
     expect(manager.startCall).toHaveBeenCalledWith({ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+  })
+
+  it("ignores a launch while already in a call (no stale join_error)", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    await userEvent.click(screen.getByText("launch"))
+    expect(manager.startCall).not.toHaveBeenCalled()
+  })
+
+  it("re-expands the pre-join gate on a fresh launch after a collapse", async () => {
+    const startCall = vi.fn(() => new Promise<void>(() => {}))
+    renderDock(makeManager({ startCall }))
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    await userEvent.click(screen.getByLabelText("Collapse call"))
+    expect(screen.getByLabelText("Expand call")).toBeInTheDocument()
+    act(() => setCallPhase("idle"))
+    await userEvent.click(screen.getByText("launch"))
+    // Without resetting `collapsed` on the launch, the gate stays hidden behind
+    // the pill and this spinner never appears.
+    expect(await screen.findByText("Joining…")).toBeInTheDocument()
+  })
+})
+
+describe("CallDock — collapsed + mobile", () => {
+  function forceMobile() {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+  }
+
+  it("auto-collapses to a pill on mobile and offers mute, camera, and leave", async () => {
+    forceMobile()
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+
+    // Collapsed: the expanded body (CallControls' diagnostics) is not mounted.
+    expect(screen.getByLabelText("Expand call")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Connection diagnostics")).toBeNull()
+
+    await userEvent.click(screen.getByLabelText("Turn camera on"))
+    expect(manager.setCameraOn).toHaveBeenCalledWith(true)
+
+    await userEvent.click(screen.getByLabelText("Mute"))
+    expect(manager.setMuted).toHaveBeenCalledWith(true)
+
+    await userEvent.click(screen.getByLabelText("Leave call"))
+    expect(manager.leaveCall).toHaveBeenCalled()
+  })
+
+  it("reflects camera-live state in the collapsed pill", () => {
+    forceMobile()
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
+    act(() => patchCallLocal({ cameraOn: true }))
+    expect(screen.getByLabelText("Turn camera off")).toBeInTheDocument()
+  })
+
+  it("surfaces a capture error indicator while collapsed", () => {
+    forceMobile()
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
+    expect(screen.getByTestId("call-capture-error")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState, type ReactNode } from "react"
+import { toast } from "sonner"
+import { ChevronDown, ChevronUp, Mic, MicOff, PhoneOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { SidePanel, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { cn } from "@/lib/utils"
+import { useCallManager } from "./call-manager-context"
+import { useCallLaunch } from "./call-launch-context"
+import {
+  useCallActiveElsewhere,
+  useCallCaptureError,
+  useCallMuted,
+  useCallPhase,
+  useCallRoster,
+  useCallStreamId,
+  useCallWorkspaceId,
+} from "./call-store-hooks"
+import { CallTile } from "./call-tile"
+import { CallControls } from "./call-controls"
+import { PreJoinGate } from "./pre-join-gate"
+import { ActiveElsewhereChip } from "./active-elsewhere-chip"
+
+function DockFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-[340px] max-w-[calc(100vw-2rem)]">
+      <SidePanel className="rounded-lg border shadow-xl sm:border">{children}</SidePanel>
+    </div>
+  )
+}
+
+function DockHeader({ title, collapsed, onToggle }: { title: string; collapsed: boolean; onToggle: () => void }) {
+  return (
+    <SidePanelHeader className="rounded-t-lg">
+      <SidePanelTitle className="text-sm">{title}</SidePanelTitle>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0"
+        aria-label={collapsed ? "Expand call" : "Collapse call"}
+        aria-expanded={!collapsed}
+        onClick={onToggle}
+      >
+        {collapsed ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </Button>
+    </SidePanelHeader>
+  )
+}
+
+/**
+ * The docked call surface. Mounts at the app-layout level and is driven purely by
+ * the call-store phase — it deliberately survives in-app navigation and takes no
+ * URL state. INV-59 exemption (plan §Call surface): a call is session-bound
+ * hardware state no URL can restore; the URL-derived surface is the stream page
+ * hosting the card, and the refresh story is the (later) rejoin bar — so deriving
+ * the dock from `useState`/store rather than the URL is the sanctioned shape here.
+ * Non-modal: a plain fixed panel on `side-panel` (never a Radix Dialog/sheet),
+ * no autofocus, so it never traps focus or steals it from the composer.
+ */
+export function CallDock() {
+  const phase = useCallPhase()
+  const { state: launch } = useCallLaunch()
+  const activeElsewhere = useCallActiveElsewhere()
+  const storeStreamId = useCallStreamId()
+  const workspaceId = useCallWorkspaceId()
+  const [collapsed, setCollapsed] = useState(false)
+
+  const launching = launch.status !== "idle"
+  const inCall = phase === "connected" || phase === "reconnecting"
+  const joining = phase === "joining"
+
+  // The dock is always mounted, so `collapsed` would otherwise leak across call
+  // lifecycles — collapse one call, leave, start another, and the new call opens
+  // as a pill. Reset it whenever a call becomes active.
+  useEffect(() => {
+    if (inCall) setCollapsed(false)
+  }, [inCall])
+
+  // Nothing to show: idle with no launch in flight. Surface the cross-tab chip if
+  // another tab holds the call, otherwise render nothing.
+  if (!launching && !inCall && !joining) {
+    if (activeElsewhere) {
+      return (
+        <div className="fixed bottom-4 right-4 z-50">
+          <ActiveElsewhereChip />
+        </div>
+      )
+    }
+    return null
+  }
+
+  const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
+
+  if (inCall) {
+    return (
+      <ActiveCallDock
+        workspaceId={workspaceId}
+        streamId={streamIdForLabel}
+        collapsed={collapsed}
+        onToggle={() => setCollapsed((c) => !c)}
+      />
+    )
+  }
+
+  // Joining / permission gate.
+  return (
+    <DockFrame>
+      <DockHeader title="Call" collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
+      {!collapsed && (
+        <div className="p-4">{joining && launch.status === "idle" ? <JoiningBody /> : <PreJoinGate />}</div>
+      )}
+    </DockFrame>
+  )
+}
+
+function JoiningBody() {
+  return <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Connecting…</div>
+}
+
+function ActiveCallDock({
+  workspaceId,
+  streamId,
+  collapsed,
+  onToggle,
+}: {
+  workspaceId: string | null
+  streamId: string | null
+  collapsed: boolean
+  onToggle: () => void
+}) {
+  const roster = useCallRoster()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  const title = name ?? "Call"
+
+  const participants = roster.filter((p) => p.participantStatus === "joined")
+
+  if (collapsed) return <CollapsedDock title={title} onToggle={onToggle} />
+
+  return (
+    <DockFrame>
+      <DockHeader title={title} collapsed={collapsed} onToggle={onToggle} />
+      <div className="flex flex-col gap-3 p-3">
+        {captureError && (
+          <p
+            className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            role="alert"
+            data-testid="call-capture-error"
+          >
+            {captureError.code === "capture_rollback_failed"
+              ? "Your microphone stopped working and couldn't be restored. Try leaving and rejoining."
+              : "Couldn't switch your microphone or camera. Your previous device is still active."}
+          </p>
+        )}
+        <div className={cn("grid gap-2", participants.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
+          {participants.map((p) => (
+            <CallTile
+              key={p.userId}
+              participant={p}
+              workspaceId={workspaceId}
+              isSelf={!!currentUserId && p.userId === currentUserId}
+            />
+          ))}
+        </div>
+        <CallControls />
+      </div>
+    </DockFrame>
+  )
+}
+
+function CollapsedDock({ title, onToggle }: { title: string; onToggle: () => void }) {
+  const manager = useCallManager()
+  const muted = useCallMuted()
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label="Expand call"
+        aria-expanded={false}
+        className="max-w-[140px] truncate text-sm font-medium"
+      >
+        {title}
+      </button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn("h-8 w-8", muted && "text-destructive")}
+        aria-label={muted ? "Unmute" : "Mute"}
+        aria-pressed={muted}
+        onClick={() => manager.setMuted(!muted)}
+      >
+        {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+      </Button>
+      <Button
+        variant="destructive"
+        size="icon"
+        className="h-8 w-8"
+        aria-label="Leave call"
+        onClick={() => void manager.leaveCall().catch(() => toast.error("Couldn't leave the call"))}
+      >
+        <PhoneOff className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, type ReactNode } from "react"
 import { toast } from "sonner"
-import { ChevronDown, ChevronUp, Mic, MicOff, PhoneOff } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronUp, Mic, MicOff, PhoneOff, Video, VideoOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SidePanel, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { cn } from "@/lib/utils"
@@ -10,13 +11,22 @@ import { useCallManager } from "./call-manager-context"
 import { useCallLaunch } from "./call-launch-context"
 import {
   useCallActiveElsewhere,
+  useCallCameraOn,
   useCallCaptureError,
+  useCallMode,
   useCallMuted,
   useCallPhase,
   useCallRoster,
   useCallStreamId,
   useCallWorkspaceId,
 } from "./call-store-hooks"
+
+// Bottom-anchored call surfaces clear the iOS home indicator on desktop (app
+// convention — see message-composer.tsx) and, on a phone, sit a composer-height
+// above the bottom (`--composer-height`, published on :root) so the dock never
+// covers the floating composer.
+const DOCK_BOTTOM =
+  "bottom-[calc(var(--composer-height,5rem)_+_1rem)] sm:bottom-[max(1rem,env(safe-area-inset-bottom))]"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { PreJoinGate } from "./pre-join-gate"
@@ -24,7 +34,7 @@ import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 
 function DockFrame({ children }: { children: ReactNode }) {
   return (
-    <div className="fixed bottom-4 right-4 z-50 w-[340px] max-w-[calc(100vw-2rem)]">
+    <div className={cn("fixed right-4 z-50 w-[340px] max-w-[calc(100vw-2rem)]", DOCK_BOTTOM)}>
       <SidePanel className="rounded-lg border shadow-xl sm:border">{children}</SidePanel>
     </div>
   )
@@ -64,6 +74,7 @@ export function CallDock() {
   const activeElsewhere = useCallActiveElsewhere()
   const storeStreamId = useCallStreamId()
   const workspaceId = useCallWorkspaceId()
+  const isMobile = useIsMobile()
   const [collapsed, setCollapsed] = useState(false)
 
   const launching = launch.status !== "idle"
@@ -71,18 +82,25 @@ export function CallDock() {
   const joining = phase === "joining"
 
   // The dock is always mounted, so `collapsed` would otherwise leak across call
-  // lifecycles — collapse one call, leave, start another, and the new call opens
-  // as a pill. Reset it whenever a call becomes active.
+  // lifecycles. The pre-join/joining window must never be collapsed — a collapsed
+  // pill would hide the PreJoinGate and its permission taxonomy — so force it open
+  // whenever a launch is in flight or the call is connecting.
   useEffect(() => {
-    if (inCall) setCollapsed(false)
-  }, [inCall])
+    if (launching || joining) setCollapsed(false)
+  }, [launching, joining])
+
+  // On connect, reset the sticky flag: desktop opens the full dock; a phone
+  // auto-collapses to a pill so the panel never covers the composer.
+  useEffect(() => {
+    if (inCall) setCollapsed(isMobile)
+  }, [inCall, isMobile])
 
   // Nothing to show: idle with no launch in flight. Surface the cross-tab chip if
   // another tab holds the call, otherwise render nothing.
   if (!launching && !inCall && !joining) {
     if (activeElsewhere) {
       return (
-        <div className="fixed bottom-4 right-4 z-50">
+        <div className={cn("fixed right-4 z-50", DOCK_BOTTOM)}>
           <ActiveElsewhereChip />
         </div>
       )
@@ -154,7 +172,12 @@ function ActiveCallDock({
               : "Couldn't switch your microphone or camera. Your previous device is still active."}
           </p>
         )}
-        <div className={cn("grid gap-2", participants.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
+        <div
+          className={cn(
+            "grid max-h-[50vh] gap-2 overflow-y-auto",
+            participants.length > 1 ? "grid-cols-2" : "grid-cols-1"
+          )}
+        >
           {participants.map((p) => (
             <CallTile
               key={p.userId}
@@ -173,8 +196,28 @@ function ActiveCallDock({
 function CollapsedDock({ title, onToggle }: { title: string; onToggle: () => void }) {
   const manager = useCallManager()
   const muted = useCallMuted()
+  const cameraOn = useCallCameraOn()
+  const mode = useCallMode()
+  const captureError = useCallCaptureError()
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl">
+    <div
+      className={cn(
+        "fixed right-4 z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl",
+        DOCK_BOTTOM
+      )}
+    >
+      {captureError && (
+        // Compact mirror of the expanded banner — a recapture failure must stay
+        // visible while collapsed. The full message is on expand.
+        <span
+          className="flex h-8 w-8 items-center justify-center rounded-full text-destructive"
+          role="alert"
+          data-testid="call-capture-error"
+          aria-label="Microphone or camera problem — expand the call to see details"
+        >
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+        </span>
+      )}
       <button
         type="button"
         onClick={onToggle}
@@ -194,6 +237,18 @@ function CollapsedDock({ title, onToggle }: { title: string; onToggle: () => voi
       >
         {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
       </Button>
+      {mode !== "audio_only" && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
+          aria-pressed={cameraOn}
+          onClick={() => void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))}
+        >
+          {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+        </Button>
+      )}
       <Button
         variant="destructive"
         size="icon"

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -1,8 +1,10 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { toast } from "sonner"
 import type { CallMode } from "@/calls/config"
 import { CallCaptureError, CallStartCancelledError } from "@/calls/call-manager"
+import { getCallState } from "@/stores/call-store"
 import { useCallManager } from "./call-manager-context"
+import { useCallPhase } from "./call-store-hooks"
 import { classifyMediaError, type MediaPermissionError } from "./media-permissions"
 
 export interface CallLaunchRequest {
@@ -25,6 +27,8 @@ export type CallLaunchState =
 
 interface CallLaunchContextValue {
   state: CallLaunchState
+  /** True while a call is active/connecting or a launch is in flight — entry points gate on it. */
+  callActive: boolean
   launch: (request: CallLaunchRequest) => void
   retry: () => void
   cancel: () => void
@@ -34,12 +38,18 @@ const CallLaunchContext = createContext<CallLaunchContextValue | null>(null)
 
 export function CallLaunchProvider({ children }: { children: ReactNode }) {
   const manager = useCallManager()
+  const phase = useCallPhase()
   const [state, setState] = useState<CallLaunchState>({ status: "idle" })
   // Guards against a stale async settling over a newer launch/cancel.
   const runIdRef = useRef(0)
 
   const run = useCallback(
     async (request: CallLaunchRequest) => {
+      // Already in (or joining) a call: startCall would synchronously reject with
+      // a plain Error, which the catch below would surface as a stale join_error
+      // carrying the wrong request (and a "Try again" that starts an unintended
+      // call). Ignore the launch — entry points also gate their affordance.
+      if (getCallState().phase !== "idle") return
       const runId = ++runIdRef.current
       setState({ status: "requesting", request })
       // startCall is the single media acquisition and must run synchronously in the
@@ -84,9 +94,20 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
     void manager.leaveCall()
   }, [manager])
 
+  // A launch error only makes sense while idle. Once a call is actually active
+  // (or connecting), any residual join_error/permission_error is stale — clear it
+  // so no unprompted "Try again" survives to a normal call exit.
+  useEffect(() => {
+    if (phase !== "idle" && (state.status === "join_error" || state.status === "permission_error")) {
+      setState({ status: "idle" })
+    }
+  }, [phase, state.status])
+
+  const callActive = phase !== "idle" || state.status === "requesting"
+
   const value = useMemo<CallLaunchContextValue>(
-    () => ({ state, launch, retry, cancel }),
-    [state, launch, retry, cancel]
+    () => ({ state, callActive, launch, retry, cancel }),
+    [state, callActive, launch, retry, cancel]
   )
 
   return <CallLaunchContext.Provider value={value}>{children}</CallLaunchContext.Provider>

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -1,0 +1,99 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react"
+import { toast } from "sonner"
+import type { CallMode } from "@/calls/config"
+import { CallCaptureError, CallStartCancelledError } from "@/calls/call-manager"
+import { useCallManager } from "./call-manager-context"
+import { classifyMediaError, type MediaPermissionError } from "./media-permissions"
+
+export interface CallLaunchRequest {
+  workspaceId: string
+  streamId: string
+  mode: CallMode
+}
+
+/**
+ * The pre-join flow state. `requesting` spans the whole join (the dock shows a
+ * joining spinner across it); `permission_error` carries the taxonomy class so the
+ * gate renders its distinct copy + retry; `join_error` is a non-media failure
+ * (REST/socket) with a plain retry.
+ */
+export type CallLaunchState =
+  | { status: "idle" }
+  | { status: "requesting"; request: CallLaunchRequest }
+  | { status: "permission_error"; request: CallLaunchRequest; error: MediaPermissionError }
+  | { status: "join_error"; request: CallLaunchRequest; message: string }
+
+interface CallLaunchContextValue {
+  state: CallLaunchState
+  launch: (request: CallLaunchRequest) => void
+  retry: () => void
+  cancel: () => void
+}
+
+const CallLaunchContext = createContext<CallLaunchContextValue | null>(null)
+
+export function CallLaunchProvider({ children }: { children: ReactNode }) {
+  const manager = useCallManager()
+  const [state, setState] = useState<CallLaunchState>({ status: "idle" })
+  // Guards against a stale async settling over a newer launch/cancel.
+  const runIdRef = useRef(0)
+
+  const run = useCallback(
+    async (request: CallLaunchRequest) => {
+      const runId = ++runIdRef.current
+      setState({ status: "requesting", request })
+      // startCall is the single media acquisition and must run synchronously in the
+      // click's transient activation — it creates+resumes the AudioContext before
+      // its first await so iOS Safari honors it. Probing media first (a prior await)
+      // would exhaust the gesture and leave the analyser's context suspended, so the
+      // permission taxonomy is derived from startCall's own typed capture failure
+      // instead of a separate pre-flight getUserMedia.
+      try {
+        await manager.startCall(request)
+        if (runId !== runIdRef.current) return
+        setState({ status: "idle" })
+      } catch (err) {
+        if (runId !== runIdRef.current) return
+        // A cancel during joining rolls the manager back cleanly — not an error surface.
+        if (err instanceof CallStartCancelledError) {
+          setState({ status: "idle" })
+          return
+        }
+        if (err instanceof CallCaptureError) {
+          const error = classifyMediaError((err as { cause?: unknown }).cause ?? err)
+          setState({ status: "permission_error", request, error })
+          return
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        setState({ status: "join_error", request, message })
+        toast.error("Couldn't start the call")
+      }
+    },
+    [manager]
+  )
+
+  const launch = useCallback((request: CallLaunchRequest) => void run(request), [run])
+
+  const retry = useCallback(() => {
+    if (state.status === "permission_error" || state.status === "join_error") void run(state.request)
+  }, [run, state])
+
+  const cancel = useCallback(() => {
+    runIdRef.current++
+    setState({ status: "idle" })
+    void manager.leaveCall()
+  }, [manager])
+
+  const value = useMemo<CallLaunchContextValue>(
+    () => ({ state, launch, retry, cancel }),
+    [state, launch, retry, cancel]
+  )
+
+  return <CallLaunchContext.Provider value={value}>{children}</CallLaunchContext.Provider>
+}
+
+export function useCallLaunch(): CallLaunchContextValue {
+  const ctx = useContext(CallLaunchContext)
+  if (!ctx) throw new Error("useCallLaunch must be used within a CallLaunchProvider")
+  return ctx
+}

--- a/apps/frontend/src/components/call/call-manager-context.tsx
+++ b/apps/frontend/src/components/call/call-manager-context.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext, type ReactNode } from "react"
+import { getCallManager, type CallController } from "@/calls/call-manager"
+
+// Components speak to the call only through this handle (INV-15 — never the
+// transport or sockets). Production resolves the account-scoped singleton;
+// tests inject a spy fake via the provider.
+const CallManagerContext = createContext<CallController | null>(null)
+
+export function CallManagerProvider({ manager, children }: { manager: CallController; children: ReactNode }) {
+  return <CallManagerContext.Provider value={manager}>{children}</CallManagerContext.Provider>
+}
+
+export function useCallManager(): CallController {
+  return useContext(CallManagerContext) ?? getCallManager()
+}

--- a/apps/frontend/src/components/call/call-store-hooks.test.tsx
+++ b/apps/frontend/src/components/call/call-store-hooks.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { act } from "@testing-library/react"
+import { render } from "@/test"
+import { clearCallState, setCallPhase, setCallSpeakingLevel, getCallState } from "@/stores/call-store"
+import { useCallPhase, useSpeakingLevelRef } from "./call-store-hooks"
+
+let renderCount = 0
+
+function PhaseConsumer() {
+  renderCount++
+  const phase = useCallPhase()
+  return <span data-testid="phase">{phase}</span>
+}
+
+function SpeakingRing() {
+  const ref = useSpeakingLevelRef<HTMLDivElement>()
+  return <div ref={ref} data-testid="ring" />
+}
+
+beforeEach(() => {
+  clearCallState()
+  renderCount = 0
+})
+
+describe("call store selector isolation (60fps guard)", () => {
+  it("does not re-render a phase consumer when only the speaking level ticks", () => {
+    render(<PhaseConsumer />)
+    expect(renderCount).toBe(1)
+
+    // A burst of analyser-frequency level updates: none touch the phase slice.
+    act(() => {
+      for (let i = 0; i < 30; i++) setCallSpeakingLevel(i / 30)
+    })
+    expect(renderCount).toBe(1)
+
+    // A real phase change does re-render.
+    act(() => setCallPhase("connected"))
+    expect(renderCount).toBe(2)
+  })
+
+  it("writes the live level into a CSS var on the ring node without React state", () => {
+    const { getByTestId } = render(<SpeakingRing />)
+    act(() => setCallSpeakingLevel(0.7))
+    expect(getByTestId("ring").style.getPropertyValue("--speaking-level")).toBe("0.7")
+    expect(getCallState().local.speakingLevel).toBe(0.7)
+  })
+})

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react"
+import {
+  subscribeCall,
+  getCallState,
+  type CallState,
+  type CallPhase,
+  type CallRosterParticipant,
+  type CallDeviceState,
+  type CallDiagnostics,
+  type CallCaptureErrorInfo,
+} from "@/stores/call-store"
+
+/**
+ * Slice-scoped reads over the call store. {@link useCallState} re-renders every
+ * consumer on ANY change — including the per-frame `speakingLevel` tick from the
+ * analyser (the 1.1 review's flagged 60fps concern). These hooks cache the
+ * selected value by reference so a store change that doesn't touch the slice
+ * yields the same snapshot and React bails the re-render. The speaking level is
+ * never selected here — it drives the tile ring through {@link useSpeakingLevelRef}
+ * (ref-only, zero re-renders) — so a talking participant never re-renders the dock.
+ */
+function useCallSelector<T>(selector: (s: CallState) => T, isEqual: (a: T, b: T) => boolean = Object.is): T {
+  const selectorRef = useRef(selector)
+  selectorRef.current = selector
+  const isEqualRef = useRef(isEqual)
+  isEqualRef.current = isEqual
+  const cache = useRef<{ value: T } | null>(null)
+  const getSnapshot = useCallback(() => {
+    const next = selectorRef.current(getCallState())
+    const prev = cache.current
+    if (prev && isEqualRef.current(prev.value, next)) return prev.value
+    cache.current = { value: next }
+    return next
+  }, [])
+  return useSyncExternalStore(subscribeCall, getSnapshot, getSnapshot)
+}
+
+export function useCallPhase(): CallPhase {
+  return useCallSelector((s) => s.phase)
+}
+
+export function useCallStreamId(): string | null {
+  return useCallSelector((s) => s.streamId)
+}
+
+export function useCallWorkspaceId(): string | null {
+  return useCallSelector((s) => s.workspaceId)
+}
+
+export function useCallRoster(): CallRosterParticipant[] {
+  // A roster update replaces the array reference, so identity equality is a
+  // precise change signal — the per-frame speaking tick never touches it.
+  return useCallSelector((s) => s.roster)
+}
+
+export function useCallMuted(): boolean {
+  return useCallSelector((s) => s.local.muted)
+}
+
+export function useCallCameraOn(): boolean {
+  return useCallSelector((s) => s.local.cameraOn)
+}
+
+export function useCallDevices(): CallDeviceState {
+  return useCallSelector((s) => s.local.devices)
+}
+
+export function useCallDiagnostics(): CallDiagnostics {
+  return useCallSelector((s) => s.diagnostics)
+}
+
+export function useCallActiveElsewhere(): boolean {
+  return useCallSelector((s) => s.activeElsewhere)
+}
+
+export function useCallCaptureError(): CallCaptureErrorInfo | null {
+  return useCallSelector((s) => s.captureError)
+}
+
+export function useCallMediaEpoch(): number {
+  return useCallSelector((s) => s.mediaEpoch)
+}
+
+/**
+ * Drive a speaking-indicator element from the local analyser level WITHOUT a
+ * React re-render: the effect subscribes to the store and writes the level into
+ * a CSS custom property (`--speaking-level`) on the referenced node on every
+ * tick. The ring's opacity/scale reads that var, so a 60fps level stream is one
+ * cheap style write per frame and zero reconciliation. Only the self tile has a
+ * level (the roster carries no per-peer level in v1), so only it uses this.
+ */
+export function useSpeakingLevelRef<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  useEffect(() => {
+    const apply = () => {
+      const el = ref.current
+      if (!el) return
+      el.style.setProperty("--speaking-level", String(getCallState().local.speakingLevel))
+    }
+    apply()
+    return subscribeCall(apply)
+  }, [])
+  return ref
+}

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -9,6 +9,7 @@ import {
   type CallDiagnostics,
   type CallCaptureErrorInfo,
 } from "@/stores/call-store"
+import type { CallMode } from "@/calls/config"
 
 /**
  * Slice-scoped reads over the call store. {@link useCallState} re-renders every
@@ -41,6 +42,10 @@ export function useCallPhase(): CallPhase {
 
 export function useCallStreamId(): string | null {
   return useCallSelector((s) => s.streamId)
+}
+
+export function useCallMode(): CallMode | null {
+  return useCallSelector((s) => s.mode)
 }
 
 export function useCallWorkspaceId(): string | null {

--- a/apps/frontend/src/components/call/call-tile.tsx
+++ b/apps/frontend/src/components/call/call-tile.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react"
+import { MicOff } from "lucide-react"
+import { getAvatarUrl } from "@threa/types"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { getInitials } from "@/lib/initials"
+import { cn } from "@/lib/utils"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+import type { CallRosterParticipant } from "@/stores/call-store"
+import { useCallManager } from "./call-manager-context"
+import { useCallMediaEpoch, useCallMuted, useSpeakingLevelRef } from "./call-store-hooks"
+
+interface CallTileProps {
+  participant: CallRosterParticipant
+  workspaceId: string | null
+  isSelf: boolean
+}
+
+/**
+ * One participant. Video attaches by ref from the manager's per-endpoint stream
+ * registry (media objects never enter the store snapshot — {@link useCallMediaEpoch}
+ * is the version tick that re-runs the attach). The self tile's speaking ring is
+ * ref-driven (`useSpeakingLevelRef`) so the analyser's per-frame level never
+ * re-renders the tile, let alone the dock.
+ */
+export function CallTile({ participant, workspaceId, isSelf }: CallTileProps) {
+  const users = useWorkspaceUsers(workspaceId ?? undefined)
+  const user = users.find((u) => u.id === participant.userId)
+  const name = user?.name ?? "Unknown"
+  const avatarUrl = user && workspaceId ? getAvatarUrl(workspaceId, user.avatarUrl, 64) : undefined
+
+  const mediaEpoch = useCallMediaEpoch()
+  const manager = useCallManager()
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [hasVideo, setHasVideo] = useState(false)
+  const endpointId = participant.endpointId
+
+  useEffect(() => {
+    const el = videoRef.current
+    const stream = endpointId ? manager.getVideoStream(endpointId) : null
+    if (el) el.srcObject = stream
+    setHasVideo(!!stream)
+    // mediaEpoch bumps whenever the manager's video ref-map changes.
+    return () => {
+      // Null the binding on unmount (symmetric with detachRemoteAudio); the manager
+      // owns the MediaStream lifecycle, so this only drops the element's reference.
+      if (el) el.srcObject = null
+    }
+  }, [manager, endpointId, mediaEpoch])
+
+  // Only the local participant carries a live speaking level; remote peers have
+  // none in v1, so the ring is self-only.
+  const selfMuted = useCallMuted()
+  const speakingRef = useSpeakingLevelRef<HTMLDivElement>()
+  const muted = isSelf ? selfMuted : participant.mediaState.muted === true
+  const reconnecting = participant.connectionStatus === "reconnecting"
+
+  return (
+    <div
+      className={cn("relative aspect-video overflow-hidden rounded-md bg-muted", reconnecting && "opacity-50")}
+      data-testid="call-tile"
+      data-user-id={participant.userId}
+    >
+      {isSelf && (
+        <div
+          ref={speakingRef}
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-md ring-2 ring-primary"
+          // Ref-driven: opacity tracks the CSS var written each analyser frame.
+          style={{ opacity: "var(--speaking-level, 0)" }}
+        />
+      )}
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        className={cn("h-full w-full object-cover", !hasVideo && "hidden")}
+        data-testid="call-tile-video"
+      />
+      {!hasVideo && (
+        <div className="flex h-full w-full items-center justify-center">
+          <Avatar className="h-12 w-12">
+            {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
+            <AvatarFallback>{getInitials(name)}</AvatarFallback>
+          </Avatar>
+        </div>
+      )}
+      <div className="absolute inset-x-0 bottom-0 flex items-center gap-1 bg-gradient-to-t from-black/60 to-transparent px-2 py-1">
+        {muted && <MicOff className="h-3 w-3 text-white" aria-label="Muted" />}
+        <span className="truncate text-xs font-medium text-white">
+          {name}
+          {isSelf && " (you)"}
+        </span>
+        {reconnecting && <span className="ml-auto text-[10px] text-white/80">Reconnecting…</span>}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/index.ts
+++ b/apps/frontend/src/components/call/index.ts
@@ -1,0 +1,3 @@
+export { CallDock } from "./call-dock"
+export { CallLaunchProvider, useCallLaunch, type CallLaunchRequest } from "./call-launch-context"
+export { CallManagerProvider, useCallManager } from "./call-manager-context"

--- a/apps/frontend/src/components/call/media-permissions.test.ts
+++ b/apps/frontend/src/components/call/media-permissions.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { classifyMediaError } from "./media-permissions"
+
+function domError(name: string, message = ""): Error {
+  return Object.assign(new Error(message), { name })
+}
+
+describe("classifyMediaError", () => {
+  it("maps a plain permission denial to denied", () => {
+    expect(classifyMediaError(domError("NotAllowedError", "Permission denied")).kind).toBe("denied")
+  })
+
+  it("maps a system/OS denial to os_denied", () => {
+    expect(classifyMediaError(domError("NotAllowedError", "Permission denied by system")).kind).toBe("os_denied")
+  })
+
+  it("maps a permissions-policy block to blocked_by_policy", () => {
+    expect(classifyMediaError(domError("NotAllowedError", "disallowed by permissions policy")).kind).toBe(
+      "blocked_by_policy"
+    )
+  })
+
+  it("maps missing hardware to no_device", () => {
+    expect(classifyMediaError(domError("NotFoundError")).kind).toBe("no_device")
+    expect(classifyMediaError(domError("OverconstrainedError")).kind).toBe("no_device")
+  })
+
+  it("maps an in-use device to device_busy", () => {
+    expect(classifyMediaError(domError("NotReadableError")).kind).toBe("device_busy")
+  })
+
+  it("falls back to unknown", () => {
+    expect(classifyMediaError(domError("WeirdError")).kind).toBe("unknown")
+  })
+})

--- a/apps/frontend/src/components/call/media-permissions.ts
+++ b/apps/frontend/src/components/call/media-permissions.ts
@@ -1,0 +1,55 @@
+/**
+ * The pre-join permission taxonomy (plan §Permission UX). A `getUserMedia`
+ * rejection carries a `DOMException` whose `name` (and, for the OS-vs-user
+ * split, a stable substring of its `message`) is an API contract, not natural
+ * language — matching on it is the sanctioned way to tell these apart, and the
+ * dock renders distinct copy + retry affordance per class.
+ */
+export type MediaPermissionErrorKind =
+  | "blocked_by_policy"
+  | "denied"
+  | "no_device"
+  | "device_busy"
+  | "os_denied"
+  | "unknown"
+
+export interface MediaPermissionError {
+  kind: MediaPermissionErrorKind
+  /** The raw error message, for diagnostics/telemetry — not shown verbatim to the user. */
+  message: string
+}
+
+function nameOf(err: unknown): string {
+  return err && typeof err === "object" && "name" in err ? String((err as { name?: unknown }).name) : ""
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Map a `getUserMedia` rejection to a taxonomy class. The OS-denial and
+ * blocked-by-policy cases both surface as `NotAllowedError`, split by the
+ * message the engine attaches (`system` for OS privacy denials, `policy` for a
+ * Permissions-Policy / feature-policy block); everything else keys on `name`.
+ */
+export function classifyMediaError(err: unknown): MediaPermissionError {
+  const name = nameOf(err)
+  const message = messageOf(err)
+  const lower = message.toLowerCase()
+
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    if (lower.includes("policy") || lower.includes("disallowed") || lower.includes("feature")) {
+      return { kind: "blocked_by_policy", message }
+    }
+    if (lower.includes("system")) return { kind: "os_denied", message }
+    return { kind: "denied", message }
+  }
+  if (name === "NotFoundError" || name === "OverconstrainedError" || name === "DevicesNotFoundError") {
+    return { kind: "no_device", message }
+  }
+  if (name === "NotReadableError" || name === "TrackStartError" || name === "AbortError") {
+    return { kind: "device_busy", message }
+  }
+  return { kind: "unknown", message }
+}

--- a/apps/frontend/src/components/call/pre-join-gate.tsx
+++ b/apps/frontend/src/components/call/pre-join-gate.tsx
@@ -39,9 +39,11 @@ const PERMISSION_COPY: Record<MediaPermissionErrorKind, { title: string; body: s
 }
 
 /**
- * The joining phase of the dock: a spinner while the permission probe + join run,
- * or the taxonomy-specific permission error with retry/cancel. Rendered by the
- * dock whenever a launch is in flight or has failed pre-connection.
+ * The joining phase of the dock: a spinner while the join runs, or the
+ * taxonomy-specific permission error with retry/cancel. There is no separate
+ * permission probe — the taxonomy derives from the start path's own typed
+ * capture failure. Rendered by the dock whenever a launch is in flight or has
+ * failed pre-connection.
  */
 export function PreJoinGate() {
   const { state, retry, cancel } = useCallLaunch()

--- a/apps/frontend/src/components/call/pre-join-gate.tsx
+++ b/apps/frontend/src/components/call/pre-join-gate.tsx
@@ -1,0 +1,97 @@
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useCallLaunch } from "./call-launch-context"
+import type { MediaPermissionErrorKind } from "./media-permissions"
+
+// Distinct copy per permission-taxonomy class (plan §Permission UX). Each states
+// what happened and the concrete next step, so the retry affordance is honest.
+const PERMISSION_COPY: Record<MediaPermissionErrorKind, { title: string; body: string; retry: string }> = {
+  blocked_by_policy: {
+    title: "Calls are blocked here",
+    body: "Your browser or organization policy is blocking camera and microphone access on this page. An administrator has to allow it.",
+    retry: "Try again",
+  },
+  denied: {
+    title: "Microphone access denied",
+    body: "Allow microphone (and camera) access for this site in your browser, then try again.",
+    retry: "Try again",
+  },
+  no_device: {
+    title: "No microphone found",
+    body: "We couldn't find a microphone to use. Connect one and try again.",
+    retry: "Try again",
+  },
+  device_busy: {
+    title: "Your microphone is busy",
+    body: "Another app is using your microphone or camera. Close it, then try again.",
+    retry: "Try again",
+  },
+  os_denied: {
+    title: "Blocked by your system",
+    body: "Your operating system is blocking microphone or camera access for this browser. Enable it in your system privacy settings, then try again.",
+    retry: "Try again",
+  },
+  unknown: {
+    title: "Couldn't access your devices",
+    body: "Something went wrong getting your microphone or camera. Try again.",
+    retry: "Try again",
+  },
+}
+
+/**
+ * The joining phase of the dock: a spinner while the permission probe + join run,
+ * or the taxonomy-specific permission error with retry/cancel. Rendered by the
+ * dock whenever a launch is in flight or has failed pre-connection.
+ */
+export function PreJoinGate() {
+  const { state, retry, cancel } = useCallLaunch()
+
+  if (state.status === "requesting") {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 text-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden />
+        <p className="text-sm text-muted-foreground">Joining…</p>
+        <Button variant="ghost" size="sm" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    )
+  }
+
+  if (state.status === "join_error") {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 text-center">
+        <p className="text-sm font-medium">Couldn't start the call</p>
+        <p className="text-xs text-muted-foreground">The call service didn't respond. Try again in a moment.</p>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={cancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={retry}>
+            Try again
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.status === "permission_error") {
+    const copy = PERMISSION_COPY[state.error.kind]
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 text-center" data-error-kind={state.error.kind}>
+        <p className="text-sm font-medium">{copy.title}</p>
+        <p className="text-xs text-muted-foreground">{copy.body}</p>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={cancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={retry}>
+            {copy.retry}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { WorkspaceBootstrap } from "@threa/types"
+import { render, screen, userEvent, waitFor } from "@/test"
+import * as authModule from "@/auth"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+
+type SeedData = Parameters<typeof seedWorkspaceCache>[1]
+type CachedWorkspaceUser = SeedData["users"][number]
+type CachedDmPeer = SeedData["dmPeers"][number]
+import type { CallController } from "@/calls/call-manager"
+import { CallLaunchProvider } from "@/components/call/call-launch-context"
+import { CallManagerProvider } from "@/components/call/call-manager-context"
+import { UserProfileModal } from "./user-profile-modal"
+
+const WORKSPACE_ID = "workspace_1"
+const PEER_ID = "usr_peer"
+
+function cachedUser(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function seed(dmPeers: CachedDmPeer[]) {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      cachedUser({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      cachedUser({ id: PEER_ID, workosUserId: "workos_peer", slug: "grace", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers,
+    personas: [],
+    bots: [],
+  })
+}
+
+function makeManager(): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+  }
+}
+
+function renderModal(manager: CallController, callsEnabled: boolean) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), {
+    workspaceSettings: { callsEnabled },
+  } as unknown as WorkspaceBootstrap)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}`]}>
+        <CallManagerProvider manager={manager}>
+          <CallLaunchProvider>
+            <Routes>
+              <Route
+                path="/w/:workspaceId"
+                element={<UserProfileModal userId={PEER_ID} open onOpenChange={() => {}} />}
+              />
+            </Routes>
+          </CallLaunchProvider>
+        </CallManagerProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const withDm: CachedDmPeer[] = [
+  {
+    id: `${WORKSPACE_ID}:stream_dm`,
+    workspaceId: WORKSPACE_ID,
+    userId: PEER_ID,
+    streamId: "stream_dm",
+    _cachedAt: Date.now(),
+  },
+]
+
+beforeEach(() => {
+  resetWorkspaceStoreCache()
+  vi.spyOn(authModule, "useAuth").mockReturnValue({ user: { id: "workos_self" } } as ReturnType<
+    typeof authModule.useAuth
+  >)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("UserProfileModal — Call entry point", () => {
+  it("hides Call entirely when the workspace calls flag is off", () => {
+    seed(withDm)
+    renderModal(makeManager(), false)
+    expect(screen.getByRole("link", { name: /Message/i })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Call$/i })).toBeNull()
+  })
+
+  it("disables Call until a DM exists (v1 has no message-less DM materialization)", () => {
+    seed([])
+    renderModal(makeManager(), true)
+    expect(screen.getByRole("button", { name: /^Call$/i })).toBeDisabled()
+  })
+
+  it("starts a call on the existing DM stream when enabled", async () => {
+    seed(withDm)
+    const manager = makeManager()
+    renderModal(manager, true)
+    await userEvent.click(screen.getByRole("button", { name: /^Call$/i }))
+    await waitFor(() =>
+      expect(manager.startCall).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_dm",
+        mode: "video",
+      })
+    )
+  })
+})

--- a/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, userEvent, waitFor } from "@/test"
 import * as authModule from "@/auth"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { clearCallState, setCallPhase } from "@/stores/call-store"
 
 type SeedData = Parameters<typeof seedWorkspaceCache>[1]
 type CachedWorkspaceUser = SeedData["users"][number]
@@ -116,6 +117,7 @@ const withDm: CachedDmPeer[] = [
 
 beforeEach(() => {
   resetWorkspaceStoreCache()
+  clearCallState()
   vi.spyOn(authModule, "useAuth").mockReturnValue({ user: { id: "workos_self" } } as ReturnType<
     typeof authModule.useAuth
   >)
@@ -149,5 +151,25 @@ describe("UserProfileModal — Call entry point", () => {
         mode: "video",
       })
     )
+  })
+
+  it("disables Call while the viewer is already in a call", () => {
+    seed(withDm)
+    setCallPhase("connected")
+    renderModal(makeManager(), true)
+    expect(screen.getByRole("button", { name: /^Call$/i })).toBeDisabled()
+  })
+
+  it("exposes the disabled reason through a focusable tooltip trigger, not a bare title", () => {
+    seed([])
+    renderModal(makeManager(), true)
+    const callBtn = screen.getByRole("button", { name: /^Call$/i })
+    expect(callBtn).toBeDisabled()
+    // A disabled button isn't focusable and screen readers ignore an ancestor's
+    // `title`, so the reason lives on a focusable Radix tooltip trigger instead.
+    const wrapper = callBtn.parentElement as HTMLElement
+    expect(wrapper).toHaveAttribute("tabindex", "0")
+    expect(wrapper).toHaveAttribute("data-state")
+    expect(wrapper).not.toHaveAttribute("title")
   })
 })

--- a/apps/frontend/src/components/user-profile/user-profile-modal.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -21,6 +22,57 @@ import { useAuth } from "@/auth"
 import { getAvatarUrl, resolveActiveStatus, type User } from "@threa/types"
 import { getInitials } from "@/lib/initials"
 import { formatStatusClearLabel } from "@/lib/status"
+
+/**
+ * The profile Call button. A call needs a real DM stream (v1 has no message-less
+ * DM materialization — `createDm` posts on first send), and can't start while the
+ * viewer is already in a call. When disabled, the reason is exposed through a
+ * focusable Tooltip wrapper rather than a native `title` on the disabled button —
+ * a disabled button isn't focusable and screen readers don't announce an
+ * ancestor's `title`, so `title` alone reaches neither keyboard, SR, nor touch.
+ */
+function ProfileCallButton({
+  workspaceId,
+  dmStreamId,
+  callActive,
+  onLaunch,
+}: {
+  workspaceId: string | undefined
+  dmStreamId: string | undefined
+  callActive: boolean
+  onLaunch: (streamId: string) => void
+}) {
+  let disabledReason: string | null = null
+  if (!dmStreamId) disabledReason = "Send a message first to start a call"
+  else if (callActive) disabledReason = "You're already in a call"
+
+  const button = (
+    <Button
+      variant="outline"
+      disabled={disabledReason !== null}
+      onClick={() => {
+        if (disabledReason !== null || !workspaceId || !dmStreamId) return
+        onLaunch(dmStreamId)
+      }}
+    >
+      <Phone className="h-4 w-4 mr-2" />
+      Call
+    </Button>
+  )
+
+  if (disabledReason === null) return button
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0} className="inline-flex rounded-md">
+          {button}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{disabledReason}</TooltipContent>
+    </Tooltip>
+  )
+}
 
 function getRoleBadge(role: User["role"]) {
   switch (role) {
@@ -64,7 +116,7 @@ export function UserProfileModal({ userId, open, onOpenChange }: UserProfileModa
 
   const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
   const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
-  const { launch: launchCall } = useCallLaunch()
+  const { launch: launchCall, callActive } = useCallLaunch()
 
   if (!user) return null
 
@@ -149,24 +201,15 @@ export function UserProfileModal({ userId, open, onOpenChange }: UserProfileModa
                   Message
                 </Link>
                 {callsEnabled && (
-                  // A call needs a real DM stream; v1 has no message-less DM
-                  // materialization path (createDm posts on first send), so Call
-                  // is disabled until a DM exists — wrapped in a titled span so
-                  // the reason shows on a disabled button.
-                  <span title={existingDmStreamId ? undefined : "Send a message first to start a call"}>
-                    <Button
-                      variant="outline"
-                      disabled={!existingDmStreamId}
-                      onClick={() => {
-                        if (!existingDmStreamId || !workspaceId) return
-                        onOpenChange(false)
-                        launchCall({ workspaceId, streamId: existingDmStreamId, mode: "video" })
-                      }}
-                    >
-                      <Phone className="h-4 w-4 mr-2" />
-                      Call
-                    </Button>
-                  </span>
+                  <ProfileCallButton
+                    workspaceId={workspaceId}
+                    dmStreamId={existingDmStreamId}
+                    callActive={callActive}
+                    onLaunch={(streamId) => {
+                      onOpenChange(false)
+                      launchCall({ workspaceId: workspaceId!, streamId, mode: "video" })
+                    }}
+                  />
                 )}
               </div>
             </>

--- a/apps/frontend/src/components/user-profile/user-profile-modal.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.tsx
@@ -2,7 +2,7 @@ import { useParams, Link } from "react-router-dom"
 import { MessageCircle, Phone, Github, Globe } from "lucide-react"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import {
   ResponsiveDialog,
@@ -13,6 +13,8 @@ import {
   ResponsiveDialogBody,
 } from "@/components/ui/responsive-dialog"
 import { createDmDraftId } from "@/hooks"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { useCallLaunch } from "@/components/call"
 import { useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useAuth } from "@/auth"
@@ -59,6 +61,10 @@ export function UserProfileModal({ userId, open, onOpenChange }: UserProfileModa
   const existingDmStreamId = idbDmPeers.find((p) => p.userId === userId)?.streamId
   const messageStreamId = existingDmStreamId ?? createDmDraftId(userId)
   const messageHref = workspaceId ? `/w/${workspaceId}/s/${messageStreamId}` : undefined
+
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
+  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
+  const { launch: launchCall } = useCallLaunch()
 
   if (!user) return null
 
@@ -133,14 +139,36 @@ export function UserProfileModal({ userId, open, onOpenChange }: UserProfileModa
           {!isOwnProfile && messageHref && (
             <>
               <Separator />
-              <Link
-                to={messageHref}
-                onClick={() => onOpenChange(false)}
-                className={buttonVariants({ className: "w-full" })}
-              >
-                <MessageCircle className="h-4 w-4 mr-2" />
-                Message
-              </Link>
+              <div className="flex gap-2">
+                <Link
+                  to={messageHref}
+                  onClick={() => onOpenChange(false)}
+                  className={buttonVariants({ className: "flex-1" })}
+                >
+                  <MessageCircle className="h-4 w-4 mr-2" />
+                  Message
+                </Link>
+                {callsEnabled && (
+                  // A call needs a real DM stream; v1 has no message-less DM
+                  // materialization path (createDm posts on first send), so Call
+                  // is disabled until a DM exists — wrapped in a titled span so
+                  // the reason shows on a disabled button.
+                  <span title={existingDmStreamId ? undefined : "Send a message first to start a call"}>
+                    <Button
+                      variant="outline"
+                      disabled={!existingDmStreamId}
+                      onClick={() => {
+                        if (!existingDmStreamId || !workspaceId) return
+                        onOpenChange(false)
+                        launchCall({ workspaceId, streamId: existingDmStreamId, mode: "video" })
+                      }}
+                    >
+                      <Phone className="h-4 w-4 mr-2" />
+                      Call
+                    </Button>
+                  </span>
+                )}
+              </div>
             </>
           )}
         </ResponsiveDialogBody>

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -226,7 +226,7 @@ export function StreamPage() {
 
   const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
   const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
-  const { launch: launchCall } = useCallLaunch()
+  const { launch: launchCall, callActive } = useCallLaunch()
 
   const isThread = stream?.type === StreamTypes.THREAD
   const isChannel = stream?.type === StreamTypes.CHANNEL
@@ -724,8 +724,9 @@ export function StreamPage() {
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8"
-                title="Start a call"
-                aria-label="Start a call"
+                title={callActive ? "You're already in a call" : "Start a call"}
+                aria-label={callActive ? "You're already in a call" : "Start a call"}
+                disabled={callActive}
                 onClick={() => launchCall({ workspaceId: workspaceId!, streamId: streamId!, mode: "video" })}
               >
                 <Phone className="h-4 w-4" />

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -20,6 +20,7 @@ import {
   PanelRight,
   ChevronDown,
   UserRound,
+  Phone,
 } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { DraftAgentSettings } from "@/components/stream-settings/draft-agent-settings"
@@ -50,7 +51,8 @@ import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-enc
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
 import { useDecryptedStreamName, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
 import { Skeleton } from "@/components/ui/skeleton"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useWorkspaceUserId, useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { useCallLaunch } from "@/components/call"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle, StreamTitlePreview } from "@/components/layout"
@@ -221,6 +223,10 @@ export function StreamPage() {
   // scratchpad. Drives the "External" pill state and its connection dot.
   // Called here (above the early returns below) to keep hook order stable.
   const activeBotPresence = useActiveBotPresence(workspaceId, streamId)
+
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
+  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
+  const { launch: launchCall } = useCallLaunch()
 
   const isThread = stream?.type === StreamTypes.THREAD
   const isChannel = stream?.type === StreamTypes.CHANNEL
@@ -711,6 +717,20 @@ export function StreamPage() {
             )}
           </div>
           <div className="flex items-center gap-1 ml-1">
+            {stream && !isDraft && (isChannel || isDm) && callsEnabled && (
+              // Dark feature: rendered only when the workspace `callsEnabled`
+              // setting is on, so an off workspace shows no calls surface at all.
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title="Start a call"
+                aria-label="Start a call"
+                onClick={() => launchCall({ workspaceId: workspaceId!, streamId: streamId!, mode: "video" })}
+              >
+                <Phone className="h-4 w-4" />
+              </Button>
+            )}
             {!isThread && !isDraft && (
               <Button
                 variant="ghost"

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -73,6 +73,7 @@ import { CreateChannelDialog } from "@/components/create-channel"
 import { AttachmentExplorer, useExplorerUrlState } from "@/components/attachment-explorer"
 import { SearchPanelProvider, useSearchPanel } from "@/components/search"
 import { E2eUnlockProvider } from "@/components/encryption/e2e-unlock-provider"
+import { CallDock, CallLaunchProvider } from "@/components/call"
 import { EnclaveRewrapNudgeListener } from "@/components/encryption/enclave-rewrap-nudge-listener"
 import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
@@ -467,62 +468,65 @@ export function WorkspaceLayout() {
           <StreamNameDecryptor workspaceId={workspaceId} />
           <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={streamIds}>
             <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>
-              <UserProfileProvider>
-                <MentionableWrapper mentionables={mentionables}>
-                  <WorkspaceCommandListProvider workspaceId={workspaceId}>
-                    <WorkspaceEmojiProvider workspaceId={workspaceId}>
-                      <PreferencesProvider workspaceId={workspaceId}>
-                        <SettingsProvider>
-                          <WorkspaceKeyboardHandler onOpenSwitcher={openSwitcher} currentStreamId={streamId}>
-                            <E2eUnlockProvider workspaceId={workspaceId}>
-                              <QuickSwitcherProvider openSwitcher={openSwitcher}>
-                                <PanelProvider>
-                                  <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
-                                  <EnclaveRewrapNudgeListener workspaceId={workspaceId} />
-                                  <MediaGalleryProvider>
-                                    <TraceProvider>
-                                      <SidebarProvider>
-                                        <SearchPanelProvider workspaceId={workspaceId}>
-                                          <SidebarKeyboardHandler />
-                                          <SearchKeyboardHandler />
-                                          <CoordinatedLoadingGate>
-                                            <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
-                                              <MainContentGate>
-                                                <Outlet />
-                                              </MainContentGate>
-                                            </AppShell>
-                                          </CoordinatedLoadingGate>
-                                          <QuickSwitcher
-                                            workspaceId={workspaceId}
-                                            open={switcherOpen}
-                                            onOpenChange={setSwitcherOpen}
-                                            initialMode={switcherMode}
-                                            currentStreamId={streamId}
-                                          />
-                                          <ComposeOverlayMount workspaceId={workspaceId} />
-                                        </SearchPanelProvider>
-                                      </SidebarProvider>
-                                      <SettingsDialog />
-                                      <WorkspaceSettingsDialog workspaceId={workspaceId} />
-                                      <AccountSwitcherDialog />
-                                      <LogoutScopeDialog />
-                                      <StreamSettingsDialog workspaceId={workspaceId} />
-                                      <CreateChannelDialog workspaceId={workspaceId} />
-                                      <AttachmentExplorer workspaceId={workspaceId} />
-                                      <TraceDialogContainer />
-                                      <Toaster />
-                                    </TraceProvider>
-                                  </MediaGalleryProvider>
-                                </PanelProvider>
-                              </QuickSwitcherProvider>
-                            </E2eUnlockProvider>
-                          </WorkspaceKeyboardHandler>
-                        </SettingsProvider>
-                      </PreferencesProvider>
-                    </WorkspaceEmojiProvider>
-                  </WorkspaceCommandListProvider>
-                </MentionableWrapper>
-              </UserProfileProvider>
+              <CallLaunchProvider>
+                <UserProfileProvider>
+                  <MentionableWrapper mentionables={mentionables}>
+                    <WorkspaceCommandListProvider workspaceId={workspaceId}>
+                      <WorkspaceEmojiProvider workspaceId={workspaceId}>
+                        <PreferencesProvider workspaceId={workspaceId}>
+                          <SettingsProvider>
+                            <WorkspaceKeyboardHandler onOpenSwitcher={openSwitcher} currentStreamId={streamId}>
+                              <E2eUnlockProvider workspaceId={workspaceId}>
+                                <QuickSwitcherProvider openSwitcher={openSwitcher}>
+                                  <PanelProvider>
+                                    <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
+                                    <EnclaveRewrapNudgeListener workspaceId={workspaceId} />
+                                    <MediaGalleryProvider>
+                                      <TraceProvider>
+                                        <SidebarProvider>
+                                          <SearchPanelProvider workspaceId={workspaceId}>
+                                            <SidebarKeyboardHandler />
+                                            <SearchKeyboardHandler />
+                                            <CoordinatedLoadingGate>
+                                              <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
+                                                <MainContentGate>
+                                                  <Outlet />
+                                                </MainContentGate>
+                                              </AppShell>
+                                            </CoordinatedLoadingGate>
+                                            <QuickSwitcher
+                                              workspaceId={workspaceId}
+                                              open={switcherOpen}
+                                              onOpenChange={setSwitcherOpen}
+                                              initialMode={switcherMode}
+                                              currentStreamId={streamId}
+                                            />
+                                            <ComposeOverlayMount workspaceId={workspaceId} />
+                                          </SearchPanelProvider>
+                                        </SidebarProvider>
+                                        <SettingsDialog />
+                                        <WorkspaceSettingsDialog workspaceId={workspaceId} />
+                                        <AccountSwitcherDialog />
+                                        <LogoutScopeDialog />
+                                        <StreamSettingsDialog workspaceId={workspaceId} />
+                                        <CreateChannelDialog workspaceId={workspaceId} />
+                                        <AttachmentExplorer workspaceId={workspaceId} />
+                                        <TraceDialogContainer />
+                                        <Toaster />
+                                      </TraceProvider>
+                                    </MediaGalleryProvider>
+                                  </PanelProvider>
+                                </QuickSwitcherProvider>
+                              </E2eUnlockProvider>
+                            </WorkspaceKeyboardHandler>
+                          </SettingsProvider>
+                        </PreferencesProvider>
+                      </WorkspaceEmojiProvider>
+                    </WorkspaceCommandListProvider>
+                  </MentionableWrapper>
+                </UserProfileProvider>
+                <CallDock />
+              </CallLaunchProvider>
             </ChannelLinkProvider>
           </CoordinatedLoadingProvider>
         </WorkspaceSyncHandler>

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -81,6 +81,15 @@ export interface CallState {
   diagnostics: CallDiagnostics
   /** Last mid-call recapture failure, or null. See {@link CallCaptureErrorInfo}. */
   captureError: CallCaptureErrorInfo | null
+  /**
+   * Monotonic tick bumped whenever the CallManager's per-endpoint video-track
+   * ref-map changes (a camera track attaches/detaches). The live
+   * `MediaStream`/`MediaStreamTrack` objects stay OFF the store snapshot — they
+   * are unstable for `useSyncExternalStore` and never belong in React state — so
+   * tiles read them from `getCallManager().getVideoStream(endpointId)` and
+   * re-attach their `<video>` when this counter changes. Discrete, not per-frame.
+   */
+  mediaEpoch: number
 }
 
 const EMPTY_DEVICES: CallDeviceState = {
@@ -106,6 +115,7 @@ function idleState(): CallState {
     confirmPending: false,
     diagnostics: { rttMs: null, packetLoss: null, qualityLimitation: null },
     captureError: null,
+    mediaEpoch: 0,
   }
 }
 
@@ -182,6 +192,11 @@ export function setCallCaptureError(captureError: CallCaptureErrorInfo | null): 
   setState({ ...state, captureError })
 }
 
+/** Bump the video ref-map version tick (see {@link CallState.mediaEpoch}). */
+export function bumpCallMediaEpoch(): void {
+  setState({ ...state, mediaEpoch: state.mediaEpoch + 1 })
+}
+
 /** Drop all call state without a hangup — the manager calls this after teardown. */
 export function clearCallState(): void {
   setState(idleState())
@@ -200,6 +215,16 @@ export function resetCallStoreCache(): void {
 function subscribe(listener: () => void): () => void {
   listeners.add(listener)
   return () => listeners.delete(listener)
+}
+
+/**
+ * Raw store subscription. Exposed so selector hooks (`call-store-hooks.ts`) can
+ * subscribe once and re-render only on the slice they read — the whole-state
+ * {@link useCallState} re-renders every consumer on any change, including the
+ * per-frame `speakingLevel` tick.
+ */
+export function subscribeCall(listener: () => void): () => void {
+  return subscribe(listener)
 }
 
 export function useCallState(): CallState {


### PR DESCRIPTION
**Stack:** PR 5 of the calls build, on #1414. The first visible UI — a call is now startable and holdable from the app.

## Problem

The media core (1.1) has no surface: no way to start a call, see who's in it, mute, or understand why devices failed.

## Solution

`apps/frontend/src/components/call/` — the dock and its satellites, driven exclusively by the 1.1 call-store/`CallManager` surface (no component touches transport or sockets, INV-15).

### How it works

- **`CallDock`**: layout-level mount (survives in-app navigation), composed on `side-panel` — non-modal, no autofocus, no focus trap; typing in the composer during a call is untouched. Collapsed/expanded, reset to expanded per call. The INV-59 exemption rationale (session-bound hardware state no URL can restore) is cited at the mount.
- **`CallTile`**: name/avatar via the canonical user hooks, ref-attached `<video>` (streams live in a manager-side map keyed by endpoint; a `mediaEpoch` tick in the store drives re-attach — media objects never enter the store snapshot, keeping `useSyncExternalStore` stable), mute badge, reconnecting dim, and a **ref-driven speaking ring**: the analyser writes `--speaking-level` straight to the DOM. A 30-tick burst leaves React consumers at render count 1 (pinned by test) — the 60fps re-render trap the 1.1 review warned about is structurally closed.
- **`CallControls` + `DevicePickerMenu` + `ConnectionDiagnostics`**: mute/camera/leave, mic + speaker pickers (speaker hidden where `setSinkId` is absent; no camera picker — 1.1 exposes no camera switch, a dead menu is worse than none), RTT/loss/quality popover.
- **`PreJoinGate`**: the permission taxonomy — `blocked_by_policy | denied | no_device | device_busy | os_denied` with distinct copy and retry, classified from `startCall`'s typed `CallCaptureError`.
- **Entry points**: header phone button (`isChannel || isDm` + `callsEnabled`, hidden when dark) and profile-modal **Call** (disabled with explanation until a DM exists — no message-less DM materialization path exists today; decision recorded). `/call` command deferred to 1.3 with the ring (the client-action seam threads four files and belongs with that work).

### Key design decisions

**1. Mic-only at join, camera via `setCameraOn`** — the adversarial verify caught the branch acquiring camera at join for `mode:'video'`: a privacy surprise, a *total lockout* for camera-less devices (`getUserMedia({audio,video})` rejects wholesale), and factually wrong "no microphone" copy. One-line 1.1 change restores the plan's decided default (mic on, camera off) and fixes all three.

**2. `startCall` runs synchronously inside the click gesture** — the first cut pre-probed devices with an `await` before starting, which exhausted iOS Safari's transient activation and left the AudioContext permanently suspended (silent calls). The probe is deleted; the taxonomy derives from the start path's own typed error, and media is acquired exactly once.

## Files

| Path | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/call/*` (9 components + 4 test files) | The dock surface |
| `apps/frontend/src/calls/call-manager.ts` | `CallController` interface, video stream map + `attachRemoteVideo`, mic-only join |
| `apps/frontend/src/stores/call-store.ts` | `mediaEpoch` tick + `subscribeCall` export |
| `apps/frontend/src/pages/{workspace-layout,stream}.tsx`, `user-profile-modal.tsx` | Mount + entry points |

## Out of scope (deliberate)

Ring/incoming UI + `/call` command (1.3), timeline card (1.4), PiP popout (M3), screen share (M3), camera device picker (no 1.1 surface).

## Test plan

- [x] Implement → xhigh verify → fix → re-verify: **2 majors + 3 minors fixed, zero residuals** (camera-at-join violation; gesture-exhausting pre-probe; probe double-acquisition; collapsed-state leak across calls; missing srcObject cleanup)
- [x] Scoped Vitest: 48 pass across calls/store/components (incl. the INV-63 guard and the render-count-1 speaking test); frontend typecheck + eslint + full pre-commit green
- [ ] Real-browser exercise lands with M1.5's e2e; visual QA implicitly deferred to the flag-on dogfood

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
