### PR TITLE
fix(search): combine quoted phrases with semantic matching

### DIFF
--- a/apps/backend/src/features/search/handlers.test.ts
+++ b/apps/backend/src/features/search/handlers.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test"
+import { searchQuerySchema } from "./handlers"
+
+describe("searchQuerySchema", () => {
+  test("accepts up to five non-empty exact phrases", () => {
+    expect(searchQuerySchema.parse({ query: "created pr", phrases: ["1429"] }).phrases).toEqual(["1429"])
+    expect(() => searchQuerySchema.parse({ phrases: [""] })).toThrow()
+    expect(() => searchQuerySchema.parse({ phrases: ["1", "2", "3", "4", "5", "6"] })).toThrow()
+  })
+})

--- a/apps/backend/src/features/search/handlers.ts
+++ b/apps/backend/src/features/search/handlers.ts
@@ -6,12 +6,13 @@ import type { SearchResult } from "./repository"
 import { resolveInFilterStreamIds, resolveUserAccessibleStreamIds } from "./access"
 import { validateRequest } from "../../lib/validation"
 import { setAuditSubjects } from "../access-log"
-import { STREAM_TYPES } from "@threa/types"
+import { MAX_SEARCH_PHRASES, STREAM_TYPES } from "@threa/types"
 
 const ARCHIVE_STATUSES = ["active", "archived"] as const
 
