### PR TITLE
fix(search): resolve archived result metadata

### DIFF
--- a/apps/frontend/src/api/search.ts
+++ b/apps/frontend/src/api/search.ts
@@ -1,5 +1,5 @@
 import api from "./client"
-import type { StreamType } from "@threa/types"
+import type { AuthorType, StreamType } from "@threa/types"
 
 export type ArchiveStatus = "active" | "archived"
 
@@ -27,7 +27,7 @@ export interface SearchResultItem {
   streamId: string
   content: string
   authorId: string
-  authorType: "user" | "persona"
+  authorType: AuthorType
   createdAt: string
   rank: number
 }

--- a/apps/frontend/src/components/search/search-results.tsx
+++ b/apps/frontend/src/components/search/search-results.tsx
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
-import { ChevronDown, ChevronRight } from "lucide-react"
-import {
-  useWorkspaceDmPeers,
-  useWorkspacePersonas,
-  useWorkspaceStreams,
-  useWorkspaceUsers,
-} from "@/stores/workspace-store"
+import { Archive, ChevronDown, ChevronRight, Loader2 } from "lucide-react"
+import { useWorkspaceDmPeers, useWorkspaceStreams, useWorkspaceUsers } from "@/stores/workspace-store"
 import { resolveStreamName, type StreamNameCaches } from "@/lib/streams"
 import { RelativeTime } from "@/components/relative-time"
 import { cn } from "@/lib/utils"
+import { useActors } from "@/hooks/use-actors"
+import { useEnsureSearchStreams } from "@/hooks/use-ensure-search-streams"
 import type { SearchResultItem } from "@/api"
 import { buildSnippet, HighlightedText } from "./highlight"
 import { groupResultsByStream } from "./group-results"
@@ -55,9 +52,13 @@ function visibleAncestorCount(ancestorCount: number, containerWidth: number): nu
  */
 export function SearchResults({ workspaceId, results, terms, activeResultId, onResultSelect }: SearchResultsProps) {
   const users = useWorkspaceUsers(workspaceId)
-  const personas = useWorkspacePersonas(workspaceId)
   const streams = useWorkspaceStreams(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
+  const { getActorName } = useActors(workspaceId)
+  const resolvingStreamIds = useEnsureSearchStreams(
+    workspaceId,
+    useMemo(() => results.map((result) => result.streamId), [results])
+  )
 
   const [collapsedStreams, setCollapsedStreams] = useState<Set<string>>(new Set())
 
@@ -98,18 +99,6 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
     return (streamId: string) => resolveStreamName(streamId, caches, "breadcrumb") ?? "Unknown stream"
   }, [streams, users, dmPeers])
 
