### PR TITLE
feat(bootstrap): ship archived-root streams in the workspace bootstrap (archived index 1/2)

### DIFF
--- a/apps/backend/src/features/streams/repository.test.ts
+++ b/apps/backend/src/features/streams/repository.test.ts
@@ -172,6 +172,14 @@ describe("StreamRepository.listArchivedRoots", () => {
     expect(text).toContain("m.member_id = ")
   })
 
+  test("ships E2E fields so a cold-loaded archived E2E scratchpad keeps its sealed name", async () => {
+    const db = makeDb([])
+    await StreamRepository.listArchivedRoots(db, "ws_1", "usr_1")
+    const text = queryText(db)
+    expect(text).toContain("LEFT JOIN e2e_streams e")
+    expect(text).toContain("e2e_name_ciphertext")
+  })
+
   test("maps archived rows through the shared row mapper", async () => {
     const archivedAt = new Date()
     const db = makeDb([

--- a/apps/backend/src/features/streams/repository.test.ts
+++ b/apps/backend/src/features/streams/repository.test.ts
@@ -130,6 +130,61 @@ describe("purpose marker (sidebar exclusion)", () => {
     expect(text).not.toContain("root.archived_at IS NOT NULL")
   })
 
+  test("listArchivedRoots excludes system-purpose streams", async () => {
+    const db = makeDb([])
+    await StreamRepository.listArchivedRoots(db, "ws_1", "usr_1")
+    expect(queryText(db)).toContain("s.purpose IS NULL")
+  })
+})
+
+// No DB-backed harness exists in the backend feature tests — every sibling repo
+// test (see `listWithPreviews` above) drives a stubbed Querier and asserts the
+// SQL text + bound params, so the access-semantics cases from the brief
+// (member-included / public-non-member-included / private-non-member-excluded /
+// own-archived-scratchpad-included / other-workspace-excluded / threads-never)
+// are enforced structurally through the predicates the query emits and the
+// params it binds, not by executing rows.
+describe("StreamRepository.listArchivedRoots", () => {
+  test("filters to archived roots, excludes threads, and workspace/user scopes (INV-8)", async () => {
+    const db = makeDb([])
+    await StreamRepository.listArchivedRoots(db, "ws_1", "usr_1")
+
+    const { text, values } = db._query.mock.calls[0]![0] as { text: string; values: unknown[] }
+    // Only archived rows.
+    expect(text).toContain("s.archived_at IS NOT NULL")
+    // Threads never returned even if somehow carrying archived_at.
+    expect(text).toContain("s.type != ")
+    // Workspace scoping (INV-8) and viewer scoping bound as params, not inlined.
+    expect(values).toContain("ws_1")
+    expect(values).toContain("usr_1")
+    expect(text).toContain("s.workspace_id = ")
+  })
+
+  test("access predicate: public streams OR streams the viewer is a member of", async () => {
+    const db = makeDb([])
+    await StreamRepository.listArchivedRoots(db, "ws_1", "usr_1")
+    const text = queryText(db)
+    // Public non-member channels are included (public grants read); private
+    // non-member channels are excluded because they satisfy neither branch.
+    expect(text).toContain("s.visibility = 'public'")
+    expect(text).toContain("FROM stream_members m")
+    expect(text).toContain("m.stream_id = s.id")
+    expect(text).toContain("m.member_id = ")
+  })
+
+  test("maps archived rows through the shared row mapper", async () => {
+    const archivedAt = new Date()
+    const db = makeDb([
+      streamRow({ id: "stream_arch", type: "channel", visibility: "public", archived_at: archivedAt }),
+    ])
+    const result = await StreamRepository.listArchivedRoots(db, "ws_1", "usr_1")
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe("stream_arch")
+    expect(result[0]!.archivedAt).toEqual(archivedAt)
+  })
+})
+
+describe("StreamRepository purpose exclusion (cont.)", () => {
   test("insert persists the purpose marker and maps it back", async () => {
     const db = makeDb([streamRow({ purpose: StreamPurposes.PERSONA_TEST })])
     const stream = await StreamRepository.insert(db, {

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -741,6 +741,35 @@ export const StreamRepository = {
     return result.rows.map(mapRowToStreamWithPreview)
   },
 
+  /**
+   * Archived root streams visible to the viewer, as slim `Stream` rows (no
+   * preview/membership/unread joins). `archived_at` is only ever set on root
+   * rows (archiving marks only the root — see `resolveWritableMessageStream`
+   * in the service), so this needs no thread→root resolution; threads are
+   * excluded outright. Visibility mirrors `listWithPreviews`: public streams
+   * plus streams the viewer is a member of, workspace-scoped (INV-8). Feeds
+   * the bootstrap `archivedStreams` index so the client retains knowledge of
+   * archival across reloads (drafts filters, saved/activity name resolution).
+   */
+  async listArchivedRoots(db: Querier, workspaceId: string, userId: string): Promise<Stream[]> {
+    const result = await db.query<StreamRow>(
+      sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams s
+          WHERE s.workspace_id = ${workspaceId}
+            AND s.archived_at IS NOT NULL
+            AND s.type != ${StreamTypes.THREAD}
+            AND (
+              s.visibility = 'public'
+              OR EXISTS (
+                SELECT 1 FROM stream_members m
+                WHERE m.stream_id = s.id AND m.member_id = ${userId}
+              )
+            )
+            AND ${sql.raw(purposeIsNull("s"))}
+          ORDER BY s.archived_at DESC`
+    )
+    return result.rows.map(mapRowToStream)
+  },
+
   async insert(db: Querier, params: InsertStreamParams): Promise<Stream> {
     const result = await db.query<StreamRow>(sql`
       INSERT INTO streams (

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -753,7 +753,7 @@ export const StreamRepository = {
    */
   async listArchivedRoots(db: Querier, workspaceId: string, userId: string): Promise<Stream[]> {
     const result = await db.query<StreamRow>(
-      sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams s
+      sql`SELECT ${sql.raw(SELECT_FIELDS_WITH_E2E)} FROM ${sql.raw(FROM_STREAMS_WITH_E2E)}
           WHERE s.workspace_id = ${workspaceId}
             AND s.archived_at IS NOT NULL
             AND s.type != ${StreamTypes.THREAD}

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -268,6 +268,14 @@ export class StreamService {
   }
 
   /**
+   * Archived root streams visible to the viewer — slim `Stream` rows for the
+   * bootstrap `archivedStreams` index. Single query, so pass `pool` (INV-30).
+   */
+  async listArchivedRoots(workspaceId: string, userId: string): Promise<Stream[]> {
+    return StreamRepository.listArchivedRoots(this.pool, workspaceId, userId)
+  }
+
+  /**
    * Resolve DM display names for bootstrap. DMs have null displayName in the DB
    * because the name is viewer-dependent ("Max" vs "Sam" depending on who's looking).
    * This populates displayName with formatted participant names for the viewing member.

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -280,11 +280,11 @@ export class StreamService {
    * because the name is viewer-dependent ("Max" vs "Sam" depending on who's looking).
    * This populates displayName with formatted participant names for the viewing member.
    */
-  async resolveDmDisplayNames(
-    streams: StreamWithPreview[],
+  async resolveDmDisplayNames<T extends Pick<StreamWithPreview, "id" | "type" | "displayName">>(
+    streams: T[],
     workspaceUsers: { id: string; name: string }[],
     viewingUserId: string
-  ): Promise<StreamWithPreview[]> {
+  ): Promise<T[]> {
     const dmStreams = streams.filter((s) => s.type === "dm")
     if (dmStreams.length === 0) return streams
 

--- a/apps/backend/src/features/workspaces/handlers.test.ts
+++ b/apps/backend/src/features/workspaces/handlers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, spyOn, afterEach } from "bun:test"
+import type { Request, Response } from "express"
+import { createWorkspaceHandlers } from "./handlers"
+import { SyncLogRepository } from "../sync"
+import { BotRepository } from "../public-api"
+import { AgentSessionRepository } from "../agents"
+
+// Bootstrap pulls from ~17 injected services plus three module-static repos.
+// Following INV-48 the statics are stubbed via `spyOn` against the namespace
+// import; the injected services are minimal benign stubs. The point of this
+// test is the new `archivedStreams` field: the handler must call
+// `streamService.listArchivedRoots` and surface the result in `data`.
+
+function makeStreamService(archivedStreams: unknown[]) {
+  return {
+    listWithPreviews: async () => [],
+    listDmPeers: async () => [],
+    resolveDmDisplayNames: async (streams: unknown[]) => streams,
+    getMembershipsBatch: async () => [],
+    getUnreadCounts: async () => new Map(),
+    getReadOverlayForMember: async () => new Map(),
+    getSequencesByEventIds: async () => new Map(),
+    listArchivedRoots: async () => archivedStreams,
+  }
+}
+
+function makeDeps(archivedStreams: unknown[]) {
+  const streamService = makeStreamService(archivedStreams)
+  return {
+    workspaceService: {
+      getWorkspaceById: async () => ({ id: "ws_1", name: "WS" }),
+      getUsers: async () => [],
+      getPersonasForWorkspace: async () => [],
+      getEmojiWeights: async () => ({}),
+    },
+    streamService,
+    userPreferencesService: { getPreferences: async () => ({}) },
+    workspaceSettingsService: { getSettings: async () => ({}) },
+    featureFlagService: { getFlags: async () => ({}) },
+    platformAdminService: { hasAccess: async () => false },
+    sidebarConfigService: { getConfig: async () => ({}) },
+    boardViewService: { list: async () => [] },
+    invitationService: { listInvitations: async () => [] },
+    workspaceIntegrationService: { getAvailableToolCategories: async () => [] },
+    commandAvailabilityService: { listWorkspaceCommands: () => [] },
+    avatarService: {},
+    labelService: { listForActor: async () => [] },
+    labelAssignmentService: { listForViewer: async () => [] },
+    workosOrgService: {},
+    pool: {} as import("pg").Pool,
+    // activityService intentionally omitted — bootstrap treats it as optional.
+  } as unknown as Parameters<typeof createWorkspaceHandlers>[0]
+}
+
+function makeReqRes() {
+  const req = {
+    user: { id: "usr_1", workosUserId: "wos_1", role: "member" },
+    authUser: { permissions: [] },
+    workspaceId: "ws_1",
+  } as unknown as Request
+
+  let jsonBody: any
+  const res = {
+    locals: {},
+    json: (body: any) => {
+      jsonBody = body
+      return res
+    },
+    status: () => res,
+  } as unknown as Response
+
+  return { req, res, getJson: () => jsonBody }
+}
+
+describe("workspace bootstrap handler", () => {
+  afterEach(() => {
+    // Bun restores spies at file teardown; nothing per-test to reset here.
+  })
+
+  it("includes archived roots from the service in the bootstrap payload", async () => {
+    spyOn(SyncLogRepository, "getHeadAndRetainedFrom").mockResolvedValue({
+      head: 0n,
+      retainedFrom: 0n,
+    } as never)
+    spyOn(BotRepository, "listVisibleTo").mockResolvedValue([] as never)
+    spyOn(AgentSessionRepository, "listRunningByWorkspace").mockResolvedValue([] as never)
+
+    const archived = [{ id: "stream_arch", workspaceId: "ws_1", type: "channel", archivedAt: new Date() }]
+    const handlers = createWorkspaceHandlers(makeDeps(archived))
+    const { req, res, getJson } = makeReqRes()
+
+    await handlers.bootstrap(req, res)
+
+    expect(getJson().data.archivedStreams).toEqual(archived)
+    // Active streams list stays a separate contract (empty here).
+    expect(getJson().data.streams).toEqual([])
+  })
+})

--- a/apps/backend/src/features/workspaces/handlers.test.ts
+++ b/apps/backend/src/features/workspaces/handlers.test.ts
@@ -15,7 +15,10 @@ function makeStreamService(archivedStreams: unknown[]) {
   return {
     listWithPreviews: async () => [],
     listDmPeers: async () => [],
-    resolveDmDisplayNames: async (streams: unknown[]) => streams,
+    // Mirrors the real resolver's contract: DM rows get a viewer-dependent
+    // displayName baked on; everything else passes through.
+    resolveDmDisplayNames: async (streams: Array<{ type?: string; displayName?: string | null }>) =>
+      streams.map((s) => (s.type === "dm" ? { ...s, displayName: "Peer Name" } : s)),
     getMembershipsBatch: async () => [],
     getUnreadCounts: async () => new Map(),
     getReadOverlayForMember: async () => new Map(),
@@ -85,13 +88,16 @@ describe("workspace bootstrap handler", () => {
     spyOn(BotRepository, "listVisibleTo").mockResolvedValue([] as never)
     spyOn(AgentSessionRepository, "listRunningByWorkspace").mockResolvedValue([] as never)
 
-    const archived = [{ id: "stream_arch", workspaceId: "ws_1", type: "channel", archivedAt: new Date() }]
-    const handlers = createWorkspaceHandlers(makeDeps(archived))
+    const archivedChannel = { id: "stream_arch", workspaceId: "ws_1", type: "channel", archivedAt: new Date() }
+    // Archived DMs are absent from dmPeers, so the handler must bake the
+    // viewer-dependent name onto the row itself.
+    const archivedDm = { id: "stream_dm", workspaceId: "ws_1", type: "dm", displayName: null, archivedAt: new Date() }
+    const handlers = createWorkspaceHandlers(makeDeps([archivedChannel, archivedDm]))
     const { req, res, getJson } = makeReqRes()
 
     await handlers.bootstrap(req, res)
 
-    expect(getJson().data.archivedStreams).toEqual(archived)
+    expect(getJson().data.archivedStreams).toEqual([archivedChannel, { ...archivedDm, displayName: "Peer Name" }])
     // Active streams list stays a separate contract (empty here).
     expect(getJson().data.streams).toEqual([])
   })

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -203,7 +203,7 @@ export function createWorkspaceHandlers({
         AgentSessionRepository.listRunningByWorkspace(pool, workspaceId),
         // Archived roots are pruned from `streams`; the client persists these
         // slim rows so archival survives reloads (drafts filters, saved/activity
-        // name resolution). No DM-name resolution — dmPeers persist independently.
+        // name resolution).
         streamService.listArchivedRoots(workspaceId, userId),
       ])
 
@@ -213,6 +213,11 @@ export function createWorkspaceHandlers({
 
       // Resolve DM display names — viewer-dependent, so computed at bootstrap time
       const resolvedStreams = await streamService.resolveDmDisplayNames(streams, users, userId)
+      // Archived DMs are excluded from dmPeers (listDmPeersForMember filters
+      // archived), so the client can't resolve their names peer-side; bake the
+      // viewer-dependent name onto the row instead so saved/activity labels
+      // survive a reload.
+      const resolvedArchivedStreams = await streamService.resolveDmDisplayNames(archivedStreams, users, userId)
 
       const streamMemberships = await streamService.getMembershipsBatch(
         resolvedStreams.map((s) => s.id),
@@ -308,7 +313,7 @@ export function createWorkspaceHandlers({
           workspace,
           users,
           streams: resolvedStreams,
-          archivedStreams,
+          archivedStreams: resolvedArchivedStreams,
           streamMemberships: serializedMemberships,
           readMessageIds,
           personas,

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -179,6 +179,7 @@ export function createWorkspaceHandlers({
         labelAssignments,
         configuredToolCategories,
         runningSessions,
+        archivedStreams,
       ] = await Promise.all([
         workspaceService.getWorkspaceById(workspaceId),
         workspaceService.getUsers(workspaceId),
@@ -200,6 +201,10 @@ export function createWorkspaceHandlers({
         // has no stream bootstrap yet).
         workspaceIntegrationService.getAvailableToolCategories(workspaceId),
         AgentSessionRepository.listRunningByWorkspace(pool, workspaceId),
+        // Archived roots are pruned from `streams`; the client persists these
+        // slim rows so archival survives reloads (drafts filters, saved/activity
+        // name resolution). No DM-name resolution — dmPeers persist independently.
+        streamService.listArchivedRoots(workspaceId, userId),
       ])
 
       if (!workspace) {
@@ -303,6 +308,7 @@ export function createWorkspaceHandlers({
           workspace,
           users,
           streams: resolvedStreams,
+          archivedStreams,
           streamMemberships: serializedMemberships,
           readMessageIds,
           personas,

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -212,12 +212,14 @@ export function createWorkspaceHandlers({
       }
 
       // Resolve DM display names — viewer-dependent, so computed at bootstrap time
-      const resolvedStreams = await streamService.resolveDmDisplayNames(streams, users, userId)
       // Archived DMs are excluded from dmPeers (listDmPeersForMember filters
       // archived), so the client can't resolve their names peer-side; bake the
-      // viewer-dependent name onto the row instead so saved/activity labels
-      // survive a reload.
-      const resolvedArchivedStreams = await streamService.resolveDmDisplayNames(archivedStreams, users, userId)
+      // viewer-dependent name onto the archived rows too so saved/activity
+      // labels survive a reload.
+      const [resolvedStreams, resolvedArchivedStreams] = await Promise.all([
+        streamService.resolveDmDisplayNames(streams, users, userId),
+        streamService.resolveDmDisplayNames(archivedStreams, users, userId),
+      ])
 
       const streamMemberships = await streamService.getMembershipsBatch(
         resolvedStreams.map((s) => s.id),

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1616,6 +1616,16 @@ export interface WorkspaceBootstrap {
    * cached before this field shipped omit it (absent reads as empty).
    */
   activeAgentSessions?: ActiveAgentSession[]
+  /**
+   * Archived root streams visible to the viewer, as slim `Stream` rows (no
+   * previews). Archived roots are pruned from `streams`, but the client must
+   * retain knowledge of archival across reloads: drafts filters hide
+   * archived-stream drafts, and Saved/Activity resolve stream names from this
+   * set once the active list no longer carries the row. Access-scoped and
+   * workspace-scoped like `streams`. Optional: payloads cached before this
+   * field shipped omit it (absent reads as empty).
+   */
+  archivedStreams?: Stream[]
 }
 
 /**


### PR DESCRIPTION
Stack 1/2 of the archived-stream index (`docs/plans/archived-stream-index.md`), based on #1418.

## Problem

The workspace bootstrap prunes archived roots (`listWithPreviews` collapses to `s.archived_at IS NULL`), and the client's bootstrap absence-sweep then deletes their IndexedDB rows. Every surface deriving "is this archived" or a stream's name from the client stream cache goes blind after a reload: archived-stream drafts reappear in the Drafts badge/page, Saved and Activity rows degrade to `"Unknown"`/snapshot labels. Live archival keeps the row in cache and everything works — the persisted state simply diverges from the in-session state.

## Solution (this PR: backend + types)

- **`WorkspaceBootstrap.archivedStreams?: Stream[]`** (`packages/types/src/api.ts`) — slim archived-root rows, plain `Stream` (no preview/membership joins). Optional for rollout.
- **`StreamRepository.listArchivedRoots(db, workspaceId, userId)`** — lean single query: `archived_at IS NOT NULL` (only ever set on roots), `type != thread`, access parity with `listWithPreviews` (`visibility = 'public' OR EXISTS(stream_members)`, purposed streams excluded), workspace-scoped (INV-8). Reuses `SELECT_FIELDS`/`mapRowToStream` (INV-35/37).
- **Service pass-through** (`streamService.listArchivedRoots`, pool per INV-30) and **bootstrap handler emission** — joins the existing `Promise.all` batch; no DM-name resolution (dmPeers persist independently client-side).

The frontend consumer (persisting these rows through the sweep, live unarchive upsert) is stack 2/2.

## Design decisions

**Slim `Stream` rows, not a separate `{id, archivedAt}` index** — the client already handles archived rows in its stream cache correctly in-session (live archival leaves them there); shipping real rows makes the reload state identical to the in-session state and also heals Saved/Activity name resolution, which needs names, not just archival bits.

**Access parity with `listWithPreviews`** — same visibility predicates, so the archived list never reveals a stream the active list wouldn't have shown before archival (archived DMs/scratchpads included for participants, purposed system streams excluded).

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts` | `WorkspaceBootstrap.archivedStreams?: Stream[]` |
| `apps/backend/src/features/streams/repository.ts` | `listArchivedRoots` lean query |
| `apps/backend/src/features/streams/service.ts` | pass-through |
| `apps/backend/src/features/workspaces/handlers.ts` | bootstrap emission |
| `apps/backend/src/features/streams/repository.test.ts` | SQL-shape + row-mapping tests (matches the suite's stubbed-querier harness) |
| `apps/backend/src/features/workspaces/handlers.test.ts` | new: bootstrap response carries `archivedStreams`; `streams` stays active-only |

## Test plan

- [x] `apps/backend` `bun test src/features/streams src/features/workspaces src/features/drafts` — 228 pass
- [x] `bunx tsc --noEmit` — apps/backend + packages/types clean
- [x] Adversarial verification pass (xhigh): access parity re-derived predicate-by-predicate against `listWithPreviews`; Promise.all destructuring positions checked; drafts feature confirmed free of the dropped `d8ab94ac` snapshot-filter residue

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787064986&installation_id=129946197&pr_number=1420&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1420&signature=601b11e89767eea1095dbb23fb802c20e6aea3a08444b5b6463cc498cbf2525c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<details><summary>📋 Full implementation plan</summary>

# Archived-stream index: durable client knowledge of archival

## Problem

The workspace bootstrap prunes archived roots entirely (`listWithPreviews` collapses to `s.archived_at IS NULL` — `apps/backend/src/features/streams/repository.ts:699,711,725,736` — plus `EXCLUDE_ARCHIVED_ROOT_THREADS` at 644-648), and the client's bootstrap absence-sweep then deletes their IndexedDB rows (`cleanupStaleEntities` → `deleteStale(db.streams, …)`, `apps/frontend/src/sync/workspace-sync.ts:2570`). Every surface deriving "is this archived" or a stream's identity from `useWorkspaceStreams` goes blind after a reload:

- **Drafts** — `isStreamArchived` (`apps/frontend/src/hooks/use-all-drafts.ts:145-155`) returns `false` for a missing row, so archived-stream drafts reappear in badge + list after reload. PR #1418's backend snapshot filter (`d8ab94ac`) papered over this per-surface, but introduced its own reload-dependence: the drafts bootstrap reconcile deletes the hidden draft from IDB, and a live unarchive never re-delivers it — the draft returns only on the *next* bootstrap.
- **Saved** — rows fall back to `saved.message?.streamName ?? "Unknown"` once the archived stream row is swept (`apps/frontend/src/components/saved/saved-item.tsx:47`).
- **Activity** — stream labels degrade to the context snapshot for the same reason (`apps/frontend/src/pages/activity.tsx:92-129`).
- **Sidebar/unarchive** — `handleStreamUnarchived` does `db.streams.update(...)` (`workspace-sync.ts:819`), a no-op when the row was swept, so even a live unarchive can't restore the local row post-reload.

Key observation: **live archival already leaves the archived row in `db.streams`** (`handleStreamArchived`, `workspace-sync.ts:792`), and every consumer of `useWorkspaceStreams` (sidebar visibility, drafts filters, name resolution) already handles archived rows correctly in that in-session state. The reload bug is exactly that the persisted state diverges from the in-session state.

## Solution

Make the persisted state match the in-session state: bootstrap ships slim archived-root rows, the client persists them in `db.streams`, and the sweep keeps them. Every consumer then works unchanged, live and across reloads.

1. **Bootstrap contract** — new optional field on `WorkspaceBootstrap` (`packages/types/src/api.ts`, before line 1619):
   `archivedStreams?: Stream[]` — archived roots only (`archived_at IS NOT NULL` is only ever set on roots), plain `Stream` shape, **no** preview/membership joins. Access-scoped with the same visibility semantics as `listWithPreviews` (member streams + public channels), workspace-scoped (INV-8).
2. **Backend** — `StreamRepository.listArchivedRoots(pool, workspaceId, userId)` (lean query reusing the existing access predicates with `archived_at IS NOT NULL`; no preview CTEs), exposed via `StreamService`, emitted from the bootstrap handler (`apps/backend/src/features/workspaces/handlers.ts` response block). Archived **DM** rows get viewer-dependent display names resolved onto them (`resolveDmDisplayNames`) because archived DMs are excluded from `dmPeers` (`listDmPeersForMember` filters archived) and the client cannot resolve them peer-side.
3. **Revert the drafts snapshot exclusion** (`d8ab94ac`, `apps/backend/src/features/drafts/repository.ts`): `listByUser` returns all live drafts again. Hiding is client-side policy, not sync-protocol truncation — the draft row stays in IDB (merely filtered from badge/list), so a live `stream:unarchived` flips `db.streams` reactively and the draft reappears **instantly**, content intact, no refetch. "Hidden, never lost" holds locally.
4. **Frontend apply** — in `applyWorkspaceBootstrap` AND `applyReconnectBootstrapBatch`: `bulkPut` `bootstrap.archivedStreams ?? []` into `db.streams` (mapped like other rows; do not touch `lastMessagePreview` on existing rows), and add their ids to the keep-set in `cleanupStaleEntities`. Do **not** add them to the TanStack `bootstrap.streams` query cache (that list stays active-only; sidebar and pickers keep their current contract).
5. **Unarchive/archive handler robustness** — `handleStreamUnarchived`/`handleStreamArchived`: replace bare `db.streams.update(...)` with upsert semantics (update, and `put` a mapped row when the update matched nothing), so a row missing from IDB is restored rather than silently dropped.

What this heals with zero per-surface work: drafts badge+list stay hidden across reloads (both `stream:` and `thread:` scopes — thread resolution reads `db.events`, which the sweep never touches), unarchive restores drafts live, Saved and Activity resolve real stream names again after reload.

## PR stack

Base rework (not a chunk): force `fix/hide-drafts-archived-streams` back to `a534bb5b` (keep the badge/list parity commit, drop `d8ab94ac`), update PR #1418's body to frontend-parity-only scope.

- **Chunk 1 — backend + types** (branch `feat/archived-stream-index-backend`, base `fix/hide-drafts-archived-streams`): `WorkspaceBootstrap.archivedStreams` type, `listArchivedRoots` repo method + service pass-through, bootstrap handler emission. Tests: repo access/workspace scoping (member sees own archived scratchpad + archived member channels + archived public channels; non-member private excluded), handler includes the field.
- **Chunk 2 — frontend** (branch `feat/archived-stream-index-frontend`, base chunk 1): bootstrap apply + sweep keep-set (both paths), archive/unarchive handler upsert, and regression tests: (a) `cleanupStaleEntities` keeps archived rows delivered by bootstrap; (b) reload-simulation — seed IDB only via `applyWorkspaceBootstrap` with an archived root + a thread draft under it → badge and list both hide it; (c) live `stream:unarchived` with no prior IDB row → row restored, draft visible again.

## Deferred (binding — do not build)

- Server-side stamping of `root_stream_id` on thread-scope draft upserts (id-authoritative host resolution without the events map). Not needed: `db.events` is not swept, so the parity fix's resolution works across reloads.
- Purging/archiving accumulated hidden drafts (explicitly out per Kris — hide, never purge).
- Payload bounding for pathological archived counts (thousands of archived roots ≈ hundreds of KB worst case; revisit with pagination/caps only if a real workspace shows pressure).
- Board-scope draft parity (pre-existing residual on both layers).
- Any Activity catch-up gaps that remain after the index (separate investigation if still observed).

</details>