-const searchQuerySchema = z.object({
+export const searchQuerySchema = z.object({
   query: z.string().optional().default(""),
+  phrases: z.array(z.string().min(1)).max(MAX_SEARCH_PHRASES).optional(),
   from: z.string().optional(), // Single author ID
   with: z.array(z.string()).optional(), // User or persona IDs (AND logic)
   in: z.array(z.string()).optional(), // Stream IDs
@@ -53,7 +54,19 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
 
       const data = validateRequest(searchQuerySchema, req.body)
 
-      const { query, from, with: withParticipants, in: inStreams, type, status, before, after, exact, limit } = data
+      const {
+        query,
+        phrases,
+        from,
+        with: withParticipants,
+        in: inStreams,
+        type,
+        status,
+        before,
+        after,
+        exact,
+        limit,
+      } = data
 
       // `in` mixes stream ids and user ids (in:@user = the DM with that user).
       // An unresolvable filter (e.g. no DM exists) must yield zero results, not
@@ -85,6 +98,7 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
         workspaceId,
         permissions: { accessibleStreamIds },
         query,
+        phrases,
         filters,
         exact,
         limit,

--- a/apps/backend/src/features/search/repository.test.ts
+++ b/apps/backend/src/features/search/repository.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { Querier } from "../../db"
+import { SearchRepository } from "./repository"
+
+function makeDb() {
+  const query = mock(() => Promise.resolve({ rows: [], rowCount: 0 }))
+  return { query, _query: query } as unknown as Querier & { _query: ReturnType<typeof mock> }
+}
+
+const filters = {}
+
+function queryConfig(db: Querier & { _query: ReturnType<typeof mock> }) {
+  return db._query.mock.calls[0]![0] as { text: string; values: unknown[] }
+}
+
+describe("SearchRepository phrase predicates", () => {
+  test("requires every phrase in full-text results", async () => {
+    const db = makeDb()
+    await SearchRepository.fullTextSearch(db, {
+      query: "created pr",
+      phrases: ["1429", "urgent"],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text.match(/m\.content_markdown ILIKE/g)).toHaveLength(2)
+    expect(values).toEqual(expect.arrayContaining(["1429", "urgent"]))
+  })
+
+  test("uses literal case-insensitive phrase matching", async () => {
+    const db = makeDb()
+    await SearchRepository.fullTextSearch(db, {
+      query: "error",
+      phrases: ["A%_\\B"],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text).toContain("ILIKE")
+    expect(values).toContain("A\\%\\_\\\\B")
+  })
+
+  test("uses recency search with phrase predicates when semantic text is empty", async () => {
+    const db = makeDb()
+    await SearchRepository.fullTextSearch(db, {
+      query: "",
+      phrases: ["1429"],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text).toContain("m.content_markdown ILIKE")
+    expect(text).toContain("ORDER BY m.created_at DESC")
+    expect(text).not.toContain("websearch_to_tsquery")
+    expect(values).toContain("1429")
+  })
+
+  test("applies every phrase to keyword and semantic hybrid CTEs", async () => {
+    const db = makeDb()
+    await SearchRepository.hybridSearch(db, {
+      query: "created pr",
+      phrases: ["1429"],
+      embedding: [0.1, 0.2],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+      semanticDistanceThreshold: 0.5,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text.match(/m\.content_markdown ILIKE/g)).toHaveLength(2)
+    expect(values.filter((value) => value === "1429")).toHaveLength(2)
+    expect(text).toContain("keyword_ranked")
+    expect(text).toContain("semantic_ranked")
+  })
+
+  test("requires the exact query and every phrase", async () => {
+    const db = makeDb()
+    await SearchRepository.exactSearch(db, {
+      query: "created pr",
+      phrases: ["1429", "urgent"],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text.match(/m\.content_markdown ILIKE/g)).toHaveLength(3)
+    expect(values).toEqual(expect.arrayContaining(["created pr", "1429", "urgent"]))
+  })
+
+  test("searches phrase-only exact requests", async () => {
+    const db = makeDb()
+    await SearchRepository.exactSearch(db, {
+      query: "",
+      phrases: ["A%_\\B"],
+      streamIds: ["stream_member_channel"],
+      filters,
+      limit: 20,
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text.match(/m\.content_markdown ILIKE/g)).toHaveLength(1)
+    expect(values).toContain("A\\%\\_\\\\B")
+  })
+})
+
+describe("SearchRepository search access", () => {
+  test("uses the canonical root access predicate for non-member threads (INV-62)", async () => {
+    const db = makeDb()
+    await SearchRepository.getAccessibleStreamsWithMembers(db, {
+      workspaceId: "ws_1",
+      userId: "usr_member_of_root",
+    })
+
+    const { text, values } = queryConfig(db)
+    expect(text).toContain("COALESCE(eff_s.root_stream_id, eff_s.id)")
+    expect(text).toContain("eff_root.visibility =")
+    expect(text).toContain("stream_id = eff_root.id AND member_id =")
+    expect(values).toEqual(expect.arrayContaining(["ws_1", "usr_member_of_root", "public"]))
+  })
+})

--- a/apps/backend/src/features/search/repository.ts
+++ b/apps/backend/src/features/search/repository.ts
@@ -79,6 +79,7 @@ export interface ResolvedFilters {
 
 export interface FullTextSearchParams {
   query: string
+  phrases?: string[]
   streamIds: string[]
   filters: ResolvedFilters
   limit: number
@@ -86,6 +87,7 @@ export interface FullTextSearchParams {
 
 export interface HybridSearchParams {
   query: string
+  phrases?: string[]
   embedding: number[]
   streamIds: string[]
   filters: ResolvedFilters
@@ -95,6 +97,18 @@ export interface HybridSearchParams {
   k?: number
   /** Max L2 distance for semantic results; only messages with distance < this are included. */
   semanticDistanceThreshold: number
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&")
+}
+
+function phrasePredicatesSql(phrases: string[]) {
+  let predicates = composeSql``
+  for (const phrase of phrases) {
+    predicates = composeSql`${predicates} AND m.content_markdown ILIKE '%' || ${escapeLike(phrase)} || '%'`
+  }
+  return predicates
 }
 
 export const SearchRepository = {
@@ -177,14 +191,14 @@ export const SearchRepository = {
    * If query is empty, returns recent messages matching filters.
    */
   async fullTextSearch(db: Querier, params: FullTextSearchParams): Promise<SearchResult[]> {
-    const { query, streamIds, filters, limit } = params
+    const { query, phrases = [], streamIds, filters, limit } = params
 
     if (streamIds.length === 0) {
       return []
     }
 
     if (!query.trim()) {
-      const result = await db.query<SearchResultRow>(sql`
+      const result = await db.query<SearchResultRow>(composeSql`
         SELECT
           m.id,
           m.stream_id,
@@ -201,6 +215,7 @@ export const SearchRepository = {
         JOIN streams s ON m.stream_id = s.id
         WHERE m.stream_id = ANY(${streamIds})
           AND m.deleted_at IS NULL
+          ${phrasePredicatesSql(phrases)}
           AND (${filters.authorId === undefined} OR m.author_id = ${filters.authorId ?? ""})
           AND (${filters.streamTypes === undefined || filters.streamTypes.length === 0} OR s.type = ANY(${filters.streamTypes ?? []}))
           AND (${filters.before === undefined} OR m.created_at < ${filters.before ?? new Date()})
@@ -211,7 +226,7 @@ export const SearchRepository = {
       return result.rows.map(mapRowToSearchResult)
     }
 
-    const result = await db.query<SearchResultRow>(sql`
+    const result = await db.query<SearchResultRow>(composeSql`
       SELECT
         m.id,
         m.stream_id,
@@ -229,6 +244,7 @@ export const SearchRepository = {
       WHERE m.stream_id = ANY(${streamIds})
         AND m.deleted_at IS NULL
         AND m.search_vector @@ websearch_to_tsquery('english', ${query})
+        ${phrasePredicatesSql(phrases)}
         AND (${filters.authorId === undefined} OR m.author_id = ${filters.authorId ?? ""})
         AND (${filters.streamTypes === undefined || filters.streamTypes.length === 0} OR s.type = ANY(${filters.streamTypes ?? []}))
         AND (${filters.before === undefined} OR m.created_at < ${filters.before ?? new Date()})
@@ -250,6 +266,7 @@ export const SearchRepository = {
   async hybridSearch(db: Querier, params: HybridSearchParams): Promise<SearchResult[]> {
     const {
       query,
+      phrases = [],
       embedding,
       streamIds,
       filters,
@@ -269,7 +286,7 @@ export const SearchRepository = {
     // Internal limit for each search type before RRF combination
     const internalLimit = 50
 
-    const result = await db.query<SearchResultRow>(sql`
+    const result = await db.query<SearchResultRow>(composeSql`
       WITH keyword_ranked AS (
         SELECT
           m.id,
@@ -288,6 +305,7 @@ export const SearchRepository = {
         WHERE m.stream_id = ANY(${streamIds})
           AND m.deleted_at IS NULL
           AND m.search_vector @@ websearch_to_tsquery('english', ${query})
+          ${phrasePredicatesSql(phrases)}
           AND (${filters.authorId === undefined} OR m.author_id = ${filters.authorId ?? ""})
           AND (${filters.streamTypes === undefined || filters.streamTypes.length === 0} OR s.type = ANY(${filters.streamTypes ?? []}))
           AND (${filters.before === undefined} OR m.created_at < ${filters.before ?? new Date()})
@@ -313,6 +331,7 @@ export const SearchRepository = {
           AND m.deleted_at IS NULL
           AND m.embedding IS NOT NULL
           AND m.embedding <=> ${embeddingLiteral}::vector < ${semanticDistanceThreshold}
+          ${phrasePredicatesSql(phrases)}
           AND (${filters.authorId === undefined} OR m.author_id = ${filters.authorId ?? ""})
           AND (${filters.streamTypes === undefined || filters.streamTypes.length === 0} OR s.type = ANY(${filters.streamTypes ?? []}))
           AND (${filters.before === undefined} OR m.created_at < ${filters.before ?? new Date()})
@@ -352,16 +371,18 @@ export const SearchRepository = {
    * Use this for error messages, IDs, or other literal text matching.
    */
   async exactSearch(db: Querier, params: FullTextSearchParams): Promise<SearchResult[]> {
-    const { query, streamIds, filters, limit } = params
+    const { query, phrases = [], streamIds, filters, limit } = params
+    const hasQuery = query.trim().length > 0
 
-    if (streamIds.length === 0 || !query.trim()) {
+    if (streamIds.length === 0 || (!hasQuery && phrases.length === 0)) {
       return []
     }
 
-    // Escape special LIKE characters (%, _, \) in the query
-    const escapedQuery = query.replace(/[%_\\]/g, "\\$&")
+    const exactQueryPredicate = hasQuery
+      ? composeSql`AND m.content_markdown ILIKE '%' || ${escapeLike(query)} || '%'`
+      : sql``
 
-    const result = await db.query<SearchResultRow>(sql`
+    const result = await db.query<SearchResultRow>(composeSql`
       SELECT
         m.id,
         m.stream_id,
@@ -378,7 +399,8 @@ export const SearchRepository = {
       JOIN streams s ON m.stream_id = s.id
       WHERE m.stream_id = ANY(${streamIds})
         AND m.deleted_at IS NULL
-        AND m.content_markdown ILIKE '%' || ${escapedQuery} || '%'
+        ${exactQueryPredicate}
+        ${phrasePredicatesSql(phrases)}
         AND (${filters.authorId === undefined} OR m.author_id = ${filters.authorId ?? ""})
         AND (${filters.streamTypes === undefined || filters.streamTypes.length === 0} OR s.type = ANY(${filters.streamTypes ?? []}))
         AND (${filters.before === undefined} OR m.created_at < ${filters.before ?? new Date()})

--- a/apps/backend/src/features/search/service.test.ts
+++ b/apps/backend/src/features/search/service.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { SearchRepository } from "./repository"
+import { SearchService } from "./service"
+
+const pool = {
+  query: mock(() => Promise.resolve({ rows: [], rowCount: 0 })),
+}
+
+describe("SearchService exact phrase search", () => {
+  afterEach(() => {
+    pool.query.mockClear()
+    mock.restore()
+  })
+
+  test("passes the query and every phrase to exact search", async () => {
+    const exactSearch = spyOn(SearchRepository, "exactSearch").mockResolvedValue([])
+    const service = new SearchService({
+      pool: pool as never,
+      embeddingService: { embed: async () => [], embedBatch: async () => [] },
+    })
+
+    await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      query: "created pr",
+      phrases: ["1429", "urgent"],
+      exact: true,
+    })
+
+    expect(exactSearch).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({ query: "created pr", phrases: ["1429", "urgent"] })
+    )
+  })
+
+  test("passes phrase-only exact searches through", async () => {
+    const exactSearch = spyOn(SearchRepository, "exactSearch").mockResolvedValue([])
+    const service = new SearchService({
+      pool: pool as never,
+      embeddingService: { embed: async () => [], embedBatch: async () => [] },
+    })
+
+    await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      query: "",
+      phrases: ["1429"],
+      exact: true,
+    })
+
+    expect(exactSearch).toHaveBeenCalledWith(pool, expect.objectContaining({ query: "", phrases: ["1429"] }))
+  })
+})

--- a/apps/backend/src/features/search/service.ts
+++ b/apps/backend/src/features/search/service.ts
@@ -35,6 +35,7 @@ export interface SearchParams {
   workspaceId: string
   permissions: SearchPermissions
   query: string
+  phrases?: string[]
   filters?: SearchFilters
   limit?: number
   /** If true, use exact substring matching (ILIKE) instead of full-text search */
@@ -86,13 +87,14 @@ export class SearchService {
       workspaceId,
       permissions,
       query,
+      phrases = [],
       filters = {},
       limit = DEFAULT_LIMIT,
       exact = false,
       skipEmbedding = false,
     } = params
 
-    logger.debug({ query, filters, workspaceId, exact }, "Search request")
+    logger.debug({ query, phrases, filters, workspaceId, exact }, "Search request")
 
     const candidateStreamIds = this.resolveStreamIds(permissions.accessibleStreamIds, filters)
 
@@ -125,6 +127,7 @@ export class SearchService {
     if (exact) {
       const results = await SearchRepository.exactSearch(this.pool, {
         query,
+        phrases,
         streamIds,
         filters: repoFilters,
         limit,
@@ -150,6 +153,7 @@ export class SearchService {
     if (!hasQuery || !hasEmbedding) {
       const results = await SearchRepository.fullTextSearch(this.pool, {
         query: normalizedQuery,
+        phrases,
         streamIds,
         filters: repoFilters,
         limit,
@@ -159,6 +163,7 @@ export class SearchService {
 
     const results = await SearchRepository.hybridSearch(this.pool, {
       query: normalizedQuery,
+      phrases,
       embedding,
       streamIds,
       filters: repoFilters,

--- a/apps/frontend/src/api/search.ts
+++ b/apps/frontend/src/api/search.ts
@@ -15,6 +15,7 @@ export interface SearchFilters {
 
 export interface SearchRequest {
   query?: string
+  phrases?: string[]
   limit?: number
   filters?: SearchFilters
   /** Use exact substring matching (ILIKE) instead of full-text/semantic search */
@@ -38,6 +39,7 @@ export interface SearchResponse {
 export async function searchMessages(workspaceId: string, request: SearchRequest): Promise<SearchResponse> {
   const body = {
     query: request.query ?? "",
+    phrases: request.phrases,
     from: request.filters?.from,
     with: request.filters?.with,
     in: request.filters?.in,

--- a/apps/frontend/src/components/search/highlight.test.tsx
+++ b/apps/frontend/src/components/search/highlight.test.tsx
@@ -11,6 +11,10 @@ describe("extractSearchTerms", () => {
     expect(extractSearchTerms('"chicken wingz" recipe')).toEqual(["chicken wingz", "recipe"])
   })
 
+  it("keeps smart-quoted phrases as a single term", () => {
+    expect(extractSearchTerms("“chicken wingz” recipe")).toEqual(["chicken wingz", "recipe"])
+  })
+
   it("drops single-character noise terms", () => {
     expect(extractSearchTerms("a deploy b")).toEqual(["deploy"])
   })

--- a/apps/frontend/src/components/search/highlight.tsx
+++ b/apps/frontend/src/components/search/highlight.tsx
@@ -8,7 +8,7 @@ import { stripMarkdownToInline } from "@/lib/markdown/strip"
  */
 export function extractSearchTerms(searchText: string): string[] {
   const terms: string[] = []
-  const phraseRegex = /"([^"]+)"|(\S+)/g
+  const phraseRegex = /["“]([^"“”]+)["”]|(\S+)/g
   let match: RegExpExecArray | null
   while ((match = phraseRegex.exec(searchText)) !== null) {
     const term = (match[1] ?? match[2]).trim()

--- a/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
@@ -270,6 +270,40 @@ describe("SidebarSearchPanel Integration Tests", () => {
       expect(markTexts).toContain("hello")
     })
 
+    it("preserves phrase-only highlighting and snippet positioning", async () => {
+      mockSearchState.results = [
+        {
+          ...mockSearchResultsList[0]!,
+          content: `${"context ".repeat(8)}matched phrase at the end`,
+        },
+      ]
+
+      const user = userEvent.setup()
+      renderPanel()
+
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, '"matched phrase"')
+
+      await waitFor(() => {
+        expect(mockSearchState.search).toHaveBeenCalledWith("", {}, ["matched phrase"])
+      })
+      expect(screen.getByText("matched phrase", { selector: "mark" })).toBeInTheDocument()
+      expect(screen.getByText("…")).toBeInTheDocument()
+    })
+
+    it("does not send more than five quoted phrases", async () => {
+      const user = userEvent.setup()
+      renderPanel()
+
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, '"one" "two" "three" "four" "five" "six"')
+
+      expect(screen.getByText("Search supports at most 5 quoted phrases.")).toBeInTheDocument()
+      expect(mockSearchState.search).not.toHaveBeenCalled()
+    })
+
     it("collapses and expands a stream group", async () => {
       mockSearchState.results = mockSearchResultsList
 

--- a/apps/frontend/src/components/search/sidebar-search-panel.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.tsx
@@ -25,7 +25,11 @@ import { SearchResults } from "./search-results"
 export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
   const navigate = useNavigate()
   const { query, setQuery, activeResultId, setActiveResultId, closeSearch, registerFocusHandler } = useSearchPanel()
-  const { results, isLoading, error, parsedFilters, searchText, hasQuery } = useMessageSearch(workspaceId, query)
+  const { results, isLoading, error, validationError, parsedFilters, searchText, hasQuery } = useMessageSearch(
+    workspaceId,
+    query
+  )
+  const displayError = validationError ?? (error ? "Search failed. Try again." : null)
   const { preferences } = usePreferences()
 
   const inputRef = useRef<RichInputRef>(null)
@@ -156,7 +160,7 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
             <SearchFilterMenu workspaceId={workspaceId} query={query} onQueryChange={setQuery} />
           </div>
 
-          {hasQuery && !isLoading && !error && (
+          {hasQuery && !isLoading && !displayError && (
             <p className="px-3 pb-2 text-[11px] tabular-nums text-muted-foreground/70">
               {results.length === 0
                 ? "No results"
@@ -186,9 +190,9 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
             </div>
           )}
 
-          {error && <p className="px-2 py-4 text-center text-xs text-destructive">Search failed. Try again.</p>}
+          {displayError && <p className="px-2 py-4 text-center text-xs text-destructive">{displayError}</p>}
 
-          {hasQuery && !error && results.length > 0 && (
+          {hasQuery && !displayError && results.length > 0 && (
             <SearchResults
               workspaceId={workspaceId}
               results={results}
@@ -198,7 +202,7 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
             />
           )}
 
-          {hasQuery && !isLoading && !error && results.length === 0 && (
+          {hasQuery && !isLoading && !displayError && results.length === 0 && (
             <div className="px-2 py-6 text-center">
               <p className="text-xs font-medium text-muted-foreground/80">No messages found</p>
               <p className="mt-1 text-[11px] text-muted-foreground/60">Try different words or remove a filter</p>

--- a/apps/frontend/src/components/search/use-message-search.ts
+++ b/apps/frontend/src/components/search/use-message-search.ts
@@ -10,7 +10,7 @@ import {
 import { parseSearchQuery, type ParsedFilter } from "@/lib/search-query-parser"
 import type { SearchFilters, SearchResultItem } from "@/api"
 import type { ArchiveStatus } from "@/api"
-import { STREAM_TYPES, type StreamType } from "@threa/types"
+import { MAX_SEARCH_PHRASES, STREAM_TYPES, type StreamType } from "@threa/types"
 
 export const SEARCH_DEBOUNCE_MS = 300
 const SEARCH_RESULT_LIMIT = 50
@@ -19,6 +19,7 @@ export interface MessageSearchState {
   results: SearchResultItem[]
   isLoading: boolean
   error: Error | null
+  validationError: string | null
   /** Structured filters parsed out of the query string (from:@…, in:#…, …). */
   parsedFilters: ParsedFilter[]
   /** Free-text part of the query with filters removed. */
@@ -40,7 +41,13 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
   const streams = useWorkspaceStreams(workspaceId)
   const { results, isLoading, error, search, clear } = useSearch({ workspaceId, limit: SEARCH_RESULT_LIMIT })
 
-  const { filters: parsedFilters, text: searchText } = useMemo(() => parseSearchQuery(query), [query])
+  const {
+    filters: parsedFilters,
+    text: searchText,
+    semanticText,
+    phrases,
+  } = useMemo(() => parseSearchQuery(query), [query])
+  const hasTooManyPhrases = phrases.length > MAX_SEARCH_PHRASES
 
   // Resolve filter slugs (user/stream handles) to ids the API understands.
   const apiFilters = useMemo((): SearchFilters => {
@@ -107,7 +114,7 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
     return filters
   }, [parsedFilters, users, personas, bots, streams])
 
-  const hasQuery = searchText.trim().length > 0 || parsedFilters.length > 0
+  const hasQuery = searchText.trim().length > 0 || phrases.length > 0 || parsedFilters.length > 0
 
   // `users`/`streams` come from live queries that produce a NEW array on every
   // workspace IndexedDB write (incoming messages, presence, …), which gives
@@ -118,19 +125,34 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
   const filtersKey = JSON.stringify(apiFilters)
   const filtersRef = useRef(apiFilters)
   filtersRef.current = apiFilters
+  const phrasesKey = JSON.stringify(phrases)
+  const phrasesRef = useRef(phrases)
+  phrasesRef.current = phrases
 
   useEffect(() => {
-    if (!hasQuery) {
+    if (!hasQuery || hasTooManyPhrases) {
       clear()
       return
     }
 
     const timer = setTimeout(() => {
-      void search(searchText, filtersRef.current)
+      if (phrasesRef.current.length > 0) {
+        void search(semanticText, filtersRef.current, phrasesRef.current)
+      } else {
+        void search(semanticText, filtersRef.current)
+      }
     }, SEARCH_DEBOUNCE_MS)
 
     return () => clearTimeout(timer)
-  }, [hasQuery, searchText, filtersKey, search, clear])
+  }, [hasQuery, hasTooManyPhrases, semanticText, filtersKey, phrasesKey, search, clear])
 
-  return { results, isLoading, error, parsedFilters, searchText, hasQuery }
+  return {
+    results,
+    isLoading,
+    error,
+    validationError: hasTooManyPhrases ? `Search supports at most ${MAX_SEARCH_PHRASES} quoted phrases.` : null,
+    parsedFilters,
+    searchText,
+    hasQuery,
+  }
 }

--- a/apps/frontend/src/hooks/use-search.ts
+++ b/apps/frontend/src/hooks/use-search.ts
@@ -11,7 +11,7 @@ interface UseSearchReturn {
   results: SearchResultItem[]
   isLoading: boolean
   error: Error | null
-  search: (query: string, filters?: SearchFilters) => Promise<void>
+  search: (query: string, filters?: SearchFilters, phrases?: string[]) => Promise<void>
   clear: () => void
 }
 
@@ -24,13 +24,13 @@ export function useSearch({ workspaceId, limit }: UseSearchOptions): UseSearchRe
   const requestIdRef = useRef(0)
 
   const search = useCallback(
-    async (query: string, filters?: SearchFilters) => {
+    async (query: string, filters?: SearchFilters, phrases?: string[]) => {
       const requestId = ++requestIdRef.current
       setIsLoading(true)
       setError(null)
 
       try {
-        const response = await searchMessages(workspaceId, { query, filters, limit })
+        const response = await searchMessages(workspaceId, { query, filters, phrases, limit })
         if (requestId !== requestIdRef.current) return
         setResults(response.results)
       } catch (e) {

--- a/apps/frontend/src/lib/search-query-parser.test.ts
+++ b/apps/frontend/src/lib/search-query-parser.test.ts
@@ -145,6 +145,48 @@ describe("parseSearchQuery", () => {
     expect(result.filters).toHaveLength(0)
     expect(result.text).toBe("from:@ hello")
   })
+
+  it("separates quoted phrases from semantic text while preserving text", () => {
+    expect(parseSearchQuery('created pr "1429"')).toMatchObject({
+      text: 'created pr "1429"',
+      semanticText: "created pr",
+      phrases: ["1429"],
+      filters: [],
+    })
+  })
+
+  it("recognizes smart punctuation quotes", () => {
+    expect(parseSearchQuery("created pr “1429”")).toMatchObject({
+      text: "created pr “1429”",
+      semanticText: "created pr",
+      phrases: ["1429"],
+    })
+  })
+
+  it("preserves semantic token boundaries around adjacent phrases", () => {
+    expect(parseSearchQuery('foo"bar"baz')).toMatchObject({
+      text: 'foo"bar"baz',
+      semanticText: "foo baz",
+      phrases: ["bar"],
+    })
+  })
+
+  it("keeps filters inside quoted phrases literal", () => {
+    expect(parseSearchQuery('"from:@martin" from:@sara')).toMatchObject({
+      text: '"from:@martin"',
+      semanticText: "",
+      phrases: ["from:@martin"],
+      filters: [{ type: "from", value: "sara", raw: "from:@sara" }],
+    })
+  })
+
+  it("keeps unbalanced quotes in semantic text", () => {
+    expect(parseSearchQuery('created "pr 1429')).toMatchObject({
+      text: 'created "pr 1429',
+      semanticText: 'created "pr 1429',
+      phrases: [],
+    })
+  })
 })
 
 describe("serializeSearchQuery", () => {

--- a/apps/frontend/src/lib/search-query-parser.ts
+++ b/apps/frontend/src/lib/search-query-parser.ts
@@ -16,6 +16,8 @@ export interface ParsedFilter {
 export interface ParsedQuery {
   filters: ParsedFilter[]
   text: string
+  phrases: string[]
+  semanticText: string
 }
 
 /**
@@ -29,39 +31,55 @@ export interface ParsedQuery {
  */
 export function parseSearchQuery(query: string): ParsedQuery {
   const filters: ParsedFilter[] = []
-  const parts: string[] = []
-
-  // Filter grammar: from:@slug, with:@slug, in:#slug, in:@slug, is:/type:streamType, status:archiveStatus, after:date, before:date
+  const textParts: string[] = []
+  const semanticParts: string[] = []
   const filterRegex = /\b(from:@|with:@|in:#|in:@|type:|status:|is:|after:|before:)(\S*)/g
+  const phraseRegex = /["“]([^"“”]+)["”]/g
 
+  const parseSegment = (segment: string) => {
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+    filterRegex.lastIndex = 0
+
+    while ((match = filterRegex.exec(segment)) !== null) {
+      if (match.index > lastIndex) {
+        const plainText = segment.slice(lastIndex, match.index)
+        textParts.push(plainText)
+        semanticParts.push(plainText)
+      }
+
+      const [raw, prefix, value] = match
+      const type = extractFilterType(prefix)
+      if (type && value) {
+        filters.push({ type, value, raw })
+      } else {
+        textParts.push(raw)
+        semanticParts.push(raw)
+      }
+      lastIndex = match.index + raw.length
+    }
+
+    if (lastIndex < segment.length) {
+      const plainText = segment.slice(lastIndex)
+      textParts.push(plainText)
+      semanticParts.push(plainText)
+    }
+  }
+
+  const phrases: string[] = []
   let lastIndex = 0
-  let match: RegExpExecArray | null
-
-  while ((match = filterRegex.exec(query)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(query.slice(lastIndex, match.index))
-    }
-
-    const [raw, prefix, value] = match
-    const type = extractFilterType(prefix)
-
-    if (type && value) {
-      filters.push({ type, value, raw })
-    } else {
-      // Invalid filter syntax — keep it as plain search text.
-      parts.push(raw)
-    }
-
-    lastIndex = match.index + raw.length
+  let phraseMatch: RegExpExecArray | null
+  while ((phraseMatch = phraseRegex.exec(query)) !== null) {
+    parseSegment(query.slice(lastIndex, phraseMatch.index))
+    textParts.push(phraseMatch[0])
+    semanticParts.push(" ")
+    phrases.push(phraseMatch[1])
+    lastIndex = phraseMatch.index + phraseMatch[0].length
   }
+  parseSegment(query.slice(lastIndex))
 
-  if (lastIndex < query.length) {
-    parts.push(query.slice(lastIndex))
-  }
-
-  const text = parts.join("").trim().replace(/\s+/g, " ")
-
-  return { filters, text }
+  const normalize = (parts: string[]) => parts.join("").trim().replace(/\s+/g, " ")
+  return { filters, text: normalize(textParts), phrases, semanticText: normalize(semanticParts) }
 }
 
 function extractFilterType(prefix: string): FilterType | null {

--- a/apps/frontend/src/pages/search.tsx
+++ b/apps/frontend/src/pages/search.tsx
@@ -60,10 +60,11 @@ export function SearchPage() {
     }
   }, [])
 
-  const { results, isLoading, error, parsedFilters, searchText, hasQuery } = useMessageSearch(
+  const { results, isLoading, error, validationError, parsedFilters, searchText, hasQuery } = useMessageSearch(
     workspaceId ?? "",
     localQuery
   )
+  const displayError = validationError ?? (error ? "Search failed. Try again." : null)
   const terms = useMemo(() => extractSearchTerms(searchText), [searchText])
 
   if (!workspaceId) {
@@ -137,9 +138,9 @@ export function SearchPage() {
             </div>
           )}
 
-          {error && <p className="py-8 text-center text-sm text-destructive">Search failed. Try again.</p>}
+          {displayError && <p className="py-8 text-center text-sm text-destructive">{displayError}</p>}
 
-          {hasQuery && !error && results.length > 0 && (
+          {hasQuery && !displayError && results.length > 0 && (
             <SearchResults
               workspaceId={workspaceId}
               results={results}
@@ -149,7 +150,7 @@ export function SearchPage() {
             />
           )}
 
-          {hasQuery && !isLoading && !error && results.length === 0 && (
+          {hasQuery && !isLoading && !displayError && results.length === 0 && (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <p className="text-sm font-medium text-muted-foreground/70">No messages found</p>
               <p className="mt-1 text-xs text-muted-foreground/50">Try different words or remove a filter</p>

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -46,6 +46,9 @@ import type { SidebarConfig } from "./sidebar"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "./tool-privacy"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
 
+/** Maximum quoted phrase filters accepted by message search. */
+export const MAX_SEARCH_PHRASES = 5
+
 interface CreateStreamInputBase {
   type: StreamType
   displayName?: string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -650,7 +650,7 @@ export { CommandKinds, CommandScopes } from "./api"
 
 // Draft scope builders (single source of truth for the scope string format)
 // and the shared bootstrap cap (the client must know when a snapshot is truncated)
-export { draftStreamScope, draftThreadScope, MAX_DRAFTS_PER_USER } from "./api"
+export { draftStreamScope, draftThreadScope, MAX_DRAFTS_PER_USER, MAX_SEARCH_PHRASES } from "./api"
 
 // Discuss-with-Ariadne client-action id (single source of truth)
 export const DISCUSS_WITH_ARIADNE_COMMAND = "discuss-with-ariadne" as const


### PR DESCRIPTION
## Problem

Message search treated quoted text as part of the semantic query. `created pr "1429"` could rank semantically related messages that did not contain `1429`, while switching to `exact: true` discarded semantic matching entirely.

## Solution

Split quoted literals from semantic text at the frontend boundary, then enforce each phrase as an escaped case-insensitive substring predicate across every backend search path.

- `parseSearchQuery` returns preserved display text, semantic text, and quoted phrases; straight and smart quotes share parsing/highlighting, quoted filter-like text remains literal, and unbalanced quotes remain semantic.
- `/search` validates at most `MAX_SEARCH_PHRASES` phrases; the shared limit prevents frontend/backend drift.
- `fullTextSearch`, both hybrid CTEs, and legacy `exactSearch` apply phrase predicates with AND semantics. Existing ranking and public API behavior remain unchanged.
- Phrase-only searches use recency ordering and exact substring filtering.

## Files

| Area | Change |
| --- | --- |
| `apps/frontend/src/lib/search-query-parser.ts` | Extract quoted phrases without breaking filters, round-tripping, or highlighting. |
| `apps/frontend/src/components/search/use-message-search.ts` | Send semantic text and exact phrases separately; surface phrase-limit errors. |
| `apps/backend/src/features/search/{handlers,service,repository}.ts` | Validate and apply exact phrase constraints to every search branch. |
| `packages/types/src/api.ts` | Define shared `MAX_SEARCH_PHRASES`. |
| Search tests | Cover parsing, handler validation, SQL branches/escaping, legacy exact mode, highlighting, and INV-62 access structure. |

## Test plan

- [x] Backend targeted search tests — 10 passed
- [x] Frontend parser, highlighting, and sidebar integration tests — 80 passed
- [x] Repository-wide lint and TypeScript checks — passed via pre-commit
- [ ] Manual browser verification — deferred until the complete search-sidebar stack is assembled

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make quoted message-search text an exact substring constraint combined with semantic relevance, rather than an alternative search mode.

## What Was Built

### Query parsing and request contract

- Extract balanced quoted phrases before parsing inline filters.
- Preserve the original free text for snippets and highlighting.
- Send unquoted text as the semantic query and quoted values as `phrases`.
- Reject more than five quoted phrases with a clear UI error.

### Backend retrieval

- Validate the additive phrase list with Zod.
- Escape `%`, `_`, and `\` before ILIKE matching.
- Apply every phrase with AND semantics in keyword-only, phrase-only, hybrid keyword, hybrid semantic, and legacy exact paths.
- Keep result ranking based on semantic/full-text relevance; phrase predicates only constrain candidates.

## Design Decisions

- Frontend query decomposition over backend parsing: inline filter syntax and highlighting already have one frontend parser.
- Additive phrase field over changing the existing `exact` boolean: public API and agent callers retain their established contract.
- Raw `content_markdown` matching matches the existing exact-search behavior; rendered-markdown matching is out of scope.

## What's NOT Included

- Actor resolution, archived stream metadata/loading, archived-inclusive defaults, and Grouped/Ranked rendering are later PRs in this stack.
- No database or public API changes.

## Status

- [x] Quoted phrase parsing and wiring
- [x] AND predicates across retrieval paths
- [x] Targeted tests and typecheck
- [ ] Remaining search-sidebar presentation PRs

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