-  // Id → name maps so each row resolves its author in O(1) instead of
-  // scanning the user/persona arrays per result on every render.
-  const authorNamesById = useMemo(() => {
-    const names = new Map<string, string>()
-    for (const user of users) names.set(user.id, user.name)
-    for (const persona of personas) names.set(persona.id, persona.name)
-    return names
-  }, [users, personas])
-
-  const authorName = (result: SearchResultItem): string =>
-    authorNamesById.get(result.authorId) ?? (result.authorType === "persona" ? "Assistant" : "Unknown")
-
   const toggleGroup = useCallback((streamId: string) => {
     setCollapsedStreams((current) => {
       const next = new Set(current)
@@ -132,9 +121,14 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
         const shownCount = visibleAncestorCount(ancestors.length, containerWidth)
         const shownAncestors = shownCount > 0 ? ancestors.slice(ancestors.length - shownCount) : []
         const hasHidden = ancestors.length > shownCount
+        const isResolving = resolvingStreamIds.has(group.streamId)
+        const stream = streamsById.get(group.streamId)
+        const rootStreamId =
+          stream?.rootStreamId ?? (stream?.parentStreamId ? group.path[0] : (stream?.id ?? group.path[0]))
+        const isArchived = rootStreamId ? streamsById.get(rootStreamId)?.archivedAt != null : false
 
         return (
-          <section key={group.streamId}>
+          <section key={group.streamId} className={cn(isArchived && "opacity-60")}>
             <button
               type="button"
               onClick={() => toggleGroup(group.streamId)}
@@ -168,7 +162,17 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
                   <ChevronRight className="h-2.5 w-2.5 shrink-0 text-muted-foreground/50" aria-hidden="true" />
                 </span>
               ))}
-              <span className="min-w-0 truncate">{currentLabel}</span>
+              {isResolving ? (
+                <Loader2
+                  className="h-3 w-3 shrink-0 animate-spin text-muted-foreground/70"
+                  aria-label="Loading stream"
+                />
+              ) : (
+                <span className="min-w-0 truncate">{currentLabel}</span>
+              )}
+              <span className="h-3 w-3 shrink-0">
+                {isArchived && <Archive className="h-3 w-3" aria-label="Archived stream" role="img" />}
+              </span>
               <span className="ml-auto shrink-0 rounded-full bg-muted px-1.5 py-px text-[10px] font-medium tabular-nums text-muted-foreground">
                 {group.results.length}
               </span>
@@ -198,7 +202,7 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
                           <HighlightedText text={snippet.text} terms={terms} />
                         </p>
                         <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground/70">
-                          <span className="min-w-0 truncate">{authorName(result)}</span>
+                          <span className="min-w-0 truncate">{getActorName(result.authorId, result.authorType)}</span>
                           <span aria-hidden="true">·</span>
                           <RelativeTime date={result.createdAt} className="shrink-0 tabular-nums" />
                         </p>

--- a/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
@@ -15,15 +15,20 @@ import { SidebarSearchPanel } from "./sidebar-search-panel"
 import { mockStreamsList } from "@/test/fixtures"
 import { mockUsersList } from "@/test/fixtures/users"
 import { mockSearchResultsList } from "@/test/fixtures/messages"
+import type { AuthorType } from "@threa/types"
+import { ApiError } from "@/api"
 import * as hooksModule from "@/hooks"
 import * as mentionablesModule from "@/hooks/use-mentionables"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as contextsModule from "@/contexts"
 
 const mockNavigate = vi.fn()
+let workspaceStreams = mockStreamsList
+
+type MockSearchResult = Omit<(typeof mockSearchResultsList)[number], "authorType"> & { authorType: AuthorType }
 
 const mockSearchState = {
-  results: [] as typeof mockSearchResultsList,
+  results: [] as MockSearchResult[],
   isLoading: false,
   search: vi.fn(),
   clear: vi.fn(),
@@ -167,13 +172,16 @@ function installSpies() {
   }) as unknown as typeof mentionablesModule.filterUsersOnly)
 
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockImplementation(
-    () => mockStreamsList as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+    () => workspaceStreams as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
   )
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockImplementation(
     () => mockUsersList as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>
   )
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockImplementation(
     () => [] as ReturnType<typeof workspaceStoreModule.useWorkspacePersonas>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockImplementation(
+    () => [] as ReturnType<typeof workspaceStoreModule.useWorkspaceBots>
   )
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockImplementation(
     () => [] as ReturnType<typeof workspaceStoreModule.useWorkspaceDmPeers>
@@ -182,12 +190,16 @@ function installSpies() {
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: null,
   } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
+    get: vi.fn(),
+  } as unknown as ReturnType<typeof contextsModule.useStreamService>)
 }
 
 describe("SidebarSearchPanel Integration Tests", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     mockNavigate.mockReset()
+    workspaceStreams = mockStreamsList
     mockSearchState.results = []
     mockSearchState.isLoading = false
     mockSearchState.search = vi.fn()
@@ -286,7 +298,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await user.type(editor, '"matched phrase"')
 
       await waitFor(() => {
-        expect(mockSearchState.search).toHaveBeenCalledWith("", {}, ["matched phrase"])
+        expect(mockSearchState.search).toHaveBeenCalledWith("", { status: ["active", "archived"] }, ["matched phrase"])
       })
       expect(screen.getByText("matched phrase", { selector: "mark" })).toBeInTheDocument()
       expect(screen.getByText("…")).toBeInTheDocument()
@@ -302,6 +314,128 @@ describe("SidebarSearchPanel Integration Tests", () => {
 
       expect(screen.getByText("Search supports at most 5 quoted phrases.")).toBeInTheDocument()
       expect(mockSearchState.search).not.toHaveBeenCalled()
+    })
+
+    it("resolves bot authors through the canonical actor lookup", async () => {
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, authorId: "bot_1", authorType: "bot" }]
+      vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([
+        { id: "bot_1", name: "Search Bot" },
+      ] as ReturnType<typeof workspaceStoreModule.useWorkspaceBots>)
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      expect(await screen.findByText("Search Bot")).toBeInTheDocument()
+    })
+
+    it("mutes a thread result when its root stream is archived", async () => {
+      const root = { ...mockStreamsList[0]!, archivedAt: "2026-01-01T00:00:00Z" }
+      const thread = { ...mockStreamsList[1]!, id: "stream_thread1", parentStreamId: root.id, rootStreamId: root.id }
+      workspaceStreams = [root, thread]
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, streamId: thread.id }]
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      const archive = await screen.findByLabelText("Archived stream")
+      expect(archive.closest("section")).toHaveClass("opacity-60")
+    })
+
+    it("mutes a nested thread result when its cached root is archived but its parent is missing", async () => {
+      const root = { ...mockStreamsList[0]!, archivedAt: "2026-01-01T00:00:00Z" }
+      const nestedThread = {
+        ...mockStreamsList[1]!,
+        id: "stream_nested_thread",
+        parentStreamId: "stream_missing_parent",
+        rootStreamId: root.id,
+      }
+      workspaceStreams = [root, nestedThread]
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, streamId: nestedThread.id }]
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      const archive = await screen.findByLabelText("Archived stream")
+      expect(archive.closest("section")).toHaveClass("opacity-60")
+    })
+
+    it("loads a missing result stream once, then renders its cached name", async () => {
+      let resolveStream: (stream: (typeof mockStreamsList)[number]) => void
+      const get = vi.fn(
+        () =>
+          new Promise<(typeof mockStreamsList)[number]>((resolve) => {
+            resolveStream = resolve
+          })
+      )
+      vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
+        get,
+      } as unknown as ReturnType<typeof contextsModule.useStreamService>)
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, streamId: "stream_missing" }]
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      expect(await screen.findByLabelText("Loading stream")).toBeInTheDocument()
+      workspaceStreams = [...workspaceStreams]
+      await user.type(editor, "!")
+      expect(get).toHaveBeenCalledTimes(1)
+
+      const recovered = { ...mockStreamsList[0]!, id: "stream_missing", displayName: "Recovered" }
+      workspaceStreams = [recovered]
+      resolveStream!(recovered)
+      await waitFor(() => expect(screen.getByText("Recovered")).toBeInTheDocument())
+      expect(get).toHaveBeenCalledTimes(1)
+    })
+
+    it("loads one missing stream request for multiple results from that stream", async () => {
+      const missing = { ...mockStreamsList[0]!, id: "stream_missing" }
+      const get = vi.fn().mockResolvedValue(missing)
+      vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
+        get,
+      } as unknown as ReturnType<typeof contextsModule.useStreamService>)
+      mockSearchState.results = [
+        { ...mockSearchResultsList[0]!, streamId: missing.id },
+        { ...mockSearchResultsList[1]!, id: "msg_missing_2", streamId: missing.id },
+      ]
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+      expect(get).toHaveBeenCalledWith("workspace_1", missing.id)
+    })
+
+    it("does not retry a terminal missing-stream failure after rerenders", async () => {
+      const get = vi.fn().mockRejectedValue(new ApiError(404, "STREAM_NOT_FOUND", "Not found"))
+      vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
+        get,
+      } as unknown as ReturnType<typeof contextsModule.useStreamService>)
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, streamId: "stream_missing" }]
+
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+
+      await waitFor(() => expect(screen.getByText("Unknown stream")).toBeInTheDocument())
+      expect(get).toHaveBeenCalledTimes(1)
     })
 
     it("collapses and expands a stream group", async () => {
@@ -382,7 +516,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await waitFor(() => {
         expect(mockSearchState.search).toHaveBeenCalled()
       })
-      expect(mockSearchState.search).toHaveBeenCalledWith("hello", {})
+      expect(mockSearchState.search).toHaveBeenCalledWith("hello", { status: ["active", "archived"] })
     })
   })
 
