### PR TITLE
feat(staging): reconcile action + nightly sweeper for orphaned PR environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Run scripts tests
+        run: bun run test:scripts
+
       - name: Create test databases
         run: |
           PGPASSWORD=threa psql -h localhost -p 5454 -U threa -d postgres -c "CREATE DATABASE threa_test;"

--- a/.github/workflows/staging-reconcile.yml
+++ b/.github/workflows/staging-reconcile.yml
@@ -12,9 +12,15 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Print the orphan plan without deleting anything"
+        description: "Print the orphan plan without deleting anything (uncheck for a real teardown)"
         type: boolean
-        default: false
+        default: true
+
+# Two overlapping reconciles race each other's DROP DATABASE into spurious red
+# runs (TOCTOU on databaseExists). Serialize; never cancel a live teardown.
+concurrency:
+  group: staging-reconcile
+  cancel-in-progress: false
 
 jobs:
   reconcile:

--- a/.github/workflows/staging-reconcile.yml
+++ b/.github/workflows/staging-reconcile.yml
@@ -1,0 +1,73 @@
+name: Staging Reconcile
+
+# Event-driven teardown (staging.yml) can never be reliable on its own: a
+# closed-without-merge PR — common in stack shuffles — often produces NO
+# workflow run at all (no merge ref → no run), so its per-PR staging resources
+# leak. This nightly sweep discovers every PR number that still owns a matching
+# resource (Railway service, pr_N/pr_N_cp databases, KV region entry), cross-
+# references the open+`staging`-labeled PRs, and tears down the rest.
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the orphan plan without deleting anything"
+        type: boolean
+        default: false
+
+jobs:
+  reconcile:
+    name: Reconcile staging
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install PostgreSQL 18 client
+        run: |
+          # The Azure-hosted runner ships Microsoft apt repos (azure-cli, prod)
+          # whose signature check intermittently fails ("NOSPLIT"), aborting
+          # apt-get update with exit 100 — a recurring, unrelated cause of staging
+          # deploy failures. We only need the pgdg repo here, so drop the MS
+          # sources before touching apt.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* || true
+          sudo apt-get install -y curl ca-certificates
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-18
+
+      - name: Reconcile orphaned PR environments
+        run: |
+          DRY_RUN_FLAG=""
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          bun scripts/staging-pr.ts --action=reconcile $DRY_RUN_FLAG
+        env:
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_KV_NAMESPACE_ID: ${{ secrets.STAGING_KV_NAMESPACE_ID }}
+          STAGING_INTERNAL_API_KEY: ${{ secrets.STAGING_INTERNAL_API_KEY }}
+          STAGING_CONTROL_PLANE_URL: ${{ secrets.STAGING_CONTROL_PLANE_URL }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typecheck": "bun run --cwd packages/types typecheck && bun run --cwd packages/prosemirror typecheck && bun run --cwd packages/crypto typecheck && bun run --cwd packages/backend-common typecheck && bun run --cwd packages/agent-runtime typecheck && bun run --cwd packages/cli typecheck && bun run --cwd apps/backend typecheck && bun run --cwd apps/control-plane typecheck && bun run --cwd apps/workspace-router typecheck && bun run --cwd apps/backoffice-router typecheck && bun run --cwd apps/frontend typecheck && bun run --cwd apps/backoffice typecheck && bun run --cwd apps/db-read-proxy typecheck && bun run --cwd apps/enclave typecheck && bun run --cwd apps/public-site typecheck",
     "eval": "bun run --cwd apps/backend eval --",
     "test": "bun run --cwd apps/backend test",
+    "test:scripts": "bun test ./scripts/",
     "test:unit": "bun run --cwd apps/backend test:unit",
     "test:e2e": "bun run --cwd apps/backend test:e2e",
     "test:browser": "bun scripts/test-silent.ts browser",

--- a/scripts/staging-pr-lib.test.ts
+++ b/scripts/staging-pr-lib.test.ts
@@ -92,6 +92,18 @@ describe("classifyStagingOrphans", () => {
     expect(plan.keep).toEqual([])
   })
 
+  test("ignores non-canonical digit strings — teardown re-derives names, so pr_0123 must not become pr_123", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: ["pr-0300-backend"],
+      dbNames: ["pr_0123", "pr_0123_cp"],
+      kvRegionKeys: ["pr-007"],
+      openLabeledPrNumbers: [],
+    })
+
+    expect(plan.orphans).toEqual([])
+    expect(plan.keep).toEqual([])
+  })
+
   test("unions candidates across sources and sorts orphans by PR number", () => {
     const plan = classifyStagingOrphans({
       serviceNames: ["pr-300-backend"],

--- a/scripts/staging-pr-lib.test.ts
+++ b/scripts/staging-pr-lib.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import { classifyStagingOrphans, stagingResourceNames } from "./staging-pr-lib"
+
+describe("stagingResourceNames", () => {
+  test("derives every per-PR name from the number", () => {
+    expect(stagingResourceNames(228)).toEqual({
+      pr: 228,
+      prDbName: "pr_228",
+      prCpDbName: "pr_228_cp",
+      regionName: "pr-228",
+      serviceName: "pr-228-backend",
+      prHostname: "pr-228-staging.threa.io",
+    })
+  })
+})
+
+describe("classifyStagingOrphans", () => {
+  test("keeps an open+labeled PR whose full resource set exists", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: ["pr-500-backend"],
+      dbNames: ["pr_500", "pr_500_cp"],
+      kvRegionKeys: ["pr-500"],
+      openLabeledPrNumbers: [500],
+    })
+
+    expect(plan.orphans).toEqual([])
+    expect(plan.keep).toEqual([{ pr: 500, hasService: true, hasDb: true, hasCpDb: true, hasKvRegion: true }])
+  })
+
+  test("keeps an open+labeled PR even when only some resources exist (partial deploy)", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: [],
+      dbNames: ["pr_501"],
+      kvRegionKeys: [],
+      openLabeledPrNumbers: [501],
+    })
+
+    expect(plan.orphans).toEqual([])
+    expect(plan.keep).toEqual([{ pr: 501, hasService: false, hasDb: true, hasCpDb: false, hasKvRegion: false }])
+  })
+
+  test("flags a DB-only orphan whose service was already hand-deleted (real case: #1252)", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: [],
+      dbNames: ["pr_1252", "pr_1252_cp"],
+      kvRegionKeys: [],
+      openLabeledPrNumbers: [],
+    })
+
+    expect(plan.keep).toEqual([])
+    expect(plan.orphans).toEqual([{ pr: 1252, hasService: false, hasDb: true, hasCpDb: true, hasKvRegion: false }])
+  })
+
+  test("flags a KV-only orphan", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: [],
+      dbNames: [],
+      kvRegionKeys: ["pr-1050"],
+      openLabeledPrNumbers: [],
+    })
+
+    expect(plan.orphans).toEqual([{ pr: 1050, hasService: false, hasDb: false, hasCpDb: false, hasKvRegion: true }])
+  })
+
+  test("handles a control-plane DB (pr_N_cp) present without its backend DB (pr_N)", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: [],
+      dbNames: ["pr_777_cp"],
+      kvRegionKeys: [],
+      openLabeledPrNumbers: [],
+    })
+
+    expect(plan.orphans).toEqual([{ pr: 777, hasService: false, hasDb: false, hasCpDb: true, hasKvRegion: false }])
+  })
+
+  test("never classifies shared infra or deleted-service suffix names", () => {
+    const plan = classifyStagingOrphans({
+      // Deleted Railway services get a UUID suffix and must NOT match `-backend$`.
+      serviceNames: [
+        "backend",
+        "control-plane",
+        "Postgres",
+        "railway",
+        "pr-1252-backend-47675d47-0f2c-4a9b-bd11-deadbeef00",
+      ],
+      dbNames: ["postgres", "template0", "template1", "staging_main", "staging_main_cp"],
+      kvRegionKeys: ["staging"],
+      openLabeledPrNumbers: [],
+    })
+
+    expect(plan.orphans).toEqual([])
+    expect(plan.keep).toEqual([])
+  })
+
+  test("unions candidates across sources and sorts orphans by PR number", () => {
+    const plan = classifyStagingOrphans({
+      serviceNames: ["pr-300-backend"],
+      dbNames: ["pr_100", "pr_100_cp", "pr_300"],
+      kvRegionKeys: ["pr-200"],
+      openLabeledPrNumbers: [300],
+    })
+
+    expect(plan.orphans).toEqual([
+      { pr: 100, hasService: false, hasDb: true, hasCpDb: true, hasKvRegion: false },
+      { pr: 200, hasService: false, hasDb: false, hasCpDb: false, hasKvRegion: true },
+    ])
+    expect(plan.keep).toEqual([{ pr: 300, hasService: true, hasDb: true, hasCpDb: false, hasKvRegion: false }])
+  })
+})

