### PR TITLE
fix(stream-settings): open the dialog for archived streams post-reload (archived index 3/3)

### DIFF
--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -9,6 +9,7 @@ import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as generalTabModule from "./general-tab"
 import * as companionTabModule from "./companion-tab"
 import * as membersTabModule from "./members-tab"
+import * as useCurrentWorkspaceUserIdModule from "@/hooks/use-current-workspace-user-id"
 
 const useStreamSettingsMock = vi.fn()
 const useWorkspaceStreamsMock = vi.fn()
@@ -107,6 +108,7 @@ describe("StreamSettingsDialog", () => {
     vi.spyOn(membersTabModule, "MembersTab").mockImplementation((() => (
       <div>Members panel</div>
     )) as unknown as typeof membersTabModule.MembersTab)
+    vi.spyOn(useCurrentWorkspaceUserIdModule, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
   })
 
   it("shows only the available sidebar items for the resolved stream type", async () => {
@@ -132,6 +134,39 @@ describe("StreamSettingsDialog", () => {
     expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
     expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
     expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
+  })
+
+  it("opens for an archived stream with no membership row (the only unarchive affordance)", async () => {
+    // Memberships aren't bootstrapped for archived streams, so after a reload
+    // the archived row exists in the stream cache but no membership does. The
+    // dialog must still open — gating the viewer id on the membership row left
+    // it stuck on the loading state, with no other way to unarchive.
+    useStreamSettingsMock.mockReturnValue({
+      isOpen: true,
+      activeTab: "general",
+      streamId: "stream_archived",
+      closeStreamSettings,
+      setTab,
+    })
+    useWorkspaceStreamsMock.mockReturnValue([
+      makeStream({
+        id: "stream_archived",
+        type: StreamTypes.CHANNEL,
+        displayName: "Old Channel",
+        slug: "old-channel",
+        archivedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ])
+    useWorkspaceStreamMembershipsMock.mockReturnValue([])
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <StreamSettingsDialog workspaceId="ws_1" />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText("General panel")).toBeVisible()
+    expect(screen.queryByText(/Loading stream settings/i)).not.toBeInTheDocument()
   })
 
   it("titles a DM with the resolved peer name when the stream row has no displayName", async () => {

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/stores/workspace-store"
 import { StreamTypes, type Stream, type StreamBootstrap, type NotificationLevel } from "@threa/types"
 import { resolveDmDisplayName, streamLabel } from "@/lib/streams"
+import { useCurrentWorkspaceUserId } from "@/hooks/use-current-workspace-user-id"
 
 const TAB_CONFIG: Record<StreamSettingsTab, { label: string; description: string }> = {
   general: { label: "General", description: "Notifications and stream details" },
@@ -58,7 +59,11 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
     return idbStreamMemberships.find((m) => m.streamId === streamId) ?? null
   }, [idbStreamMemberships, streamId])
 
-  const currentUserId = currentMembership?.memberId ?? null
+  // The viewer's identity must not come from the membership row: memberships
+  // aren't bootstrapped for archived streams, so gating the dialog on one left
+  // an archived stream (its only unarchive affordance) stuck on the loading
+  // state after a reload. Membership is only the notification-level source.
+  const currentUserId = useCurrentWorkspaceUserId(workspaceId)
   const currentNotificationLevel: NotificationLevel | null = currentMembership?.notificationLevel ?? null
 
   const workspaceUsers = useWorkspaceUsers(workspaceId)


### PR DESCRIPTION
Stack 3/3 of the archived-stream index (on #1421). Fixes the gap found during the live browser verification.

## Problem

After a reload, opening Stream Settings for an **archived** stream hung forever on "Loading stream settings…". The dialog derived the viewer's id from the IDB `stream_memberships` row (`currentUserId = currentMembership?.memberId`), but memberships aren't bootstrapped for archived streams — the archived-stream index deliberately ships only the slim stream rows, because shipping memberships would make the sync engine join rooms for archived streams. Since the settings dialog is the only unarchive affordance, archive → reload → unarchive had no working UI path (verified live; the unarchive endpoint works, the UI didn't).

## Solution

Resolve the viewer with the canonical `useCurrentWorkspaceUserId(workspaceId)` (auth user → workspace user id) instead of the membership-row proxy. The membership row remains only the notification-level source — `null` for archived streams, which `GeneralTab` already tolerates.

## Test

`stream-settings-dialog.test.tsx`: new case renders the dialog for an archived channel present only in the stream cache with **no** membership row and asserts the panel renders (no loading state). Existing dialog tests updated to mock the new hook.

- [x] `bunx vitest run src/components/stream-settings/stream-settings-dialog.test.tsx` — 3 pass (folder-wide run shows unrelated load flakes that pass in isolation)
- [x] `bunx tsc --noEmit` — clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
