### PR TITLE
fix(sync): persist archived-root streams through the bootstrap sweep (archived index 2/2)

### DIFF
--- a/apps/frontend/src/components/editor/triggers/use-channel-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-channel-suggestion.tsx
@@ -20,7 +20,10 @@ export function useChannelSuggestion() {
 
   const channels = useMemo<ChannelItem[]>(() => {
     return streams
-      .filter((stream) => stream.type === "channel" && stream.slug)
+      // Archived rows persist in the stream cache (archived-stream index);
+      // offering a workspace's whole archival history as #-link targets is
+      // noise, so suggest active channels only.
+      .filter((stream) => stream.type === "channel" && stream.slug && !stream.archivedAt)
       .map((stream) => ({
         id: stream.id,
         slug: stream.slug!,

--- a/apps/frontend/src/components/editor/triggers/use-in-channel-filter-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-in-channel-filter-suggestion.tsx
@@ -21,7 +21,11 @@ export function useInChannelFilterSuggestion() {
 
   const channels = useMemo<ChannelItem[]>(() => {
     return streams
-      .filter((stream) => stream.slug) // Only streams with slugs (channels)
+      // Slugged streams only (channels/scratchpads). Archived ones are kept on
+      // purpose: search is the one surface where scoping INTO archived content
+      // is legitimate, and their rows persist in the cache (archived-stream
+      // index) precisely so references like this stay resolvable.
+      .filter((stream) => stream.slug)
       .map((stream) => ({
         id: stream.id,
         slug: stream.slug!,

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -306,6 +306,22 @@ describe("QuickSwitcher Integration Tests", () => {
       expect(screen.getByLabelText("Quick switcher input")).toBeInTheDocument()
     })
 
+    it("excludes archived streams from the default palette (they persist in the cache)", () => {
+      mockWorkspaceBootstrap.data.streams = [
+        ...mockStreamsList,
+        {
+          ...(mockStreamsList[0] as object),
+          id: "stream_archived_qs",
+          slug: "archived-qs",
+          displayName: "Archived QS Channel",
+          archivedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ]
+      renderWithProviders(<QuickSwitcher {...defaultProps} open={true} />)
+
+      expect(screen.queryByText("Archived QS Channel")).not.toBeInTheDocument()
+    })
+
     it("should not render dialog content when open=false", () => {
       renderWithProviders(<QuickSwitcher {...defaultProps} open={false} />)
 

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -141,8 +141,11 @@ export function useStreamItems(context: ModeContext): ModeResult {
     const dmPeerByStreamId = new Map((dmPeers ?? []).map((peer) => [peer.streamId, peer.userId]))
 
     // Active streams are CachedStream (with lastMessagePreview), archived come from API as Stream.
+    // The stream cache durably holds archived rows (archived-stream index), so
+    // the active palette must exclude them — archived is its own gated surface
+    // below, and letting both in would double-list every archived stream.
     const allStreams: StreamLike[] = [
-      ...(showActive ? activeStreams : []),
+      ...(showActive ? activeStreams.filter((s) => !s.archivedAt) : []),
       ...(showArchived && archivedStreams ? archivedStreams : []),
     ]
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
-import type { JSONContent } from "@threa/types"
+import {
+  DEFAULT_SIDEBAR_CONFIG,
+  defaultFeatureFlags,
+  type JSONContent,
+  type Stream,
+  type WorkspaceBootstrap,
+} from "@threa/types"
 import { db, type CachedDraft } from "@/db"
+import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
@@ -86,6 +93,72 @@ function seedMessageEvent(messageId: string, streamId: string, seq: number): Pro
     createdAt: new Date(seq).toISOString(),
     _cachedAt: seq,
   } as never)
+}
+
+function makeArchivedRoot(id: string): Stream {
+  return {
+    id,
+    workspaceId,
+    type: "channel",
+    displayName: `Archived ${id}`,
+    slug: id,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    archivedAt: "2026-01-01T00:00:00Z",
+  }
+}
+
+function makeReloadBootstrap(archivedStreams: Stream[], streams: Stream[] = []): WorkspaceBootstrap {
+  return {
+    workspace: {
+      id: workspaceId,
+      name: "Test",
+      slug: "test",
+      createdBy: "user_1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    users: [],
+    // Active-only, exactly as the backend now ships it — the archived root is
+    // absent here and rides in `archivedStreams`.
+    streams: streams.map((s) => ({ ...s, lastMessagePreview: null })),
+    archivedStreams,
+    streamMemberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+    labels: [],
+    labelAssignments: [],
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    mutedStreamIds: [],
+    featureFlags: defaultFeatureFlags(),
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
+    userPreferences: {
+      workspaceId,
+      userId: "user_1",
+      theme: "system",
+      messageSendMode: "enter",
+      messageDisplay: "default",
+      accessibility: { fontSize: "medium", fontFamily: "default", reducedMotion: false, highContrast: false },
+      keyboardShortcuts: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  } as unknown as WorkspaceBootstrap
 }
 
 beforeEach(async () => {
@@ -448,6 +521,39 @@ describe("useAllDrafts archived streams", () => {
       expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_live"])
       expect(result.current.summary.draftCount).toBe(1)
       expect(result.current.summary.draftCount).toBe(result.current.all.drafts.length)
+    })
+  })
+})
+
+describe("useAllDrafts archived-root persistence across reload (the whole-feature regression)", () => {
+  it("hides a thread draft whose host arrives only via bootstrap.archivedStreams", async () => {
+    const archivedRoot = makeArchivedRoot("stream_arch_reload")
+    const activeRoot: Stream = { ...makeArchivedRoot("stream_active_reload"), archivedAt: null }
+
+    // A thread-reply draft to a message in the archived root, plus an active
+    // control draft. The control anchors the settle: the assertion only holds
+    // once the hook has resolved (control present) AND the archived-root draft
+    // is excluded — so it can't pass trivially on the empty loading state.
+    await seedMessageEvent("msg_parent", "stream_arch_reload", 1)
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_reload", scope: "thread:msg_parent", contentJson: makeDoc("reply") }),
+      syncedDraft({ id: "draft_control", scope: "stream:stream_active_reload", contentJson: makeDoc("keep") }),
+    ])
+
+    // Reload: stream rows land in IDB ONLY through the bootstrap apply. Without
+    // deliverables 1+2 the archived root is swept (or never written), so
+    // isStreamArchived resolves false and the archived draft wrongly reappears.
+    await applyWorkspaceBootstrap(workspaceId, makeReloadBootstrap([archivedRoot], [activeRoot]), Date.now())
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(
+      () => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_control"])
+      expect(result.current.summary.draftCount).toBe(1)
     })
   })
 })

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -50,6 +50,29 @@ describe("useLastLocation — stream arm", () => {
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({ redirectStreamId: null, shouldOpenSidebar: true, boardHref: null })
   })
+
+  it("never falls back into an archived stream, even when it is the most recent", () => {
+    // Archiving bumps updated_at, so an unfiltered fallback would pick it.
+    const archived = { ...stream("stream_archived", "2026-03-01T00:00:00.000Z"), archivedAt: "2026-03-01T00:00:00.000Z" } as CachedStream
+    setup({ streams: [archived, stream("stream_active", "2026-01-01T00:00:00.000Z")] })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current.redirectStreamId).toBe("stream_active")
+  })
+
+  it("lands on the fresh-start state when every stream is archived", () => {
+    const archived = { ...stream("stream_archived"), archivedAt: "2026-03-01T00:00:00.000Z" } as CachedStream
+    setup({ streams: [archived] })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current).toMatchObject({ redirectStreamId: null, shouldOpenSidebar: true })
+  })
+
+  it("still honors a stored pointer to a stream archived since the last visit", () => {
+    const archived = { ...stream("stream_archived"), archivedAt: "2026-03-01T00:00:00.000Z" } as CachedStream
+    setup({ streams: [archived] })
+    setLastLocation(USER, WS, { surface: "stream", streamId: "stream_archived", board: null })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current.redirectStreamId).toBe("stream_archived")
+  })
 })
 
 describe("useLastLocation — board arm", () => {

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -33,9 +33,15 @@ interface UseLastLocationResult {
  */
 export function useLastLocation(workspaceId: string): UseLastLocationResult {
   const { user } = useAuth()
-  const streams = useWorkspaceStreams(workspaceId)
+  const allStreams = useWorkspaceStreams(workspaceId)
 
   const result = useMemo(() => {
+    // The stream cache durably holds archived rows (archived-stream index).
+    // They must not count as landing targets: archiving bumps updated_at, so an
+    // unfiltered most-recent fallback would redirect a fresh device INTO the
+    // most-recently-archived stream, and a workspace whose only streams are
+    // archived must still land on the fresh-start state.
+    const streams = allStreams.filter((s) => !s.archivedAt)
     const record = user ? getLastLocation(user.id, workspaceId) : null
 
     if (record?.surface === "board" && record.board) {
@@ -53,7 +59,10 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
 
     const storedId = record?.streamId ?? null
     if (storedId) {
-      const stillExists = streams.some((s) => s.id === storedId)
+      // Deliberately checked against ALL rows: a stored pointer to a stream
+      // archived since the last visit is still viewable, so honor it rather
+      // than evicting the record. Only the fallbacks below exclude archived.
+      const stillExists = allStreams.some((s) => s.id === storedId)
       if (stillExists) {
         return {
           redirectStreamId: storedId,
@@ -85,7 +94,7 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
       shouldOpenSidebar: true,
       staleStoredId: false,
     }
-  }, [user, workspaceId, streams])
+  }, [user, workspaceId, allStreams])
 
   useEffect(() => {
     if (result.staleStoredId && user) {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -432,6 +432,24 @@ describe("mergeReconnectWorkspaceBootstrap", () => {
     ).toBe("evt_new")
   })
 
+  it("never promotes an archived local row into the active streams list, even when locally fresher", () => {
+    const fetchStartedAt = Date.now() - 1000
+    const merged = mergeReconnectWorkspaceBootstrap({
+      workspaceBootstrap: makeBootstrap({ streams: [] }),
+      successfulStreamBootstraps: new Map(),
+      staleStreamIds: new Set(),
+      terminalStreamIds: new Set(),
+      localStreams: [
+        { ...makeStream("stream_archived_fresh", { archivedAt: new Date().toISOString() }), _cachedAt: Date.now() },
+        { ...makeStream("stream_active_fresh"), _cachedAt: Date.now() },
+      ],
+      localMemberships: [],
+      fetchStartedAt,
+    })
+
+    expect(merged.streams.map((s) => s.id)).toEqual(["stream_active_fresh"])
+  })
+
   it("preserves prior local state for visible streams that fail reconnect bootstrap", () => {
     const workspaceBootstrap = makeBootstrap({
       streams: [],

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -341,6 +341,21 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     expect(row?.archivedAt).toBe("2026-01-01T00:00:00Z")
   })
 
+  it("seeds archived roots into the synchronous in-memory cache (no first-paint flash)", async () => {
+    const fetchStartedAt = Date.now()
+    const archivedRoot = makeStream("stream_arch_seed", { archivedAt: "2026-01-01T00:00:00Z" })
+
+    await applyWorkspaceBootstrap("ws_1", makeBootstrap({ archivedStreams: [archivedRoot] }), fetchStartedAt)
+
+    // The seed is what the first render reads before the async IDB query
+    // resolves; if archived roots are missing here, isStreamArchived is blind
+    // for one frame and archived-root drafts flash visible.
+    const { renderHook } = await import("@testing-library/react")
+    const { useWorkspaceStreamsRaw } = await import("@/stores/workspace-store")
+    const { result } = renderHook(() => useWorkspaceStreamsRaw("ws_1"))
+    expect(result.current.map((s) => s.id)).toContain("stream_arch_seed")
+  })
+
   it("preserves an existing row's lastMessagePreview when re-persisting an archived root", async () => {
     const fetchStartedAt = Date.now()
     const archivedRoot = makeStream("stream_arch_root", { archivedAt: "2026-01-01T00:00:00Z" })

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -22,6 +22,7 @@ import {
   type LabelAssignment,
   type SavedMessageView,
   type ScheduledMessageView,
+  type Stream,
   type StreamBootstrap,
   type StreamMember,
   type StreamWithPreview,
@@ -110,6 +111,28 @@ function makeStreamBootstrap(streamId: string, overrides: Partial<StreamBootstra
     unreadCount: 0,
     mentionCount: 0,
     activityCount: 0,
+    ...overrides,
+  }
+}
+
+function makeStream(id: string, overrides: Partial<Stream> = {}): Stream {
+  return {
+    id,
+    workspaceId: "ws_1",
+    type: "channel",
+    displayName: `Stream ${id}`,
+    slug: id,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    archivedAt: null,
     ...overrides,
   }
 }
@@ -301,6 +324,39 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     await applyWorkspaceBootstrap("ws_1", makeBootstrap())
 
     expect(await db.streams.get("stream_keep")).toBeDefined()
+  })
+
+  it("persists archived roots from bootstrap.archivedStreams and the sweep keeps them", async () => {
+    const fetchStartedAt = Date.now()
+    const archivedRoot = makeStream("stream_arch_root", { archivedAt: "2026-01-01T00:00:00Z" })
+
+    // A root live-archived in a prior session, now stale in IDB and absent from
+    // the active `streams` snapshot — old behaviour swept it on reload.
+    await db.streams.put({ ...archivedRoot, _cachedAt: fetchStartedAt - 86400000 })
+
+    await applyWorkspaceBootstrap("ws_1", makeBootstrap({ archivedStreams: [archivedRoot] }), fetchStartedAt)
+
+    const row = await db.streams.get("stream_arch_root")
+    expect(row).toBeDefined()
+    expect(row?.archivedAt).toBe("2026-01-01T00:00:00Z")
+  })
+
+  it("preserves an existing row's lastMessagePreview when re-persisting an archived root", async () => {
+    const fetchStartedAt = Date.now()
+    const archivedRoot = makeStream("stream_arch_root", { archivedAt: "2026-01-01T00:00:00Z" })
+
+    await db.streams.put({
+      ...archivedRoot,
+      lastMessagePreview: { authorId: "user_1", authorType: "user", content: "kept", createdAt: "2026-01-01T00:00:00Z" },
+      _cachedAt: fetchStartedAt - 1000,
+    })
+
+    // Bootstrap ships the slim archived root (no preview); the merge must not
+    // clobber the preview the live-archived row already carried.
+    await applyWorkspaceBootstrap("ws_1", makeBootstrap({ archivedStreams: [archivedRoot] }), fetchStartedAt)
+
+    const row = await db.streams.get("stream_arch_root")
+    expect(row?.lastMessagePreview?.content).toBe("kept")
   })
 })
 
@@ -1677,6 +1733,55 @@ describe("registerWorkspaceSocketHandlers", () => {
     })
     expect(await db.streams.get("stream_1")).toMatchObject({
       lastReadEventId: "event_new",
+    })
+
+    cleanup()
+  })
+
+  it("puts a stream row on stream:unarchived when none exists in IDB (swept while archived)", async () => {
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    // No pre-existing row — a bare .update() would no-op and silently lose it.
+    emit("stream:unarchived", {
+      workspaceId: "ws_1",
+      streamId: "stream_unarch",
+      stream: makeStream("stream_unarch", { archivedAt: null }),
+    })
+
+    await vi.waitFor(async () => {
+      const row = await db.streams.get("stream_unarch")
+      expect(row).toBeDefined()
+      expect(row?.archivedAt).toBeNull()
+      expect(row?.lastMessagePreview).toBeNull()
+    })
+
+    cleanup()
+  })
+
+  it("preserves an existing row's lastMessagePreview on stream:unarchived", async () => {
+    await db.streams.put({
+      ...makeStream("stream_unarch2", { archivedAt: "2026-01-01T00:00:00Z" }),
+      lastMessagePreview: { authorId: "member_1", authorType: "user", content: "kept", createdAt: "2026-01-01T00:00:00Z" },
+      _cachedAt: Date.now(),
+    })
+
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("stream:unarchived", {
+      workspaceId: "ws_1",
+      streamId: "stream_unarch2",
+      stream: makeStream("stream_unarch2", { archivedAt: null }),
+    })
+
+    await vi.waitFor(async () => {
+      const row = await db.streams.get("stream_unarch2")
+      expect(row?.archivedAt).toBeNull()
+      // Partial-merge upsert keeps the preview the socket payload never carries.
+      expect(row?.lastMessagePreview?.content).toBe("kept")
     })
 
     cleanup()

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -431,7 +431,9 @@ export function mergeReconnectWorkspaceBootstrap({
 
   for (const streamId of staleStreamIds) {
     const localStream = localStreamById.get(streamId)
-    if (localStream) {
+    // Same archived guard as the locally-fresher loop above: archived rows
+    // persist in db.streams now, and this list must stay active-only.
+    if (localStream && !localStream.archivedAt) {
       streamsById.set(streamId, toWorkspaceBootstrapStream(localStream))
     }
 
@@ -2544,7 +2546,14 @@ export async function applyReconnectBootstrapBatch(
       })),
       // Mirrors applyWorkspaceBootstrap: archived roots ride the seed so the
       // first paint after reconnect knows they're archived (no draft flash).
-      ...mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], new Map(localStreams.map((s) => [s.id, s])), now),
+      // An archived stream open during reconnect can also land in the merged
+      // streams list via its per-stream bootstrap — skip those ids so the seed
+      // never carries duplicates.
+      ...mapArchivedStreamRows(
+        (finalBootstrap.archivedStreams ?? []).filter((s) => !finalBootstrap.streams.some((a) => a.id === s.id)),
+        new Map(localStreams.map((s) => [s.id, s])),
+        now
+      ),
     ],
     memberships: finalBootstrap.streamMemberships.map((membership) => ({
       ...membership,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2305,12 +2305,18 @@ export async function applyWorkspaceBootstrap(
   seedWorkspaceCache(workspaceId, {
     workspace: { ...bootstrap.workspace, _cachedAt: now },
     users: bootstrap.users.map((u) => ({ ...u, _cachedAt: now })),
-    streams: bootstrap.streams.map((s) => ({
-      ...s,
-      notificationLevel: membershipByStream.get(s.id)?.notificationLevel,
-      lastReadEventId: membershipByStream.get(s.id)?.lastReadEventId,
-      _cachedAt: now,
-    })),
+    streams: [
+      ...bootstrap.streams.map((s) => ({
+        ...s,
+        notificationLevel: membershipByStream.get(s.id)?.notificationLevel,
+        lastReadEventId: membershipByStream.get(s.id)?.lastReadEventId,
+        _cachedAt: now,
+      })),
+      // Archived roots must be in the synchronous seed too, or the first paint
+      // can't tell a stream is archived until the IDB read resolves — a
+      // one-frame flash of archived-root drafts (INV-21-adjacent).
+      ...mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now),
+    ],
     memberships: bootstrap.streamMemberships.map((sm) => ({
       ...sm,
       id: `${workspaceId}:${sm.streamId}`,
@@ -2529,12 +2535,17 @@ export async function applyReconnectBootstrapBatch(
   seedWorkspaceCache(workspaceId, {
     workspace: { ...finalBootstrap.workspace, _cachedAt: now },
     users: finalBootstrap.users.map((user) => ({ ...user, _cachedAt: now })),
-    streams: finalBootstrap.streams.map((stream) => ({
-      ...stream,
-      notificationLevel: membershipByStream.get(stream.id)?.notificationLevel,
-      lastReadEventId: membershipByStream.get(stream.id)?.lastReadEventId,
-      _cachedAt: now,
-    })),
+    streams: [
+      ...finalBootstrap.streams.map((stream) => ({
+        ...stream,
+        notificationLevel: membershipByStream.get(stream.id)?.notificationLevel,
+        lastReadEventId: membershipByStream.get(stream.id)?.lastReadEventId,
+        _cachedAt: now,
+      })),
+      // Mirrors applyWorkspaceBootstrap: archived roots ride the seed so the
+      // first paint after reconnect knows they're archived (no draft flash).
+      ...mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], new Map(localStreams.map((s) => [s.id, s])), now),
+    ],
     memberships: finalBootstrap.streamMemberships.map((membership) => ({
       ...membership,
       id: `${workspaceId}:${membership.streamId}`,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -392,6 +392,10 @@ export function mergeReconnectWorkspaceBootstrap({
     for (const stream of localStreams) {
       if (stream._cachedAt < fetchStartedAt) continue
       if (successfulStreamIds.has(stream.id)) continue
+      // Archived rows persist in db.streams (they ride bootstrap.archivedStreams),
+      // so a fresh _cachedAt no longer implies active — promoting one here would
+      // leak it into the active-only streams cache the sidebar seeds from.
+      if (stream.archivedAt) continue
       streamsById.set(stream.id, toWorkspaceBootstrapStream(stream))
     }
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -788,8 +788,9 @@ export function registerWorkspaceSocketHandlers(
       }
     })
 
-    // Update IndexedDB — partial merge to preserve lastMessagePreview etc.
-    db.streams.update(payload.stream.id, { ...payload.stream, _cachedAt: Date.now() })
+    // Upsert IndexedDB — partial merge preserves lastMessagePreview etc.; a
+    // missing row (swept while archived) is restored rather than silently lost.
+    void upsertStreamRow(payload.stream)
   }
 
   const handleStreamUnarchived = (payload: StreamPayload) => {
@@ -815,8 +816,9 @@ export function registerWorkspaceSocketHandlers(
       }
     })
 
-    // Update IndexedDB — partial merge to preserve lastMessagePreview etc.
-    db.streams.update(payload.stream.id, { ...payload.stream, _cachedAt: Date.now() })
+    // Upsert IndexedDB — partial merge preserves lastMessagePreview etc.; a
+    // missing row (swept while archived) is restored rather than silently lost.
+    void upsertStreamRow(payload.stream)
   }
 
   const handleWorkspaceUserAdded = (payload: WorkspaceUserAddedPayload) => {
@@ -2105,6 +2107,36 @@ export function registerWorkspaceSocketHandlers(
  *
  * This prevents stale data from accumulating across environments or DB resets.
  */
+/**
+ * Upsert a stream row into IDB. Partial-merges onto an existing row so the
+ * socket payload doesn't clobber fields it never carries (lastMessagePreview,
+ * membership). When no row exists — an archived root swept before it was
+ * unarchived live — a fully-mapped row is put instead, so a live
+ * archive/unarchive can't silently drop the local row (INV-11: no silent loss).
+ */
+async function upsertStreamRow(stream: Stream): Promise<void> {
+  const now = Date.now()
+  const updated = await db.streams.update(stream.id, { ...stream, _cachedAt: now })
+  if (updated === 0) {
+    await db.streams.put({ ...stream, lastMessagePreview: null, _cachedAt: now })
+  }
+}
+
+/**
+ * Map slim archived-root `Stream` rows (bootstrap.archivedStreams — no preview
+ * or membership joins) to `CachedStream` rows, merging onto any existing row so
+ * a live-archived row's `lastMessagePreview`/membership/`contextBag` survive a
+ * reload's bootstrap apply. When no local row exists, the result is just the
+ * plain stream fields stamped with `_cachedAt`.
+ */
+function mapArchivedStreamRows(
+  archivedStreams: Stream[],
+  existingByStreamId: Map<string, CachedStream>,
+  now: number
+): CachedStream[] {
+  return archivedStreams.map((s) => ({ ...existingByStreamId.get(s.id), ...s, _cachedAt: now }))
+}
+
 export async function applyWorkspaceBootstrap(
   workspaceId: string,
   bootstrap: WorkspaceBootstrap,
@@ -2174,6 +2206,11 @@ export async function applyWorkspaceBootstrap(
             }
           })
         ),
+        // Archived roots ship slim (no preview/membership) but must persist so
+        // every `useWorkspaceStreams` consumer (drafts, name resolution) keeps
+        // seeing them across a reload. Not added to the TanStack bootstrap
+        // `streams` cache — that list stays active-only.
+        db.streams.bulkPut(mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now)),
         db.streamMemberships.bulkPut(
           bootstrap.streamMemberships.map((sm) => ({
             ...sm,
@@ -2401,6 +2438,10 @@ export async function applyReconnectBootstrapBatch(
             }
           })
         ),
+        // Persist archived roots on reconnect too (mirrors applyWorkspaceBootstrap).
+        db.streams.bulkPut(
+          mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], new Map(localStreams.map((s) => [s.id, s])), now)
+        ),
         db.streamMemberships.bulkPut(
           finalBootstrap.streamMemberships.map((membership) => ({
             ...membership,
@@ -2553,7 +2594,13 @@ export async function applyReconnectBootstrapBatch(
 }
 
 async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBootstrap, now: number): Promise<void> {
-  const bootstrapStreamIds = new Set(bootstrap.streams.map((s) => s.id))
+  // Archived roots ride in bootstrap.archivedStreams (absent from .streams);
+  // keep them so the absence-sweep doesn't delete rows every consumer still
+  // needs (drafts hiding, name resolution) across a reload.
+  const bootstrapStreamIds = new Set([
+    ...bootstrap.streams.map((s) => s.id),
+    ...(bootstrap.archivedStreams ?? []).map((s) => s.id),
+  ])
   const bootstrapUserIds = new Set(bootstrap.users.map((u) => u.id))
   const bootstrapMembershipIds = new Set(bootstrap.streamMemberships.map((sm) => `${workspaceId}:${sm.streamId}`))
   const bootstrapDmPeerIds = new Set(bootstrap.dmPeers.map((dp) => `${workspaceId}:${dp.streamId}`))


### PR DESCRIPTION
Stack 2/2 of the archived-stream index (`docs/plans/archived-stream-index.md`), based on #1420.

## Problem

Live archival leaves the archived row in `db.streams` and every consumer (sidebar visibility, drafts `isStreamArchived`, `useStreamName` for Saved/Activity labels) handles it correctly — but on reload, the bootstrap absence-sweep (`cleanupStaleEntities` → `deleteStale(db.streams, …)`) deleted archived rows because `bootstrap.streams` omits them. So archived-stream drafts reappeared in the badge/page after reload, Saved/Activity labels degraded to snapshots/"Unknown", and `handleStreamUnarchived`'s bare `db.streams.update(...)` no-op'd on the swept row, so even a live unarchive couldn't restore it.

## Solution

Make the persisted state match the in-session state:

- **`applyWorkspaceBootstrap` + `applyReconnectBootstrapBatch`** persist `bootstrap.archivedStreams` into `db.streams` via `mapArchivedStreamRows` — spreads the existing row first so a live-archived row keeps `lastMessagePreview`/membership fields (the wire `Stream` carries no preview keys, so nothing is clobbered with `undefined`).
- **`cleanupStaleEntities`** keeps archived ids in the sweep's keep-set (both paths).
- **`upsertStreamRow`** shared helper: `handleStreamArchived`/`handleStreamUnarchived` now `update` and fall back to `put` when the row is missing, so a live unarchive restores a previously swept row.
- The TanStack `workspaceKeys.bootstrap` `streams` cache stays **active-only** — archived rows live only in IDB, exactly like the in-session post-archive state. `use-all-drafts.ts` production code is untouched.

Net behavior: drafts under archived roots stay hidden across reloads (thread scopes too — `db.events` is never swept), a live unarchive makes the draft reappear instantly with its content (rows are hidden by client policy, never deleted by the sync protocol), and Saved/Activity keep resolving real stream names after reload (DM names ride the rows via #1420's server-side resolution).

## Tests

- **Reload regression (the headline):** seeds stream rows *only* via `applyWorkspaceBootstrap` (archived root present in `archivedStreams`, absent from `streams`) plus a `thread:`-scoped draft and its parent `message_created` event, mounts the real `useDraftSummary`/`useAllDrafts` hooks (INV-39), and asserts the archived-root draft is hidden while an active control draft stays. Verified discriminating: fails with the bulkPut/keep-set reverted.
- Sweep keeps archived rows across a second apply; `lastMessagePreview` preserved on merge.
- `stream:unarchived` puts a missing row; preserves preview on an existing row.

## Test plan

- [x] `apps/frontend` `bunx vitest run src/sync src/hooks/use-all-drafts.test.ts` — 385 pass
- [x] `bunx tsc --noEmit` — clean
- [x] Adversarial verification pass (xhigh): sweep-guard interaction with `fetchStartedAt`, reconnect merge carries `archivedStreams` through, spread-merge clobber analysis, terminal-stream interaction, upsert race — clean. Its one major (archived-DM names) was fixed server-side in #1420 (`resolveDmDisplayNames` on archived rows).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787066242&installation_id=129946197&pr_number=1421&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1421&signature=a43ca52604c616221774f84b4c0f7a58dffaca47cc930831ec541dd6215b6bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<details><summary>📋 Full implementation plan</summary>

# Archived-stream index: durable client knowledge of archival

## Problem

The workspace bootstrap prunes archived roots entirely (`listWithPreviews` collapses to `s.archived_at IS NULL` — `apps/backend/src/features/streams/repository.ts:699,711,725,736` — plus `EXCLUDE_ARCHIVED_ROOT_THREADS` at 644-648), and the client's bootstrap absence-sweep then deletes their IndexedDB rows (`cleanupStaleEntities` → `deleteStale(db.streams, …)`, `apps/frontend/src/sync/workspace-sync.ts:2570`). Every surface deriving "is this archived" or a stream's identity from `useWorkspaceStreams` goes blind after a reload:

- **Drafts** — `isStreamArchived` (`apps/frontend/src/hooks/use-all-drafts.ts:145-155`) returns `false` for a missing row, so archived-stream drafts reappear in badge + list after reload. PR #1418's backend snapshot filter (`d8ab94ac`) papered over this per-surface, but introduced its own reload-dependence: the drafts bootstrap reconcile deletes the hidden draft from IDB, and a live unarchive never re-delivers it — the draft returns only on the *next* bootstrap.
- **Saved** — rows fall back to `saved.message?.streamName ?? "Unknown"` once the archived stream row is swept (`apps/frontend/src/components/saved/saved-item.tsx:47`).
- **Activity** — stream labels degrade to the context snapshot for the same reason (`apps/frontend/src/pages/activity.tsx:92-129`).
- **Sidebar/unarchive** — `handleStreamUnarchived` does `db.streams.update(...)` (`workspace-sync.ts:819`), a no-op when the row was swept, so even a live unarchive can't restore the local row post-reload.

Key observation: **live archival already leaves the archived row in `db.streams`** (`handleStreamArchived`, `workspace-sync.ts:792`), and every consumer of `useWorkspaceStreams` (sidebar visibility, drafts filters, name resolution) already handles archived rows correctly in that in-session state. The reload bug is exactly that the persisted state diverges from the in-session state.

## Solution

Make the persisted state match the in-session state: bootstrap ships slim archived-root rows, the client persists them in `db.streams`, and the sweep keeps them. Every consumer then works unchanged, live and across reloads.

1. **Bootstrap contract** — new optional field on `WorkspaceBootstrap` (`packages/types/src/api.ts`, before line 1619):
   `archivedStreams?: Stream[]` — archived roots only (`archived_at IS NOT NULL` is only ever set on roots), plain `Stream` shape, **no** preview/membership joins. Access-scoped with the same visibility semantics as `listWithPreviews` (member streams + public channels), workspace-scoped (INV-8).
2. **Backend** — `StreamRepository.listArchivedRoots(pool, workspaceId, userId)` (lean query reusing the existing access predicates with `archived_at IS NOT NULL`; no preview CTEs), exposed via `StreamService`, emitted from the bootstrap handler (`apps/backend/src/features/workspaces/handlers.ts` response block). Archived **DM** rows get viewer-dependent display names resolved onto them (`resolveDmDisplayNames`) because archived DMs are excluded from `dmPeers` (`listDmPeersForMember` filters archived) and the client cannot resolve them peer-side.
3. **Revert the drafts snapshot exclusion** (`d8ab94ac`, `apps/backend/src/features/drafts/repository.ts`): `listByUser` returns all live drafts again. Hiding is client-side policy, not sync-protocol truncation — the draft row stays in IDB (merely filtered from badge/list), so a live `stream:unarchived` flips `db.streams` reactively and the draft reappears **instantly**, content intact, no refetch. "Hidden, never lost" holds locally.
4. **Frontend apply** — in `applyWorkspaceBootstrap` AND `applyReconnectBootstrapBatch`: `bulkPut` `bootstrap.archivedStreams ?? []` into `db.streams` (mapped like other rows; do not touch `lastMessagePreview` on existing rows), and add their ids to the keep-set in `cleanupStaleEntities`. Do **not** add them to the TanStack `bootstrap.streams` query cache (that list stays active-only; sidebar and pickers keep their current contract).
5. **Unarchive/archive handler robustness** — `handleStreamUnarchived`/`handleStreamArchived`: replace bare `db.streams.update(...)` with upsert semantics (update, and `put` a mapped row when the update matched nothing), so a row missing from IDB is restored rather than silently dropped.

What this heals with zero per-surface work: drafts badge+list stay hidden across reloads (both `stream:` and `thread:` scopes — thread resolution reads `db.events`, which the sweep never touches), unarchive restores drafts live, Saved and Activity resolve real stream names again after reload.

## PR stack

Base rework (not a chunk): force `fix/hide-drafts-archived-streams` back to `a534bb5b` (keep the badge/list parity commit, drop `d8ab94ac`), update PR #1418's body to frontend-parity-only scope.

- **Chunk 1 — backend + types** (branch `feat/archived-stream-index-backend`, base `fix/hide-drafts-archived-streams`): `WorkspaceBootstrap.archivedStreams` type, `listArchivedRoots` repo method + service pass-through, bootstrap handler emission. Tests: repo access/workspace scoping (member sees own archived scratchpad + archived member channels + archived public channels; non-member private excluded), handler includes the field.
- **Chunk 2 — frontend** (branch `feat/archived-stream-index-frontend`, base chunk 1): bootstrap apply + sweep keep-set (both paths), archive/unarchive handler upsert, and regression tests: (a) `cleanupStaleEntities` keeps archived rows delivered by bootstrap; (b) reload-simulation — seed IDB only via `applyWorkspaceBootstrap` with an archived root + a thread draft under it → badge and list both hide it; (c) live `stream:unarchived` with no prior IDB row → row restored, draft visible again.

## Deferred (binding — do not build)

- Server-side stamping of `root_stream_id` on thread-scope draft upserts (id-authoritative host resolution without the events map). Not needed: `db.events` is not swept, so the parity fix's resolution works across reloads.
- Purging/archiving accumulated hidden drafts (explicitly out per Kris — hide, never purge).
- Payload bounding for pathological archived counts (thousands of archived roots ≈ hundreds of KB worst case; revisit with pagination/caps only if a real workspace shows pressure).
- Board-scope draft parity (pre-existing residual on both layers).
- Any Activity catch-up gaps that remain after the index (separate investigation if still observed).

</details>
