### PR TITLE
fix: terminate offline-replay ops on permanent 4xx (prod send-now denial loop)

### DIFF
--- a/apps/backend/src/features/access-log/middleware.test.ts
+++ b/apps/backend/src/features/access-log/middleware.test.ts
@@ -1,9 +1,87 @@
 import { describe, expect, it } from "bun:test"
 import express from "express"
+import type { AddressInfo } from "node:net"
 import { assertAuditCoverage, createAuditMiddleware } from "./middleware"
+import { setAuditSubjects } from "./subjects"
 import type { AccessLogService } from "./service"
 
 const noopService = { record() {} } as unknown as AccessLogService
+
+function recordingService() {
+  const rows: Record<string, unknown>[] = []
+  const service = {
+    record(row: Record<string, unknown>) {
+      rows.push(row)
+    },
+  } as unknown as AccessLogService
+  return { service, rows }
+}
+
+async function requestAndAwaitRow(app: express.Express, path: string, rows: unknown[]): Promise<void> {
+  const server = app.listen(0)
+  try {
+    const port = (server.address() as AddressInfo).port
+    await fetch(`http://127.0.0.1:${port}${path}`, { method: "POST" })
+    // The record hook fires on the response 'finish' event, after the fetch
+    // resolves — poll briefly rather than racing it.
+    const deadline = Date.now() + 2000
+    while (rows.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5))
+    }
+  } finally {
+    server.close()
+  }
+  expect(rows.length).toBe(1)
+}
+
+describe("audit() denied-row forensics", () => {
+  it("records detail.status and route-param subject refs on a denial with no service subjects", async () => {
+    const { service, rows } = recordingService()
+    const audit = createAuditMiddleware(service)
+    const app = express()
+    app.post(
+      "/api/workspaces/:workspaceId/scheduled/:id/send-now",
+      audit("scheduled_messages.send_now", "write"),
+      (_req, res) => void res.status(409).json({ error: "already sent" })
+    )
+
+    await requestAndAwaitRow(app, "/api/workspaces/ws_1/scheduled/sched_1/send-now", rows)
+
+    expect(rows[0]).toMatchObject({
+      operation: "scheduled_messages.send_now",
+      outcome: "denied",
+      workspaceId: "ws_1",
+      detail: { status: 409 },
+      subjects: [{ type: "param", id: "sched_1" }],
+    })
+  })
+
+  it("keeps service-set subjects over the param fallback and omits detail on success", async () => {
+    const { service, rows } = recordingService()
+    const audit = createAuditMiddleware(service)
+    const app = express()
+    app.post(
+      "/api/workspaces/:workspaceId/streams/:id/read",
+      (req, _res, next) => {
+        req.user = { id: "usr_1" } as NonNullable<express.Request["user"]>
+        next()
+      },
+      audit("streams.get", "read"),
+      (_req, res) => {
+        setAuditSubjects(res, [{ type: "stream", id: "stream_1" }])
+        res.status(200).json({ ok: true })
+      }
+    )
+
+    await requestAndAwaitRow(app, "/api/workspaces/ws_1/streams/stream_9/read", rows)
+
+    expect(rows[0]).toMatchObject({
+      outcome: "success",
+      detail: null,
+      subjects: [{ type: "stream", id: "stream_1" }],
+    })
+  })
+})
 
 describe("assertAuditCoverage", () => {
   it("passes when every /api route carries an audit annotation", () => {

--- a/apps/backend/src/features/access-log/middleware.ts
+++ b/apps/backend/src/features/access-log/middleware.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, RequestHandler, Response } from "express"
 import type { AccessLogService } from "./service"
 import type { AccessKind, AccessLogOperation, AccessOutcome, ActorType } from "./operations"
-import { readAuditSubjects } from "./subjects"
+import { capSubjects, readAuditSubjects } from "./subjects"
 
 /**
  * The marker a route's audit middleware carries so the boot-time coverage guard
@@ -65,6 +65,20 @@ function outcomeFromStatus(status: number): AccessOutcome {
 }
 
 /**
+ * Non-success rows carry the HTTP status in `detail` — `denied` deliberately
+ * over-approximates all 4xx, so without the status a row can't distinguish a
+ * real 403 from a 404/409 (the 2026-07-19 send-now loop needed a prod-DB dig
+ * to tell). A status code is content-free, so the design's no-content rule
+ * (§5) is untouched.
+ */
+function buildDetail(aborted: boolean, outcome: AccessOutcome, status: number): Record<string, unknown> | null {
+  const detail: Record<string, unknown> = {}
+  if (aborted) detail.aborted = true
+  if (outcome !== "success") detail.status = status
+  return Object.keys(detail).length > 0 ? detail : null
+}
+
+/**
  * Fire `cb` exactly once when the response is done: 'finish' for a fully
  * written response, 'close' for an aborted one (client gone or stream torn
  * down mid-write). Data may already have egressed either way, so an aborted
@@ -88,6 +102,13 @@ export function createAuditMiddleware(accessLogService: AccessLogService): Audit
       // Captured synchronously: Express restores `req.params` as the routing
       // stack unwinds, so it is not reliable inside the deferred hook.
       const routeWorkspaceId = req.params.workspaceId ?? null
+      // A handler that denies never reaches the service code that sets
+      // subjects, so the route params are the only refs available to say WHAT
+      // was denied. capSubjects shape-enforces them: an id-shaped param is a
+      // ref, probed free text is redacted (no-content rule, design §5).
+      const routeParamRefs = Object.entries(req.params)
+        .filter(([name]) => name !== "workspaceId")
+        .map(([, value]) => ({ type: "param", id: value }))
       onResponseDone(res, (aborted) => {
         const identity = resolveIdentity(req)
         const outcome = aborted && !res.headersSent ? "error" : outcomeFromStatus(res.statusCode)
@@ -105,8 +126,10 @@ export function createAuditMiddleware(accessLogService: AccessLogService): Audit
           operation,
           accessKind: kind,
           outcome,
-          subjects: readAuditSubjects(res) ?? null,
-          detail: aborted ? { aborted: true } : null,
+          subjects:
+            readAuditSubjects(res) ??
+            (outcome === "denied" && routeParamRefs.length > 0 ? capSubjects(routeParamRefs) : null),
+          detail: buildDetail(aborted, outcome, res.statusCode),
           ip: req.ip ?? null,
           userAgent: req.headers["user-agent"] ?? null,
           requestId: (req as Request & { id?: string }).id ?? null,
@@ -146,7 +169,7 @@ export function createAuditMiddleware(accessLogService: AccessLogService): Audit
         accessKind: req.method === "GET" ? "read" : "write",
         outcome,
         subjects: workspaceId ? [{ type: "workspace", id: workspaceId }] : null,
-        detail: aborted ? { aborted: true } : null,
+        detail: buildDetail(aborted, outcome, res.statusCode),
         ip: req.ip ?? null,
         userAgent: req.headers["user-agent"] ?? null,
         requestId: (req as Request & { id?: string }).id ?? null,

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -14,6 +14,23 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * A 4xx verdict the server will keep returning no matter how many times the
+ * same request is replayed (excluding 408 timeout and 429 rate-limit, which
+ * are transient). Offline-replay and retry paths must treat these as
+ * terminal: drop the operation and reconcile local state to the server's
+ * answer instead of retrying.
+ */
+export function isPermanentApiError(error: unknown): error is ApiError {
+  return (
+    ApiError.isApiError(error) &&
+    error.status >= 400 &&
+    error.status < 500 &&
+    error.status !== 408 &&
+    error.status !== 429
+  )
+}
+
 // Canonical error shape emitted by the backend's `errorHandler` middleware
 // (packages/backend-common/src/middleware/error-handler.ts) and matched by
 // inline handler responses: `{ error: "<message>", code?: "<CODE>" }`.

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -1,4 +1,4 @@
-export { api, ApiError } from "./client"
+export { api, ApiError, isPermanentApiError } from "./client"
 export { accountsApi, ACCOUNTS_LIST_KEY, type AccountSummary } from "./accounts"
 export { workspacesApi, type WorkspaceBootstrap } from "./workspaces"
 export { boardViewsApi, type SaveBoardViewInput, type UpdateBoardViewInput } from "./board-views"

--- a/apps/frontend/src/hooks/use-scheduled.ts
+++ b/apps/frontend/src/hooks/use-scheduled.ts
@@ -9,6 +9,7 @@ import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { useBatchedValue } from "@/stores/apply-window"
 import { db, type CachedScheduledMessage } from "@/db"
 import { enqueueOperation } from "@/sync/operation-queue"
+import { isPermanentApiError } from "@/api"
 import type {
   ScheduledMessageView,
   ScheduledMessageStatus,
@@ -368,11 +369,14 @@ export function useCancelScheduled(workspaceId: string) {
     mutationFn: async (id: string) => {
       try {
         await scheduledService.delete(workspaceId, id)
-      } catch {
+      } catch (err) {
         // Local placeholder rows have no server-side counterpart — just
         // dropping the placeholder is enough; the schedule op may still be
         // queued and will be a no-op for a row the user already cancelled.
-        if (!isLocalScheduledId(id)) {
+        // A permanent 4xx (already sent/gone) is equally final: the optimistic
+        // removal already matches server truth, so enqueueing would only
+        // replay a request the server will refuse forever.
+        if (!isLocalScheduledId(id) && !isPermanentApiError(err)) {
           await enqueueOperation(workspaceId, "cancel_scheduled_message", { id })
           syncEngine.kickOperationQueue()
         }
@@ -449,8 +453,15 @@ export function useSendScheduledNow(workspaceId: string) {
         return await scheduledService.sendNow(workspaceId, id)
       } catch (err) {
         if (!isLocalScheduledId(id)) {
-          await enqueueOperation(workspaceId, "send_scheduled_now", { id })
-          syncEngine.kickOperationQueue()
+          if (isPermanentApiError(err)) {
+            // Already sent/cancelled/deleted server-side: retrying can never
+            // succeed. Evict the stale local row so the UI stops offering the
+            // action; the caller's onError toasts the reason.
+            await removeScheduledRow(id)
+          } else {
+            await enqueueOperation(workspaceId, "send_scheduled_now", { id })
+            syncEngine.kickOperationQueue()
+          }
         }
         throw err
       }

--- a/apps/frontend/src/hooks/use-scheduled.ts
+++ b/apps/frontend/src/hooks/use-scheduled.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { toast } from "sonner"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { serializeToMarkdown } from "@threa/prosemirror"
@@ -472,5 +473,11 @@ export function useSendScheduledNow(workspaceId: string) {
         queryClient.invalidateQueries({ queryKey: scheduledKeys.all })
       }
     },
+    // Hook-level so every surface gets failure feedback (INV-63) — the
+    // composer picker calls mutate() bare, and the permanent-4xx path above
+    // makes the row vanish, which would otherwise read as success. `||` not
+    // `??`: Error.message is typed string, so an empty message must also
+    // fall through to the human label.
+    onError: (err: Error) => toast.error(err.message || "Could not send"),
   })
 }

--- a/apps/frontend/src/pages/scheduled.tsx
+++ b/apps/frontend/src/pages/scheduled.tsx
@@ -65,9 +65,7 @@ function ScheduledPageInner({ workspaceId, tab }: InnerProps) {
   }
 
   const handleSendNow = (id: string) => {
-    sendNowMutation.mutate(id, {
-      onError: (err: Error) => toast.error(err.message || "Could not send"),
-    })
+    sendNowMutation.mutate(id)
   }
 
   const handleEdit = (id: string) => {

--- a/apps/frontend/src/sync/operation-queue.test.ts
+++ b/apps/frontend/src/sync/operation-queue.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { db, type CachedScheduledMessage } from "@/db"
+import { ApiError } from "@/api"
+import { enqueueOperation, processOperationQueue } from "./operation-queue"
+
+const workspaceId = "ws_1"
+const schedId = "sched_01TESTROW00000000000000000"
+
+function cachedScheduledRow(overrides: Partial<CachedScheduledMessage> = {}): CachedScheduledMessage {
+  return {
+    id: schedId,
+    workspaceId,
+    userId: "usr_1",
+    streamId: "stream_1",
+    parentMessageId: null,
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "hello",
+    attachmentIds: [],
+    metadata: null,
+    scheduledFor: "2026-07-19T12:00:00.000Z",
+    status: "pending",
+    sentMessageId: null,
+    lastError: null,
+    editActiveUntil: null,
+    clientMessageId: null,
+    version: 1,
+    createdAt: "2026-07-19T11:00:00.000Z",
+    updatedAt: "2026-07-19T11:00:00.000Z",
+    statusChangedAt: "2026-07-19T11:00:00.000Z",
+    _scheduledForMs: Date.parse("2026-07-19T12:00:00.000Z"),
+    _statusChangedAtMs: Date.parse("2026-07-19T11:00:00.000Z"),
+    _cachedAt: Date.parse("2026-07-19T11:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+const messageService = {
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+const reactionService = {
+  add: vi.fn(),
+  remove: vi.fn(),
+}
+
+function scheduledServiceRejectingWith(error: unknown) {
+  return {
+    create: vi.fn().mockRejectedValue(error),
+    delete: vi.fn().mockRejectedValue(error),
+    sendNow: vi.fn().mockRejectedValue(error),
+  }
+}
+
+async function process(scheduledService: ReturnType<typeof scheduledServiceRejectingWith>) {
+  await processOperationQueue(messageService, reactionService, scheduledService, undefined, () => true)
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await db.pendingOperations.clear()
+  await db.scheduledMessages.clear()
+})
+
+describe("processOperationQueue permanent-4xx handling", () => {
+  // The prod 2026-07-19 send-now loop: 11 IDB ops replaying a 409 on every
+  // queue kick, forever. A permanent 4xx must kill the op AND the stale row
+  // that keeps inviting the user to re-tap.
+  it("drops a send_scheduled_now op on 409 and evicts the stale local row", async () => {
+    await db.scheduledMessages.put(cachedScheduledRow())
+    await enqueueOperation(workspaceId, "send_scheduled_now", { id: schedId })
+
+    const scheduledService = scheduledServiceRejectingWith(
+      new ApiError(409, "SCHEDULED_MESSAGE_ALREADY_SENT", "Already sent")
+    )
+    await process(scheduledService)
+
+    expect(await db.pendingOperations.toArray()).toEqual([])
+    expect(await db.scheduledMessages.get(schedId)).toBeUndefined()
+
+    // A later kick must not replay the dropped op.
+    await process(scheduledService)
+    expect(scheduledService.sendNow).toHaveBeenCalledTimes(1)
+  })
+
+  it("drops a cancel_scheduled_message op on 404 and evicts the stale local row", async () => {
+    await db.scheduledMessages.put(cachedScheduledRow())
+    await enqueueOperation(workspaceId, "cancel_scheduled_message", { id: schedId })
+
+    await process(scheduledServiceRejectingWith(new ApiError(404, "SCHEDULED_MESSAGE_NOT_FOUND", "Not found")))
+
+    expect(await db.pendingOperations.toArray()).toEqual([])
+    expect(await db.scheduledMessages.get(schedId)).toBeUndefined()
+  })
+
+  it("retains the op for retry on a network error", async () => {
+    await enqueueOperation(workspaceId, "send_scheduled_now", { id: schedId })
+
+    await process(scheduledServiceRejectingWith(new TypeError("Failed to fetch")))
+
+    const [op] = await db.pendingOperations.toArray()
+    expect(op).toMatchObject({ type: "send_scheduled_now", retryCount: 1 })
+  })
+
+  it("retains the op for retry on 429", async () => {
+    await enqueueOperation(workspaceId, "send_scheduled_now", { id: schedId })
+
+    await process(scheduledServiceRejectingWith(new ApiError(429, "RATE_LIMITED", "Slow down")))
+
+    const [op] = await db.pendingOperations.toArray()
+    expect(op).toMatchObject({ type: "send_scheduled_now", retryCount: 1 })
+  })
+})

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -1,8 +1,8 @@
 import { db, sequenceToNum } from "@/db"
 import type { CachedEvent, PendingOperation } from "@/db/database"
 import type { CommandFailedPayload, ScheduleMessageInput, ScheduledMessageView } from "@threa/types"
-import { ApiError, commandsApi } from "@/api"
-import { persistScheduledRows, replaceLocalScheduledRow } from "@/hooks/use-scheduled"
+import { ApiError, commandsApi, isPermanentApiError } from "@/api"
+import { persistScheduledRows, removeScheduledRow, replaceLocalScheduledRow } from "@/hooks/use-scheduled"
 import { executeDraftDelete, executeDraftResolve, executeDraftUpsert, type DraftsServiceLike } from "./draft-sync"
 
 function getRetryDelay(retryCount: number): number {
@@ -32,14 +32,22 @@ interface ScheduledServiceLike {
   sendNow: (workspaceId: string, id: string) => Promise<ScheduledMessageView>
 }
 
-function isPermanentCommandDispatchError(error: unknown): error is ApiError {
-  return (
-    ApiError.isApiError(error) &&
-    error.status >= 400 &&
-    error.status < 500 &&
-    error.status !== 408 &&
-    error.status !== 429
-  )
+/**
+ * A permanently-rejected op's local optimistic state must be unwound, or the
+ * UI keeps offering an action the server will always refuse (the user re-taps,
+ * a fresh op enqueues, and the queue grows a phantom-row loop). Scheduled ops
+ * evict the local row — bootstrap/socket events restore the server's truth.
+ */
+async function reconcileRejectedOperation(op: PendingOperation): Promise<void> {
+  switch (op.type) {
+    case "schedule_message":
+      await removeScheduledRow(op.payload.placeholderId as string)
+      break
+    case "send_scheduled_now":
+    case "cancel_scheduled_message":
+      await removeScheduledRow(op.payload.id as string)
+      break
+  }
 }
 
 async function markCommandDispatchFailed(workspaceId: string, optimisticEventId: string, error: Error): Promise<void> {
@@ -118,13 +126,22 @@ export async function processOperationQueue(
         await db.pendingOperations.update(next.id, { startedAt: Date.now() })
         await executeOperation(next, messageService, reactionService, scheduledService, draftsService)
         await db.pendingOperations.delete(next.id)
-      } catch {
-        const retryCount = next.retryCount + 1
-        await db.pendingOperations.update(next.id, {
-          retryCount,
-          retryAfter: Date.now() + getRetryDelay(retryCount),
-        })
-        skipped.add(next.id)
+      } catch (error) {
+        if (isPermanentApiError(error)) {
+          // A 4xx (minus 408/429) is the server's final answer for this
+          // payload — replaying it can never succeed, so the op must die
+          // here or it refires on every queue kick forever (the prod
+          // send-now denial loop of 2026-07-19).
+          await reconcileRejectedOperation(next)
+          await db.pendingOperations.delete(next.id)
+        } else {
+          const retryCount = next.retryCount + 1
+          await db.pendingOperations.update(next.id, {
+            retryCount,
+            retryAfter: Date.now() + getRetryDelay(retryCount),
+          })
+          skipped.add(next.id)
+        }
       }
     }
   }
@@ -217,7 +234,7 @@ async function executeOperation(
           })
         })
       } catch (error) {
-        if (!isPermanentCommandDispatchError(error)) throw error
+        if (!isPermanentApiError(error)) throw error
         await markCommandDispatchFailed(workspaceId, optimisticEventId, error)
       }
       break


### PR DESCRIPTION
## Problem

Day one of the access log in prod (2026-07-19) surfaced a client stuck in a denial loop: 270 `scheduled_messages.send_now` rows with `outcome='denied'` between 12:20 and 15:17 UTC, all from one Android device. Prod state showed why: every `scheduled_messages` row in the workspace is `status='sent'` — the phone was replaying a send-now for a message sent 14.5 hours earlier, getting 409 `SCHEDULED_MESSAGE_ALREADY_SENT` forever.

Two compounding client bugs:

1. **`useSendScheduledNow` / `useCancelScheduled` (`apps/frontend/src/hooks/use-scheduled.ts`) enqueued an offline-replay op on *any* error**, including 4xx. Each tap on the phantom row minted one more op — the log's exactly-11-requests-per-burst shape is 11 accumulated ops in IDB, each attempted once per queue kick.
2. **`processOperationQueue` (`apps/frontend/src/sync/operation-queue.ts`) had no terminal path**: every failure bumped `retryCount` and set `retryAfter` (120s floor), never deleting the op. And a 409 replay never runs the success-path `persistScheduledRows`, so the stale "pending" row in IDB never corrected — which is what kept inviting the next tap.

The ops were intended to be idempotent, and they are on the success side (the server CAS in `assertPendingOrThrow` prevents double-send). What was missing is convergence on the failure side: a 4xx replay neither succeeds nor dies.

The diagnosis itself needed a prod-DB dig because v1 denied rows carried no HTTP status and no subject refs — `denied` deliberately over-approximates all 4xx (design §7.1), so the row alone can't tell a 403 probe from a 409 replay.

## Solution

4xx (minus 408/429) is the server's final answer for a given payload: drop the op and unwind the optimistic state instead of retrying. Plus the small log change that would have made this diagnosis one query.

### How it works

- `isPermanentApiError(error)` in `apps/frontend/src/api/client.ts`: 4xx excluding 408 (timeout) and 429 (rate limit). Generalizes the identical predicate that `dispatch_command` already used privately (`isPermanentCommandDispatchError`, now deleted).
- `processOperationQueue` catch: permanent error → `reconcileRejectedOperation` + delete the op. Transient error → existing retry/backoff path, unchanged. Reconciliation evicts the stale local scheduled row (`removeScheduledRow`) for `send_scheduled_now` / `cancel_scheduled_message` / `schedule_message` (placeholder id); bootstrap/socket events restore server truth.
- `useSendScheduledNow`: permanent 4xx no longer enqueues — it evicts the stale row and rethrows so the caller's existing `toast.error` fires (INV-63: failures toast). Transient errors enqueue + kick as before.
- `useCancelScheduled`: permanent 4xx no longer enqueues; the optimistic removal already matches server truth (row gone or non-pending).
- Access-log middleware (`apps/backend/src/features/access-log/middleware.ts`): non-success rows now carry `detail.status` (both route-level `audit(...)` and `audit.boundary`), and a route-level denial with no service-set subjects records the route params (minus `workspaceId`) as `{type:'param', id}` refs through `capSubjects` — shape-enforced, so an id-shaped param is a ref and probed free text is redacted. Both are content-free per the design's §5 no-content rule.

### Key design decisions

**1. Drop-and-reconcile, not server-side idempotent success.** Making `send_now` return 200 on an already-sent row would fix this one loop but change API semantics for every caller and still leave the queue with no terminal path for genuinely-invalid ops (404s, cancelled rows). The client-side terminal path fixes the whole bug class, including `edit_message`/`delete_message`/reaction ops that had the same infinite-retry behavior.

**2. No retry cap for transient errors.** The handover suggested one, but `retryCount` only advances on failed *online* attempts, and capping would silently drop a user's queued edit after a long flaky-network stretch — data loss to fix a problem the 4xx-terminal path already fixes. Transient retries stay unbounded at the 120s floor.

**3. Stuck devices self-heal.** The 11 ops on the affected phone each 409 once on the next queue kick, get dropped, and the phantom row is evicted — no manual IDB surgery needed.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/api/client.ts` | New `isPermanentApiError` predicate |
| `apps/frontend/src/api/index.ts` | Export it |
| `apps/frontend/src/sync/operation-queue.ts` | Permanent-4xx terminal path: drop op + `reconcileRejectedOperation`; `dispatch_command` reuses the shared predicate |
| `apps/frontend/src/hooks/use-scheduled.ts` | Send-now/cancel enqueue only on transient errors; permanent 4xx evicts the stale row |
| `apps/backend/src/features/access-log/middleware.ts` | `detail.status` on non-success rows; route-param subject refs on subject-less denials |
| `apps/frontend/src/sync/operation-queue.test.ts` | New: 409/404 drop + row eviction, network/429 retained |
| `apps/backend/src/features/access-log/middleware.test.ts` | New: denied row carries `detail.status` + param refs; success row keeps service subjects, null detail |

## Out of scope (deliberate)

- No failure surfacing when a queued `edit_message`/`delete_message`/reaction op is dropped on 4xx — pre-existing gap; the drop is still strictly better than the previous infinite retry. (`dispatch_command` already surfaces via `command_failed`.)
- Backfill of `detail.status` onto existing prod rows — new rows only.
- Server-side idempotent send-now semantics (decision 1).

## Test plan

- [x] `bunx vitest run src/sync/` (frontend) — 367 pass across 13 files, incl. 4 new operation-queue tests
- [x] `bun test src/features/access-log/` (backend) — 16 pass, incl. 2 new middleware behavior tests
- [x] `tsc --noEmit` frontend + backend clean; full pre-commit lint/typecheck sweep across the monorepo passed
- [x] Prod forensics (read-only): denial histogram, scheduled-row states, actor identity — findings in Problem above
- [ ] Live repro on the affected device (Kris's phone) — expected to self-heal on next app open; verify the denial loop stops in `access_log` after deploy

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787067017&installation_id=129946197&pr_number=1423&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1423&signature=091b5b78335fa7c1d54a63c171638f750acdcf36f2c1f3a519de29e36e08646a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->