--- a/scripts/staging-pr-lib.ts
+++ b/scripts/staging-pr-lib.ts
@@ -41,9 +41,23 @@ export function stagingResourceNames(prNumber: number): StagingResourceNames {
 // shared infra — `backend`, `control-plane`, `Postgres`, `staging_main`,
 // `staging_main_cp`, `railway`, `postgres`, `template0/1` — matches none of
 // these, so it is structurally unreachable, not merely skipped.
+//
+// The flip side: the whole `pr_<digits>` / `pr-<digits>` namespace is
+// reserved-and-reaped. A hand-made `pr_9999` experiment DB WILL be swept as an
+// orphan on the next nightly run — name experiments anything else.
 export const STAGING_SERVICE_RE = /^pr-(\d+)-backend$/
 export const STAGING_DB_RE = /^pr_(\d+)(_cp)?$/
 export const STAGING_KV_REGION_RE = /^pr-(\d+)$/
+
+/**
+ * Teardown re-derives resource names from the parsed number, so a discovered
+ * name must round-trip exactly (`pr_0123` → 123 → `pr_123` would drop the
+ * wrong DB and leak the discovered one). Reject non-canonical digit strings.
+ */
+function canonicalPrNumber(digits: string): number | null {
+  const pr = Number(digits)
+  return String(pr) === digits ? pr : null
+}
 
 export interface StagingReconcileInput {
   /** All Railway service names in the project. */
@@ -97,20 +111,23 @@ export function classifyStagingOrphans(input: StagingReconcileInput): StagingRec
 
   for (const name of input.serviceNames) {
     const match = STAGING_SERVICE_RE.exec(name)
-    if (match) get(Number(match[1])).hasService = true
+    const pr = match ? canonicalPrNumber(match[1]) : null
+    if (pr !== null) get(pr).hasService = true
   }
 
   for (const name of input.dbNames) {
     const match = STAGING_DB_RE.exec(name)
-    if (!match) continue
-    const entry = get(Number(match[1]))
+    const pr = match ? canonicalPrNumber(match[1]) : null
+    if (match === null || pr === null) continue
+    const entry = get(pr)
     if (match[2] === "_cp") entry.hasCpDb = true
     else entry.hasDb = true
   }
 
   for (const key of input.kvRegionKeys) {
     const match = STAGING_KV_REGION_RE.exec(key)
-    if (match) get(Number(match[1])).hasKvRegion = true
+    const pr = match ? canonicalPrNumber(match[1]) : null
+    if (pr !== null) get(pr).hasKvRegion = true
   }
 
   const openSet = new Set(input.openLabeledPrNumbers)

--- a/scripts/staging-pr-lib.ts
+++ b/scripts/staging-pr-lib.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure helpers for staging PR lifecycle management, extracted so the orphan
+ * classification can be unit-tested without touching Railway / Cloudflare /
+ * Postgres. `staging-pr.ts` imports these; keep this module side-effect free.
+ */
+
+/** Resource names for one PR, derived from its number. */
+export interface StagingResourceNames {
+  readonly pr: number
+  /** Backend database, e.g. `pr_228`. */
+  readonly prDbName: string
+  /** Control-plane database, e.g. `pr_228_cp`. */
+  readonly prCpDbName: string
+  /** KV `__regions_config__` key, e.g. `pr-228`. */
+  readonly regionName: string
+  /** Railway service, e.g. `pr-228-backend`. */
+  readonly serviceName: string
+  /** Frontend hostname, e.g. `pr-228-staging.threa.io`. */
+  readonly prHostname: string
+}
+
+/**
+ * Single source of truth for per-PR resource names. A pure function of the PR
+ * number so teardown can run for many numbers in one process (reconcile).
+ */
+export function stagingResourceNames(prNumber: number): StagingResourceNames {
+  return {
+    pr: prNumber,
+    prDbName: `pr_${prNumber}`,
+    prCpDbName: `pr_${prNumber}_cp`,
+    regionName: `pr-${prNumber}`,
+    serviceName: `pr-${prNumber}-backend`,
+    prHostname: `pr-${prNumber}-staging.threa.io`,
+  }
+}
+
+// Strict, end-anchored patterns are the safety boundary: only names matching
+// these can ever yield a teardown candidate. Live Railway service names are
+// exact (`pr-228-backend`); a DELETED service is renamed with a UUID suffix
+// (`pr-228-backend-47675d47-...`), which the `-backend$` anchor rejects. The
+// shared infra — `backend`, `control-plane`, `Postgres`, `staging_main`,
+// `staging_main_cp`, `railway`, `postgres`, `template0/1` — matches none of
+// these, so it is structurally unreachable, not merely skipped.
+export const STAGING_SERVICE_RE = /^pr-(\d+)-backend$/
+export const STAGING_DB_RE = /^pr_(\d+)(_cp)?$/
+export const STAGING_KV_REGION_RE = /^pr-(\d+)$/
+
+export interface StagingReconcileInput {
+  /** All Railway service names in the project. */
+  readonly serviceNames: readonly string[]
+  /** All `datname` values from `pg_database`. */
+  readonly dbNames: readonly string[]
+  /** All keys present in the `__regions_config__` KV blob. */
+  readonly kvRegionKeys: readonly string[]
+  /** PR numbers that are open AND carry the `staging` label. */
+  readonly openLabeledPrNumbers: readonly number[]
+}
+
+/** Which resources exist for one discovered PR number. */
+export interface StagingCandidate {
+  readonly pr: number
+  readonly hasService: boolean
+  /** Backend DB `pr_N` exists. */
+  readonly hasDb: boolean
+  /** Control-plane DB `pr_N_cp` exists. */
+  readonly hasCpDb: boolean
+  readonly hasKvRegion: boolean
+}
+
+export interface StagingReconcilePlan {
+  /** Discovered PR numbers NOT open+labeled — safe to tear down. */
+  readonly orphans: StagingCandidate[]
+  /** Discovered PR numbers that ARE open+labeled — left untouched. */
+  readonly keep: StagingCandidate[]
+}
+
+/**
+ * Classify every PR number that owns at least one matching staging resource as
+ * either an orphan (tear down) or keep (open+labeled — never touched, even if
+ * only some of its resources exist, e.g. a partial deploy in progress).
+ *
+ * Pure: the strict `STAGING_*_RE` patterns are the only path from a raw name to
+ * a candidate number, so nothing outside the `pr_N`/`pr-N` shapes can ever be
+ * classified — the safety invariant is structural.
+ */
+export function classifyStagingOrphans(input: StagingReconcileInput): StagingReconcilePlan {
+  const candidates = new Map<number, { hasService: boolean; hasDb: boolean; hasCpDb: boolean; hasKvRegion: boolean }>()
+
+  const get = (pr: number) => {
+    let entry = candidates.get(pr)
+    if (!entry) {
+      entry = { hasService: false, hasDb: false, hasCpDb: false, hasKvRegion: false }
+      candidates.set(pr, entry)
+    }
+    return entry
+  }
+
+  for (const name of input.serviceNames) {
+    const match = STAGING_SERVICE_RE.exec(name)
+    if (match) get(Number(match[1])).hasService = true
+  }
+
+  for (const name of input.dbNames) {
+    const match = STAGING_DB_RE.exec(name)
+    if (!match) continue
+    const entry = get(Number(match[1]))
+    if (match[2] === "_cp") entry.hasCpDb = true
+    else entry.hasDb = true
+  }
+
+  for (const key of input.kvRegionKeys) {
+    const match = STAGING_KV_REGION_RE.exec(key)
+    if (match) get(Number(match[1])).hasKvRegion = true
+  }
+
+  const openSet = new Set(input.openLabeledPrNumbers)
+  const orphans: StagingCandidate[] = []
+  const keep: StagingCandidate[] = []
+
+  for (const [pr, resources] of [...candidates.entries()].sort((a, b) => a[0] - b[0])) {
+    const candidate: StagingCandidate = { pr, ...resources }
+    if (openSet.has(pr)) keep.push(candidate)
+    else orphans.push(candidate)
+  }
+
+  return { orphans, keep }
+}

--- a/scripts/staging-pr.ts
+++ b/scripts/staging-pr.ts
@@ -811,14 +811,19 @@ async function resetDb(names: StagingResourceNames, branch: string): Promise<voi
 async function teardownResources(names: StagingResourceNames): Promise<void> {
   const { regionName, prHostname, serviceName, prDbName, prCpDbName } = names
 
-  await unregisterRegion(regionName)
-
+  // KV goes LAST: it is one of reconcile's discovery sources while DNS/route
+  // are not, so removing it first would let a mid-teardown crash strand a
+  // DNS+route-only leftover with no remaining signal to rediscover it by.
+  // A KV entry outliving its DNS/route/service is harmless in the meantime —
+  // nothing routes to the pr-N hostname once the route is gone.
   await deletePrDnsAndRoute(prHostname)
 
   await deleteRailwayService(serviceName)
 
   await dropDatabase(prDbName)
   await dropDatabase(prCpDbName)
+
+  await unregisterRegion(regionName)
 }
 
 async function teardown(names: StagingResourceNames): Promise<void> {
@@ -834,9 +839,14 @@ async function teardown(names: StagingResourceNames): Promise<void> {
  * every PR number that owns a matching resource, cross-references the open+
  * `staging`-labeled PRs, and tears down the rest.
  *
- * Fail-hard-before-mutation: the open-PR fetch runs (and throws on any GitHub
- * error) BEFORE the first teardown, so a GitHub outage aborts the whole run
- * rather than misclassifying live PRs as orphans and deleting them.
+ * Fail-hard-before-mutation, twice over. A transport failure on any GitHub
+ * call throws before the first teardown. But a wrong-yet-HTTP-200 answer (the
+ * `staging` label renamed → `labels=staging` returns an empty set) is the
+ * catastrophic case for an unattended nightly sweep, so two structural guards
+ * defend it: the label's existence is asserted up front, and every would-be
+ * orphan is re-verified against the per-PR endpoint (an independent signal)
+ * before ANY deletion — a single open+labeled hit there aborts the whole run
+ * as an endpoint inconsistency.
  */
 async function reconcile(dryRun: boolean): Promise<void> {
   const GITHUB_TOKEN = requireEnv("GITHUB_TOKEN")
@@ -851,6 +861,8 @@ async function reconcile(dryRun: boolean): Promise<void> {
   const kvRaw = await kvGet("__regions_config__")
   const kvRegionKeys = kvRaw ? Object.keys(JSON.parse(kvRaw) as Record<string, unknown>) : []
 
+  await assertStagingLabelExists(GITHUB_TOKEN)
+
   // Fetch open+labeled PRs. THROWS on any GitHub error — must run before any
   // teardown so a transient API failure never reads as "everything is orphaned".
   const openLabeledPrNumbers = await fetchOpenStagingPrs(GITHUB_TOKEN)
@@ -861,6 +873,11 @@ async function reconcile(dryRun: boolean): Promise<void> {
   if (dryRun) {
     console.log(`\nDry-run — no resources modified.`)
     return
+  }
+
+  // Second, independent confirmation for EVERY orphan before ANY deletion.
+  for (const orphan of plan.orphans) {
+    await assertOrphanNotOpenLabeled(GITHUB_TOKEN, orphan.pr)
   }
 
   const failures: { pr: number; error: string }[] = []
@@ -885,6 +902,34 @@ async function reconcile(dryRun: boolean): Promise<void> {
 }
 
 const GITHUB_REPO = "threahq/threa"
+const STAGING_LABEL = "staging"
+
+async function githubGet(token: string, path: string): Promise<Response> {
+  return fetch(`https://api.github.com/repos/${GITHUB_REPO}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "threa-staging-reconcile",
+    },
+  })
+}
+
+/**
+ * The `labels=staging` filter answers `200 []` for a renamed/deleted label —
+ * indistinguishable from "no open staging PRs", which would classify every
+ * live environment as an orphan. Asserting the label itself exists turns that
+ * silent mass-delete into a loud abort.
+ */
+async function assertStagingLabelExists(token: string): Promise<void> {
+  const res = await githubGet(token, `/labels/${STAGING_LABEL}`)
+  if (res.status === 404) {
+    throw new Error(`Label '${STAGING_LABEL}' does not exist on ${GITHUB_REPO} — refusing to reconcile (renamed?)`)
+  }
+  if (!res.ok) {
+    throw new Error(`GitHub label check HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
+  }
+}
 
 /**
  * Open PR numbers carrying the `staging` label. The issues endpoint returns PRs
@@ -895,15 +940,7 @@ const GITHUB_REPO = "threahq/threa"
 async function fetchOpenStagingPrs(token: string): Promise<number[]> {
   const numbers: number[] = []
   for (let page = 1; ; page++) {
-    const url = `https://api.github.com/repos/${GITHUB_REPO}/issues?labels=staging&state=open&per_page=100&page=${page}`
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "threa-staging-reconcile",
-      },
-    })
+    const res = await githubGet(token, `/issues?labels=${STAGING_LABEL}&state=open&per_page=100&page=${page}`)
     if (!res.ok) {
       throw new Error(`GitHub API HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
     }
@@ -914,6 +951,31 @@ async function fetchOpenStagingPrs(token: string): Promise<number[]> {
     if (items.length < 100) break
   }
   return numbers
+}
+
+/**
+ * Independent second signal before deletion: the per-PR endpoint, not the
+ * label-filtered issues listing. 404 = the number was never a PR (e.g. a
+ * hand-made pr_N experiment DB) — confirmed orphan. An open PR that carries
+ * the staging label here means the issues listing lied (label index lag,
+ * token scoping) — abort the ENTIRE run, trusting neither endpoint. This also
+ * closes the just-labeled-PR race: a deploy triggered seconds ago shows
+ * open+labeled here even if the listing missed it.
+ */
+async function assertOrphanNotOpenLabeled(token: string, pr: number): Promise<void> {
+  const res = await githubGet(token, `/pulls/${pr}`)
+  if (res.status === 404) return
+  if (!res.ok) {
+    throw new Error(`GitHub PR #${pr} check HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
+  }
+  const data = (await res.json()) as { state?: string; labels?: { name?: string }[] }
+  const isOpenLabeled = data.state === "open" && (data.labels ?? []).some((l) => l.name === STAGING_LABEL)
+  if (isOpenLabeled) {
+    throw new Error(
+      `PR #${pr} is open with the '${STAGING_LABEL}' label but was classified as an orphan — ` +
+        `endpoint inconsistency, aborting the whole reconcile without deleting anything`
+    )
+  }
 }
 
 function printReconcilePlan(plan: StagingReconcilePlan, openLabeledPrNumbers: number[], dryRun: boolean): void {

--- a/scripts/staging-pr.ts
+++ b/scripts/staging-pr.ts
@@ -21,6 +21,12 @@ import { parseArgs } from "util"
 import { $ } from "bun"
 import path from "path"
 import { readdir } from "fs/promises"
+import {
+  classifyStagingOrphans,
+  stagingResourceNames,
+  type StagingReconcilePlan,
+  type StagingResourceNames,
+} from "./staging-pr-lib"
 
 const { values } = parseArgs({
   args: process.argv.slice(2),
@@ -28,26 +34,36 @@ const { values } = parseArgs({
     action: { type: "string" },
     pr: { type: "string" },
     branch: { type: "string" },
+    "dry-run": { type: "boolean" },
   },
 })
 
 const action = values.action
 const prNumber = values.pr
 const branch = values.branch
+const dryRun = values["dry-run"] ?? false
 
-if (!action || !prNumber) {
-  console.error("Usage: --action=deploy|teardown --pr=<number> [--branch=<name>]")
+if (!action) {
+  console.error("Usage: --action=deploy|teardown|reset-db|reconcile --pr=<number> [--branch=<name>] [--dry-run]")
   process.exit(1)
 }
 
-if (!/^\d+$/.test(prNumber)) {
-  console.error("--pr must be a positive integer")
-  process.exit(1)
-}
+// reconcile discovers PR numbers itself, so it takes no --pr/--branch.
+if (action !== "reconcile") {
+  if (!prNumber) {
+    console.error("Usage: --action=deploy|teardown|reset-db --pr=<number> [--branch=<name>]")
+    process.exit(1)
+  }
 
-if ((action === "deploy" || action === "reset-db") && !branch) {
-  console.error("--branch is required for deploy and reset-db actions")
-  process.exit(1)
+  if (!/^\d+$/.test(prNumber)) {
+    console.error("--pr must be a positive integer")
+    process.exit(1)
+  }
+
+  if ((action === "deploy" || action === "reset-db") && !branch) {
+    console.error("--branch is required for deploy and reset-db actions")
+    process.exit(1)
+  }
 }
 
 function requireEnv(name: string): string {
@@ -71,12 +87,10 @@ const CLOUDFLARE_ZONE_ID = requireEnv("CLOUDFLARE_ZONE_ID")
 const STAGING_WORKER_NAME = process.env.STAGING_WORKER_NAME ?? "workspace-router-staging"
 const STAGING_CORS_ORIGINS = process.env.STAGING_CORS_ORIGINS ?? ""
 
-const prDbName = `pr_${prNumber}`
-const prCpDbName = `pr_${prNumber}_cp`
-const regionName = `pr-${prNumber}`
-const serviceName = `pr-${prNumber}-backend`
-/** Flat subdomain: pr-228-staging.threa.io (covered by *.threa.io cert) */
-const prHostname = `pr-${prNumber}-staging.threa.io`
+// Per-PR resource names (pr_N, pr-N, pr-N-backend, pr-N-staging.threa.io) come
+// from stagingResourceNames() in staging-pr-lib.ts so teardown can run for many
+// numbers in one process (reconcile). Flat subdomain pr-N-staging.threa.io is
+// covered by the *.threa.io cert.
 
 // STAGING_DATABASE_URL is the public proxy URL (required so GH Actions runners
 // can reach Postgres for psql/pg_dump). Railway services in the same project
@@ -246,7 +260,7 @@ async function dropDatabase(dbName: string): Promise<void> {
   console.log(`Dropped '${dbName}'`)
 }
 
-async function updateWorkspaceSlug(dbName: string, branchName: string): Promise<void> {
+async function updateWorkspaceSlug(dbName: string, branchName: string, pr: number): Promise<void> {
   const slug = branchName
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, "-")
@@ -254,7 +268,7 @@ async function updateWorkspaceSlug(dbName: string, branchName: string): Promise<
     .replace(/^-|-$/g, "")
     .slice(0, 48)
 
-  const name = `PR #${prNumber}`
+  const name = `PR #${pr}`
 
   console.log(`Updating workspace slug to '${slug}' and name to '${name}'...`)
   await runPsql(
@@ -355,12 +369,8 @@ async function listServices(): Promise<{ id: string; name: string }[]> {
   return data.project.services.edges.map((e) => e.node)
 }
 
-async function railwayServiceExists(): Promise<boolean> {
-  const services = await listServices()
-  return services.some((s) => s.name === serviceName)
-}
-
-async function createRailwayService(): Promise<string> {
+async function createRailwayService(names: StagingResourceNames): Promise<string> {
+  const { serviceName, regionName, prDbName } = names
   console.log(`Creating Railway service '${serviceName}'...`)
 
   let serviceId: string
@@ -445,7 +455,7 @@ async function createRailwayService(): Promise<string> {
   return serviceId
 }
 
-async function deployRailwayService(): Promise<string> {
+async function deployRailwayService(serviceName: string, branch: string): Promise<string> {
   console.log(`Deploying to Railway service '${serviceName}'...`)
 
   const services = await listServices()
@@ -484,7 +494,7 @@ async function deployRailwayService(): Promise<string> {
   return `https://${newDomain.serviceDomainCreate.domain}`
 }
 
-async function deleteRailwayService(): Promise<void> {
+async function deleteRailwayService(serviceName: string): Promise<void> {
   const services = await listServices()
   const service = services.find((s) => s.name === serviceName)
   if (!service) {
@@ -526,7 +536,7 @@ async function kvPut(key: string, value: string): Promise<void> {
  * on the next push. A proper fix would use KV metadata + compare-and-swap or a
  * mutex (e.g. Cloudflare Durable Object lock).
  */
-async function registerRegion(backendUrl: string): Promise<void> {
+async function registerRegion(regionName: string, backendUrl: string): Promise<void> {
   const existing = await kvGet("__regions_config__")
   const regions: Record<string, { apiUrl: string; wsUrl: string }> = existing ? JSON.parse(existing) : {}
 
@@ -579,7 +589,7 @@ async function registerStagingRegion(): Promise<void> {
   console.log(`Registered 'staging' region → ${backendUrl}`)
 }
 
-async function unregisterRegion(): Promise<void> {
+async function unregisterRegion(regionName: string): Promise<void> {
   const existing = await kvGet("__regions_config__")
   if (!existing) return
 
@@ -623,16 +633,16 @@ async function findWorkerRoute(pattern: string): Promise<string | null> {
   return data.result?.find((r) => r.pattern === pattern)?.id ?? null
 }
 
-async function createPrDnsAndRoute(): Promise<void> {
+async function createPrDnsAndRoute(pr: number, prHostname: string): Promise<void> {
   // Create proxied AAAA record for pr-N-staging.threa.io
   const existingDns = await findDnsRecord(prHostname)
   if (!existingDns) {
     const dns = await cfApi("/dns_records", "POST", {
       type: "AAAA",
-      name: `pr-${prNumber}-staging`,
+      name: `pr-${pr}-staging`,
       content: "100::",
       proxied: true,
-      comment: `Staging PR #${prNumber}`,
+      comment: `Staging PR #${pr}`,
     })
     if (!dns.success) {
       throw new Error(`Failed to create DNS record: ${dns.errors?.[0]?.message}`)
@@ -658,7 +668,7 @@ async function createPrDnsAndRoute(): Promise<void> {
   }
 }
 
-async function deletePrDnsAndRoute(): Promise<void> {
+async function deletePrDnsAndRoute(prHostname: string): Promise<void> {
   const routePattern = `${prHostname}/*`
   const routeId = await findWorkerRoute(routePattern)
   if (routeId) {
@@ -678,7 +688,7 @@ async function deletePrDnsAndRoute(): Promise<void> {
  * Used after a DB reset so the backend picks up fresh connections and re-runs
  * migrations against the newly cloned database.
  */
-async function redeployRailwayService(): Promise<void> {
+async function redeployRailwayService(serviceName: string, branch: string): Promise<void> {
   const services = await listServices()
   const service = services.find((s) => s.name === serviceName)
   if (!service) {
@@ -701,8 +711,9 @@ async function redeployRailwayService(): Promise<void> {
   console.log(`Restart triggered — service will reconnect to the fresh database and run pending migrations`)
 }
 
-async function deploy(): Promise<void> {
-  console.log(`\n=== Deploying staging environment for PR #${prNumber} (branch: ${branch}) ===\n`)
+async function deploy(names: StagingResourceNames, branch: string): Promise<void> {
+  const { pr, prDbName, prCpDbName, regionName, serviceName, prHostname } = names
+  console.log(`\n=== Deploying staging environment for PR #${pr} (branch: ${branch}) ===\n`)
 
   // 1. Create and clone databases on first deploy only.
   //    We check pure existence — NOT data integrity. Dropping a live DB to
@@ -718,7 +729,7 @@ async function deploy(): Promise<void> {
       console.log(`Creating and cloning backend database '${prDbName}'...`)
       await runPsqlOnDefault(`CREATE DATABASE "${prDbName}"`)
       await cloneDatabase("staging_main", prDbName)
-      await updateWorkspaceSlug(prDbName, branch!)
+      await updateWorkspaceSlug(prDbName, branch, pr)
     } else {
       console.log(`Backend database '${prDbName}' already exists — skipping clone`)
     }
@@ -741,8 +752,8 @@ async function deploy(): Promise<void> {
   await seedPreExistingMigrations(prDbName, "staging_main", "apps/backend/src/db/migrations")
   await seedPreExistingMigrations(prCpDbName, "staging_main_cp", "apps/control-plane/src/db/migrations")
 
-  await createRailwayService()
-  const backendUrl = await deployRailwayService()
+  await createRailwayService(names)
+  const backendUrl = await deployRailwayService(serviceName, branch)
 
   // 3. Register in Cloudflare KV
   //    - This PR's ephemeral region (pr-N → PR backend URL)
@@ -753,10 +764,10 @@ async function deploy(): Promise<void> {
   //    staging) for all staging traffic, so the per-workspace KV mapping is
   //    unnecessary in staging — and actively harmful, since cloned PR DBs
   //    share workspace IDs with staging_main and would clobber each other.
-  await registerRegion(backendUrl)
+  await registerRegion(regionName, backendUrl)
   await registerStagingRegion()
 
-  await createPrDnsAndRoute()
+  await createPrDnsAndRoute(pr, prHostname)
 
   console.log(`\n=== Staging environment deployed ===`)
   console.log(`Frontend: https://${prHostname}`)
@@ -765,13 +776,14 @@ async function deploy(): Promise<void> {
   console.log(`Database: ${prDbName}`)
 }
 
-async function resetDb(): Promise<void> {
-  console.log(`\n=== Resetting databases for PR #${prNumber} (branch: ${branch}) ===\n`)
+async function resetDb(names: StagingResourceNames, branch: string): Promise<void> {
+  const { pr, prDbName, prCpDbName, serviceName } = names
+  console.log(`\n=== Resetting databases for PR #${pr} (branch: ${branch}) ===\n`)
 
   await dropDatabase(prDbName)
   await runPsqlOnDefault(`CREATE DATABASE "${prDbName}"`)
   await cloneDatabase("staging_main", prDbName)
-  await updateWorkspaceSlug(prDbName, branch!)
+  await updateWorkspaceSlug(prDbName, branch, pr)
 
   await dropDatabase(prCpDbName)
   await runPsqlOnDefault(`CREATE DATABASE "${prCpDbName}"`)
@@ -783,38 +795,175 @@ async function resetDb(): Promise<void> {
 
   // Restart the Railway service so it starts with fresh DB connections and runs
   // any new PR-branch migrations against the restored schema
-  await redeployRailwayService()
+  await redeployRailwayService(serviceName, branch)
 
   console.log(`\n=== Database reset complete ===`)
   console.log(`Backend DB:       ${prDbName} (cloned from staging_main)`)
   console.log(`Control-plane DB: ${prCpDbName} (cloned from staging_main_cp)`)
 }
 
-async function teardown(): Promise<void> {
-  console.log(`\n=== Tearing down staging environment for PR #${prNumber} ===\n`)
+/**
+ * Delete every resource owned by one PR number. Each step is idempotent and
+ * tolerates absence, so it is safe to run for an orphan whose resources were
+ * only partially provisioned (or already hand-deleted). Shared by the CLI
+ * teardown action and the reconcile sweeper.
+ */
+async function teardownResources(names: StagingResourceNames): Promise<void> {
+  const { regionName, prHostname, serviceName, prDbName, prCpDbName } = names
 
-  await unregisterRegion()
+  await unregisterRegion(regionName)
 
-  await deletePrDnsAndRoute()
+  await deletePrDnsAndRoute(prHostname)
 
-  await deleteRailwayService()
+  await deleteRailwayService(serviceName)
 
   await dropDatabase(prDbName)
   await dropDatabase(prCpDbName)
+}
 
+async function teardown(names: StagingResourceNames): Promise<void> {
+  console.log(`\n=== Tearing down staging environment for PR #${names.pr} ===\n`)
+  await teardownResources(names)
   console.log(`\n=== Staging environment torn down ===`)
+}
+
+/**
+ * Sweep orphaned PR staging resources. Event-driven teardown can never be
+ * reliable on its own: a closed-unmerged PR (common in stack shuffles) often
+ * produces NO GitHub workflow run at all, so its resources leak. This discovers
+ * every PR number that owns a matching resource, cross-references the open+
+ * `staging`-labeled PRs, and tears down the rest.
+ *
+ * Fail-hard-before-mutation: the open-PR fetch runs (and throws on any GitHub
+ * error) BEFORE the first teardown, so a GitHub outage aborts the whole run
+ * rather than misclassifying live PRs as orphans and deleting them.
+ */
+async function reconcile(dryRun: boolean): Promise<void> {
+  const GITHUB_TOKEN = requireEnv("GITHUB_TOKEN")
+  console.log(`\n=== Reconciling staging environments${dryRun ? " (dry-run)" : ""} ===\n`)
+
+  // Discover candidate resources (all read-only).
+  const serviceNames = (await listServices()).map((s) => s.name)
+  const dbNames = (await runPsqlOnDefault("SELECT datname FROM pg_database ORDER BY datname"))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const kvRaw = await kvGet("__regions_config__")
+  const kvRegionKeys = kvRaw ? Object.keys(JSON.parse(kvRaw) as Record<string, unknown>) : []
+
+  // Fetch open+labeled PRs. THROWS on any GitHub error — must run before any
+  // teardown so a transient API failure never reads as "everything is orphaned".
+  const openLabeledPrNumbers = await fetchOpenStagingPrs(GITHUB_TOKEN)
+
+  const plan = classifyStagingOrphans({ serviceNames, dbNames, kvRegionKeys, openLabeledPrNumbers })
+  printReconcilePlan(plan, openLabeledPrNumbers, dryRun)
+
+  if (dryRun) {
+    console.log(`\nDry-run — no resources modified.`)
+    return
+  }
+
+  const failures: { pr: number; error: string }[] = []
+  for (const orphan of plan.orphans) {
+    console.log(`\n--- Tearing down orphan PR #${orphan.pr} ---`)
+    try {
+      await teardownResources(stagingResourceNames(orphan.pr))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      failures.push({ pr: orphan.pr, error: message })
+      console.error(`Teardown failed for PR #${orphan.pr}: ${message}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n=== Reconcile finished with ${failures.length} failure(s) ===`)
+    for (const f of failures) console.error(`  PR #${f.pr}: ${f.error}`)
+    process.exit(1)
+  }
+
+  console.log(`\n=== Reconcile complete — ${plan.orphans.length} orphan(s) torn down ===`)
+}
+
+const GITHUB_REPO = "threahq/threa"
+
+/**
+ * Open PR numbers carrying the `staging` label. The issues endpoint returns PRs
+ * too (and filters by label server-side); we keep only entries with a
+ * `pull_request` field so plain issues never count. Throws on any non-2xx so
+ * the caller aborts before mutating.
+ */
+async function fetchOpenStagingPrs(token: string): Promise<number[]> {
+  const numbers: number[] = []
+  for (let page = 1; ; page++) {
+    const url = `https://api.github.com/repos/${GITHUB_REPO}/issues?labels=staging&state=open&per_page=100&page=${page}`
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "threa-staging-reconcile",
+      },
+    })
+    if (!res.ok) {
+      throw new Error(`GitHub API HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
+    }
+    const items = (await res.json()) as { number: number; pull_request?: unknown }[]
+    for (const item of items) {
+      if (item.pull_request) numbers.push(item.number)
+    }
+    if (items.length < 100) break
+  }
+  return numbers
+}
+
+function printReconcilePlan(plan: StagingReconcilePlan, openLabeledPrNumbers: number[], dryRun: boolean): void {
+  const resourceList = (c: { hasService: boolean; hasDb: boolean; hasCpDb: boolean; hasKvRegion: boolean }): string => {
+    const parts: string[] = []
+    if (c.hasService) parts.push("service")
+    if (c.hasDb) parts.push("db")
+    if (c.hasCpDb) parts.push("cp-db")
+    if (c.hasKvRegion) parts.push("kv-region")
+    return parts.join(", ") || "(none)"
+  }
+
+  const sortedOpen = [...openLabeledPrNumbers].sort((a, b) => a - b)
+  console.log(`Open+labeled staging PRs (${sortedOpen.length}): ${sortedOpen.join(", ") || "(none)"}`)
+  console.log(`\nClassification:`)
+  for (const c of plan.keep) {
+    console.log(`  KEEP  PR #${c.pr} — open+labeled — resources: ${resourceList(c)}`)
+  }
+  for (const c of plan.orphans) {
+    console.log(`  ORPHAN PR #${c.pr} — not open+labeled — resources: ${resourceList(c)}`)
+  }
+
+  if (plan.orphans.length === 0) {
+    console.log(`\nNo orphans found.`)
+    return
+  }
+
+  console.log(`\n${dryRun ? "Would tear down" : "Tearing down"} ${plan.orphans.length} orphan(s):`)
+  for (const c of plan.orphans) {
+    const names = stagingResourceNames(c.pr)
+    console.log(
+      `  PR #${c.pr}: unregister KV '${names.regionName}', delete DNS+route '${names.prHostname}', ` +
+        `delete service '${names.serviceName}', drop DB '${names.prDbName}' + '${names.prCpDbName}'`
+    )
+  }
 }
 
 async function main() {
   switch (action) {
     case "deploy":
-      await deploy()
+      await deploy(stagingResourceNames(Number(prNumber)), branch!)
       break
     case "teardown":
-      await teardown()
+      await teardown(stagingResourceNames(Number(prNumber)))
       break
     case "reset-db":
-      await resetDb()
+      await resetDb(stagingResourceNames(Number(prNumber)), branch!)
+      break
+    case "reconcile":
+      await reconcile(dryRun)
       break
     default:
       console.error(`Unknown action: ${action}`)


### PR DESCRIPTION
Stack 3/3 on #1426 (plan: `docs/plans/make-staging-cheaper.md`, embedded in #1425).

## Problem

PR staging environments outlive their PRs. Teardown fires only from the GitHub Actions `closed`/`unlabeled` events in `staging.yml` — and a PR closed **without merging** (the routine stack-shuffle case) often produces **no workflow run at all**: with no merge ref, GitHub creates no `pull_request` run (the repo's documented "unmergeable PR = no CI" gotcha). Verified zombies: **#1252** closed Jul 11, its backend ran until Jul 19 (service hand-deleted in the UI; DBs/DNS/KV still leaked); **#1050** closed Jun 23 — 16 minutes after its deploy started — and ran **15 more days**. Staging Postgres holds **10 orphaned DB pairs** today, back to `pr_276`. The teardown path also has a flaky `apt-get` step in front of it and nothing retries a failed run. Event-driven teardown alone can never be reliable; it needs a reconciler.

## Solution

A nightly sweeper that computes *what exists* minus *what should exist* and tears down the difference — with the safety boundary structural rather than skip-listed.

### How it works

1. **`scripts/staging-pr-lib.ts`** (new, pure): `stagingResourceNames(pr)` is the single source of truth for the five per-PR names (`pr_N`, `pr_N_cp`, `pr-N`, `pr-N-backend`, `pr-N-staging.threa.io`); `classifyStagingOrphans()` maps resource-name lists + the open-PR set to a keep/orphan plan. The only name→number path is three **end-anchored** regexes (`^pr-(\d+)-backend$`, `^pr_(\d+)(_cp)?$`, `^pr-(\d+)$`) — `backend`, `control-plane`, `Postgres`, `staging_main*`, `railway`, `postgres`, and the UUID-suffixed deleted-service form are structurally unmatchable, and tests assert it.
2. **`staging-pr.ts --action=reconcile [--dry-run]`**: discovers candidates from three sources (Railway services via `listServices`, `pg_database` names, KV `__regions_config__` keys), fetches open PRs labeled `staging` (paginated `GET /issues?labels=staging&state=open`, `GITHUB_TOKEN`), classifies, and runs the per-number teardown steps for each orphan. Three ordered guards protect the unattended path:
   - **Transport**: any GitHub non-2xx/network failure throws before the first mutation.
   - **`assertStagingLabelExists`**: a renamed/deleted `staging` label makes `labels=staging` answer `200 []` — indistinguishable from "no open staging PRs" and the one input that would nightly-sweep every live environment. The label's existence is asserted up front; missing → loud abort.
   - **`assertOrphanNotOpenLabeled`**: before ANY deletion, every would-be orphan is re-verified against the per-PR endpoint (`GET /pulls/<n>`) — an independent signal from the label-filtered listing. An open+labeled hit aborts the entire run as an endpoint inconsistency; 404 means the number was never a PR (confirmed orphan, covers hand-made `pr_N` DBs). This also closes the just-labeled-PR race: a deploy triggered seconds before reconcile shows open+labeled on the direct check even if the listing's label index lagged.
   Individual orphan failures are recorded and the process exits non-zero so the nightly run goes red; `--dry-run` returns after printing the plan, before verification and teardown, with only GET/SELECT calls made.
3. **Refactor**: the five module-level name consts became `stagingResourceNames(pr)` so teardown is callable per-number; `GITHUB_TOKEN` is required only inside `reconcile()`. Dead `railwayServiceExists` deleted (INV-38). The classification additionally rejects non-canonical digit strings (`pr_0123` would re-derive to `pr_123` and drop the wrong DB — now ignored). One **deliberate** behavior change to teardown step order: KV is now removed **last** (was first) — KV is a reconcile discovery source while DNS/route are not, so removing it first would let a mid-teardown crash strand a DNS-only leftover with no signal to rediscover it by; a KV entry outliving its route is harmless since nothing routes to the hostname. Everything else in `deploy`/`teardown`/`reset-db` is byte-compatible (verifier diffed the mutation call sequences against the base).
4. **`.github/workflows/staging-reconcile.yml`**: cron `17 3 * * *` (always a real run — `inputs` is empty on schedule events) + `workflow_dispatch` with `dry_run` **defaulting to true** so a reflexive manual "Run workflow" click is safe; a real manual teardown requires deliberately unchecking the box. A `concurrency: staging-reconcile` group (no cancel-in-progress) serializes overlapping runs, whose `databaseExists`→`DROP` TOCTOU would otherwise produce spurious red runs. Teardown-job secrets + `GITHUB_TOKEN`; least-privilege `permissions`; the hardened PG-18 apt block byte-identical to `staging.yml`'s. Nightly cadence means a flaky apt run self-heals the next night.
5. **Test wiring**: `bunfig.toml` pins the bun test root to `apps/backend/src`, so nothing scanned `scripts/` — new root script `test:scripts` (`bun test ./scripts/`, the path form overrides the root) runs the 8 lib tests, added as a CI step in the `test` job.

### Key design decisions

**1. Reconcile-by-difference, not better events.** Fixing the `closed`-event gap is impossible from inside Actions (no run is created to fix). A sweeper subsumes every failure class at once: missed events, failed runs, apt flakes, hand-deleted services (a DB-only orphan like today's #1252 state is discovered via its DBs/KV even though the service is gone).

**2. Structural safety over skip-lists.** Shared infra is protected by being unmatchable by the anchored patterns, not by a deny-list someone must maintain. An open+labeled PR is kept in full even when only some of its resources exist yet (deploy in progress).

**3. Fail-hard-before-mutation on the GitHub fetch.** The catastrophic misclassification (API outage → empty open set → everything is an orphan) is cut off by ordering: the fetch throws on any non-2xx and runs before the teardown loop.

**4. DNS/worker-routes are swept per-number, not enumerated for discovery.** Any PR that reached DNS creation necessarily wrote its KV region entry first (deploy order), so KV discovery covers it; enumeration would add a CF list API for no reachable case.

## New files

| File | Purpose |
| ---- | ------- |
| `scripts/staging-pr-lib.ts` | Pure name derivation + orphan classification (the safety boundary) |
| `scripts/staging-pr-lib.test.ts` | 8 tests: keeps open+labeled (incl. partial deploys), DB-only/KV-only orphans, shared-infra + suffix-form unmatchability |
| `.github/workflows/staging-reconcile.yml` | Nightly sweep + manual dispatch with dry-run |

## Modified files

| File | Change |
| ---- | ------ |
| `scripts/staging-pr.ts` | Per-number names via `stagingResourceNames`; `reconcile` action; shared `teardownResources`; dead `railwayServiceExists` removed |
| `package.json` | `test:scripts` script |
| `.github/workflows/ci.yml` | Run `test:scripts` in the `test` job |

## Out of scope (deliberate)

- Running reconcile against live staging — post-merge ops: one supervised `--dry-run` (plan output for the ~10 known orphan DB pairs), then the real run / nightly cron takes over.
- Fixing `staging.yml`'s own event handling (subsumed by the sweeper) or its apt flake.
- A Threa-notification step for sweep results (the workflow run log is the record).

## Test plan

- [x] `bun run test:scripts` — 9 pass / 0 fail (incl. the new non-canonical-digits case; CI's new step discovers the file despite the bunfig root pin)
- [x] `bunx tsc --noEmit --strict --target esnext --module esnext --moduleResolution bundler --esModuleInterop --types bun scripts/staging-pr.ts scripts/staging-pr-lib.ts` — clean (scripts are in no tsconfig; this is their only typecheck)
- [x] `bun run --cwd apps/backend test:unit` — untouched-green modulo the documented 14 stray-`.env` `env.test.ts` baseline (no backend code in this diff)
- [x] Implement (Opus) → adversarial verify (Opus xhigh): SHIP — walked the transport-failure abort ordering, traced every mutating call under `--dry-run`, diffed deploy/teardown compatibility, checked the `dry_run` input wiring for cron + both dispatch states
- [x] Independent fresh-eyes Opus adversarial review (no prior context): FIX-FIRST on one MAJOR — a wrong-but-HTTP-200 open-PR set (label renamed, `200 []`) had no defense. Fixed with the label assertion + per-orphan re-verification above; its MINORs (leading-zeros round-trip, missing workflow concurrency group, destructive dispatch default, KV-first strand-leak) are all folded in
- [ ] Live dry-run against staging — deliberately deferred to post-merge ops (no secrets locally; first supervised run doubles as the acceptance test)
- [ ] Note: CI's `test:scripts` step won't fire on this stacked PR (`ci.yml` triggers on PRs targeting `main` only) — it runs once the stack retargets `main`; the counts above are local runs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
