### PR TITLE
docs: capture GitHub stack merge web request

### DIFF
--- a/docs/investigations/github-stacked-pr-merge.md
+++ b/docs/investigations/github-stacked-pr-merge.md
@@ -19,3 +19,31 @@ The stack resource includes its base and ordered pull requests. Pull request res
 GitHub's [stacked PR guide](https://github.github.com/gh-stack/guides/stacked-prs/#merging-a-stack) defines merge by position: merging a pull request also merges every unmerged pull request below it. Merging the top pull request lands the whole stack; merging the bottom lands only that pull request. Remaining pull requests are rebased and retargeted after a partial merge.
 
 The documented REST surface does not include the merge operation used by the web UI.
+
+## Web merge request
+
+The pull request UI performs a stack merge through an internal website endpoint on the selected pull request:
+
+```http
+POST /{owner}/{repo}/pull/{pull_number}/page_data/enqueue_stack
+```
+
+```json
+{
+  "commitTitle": "…",
+  "commitMessage": "…",
+  "mergeMethod": "SQUASH"
+}
+```
+
+`mergeMethod` accepts `MERGE`, `SQUASH`, or `REBASE`. The UI also sends `authorEmail` when the account has selectable commit emails. Selecting a pull request merges that pull request and every unmerged entry below it, so the top pull request selects the whole stack.
+
+This is a website route, not an `api.github.com` REST endpoint. It requires an authenticated GitHub web session and the page's rotating `X-Fetch-Nonce`, along with GitHub's verified-fetch headers. A GitHub API token does not authenticate this route.
+
+## Probe results
+
+- `POST` probes of `/stacks/{number}/merge`, `/merges`, `/stack-merge`, `/enqueue`, and `/enqueue_stack` all returned `404 Not Found` through `gh api`.
+- A token-authenticated request to the website route failed before reaching the handler.
+- An authenticated browser replay against completed stack 1437 reached the handler and returned `422` because the stack was already merged. The stack resource was unchanged.
+
+A token-only `gh` command therefore cannot reproduce the web merge. Browser automation can invoke the route, but depends on private website behavior and a live browser session. Keep the documented per-layer CLI merge procedure as the non-browser fallback.


### PR DESCRIPTION
## Problem

GitHub documents stack management but not the server-side operation behind “Merge stack.” Token-authenticated API probing alone cannot distinguish that website-only operation.

## Solution

Extend `docs/investigations/github-stacked-pr-merge.md` with the captured `page_data/enqueue_stack` route, request payload, browser-session requirements, replay result, and token-only CLI verdict.

## Test plan

- [x] `git diff --check`
- [x] authenticated replay against completed stack 1437 returned `422`; stack resource remained unchanged
- [x] pre-commit lint, typecheck, Dockerfile/migration checks, Astro checks, and generated API docs check

---

<sub>Stack 2/2 · created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>


## Live validation

- GitHub stack `#1443`: PRs `#1441` → `#1442`.
- `POST /threahq/threa/pull/1442/page_data/enqueue_stack` returned `200` with `Stack enqueue request successfully created`.
- `#1441` squash-merged at `09:37:08Z`; `#1442` at `09:37:09Z`.
- `main` advanced from `4f9a3ac5` to `75c744a5`; both PRs report `MERGED` and stack `open: false`.