@@ -419,6 +553,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await waitFor(() => {
         expect(mockSearchState.search).toHaveBeenCalledWith("hello", {
           before: new Date(2026, 5, 19).toISOString(),
+          status: ["active", "archived"],
         })
       })
     })
@@ -432,7 +567,10 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await user.type(editor, "from:@martin hello")
 
       await waitFor(() => {
-        expect(mockSearchState.search).toHaveBeenCalledWith("hello", { from: "member_1" })
+        expect(mockSearchState.search).toHaveBeenCalledWith("hello", {
+          from: "member_1",
+          status: ["active", "archived"],
+        })
       })
     })
 
@@ -536,7 +674,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       })
       // The slug resolves to the user id in the API call, same as the typed path
       await waitFor(() => {
-        expect(mockSearchState.search).toHaveBeenCalledWith("", { from: "member_1" })
+        expect(mockSearchState.search).toHaveBeenCalledWith("", { from: "member_1", status: ["active", "archived"] })
       })
     })
 
@@ -557,7 +695,10 @@ describe("SidebarSearchPanel Integration Tests", () => {
         expect(editor.textContent).toContain("in:#general")
       })
       await waitFor(() => {
-        expect(mockSearchState.search).toHaveBeenCalledWith("", { in: ["stream_channel1"] })
+        expect(mockSearchState.search).toHaveBeenCalledWith("", {
+          in: ["stream_channel1"],
+          status: ["active", "archived"],
+        })
       })
     })
 
