### PR TITLE
fix(harnessd): back off probes for durably inaccessible scratchpads

### DIFF
--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -25,7 +25,10 @@ import {
   latestAgents,
   parseScratchpadUrl,
   preflightRuntimeSession,
+  probeSuppressed,
   recordedNoYolo,
+  withProbeBackoff,
+  withoutProbeBackoff,
   type RuntimePreflightResult,
   type ScratchpadStatus,
 } from "./resume"
@@ -131,7 +134,10 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
         if (!options.dryRun) ensureTmuxSession(session, true)
         // Unarchive/boot revival restores pruned worktrees: unarchiving on Threa
         // is an explicit revive request. Manual `up` requires --recreate-worktree.
-        const unavailable = await resumeActive({ ...options, tmux: session, recreateWorktree: true }, target)
+        const unavailable = await resumeActive(
+          { ...options, tmux: session, recreateWorktree: true, respectProbeBackoff: true },
+          target
+        )
         if (!unavailable) {
           // A targeted restore event must not cancel an outstanding full
           // reconnect catch-up: another dormant runtime may still need it.
@@ -313,12 +319,29 @@ export async function reviveAgent(
   const targetWorkspaceId = scratchpad.workspaceId || workspaceId
   if (!targetWorkspaceId || !apiKey) return { status: "skipped missing credentials" }
 
+  // A targeted restore event is the server saying this stream is live again, so it
+  // always probes; only the untargeted sweep honours the backoff.
+  if (options.respectProbeBackoff && !target && probeSuppressed(agent, Date.now())) {
+    return { status: "skipped inaccessible", detail: `probe suppressed until ${agent.probeBackoffUntil}` }
+  }
   const status = await deps.scratchpadStatus({
     baseUrl,
     workspaceId: targetWorkspaceId,
     apiKey,
     streamId: scratchpad.streamId,
   })
+  if (status === "inaccessible") {
+    const backedOff = withProbeBackoff(agent, { intervalMs: watchIntervalMs(), nowMs: Date.now() })
+    if (!options.dryRun) deps.persist(backedOff)
+    return { status: "skipped inaccessible", detail: `next probe after ${backedOff.probeBackoffUntil}` }
+  }
+  if (status !== "unavailable") {
+    const cleared = withoutProbeBackoff(agent, Date.now())
+    if (cleared) {
+      if (!options.dryRun) deps.persist(cleared)
+      agent = cleared
+    }
+  }
   if (status !== "active") return { status: `skipped ${status}` }
   if (agent.runtime === "pi" && !agent.runtimeSessionId) {
     return { status: "skipped missing session id", detail: "original Pi --session-id is not recorded" }

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -24,6 +24,8 @@ interface ManagedAgentRow {
   created_at: string
   updated_at: string
   last_output: string | null
+  probe_failures: number | null
+  probe_backoff_until: string | null
 }
 
 export function inventoryPath(): string {
@@ -50,15 +52,24 @@ function openInventory(): Database {
       command_json TEXT NOT NULL,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
-      last_output TEXT
+      last_output TEXT,
+      probe_failures INTEGER,
+      probe_backoff_until TEXT
     )
   `)
   // Inventories predating the window-id column: CREATE TABLE IF NOT EXISTS
   // won't extend an existing table, so add the column in place.
   const columns = db.query("PRAGMA table_info(managed_agents)").all() as Array<{ name: string }>
-  for (const column of ["tmux_window_id", "instance_id", "runtime_session_id"]) {
+  const added: Array<[string, string]> = [
+    ["tmux_window_id", "TEXT"],
+    ["instance_id", "TEXT"],
+    ["runtime_session_id", "TEXT"],
+    ["probe_failures", "INTEGER"],
+    ["probe_backoff_until", "TEXT"],
+  ]
+  for (const [column, type] of added) {
     if (!columns.some((existing) => existing.name === column)) {
-      db.exec(`ALTER TABLE managed_agents ADD COLUMN ${column} TEXT`)
+      db.exec(`ALTER TABLE managed_agents ADD COLUMN ${column} ${type}`)
     }
   }
   return db
@@ -82,6 +93,8 @@ function rowToAgent(row: ManagedAgentRow): ManagedAgent {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     lastOutput: row.last_output ?? undefined,
+    probeFailures: row.probe_failures ?? undefined,
+    probeBackoffUntil: row.probe_backoff_until ?? undefined,
   }
 }
 
@@ -104,8 +117,8 @@ export function upsertAgent(agent: ManagedAgent): void {
       INSERT INTO managed_agents (
         id, name, runtime, status, worktree, branch, tmux_session, tmux_window,
         tmux_window_id, scratchpad_url, instance_id, runtime_session_id, command_json,
-        created_at, updated_at, last_output
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, last_output, probe_failures, probe_backoff_until
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         runtime = excluded.runtime,
@@ -120,7 +133,9 @@ export function upsertAgent(agent: ManagedAgent): void {
         runtime_session_id = excluded.runtime_session_id,
         command_json = excluded.command_json,
         updated_at = excluded.updated_at,
-        last_output = excluded.last_output
+        last_output = excluded.last_output,
+        probe_failures = excluded.probe_failures,
+        probe_backoff_until = excluded.probe_backoff_until
     `
     ).run(
       agent.id,
@@ -138,7 +153,9 @@ export function upsertAgent(agent: ManagedAgent): void {
       JSON.stringify(agent.command),
       agent.createdAt,
       agent.updatedAt,
-      agent.lastOutput ?? null
+      agent.lastOutput ?? null,
+      agent.probeFailures ?? null,
+      agent.probeBackoffUntil ?? null
     )
   } finally {
     db.close()

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -441,6 +441,49 @@ test("an explicit CLI run and a targeted restore event both probe through the ba
   expect(probes).toEqual(["status", "status"])
 })
 
+test("unarchiving revives immediately even when the row carries a probe backoff", async () => {
+  const probes: string[] = []
+  const deps = reviveDeps({
+    scratchpadStatus: async () => {
+      probes.push("status")
+      return "active"
+    },
+  })
+  const target = { botId: "bot_1", rootStreamId: "stream_01ABCDEF", instanceId: "cc-one", runtimeSessionId: "ccs-one" }
+  const backedOff = linkedAgent({
+    probeFailures: 9,
+    probeBackoffUntil: new Date(Date.now() + 6 * 3_600_000).toISOString(),
+  })
+
+  expect(await runRevive(backedOff, { dryRun: true, respectProbeBackoff: true }, deps, target)).toEqual({
+    status: "would start",
+    detail: "https://app.threa.io/w/ws_1/s/stream_01ABCDEF",
+  })
+  expect(probes).toEqual(["status"])
+})
+
+test("an archived scratchpad answers 200, so it never enters the backoff", async () => {
+  const persisted: ManagedAgent[] = []
+  const deps = reviveDeps({ scratchpadStatus: async () => "archived", persist: (managed) => persisted.push(managed) })
+  const probes: string[] = []
+  const counting = reviveDeps({
+    ...deps,
+    scratchpadStatus: async () => {
+      probes.push("status")
+      return "archived"
+    },
+  })
+
+  expect(await runRevive(linkedAgent(), { respectProbeBackoff: true }, counting)).toEqual({
+    status: "skipped archived",
+  })
+  expect(await runRevive(linkedAgent(), { respectProbeBackoff: true }, counting)).toEqual({
+    status: "skipped archived",
+  })
+  expect(probes).toEqual(["status", "status"])
+  expect(persisted).toEqual([])
+})
+
 test("a scratchpad that answers clears its recorded backoff", async () => {
   for (const status of ["active", "archived"] as const) {
     const persisted: ManagedAgent[] = []

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -8,6 +8,7 @@ import {
   latestAgents,
   parseScratchpadUrl,
   preflightRuntimeSession,
+  probeSuppressed,
   recordedNoYolo,
 } from "./resume"
 import { launchAgentPlist } from "./boot"
@@ -23,7 +24,13 @@ import {
   piResumeCommand,
 } from "./spawners"
 import type { ManagedAgent, ResumeOptions } from "./types"
-import { runWatchLoop, unavailableBackoffMs, uniqueSupervisorTargets, watchIntervalMs } from "./watch"
+import {
+  inaccessibleBackoffMs,
+  runWatchLoop,
+  unavailableBackoffMs,
+  uniqueSupervisorTargets,
+  watchIntervalMs,
+} from "./watch"
 
 afterEach(() => mock.restore())
 
@@ -69,9 +76,17 @@ test("migrates legacy inventory and persists runtime identity", () => {
   db.close()
   process.env.THREA_HARNESSD_INVENTORY = path
   try {
-    const managed = agent({ instanceId: "cc-one", runtimeSessionId: "ccs-one" })
+    const managed = agent({
+      instanceId: "cc-one",
+      runtimeSessionId: "ccs-one",
+      probeFailures: 3,
+      probeBackoffUntil: "2026-07-20T12:00:00.000Z",
+    })
     upsertAgent(managed)
     expect(readInventory()).toEqual([managed])
+    const cleared = { ...managed, probeFailures: undefined, probeBackoffUntil: undefined }
+    upsertAgent(cleared)
+    expect(readInventory()).toEqual([cleared])
   } finally {
     if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
     else process.env.THREA_HARNESSD_INVENTORY = previousPath
@@ -315,6 +330,7 @@ const REVIVE_ENV_KEYS = [
   "THREA_DEFAULT_LABEL",
   "THREA_INSTANCE_ID",
   "THREA_RUNTIME_SESSION_ID",
+  "THREA_HARNESSD_WATCH_INTERVAL_MS",
 ] as const
 
 function reviveDeps(overrides: Partial<ReviveDeps> = {}): ReviveDeps {
@@ -373,9 +389,100 @@ test("up skips archived and inaccessible scratchpads without launching", async (
   expect(await runRevive(linkedAgent(), {}, reviveDeps({ scratchpadStatus: async () => "archived" }))).toEqual({
     status: "skipped archived",
   })
-  expect(await runRevive(linkedAgent(), {}, reviveDeps({ scratchpadStatus: async () => "inaccessible" }))).toEqual({
-    status: "skipped inaccessible",
+  const inaccessible = await runRevive(linkedAgent(), {}, reviveDeps({ scratchpadStatus: async () => "inaccessible" }))
+  expect(inaccessible?.status).toBe("skipped inaccessible")
+})
+
+test("an inaccessible scratchpad records an escalating probe backoff", async () => {
+  const persisted: ManagedAgent[] = []
+  const deps = reviveDeps({
+    scratchpadStatus: async () => "inaccessible",
+    persist: (managed) => persisted.push(managed),
   })
+  await runRevive(linkedAgent(), {}, deps)
+  await runRevive(linkedAgent({ probeFailures: 4 }), {}, deps)
+
+  expect(persisted.map((managed) => managed.probeFailures)).toEqual([1, 5])
+  const [first, fifth] = persisted.map((managed) => Date.parse(managed.probeBackoffUntil!) - Date.now())
+  expect(first).toBeGreaterThan(60_000)
+  expect(fifth).toBeGreaterThan(first)
+})
+
+test("the watcher sweep does not re-probe a scratchpad inside its backoff window", async () => {
+  const probes: string[] = []
+  const deps = reviveDeps({
+    scratchpadStatus: async () => {
+      probes.push("status")
+      return "inaccessible"
+    },
+  })
+  const backedOff = linkedAgent({ probeFailures: 3, probeBackoffUntil: new Date(Date.now() + 3_600_000).toISOString() })
+
+  expect(await runRevive(backedOff, { respectProbeBackoff: true }, deps)).toEqual({
+    status: "skipped inaccessible",
+    detail: `probe suppressed until ${backedOff.probeBackoffUntil}`,
+  })
+  expect(probes).toEqual([])
+})
+
+test("an explicit CLI run and a targeted restore event both probe through the backoff (#1440)", async () => {
+  const probes: string[] = []
+  const deps = reviveDeps({
+    scratchpadStatus: async () => {
+      probes.push("status")
+      return "inaccessible"
+    },
+  })
+  const backedOff = linkedAgent({ probeFailures: 3, probeBackoffUntil: new Date(Date.now() + 3_600_000).toISOString() })
+  const target = { botId: "bot_1", rootStreamId: "stream_01ABCDEF", instanceId: "cc-one", runtimeSessionId: "ccs-one" }
+
+  await runRevive(backedOff, {}, deps)
+  await runRevive(backedOff, { respectProbeBackoff: true }, deps, target)
+  expect(probes).toEqual(["status", "status"])
+})
+
+test("a scratchpad that answers clears its recorded backoff", async () => {
+  for (const status of ["active", "archived"] as const) {
+    const persisted: ManagedAgent[] = []
+    // pathExists stops an "active" row right after the clear, before any launch.
+    const deps = reviveDeps({
+      scratchpadStatus: async () => status,
+      persist: (managed) => persisted.push(managed),
+      pathExists: () => false,
+    })
+    const backedOff = linkedAgent({ probeFailures: 3, probeBackoffUntil: "2026-07-20T00:00:00.000Z" })
+    await runRevive(backedOff, { dryRun: true }, deps)
+    await runRevive(backedOff, {}, deps)
+
+    expect(persisted).toEqual([
+      { ...backedOff, probeFailures: undefined, probeBackoffUntil: undefined, updatedAt: persisted[0]?.updatedAt },
+    ])
+    expect(Date.parse(persisted[0]!.updatedAt)).toBeGreaterThan(Date.parse(backedOff.updatedAt))
+  }
+})
+
+test("an unavailable Threa neither records nor clears a probe backoff", async () => {
+  const persisted: ManagedAgent[] = []
+  const deps = reviveDeps({
+    scratchpadStatus: async () => "unavailable",
+    persist: (managed) => persisted.push(managed),
+  })
+  expect(await runRevive(linkedAgent({ probeFailures: 3 }), {}, deps)).toEqual({ status: "skipped unavailable" })
+  expect(persisted).toEqual([])
+})
+
+test("probe suppression reads a missing or unparseable instant as due", () => {
+  const nowMs = Date.parse("2026-07-20T12:00:00.000Z")
+  expect(probeSuppressed(agent(), nowMs)).toBeFalse()
+  expect(probeSuppressed(agent({ probeBackoffUntil: "not-a-date" }), nowMs)).toBeFalse()
+  expect(probeSuppressed(agent({ probeBackoffUntil: "2026-07-20T11:00:00.000Z" }), nowMs)).toBeFalse()
+  expect(probeSuppressed(agent({ probeBackoffUntil: "2026-07-20T13:00:00.000Z" }), nowMs)).toBeTrue()
+})
+
+test("inaccessible probes back off for hours where unavailable ones cap at minutes", () => {
+  expect(inaccessibleBackoffMs(60_000, 1, () => 0)).toBe(120_000)
+  expect(inaccessibleBackoffMs(60_000, 99, () => 0)).toBe(6 * 60 * 60_000)
+  expect(unavailableBackoffMs(60_000, 99, () => 0)).toBe(15 * 60_000)
 })
 
 test("up skips an already-running agent before touching the network", async () => {

--- a/extensions/harness-daemon/src/resume.ts
+++ b/extensions/harness-daemon/src/resume.ts
@@ -1,4 +1,5 @@
 import type { ManagedAgent } from "./types"
+import { inaccessibleBackoffMs } from "./watch"
 
 export interface ScratchpadRef {
   baseUrl: string
@@ -33,6 +34,33 @@ export function latestAgents(agents: ManagedAgent[]): ManagedAgent[] {
 
 export function recordedNoYolo(agent: ManagedAgent): boolean {
   return agent.command.includes("--no-yolo")
+}
+
+/** An unparseable stored instant must not suppress forever, so it reads as due. */
+export function probeSuppressed(agent: ManagedAgent, nowMs: number): boolean {
+  if (!agent.probeBackoffUntil) return false
+  const until = Date.parse(agent.probeBackoffUntil)
+  return Number.isFinite(until) && until > nowMs
+}
+
+export function withProbeBackoff(
+  agent: ManagedAgent,
+  params: { intervalMs: number; nowMs: number; random?: () => number }
+): ManagedAgent {
+  const probeFailures = (agent.probeFailures ?? 0) + 1
+  const delayMs = inaccessibleBackoffMs(params.intervalMs, probeFailures, params.random)
+  return {
+    ...agent,
+    probeFailures,
+    probeBackoffUntil: new Date(params.nowMs + delayMs).toISOString(),
+    updatedAt: new Date(params.nowMs).toISOString(),
+  }
+}
+
+/** Undefined when there is nothing recorded, so a healthy row is never rewritten every pass. */
+export function withoutProbeBackoff(agent: ManagedAgent, nowMs: number): ManagedAgent | undefined {
+  if (agent.probeFailures === undefined && agent.probeBackoffUntil === undefined) return undefined
+  return { ...agent, probeFailures: undefined, probeBackoffUntil: undefined, updatedAt: new Date(nowMs).toISOString() }
 }
 
 export type ScratchpadStatus = "active" | "archived" | "inaccessible" | "unavailable"

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -19,6 +19,10 @@ export interface ManagedAgent {
   createdAt: string
   updatedAt: string
   lastOutput?: string
+  /** Consecutive 403/404 probes; resets the moment the scratchpad answers. */
+  probeFailures?: number
+  /** ISO instant before which the revival probe is suppressed for this row. */
+  probeBackoffUntil?: string
 }
 
 export interface SpawnOptions {
@@ -39,6 +43,12 @@ export interface ResumeOptions {
   tmux?: string
   dryRun?: boolean
   recreateWorktree?: boolean
+  /**
+   * Opt-in for the unattended watcher only: it re-sweeps every row every 60s, so a
+   * durably 403/404 scratchpad must not be re-probed each pass. An explicit CLI run
+   * always probes live, because live state is what decides revival.
+   */
+  respectProbeBackoff?: boolean
 }
 
 export interface SpawnResult {

--- a/extensions/harness-daemon/src/watch.ts
+++ b/extensions/harness-daemon/src/watch.ts
@@ -25,9 +25,24 @@ export function watchIntervalMs(value = process.env.THREA_HARNESSD_WATCH_INTERVA
   return Math.floor(parsed)
 }
 
+const UNAVAILABLE_BACKOFF_CAP_MS = 15 * 60_000
+const INACCESSIBLE_BACKOFF_CAP_MS = 6 * 60 * 60_000
+
+function backoffMs(intervalMs: number, failures: number, capMs: number, random: () => number): number {
+  const base = Math.min(intervalMs * 2 ** Math.max(1, failures), capMs)
+  return Math.min(base + Math.floor(base * 0.1 * random()), capMs)
+}
+
 export function unavailableBackoffMs(intervalMs: number, failures: number, random = Math.random): number {
-  const base = Math.min(intervalMs * 2 ** Math.max(1, failures), 15 * 60_000)
-  return Math.min(base + Math.floor(base * 0.1 * random()), 15 * 60_000)
+  return backoffMs(intervalMs, failures, UNAVAILABLE_BACKOFF_CAP_MS, random)
+}
+
+/**
+ * 403/404 means a revoked grant or a deleted stream, which outlives a pass, so its cap is
+ * hours rather than minutes. Backoff and not pruning: a re-granted stream still heals itself.
+ */
+export function inaccessibleBackoffMs(intervalMs: number, failures: number, random = Math.random): number {
+  return backoffMs(intervalMs, failures, INACCESSIBLE_BACKOFF_CAP_MS, random)
 }
 
 export async function runWatchLoop(params: {


### PR DESCRIPTION
## Problem

The read/access log caught this on its first day in production: the Claude Channel bot was logging **~1,050 denied `public_api.getStream` rows every morning**, sweeping ~55 distinct streams, and stopping dead at each deploy restart. That restart correlation pinned it to `threa-harnessd`, the launchd supervisor.

Three facts compound:

1. **The inventory is insert-only.** `managed_agents` (`~/.threa/harnessd/inventory.sqlite`) has no delete path anywhere in the package, and every spawn writes a new row id (`${runtime}-${Date.now()}-${uuid}`). Rows for archived scratchpads and revoked bot grants live there forever.
2. **The sweep runs on every socket reconnect.** `reconcile()` is wired to `onReady`, which fires on every successful supervisor subscribe; `runWatchLoop` reconnects every 60s across **two** transports (Claude config + Pi config). Each one replays a full `resumeActiveUnlocked` sweep.
3. **Permanent 4xx was a free no-op.** `fetchScratchpadStatus` maps 403/404 to `"inaccessible"`, and the consumer logged a skip line and `continue`d. The row was never touched, so the next pass probed it identically.

The backoff was exactly inverted: 429/5xx (`"unavailable"`) already gets exponential retry to a 15-minute cap, while permanent 4xx retried at 60s forever.

## Solution

Give the row a memory. An inaccessible probe records `probe_failures` and `probe_backoff_until` on the inventory row and backs off exponentially to a **6-hour cap**; any answer from the scratchpad clears both.

**Backoff, not pruning.** A revoked grant that gets re-granted still heals on its own — the row is never deleted and never marked terminal. At the cap that's ~4 probes/day/stream instead of ~1,440.

### Preserving #1440

[#1440](https://github.com/threahq/threa/pull/1440) established that **live scratchpad state decides revival** (after the revive-archived incident). Three things keep that intact:

1. **Suppression can only skip, never revive.** It returns `skipped inaccessible` before the probe; there is no path where an agent starts without a fresh `active` probe. Fail-closed.
2. **The post-launch TOCTOU recheck is untouched.** The second `scratchpadStatus` call that kills a window when the scratchpad was archived mid-launch is a safety verification, not a poll — it neither honours nor records backoff.
3. **The backoff is opt-in.** New `ResumeOptions.respectProbeBackoff`, set only at the watcher's `resumeActive` call site. An explicit `threa-harnessd up` and dry-runs probe live exactly as they do today, and a targeted `onSessionRestored` event bypasses suppression because it is the server saying the stream is live again.

`"unavailable"` semantics are also unchanged: it neither records nor clears backoff (can't distinguish a dead stream from a dead network), and still aborts the sweep into the existing 15-minute retry.

### How it works

- `withProbeBackoff` / `withoutProbeBackoff` / `probeSuppressed` (`resume.ts`) are pure functions over `ManagedAgent`.
- `inaccessibleBackoffMs` (`watch.ts`) shares one `backoffMs` helper with `unavailableBackoffMs`, differing only in cap (6h vs 15m). Same jittered `intervalMs * 2 ** failures` shape. At the 60s default it takes 9 consecutive failures to reach the cap.
- Two nullable columns via the existing in-place `ALTER TABLE` migration loop, which now carries a type per column so `probe_failures` can be `INTEGER`.
- Dry-run never persists, in either direction.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/commands.ts` | Suppression check before the probe; record on inaccessible, clear on any answer; watcher passes `respectProbeBackoff` |
| `extensions/harness-daemon/src/resume.ts` | `probeSuppressed`, `withProbeBackoff`, `withoutProbeBackoff` |
| `extensions/harness-daemon/src/watch.ts` | `inaccessibleBackoffMs` (6h cap) over a shared `backoffMs` helper |
| `extensions/harness-daemon/src/inventory.ts` | `probe_failures` / `probe_backoff_until` columns, migration, round-trip |
| `extensions/harness-daemon/src/types.ts` | `ManagedAgent` probe fields; `ResumeOptions.respectProbeBackoff` |
| `extensions/harness-daemon/src/resume.test.ts` | 7 new tests |

## Out of scope (deliberate)

- **Pruning the inventory.** Rows still accumulate one per spawn forever. Backing off makes that harmless for probe volume, but `latestAgents` dedupes only by name, so genuinely stale rows linger. A retention pass is a separate change.
- **The sweep-per-reconnect amplification.** `onReady` still replays a full sweep on every socket reconnect across both transports. With backoff the dead rows cost nothing, so this stops being a volume problem, but it remains structurally wasteful.
- **Recording backoff from the post-launch recheck.** Left alone on purpose (see above). Such a row lands in `status: "error"` and picks up backoff on the next normal pass anyway.

## Test plan

- [x] `bun run --cwd extensions/harness-daemon test` — 39 pass, 0 fail (7 new)
- [x] Full CI extension matrix run locally — `bot-runtime-client` 53, `remote-session` 118, `claude-code-remote` 101, `harness-daemon` 39; all four `tsc --noEmit` clean
- [x] `prettier --check` clean
- [ ] Not verified against the live daemon — needs a `threa-harnessd` restart on Kris's machine to confirm the morning denial count drops. The prod check is `SELECT count(*) FROM access_log WHERE operation = 'public_api.getStream' AND outcome = 'denied'` bucketed by hour.

Regression coverage for the #1440 contract specifically: `the watcher sweep does not re-probe a scratchpad inside its backoff window` (asserts zero network calls) and `an explicit CLI run and a targeted restore event both probe through the backoff (#1440)` (asserts two).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
