### PR TITLE
feat(calls): ring + invitations end-to-end (stack 6/8)

### DIFF
--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -117,7 +117,9 @@ function conflictClauseFor(activityType: string) {
       "ON CONFLICT (user_id, message_id, actor_id, emoji) WHERE activity_type = 'reaction' DO UPDATE SET id = user_activity.id"
     )
   }
-  if (activityType === ActivityTypes.SAVED_REMINDER) {
+  if (activityType === ActivityTypes.SAVED_REMINDER || activityType === ActivityTypes.MISSED_CALL) {
+    // Both carry a null message_id, so the (…, message_id, …) dedup arbiter can
+    // never match — emit a plain INSERT and let every occurrence mint a row.
     return sql.raw("")
   }
   return sql.raw(

--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -153,6 +153,20 @@ export function createCallHandlers({
       res.json({ invitation })
     },
 
+    async cancelInvitation(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { invitationId } = req.params
+      await assertAvailable(workspaceId)
+
+      // Inviter hang-up before an answer — scoped to the caller's own ring
+      // (`cancelInvitation` CASes on inviter_user_id), so a non-inviter gets the
+      // 409 not-actionable. Abandonment via leaving the call is handled in the
+      // service's leave/reap/grace paths; this is the explicit stop-ringing lever.
+      const invitation = await callService.cancelInvitation({ workspaceId, invitationId, userId })
+      res.json({ invitation })
+    },
+
     async bootstrap(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
       const userId = req.user!.id

--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -140,6 +140,19 @@ export function createCallHandlers({
       })
     },
 
+    async declineInvitation(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const userId = req.user!.id
+      const { invitationId } = req.params
+      await assertAvailable(workspaceId)
+
+      // Scoped to the invitee's own ring — `declineInvitation` CASes on
+      // invitee_user_id, so a non-invitee gets the 409 not-actionable, never
+      // another user's invitation.
+      const invitation = await callService.declineInvitation({ workspaceId, invitationId, userId })
+      res.json({ invitation })
+    },
+
     async bootstrap(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
       const userId = req.user!.id

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -400,6 +400,57 @@ export const CallInvitationRepository = {
     return result.rows[0] ? mapInvitation(result.rows[0]) : null
   },
 
+  /**
+   * CAS every `ringing` invitation on a call to `cancelled` (INV-56). The caller
+   * abandoned the call (last participant left, or a sweeper ended it), so every
+   * outstanding ring is retracted in the same transaction. Returns the cancelled
+   * rows so the service can settle each one; a ring already terminal is skipped.
+   */
+  async cancelRingingForCall(db: Querier, params: { workspaceId: string; callId: string }): Promise<CallInvitation[]> {
+    const result = await db.query<CallInvitationRow>(sql`
+      UPDATE call_invitations SET status = 'cancelled', status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND call_id = ${params.callId} AND status = 'ringing'
+      RETURNING ${sql.raw(INVITATION_COLUMNS)}
+    `)
+    return result.rows.map(mapInvitation)
+  },
+
+  /**
+   * CAS every `ringing` invitation on a call whose inviter is the given user to
+   * `cancelled`: an inviter leaving a DM call abandons their outgoing ring even
+   * when other participants remain. Returns the cancelled rows.
+   */
+  async cancelRingingByInviter(
+    db: Querier,
+    params: { workspaceId: string; callId: string; inviterUserId: string }
+  ): Promise<CallInvitation[]> {
+    const result = await db.query<CallInvitationRow>(sql`
+      UPDATE call_invitations SET status = 'cancelled', status_changed_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND call_id = ${params.callId}
+        AND inviter_user_id = ${params.inviterUserId} AND status = 'ringing'
+      RETURNING ${sql.raw(INVITATION_COLUMNS)}
+    `)
+    return result.rows.map(mapInvitation)
+  },
+
+  /**
+   * Batch cancel for the sweeper cascades (INV-56): CAS every `ringing`
+   * invitation across the given calls to `cancelled` in one statement, when those
+   * calls just graced/ended with no live participant. Cancelling here (rather than
+   * letting the ring lapse to `expired`) is what keeps an abandoned call from
+   * landing a spurious missed-call activity. Workspace-agnostic, matching the
+   * other sweeper batch methods (call ids are globally-unique ULIDs).
+   */
+  async cancelRingingForCalls(db: Querier, callIds: readonly string[]): Promise<CallInvitation[]> {
+    if (callIds.length === 0) return []
+    const result = await db.query<CallInvitationRow>(sql`
+      UPDATE call_invitations SET status = 'cancelled', status_changed_at = NOW()
+      WHERE call_id = ANY(${callIds as string[]}) AND status = 'ringing'
+      RETURNING ${sql.raw(INVITATION_COLUMNS)}
+    `)
+    return result.rows.map(mapInvitation)
+  },
+
   /** Set-based ring expiry (INV-56): `ringing → expired` past `expires_at`. */
   async expireStaleRings(db: Querier, now: Date): Promise<CallInvitation[]> {
     const result = await db.query<CallInvitationRow>(sql`

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -12,7 +12,10 @@ import {
 } from "./repository"
 import * as accessModule from "./access"
 import * as streamsModule from "../streams"
+import * as workspacesModule from "../workspaces"
+import * as activityModule from "../activity"
 import * as dbModule from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
 import { CALL_PRODUCT_CAP } from "./config"
 
 const NOW = new Date("2026-07-19T12:00:00.000Z")
@@ -84,6 +87,10 @@ function stubTransaction() {
   // that cares spies CallRepository.bumpRosterVersion(Batch) directly and asserts.
   const client = { query: async () => ({ rows: [] }) } as unknown as PoolClient
   spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn(client))
+  // Ring lifecycle now emits outbox events in-tx; stub the insert so unspied
+  // emissions don't hit the no-op client (which would map an empty row set).
+  spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+  spyOn(workspacesModule.UserRepository, "findById").mockResolvedValue({ id: "usr_a", name: "Ada" } as never)
 }
 
 function makeService() {
@@ -201,13 +208,28 @@ describe("CallService.startCall — DM ring", () => {
       { memberId: "usr_a" } as never,
       { memberId: "usr_peer" } as never,
     ])
-    const ring = spyOn(CallInvitationRepository, "insertRinging").mockResolvedValue({} as never)
+    const ring = spyOn(CallInvitationRepository, "insertRinging").mockResolvedValue({
+      id: "callinv_1",
+      expiresAt: NOW,
+    } as never)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
 
     await makeService().startCall({ workspaceId: "ws_1", streamId: "stream_dm", userId: "usr_a", mode: "audio_only" })
 
     expect(ring).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ inviteeUserId: "usr_peer", inviterUserId: "usr_a", callId: "call_1" })
+    )
+    // The ring reaches the invitee (INV-4): user-scoped created event in the same tx.
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_created",
+      expect.objectContaining({
+        targetUserId: "usr_peer",
+        attemptId: "callinv_1",
+        callId: "call_1",
+        mode: "audio_only",
+      })
     )
   })
 
@@ -254,8 +276,11 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
     spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
     stubCleanEndpointAdmission()
-    const accept = spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+    const accept = spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([
+      { id: "callinv_1", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_b" } as never,
+    ])
     const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
 
     const result = await makeService().joinCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_b" })
 
@@ -263,6 +288,12 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
     expect(accept).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ inviteeUserId: "usr_b" }))
     // A join bumps the roster version in the same tx (INV-66) so peers don't drop the arrival.
     expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
+    // Accepting the ring on join settles it across the invitee's devices.
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ targetUserId: "usr_b", attemptId: "callinv_1", outcome: "accepted" })
+    )
     expect(result.endpoint.id).toBe("callep_1")
   })
 
@@ -518,9 +549,16 @@ describe("CallService.removeParticipant", () => {
 describe("CallService invitations", () => {
   afterEach(() => mock.restore())
 
-  it("declineInvitation returns the declined ring", async () => {
+  it("declineInvitation returns the declined ring and settles it to the invitee", async () => {
     stubTransaction()
-    spyOn(CallInvitationRepository, "decline").mockResolvedValue({ id: "callinv_1", status: "declined" } as never)
+    spyOn(CallInvitationRepository, "decline").mockResolvedValue({
+      id: "callinv_1",
+      status: "declined",
+      workspaceId: "ws_1",
+      callId: "call_1",
+      inviteeUserId: "usr_peer",
+    } as never)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
 
     const result = await makeService().declineInvitation({
       workspaceId: "ws_1",
@@ -529,6 +567,31 @@ describe("CallService invitations", () => {
     })
 
     expect(result).toMatchObject({ status: "declined" })
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ targetUserId: "usr_peer", attemptId: "callinv_1", outcome: "declined" })
+    )
+  })
+
+  it("cancelInvitation settles the ring to the invitee as cancelled", async () => {
+    stubTransaction()
+    spyOn(CallInvitationRepository, "cancel").mockResolvedValue({
+      id: "callinv_1",
+      status: "cancelled",
+      workspaceId: "ws_1",
+      callId: "call_1",
+      inviteeUserId: "usr_peer",
+    } as never)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+
+    await makeService().cancelInvitation({ workspaceId: "ws_1", invitationId: "callinv_1", userId: "usr_a" })
+
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ targetUserId: "usr_peer", attemptId: "callinv_1", outcome: "cancelled" })
+    )
   })
 
   it("declineInvitation throws when the ring is no longer ringing", async () => {
@@ -597,9 +660,49 @@ describe("CallService sweeps", () => {
     stubTransaction()
     spyOn(CallInvitationRepository, "expireStaleRings").mockResolvedValue([{ id: "callinv_1" } as never])
     spyOn(CallRepository, "endGraceExpired").mockResolvedValue([fakeCall({ status: "ended" })])
+    spyOn(CallRepository, "findById").mockResolvedValue(null)
 
     expect(await makeService().expireStaleRings(NOW)).toEqual({ expired: 1 })
     expect(await makeService().endGraceExpiredCalls(NOW)).toEqual({ ended: 1 })
+  })
+
+  it("expireStaleRings settles each ring and lands a missed-call activity for the invitee", async () => {
+    stubTransaction()
+    spyOn(CallInvitationRepository, "expireStaleRings").mockResolvedValue([
+      { id: "callinv_1", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_peer", inviterUserId: "usr_a" },
+    ] as never)
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ streamId: "stream_dm", mode: "audio_only" }))
+    const activityInsert = spyOn(activityModule.ActivityRepository, "insert").mockResolvedValue({
+      id: "act_1",
+      activityType: "missed_call",
+      streamId: "stream_dm",
+      messageId: null,
+      actorId: "usr_a",
+      actorType: "user",
+      context: {},
+      createdAt: NOW,
+      isSelf: false,
+      emoji: null,
+    } as never)
+    spyOn(activityModule.ActivityRepository, "countUnreadForPairs").mockResolvedValue(new Map())
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+
+    await makeService().expireStaleRings(NOW)
+
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ targetUserId: "usr_peer", attemptId: "callinv_1", outcome: "expired" })
+    )
+    expect(activityInsert).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ activityType: "missed_call", userId: "usr_peer", streamId: "stream_dm" })
+    )
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "activity:created",
+      expect.objectContaining({ targetUserId: "usr_peer" })
+    )
   })
 
   it("reapLapsedEndpoints closes the CF sessions of reaped endpoints AFTER commit", async () => {

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -476,6 +476,67 @@ describe("CallService.leaveCall", () => {
     ).rejects.toMatchObject({ code: "CALL_ENDPOINT_NOT_FOUND", status: 404 })
     expect(close).not.toHaveBeenCalled()
   })
+
+  it("cancels the outstanding ring when the inviter hangs up before an answer (no missed call)", async () => {
+    stubTransaction()
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallEndpointRepository, "findById").mockResolvedValue(fakeEndpoint())
+    spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant())
+    spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ status: "closed" }))
+    spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
+    spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    const cancelAll = spyOn(CallInvitationRepository, "cancelRingingForCall").mockResolvedValue([
+      { id: "callinv_1", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_peer", inviterUserId: "usr_a" },
+    ] as never)
+    const activityInsert = spyOn(activityModule.ActivityRepository, "insert").mockResolvedValue({} as never)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+
+    await makeService().leaveCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a", endpointId: "callep_1" })
+
+    expect(cancelAll).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ callId: "call_1" }))
+    // The retracted ring settles as cancelled to the invitee in the same tx (INV-7).
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ targetUserId: "usr_peer", attemptId: "callinv_1", outcome: "cancelled" })
+    )
+    // A cancelled ring never lapses to expired → no missed-call activity is created.
+    expect(activityInsert).not.toHaveBeenCalled()
+  })
+
+  it("cancels the leaving inviter's ring even when other participants remain", async () => {
+    stubTransaction()
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallEndpointRepository, "findById").mockResolvedValue(fakeEndpoint())
+    spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant())
+    spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ status: "closed" }))
+    spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(2)
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
+    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(null)
+    const cancelByInviter = spyOn(CallInvitationRepository, "cancelRingingByInviter").mockResolvedValue([
+      { id: "callinv_2", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_peer", inviterUserId: "usr_a" },
+    ] as never)
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+
+    await makeService().leaveCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a", endpointId: "callep_1" })
+
+    // The call lives on (others remain) — only the leaver's own ring is retracted.
+    expect(grace).not.toHaveBeenCalled()
+    expect(cancelByInviter).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ callId: "call_1", inviterUserId: "usr_a" })
+    )
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "call:invitation_settled",
+      expect.objectContaining({ attemptId: "callinv_2", outcome: "cancelled" })
+    )
+  })
 })
 
 describe("CallService.renewEndpointLease — fencing", () => {

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -368,6 +368,23 @@ export class CallService {
           graceDeadline: new Date(Date.now() + EMPTY_GRACE_MS),
           reason: "completed",
         })
+        // The call is now empty: retract every outstanding ring in the same tx
+        // (INV-7). Cancelling (not letting it lapse) is what prevents a
+        // missed-call activity for a caller who hung up before an answer.
+        const cancelled = await CallInvitationRepository.cancelRingingForCall(client, {
+          workspaceId: params.workspaceId,
+          callId: params.callId,
+        })
+        await this.settleCancelledRings(client, cancelled)
+      } else {
+        // The call lives on, but the leaving user's own outgoing ring is
+        // abandoned (a DM inviter hanging up while a group call continues).
+        const cancelled = await CallInvitationRepository.cancelRingingByInviter(client, {
+          workspaceId: params.workspaceId,
+          callId: params.callId,
+          inviterUserId: params.userId,
+        })
+        await this.settleCancelledRings(client, cancelled)
       }
 
       // A leave is a membership change: bump the roster version in the same tx as
@@ -427,13 +444,24 @@ export class CallService {
     invitation: CallInvitation,
     outcome: "accepted" | "declined" | "cancelled" | "expired" | "superseded"
   ): Promise<void> {
+    // Carry the inviter name so the SW's offline "Call ended" fallback can name
+    // the caller when the cancel push collapsed a ring that was never shown.
+    const inviter = await UserRepository.findById(client, invitation.workspaceId, invitation.inviterUserId)
     await OutboxRepository.insert(client, "call:invitation_settled", {
       workspaceId: invitation.workspaceId,
       targetUserId: invitation.inviteeUserId,
       attemptId: invitation.id,
       callId: invitation.callId,
       outcome,
+      inviterName: inviter?.name ?? null,
     })
+  }
+
+  /** Cancel the given outstanding rings (`ringing → cancelled` already applied) and settle each. */
+  private async settleCancelledRings(client: PoolClient, invitations: CallInvitation[]): Promise<void> {
+    for (const invitation of invitations) {
+      await this.emitSettled(client, invitation, "cancelled")
+    }
   }
 
   /**
@@ -956,6 +984,15 @@ export class CallService {
         graceDeadline: new Date(now.getTime() + EMPTY_GRACE_MS),
       })
 
+      // A graced call is abandoned (its last live endpoint lapsed): retract every
+      // outstanding ring in the same tx (INV-7) so the invitee's overlay clears
+      // and the caller-gone ring never lands a missed-call activity.
+      const cancelledRings = await CallInvitationRepository.cancelRingingForCalls(
+        client,
+        graced.map((c) => c.id)
+      )
+      await this.settleCancelledRings(client, cancelledRings)
+
       // The reap changed membership on every call it touched: bump their roster
       // versions in the same tx (the call rows are already locked FOR UPDATE) so a
       // later roster fan-out is strictly newer than what peers hold (INV-66).
@@ -982,6 +1019,14 @@ export class CallService {
   async endGraceExpiredCalls(now: Date = new Date()): Promise<{ ended: number }> {
     return withTransaction(this.pool, async (client) => {
       const ended = await CallRepository.endGraceExpired(client, now)
+      // Belt for any ring still ringing on a call that reaches `ended` without
+      // having been abandoned through leave/reap: cancel and settle it in the
+      // same tx (INV-7) rather than leaving it to lapse into a missed call.
+      const cancelledRings = await CallInvitationRepository.cancelRingingForCalls(
+        client,
+        ended.map((c) => c.id)
+      )
+      await this.settleCancelledRings(client, cancelledRings)
       return { ended: ended.length }
     })
   }

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -1,10 +1,13 @@
 import type { Pool, PoolClient } from "pg"
-import { StreamTypes } from "@threa/types"
+import { StreamTypes, ActivityTypes, AuthorTypes } from "@threa/types"
 import { withTransaction, withClient } from "../../db"
 import { HttpError } from "../../lib/errors"
 import { logger } from "../../lib/logger"
 import { callId, callInvitationId, callParticipantId, callEndpointId } from "../../lib/id"
-import { checkStreamAccess, StreamMemberRepository } from "../streams"
+import { checkStreamAccess, StreamMemberRepository, StreamRepository } from "../streams"
+import { UserRepository } from "../workspaces"
+import { ActivityRepository } from "../activity"
+import { OutboxRepository } from "../../lib/outbox"
 import { checkCallAccess } from "./access"
 import {
   CallRepository,
@@ -143,13 +146,26 @@ export class CallService {
       if (created && stream.type === StreamTypes.DM) {
         const peerId = await this.findDmPeer(client, params.streamId, params.userId)
         if (peerId) {
-          await CallInvitationRepository.insertRinging(client, {
+          const invitation = await CallInvitationRepository.insertRinging(client, {
             id: callInvitationId(),
             workspaceId: params.workspaceId,
             callId: targetCallId,
             inviteeUserId: peerId,
             inviterUserId: params.userId,
             expiresAt: new Date(Date.now() + INVITATION_TTL_MS),
+          })
+          // Ring reaches the invitee (INV-4): user-scoped to their room so every
+          // device rings off one attempt id. Same tx as the invitation insert.
+          const inviter = await UserRepository.findById(client, params.workspaceId, params.userId)
+          await OutboxRepository.insert(client, "call:invitation_created", {
+            workspaceId: params.workspaceId,
+            targetUserId: peerId,
+            attemptId: invitation.id,
+            callId: targetCallId,
+            streamId: params.streamId,
+            inviter: { id: params.userId, name: inviter?.name ?? null },
+            mode: params.mode,
+            expiresAt: invitation.expiresAt.toISOString(),
           })
         }
       }
@@ -222,11 +238,17 @@ export class CallService {
     const live = await CallEndpointRepository.findLiveByParticipant(client, params.workspaceId, participant.id)
     const endpoint = await this.admitEndpoint(client, { params, participant, live, incarnation })
 
-    await CallInvitationRepository.acceptRingingForUser(client, {
+    const accepted = await CallInvitationRepository.acceptRingingForUser(client, {
       workspaceId: params.workspaceId,
       callId: params.callId,
       inviteeUserId: params.userId,
     })
+    // Settle the invitee's ring across their other devices (accept on the phone
+    // clears the laptop) and cancel the ring push. No-op for the creator's own
+    // join (they are the inviter, never an invitee here).
+    for (const invitation of accepted) {
+      await this.emitSettled(client, invitation, "accepted")
+    }
 
     // A join is a membership change: bump the roster version in the same tx as
     // the membership/endpoint writes so the snapshot the gateway reads after
@@ -371,6 +393,7 @@ export class CallService {
       if (!declined) {
         throw new HttpError("Invitation is not ringing", { status: 409, code: "CALL_INVITATION_NOT_ACTIONABLE" })
       }
+      await this.emitSettled(client, declined, "declined")
       return declined
     })
   }
@@ -389,7 +412,27 @@ export class CallService {
       if (!cancelled) {
         throw new HttpError("Invitation is not ringing", { status: 409, code: "CALL_INVITATION_NOT_ACTIONABLE" })
       }
+      await this.emitSettled(client, cancelled, "cancelled")
       return cancelled
+    })
+  }
+
+  /**
+   * User-scoped settle broadcast to the invitee (INV-4): clears the overlay on
+   * every device and cancels the ring push. Emitted in the caller's transaction
+   * on every terminal ring CAS (accept, decline, cancel, expire).
+   */
+  private async emitSettled(
+    client: PoolClient,
+    invitation: CallInvitation,
+    outcome: "accepted" | "declined" | "cancelled" | "expired" | "superseded"
+  ): Promise<void> {
+    await OutboxRepository.insert(client, "call:invitation_settled", {
+      workspaceId: invitation.workspaceId,
+      targetUserId: invitation.inviteeUserId,
+      attemptId: invitation.id,
+      callId: invitation.callId,
+      outcome,
     })
   }
 
@@ -801,11 +844,77 @@ export class CallService {
     })
   }
 
-  /** Sweep: expire `ringing` invitations past their deadline. Returns the count. */
+  /**
+   * Sweep: expire `ringing` invitations past their deadline. Each expiry, in the
+   * same transaction (INV-7): settle the invitee's ring across their devices and
+   * cancel the ring push (`call:invitation_settled` outcome `expired`), and land
+   * a missed-call activity row for the invitee whose `activity:created` the push
+   * handler then delivers under the invitee's normal notification preferences
+   * (structured payload — the frontend formats it, INV-46). Returns the count.
+   */
   async expireStaleRings(now: Date = new Date()): Promise<{ expired: number }> {
     return withTransaction(this.pool, async (client) => {
       const expired = await CallInvitationRepository.expireStaleRings(client, now)
+      for (const invitation of expired) {
+        await this.emitSettled(client, invitation, "expired")
+        await this.recordMissedCall(client, invitation)
+      }
       return { expired: expired.length }
+    })
+  }
+
+  /**
+   * Insert the missed-call activity row for the invitee of an expired ring and
+   * emit its `activity:created` (with the invitee's absolute unread counts, sync
+   * phase 2c) so the badge and push land the same way a mention or DM message
+   * would. The call row supplies the host stream and mode; a missing call/inviter
+   * degrades to a row without those context fields rather than skipping the miss.
+   */
+  private async recordMissedCall(client: PoolClient, invitation: CallInvitation): Promise<void> {
+    const call = await CallRepository.findById(client, invitation.workspaceId, invitation.callId)
+    if (!call) return
+    const inviter = await UserRepository.findById(client, invitation.workspaceId, invitation.inviterUserId)
+    const stream = await StreamRepository.findById(client, call.streamId)
+    const context = {
+      authorName: inviter?.name ?? null,
+      streamName: stream?.displayName ?? stream?.slug ?? null,
+      callId: invitation.callId,
+      mode: call.mode,
+    }
+    const activity = await ActivityRepository.insert(client, {
+      workspaceId: invitation.workspaceId,
+      userId: invitation.inviteeUserId,
+      activityType: ActivityTypes.MISSED_CALL,
+      streamId: call.streamId,
+      messageId: null,
+      actorId: invitation.inviterUserId,
+      actorType: AuthorTypes.USER,
+      context,
+    })
+    if (!activity) return
+    const counts = await ActivityRepository.countUnreadForPairs(client, invitation.workspaceId, [
+      { userId: invitation.inviteeUserId, streamId: call.streamId },
+    ])
+    const pair = counts.get(`${invitation.inviteeUserId}:${call.streamId}`)
+    await OutboxRepository.insert(client, "activity:created", {
+      workspaceId: invitation.workspaceId,
+      targetUserId: invitation.inviteeUserId,
+      counts: {
+        mentionCount: pair?.mentionCount ?? 0,
+        activityCount: pair?.totalCount ?? 0,
+      },
+      activity: {
+        id: activity.id,
+        activityType: activity.activityType,
+        streamId: activity.streamId,
+        messageId: activity.messageId,
+        actorId: activity.actorId,
+        actorType: activity.actorType,
+        context: activity.context,
+        createdAt: activity.createdAt.toISOString(),
+        isSelf: activity.isSelf,
+        emoji: activity.emoji,
+      },
     })
   }
 

--- a/apps/backend/src/features/push/call-ring-outbox-handler.ts
+++ b/apps/backend/src/features/push/call-ring-outbox-handler.ts
@@ -1,0 +1,62 @@
+import type { Pool } from "pg"
+import {
+  DebouncedOutboxHandler,
+  type DebouncedOutboxHandlerConfig,
+  type OutboxEvent,
+  type CallInvitationCreatedOutboxPayload,
+  type CallInvitationSettledOutboxPayload,
+} from "../../lib/outbox"
+import { logger } from "../../lib/logger"
+import type { PushService } from "./service"
+
+// A ring must not wait behind the debounce/batch window that the activity push
+// handler uses — a delayed ring is a missed call. Zero debounce fires the send
+// on the next tick, and a small batch keeps ring + cancel in delivery order.
+const HANDLER_CONFIG: DebouncedOutboxHandlerConfig = {
+  batchSize: 20,
+  debounceMs: 0,
+  maxWaitMs: 0,
+}
+
+interface CallRingPushHandlerDeps {
+  pool: Pool
+  pushService: PushService
+}
+
+/**
+ * Delivers the incoming-call ring push (`call:invitation_created`) and its
+ * cancellation (`call:invitation_settled`, every outcome). Kept off the shared
+ * `push-notifications` handler so its immediate dispatch doesn't share a cursor
+ * with the batched activity/reminder pushes. Infrastructure-only (INV-34):
+ * preference gating and stale-subscription eviction live in PushService.
+ */
+export class CallRingPushHandler extends DebouncedOutboxHandler {
+  private readonly pushService: PushService
+
+  constructor(deps: CallRingPushHandlerDeps) {
+    super(deps.pool, { listenerId: "call-ring-push", ...HANDLER_CONFIG })
+    this.pushService = deps.pushService
+  }
+
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType === "call:invitation_created") {
+      const payload = event.payload as CallInvitationCreatedOutboxPayload
+      if (!payload?.workspaceId || !payload?.targetUserId || !payload?.attemptId) {
+        logger.warn({ eventId: event.id }, "Skipping malformed call:invitation_created payload")
+        return
+      }
+      await this.pushService.deliverCallRing(payload)
+      return
+    }
+
+    if (event.eventType === "call:invitation_settled") {
+      const payload = event.payload as CallInvitationSettledOutboxPayload
+      if (!payload?.workspaceId || !payload?.targetUserId || !payload?.attemptId) {
+        logger.warn({ eventId: event.id }, "Skipping malformed call:invitation_settled payload")
+        return
+      }
+      await this.pushService.deliverCallRingCancel(payload)
+      return
+    }
+  }
+}

--- a/apps/backend/src/features/push/index.ts
+++ b/apps/backend/src/features/push/index.ts
@@ -10,5 +10,7 @@ export { createPushHandlers } from "./handlers"
 
 export { PushNotificationHandler } from "./outbox-handler"
 
+export { CallRingPushHandler } from "./call-ring-outbox-handler"
+
 export { createPushSessionCleanup } from "./session-cleanup"
 export type { PushSessionCleanup } from "./session-cleanup"

--- a/apps/backend/src/features/push/service.test.ts
+++ b/apps/backend/src/features/push/service.test.ts
@@ -60,6 +60,20 @@ describe("PushService do-not-disturb gating", () => {
     expect(findByUserId).not.toHaveBeenCalled()
   })
 
+  it("suppresses the ring push while notifications are paused (the socket ring still fires)", async () => {
+    await makeService(true).deliverCallRing({
+      workspaceId: "ws_1",
+      targetUserId: "usr_1",
+      attemptId: "callinv_01ABCDEF",
+      callId: "call_1",
+      streamId: "stream_dm",
+      inviter: { id: "usr_2", name: "Ada" },
+      mode: "video",
+      expiresAt: "2026-07-19T12:00:45.000Z",
+    })
+    expect(findByUserId).not.toHaveBeenCalled()
+  })
+
   it("resolves the user's devices when notifications are not paused", async () => {
     await makeService(false).deliverPushForActivity(makeActivityPayload())
     expect(findByUserId).toHaveBeenCalledTimes(1)
@@ -117,6 +131,38 @@ describe("PushService delivery options", () => {
 
     const [, , options] = sendNotification.mock.calls[0] as [unknown, string, Record<string, unknown>]
     expect(options.topic).toBe("1m")
+  })
+
+  it("sends a call ring with high urgency, a 45s TTL, and an attempt-keyed topic", async () => {
+    await makeService(false).deliverCallRing({
+      workspaceId: "ws_1",
+      targetUserId: "usr_1",
+      attemptId: "callinv_01ABCDEF",
+      callId: "call_1",
+      streamId: "stream_dm",
+      inviter: { id: "usr_2", name: "Ada" },
+      mode: "video",
+      expiresAt: "2026-07-19T12:00:45.000Z",
+    })
+
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const [, payload, options] = sendNotification.mock.calls[0] as [unknown, string, Record<string, unknown>]
+    expect(JSON.parse(payload).data).toMatchObject({ kind: "call_ring", attemptId: "callinv_01ABCDEF", mode: "video" })
+    expect(options).toEqual({ timeout: 10_000, TTL: 45, urgency: "high", topic: "01ABCDEFc" })
+  })
+
+  it("sends the ring cancel on the same topic so an undelivered ring collapses to it", async () => {
+    await makeService(false).deliverCallRingCancel({
+      workspaceId: "ws_1",
+      targetUserId: "usr_1",
+      attemptId: "callinv_01ABCDEF",
+      callId: "call_1",
+      outcome: "declined",
+    })
+
+    const [, payload, options] = sendNotification.mock.calls[0] as [unknown, string, Record<string, unknown>]
+    expect(JSON.parse(payload).data).toMatchObject({ kind: "call_ring_cancel", attemptId: "callinv_01ABCDEF" })
+    expect(options).toEqual({ timeout: 10_000, TTL: 45, urgency: "high", topic: "01ABCDEFc" })
   })
 
   it("sends the diagnostic test push with a short TTL so it can't arrive stale", async () => {

--- a/apps/backend/src/features/push/service.test.ts
+++ b/apps/backend/src/features/push/service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test"
 import webpush from "web-push"
 import type { Pool } from "pg"
-import { ActivityTypes, PrefNotificationLevels, SavedStatuses } from "@threa/types"
+import { ActivityTypes, PrefNotificationLevels, SavedStatuses, type PrefNotificationLevel } from "@threa/types"
 import { PushService } from "./service"
 import { PushSubscriptionRepository } from "./repository"
 import type { ActivityCreatedOutboxPayload, SavedReminderFiredOutboxPayload } from "../../lib/outbox"
@@ -30,13 +30,16 @@ const fakePool = {
   connect: async () => ({ query: async () => ({ rows: [] }), release: () => {} }),
 } as unknown as Pool
 
-function makeService(isNotificationPaused: boolean): PushService {
+function makeService(
+  isNotificationPaused: boolean,
+  level: PrefNotificationLevel = PrefNotificationLevels.ALL
+): PushService {
   const keys = webpush.generateVAPIDKeys()
   return new PushService({
     pool: fakePool,
     vapidConfig: { publicKey: keys.publicKey, privateKey: keys.privateKey, subject: "mailto:test@example.com" },
     lookups: {
-      getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
+      getUserNotificationLevel: async () => level,
       isNotificationPaused: async () => isNotificationPaused,
       getStreamType: async () => "channel",
       getWorkosUserId: async () => "workos_1",
@@ -70,6 +73,30 @@ describe("PushService do-not-disturb gating", () => {
       inviter: { id: "usr_2", name: "Ada" },
       mode: "video",
       expiresAt: "2026-07-19T12:00:45.000Z",
+    })
+    expect(findByUserId).not.toHaveBeenCalled()
+  })
+
+  it("does not send a ring cancel when the invitee's notification level is none", async () => {
+    // The ring itself was suppressed, so nothing was queued to collapse — a cancel
+    // that shows no notification would burn the browser's silent-push quota.
+    await makeService(false, PrefNotificationLevels.NONE).deliverCallRingCancel({
+      workspaceId: "ws_1",
+      targetUserId: "usr_1",
+      attemptId: "callinv_01ABCDEF",
+      callId: "call_1",
+      outcome: "cancelled",
+    })
+    expect(findByUserId).not.toHaveBeenCalled()
+  })
+
+  it("does not send a ring cancel while notifications are paused", async () => {
+    await makeService(true).deliverCallRingCancel({
+      workspaceId: "ws_1",
+      targetUserId: "usr_1",
+      attemptId: "callinv_01ABCDEF",
+      callId: "call_1",
+      outcome: "cancelled",
     })
     expect(findByUserId).not.toHaveBeenCalled()
   })
@@ -157,11 +184,17 @@ describe("PushService delivery options", () => {
       targetUserId: "usr_1",
       attemptId: "callinv_01ABCDEF",
       callId: "call_1",
-      outcome: "declined",
+      outcome: "cancelled",
+      inviterName: "Ada",
     })
 
     const [, payload, options] = sendNotification.mock.calls[0] as [unknown, string, Record<string, unknown>]
-    expect(JSON.parse(payload).data).toMatchObject({ kind: "call_ring_cancel", attemptId: "callinv_01ABCDEF" })
+    // Inviter name rides the cancel so the SW's offline "Call ended" fallback can name the caller.
+    expect(JSON.parse(payload).data).toMatchObject({
+      kind: "call_ring_cancel",
+      attemptId: "callinv_01ABCDEF",
+      inviterName: "Ada",
+    })
     expect(options).toEqual({ timeout: 10_000, TTL: 45, urgency: "high", topic: "01ABCDEFc" })
   })
 

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -20,6 +20,8 @@ import type {
   ActivityCreatedOutboxPayload,
   SavedReminderFiredOutboxPayload,
   EnclaveRewrapNudgeOutboxPayload,
+  CallInvitationCreatedOutboxPayload,
+  CallInvitationSettledOutboxPayload,
 } from "../../lib/outbox"
 
 /** Maximum push subscriptions per user per workspace to bound parallel delivery calls */
@@ -47,6 +49,14 @@ const SESSION_EXPIRED_TTL_SECONDS = 7 * 24 * 60 * 60
 
 /** A test push is only meaningful while the user is watching for it. */
 const TEST_PUSH_TTL_SECONDS = 60
+
+/**
+ * A ring is only worth delivering while it's still ringing. Bounded to the
+ * invitation TTL so a device that reconnects after the ring lapsed never wakes
+ * to a call that already went to the missed-call feed. The matching cancel push
+ * rides the same topic to collapse an undelivered ring.
+ */
+const CALL_RING_TTL_SECONDS = 45
 
 /**
  * Delivery class for a push send. `urgency: "high"` wakes a dozing Android
@@ -382,11 +392,16 @@ export class PushService {
     const recipientWorkosUserId = await this.lookups.getWorkosUserId(workspaceId, targetUserId)
 
     const context = activity.context as
-      | { contentPreview?: string; streamName?: string; authorName?: string; emoji?: string }
+      | { contentPreview?: string; streamName?: string; authorName?: string; emoji?: string; mode?: string }
       | null
       | undefined
+    // A missed call renders with its own SW branch ("Missed call from …"): the
+    // generic message-grouping path has no missed_call copy, so it would title
+    // the banner "New message". The kind + mode route it to the dedicated branch.
+    const isMissedCall = activity.activityType === ActivityTypes.MISSED_CALL
     const pushPayload = JSON.stringify({
       data: {
+        ...(isMissedCall ? { kind: "missed_call" as const, mode: context?.mode } : {}),
         workspaceId,
         workosUserId: recipientWorkosUserId ?? undefined,
         streamId: activity.streamId,
@@ -542,6 +557,12 @@ export class PushService {
       return true
     }
 
+    // A missed call is direct communication like a DM message — it pushes in
+    // mentions mode regardless of the host stream type.
+    if (activityType === ActivityTypes.MISSED_CALL) {
+      return true
+    }
+
     if ((activityType === ActivityTypes.MESSAGE || activityType === ActivityTypes.REACTION) && streamId !== null) {
       const streamType = await this.lookups.getStreamType(workspaceId, streamId)
       if (streamType === StreamTypes.DM || streamType === StreamTypes.SCRATCHPAD) {
@@ -550,6 +571,72 @@ export class PushService {
     }
 
     return false
+  }
+
+  /**
+   * Deliver the incoming-call ring push. High-urgency, short-TTL, topic-collapsed
+   * on the attempt id so the matching cancel push supersedes an undelivered ring.
+   * Respects the invitee's notification preference and do-not-disturb (NONE or
+   * DND → no push; the in-app socket ring still fires, and the overlay is
+   * quiet-able). Fans to the invitee's devices without the focus-suppression
+   * of `getTargetSubscriptions` — a ring must reach a locked phone. Structured
+   * payload (INV-46): the service worker composes the notification.
+   */
+  async deliverCallRing(payload: CallInvitationCreatedOutboxPayload): Promise<void> {
+    if (!this.canSend) return
+    const { workspaceId, targetUserId, attemptId, callId, streamId, inviter, mode, expiresAt } = payload
+
+    const prefLevel = await this.lookups.getUserNotificationLevel(workspaceId, targetUserId)
+    if (prefLevel === PrefNotificationLevels.NONE) return
+    if (await this.lookups.isNotificationPaused(workspaceId, targetUserId)) return
+
+    const subscriptions = await PushSubscriptionRepository.findByUserId(this.pool, workspaceId, targetUserId)
+    if (subscriptions.length === 0) return
+
+    const recipientWorkosUserId = await this.lookups.getWorkosUserId(workspaceId, targetUserId)
+    const pushPayload = JSON.stringify({
+      data: {
+        kind: "call_ring",
+        workspaceId,
+        workosUserId: recipientWorkosUserId ?? undefined,
+        attemptId,
+        callId,
+        streamId,
+        inviterName: inviter.name ?? undefined,
+        mode,
+        expiresAt,
+      },
+    })
+
+    await this.sendAndEvictStale(workspaceId, subscriptions, pushPayload, {
+      ttlSeconds: CALL_RING_TTL_SECONDS,
+      urgency: "high",
+      topic: pushTopic(attemptId, "c"),
+    })
+  }
+
+  /**
+   * Cancel a ring push on every settle (accept/decline/cancel/expire). Same topic
+   * as the ring so an undelivered ring queued for an offline device collapses to
+   * this cancel; a delivered ring is closed by the service worker. No preference
+   * gate — a cancel must always chase whatever ring might have gone out.
+   */
+  async deliverCallRingCancel(payload: CallInvitationSettledOutboxPayload): Promise<void> {
+    if (!this.canSend) return
+    const { workspaceId, targetUserId, attemptId } = payload
+
+    const subscriptions = await PushSubscriptionRepository.findByUserId(this.pool, workspaceId, targetUserId)
+    if (subscriptions.length === 0) return
+
+    const pushPayload = JSON.stringify({
+      data: { kind: "call_ring_cancel", workspaceId, attemptId },
+    })
+
+    await this.sendAndEvictStale(workspaceId, subscriptions, pushPayload, {
+      ttlSeconds: CALL_RING_TTL_SECONDS,
+      urgency: "high",
+      topic: pushTopic(attemptId, "c"),
+    })
   }
 
   /**

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -618,18 +618,27 @@ export class PushService {
   /**
    * Cancel a ring push on every settle (accept/decline/cancel/expire). Same topic
    * as the ring so an undelivered ring queued for an offline device collapses to
-   * this cancel; a delivered ring is closed by the service worker. No preference
-   * gate — a cancel must always chase whatever ring might have gone out.
+   * this cancel; a delivered ring is closed by the service worker.
+   *
+   * Gated on the same preference/DND check as {@link deliverCallRing}: if the ring
+   * itself was suppressed (NONE / do-not-disturb) then nothing was ever queued to
+   * collapse, and a cancel push that shows no notification would burn the browser's
+   * silent-push quota (Firefox revokes the subscription at 0) — so there is nothing
+   * to cancel.
    */
   async deliverCallRingCancel(payload: CallInvitationSettledOutboxPayload): Promise<void> {
     if (!this.canSend) return
-    const { workspaceId, targetUserId, attemptId } = payload
+    const { workspaceId, targetUserId, attemptId, inviterName } = payload
+
+    const prefLevel = await this.lookups.getUserNotificationLevel(workspaceId, targetUserId)
+    if (prefLevel === PrefNotificationLevels.NONE) return
+    if (await this.lookups.isNotificationPaused(workspaceId, targetUserId)) return
 
     const subscriptions = await PushSubscriptionRepository.findByUserId(this.pool, workspaceId, targetUserId)
     if (subscriptions.length === 0) return
 
     const pushPayload = JSON.stringify({
-      data: { kind: "call_ring_cancel", workspaceId, attemptId },
+      data: { kind: "call_ring_cancel", workspaceId, attemptId, inviterName: inviterName ?? undefined },
     })
 
     await this.sendAndEvictStale(workspaceId, subscriptions, pushPayload, {

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -210,6 +210,39 @@ describe("resolveDeliveryGroups — conversation events (board liveness)", () =>
   })
 })
 
+describe("resolveDeliveryGroups — call ring lifecycle", () => {
+  it("routes call:invitation_created to the invitee's user room only", () => {
+    const groups = resolveDeliveryGroups(
+      event("call:invitation_created", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_invitee",
+        attemptId: "callinv_1",
+        callId: "call_1",
+        streamId: "stream_dm",
+        inviter: { id: "usr_caller", name: "Ada" },
+        mode: "video",
+        expiresAt: "2026-07-19T12:00:45.000Z",
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_invitee")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+  })
+
+  it("routes call:invitation_settled to the invitee's user room only (cross-device clear)", () => {
+    const groups = resolveDeliveryGroups(
+      event("call:invitation_settled", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_invitee",
+        attemptId: "callinv_1",
+        callId: "call_1",
+        outcome: "accepted",
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_invitee")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+  })
+})
+
 describe("permissionGroupsForRole", () => {
   it("grants the members:write delivery group to admins and owners", () => {
     expect(permissionGroupsForRole("admin")).toEqual([MEMBERS_WRITE_GROUP])

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -71,6 +71,8 @@ export {
   type EnclaveRewrapNeededOutboxPayload,
   type EnclaveRewrapNudgeOutboxPayload,
   type LinkPreviewReadyOutboxPayload,
+  type CallInvitationCreatedOutboxPayload,
+  type CallInvitationSettledOutboxPayload,
   type UserScopedEventType,
   isUserScopedEvent,
 } from "./repository"

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -123,6 +123,8 @@ export type OutboxEventType =
   | "enclave:rewrap_nudge"
   | "github_route:register"
   | "github_route:unregister"
+  | "call:invitation_created"
+  | "call:invitation_settled"
 
 /** Events that are scoped to a stream (have streamId) */
 export type StreamScopedEventType =
@@ -890,6 +892,39 @@ export interface GithubRouteUnregisterOutboxPayload extends WorkspaceScopedPaylo
   region: string
 }
 
+/**
+ * A DM call is ringing the invitee. User-scoped to the invitee (their user room,
+ * cross-device by construction) and emitted in the same tx as the invitation
+ * insert (INV-4). Carries everything the incoming-call overlay and the ring push
+ * need without a follow-up fetch: `attemptId` is the invitation id (the
+ * attempt-keyed handle M2 group-invites reuse), `expiresAt` bounds the ring so a
+ * stale replay self-dismisses. `mode` is the call's media mode ("video" |
+ * "audio_only").
+ */
+export interface CallInvitationCreatedOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  attemptId: string
+  callId: string
+  streamId: string
+  inviter: { id: string; name: string | null }
+  mode: string
+  expiresAt: string
+}
+
+/**
+ * A ring reached a terminal state. User-scoped to the invitee so every one of
+ * their devices clears the overlay (an accept on the phone silences the laptop)
+ * and the ring push is cancelled. Emitted on every terminal CAS — join-accept,
+ * decline, cancel, sweeper-expire. `settledBy` is an optional device hint.
+ */
+export interface CallInvitationSettledOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  attemptId: string
+  callId: string
+  outcome: "accepted" | "declined" | "cancelled" | "expired" | "superseded"
+  settledBy?: string
+}
+
 // Bot event payloads
 export interface BotCreatedOutboxPayload extends WorkspaceScopedPayload {
   bot: WireBot
@@ -1113,6 +1148,8 @@ export interface OutboxEventPayloadMap {
   "enclave:rewrap_nudge": EnclaveRewrapNudgeOutboxPayload
   "github_route:register": GithubRouteRegisterOutboxPayload
   "github_route:unregister": GithubRouteUnregisterOutboxPayload
+  "call:invitation_created": CallInvitationCreatedOutboxPayload
+  "call:invitation_settled": CallInvitationSettledOutboxPayload
 }
 
 export type OutboxEventPayload<T extends OutboxEventType> = OutboxEventPayloadMap[T]
@@ -1234,6 +1271,8 @@ export type UserScopedEventType =
   | "board:stream_mute_changed"
   | "feature_flags:updated"
   | "enclave:rewrap_needed"
+  | "call:invitation_created"
+  | "call:invitation_settled"
 
 const USER_SCOPED_EVENTS: UserScopedEventType[] = [
   "activity:created",
@@ -1250,6 +1289,8 @@ const USER_SCOPED_EVENTS: UserScopedEventType[] = [
   "board:stream_mute_changed",
   "feature_flags:updated",
   "enclave:rewrap_needed",
+  "call:invitation_created",
+  "call:invitation_settled",
 ]
 
 /**

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -923,6 +923,12 @@ export interface CallInvitationSettledOutboxPayload extends WorkspaceScopedPaylo
   callId: string
   outcome: "accepted" | "declined" | "cancelled" | "expired" | "superseded"
   settledBy?: string
+  /**
+   * Inviter display name, for the SW's offline "Call ended" fallback. Present so
+   * a cancel that collapsed an unshown ring can still name the caller; null when
+   * the inviter row is gone.
+   */
+  inviterName?: string | null
 }
 
 // Bot event payloads

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1641,6 +1641,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     rateLimits.calls,
     calls.declineInvitation
   )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/invitations/:invitationId/cancel",
+    ...authed,
+    audit("calls.cancel_invitation", "write"),
+    rateLimits.calls,
+    calls.cancelInvitation
+  )
   app.get(
     "/api/workspaces/:workspaceId/calls/:callId",
     ...authed,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1634,6 +1634,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     rateLimits.calls,
     calls.start
   )
+  app.post(
+    "/api/workspaces/:workspaceId/calls/invitations/:invitationId/decline",
+    ...authed,
+    audit("calls.decline_invitation", "write"),
+    rateLimits.calls,
+    calls.declineInvitation
+  )
   app.get(
     "/api/workspaces/:workspaceId/calls/:callId",
     ...authed,

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -157,7 +157,7 @@ import { SavedSuggestionsService, SuggestionExtractor } from "./features/saved-s
 import { ScheduledMessagesService, createScheduledMessageSendWorker } from "./features/scheduled-messages"
 import { DraftsService } from "./features/drafts"
 import { LabelService, LabelAssignmentService, LabelMessageService } from "./features/labels"
-import { PushService, PushNotificationHandler, createPushSessionCleanup } from "./features/push"
+import { PushService, PushNotificationHandler, CallRingPushHandler, createPushSessionCleanup } from "./features/push"
 import { AttachmentUploadedHandler, AttachmentEmbeddingHandler } from "./features/attachments"
 import { AICostService, AIBudgetService } from "./features/ai-usage"
 import { CommandRegistry, InviteCommand, createCommandWorker, CommandHandler } from "./features/commands"
@@ -1448,6 +1448,9 @@ export async function startServer(): Promise<ServerInstance> {
   const pushNotificationHandler = pushService.isEnabled()
     ? new PushNotificationHandler({ pool: pools.realtime, pushService })
     : null
+  const callRingPushHandler = pushService.isEnabled()
+    ? new CallRingPushHandler({ pool: pools.realtime, pushService })
+    : null
   const linkPreviewOutboxHandler = new LinkPreviewOutboxHandler(pool, jobQueue)
   const shadowSyncHandler =
     controlPlaneClient && config.region
@@ -1483,6 +1486,7 @@ export async function startServer(): Promise<ServerInstance> {
     linkPreviewOutboxHandler,
     ...(enclaveDispatchHandler ? [enclaveDispatchHandler] : []),
     ...(pushNotificationHandler ? [pushNotificationHandler] : []),
+    ...(callRingPushHandler ? [callRingPushHandler] : []),
     ...(shadowSyncHandler ? [shadowSyncHandler] : []),
     ...(githubRouteSyncHandler ? [githubRouteSyncHandler] : []),
   ]

--- a/apps/frontend/src/auth/account-scope.test.tsx
+++ b/apps/frontend/src/auth/account-scope.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor } from "@/test"
 import { AuthProvider } from "@/auth"
 import { AccountScopeProvider, useAccountScope, type AccountScopeValue } from "@/auth/account-scope"
 import { hasSeededWorkspaceCache, seedWorkspaceCache } from "@/stores/workspace-store"
+import { addIncomingCall, getIncomingCalls } from "@/stores/incoming-call-store"
 import type { CachedWorkspace } from "@/db"
 
 // PR-4a headline test. Mounts the real AuthProvider + AccountScopeProvider
@@ -160,6 +161,20 @@ describe("AccountScope", () => {
     })
     expect(hasSeededWorkspaceCache("workspace_A")).toBe(true)
 
+    // A live incoming-call ring must not survive an account switch — the store
+    // is registered in flushModuleStoreCaches; this guards that registration.
+    addIncomingCall({
+      attemptId: "callinv_A",
+      callId: "call_A",
+      workspaceId: "workspace_A",
+      streamId: "stream_A",
+      inviterId: "user_A",
+      inviterName: "A",
+      mode: "video",
+      expiresAtMs: Date.now() + 60_000,
+    })
+    expect(getIncomingCalls()).toHaveLength(1)
+
     await act(async () => {
       await scope.switchAccount("workos_B")
     })
@@ -185,6 +200,7 @@ describe("AccountScope", () => {
 
     // Layer 3 — module store cache: flushed on switch.
     expect(hasSeededWorkspaceCache("workspace_A")).toBe(false)
+    expect(getIncomingCalls()).toHaveLength(0)
   })
 
   it("flips a second tab over BroadcastChannel and serves no cross-account data", async () => {

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -17,6 +17,7 @@ import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
 import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
 import { resetCallStoreCache } from "@/stores/call-store"
+import { resetIncomingCallStoreCache } from "@/stores/incoming-call-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
 import { useAuth } from "./hooks"
 
@@ -82,6 +83,7 @@ function flushModuleStoreCaches(): void {
   // the transport, and stops tracks (the CallManager's registered hangup) so an
   // account switch with a live call never leaves the prior account's mic hot.
   resetCallStoreCache()
+  resetIncomingCallStoreCache()
   resetRevealGate()
 }
 

--- a/apps/frontend/src/calls/call-ring-cancel.test.ts
+++ b/apps/frontend/src/calls/call-ring-cancel.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest"
+import { planRingCancel } from "./call-ring-cancel"
+
+describe("planRingCancel", () => {
+  it("closes without a fallback when a tagged ring notification is shown", () => {
+    expect(planRingCancel(1, { attemptId: "callinv_1" })).toEqual({ show: false })
+  })
+
+  it("shows a silent, non-vibrating Call ended fallback when the cancel collapsed an unshown ring", () => {
+    const plan = planRingCancel(0, { attemptId: "callinv_1", inviterName: "Ada" })
+    expect(plan).toMatchObject({
+      show: true,
+      title: "Ada's call ended",
+      // Reuses the ring tag so a late ring push replaces it; quiet close.
+      options: { tag: "call-callinv_1", silent: true, renotify: false },
+    })
+    // Never vibrates — the ring is over.
+    expect((plan as Extract<typeof plan, { show: true }>).options).not.toHaveProperty("vibrate")
+  })
+
+  it("falls back to a generic title when no inviter name is present", () => {
+    const plan = planRingCancel(0, { attemptId: "callinv_1" })
+    expect(plan).toMatchObject({ show: true, title: "Call ended" })
+  })
+})

--- a/apps/frontend/src/calls/call-ring-cancel.ts
+++ b/apps/frontend/src/calls/call-ring-cancel.ts
@@ -1,0 +1,42 @@
+// Pure decision helper for the service worker's `call_ring_cancel` push branch,
+// extracted so the fallback logic is testable without importing the SW module
+// (which touches `self`/`ServiceWorkerGlobalScope` at load).
+
+/** The subset of a `call_ring_cancel` push payload the fallback needs. */
+export interface RingCancelData {
+  attemptId?: string
+  inviterName?: string
+}
+
+/** A shown fallback notification, or nothing when a tagged ring was closed. */
+export type RingCancelPlan =
+  | { show: false }
+  | { show: true; title: string; options: NotificationOptions & { renotify?: boolean } }
+
+/**
+ * Decide what a `call_ring_cancel` push does given how many tagged ring
+ * notifications are currently shown for this attempt.
+ *
+ * - One or more are shown ⇒ the caller closes them; there is nothing new to show.
+ * - None are shown ⇒ the cancel collapsed a ring this device never displayed
+ *   (offline topic-collapse: the cancel replaced the queued ring). A push that
+ *   results in no visible notification burns the browser's silent-push quota
+ *   (Firefox revokes the subscription at 0, iOS after 3), so show a minimal,
+ *   silent "Call ended" instead — reusing the ring tag so a late ring push
+ *   replaces it, and never vibrating (the ring is over; keep it quiet).
+ */
+export function planRingCancel(shownCount: number, data: RingCancelData): RingCancelPlan {
+  if (shownCount > 0) return { show: false }
+  return {
+    show: true,
+    title: data.inviterName ? `${data.inviterName}'s call ended` : "Call ended",
+    options: {
+      icon: "/threa-logo-192.png",
+      badge: "/threa-logo-192.png",
+      tag: data.attemptId ? `call-${data.attemptId}` : "call",
+      silent: true,
+      renotify: false,
+      data: { ...data, kind: "call_ring_cancel" as const },
+    },
+  }
+}

--- a/apps/frontend/src/calls/ring-tone.ts
+++ b/apps/frontend/src/calls/ring-tone.ts
@@ -1,0 +1,117 @@
+// Runtime-synthesized incoming-call ring. No bundled audio asset — a short
+// two-tone warble from a WebAudio oscillator pair, gated by a repeating gain
+// cadence (ring ~1.5s, silence ~2.5s), which is smaller than any file and needs
+// no asset pipeline. Playback requires a resumed AudioContext (browser autoplay
+// policy), so a page with no prior user gesture (sticky activation) can't sound;
+// callers fall back to a local SW notification for the OS sound in that case.
+
+let ctx: AudioContext | null = null
+let ringNodes: { osc1: OscillatorNode; osc2: OscillatorNode; gain: GainNode } | null = null
+let cadenceTimer: ReturnType<typeof setInterval> | null = null
+let warmupInstalled = false
+
+function createContext(): AudioContext | null {
+  if (typeof window === "undefined") return null
+  const Ctor =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  if (!Ctor) return null
+  try {
+    return new Ctor()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resume (or lazily create) the ring AudioContext from a user gesture. Idempotent
+ * — safe to call on every gesture. The context can only leave `suspended` inside
+ * a gesture, so this is what makes a later `startRing()` audible.
+ */
+export function warmRingAudio(): void {
+  if (!ctx) ctx = createContext()
+  if (ctx && ctx.state === "suspended") void ctx.resume().catch(() => {})
+}
+
+/**
+ * Install one-time global gesture listeners that warm the ring context, so a
+ * ring that arrives later can sound without needing a gesture at ring time.
+ * Returns a teardown. Idempotent across mounts.
+ */
+export function installRingAudioWarmup(): () => void {
+  if (warmupInstalled || typeof window === "undefined") return () => {}
+  warmupInstalled = true
+  const onGesture = () => warmRingAudio()
+  window.addEventListener("pointerdown", onGesture, { passive: true })
+  window.addEventListener("keydown", onGesture)
+  return () => {
+    window.removeEventListener("pointerdown", onGesture)
+    window.removeEventListener("keydown", onGesture)
+    warmupInstalled = false
+  }
+}
+
+/** Whether a `startRing()` right now would actually be audible (context running). */
+export function isRingAudioReady(): boolean {
+  return ctx !== null && ctx.state === "running"
+}
+
+/**
+ * Start the looping ring. Returns true if it is audible; false when no resumed
+ * AudioContext exists (no prior gesture) — the caller then relies on the SW
+ * notification for the OS sound. Idempotent: a second call is a no-op.
+ */
+export function startRing(): boolean {
+  if (ringNodes) return isRingAudioReady()
+  if (!ctx) ctx = createContext()
+  if (!ctx || ctx.state !== "running") return false
+
+  const gain = ctx.createGain()
+  gain.gain.value = 0
+  gain.connect(ctx.destination)
+
+  const osc1 = ctx.createOscillator()
+  const osc2 = ctx.createOscillator()
+  osc1.type = "sine"
+  osc2.type = "sine"
+  osc1.frequency.value = 440
+  osc2.frequency.value = 480
+  osc1.connect(gain)
+  osc2.connect(gain)
+  osc1.start()
+  osc2.start()
+  ringNodes = { osc1, osc2, gain }
+
+  const pulse = () => {
+    if (!ctx || !ringNodes) return
+    const now = ctx.currentTime
+    const g = ringNodes.gain.gain
+    g.cancelScheduledValues(now)
+    g.setValueAtTime(0, now)
+    g.linearRampToValueAtTime(0.18, now + 0.05)
+    g.setValueAtTime(0.18, now + 1.4)
+    g.linearRampToValueAtTime(0, now + 1.5)
+  }
+  pulse()
+  cadenceTimer = setInterval(pulse, 4000)
+  return true
+}
+
+/** Stop the ring and release its nodes. Idempotent. */
+export function stopRing(): void {
+  if (cadenceTimer) {
+    clearInterval(cadenceTimer)
+    cadenceTimer = null
+  }
+  if (ringNodes) {
+    try {
+      ringNodes.osc1.stop()
+      ringNodes.osc2.stop()
+      ringNodes.osc1.disconnect()
+      ringNodes.osc2.disconnect()
+      ringNodes.gain.disconnect()
+    } catch {
+      // Nodes already stopped/disconnected.
+    }
+    ringNodes = null
+  }
+}

--- a/apps/frontend/src/components/activity/activity-content.tsx
+++ b/apps/frontend/src/components/activity/activity-content.tsx
@@ -16,6 +16,7 @@ const ACTIVITY_DISPLAY: Record<string, ActivityDisplay> = {
   reaction: { kind: "actor-prefixed", verb: "reacted to a message in", selfVerb: "You reacted to a message in" },
   saved_reminder: { kind: "verb-only", verb: "Reminder for message in" },
   member_added: { kind: "actor-prefixed", verb: "added you to", selfVerb: "You were added to" },
+  missed_call: { kind: "actor-prefixed", verb: "called you in", selfVerb: "You called" },
 }
 
 // Standalone (message-less) saved-item reminders have no stream to name —

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -24,9 +24,17 @@ import {
 // Bottom-anchored call surfaces clear the iOS home indicator on desktop (app
 // convention — see message-composer.tsx) and, on a phone, sit a composer-height
 // above the bottom (`--composer-height`, published on :root) so the dock never
-// covers the floating composer.
-const DOCK_BOTTOM =
+// covers the floating composer. Shared with the incoming-call overlay so the two
+// bottom-right surfaces line up (INV-35).
+export const DOCK_BOTTOM =
   "bottom-[calc(var(--composer-height,5rem)_+_1rem)] sm:bottom-[max(1rem,env(safe-area-inset-bottom))]"
+
+// The incoming-ring overlay lifted clear of the dock when both render (in a call
+// + a second ring arrives): the dock's own bottom offset plus a fixed clearance
+// so the ring card sits above the dock frame and never covers its controls (which
+// live at the dock's bottom edge).
+export const RING_ABOVE_DOCK_BOTTOM =
+  "bottom-[calc(var(--composer-height,5rem)_+_5.5rem)] sm:bottom-[calc(max(1rem,env(safe-area-inset-bottom))_+_4.5rem)]"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { PreJoinGate } from "./pre-join-gate"

--- a/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { render, screen, cleanup, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { IncomingCallOverlay } from "./incoming-call-overlay"
+import * as launchCtx from "./call-launch-context"
+import * as ringTone from "@/calls/ring-tone"
+import { api } from "@/api/client"
+import {
+  addIncomingCall,
+  settleIncomingCall,
+  resetIncomingCallStoreCache,
+  getIncomingCalls,
+  type IncomingCall,
+} from "@/stores/incoming-call-store"
+
+function makeCall(overrides: Partial<IncomingCall> = {}): IncomingCall {
+  return {
+    attemptId: "callinv_1",
+    callId: "call_1",
+    workspaceId: "ws_1",
+    streamId: "stream_dm",
+    inviterId: "usr_a",
+    inviterName: "Ada",
+    mode: "video",
+    expiresAtMs: Date.now() + 45_000,
+    ...overrides,
+  }
+}
+
+let launch: ReturnType<typeof vi.fn>
+
+function renderOverlay() {
+  return render(
+    <MemoryRouter>
+      <IncomingCallOverlay />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  resetIncomingCallStoreCache()
+  launch = vi.fn()
+  vi.spyOn(launchCtx, "useCallLaunch").mockReturnValue({
+    launch: launch as unknown as (request: launchCtx.CallLaunchRequest) => void,
+    callActive: false,
+    state: { status: "idle" },
+    retry: vi.fn(),
+    cancel: vi.fn(),
+  })
+  vi.spyOn(ringTone, "installRingAudioWarmup").mockReturnValue(() => {})
+  vi.spyOn(ringTone, "startRing").mockReturnValue(true)
+  vi.spyOn(ringTone, "stopRing").mockReturnValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  resetIncomingCallStoreCache()
+  vi.restoreAllMocks()
+})
+
+describe("IncomingCallOverlay", () => {
+  it("renders a live ring with the caller name and media mode", () => {
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+    expect(screen.getByText("Ada is calling…")).toBeInTheDocument()
+    expect(screen.getByText("Video call")).toBeInTheDocument()
+  })
+
+  it("does not steal focus on mount (no autofocus, no key binding)", () => {
+    const input = document.createElement("input")
+    document.body.appendChild(input)
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    // The overlay mounted but the pre-existing focus is untouched.
+    expect(screen.getByLabelText("Accept call")).toBeInTheDocument()
+    expect(document.activeElement).toBe(input)
+    input.remove()
+  })
+
+  it("Accept joins the call and clears the ring", async () => {
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    await userEvent.click(screen.getByLabelText("Accept call"))
+
+    expect(launch).toHaveBeenCalledWith({ workspaceId: "ws_1", streamId: "stream_dm", mode: "video" })
+    expect(getIncomingCalls()).toEqual([])
+  })
+
+  it("Decline hits the invitee-scoped REST endpoint and clears the ring", async () => {
+    const post = vi.spyOn(api, "post").mockResolvedValue({} as never)
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    await userEvent.click(screen.getByLabelText("Decline call"))
+
+    expect(post).toHaveBeenCalledWith("/api/workspaces/ws_1/calls/invitations/callinv_1/decline", {})
+    expect(getIncomingCalls()).toEqual([])
+  })
+
+  it("clears when the ring settles from another device", () => {
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+    expect(screen.getByText("Ada is calling…")).toBeInTheDocument()
+
+    act(() => settleIncomingCall("callinv_1"))
+    expect(screen.queryByText("Ada is calling…")).not.toBeInTheDocument()
+  })
+
+  it("falls back to a local SW notification when the ring audio can't sound (no gesture yet)", async () => {
+    vi.spyOn(ringTone, "startRing").mockReturnValue(false)
+    const showNotification = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(global.navigator, "serviceWorker", {
+      configurable: true,
+      value: { ready: Promise.resolve({ showNotification }) },
+    })
+
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+    await Promise.resolve()
+
+    expect(showNotification).toHaveBeenCalledWith(
+      "Ada is calling…",
+      expect.objectContaining({ tag: "call-callinv_1", body: "Video call" })
+    )
+  })
+})

--- a/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
@@ -2,9 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { render, screen, cleanup, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
+import { toast } from "sonner"
 import { IncomingCallOverlay } from "./incoming-call-overlay"
 import * as launchCtx from "./call-launch-context"
 import * as ringTone from "@/calls/ring-tone"
+import * as workspacesHooks from "@/hooks/use-workspaces"
+import * as workspaceStore from "@/stores/workspace-store"
 import { api } from "@/api/client"
 import {
   addIncomingCall,
@@ -33,7 +36,7 @@ let launch: ReturnType<typeof vi.fn>
 function renderOverlay() {
   return render(
     <MemoryRouter>
-      <IncomingCallOverlay />
+      <IncomingCallOverlay workspaceId="ws_1" />
     </MemoryRouter>
   )
 }
@@ -51,6 +54,9 @@ beforeEach(() => {
   vi.spyOn(ringTone, "installRingAudioWarmup").mockReturnValue(() => {})
   vi.spyOn(ringTone, "startRing").mockReturnValue(true)
   vi.spyOn(ringTone, "stopRing").mockReturnValue(undefined)
+  // Default: no notification suppression (level not none, no do-not-disturb).
+  vi.spyOn(workspacesHooks, "useCurrentWorkspaceUser").mockReturnValue(null)
+  vi.spyOn(workspaceStore, "useWorkspaceUserPreferences").mockReturnValue(undefined)
 })
 
 afterEach(() => {
@@ -128,5 +134,64 @@ describe("IncomingCallOverlay", () => {
       "Ada is calling…",
       expect.objectContaining({ tag: "call-callinv_1", body: "Video call" })
     )
+  })
+
+  it("suppresses the audible ring on do-not-disturb but still renders the card", () => {
+    vi.spyOn(workspacesHooks, "useCurrentWorkspaceUser").mockReturnValue({
+      statusEmoji: null,
+      statusText: null,
+      statusExpiresAt: null,
+      statusPausesNotifications: false,
+      notificationsPausedUntil: null,
+      notificationsPausedIndefinitely: true,
+    } as never)
+
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    // The visual card stays — the ring is still actionable, just silent.
+    expect(screen.getByText("Ada is calling…")).toBeInTheDocument()
+    expect(ringTone.startRing).not.toHaveBeenCalled()
+  })
+
+  it("suppresses the audible ring when the notification level is none", () => {
+    vi.spyOn(workspaceStore, "useWorkspaceUserPreferences").mockReturnValue({ notificationLevel: "none" } as never)
+
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    expect(screen.getByText("Ada is calling…")).toBeInTheDocument()
+    expect(ringTone.startRing).not.toHaveBeenCalled()
+  })
+
+  it("scopes mute per attempt — a later ring still sounds", async () => {
+    act(() => addIncomingCall(makeCall({ attemptId: "callinv_A", callId: "call_A" })))
+    renderOverlay()
+
+    await userEvent.click(screen.getByLabelText("Silence ring"))
+    ;(ringTone.startRing as ReturnType<typeof vi.fn>).mockClear()
+
+    act(() => addIncomingCall(makeCall({ attemptId: "callinv_B", callId: "call_B", inviterName: "Bo" })))
+
+    expect(ringTone.startRing).toHaveBeenCalled()
+  })
+
+  it("tells the user when a ?call deep-link has no matching live ring", () => {
+    const info = vi.spyOn(toast, "info").mockReturnValue("t" as never)
+
+    render(
+      <MemoryRouter initialEntries={["/?call=call_missing"]}>
+        <IncomingCallOverlay workspaceId="ws_1" />
+      </MemoryRouter>
+    )
+
+    expect(info).toHaveBeenCalledWith("This call has ended")
+  })
+
+  it("announces the ring through an alert live region", () => {
+    act(() => addIncomingCall(makeCall()))
+    renderOverlay()
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Ada is calling…")
   })
 })

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -1,11 +1,17 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
+import { toast } from "sonner"
 import { Phone, PhoneOff, BellOff, Video } from "lucide-react"
+import { PrefNotificationLevels, resolveNotificationPause } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
+import { cn } from "@/lib/utils"
+import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
+import { useWorkspaceUserPreferences } from "@/stores/workspace-store"
 import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/stores/incoming-call-store"
 import { installRingAudioWarmup, startRing, stopRing } from "@/calls/ring-tone"
 import { useCallLaunch } from "./call-launch-context"
+import { DOCK_BOTTOM, RING_ABOVE_DOCK_BOTTOM } from "./call-dock"
 
 /**
  * Fire a local service-worker notification for a ring when the page can't sound
@@ -35,48 +41,68 @@ function fireLocalRingNotification(call: IncomingCall): void {
  * binding — an arriving ring never hijacks the keyboard from whatever the user
  * is doing. Accept joins the call immediately (the pre-join gate only appears if
  * devices fail, via CallLaunch); Decline hits the invitee-scoped REST endpoint;
- * Mute silences the audible ring without settling the ring. The shared ring
- * plays while any ring is live and the user isn't already in/joining a call;
+ * Mute silences the audible ring for that one attempt without settling it. The
+ * shared ring plays while any un-muted ring is live and the user isn't already
+ * in/joining a call — unless the user has notifications off or is on
+ * do-not-disturb, in which case the visual card still shows but stays silent.
  * INV-63 — no success toasts, the overlay is its own feedback.
  */
-export function IncomingCallOverlay() {
+export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   const calls = useIncomingCalls()
   const { launch, callActive } = useCallLaunch()
   const [searchParams, setSearchParams] = useSearchParams()
-  const mutedRef = useRef(false)
   const notifiedRef = useRef<Set<string>>(new Set())
+  // Per-attempt mute (INV-... scoped so a fresh ring rings again). State, not a
+  // ref, so muting one ring re-evaluates whether any other ring should still sound.
+  const [mutedAttempts, setMutedAttempts] = useState<Set<string>>(() => new Set())
+
+  // Audible ring respects the invitee's notification prefs like the push does:
+  // level NONE or an active do-not-disturb pause suppresses the sound (the card
+  // stays visible — the ring is still actionable, just silent).
+  const prefs = useWorkspaceUserPreferences(workspaceId)
+  const currentUser = useCurrentWorkspaceUser(workspaceId)
+  const notificationsSuppressed =
+    prefs?.notificationLevel === PrefNotificationLevels.NONE ||
+    (currentUser ? resolveNotificationPause(currentUser, new Date()) !== null : false)
 
   useEffect(() => installRingAudioWarmup(), [])
 
-  // Any live ring while not already in/joining a call → ring. A mute silences the
-  // audible tone (kept in a ref so toggling it re-runs this effect). When the
-  // page can't sound, fall back to a local SW notification, once per attempt.
-  const hasRing = calls.length > 0
+  // Any un-muted live ring while not already in/joining a call and not suppressed
+  // → ring. When the page can't sound, fall back to a local SW notification, once
+  // per attempt.
+  const hasAudibleRing = calls.some((c) => !mutedAttempts.has(c.attemptId))
   useEffect(() => {
-    if (!hasRing || callActive || mutedRef.current) {
+    if (!hasAudibleRing || callActive || notificationsSuppressed) {
       stopRing()
       return
     }
     const audible = startRing()
     if (!audible) {
       for (const call of calls) {
-        if (!notifiedRef.current.has(call.attemptId)) {
-          notifiedRef.current.add(call.attemptId)
-          fireLocalRingNotification(call)
-        }
+        if (mutedAttempts.has(call.attemptId) || notifiedRef.current.has(call.attemptId)) continue
+        notifiedRef.current.add(call.attemptId)
+        fireLocalRingNotification(call)
       }
     }
     return () => stopRing()
-  }, [hasRing, callActive, calls])
+  }, [hasAudibleRing, callActive, notificationsSuppressed, calls, mutedAttempts])
 
-  // Drop notified-markers for attempts that have settled so a future reuse
-  // (never, ids are unique) or memory growth can't accumulate.
+  // Drop markers for attempts that have settled so memory can't accumulate and a
+  // (never-happening) id reuse would ring again.
   useEffect(() => {
     const live = new Set(calls.map((c) => c.attemptId))
     for (const id of notifiedRef.current) {
       if (!live.has(id)) notifiedRef.current.delete(id)
     }
-    if (calls.length === 0) mutedRef.current = false
+    setMutedAttempts((prev) => {
+      let changed = false
+      const next = new Set<string>()
+      for (const id of prev) {
+        if (live.has(id)) next.add(id)
+        else changed = true
+      }
+      return changed ? next : prev
+    })
   }, [calls])
 
   const accept = useCallback(
@@ -94,20 +120,24 @@ export function IncomingCallOverlay() {
     void api.post(`/api/workspaces/${call.workspaceId}/calls/invitations/${call.attemptId}/decline`, {}).catch(() => {})
   }, [])
 
-  const muteRing = useCallback(() => {
-    mutedRef.current = true
-    stopRing()
+  const muteRing = useCallback((attemptId: string) => {
+    setMutedAttempts((prev) => {
+      if (prev.has(attemptId)) return prev
+      const next = new Set(prev)
+      next.add(attemptId)
+      return next
+    })
   }, [])
 
   // Accept-intent from a ring notification click (`?call=<callId>`). Accept when
-  // the ring is still live in-store; otherwise (cold open, push-only) just strip
-  // the param and leave the user on the host stream — there's no live ring or
-  // known media mode to safely auto-join from a bare id.
+  // the ring is still live in-store; otherwise (cold open, push-only, or the call
+  // already ended) tell the user rather than silently stripping the param.
   const callParam = searchParams.get("call")
   useEffect(() => {
     if (!callParam) return
     const ring = calls.find((c) => c.callId === callParam)
     if (ring) accept(ring)
+    else toast.info("This call has ended")
     const next = new URLSearchParams(searchParams)
     next.delete("call")
     setSearchParams(next, { replace: true })
@@ -116,11 +146,17 @@ export function IncomingCallOverlay() {
   if (calls.length === 0) return null
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div
+      className={cn(
+        "pointer-events-none fixed right-4 z-50 flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
+        callActive ? RING_ABOVE_DOCK_BOTTOM : DOCK_BOTTOM
+      )}
+    >
       {calls.map((call) => (
         <div
           key={call.attemptId}
-          className="pointer-events-auto flex w-80 items-center gap-3 rounded-lg border bg-popover p-3 text-popover-foreground shadow-lg"
+          role="alert"
+          className="pointer-events-auto flex items-center gap-3 rounded-lg border bg-popover p-3 text-popover-foreground shadow-lg"
         >
           <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
             {call.mode === "video" ? <Video className="size-4" /> : <Phone className="size-4" />}
@@ -130,7 +166,7 @@ export function IncomingCallOverlay() {
             <p className="text-xs text-muted-foreground">{call.mode === "video" ? "Video call" : "Voice call"}</p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <Button size="icon" variant="ghost" aria-label="Silence ring" onClick={muteRing}>
+            <Button size="icon" variant="ghost" aria-label="Silence ring" onClick={() => muteRing(call.attemptId)}>
               <BellOff className="size-4" />
             </Button>
             <Button size="icon" variant="destructive" aria-label="Decline call" onClick={() => decline(call)}>

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useSearchParams } from "react-router-dom"
+import { Phone, PhoneOff, BellOff, Video } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { api } from "@/api/client"
+import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/stores/incoming-call-store"
+import { installRingAudioWarmup, startRing, stopRing } from "@/calls/ring-tone"
+import { useCallLaunch } from "./call-launch-context"
+
+/**
+ * Fire a local service-worker notification for a ring when the page can't sound
+ * (no gesture yet → suspended AudioContext), so the OS still alerts. Tagged
+ * `call-<attemptId>` — the same tag the backend ring push uses — so a socket
+ * fallback and a push never stack two notifications for one attempt; a
+ * `call_ring_cancel` push or the settle-close path removes it.
+ */
+function fireLocalRingNotification(call: IncomingCall): void {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return
+  void navigator.serviceWorker.ready
+    .then((registration) =>
+      registration.showNotification(call.inviterName ? `${call.inviterName} is calling…` : "Incoming call…", {
+        body: call.mode === "video" ? "Video call" : "Voice call",
+        icon: "/threa-logo-192.png",
+        badge: "/threa-logo-192.png",
+        tag: `call-${call.attemptId}`,
+        data: { kind: "call_ring", callId: call.callId, workspaceId: call.workspaceId, streamId: call.streamId },
+      } as NotificationOptions)
+    )
+    .catch(() => {})
+}
+
+/**
+ * The incoming-call ring surface. Non-modal and deliberately non-focus-stealing
+ * (the plan is explicit): fixed to a corner, no autofocus, no Enter/Escape
+ * binding — an arriving ring never hijacks the keyboard from whatever the user
+ * is doing. Accept joins the call immediately (the pre-join gate only appears if
+ * devices fail, via CallLaunch); Decline hits the invitee-scoped REST endpoint;
+ * Mute silences the audible ring without settling the ring. The shared ring
+ * plays while any ring is live and the user isn't already in/joining a call;
+ * INV-63 — no success toasts, the overlay is its own feedback.
+ */
+export function IncomingCallOverlay() {
+  const calls = useIncomingCalls()
+  const { launch, callActive } = useCallLaunch()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const mutedRef = useRef(false)
+  const notifiedRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => installRingAudioWarmup(), [])
+
+  // Any live ring while not already in/joining a call → ring. A mute silences the
+  // audible tone (kept in a ref so toggling it re-runs this effect). When the
+  // page can't sound, fall back to a local SW notification, once per attempt.
+  const hasRing = calls.length > 0
+  useEffect(() => {
+    if (!hasRing || callActive || mutedRef.current) {
+      stopRing()
+      return
+    }
+    const audible = startRing()
+    if (!audible) {
+      for (const call of calls) {
+        if (!notifiedRef.current.has(call.attemptId)) {
+          notifiedRef.current.add(call.attemptId)
+          fireLocalRingNotification(call)
+        }
+      }
+    }
+    return () => stopRing()
+  }, [hasRing, callActive, calls])
+
+  // Drop notified-markers for attempts that have settled so a future reuse
+  // (never, ids are unique) or memory growth can't accumulate.
+  useEffect(() => {
+    const live = new Set(calls.map((c) => c.attemptId))
+    for (const id of notifiedRef.current) {
+      if (!live.has(id)) notifiedRef.current.delete(id)
+    }
+    if (calls.length === 0) mutedRef.current = false
+  }, [calls])
+
+  const accept = useCallback(
+    (call: IncomingCall) => {
+      launch({ workspaceId: call.workspaceId, streamId: call.streamId, mode: call.mode })
+      settleIncomingCall(call.attemptId)
+    },
+    [launch]
+  )
+
+  const decline = useCallback((call: IncomingCall) => {
+    // Clear locally first (the ring is over for this user); the REST decline
+    // drives the settle broadcast to the caller and this user's other devices.
+    settleIncomingCall(call.attemptId)
+    void api.post(`/api/workspaces/${call.workspaceId}/calls/invitations/${call.attemptId}/decline`, {}).catch(() => {})
+  }, [])
+
+  const muteRing = useCallback(() => {
+    mutedRef.current = true
+    stopRing()
+  }, [])
+
+  // Accept-intent from a ring notification click (`?call=<callId>`). Accept when
+  // the ring is still live in-store; otherwise (cold open, push-only) just strip
+  // the param and leave the user on the host stream — there's no live ring or
+  // known media mode to safely auto-join from a bare id.
+  const callParam = searchParams.get("call")
+  useEffect(() => {
+    if (!callParam) return
+    const ring = calls.find((c) => c.callId === callParam)
+    if (ring) accept(ring)
+    const next = new URLSearchParams(searchParams)
+    next.delete("call")
+    setSearchParams(next, { replace: true })
+  }, [callParam, calls, accept, searchParams, setSearchParams])
+
+  if (calls.length === 0) return null
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {calls.map((call) => (
+        <div
+          key={call.attemptId}
+          className="pointer-events-auto flex w-80 items-center gap-3 rounded-lg border bg-popover p-3 text-popover-foreground shadow-lg"
+        >
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            {call.mode === "video" ? <Video className="size-4" /> : <Phone className="size-4" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{call.inviterName ?? "Someone"} is calling…</p>
+            <p className="text-xs text-muted-foreground">{call.mode === "video" ? "Video call" : "Voice call"}</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button size="icon" variant="ghost" aria-label="Silence ring" onClick={muteRing}>
+              <BellOff className="size-4" />
+            </Button>
+            <Button size="icon" variant="destructive" aria-label="Decline call" onClick={() => decline(call)}>
+              <PhoneOff className="size-4" />
+            </Button>
+            <Button size="icon" aria-label="Accept call" onClick={() => accept(call)}>
+              <Phone className="size-4" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/index.ts
+++ b/apps/frontend/src/components/call/index.ts
@@ -1,3 +1,4 @@
 export { CallDock } from "./call-dock"
+export { IncomingCallOverlay } from "./incoming-call-overlay"
 export { CallLaunchProvider, useCallLaunch, type CallLaunchRequest } from "./call-launch-context"
 export { CallManagerProvider, useCallManager } from "./call-manager-context"

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -526,7 +526,7 @@ export function WorkspaceLayout() {
                   </MentionableWrapper>
                 </UserProfileProvider>
                 <CallDock />
-                <IncomingCallOverlay />
+                <IncomingCallOverlay workspaceId={workspaceId} />
               </CallLaunchProvider>
             </ChannelLinkProvider>
           </CoordinatedLoadingProvider>

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -73,7 +73,7 @@ import { CreateChannelDialog } from "@/components/create-channel"
 import { AttachmentExplorer, useExplorerUrlState } from "@/components/attachment-explorer"
 import { SearchPanelProvider, useSearchPanel } from "@/components/search"
 import { E2eUnlockProvider } from "@/components/encryption/e2e-unlock-provider"
-import { CallDock, CallLaunchProvider } from "@/components/call"
+import { CallDock, CallLaunchProvider, IncomingCallOverlay } from "@/components/call"
 import { EnclaveRewrapNudgeListener } from "@/components/encryption/enclave-rewrap-nudge-listener"
 import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
@@ -526,6 +526,7 @@ export function WorkspaceLayout() {
                   </MentionableWrapper>
                 </UserProfileProvider>
                 <CallDock />
+                <IncomingCallOverlay />
               </CallLaunchProvider>
             </ChannelLinkProvider>
           </CoordinatedLoadingProvider>

--- a/apps/frontend/src/stores/incoming-call-store.test.ts
+++ b/apps/frontend/src/stores/incoming-call-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import {
+  useIncomingCalls,
+  addIncomingCall,
+  settleIncomingCall,
+  resetIncomingCallStoreCache,
+  getIncomingCalls,
+  type IncomingCall,
+} from "./incoming-call-store"
+
+function makeCall(overrides: Partial<IncomingCall> = {}): IncomingCall {
+  return {
+    attemptId: "callinv_1",
+    callId: "call_1",
+    workspaceId: "ws_1",
+    streamId: "stream_dm",
+    inviterId: "usr_a",
+    inviterName: "Ada",
+    mode: "video",
+    expiresAtMs: Date.now() + 45_000,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  resetIncomingCallStoreCache()
+})
+
+afterEach(() => {
+  resetIncomingCallStoreCache()
+  vi.useRealTimers()
+})
+
+describe("incoming call store", () => {
+  it("surfaces a live ring and clears it on settle (cross-device accept path)", () => {
+    const { result } = renderHook(() => useIncomingCalls())
+    expect(result.current).toEqual([])
+
+    act(() => addIncomingCall(makeCall()))
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].attemptId).toBe("callinv_1")
+
+    // A settle arriving from any device (or this one) removes the overlay.
+    act(() => settleIncomingCall("callinv_1"))
+    expect(result.current).toEqual([])
+  })
+
+  it("is idempotent on a duplicate attempt id (one ring per attempt across devices)", () => {
+    const { result } = renderHook(() => useIncomingCalls())
+    act(() => addIncomingCall(makeCall()))
+    act(() => addIncomingCall(makeCall({ inviterName: "Someone else" })))
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].inviterName).toBe("Ada")
+  })
+
+  it("drops a ring already past its deadline (stale sync-log replay after being offline)", () => {
+    act(() => addIncomingCall(makeCall({ expiresAtMs: Date.now() - 1 })))
+    expect(getIncomingCalls()).toEqual([])
+  })
+
+  it("self-dismisses at the deadline when no settle arrives", () => {
+    const { result } = renderHook(() => useIncomingCalls())
+    act(() => addIncomingCall(makeCall({ expiresAtMs: Date.now() + 1_000 })))
+    expect(result.current).toHaveLength(1)
+    act(() => vi.advanceTimersByTime(1_000))
+    expect(result.current).toEqual([])
+  })
+
+  it("resets every ring on account switch", () => {
+    act(() => addIncomingCall(makeCall()))
+    act(() => addIncomingCall(makeCall({ attemptId: "callinv_2" })))
+    expect(getIncomingCalls()).toHaveLength(2)
+    act(() => resetIncomingCallStoreCache())
+    expect(getIncomingCalls()).toEqual([])
+  })
+})

--- a/apps/frontend/src/stores/incoming-call-store.ts
+++ b/apps/frontend/src/stores/incoming-call-store.ts
@@ -1,0 +1,90 @@
+import { useSyncExternalStore } from "react"
+import type { CallMode } from "@/calls/config"
+
+// Module store (useSyncExternalStore) for live incoming-call rings, keyed by
+// attemptId (the invitation id). Rings arrive user-scoped on the account socket
+// (workspace-sync) and are settled by a matching event from any of the user's
+// devices — an accept on the phone clears the laptop's overlay. Registered in
+// account-scope `flushModuleStoreCaches` so a switch drops the prior account's
+// rings. One attempt = one ring across every device (multi-device single id).
+
+export interface IncomingCall {
+  attemptId: string
+  callId: string
+  workspaceId: string
+  streamId: string
+  inviterId: string
+  inviterName: string | null
+  mode: CallMode
+  /** Epoch ms; the ring self-dismisses at this deadline if no settle arrives. */
+  expiresAtMs: number
+}
+
+let calls: IncomingCall[] = []
+const timers = new Map<string, ReturnType<typeof setTimeout>>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+function clearTimer(attemptId: string): void {
+  const timer = timers.get(attemptId)
+  if (timer) {
+    clearTimeout(timer)
+    timers.delete(attemptId)
+  }
+}
+
+/**
+ * Register a live ring. A ring already past its deadline (a stale sync-log
+ * replay after being offline) is dropped rather than surfaced. Re-adding the
+ * same attempt id is idempotent. Schedules a local self-dismiss at the deadline
+ * so the overlay clears even if the server's expire settle is missed.
+ */
+export function addIncomingCall(call: IncomingCall): void {
+  if (call.expiresAtMs <= Date.now()) return
+  if (calls.some((c) => c.attemptId === call.attemptId)) return
+  calls = [...calls, call]
+  clearTimer(call.attemptId)
+  timers.set(
+    call.attemptId,
+    setTimeout(() => settleIncomingCall(call.attemptId), Math.max(0, call.expiresAtMs - Date.now()))
+  )
+  emit()
+}
+
+/** Remove a ring (settled on any device, timed out, or acted on locally). */
+export function settleIncomingCall(attemptId: string): void {
+  clearTimer(attemptId)
+  if (!calls.some((c) => c.attemptId === attemptId)) return
+  calls = calls.filter((c) => c.attemptId !== attemptId)
+  emit()
+}
+
+/** Clear every ring on account switch (account-scope `flushModuleStoreCaches`). */
+export function resetIncomingCallStoreCache(): void {
+  for (const timer of timers.values()) clearTimeout(timer)
+  timers.clear()
+  if (calls.length === 0) return
+  calls = []
+  emit()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): IncomingCall[] {
+  return calls
+}
+
+export function useIncomingCalls(): IncomingCall[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/** Non-reactive read for imperative callers (tests, the SW click bridge). */
+export function getIncomingCalls(): IncomingCall[] {
+  return calls
+}

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -357,9 +357,21 @@ interface PushData {
    * Payload kind: "test" is sent by the in-app diagnostic to verify
    * end-to-end delivery; "saved_reminder" marks reminder pushes so clicks on
    * standalone (message-less) items can land on the Saved page;
-   * "rewrap_needed" pulls the owner back to re-key a stuck encrypted scratchpad.
+   * "rewrap_needed" pulls the owner back to re-key a stuck encrypted scratchpad;
+   * "call_ring" is an incoming DM call, "call_ring_cancel" retracts it;
+   * "missed_call" is a ring that lapsed while the app was closed.
    */
-  kind?: "test" | "saved_reminder" | "rewrap_needed"
+  kind?: "test" | "saved_reminder" | "rewrap_needed" | "call_ring" | "call_ring_cancel" | "missed_call"
+  /** Ring attempt id (invitation id) — the `call-<attemptId>` notification tag key. */
+  attemptId?: string
+  /** Call id a ring click accepts into. */
+  callId?: string
+  /** Inviter display name for the ring notification title. */
+  inviterName?: string
+  /** Ring media mode ("video" | "audio_only"). */
+  mode?: string
+  /** ISO deadline the ring lapses at. */
+  expiresAt?: string
 }
 
 self.addEventListener("push", (event) => {
@@ -442,6 +454,62 @@ self.addEventListener("push", (event) => {
         renotify: true, // Re-alert (vibrate/sound) when a later nudge replaces an earlier same-tag one
         vibrate: THREA_VIBRATION_PATTERN,
         data: { ...data, kind: "rewrap_needed" },
+      } as ExtendedNotificationOptions)
+    )
+    return
+  }
+
+  // Incoming call ring. Always display (a ring the user isn't looking at is the
+  // whole point) with a distinct tag so the in-app socket-fallback notification
+  // and this push collapse to one entry per attempt. `renotify` re-alerts.
+  // Clicking opens/focuses the app to the host stream with `?call=<callId>`,
+  // which the app reads as accept-intent (declining from the notification is
+  // v1-omitted — no notification action buttons yet).
+  if (data.kind === "call_ring") {
+    if (!data.attemptId) return
+    event.waitUntil(
+      self.registration.showNotification(data.inviterName ? `${data.inviterName} is calling…` : "Incoming call…", {
+        body: data.mode === "audio_only" ? "Voice call" : "Video call",
+        icon: "/threa-logo-192.png",
+        badge: "/threa-logo-192.png",
+        tag: `call-${data.attemptId}`,
+        renotify: true,
+        vibrate: THREA_VIBRATION_PATTERN,
+        data: { ...data, kind: "call_ring" },
+      } as ExtendedNotificationOptions)
+    )
+    return
+  }
+
+  // Ring retracted (accepted elsewhere / declined / cancelled / expired). Close
+  // the ring notification best-effort — platform retract support varies (some
+  // won't remove an already-shown notification), documented in the plan.
+  if (data.kind === "call_ring_cancel") {
+    if (!data.attemptId) return
+    event.waitUntil(
+      self.registration.getNotifications({ tag: `call-${data.attemptId}` }).then((ns) => {
+        for (const n of ns) n.close()
+      })
+    )
+    return
+  }
+
+  // Missed call (ring expired while the app was closed). Its own copy — the
+  // generic message-grouping path below has no missed_call branch and would
+  // title the banner "New message" with the caller's name as the body. Clicking
+  // opens the host stream via the generic deep-link handler.
+  if (data.kind === "missed_call") {
+    const inviter = data.authorName
+    const where = data.streamName ? ` in ${data.streamName}` : ""
+    event.waitUntil(
+      self.registration.showNotification(inviter ? `Missed call from ${inviter}` : "Missed call", {
+        body: (data.mode === "audio_only" ? "Voice call" : "Video call") + where,
+        icon: "/threa-logo-192.png",
+        badge: "/threa-logo-192.png",
+        tag: data.streamId ? `missed-call:${data.streamId}` : "missed-call",
+        renotify: true,
+        vibrate: THREA_VIBRATION_PATTERN,
+        data: { ...data, kind: "missed_call" },
       } as ExtendedNotificationOptions)
     )
     return
@@ -541,7 +609,13 @@ self.addEventListener("notificationclick", (event) => {
   const data = event.notification.data as PushData | undefined
   let targetUrl = "/"
 
-  if (data?.workspaceId && data?.conversationId) {
+  if (data?.workspaceId && data?.callId && data.kind === "call_ring") {
+    // Ring click = accept-intent: land on the host stream with `?call=<callId>`,
+    // which the app interprets as "join this call".
+    targetUrl = data.streamId
+      ? `/w/${data.workspaceId}/s/${data.streamId}?call=${data.callId}`
+      : `/w/${data.workspaceId}?call=${data.callId}`
+  } else if (data?.workspaceId && data?.conversationId) {
     // Conversation origin wins over the stream permalink: reopen the message in
     // the conversation panel. `conv:` is the panel-id wire prefix
     // (createConversationPanelId); inlined here since the SW can't import the

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -1,6 +1,7 @@
 /// <reference lib="webworker" />
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { resolveTag } from "./lib/sw-notification-format"
+import { planRingCancel } from "./calls/call-ring-cancel"
 import { isDevicePresent, PRESENCE_CACHE } from "./lib/sw-presence"
 import { readVisibleStreams } from "./lib/visible-streams"
 import {
@@ -482,13 +483,21 @@ self.addEventListener("push", (event) => {
   }
 
   // Ring retracted (accepted elsewhere / declined / cancelled / expired). Close
-  // the ring notification best-effort — platform retract support varies (some
-  // won't remove an already-shown notification), documented in the plan.
+  // the tagged ring notification best-effort — platform retract support varies
+  // (some won't remove an already-shown notification), documented in the plan.
+  // When nothing was closed the cancel collapsed a ring this device never showed
+  // (offline topic-collapse); show a minimal, silent "Call ended" so the push is
+  // never notification-less (a silent-result push burns the browser's silent-push
+  // quota — Firefox revokes the subscription at 0).
   if (data.kind === "call_ring_cancel") {
     if (!data.attemptId) return
     event.waitUntil(
       self.registration.getNotifications({ tag: `call-${data.attemptId}` }).then((ns) => {
         for (const n of ns) n.close()
+        const plan = planRingCancel(ns.length, data)
+        if (plan.show) {
+          return self.registration.showNotification(plan.title, plan.options as ExtendedNotificationOptions)
+        }
       })
     )
     return

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -51,6 +51,8 @@ import type {
 import { cachedPersonaFromListItem } from "@/lib/personas"
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
 import { conversationKeys } from "@/hooks/use-conversations"
+import { addIncomingCall, settleIncomingCall } from "@/stores/incoming-call-store"
+import type { CallMode } from "@/calls/config"
 import { personaKeys } from "@/hooks/use-personas"
 import { mergeBoardConversation, addBoardConversationStream } from "@/stores/board-store"
 import { putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
@@ -1968,6 +1970,38 @@ export function registerWorkspaceSocketHandlers(
   // that stream on the board row so the card subscribes to its rail and draws the
   // member live — no board refetch. The aggregate `conversation:updated` re-sorts
   // the card; this only widens its stream set.
+  // Incoming DM call ring (user-scoped: lands in the account's user room, so it
+  // reaches every device this user has open). One attempt id = one ring across
+  // devices; the store drops a ring already past its deadline (stale replay).
+  const handleCallInvitationCreated = (payload: {
+    workspaceId: string
+    attemptId: string
+    callId: string
+    streamId: string
+    inviter: { id: string; name: string | null }
+    mode: string
+    expiresAt: string
+  }) => {
+    if (payload.workspaceId !== workspaceId) return
+    addIncomingCall({
+      attemptId: payload.attemptId,
+      callId: payload.callId,
+      workspaceId: payload.workspaceId,
+      streamId: payload.streamId,
+      inviterId: payload.inviter.id,
+      inviterName: payload.inviter.name,
+      mode: payload.mode as CallMode,
+      expiresAtMs: Date.parse(payload.expiresAt),
+    })
+  }
+
+  // Ring settled anywhere (accept on another device, decline, cancel, expire) →
+  // drop the overlay on this device too.
+  const handleCallInvitationSettled = (payload: { workspaceId: string; attemptId: string }) => {
+    if (payload.workspaceId !== workspaceId) return
+    settleIncomingCall(payload.attemptId)
+  }
+
   const handleConversationMessageAssigned = (payload: {
     workspaceId: string
     streamId: string
@@ -2036,6 +2070,8 @@ export function registerWorkspaceSocketHandlers(
   socket.on("conversation:created", handleConversationUpserted)
   socket.on("conversation:updated", handleConversationUpserted)
   socket.on("conversation:message_assigned", handleConversationMessageAssigned)
+  socket.on("call:invitation_created", handleCallInvitationCreated)
+  socket.on("call:invitation_settled", handleCallInvitationSettled)
 
   return () => {
     abortController.abort()
@@ -2100,6 +2136,8 @@ export function registerWorkspaceSocketHandlers(
     socket.off("conversation:created", handleConversationUpserted)
     socket.off("conversation:updated", handleConversationUpserted)
     socket.off("conversation:message_assigned", handleConversationMessageAssigned)
+    socket.off("call:invitation_created", handleCallInvitationCreated)
+    socket.off("call:invitation_settled", handleCallInvitationSettled)
   }
 }
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -241,7 +241,14 @@ export const NOTIFICATION_CONFIG: Record<StreamType, NotificationConfig> = {
   thread: { defaultLevel: "activity", allowedLevels: ["everything", "activity", "mentions", "muted"] },
 }
 
-export const ACTIVITY_TYPES = ["mention", "message", "reaction", "saved_reminder", "member_added"] as const
+export const ACTIVITY_TYPES = [
+  "mention",
+  "message",
+  "reaction",
+  "saved_reminder",
+  "member_added",
+  "missed_call",
+] as const
 export type ActivityType = (typeof ACTIVITY_TYPES)[number]
 
 export const ActivityTypes = {
@@ -250,6 +257,7 @@ export const ActivityTypes = {
   REACTION: "reaction",
   SAVED_REMINDER: "saved_reminder",
   MEMBER_ADDED: "member_added",
+  MISSED_CALL: "missed_call",
 } as const satisfies Record<string, ActivityType>
 
 export const SAVED_STATUSES = ["saved", "done", "archived"] as const


### PR DESCRIPTION
**Stack:** PR 6 of the calls build, on #1416. Rings now reach people — a DM call makes the peer's devices ring, everywhere, and stop everywhere.

## Problem

0.1's invitation rows had a full lifecycle but no delivery: no socket event reached the invitee, no push woke a background device, declining had no endpoint, and an expired ring vanished without a trace.

## Solution

The invitation machinery goes end-to-end: same-transaction outbox events, a dedicated ring push class with explicit cancellation, service-worker ring/close handlers, the in-app overlay, and missed-call activity.

### How it works

- **Outbox**: `call:invitation_created` / `call:invitation_settled`, **user-scoped** to the invitee (their user room reaches every device by construction), emitted in the same transactions as the CAS transitions they describe (INV-4/7) — including the sweeper's expiries. Registered across all four registration points with delivery-group routing tests.
- **Push**: `deliverCallRing` — `{ttlSeconds: 45, urgency: 'high', topic: per-attempt}` so an unanswered ring collapses in the tray and never arrives stale; `deliverCallRingCancel` on *every* terminal transition (same topic replaces queued, SW closes displayed). Rings ride a **dedicated non-debounced outbox handler** — a ring must not queue behind batched activity pushes. DND/preference gating consulted; cancellation is deliberately ungated.
- **Service worker**: `call_ring` → tagged notification (renotify, vibrate); `call_ring_cancel` → close-by-tag (best-effort per platform, as the plan documents); clicks deep-link to the host stream with `?call=` accept-intent (live ring in store → accept; cold open → land on the stream, no blind auto-join).
- **In-app**: `incoming-call-store` (attemptId-keyed, flush-registered with a teardown guard test) + `IncomingCallOverlay` — non-modal, **no focus steal** (pinned by an `activeElement` test), no Enter/Escape bindings; Accept joins through the 1.2 launch flow; Decline hits the new invitee-scoped REST endpoint (the CAS's `invitee_user_id` fence is the authorization — a cross-user decline matches nothing); Mute silences without settling. Cross-device: any settle clears every device's overlay and tray entry.
- **Ring sound**: a runtime WebAudio two-tone warble (no binary asset — the repo has no sound pipeline), gesture-warmed; when the context is suspended (restored tab), `startRing` returns false and the overlay fires a local SW notification so the OS makes the sound instead.
- **Missed calls**: ring expiry → activity row in the same sweep transaction (push rides the existing activity handler) with dedicated copy — "Missed call from <inviter>", voice/video + stream name (the adversarial verify caught the generic path rendering **"New message"** for a missed call; it now has its own `kind` end to end).

### Latitude decisions (recorded)

`/call` slash command skipped (not in the deliverables; the composer seam is real scope — noted for follow-up). SW unit tests skipped per the brief's condition (no existing test seam; the two branches are thin inline calls). Missed-call activity created in-service rather than a new handler branch — row + event + settle stay atomic.

## Files

| Path | Purpose |
| ---- | ------- |
| Backend: `lib/outbox/*`, `features/calls/{service,handlers}.ts`, `features/push/{service,call-ring-outbox-handler}.ts`, `features/activity/repository.ts`, `routes.ts`, `server.ts`, `packages/types` | Events, ring/cancel push, decline endpoint, missed-call activity |
| Frontend: `stores/incoming-call-store.ts`, `calls/ring-tone.ts`, `components/call/incoming-call-overlay.tsx`, `sync/workspace-sync.ts`, `sw.ts`, `components/activity/activity-content.tsx`, `auth/account-scope.tsx` | Store, tone, overlay, socket handlers, SW branches, feed row |

## Out of scope (deliberate)

Timeline card (1.4), group invite picker (M2), `/call` command (follow-up), notification action buttons (v1 click-to-accept only).

## Test plan

- [x] Implement → xhigh verify → fix → re-verify: **1 major fixed** (missed-call push copy) + teardown-guard and SW-permission minors; recheck confirmed with zero open residuals
- [x] Backend scoped (activity/calls/push/outbox): 217 pass; frontend scoped: 65 pass (incl. no-focus-steal and suspended-audio→SW-fallback); all typechecks + full pre-commit green
- [ ] Real push delivery (FCM/APNs paths) exercised only via the existing webpush stubs — live-device verification is a flag-on dogfood item

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