@@ -577,7 +718,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
         expect(editor.textContent).toContain("in:@martin")
       })
       await waitFor(() => {
-        expect(mockSearchState.search).toHaveBeenCalledWith("", { in: ["member_1"] })
+        expect(mockSearchState.search).toHaveBeenCalledWith("", { in: ["member_1"], status: ["active", "archived"] })
       })
     })
 

--- a/apps/frontend/src/components/search/use-message-search.ts
+++ b/apps/frontend/src/components/search/use-message-search.ts
@@ -111,6 +111,10 @@ export function useMessageSearch(workspaceId: string, query: string): MessageSea
       }
     }
 
+    if (!parsedFilters.some((filter) => filter.type === "status")) {
+      filters.status = ["active", "archived"]
+    }
+
     return filters
   }, [parsedFilters, users, personas, bots, streams])
 

--- a/apps/frontend/src/hooks/use-ensure-search-streams.ts
+++ b/apps/frontend/src/hooks/use-ensure-search-streams.ts
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { ApiError } from "@/api"
+import { useStreamService } from "@/contexts"
+import { db } from "@/db"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import type { Stream } from "@threa/types"
+
+const MAX_HYDRATION_ATTEMPTS = 3
+
+async function cacheStreamMetadata(stream: Stream): Promise<void> {
+  await db.transaction("rw", db.streams, async () => {
+    const existing = await db.streams.get(stream.id)
+    await db.streams.put({ ...existing, ...stream, _cachedAt: Date.now() })
+  })
+}
+
+/**
+ * Hydrates result streams absent from the workspace cache. Requests are
+ * deduplicated while in flight; terminal misses stop and transient failures
+ * retry at most three times as the reactive workspace cache changes.
+ */
+export function useEnsureSearchStreams(workspaceId: string, streamIds: readonly string[]): ReadonlySet<string> {
+  const streamService = useStreamService()
+  const streams = useWorkspaceStreams(workspaceId)
+  const attemptCounts = useRef(new Map<string, number>())
+  const terminalIds = useRef(new Set<string>())
+  const inFlightIds = useRef(new Set<string>())
+  const [resolvingIds, setResolvingIds] = useState<ReadonlySet<string>>(() => new Set())
+  const cachedIds = useMemo(() => new Set(streams.map((stream) => stream.id)), [streams])
+  const streamIdsKey = useMemo(() => [...new Set(streamIds)].sort().join("\u0000"), [streamIds])
+
+  useEffect(() => {
+    if (!workspaceId) return
+
+    const missingIds = [...new Set(streamIds)].filter((id) => {
+      const attempts = attemptCounts.current.get(id) ?? 0
+      return (
+        !cachedIds.has(id) &&
+        !terminalIds.current.has(id) &&
+        !inFlightIds.current.has(id) &&
+        attempts < MAX_HYDRATION_ATTEMPTS
+      )
+    })
+    if (missingIds.length === 0) return
+
+    for (const id of missingIds) {
+      attemptCounts.current.set(id, (attemptCounts.current.get(id) ?? 0) + 1)
+      inFlightIds.current.add(id)
+    }
+    setResolvingIds((current) => new Set([...current, ...missingIds]))
+
+    for (const streamId of missingIds) {
+      void streamService
+        .get(workspaceId, streamId)
+        .then(cacheStreamMetadata)
+        .catch((error: unknown) => {
+          if (ApiError.isApiError(error) && (error.status === 403 || error.status === 404)) {
+            terminalIds.current.add(streamId)
+          }
+          console.warn(`[search] Failed to hydrate result stream ${streamId}`, error)
+        })
+        .finally(() => {
+          inFlightIds.current.delete(streamId)
+          setResolvingIds((current) => {
+            if (!current.has(streamId)) return current
+            const next = new Set(current)
+            next.delete(streamId)
+            return next
+          })
+        })
+    }
+  }, [workspaceId, streamIdsKey, cachedIds, streamIds, streamService])
+
+  return resolvingIds
+}


