### PR TITLE
test(config): github production tests set S3_REGION — restores red main CI

### DIFF
--- a/apps/backend/src/lib/env.test.ts
+++ b/apps/backend/src/lib/env.test.ts
@@ -166,6 +166,7 @@ describe("loadConfig github app configuration", () => {
   test("requires a control-plane destination for regional GitHub in production", () => {
     setBaseEnv()
     process.env.NODE_ENV = "production"
+    process.env.S3_REGION = "eu-north-1"
     process.env.USE_STUB_AUTH = "false"
     process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com"
     process.env.WORKOS_API_KEY = "key"
@@ -186,6 +187,7 @@ describe("loadConfig github app configuration", () => {
   test("throws when GitHub is enabled in production with neither control plane nor region", () => {
     setBaseEnv()
     process.env.NODE_ENV = "production"
+    process.env.S3_REGION = "eu-north-1"
     process.env.USE_STUB_AUTH = "false"
     process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com"
     process.env.WORKOS_API_KEY = "key"
@@ -205,6 +207,7 @@ describe("loadConfig github app configuration", () => {
   test("keeps the precise REGION-missing message when only CONTROL_PLANE_URL is set", () => {
     setBaseEnv()
     process.env.NODE_ENV = "production"
+    process.env.S3_REGION = "eu-north-1"
     process.env.USE_STUB_AUTH = "false"
     process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com"
     process.env.WORKOS_API_KEY = "key"
@@ -223,6 +226,7 @@ describe("loadConfig github app configuration", () => {
   test("boots when GitHub is enabled in production with both control plane and region", () => {
     setBaseEnv()
     process.env.NODE_ENV = "production"
+    process.env.S3_REGION = "eu-north-1"
     process.env.USE_STUB_AUTH = "false"
     process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com"
     process.env.WORKOS_API_KEY = "key"


### PR DESCRIPTION
## Problem

Main's Tests job has been red since `b55c8d73` (#1387, the G-17 S3_REGION production guard): the four `loadConfig` github-app production-mode tests in `apps/backend/src/lib/env.test.ts` construct a production env without `S3_REGION`, so the new guard throws before their expected assertions run. #1387's own CI run failed and every PR branched from current main inherits the red (first seen on #1429).

## Solution

Each of the four production blocks sets `S3_REGION = "eu-north-1"`. The dedicated "requires S3_REGION in production" test still deletes it and pins the guard itself. No runtime code touched.

## Test plan

- [x] `bun test src/lib/env.test.ts` — 25/25 pass (run without the stray local `apps/backend/.env`, per the documented env-leakage gotcha; CI has no such file)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787087504&installation_id=129946197&pr_number=1433&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1433&signature=630b02bef6b22f905845d969ba6a094733dd947d34a46c20a98a832af4c3eb26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->