### PR TITLE
fix(frontend): stop the AI usage header from breaking on mobile

### DIFF
--- a/apps/frontend/src/components/layout/sidebar-toggle.tsx
+++ b/apps/frontend/src/components/layout/sidebar-toggle.tsx
@@ -41,7 +41,9 @@ export function SidebarToggle({ location, className }: SidebarToggleProps) {
   return (
     <div
       className={cn(
-        "flex items-center overflow-hidden transition-[width,margin,transform,opacity] duration-200 ease-out",
+        // shrink-0: overflow-hidden below means a squeezed wrapper slices the
+        // button rather than fitting it. Crowded headers shrink the title.
+        "flex shrink-0 items-center overflow-hidden transition-[width,margin,transform,opacity] duration-200 ease-out",
         hidden ? "pointer-events-none ml-0 -mr-2 w-0 -translate-x-2 opacity-0" : cn("w-8 opacity-100", offsetClass),
         className
       )}

--- a/apps/frontend/src/pages/ai-usage-admin.tsx
+++ b/apps/frontend/src/pages/ai-usage-admin.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, useParams, useSearchParams } from "react-router-dom"
 import { ArrowLeft, DollarSign } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { useAIBudget, useAIUsage, useUpdateAIBudget } from "@/hooks"
 import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
@@ -160,18 +161,22 @@ export function AIUsageAdminPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 items-center gap-2 border-b px-4">
-        <SidebarToggle location="page" />
-        <Link to={`/w/${workspaceId}`}>
-          <Button variant="ghost" size="icon" className="h-8 w-8">
+      {/* Two rows on mobile — the zone label can't truncate usefully, and on one
+          phone row it swallows the title. Same shape as PageHeaderTabs. */}
+      <header className="flex flex-col gap-1 border-b px-4 py-2 sm:h-12 sm:flex-row sm:items-center sm:gap-2 sm:py-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <SidebarToggle location="page" />
+          <Link
+            to={`/w/${workspaceId}`}
+            className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "h-8 w-8 shrink-0")}
+            aria-label="Back to workspace"
+          >
             <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
-        <div className="flex items-center gap-2">
-          <DollarSign className="h-5 w-5 text-muted-foreground" />
-          <h1 className="font-semibold">AI Usage &amp; Budget</h1>
+          </Link>
+          <DollarSign className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <h1 className="truncate font-semibold">AI Usage &amp; Budget</h1>
         </div>
-        <div className="ml-auto">
+        <div className="flex min-w-0 sm:ml-auto sm:shrink-0">
           <UsageTimezoneSelector
             mode={tzMode}
             onModeChange={setTzMode}


### PR DESCRIPTION
Reported from a phone: the AI Usage header was unreadable.

## Problem

**Before** (360px):

![before](https://seer.build/ws_vbyzjvdg6g/i/img_wvcqa6s499/ai-usage-header-before-c3dd95.webp)

The title wraps to three lines inside a fixed `h-12`, spilling 24px past the border top and bottom; the sidebar toggle is gone entirely; the timezone selector truncates to `Your...`.

Two causes:

1. **`SidebarToggle` had `w-8` but no `shrink-0`** (`sidebar-toggle.tsx:43`). As a flex child that width is only a basis, so a crowded header squeezes the wrapper and its own `overflow-hidden` slices the 32px button inside. Measured at 360px: a **16px button in a 1px wrapper**. Latent in every header using it, not just this page — `files.tsx`, `app-status.tsx`, and `drafts.tsx` share the exposure.
2. **This header skipped the house pattern** the sibling headers follow (`board.tsx:718`, `label-detail.tsx:172`, `PageHeaderTabs`): no `min-w-0` on the title group, no `truncate` on the `h1`, no `shrink-0` on the icon or the right-hand control. Nothing stopped the unbreakable title box from winning the flex fight.

## Solution

**After:**

![after](https://seer.build/ws_vbyzjvdg6g/i/img_ejwk1ax6dr/ai-usage-header-after-47b65c.webp)

- `shrink-0` on the `SidebarToggle` wrapper — fixes the clipping at its source rather than per-caller.
- House-pattern classes on the header: `min-w-0` title group, `truncate` `h1`, `shrink-0` on the icon and the selector wrapper.
- **Two rows below `sm:`, unchanged 48px row above it.** The title and the selector genuinely don't fit one phone row — the selector carries a zone label (`Europe/Stockholm · UTC+2`) that truncates to nothing useful, and `PageHeaderTabs` already stacks for exactly this reason ("on mobile there isn't room for both — the non-shrinking chips would otherwise swallow the title").
- Back link uses `buttonVariants` on the `Link` instead of nesting a `<Button>` inside an `<a>` (invalid nesting; sibling headers already do it this way).

## Measured at 360px

| | before | after |
| --- | --- | --- |
| title box height | 72px (3 lines) | 24px (1 line) |
| spill past header | h1 + wrapper 24px, zone label 15px | none |
| sidebar toggle | 16px button in a 1px wrapper | 32px in 32px |
| horizontal page overflow | 0px | 0px |
| desktop header height | 48px | 48px |

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar-toggle.tsx` | `shrink-0` on the wrapper |
| `apps/frontend/src/pages/ai-usage-admin.tsx` | House-pattern classes; two-row header below `sm:`; `buttonVariants` back link |

## Out of scope (deliberate)

- **The other headers missing the house pattern** (`files.tsx:13`, `app-status.tsx:155`, `drafts.tsx:244`) — their titles are short enough not to wrap today, and the `shrink-0` fix here already protects their toggles. Worth a sweep, but not smuggled into a bug fix.
- **The hero card's chart legend** wraps awkwardly at 360px ("Over budget" drops to its own right-aligned line). Visible in the full-page screenshot, unrelated to the header, and pre-existing.

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] Frontend full suite — 4510 pass, 0 fail (`SidebarToggle` renders in most headers, so the whole suite is the relevant blast radius)
- [x] `apps/frontend` `layout` + `pages` — 306 pass
- [x] **Live at 360px** (`dev:test`, Playwright mobile emulation, `isMobile` + `hasTouch`): measurements in the table above, taken before and after on the same harness — not eyeballed against the reported screenshot
- [x] Live at 1280px — header unchanged at 48px, one row
- [ ] No unit test asserts the layout — the failure is geometric (a wrapped box overflowing a fixed height), which jsdom cannot measure; covered by the live measurements instead

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787115685&installation_id=129946197&pr_number=1439&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1439&signature=2c7304c81c411ad08c63bdada657e222aab6f10a1fb5e0d19a26b3818c6a6b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->