### PR DESCRIPTION
## Problem

Search results used a users+personas-only author map, so bot-authored messages rendered as “Unknown”. Results from uncached threads also showed “Unknown stream” until visited, and the UI excluded archived streams unless explicitly requested.

## Solution

Reuse canonical actor resolution, hydrate missing result streams into the existing IndexedDB cache, and include archived results with clear inherited archive styling.

- `SearchResultItem.authorType` now uses canonical `AuthorType`; `SearchResults` calls `useActors().getActorName`.
- `useMessageSearch` sends active+archived statuses unless the query contains an explicit `status:` filter. Backend/public API defaults remain unchanged.
- `useEnsureSearchStreams` deduplicates missing and in-flight IDs, stops terminal 403/404 retries, caps transient retries at three, and transactionally merges metadata into the established stream cache.
- Archived state follows `rootStreamId`, including nested threads whose intermediate parent is not cached. Archived groups reserve icon space and render muted without layout shift.

## Files

| File | Change |
| --- | --- |
| `apps/frontend/src/api/search.ts` | Widen result author type to `AuthorType`. |
| `apps/frontend/src/components/search/search-results.tsx` | Canonical actor names, metadata loader, inherited archive styling. |
| `apps/frontend/src/hooks/use-ensure-search-streams.ts` | **New:** one-attempt reactive stream metadata hydration. |
| `apps/frontend/src/components/search/use-message-search.ts` | Active+archived UI default with explicit-filter override. |
| `sidebar-search-panel.integration.test.tsx` | Bot, status, hydration, dedupe/failure, and archived-root coverage. |

## Test plan

- [x] Sidebar search integration tests — 35 passed
- [x] Repository-wide lint and TypeScript checks — passed via pre-commit
- [ ] Manual browser verification — deferred until the final rendering-mode PR

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make search-result metadata correct before navigation: resolve every actor type, load absent stream names, and identify results inherited from archived roots.

## What Was Built

### Actor and status correctness

- Use `AuthorType` and canonical `useActors` lookup.
- Default only the frontend message-search surface to active+archived.
- Preserve explicit `status:active` and `status:archived` filters.

### Stream metadata hydration

- Compare deduplicated result stream IDs against reactive cached streams.
- Fetch each missing stream through `streamService.get`; deduplicate in-flight requests and cap transient retries at three.
- Transactionally merge returned rows into `db.streams`, preserving cache-only fields; `useWorkspaceStreams` rerenders labels reactively.
- Stop 403/404 retries; allow bounded recoverable retries on later reactive cache changes.

### Archived presentation

- Resolve archive state from the result stream's root ID, not an incomplete breadcrumb path.
- Mute the entire archived group and expose an accessible archive icon.
- Reserve icon footprint for active rows to avoid layout shift (INV-21).

## Design Decisions

- UI-scoped archive default over changing `parseArchiveStatusFilter`: public API and agent callers keep active-only behavior.
- Lazy per-result metadata over loading all archived streams: bounded by the 50-result search window and deduplicated by stream.

## What's NOT Included

- Grouped/Ranked switching and ranked row stream labels are the next PR.
- No backend, schema, or public API changes.

## Status

- [x] Actor resolution
- [x] Archived-inclusive UI search
- [x] Missing stream hydration
- [x] Archived inherited styling
- [ ] Grouped/Ranked modes

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

