### PR TITLE
feat(search): add grouped and ranked result modes

### DIFF
--- a/apps/frontend/src/components/search/highlight.tsx
+++ b/apps/frontend/src/components/search/highlight.tsx
@@ -83,7 +83,7 @@ export function HighlightedText({ text, terms }: { text: string; terms: string[]
       {segments.map((segment, index) =>
         // Odd indices are capture-group matches by String.split contract
         index % 2 === 1 ? (
-          <mark key={index} className="rounded-[2px] bg-primary/20 px-px text-foreground">
+          <mark key={index} className="rounded-[2px] bg-primary/20 px-px font-medium text-foreground">
             {segment}
           </mark>
         ) : (

--- a/apps/frontend/src/components/search/search-result-display-toggle.tsx
+++ b/apps/frontend/src/components/search/search-result-display-toggle.tsx
@@ -1,0 +1,53 @@
+import { List, Rows3 } from "lucide-react"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { cn } from "@/lib/utils"
+import type { SearchResultDisplayMode } from "@/lib/search-result-display-mode"
+
+interface SearchResultDisplayToggleProps {
+  value: SearchResultDisplayMode
+  onChange: (mode: SearchResultDisplayMode) => void
+  size?: "sm" | "touch"
+  className?: string
+}
+
+const ITEM_CLASS =
+  "min-w-0 gap-1 rounded-[0.3125rem] px-2 text-[11px] font-medium text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm [&_svg]:size-3.5"
+
+const ITEM_SIZE: Record<NonNullable<SearchResultDisplayToggleProps["size"]>, string> = {
+  sm: "h-6",
+  touch: "h-9",
+}
+
+export function SearchResultDisplayToggle({ value, onChange, size = "sm", className }: SearchResultDisplayToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      value={value}
+      onValueChange={(next) => {
+        if (next === "grouped" || next === "ranked") onChange(next)
+      }}
+      aria-label="Search result display"
+      className={cn("shrink-0 gap-0.5 rounded-md bg-muted p-0.5", className)}
+    >
+      <ToggleGroupItem
+        value="grouped"
+        aria-label="Grouped results"
+        title="Grouped results"
+        className={cn(ITEM_CLASS, ITEM_SIZE[size])}
+      >
+        <Rows3 aria-hidden="true" />
+        <span>Grouped</span>
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="ranked"
+        aria-label="Ranked results"
+        title="Ranked results"
+        className={cn(ITEM_CLASS, ITEM_SIZE[size])}
+      >
+        <List aria-hidden="true" />
+        <span>Ranked</span>
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/frontend/src/components/search/search-results.tsx
+++ b/apps/frontend/src/components/search/search-results.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom"
 import { Archive, ChevronDown, ChevronRight, Loader2 } from "lucide-react"
 import { useWorkspaceDmPeers, useWorkspaceStreams, useWorkspaceUsers } from "@/stores/workspace-store"
 import { resolveStreamName, type StreamNameCaches } from "@/lib/streams"
+import type { SearchResultDisplayMode } from "@/lib/search-result-display-mode"
 import { RelativeTime } from "@/components/relative-time"
 import { cn } from "@/lib/utils"
 import { useActors } from "@/hooks/use-actors"
@@ -14,43 +15,94 @@ import { groupResultsByStream } from "./group-results"
 interface SearchResultsProps {
   workspaceId: string
   results: SearchResultItem[]
-  /** Highlightable free-text terms from the query. */
   terms: string[]
-  /** Message id of the result the user last opened (active row styling). */
   activeResultId: string | null
-  /** Called when the user opens a result (click or keyboard). */
   onResultSelect: (result: SearchResultItem) => void
+  mode: SearchResultDisplayMode
 }
 
-/** Per-ancestor-segment budget when truncating breadcrumbs (px). */
 const ANCESTOR_SEGMENT_WIDTH = 104
-/** Separator chevron width incl. gaps (px). */
 const SEPARATOR_WIDTH = 16
-/** Chrome around the breadcrumb: expand chevron, count badge, paddings (px). */
 const HEADER_CHROME_WIDTH = 72
-/** Minimum room the current (last) segment keeps for itself (px). */
 const CURRENT_SEGMENT_MIN_WIDTH = 72
 
-/**
- * Decide how many trailing ancestors fit next to the current label. Hidden
- * ancestors collapse into a leading "…" — the truncation leans toward the
- * end of the path ("… › Doubly nested thread"), matching the thread panel.
- */
 function visibleAncestorCount(ancestorCount: number, containerWidth: number): number {
   const available = containerWidth - HEADER_CHROME_WIDTH - CURRENT_SEGMENT_MIN_WIDTH
-  const perAncestor = ANCESTOR_SEGMENT_WIDTH + SEPARATOR_WIDTH
-  return Math.max(0, Math.min(ancestorCount, Math.floor(available / perAncestor)))
+  return Math.max(0, Math.min(ancestorCount, Math.floor(available / (ANCESTOR_SEGMENT_WIDTH + SEPARATOR_WIDTH))))
 }
 
-/**
- * Search results grouped by stream, VS Code search-panel style: collapsible
- * per-stream sections ordered as a depth-first walk of the stream tree
- * (channel first, then its threads by creation), dense rows with highlighted
- * match snippets. Thread groups carry their full nesting as a breadcrumb.
- * Rows are links to the stream focused on the matched message (`?m=`), so the
- * timeline scrolls to and highlights it (INV-40 — navigation is a link).
- */
-export function SearchResults({ workspaceId, results, terms, activeResultId, onResultSelect }: SearchResultsProps) {
+interface ResultRowProps {
+  workspaceId: string
+  result: SearchResultItem
+  terms: string[]
+  isActive: boolean
+  onResultSelect: (result: SearchResultItem) => void
+  actorName: string
+  streamLabel?: string
+  isResolving: boolean
+  isArchived: boolean
+}
+
+function ResultRow({
+  workspaceId,
+  result,
+  terms,
+  isActive,
+  onResultSelect,
+  actorName,
+  streamLabel,
+  isResolving,
+  isArchived,
+}: ResultRowProps) {
+  const snippet = buildSnippet(result.content, terms)
+  return (
+    <li>
+      <Link
+        to={`/w/${workspaceId}/s/${result.streamId}?m=${result.id}`}
+        onClick={() => onResultSelect(result)}
+        data-search-result-id={result.id}
+        aria-current={isActive ? "true" : undefined}
+        className={cn(
+          "block rounded-md border-l-2 py-1.5 pl-3 pr-2 transition-colors",
+          isActive ? "border-primary bg-accent" : "border-transparent hover:bg-muted/60"
+        )}
+      >
+        {streamLabel !== undefined && (
+          <p className="mb-0.5 flex h-3 items-center gap-1 text-[10px] leading-3 text-muted-foreground">
+            {isResolving ? (
+              <Loader2 className="h-3 w-3 shrink-0 animate-spin" aria-label="Loading stream" />
+            ) : (
+              <span className="min-w-0 truncate" data-search-stream-label={result.streamId}>
+                {streamLabel}
+              </span>
+            )}
+            <span className="h-3 w-3 shrink-0">
+              {isArchived && <Archive className="h-3 w-3 text-foreground" aria-label="Archived stream" role="img" />}
+            </span>
+          </p>
+        )}
+        <p className="text-xs leading-snug text-foreground/90 line-clamp-2 [overflow-wrap:anywhere]">
+          {snippet.truncatedStart && <span className="text-muted-foreground/60">…</span>}
+          <HighlightedText text={snippet.text} terms={terms} />
+        </p>
+        <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground/70">
+          <span className="min-w-0 truncate">{actorName}</span>
+          <span aria-hidden="true">·</span>
+          <RelativeTime date={result.createdAt} className="shrink-0 tabular-nums" />
+        </p>
+      </Link>
+    </li>
+  )
+}
+
+export function SearchResults({
+  workspaceId,
+  results,
+  terms,
+  activeResultId,
+  onResultSelect,
+  mode,
+}: SearchResultsProps) {
   const users = useWorkspaceUsers(workspaceId)
   const streams = useWorkspaceStreams(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -59,32 +111,40 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
     workspaceId,
     useMemo(() => results.map((result) => result.streamId), [results])
   )
-
   const [collapsedStreams, setCollapsedStreams] = useState<Set<string>>(new Set())
-
-  // Track the rendered width so breadcrumb truncation adapts to the sidebar
-  // width (resizable 200–400px) and the full-page layout alike.
   const containerRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState(260)
+
   useEffect(() => {
     const container = containerRef.current
-    if (!container) return
+    if (!container || mode !== "grouped") return
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) setContainerWidth(entry.contentRect.width)
     })
     observer.observe(container)
     setContainerWidth(container.offsetWidth)
     return () => observer.disconnect()
-  }, [])
+  }, [mode])
 
-  const streamsById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
+  const streamsById = useMemo(() => new Map(streams.map((stream) => [stream.id, stream])), [streams])
   const groups = useMemo(() => groupResultsByStream(results, streamsById), [results, streamsById])
+  const streamLabel = useMemo(() => {
+    const caches: StreamNameCaches = { streams, users, dmPeers }
+    return (streamId: string) => resolveStreamName(streamId, caches, "breadcrumb") ?? "Unknown stream"
+  }, [streams, users, dmPeers])
+  const isArchived = useCallback(
+    (streamId: string, fallbackRootId?: string) => {
+      const stream = streamsById.get(streamId)
+      const rootStreamId =
+        stream?.rootStreamId ?? (stream?.parentStreamId ? fallbackRootId : (stream?.id ?? fallbackRootId))
+      return rootStreamId ? streamsById.get(rootStreamId)?.archivedAt != null : false
+    },
+    [streamsById]
+  )
 
-  // Keyboard navigation can land on a result inside a collapsed group —
-  // reveal it rather than highlighting an invisible row.
   useEffect(() => {
-    if (!activeResultId) return
-    const streamId = results.find((r) => r.id === activeResultId)?.streamId
+    if (mode !== "grouped" || !activeResultId) return
+    const streamId = results.find((result) => result.id === activeResultId)?.streamId
     if (!streamId) return
     setCollapsedStreams((current) => {
       if (!current.has(streamId)) return current
@@ -92,52 +152,59 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
       next.delete(streamId)
       return next
     })
-  }, [activeResultId, results])
-
-  const nodeLabel = useMemo(() => {
-    const caches: StreamNameCaches = { streams, users, dmPeers }
-    return (streamId: string) => resolveStreamName(streamId, caches, "breadcrumb") ?? "Unknown stream"
-  }, [streams, users, dmPeers])
+  }, [activeResultId, mode, results])
 
   const toggleGroup = useCallback((streamId: string) => {
     setCollapsedStreams((current) => {
       const next = new Set(current)
-      if (next.has(streamId)) {
-        next.delete(streamId)
-      } else {
-        next.add(streamId)
-      }
+      if (next.has(streamId)) next.delete(streamId)
+      else next.add(streamId)
       return next
     })
   }, [])
 
+  if (mode === "ranked") {
+    return (
+      <ul className="flex flex-col gap-0.5">
+        {results.map((result) => (
+          <ResultRow
+            key={result.id}
+            workspaceId={workspaceId}
+            result={result}
+            terms={terms}
+            isActive={result.id === activeResultId}
+            onResultSelect={onResultSelect}
+            actorName={getActorName(result.authorId, result.authorType)}
+            streamLabel={streamLabel(result.streamId)}
+            isResolving={resolvingStreamIds.has(result.streamId)}
+            isArchived={isArchived(result.streamId)}
+          />
+        ))}
+      </ul>
+    )
+  }
+
   return (
-    <div ref={containerRef} className="flex flex-col gap-0.5">
+    <div ref={containerRef} className="flex flex-col gap-1">
       {groups.map((group) => {
         const isCollapsed = collapsedStreams.has(group.streamId)
-        const pathLabels = group.path.map(nodeLabel)
+        const pathLabels = group.path.map(streamLabel)
         const currentLabel = pathLabels[pathLabels.length - 1] ?? "Unknown stream"
         const ancestors = pathLabels.slice(0, -1)
         const shownCount = visibleAncestorCount(ancestors.length, containerWidth)
         const shownAncestors = shownCount > 0 ? ancestors.slice(ancestors.length - shownCount) : []
         const hasHidden = ancestors.length > shownCount
-        const isResolving = resolvingStreamIds.has(group.streamId)
-        const stream = streamsById.get(group.streamId)
-        const rootStreamId =
-          stream?.rootStreamId ?? (stream?.parentStreamId ? group.path[0] : (stream?.id ?? group.path[0]))
-        const isArchived = rootStreamId ? streamsById.get(rootStreamId)?.archivedAt != null : false
-
+        const archived = isArchived(group.streamId, group.path[0])
         return (
-          <section key={group.streamId} className={cn(isArchived && "opacity-60")}>
+          <section key={group.streamId}>
             <button
               type="button"
               onClick={() => toggleGroup(group.streamId)}
               aria-expanded={!isCollapsed}
               title={pathLabels.join(" › ")}
               className={cn(
-                "flex w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-left",
-                "text-xs font-semibold text-foreground/90 transition-colors hover:bg-muted/60",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                "flex w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-left text-xs font-semibold transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                archived ? "text-muted-foreground" : "text-foreground/90"
               )}
             >
               {isCollapsed ? (
@@ -162,7 +229,7 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
                   <ChevronRight className="h-2.5 w-2.5 shrink-0 text-muted-foreground/50" aria-hidden="true" />
                 </span>
               ))}
-              {isResolving ? (
+              {resolvingStreamIds.has(group.streamId) ? (
                 <Loader2
                   className="h-3 w-3 shrink-0 animate-spin text-muted-foreground/70"
                   aria-label="Loading stream"
@@ -171,45 +238,27 @@ export function SearchResults({ workspaceId, results, terms, activeResultId, onR
                 <span className="min-w-0 truncate">{currentLabel}</span>
               )}
               <span className="h-3 w-3 shrink-0">
-                {isArchived && <Archive className="h-3 w-3" aria-label="Archived stream" role="img" />}
+                {archived && <Archive className="h-3 w-3 text-foreground" aria-label="Archived stream" role="img" />}
               </span>
               <span className="ml-auto shrink-0 rounded-full bg-muted px-1.5 py-px text-[10px] font-medium tabular-nums text-muted-foreground">
                 {group.results.length}
               </span>
             </button>
-
             {!isCollapsed && (
-              <ul className="mb-1 flex flex-col">
-                {group.results.map((result) => {
-                  const snippet = buildSnippet(result.content, terms)
-                  const isActive = result.id === activeResultId
-                  return (
-                    <li key={result.id}>
-                      <Link
-                        to={`/w/${workspaceId}/s/${result.streamId}?m=${result.id}`}
-                        onClick={() => onResultSelect(result)}
-                        data-search-result-id={result.id}
-                        aria-current={isActive ? "true" : undefined}
-                        className={cn(
-                          "block rounded-md border-l-2 py-1.5 pl-3 pr-2 ml-[5px] transition-colors",
-                          isActive
-                            ? "border-primary bg-accent"
-                            : "border-border/60 hover:border-border hover:bg-muted/50"
-                        )}
-                      >
-                        <p className="text-xs leading-snug text-foreground/90 line-clamp-2 [overflow-wrap:anywhere]">
-                          {snippet.truncatedStart && <span className="text-muted-foreground/60">…</span>}
-                          <HighlightedText text={snippet.text} terms={terms} />
-                        </p>
-                        <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground/70">
-                          <span className="min-w-0 truncate">{getActorName(result.authorId, result.authorType)}</span>
-                          <span aria-hidden="true">·</span>
-                          <RelativeTime date={result.createdAt} className="shrink-0 tabular-nums" />
-                        </p>
-                      </Link>
-                    </li>
-                  )
-                })}
+              <ul className="mb-1 ml-2 flex flex-col gap-px">
+                {group.results.map((result) => (
+                  <ResultRow
+                    key={result.id}
+                    workspaceId={workspaceId}
+                    result={result}
+                    terms={terms}
+                    isActive={result.id === activeResultId}
+                    onResultSelect={onResultSelect}
+                    actorName={getActorName(result.authorId, result.authorType)}
+                    isResolving={false}
+                    isArchived={false}
+                  />
+                ))}
               </ul>
             )}
           </section>

--- a/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
@@ -199,6 +199,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     mockNavigate.mockReset()
+    localStorage.clear()
     workspaceStreams = mockStreamsList
     mockSearchState.results = []
     mockSearchState.isLoading = false
@@ -282,6 +283,48 @@ describe("SidebarSearchPanel Integration Tests", () => {
       expect(markTexts).toContain("hello")
     })
 
+    it("defaults to grouped results and persists ranked mode per workspace in API order", async () => {
+      mockSearchState.results = [mockSearchResultsList[1]!, mockSearchResultsList[0]!]
+      const user = userEvent.setup()
+      const view = renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      expect(await screen.findByText("#general")).toBeInTheDocument()
+      await user.click(screen.getByRole("radio", { name: "Ranked results" }))
+
+      await waitFor(() => expect(document.querySelector("section")).toBeNull())
+      expect(
+        Array.from(document.querySelectorAll("[data-search-result-id]"), (row) =>
+          row.getAttribute("data-search-result-id")
+        )
+      ).toEqual(["msg_2", "msg_1"])
+      expect(document.querySelectorAll("[data-search-stream-label]")).toHaveLength(2)
+      expect(localStorage.getItem("threa-search-result-display:workspace_1")).toBe("ranked")
+
+      view.unmount()
+      renderPanel()
+      const persistedEditor = screen.getByLabelText("Search messages")
+      await user.click(persistedEditor)
+      await user.type(persistedEditor, "hello")
+      await waitFor(() => expect(document.querySelector("section")).toBeNull())
+    })
+
+    it("shows archived stream metadata on ranked rows", async () => {
+      workspaceStreams = [{ ...mockStreamsList[0]!, archivedAt: "2026-01-01T00:00:00Z" }]
+      mockSearchState.results = [{ ...mockSearchResultsList[0]!, streamId: mockStreamsList[0]!.id }]
+      localStorage.setItem("threa-search-result-display:workspace_1", "ranked")
+      const user = userEvent.setup()
+      renderPanel()
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      await user.type(editor, "hello")
+
+      expect(await screen.findByLabelText("Archived stream")).toBeInTheDocument()
+      expect(document.querySelector(`[data-search-stream-label="${mockStreamsList[0]!.id}"]`)).toBeInTheDocument()
+    })
+
     it("preserves phrase-only highlighting and snippet positioning", async () => {
       mockSearchState.results = [
         {
@@ -331,7 +374,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       expect(await screen.findByText("Search Bot")).toBeInTheDocument()
     })
 
-    it("mutes a thread result when its root stream is archived", async () => {
+    it("marks a thread result archived when its root stream is archived", async () => {
       const root = { ...mockStreamsList[0]!, archivedAt: "2026-01-01T00:00:00Z" }
       const thread = { ...mockStreamsList[1]!, id: "stream_thread1", parentStreamId: root.id, rootStreamId: root.id }
       workspaceStreams = [root, thread]
@@ -343,11 +386,10 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await user.click(editor)
       await user.type(editor, "hello")
 
-      const archive = await screen.findByLabelText("Archived stream")
-      expect(archive.closest("section")).toHaveClass("opacity-60")
+      expect(await screen.findByLabelText("Archived stream")).toBeInTheDocument()
     })
 
-    it("mutes a nested thread result when its cached root is archived but its parent is missing", async () => {
+    it("marks a nested thread result archived when its cached root is archived but its parent is missing", async () => {
       const root = { ...mockStreamsList[0]!, archivedAt: "2026-01-01T00:00:00Z" }
       const nestedThread = {
         ...mockStreamsList[1]!,
@@ -364,11 +406,11 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await user.click(editor)
       await user.type(editor, "hello")
 
-      const archive = await screen.findByLabelText("Archived stream")
-      expect(archive.closest("section")).toHaveClass("opacity-60")
+      expect(await screen.findByLabelText("Archived stream")).toBeInTheDocument()
     })
 
-    it("loads a missing result stream once, then renders its cached name", async () => {
+    it("shows ranked loading metadata until a missing stream resolves once", async () => {
+      localStorage.setItem("threa-search-result-display:workspace_1", "ranked")
       let resolveStream: (stream: (typeof mockStreamsList)[number]) => void
       const get = vi.fn(
         () =>
@@ -459,8 +501,9 @@ describe("SidebarSearchPanel Integration Tests", () => {
       expect(screen.getByText(/from the search results/)).toBeInTheDocument()
     })
 
-    it("navigates to the stream focused on the message when clicking a result", async () => {
+    it("uses ranked result Links to navigate to the focused message", async () => {
       mockSearchState.results = mockSearchResultsList
+      localStorage.setItem("threa-search-result-display:workspace_1", "ranked")
 
       const user = userEvent.setup()
       renderPanel()
@@ -481,7 +524,7 @@ describe("SidebarSearchPanel Integration Tests", () => {
       expect(screen.getByTestId("search-panel-probe")).toHaveAttribute("data-open", "true")
     })
 
-    it("steps through results with ArrowDown and opens the active one with Enter", async () => {
+    it("keeps API-order keyboard navigation after switching to ranked", async () => {
       mockSearchState.results = mockSearchResultsList
 
       const user = userEvent.setup()
@@ -494,10 +537,12 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await waitFor(() => {
         expect(screen.getByText(/from the search results/)).toBeInTheDocument()
       })
+      await user.click(screen.getByRole("radio", { name: "Ranked results" }))
+      await user.click(editor)
 
       await user.keyboard("{ArrowDown}{ArrowDown}")
 
-      // Second result is now active
+      // Second API result is now active
       const activeRow = document.querySelector('[aria-current="true"]')
       expect(activeRow?.textContent).toContain("Another search result message")
 

--- a/apps/frontend/src/components/search/sidebar-search-panel.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.tsx
@@ -15,6 +15,8 @@ import { extractSearchTerms } from "./highlight"
 import { SearchFilterChips } from "./search-filter-chips"
 import { SearchFilterMenu } from "./search-filter-menu"
 import { SearchResults } from "./search-results"
+import { SearchResultDisplayToggle } from "./search-result-display-toggle"
+import { useStoredSearchResultDisplayMode } from "@/lib/search-result-display-mode"
 
 /**
  * Desktop sidebar in search mode — VS Code-style: the stream list swaps for a
@@ -31,6 +33,7 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
   )
   const displayError = validationError ?? (error ? "Search failed. Try again." : null)
   const { preferences } = usePreferences()
+  const [displayMode, setDisplayMode] = useStoredSearchResultDisplayMode(workspaceId)
 
   const inputRef = useRef<RichInputRef>(null)
   const resultsRef = useRef<HTMLDivElement>(null)
@@ -161,11 +164,14 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
           </div>
 
           {hasQuery && !isLoading && !displayError && (
-            <p className="px-3 pb-2 text-[11px] tabular-nums text-muted-foreground/70">
-              {results.length === 0
-                ? "No results"
-                : `${results.length} result${results.length === 1 ? "" : "s"} in ${streamCount} stream${streamCount === 1 ? "" : "s"}`}
-            </p>
+            <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1.5 px-3 pb-2">
+              <p className="min-w-0 truncate text-[11px] tabular-nums text-muted-foreground">
+                {results.length === 0
+                  ? "No results"
+                  : `${results.length} result${results.length === 1 ? "" : "s"} in ${streamCount} stream${streamCount === 1 ? "" : "s"}`}
+              </p>
+              <SearchResultDisplayToggle value={displayMode} onChange={setDisplayMode} />
+            </div>
           )}
         </div>
       }
@@ -199,6 +205,7 @@ export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
               terms={terms}
               activeResultId={activeResultId}
               onResultSelect={handleResultSelect}
+              mode={displayMode}
             />
           )}
 

--- a/apps/frontend/src/lib/search-result-display-mode.test.tsx
+++ b/apps/frontend/src/lib/search-result-display-mode.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  readStoredSearchResultDisplayMode,
+  useStoredSearchResultDisplayMode,
+  writeStoredSearchResultDisplayMode,
+} from "./search-result-display-mode"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe("search result display mode", () => {
+  it("keeps preferences isolated by workspace", () => {
+    writeStoredSearchResultDisplayMode("workspace_1", "ranked")
+
+    expect(readStoredSearchResultDisplayMode("workspace_1")).toBe("ranked")
+    expect(readStoredSearchResultDisplayMode("workspace_2")).toBe("grouped")
+  })
+
+  it("falls back to grouped when localStorage cannot be read or written", () => {
+    const getItem = vi.fn(() => {
+      throw new Error("Storage unavailable")
+    })
+    const setItem = vi.fn(() => {
+      throw new Error("Storage unavailable")
+    })
+    vi.stubGlobal("localStorage", { getItem, setItem })
+
+    expect(readStoredSearchResultDisplayMode("workspace_1")).toBe("grouped")
+    expect(() => writeStoredSearchResultDisplayMode("workspace_1", "ranked")).not.toThrow()
+    expect(setItem).toHaveBeenCalledWith("threa-search-result-display:workspace_1", "ranked")
+  })
+
+  it("reloads the workspace-specific preference when the workspace changes", () => {
+    writeStoredSearchResultDisplayMode("workspace_2", "ranked")
+    const { result, rerender } = renderHook(({ workspaceId }) => useStoredSearchResultDisplayMode(workspaceId), {
+      initialProps: { workspaceId: "workspace_1" },
+    })
+
+    expect(result.current[0]).toBe("grouped")
+    rerender({ workspaceId: "workspace_2" })
+    expect(result.current[0]).toBe("ranked")
+
+    act(() => result.current[1]("grouped"))
+    expect(readStoredSearchResultDisplayMode("workspace_2")).toBe("grouped")
+    expect(readStoredSearchResultDisplayMode("workspace_1")).toBe("grouped")
+  })
+})

--- a/apps/frontend/src/lib/search-result-display-mode.ts
+++ b/apps/frontend/src/lib/search-result-display-mode.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from "react"
+
+export type SearchResultDisplayMode = "grouped" | "ranked"
+
+function storageKey(workspaceId: string): string {
+  return `threa-search-result-display:${workspaceId}`
+}
+
+export function readStoredSearchResultDisplayMode(workspaceId: string): SearchResultDisplayMode {
+  try {
+    return localStorage.getItem(storageKey(workspaceId)) === "ranked" ? "ranked" : "grouped"
+  } catch {
+    return "grouped"
+  }
+}
+
+export function writeStoredSearchResultDisplayMode(workspaceId: string, mode: SearchResultDisplayMode): void {
+  try {
+    localStorage.setItem(storageKey(workspaceId), mode)
+  } catch {
+    // localStorage can throw (private mode, quota); the preference is best-effort
+  }
+}
+
+export function useStoredSearchResultDisplayMode(
+  workspaceId: string
+): [SearchResultDisplayMode, (next: SearchResultDisplayMode) => void] {
+  const [mode, setModeState] = useState<SearchResultDisplayMode>(() => readStoredSearchResultDisplayMode(workspaceId))
+  useEffect(() => {
+    setModeState(readStoredSearchResultDisplayMode(workspaceId))
+  }, [workspaceId])
+  const setMode = useCallback(
+    (next: SearchResultDisplayMode) => {
+      setModeState(next)
+      writeStoredSearchResultDisplayMode(workspaceId, next)
+    },
+    [workspaceId]
+  )
+  return [mode, setMode]
+}

--- a/apps/frontend/src/pages/search.test.tsx
+++ b/apps/frontend/src/pages/search.test.tsx
@@ -1,0 +1,108 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { SidebarProvider } from "@/contexts/sidebar-context"
+import { SearchPanelProvider } from "@/components/search/search-panel-context"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { mockSearchResultsList } from "@/test/fixtures/messages"
+import { mockStreamsList } from "@/test/fixtures"
+import { mockUsersList } from "@/test/fixtures/users"
+import * as hooksModule from "@/hooks"
+import * as mentionablesModule from "@/hooks/use-mentionables"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as contextsModule from "@/contexts"
+import { SearchPage } from "./search"
+
+const search = vi.fn()
+const clear = vi.fn()
+
+function LocationProbe() {
+  const location = useLocation()
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+}
+
+function renderPage() {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/w/workspace_1/search?q=hello"]}>
+          <SidebarProvider>
+            <SearchPanelProvider workspaceId="workspace_1">
+              <Routes>
+                <Route path="/w/:workspaceId/search" element={<SearchPage />} />
+              </Routes>
+              <LocationProbe />
+            </SearchPanelProvider>
+          </SidebarProvider>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe("SearchPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    search.mockReset()
+    clear.mockReset()
+    vi.spyOn(hooksModule, "useSearch").mockReturnValue({
+      results: [mockSearchResultsList[1]!, mockSearchResultsList[0]!],
+      isLoading: false,
+      error: null,
+      search,
+      clear,
+    } as unknown as ReturnType<typeof hooksModule.useSearch>)
+    vi.spyOn(mentionablesModule, "useMentionables").mockReturnValue({
+      mentionables: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof mentionablesModule.useMentionables>)
+    vi.spyOn(mentionablesModule, "filterMentionables").mockImplementation((items) => items)
+    vi.spyOn(mentionablesModule, "filterSearchMentionables").mockImplementation((items) => items)
+    vi.spyOn(mentionablesModule, "filterUsersOnly").mockImplementation((items) => items)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(
+      mockStreamsList as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+    )
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue(
+      mockUsersList as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>
+    )
+    vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([])
+    vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+      preferences: null,
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+    vi.spyOn(contextsModule, "useStreamService").mockReturnValue({ get: vi.fn() } as never)
+  })
+
+  it("shares ranked mode, API order, Link navigation, and touch-sized controls with the sidebar", async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    expect(await screen.findByText("#general")).toBeInTheDocument()
+    const ranked = screen.getByRole("radio", { name: "Ranked results" })
+    expect(ranked).toHaveClass("h-9")
+    await user.click(ranked)
+
+    expect(
+      Array.from(document.querySelectorAll("[data-search-result-id]"), (row) =>
+        row.getAttribute("data-search-result-id")
+      )
+    ).toEqual(["msg_2", "msg_1"])
+    expect(localStorage.getItem("threa-search-result-display:workspace_1")).toBe("ranked")
+
+    await user.click(screen.getByText(/from the search results/))
+    expect(screen.getByTestId("location")).toHaveTextContent("/w/workspace_1/s/stream_channel1?m=msg_1")
+  })
+
+  it("uses the persisted workspace-specific display mode", async () => {
+    localStorage.setItem("threa-search-result-display:workspace_1", "ranked")
+    localStorage.setItem("threa-search-result-display:workspace_2", "grouped")
+    renderPage()
+
+    await waitFor(() => expect(document.querySelector("section")).toBeNull())
+    expect(screen.getByRole("radio", { name: "Ranked results" })).toHaveAttribute("data-state", "on")
+  })
+})

--- a/apps/frontend/src/pages/search.tsx
+++ b/apps/frontend/src/pages/search.tsx
@@ -12,6 +12,8 @@ import { extractSearchTerms } from "@/components/search/highlight"
 import { SearchFilterChips } from "@/components/search/search-filter-chips"
 import { SearchFilterMenu } from "@/components/search/search-filter-menu"
 import { SearchResults } from "@/components/search/search-results"
+import { SearchResultDisplayToggle } from "@/components/search/search-result-display-toggle"
+import { useStoredSearchResultDisplayMode } from "@/lib/search-result-display-mode"
 import { useInputMode } from "@/hooks/use-input-mode"
 
 /**
@@ -66,6 +68,7 @@ export function SearchPage() {
   )
   const displayError = validationError ?? (error ? "Search failed. Try again." : null)
   const terms = useMemo(() => extractSearchTerms(searchText), [searchText])
+  const [displayMode, setDisplayMode] = useStoredSearchResultDisplayMode(workspaceId ?? "")
 
   if (!workspaceId) {
     return null
@@ -110,6 +113,9 @@ export function SearchPage() {
             onQueryChange={handleQueryChange}
             className="h-7"
           />
+          {hasQuery && !isLoading && !displayError && (
+            <SearchResultDisplayToggle value={displayMode} onChange={setDisplayMode} size="touch" className="ml-auto" />
+          )}
         </div>
       </header>
 
@@ -147,6 +153,7 @@ export function SearchPage() {
               terms={terms}
               activeResultId={activeResultId}
               onResultSelect={(result) => setActiveResultId(result.id)}
+              mode={displayMode}
             />
           )}
 


### PR DESCRIPTION
## Problem

Grouping search results by stream preserves conversation context but hides the global relevance order. Users need both the existing grouped view and a flat best-match-first view without losing result metadata or navigation behavior.

## Solution

Add a persisted Grouped/Ranked display preference shared by desktop sidebar and mobile search.

- Grouped remains the default and preserves collapsible stream ordering.
- Ranked renders the backend response order unchanged, with a tiny stream label above each shared result row.
- Both modes reuse the same Link, stripped/highlighted snippet, actor/time metadata, loading state, and inherited archive styling.
- The mode is stored per workspace; unavailable localStorage reads default to Grouped; failed writes keep the in-memory choice without breaking search.
- Compact labeled ToggleGroup controls are keyboard- and touch-operable on both surfaces.
- Segmented mode chrome, indented grouped rows, borderless inactive ranked rows, full-contrast archived snippets, and stronger match weight align the surface with Threa’s compact warm UI.

## Screenshots

**Grouped**

![Grouped search results](https://seer.build/ws_vbyzjvdg6g/i/img_42m28d313g/search-sidebar-grouped-fable.webp)

**Ranked**

![Ranked search results](https://seer.build/ws_vbyzjvdg6g/i/img_bts44kpvzt/search-sidebar-ranked-fable.webp)

## Files

| File | Change |
| --- | --- |
| `search-results.tsx` | Shared row primitive plus Grouped and Ranked renderers. |
| `search-result-display-toggle.tsx` | **New:** accessible Grouped/Ranked control. |
| `search-result-display-mode.ts` | **New:** per-workspace preference hook with safe storage fallback. |
| `sidebar-search-panel.tsx` | Desktop mode control and renderer wiring. |
| `pages/search.tsx` | Mobile/full-page mode parity. |
| Search tests | Persistence, failure fallback, ranked order/metadata/navigation, keyboard, and mobile coverage. |

## Test plan

- [x] Targeted display-mode, sidebar, and mobile search tests — 42 passed
- [x] Repository-wide lint and TypeScript checks — passed via pre-commit
- [ ] Manual browser verification — not run

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Let users choose conversation-oriented grouping or global relevance ordering while preserving one metadata and navigation path.

## What Was Built

### Persisted display mode

- `useStoredSearchResultDisplayMode` defaults to Grouped and stores one value per workspace.
- Storage read failures default to Grouped; write failures leave the selected mode in memory for the current session.
- Sidebar and mobile page render the same labeled ToggleGroup control.

### Ranked results

- Iterate the API result array directly; no client-side reorder.
- Render resolved stream name in tiny muted metadata above the snippet.
- Carry unresolved-name loader and inherited archive icon/muting from the metadata PR.

### Shared rows

- `ResultRow` owns Link navigation, active state, snippet/highlighting, actor, and time.
- Grouped owns only stream headers/collapse behavior; Ranked owns only flat ordering and stream metadata.

## Design Decisions

- Local display preference over URL state: the desktop sidebar has no search route, and mode does not change the selected resource.
- Labeled controls over icon-only buttons: both modes remain discoverable at sidebar and touch sizes.
- Backend order over client reranking: `rank` remains authoritative and stable.

## What's NOT Included

- No backend, ranking, grouping-algorithm, or schema changes.
- Manual visual QA remains pending.

## Status

- [x] Grouped mode
- [x] Ranked mode
- [x] Per-workspace persistence
- [x] Desktop/mobile parity
- [x] Targeted tests and typecheck

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_



