### PR TITLE
perf(idle): env knobs for outbox fallback poll + CP WorkOS poller intervals

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1374,7 +1374,10 @@ export async function startServer(): Promise<ServerInstance> {
   await jobQueue.schedule(JobQueues.ATTACHMENT_UPLOAD_SWEEP, 900, { workspaceId: "system" }, null)
 
   // Outbox dispatcher - single LISTEN connection fans out to all handlers
-  const outboxDispatcher = new OutboxDispatcher({ listenPool: pools.listen })
+  const outboxDispatcher = new OutboxDispatcher({
+    listenPool: pools.listen,
+    fallbackPollMs: Number(process.env.OUTBOX_FALLBACK_POLL_MS) || 2000,
+  })
 
   // Real-time delivery handlers (broadcast, push) use a dedicated `pools.realtime`
   // so a saturated main pool (AI workers, file processing, embeddings) can never

--- a/apps/control-plane/src/config.ts
+++ b/apps/control-plane/src/config.ts
@@ -60,6 +60,12 @@ export interface ControlPlaneConfig {
     authMax: number
     waitlistMax: number
   }
+  /** Outbox dispatcher fallback poll interval (ms) — LISTEN-miss safety net. */
+  outboxFallbackPollMs: number
+  /** WorkOS authz-mirror poller interval (ms). */
+  workosAuthzPollIntervalMs: number
+  /** auth_log ingestion poller interval (ms). */
+  authLogPollIntervalMs: number
   waitlist: {
     /**
      * Resend API key for the waitlist confirmation email. Null falls back to a
@@ -170,6 +176,9 @@ export function loadControlPlaneConfig(): ControlPlaneConfig {
       authMax: Number(process.env.AUTH_RATE_LIMIT_MAX) || 20,
       waitlistMax: Number(process.env.WAITLIST_RATE_LIMIT_MAX) || 10,
     },
+    outboxFallbackPollMs: Number(process.env.OUTBOX_FALLBACK_POLL_MS) || 2000,
+    workosAuthzPollIntervalMs: Number(process.env.WORKOS_AUTHZ_POLL_INTERVAL_MS) || 5000,
+    authLogPollIntervalMs: Number(process.env.AUTH_LOG_POLL_INTERVAL_MS) || 5000,
     waitlist: {
       resendApiKey: process.env.RESEND_API_KEY?.trim() || null,
       fromEmail: process.env.WAITLIST_FROM_EMAIL?.trim() || "Threa <hello@threa.io>",

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -169,7 +169,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     handle: () => debouncer.trigger(),
   }
 
-  const outboxDispatcher = new OutboxDispatcher({ listenPool })
+  const outboxDispatcher = new OutboxDispatcher({ listenPool, fallbackPollMs: config.outboxFallbackPollMs })
 
   // WorkOS authz mirror — passive polling, no fan-out yet (Phase 1).
   // Multi-instance safe via the time-based lease in WorkosEventPollerLock,
@@ -212,7 +212,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       workosOrgService,
       authzService,
       lock: workosEventLock,
-      pollIntervalMs: 5_000,
+      pollIntervalMs: config.workosAuthzPollIntervalMs,
       batchSize: 100,
     })
 
@@ -248,7 +248,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       workosOrgService,
       authLogService,
       lock: authLogLock,
-      pollIntervalMs: 5_000,
+      pollIntervalMs: config.authLogPollIntervalMs,
       batchSize: 100,
     })
     authLogPoller.start()


### PR DESCRIPTION
Stack 2/3 on #1425 (plan: `docs/plans/make-staging-cheaper.md`, embedded in #1425).

## Problem

At zero traffic each backend pod fires ~3,100–3,600 Postgres queries/min. ~80% is the outbox dispatcher's **2 s fallback poll** fanning out to ~19 registered handlers, each running a 5-query cursor-lock cycle (`isReadyToProcess` → `tryClaimLock` → `fetchAfterId` → `resetRetryState` → `releaseLock`) that finds nothing. `NOTIFY` (`packages/backend-common/src/outbox/repository.ts:77,98`) is the actual delivery path — the fallback timer only bounds recovery from a lost notification — yet its interval is hard-coded via the dispatcher's `DEFAULT_CONFIG` with no way to tune an idle-heavy environment. The control-plane adds ~200 q/min plus **24 WorkOS HTTP calls/min** from two pollers with literal `pollIntervalMs: 5_000` (`WorkosAuthzPoller`, `AuthLogPoller`).

Staging + every PR-deploy backend runs this chatter 24/7 against one shared Postgres.

## Solution

Expose the three intervals as env vars with byte-identical defaults; values change only where ops sets them (staging/PR backends), prod is untouched until deliberately tuned.

- `OUTBOX_FALLBACK_POLL_MS` — backend `server.ts` dispatcher construction (inline env read, same file's `OUTBOX_RETENTION_*` precedent) and control-plane via `config.ts`. Default 2000 = the dispatcher's own `DEFAULT_CONFIG.fallbackPollMs`.
- `WORKOS_AUTHZ_POLL_INTERVAL_MS`, `AUTH_LOG_POLL_INTERVAL_MS` — control-plane `config.ts` fields (`workosAuthzPollIntervalMs`, `authLogPollIntervalMs`, documented, grouped after `rateLimits` per the file's structure), consumed in `server.ts` where `5_000` was hard-coded. Defaults 5000.

The poller *lock* timings (`lockDurationMs: 10_000`, `refreshIntervalMs: 5_000`) stay hard-coded deliberately — they bound lease correctness, not idle cost.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/server.ts` | `fallbackPollMs: Number(process.env.OUTBOX_FALLBACK_POLL_MS) \|\| 2000` on the dispatcher |
| `apps/control-plane/src/config.ts` | Three documented config fields + env reads, defaults 2000/5000/5000 |
| `apps/control-plane/src/server.ts` | Dispatcher + both pollers consume the config fields |

## Out of scope (deliberate)

- Setting the Railway staging variables (post-merge ops: staging backend `OUTBOX_FALLBACK_POLL_MS=30000` + `QUEUE_POLL_INTERVAL_MS=5000`; CP `OUTBOX_FALLBACK_POLL_MS=30000`, `WORKOS_AUTHZ_POLL_INTERVAL_MS=60000`, `AUTH_LOG_POLL_INTERVAL_MS=60000`; PR backends inherit automatically via `staging-pr.ts` var copy).
- Outbox `keepaliveMs`, queue-lib code, `QUEUE_POLL_INTERVAL_MS` default (already env-tunable).
- Known precedent quirk kept as-is: `Number(x) || default` treats an explicit `0` as unset — matches every existing env read in both files, and 0 is not a meaningful poll interval.

## Test plan

- [x] `cd apps/backend && bun run typecheck` — clean; `apps/control-plane` `tsc --noEmit` — clean
- [x] `apps/control-plane` full `bun run test` — 244 pass / 0 fail (live PG)
- [x] `bun run --cwd apps/backend test:unit` — 3238 pass; the 14 `env.test.ts` failures are the documented stray-local-`.env` baseline (verifier re-confirmed `env.ts` imports nothing in this diff)
- [x] Implement (Opus) → adversarial verify (Opus xhigh, independent diff re-derivation + gate re-runs): verdict SHIP; confirmed the env-unset path is byte-identical to the previous hard-coded behavior at all three sites
- [ ] No CP config test harness exists (`loadControlPlaneConfig` has never had tests) — new fields follow the untested precedent rather than inventing a harness in this PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787076080&installation_id=129946197&pr_number=1426&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1426&signature=50d73291ca96a3a2edd0da48c8dd09321aa5fb2ba64dfb9e2caa078dfa3d4c43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->