### PR TITLE
fix: harden GitHub stack merge wrapper

### DIFF
--- a/.agents/skills/gh-stack/scripts/merge-stack.test.ts
+++ b/.agents/skills/gh-stack/scripts/merge-stack.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { assertExpectedHeads, createMergePlan, parseArgs } from "./merge-stack"
+import { assertCompletedMerge, assertExpectedHeads, createMergePlan, parseArgs } from "./merge-stack"
 
 const stack = {
   number: 42,
@@ -13,23 +13,23 @@ const stack = {
   pull_requests: [
     {
       number: 101,
-      state: "open" as const,
+      state: "open" as "open" | "closed",
       draft: false,
-      merged_at: null,
+      merged_at: null as string | null,
       head: { ref: "layer-one", sha: "aaa111" },
     },
     {
       number: 102,
-      state: "open" as const,
+      state: "open" as "open" | "closed",
       draft: false,
-      merged_at: null,
+      merged_at: null as string | null,
       head: { ref: "layer-two", sha: "bbb222" },
     },
     {
       number: 103,
-      state: "open" as const,
+      state: "open" as "open" | "closed",
       draft: false,
-      merged_at: null,
+      merged_at: null as string | null,
       head: { ref: "layer-three", sha: "ccc333" },
     },
   ],
@@ -51,7 +51,7 @@ async function createSubprocessFixture(chrome: string): Promise<{
   await mkdir(bin, { recursive: true })
   await writeFile(join(root, "profile", "Local State"), "{}")
   const cookies = new Database(join(profile, "Cookies"), { create: true })
-  cookies.exec("CREATE TABLE cookies (name TEXT)")
+  cookies.exec("CREATE TABLE cookies (name TEXT, host_key TEXT)")
   cookies.close()
 
   const gh = join(bin, "gh")
@@ -107,13 +107,32 @@ describe("createMergePlan", () => {
       baseRef: "main",
       entries: stack.pull_requests.slice(0, 2),
       expectedHeads: { 101: "aaa111", 102: "bbb222" },
+      remainingEntries: [{ number: 103, state: "open", mergedAt: null }],
     })
   })
 
-  test("rejects a draft downstack pull request", () => {
-    const blocked = structuredClone(stack)
-    blocked.pull_requests[0]!.draft = true
-    expect(() => createMergePlan(blocked, 102)).toThrow("#101 is draft")
+  test("resumes above previously merged entries", () => {
+    const resumed = structuredClone(stack)
+    resumed.pull_requests[0]!.state = "closed"
+    resumed.pull_requests[0]!.merged_at = "2026-07-20T10:00:00Z"
+    expect(createMergePlan(resumed, 102).entries.map((entry) => entry.number)).toEqual([102])
+  })
+
+  test("rejects closed, draft, missing, and merged targets", () => {
+    const draft = structuredClone(stack)
+    draft.pull_requests[0]!.draft = true
+    expect(() => createMergePlan(draft, 102)).toThrow("#101 is draft")
+
+    const closed = structuredClone(stack)
+    closed.pull_requests[0]!.state = "closed"
+    expect(() => createMergePlan(closed, 102)).toThrow("#101 is closed")
+
+    expect(() => createMergePlan(stack, 999)).toThrow("not in stack")
+
+    const merged = structuredClone(stack)
+    merged.pull_requests[1]!.state = "closed"
+    merged.pull_requests[1]!.merged_at = "2026-07-20T10:00:00Z"
+    expect(() => createMergePlan(merged, 102)).toThrow("target pull request #102 is not open")
   })
 })
 
@@ -151,6 +170,36 @@ describe("assertExpectedHeads", () => {
   })
 })
 
+describe("assertCompletedMerge", () => {
+  const plan = createMergePlan(stack, 102)
+
+  test("accepts exactly the requested partial range", () => {
+    const completed = structuredClone(stack)
+    completed.pull_requests[0]!.state = "closed"
+    completed.pull_requests[0]!.merged_at = "2026-07-20T10:00:00Z"
+    completed.pull_requests[1]!.state = "closed"
+    completed.pull_requests[1]!.merged_at = "2026-07-20T10:00:01Z"
+    expect(() => assertCompletedMerge(plan, completed)).not.toThrow()
+  })
+
+  test("detects an over-merge and an unexpected selected head", () => {
+    const overMerged = structuredClone(stack)
+    for (const pull of overMerged.pull_requests) {
+      pull.state = "closed"
+      pull.merged_at = "2026-07-20T10:00:00Z"
+    }
+    expect(() => assertCompletedMerge(plan, overMerged)).toThrow("merged more than the requested range")
+
+    const wrongHead = structuredClone(stack)
+    wrongHead.pull_requests[0]!.state = "closed"
+    wrongHead.pull_requests[0]!.merged_at = "2026-07-20T10:00:00Z"
+    wrongHead.pull_requests[0]!.head.sha = "unexpected"
+    wrongHead.pull_requests[1]!.state = "closed"
+    wrongHead.pull_requests[1]!.merged_at = "2026-07-20T10:00:01Z"
+    expect(() => assertCompletedMerge(plan, wrongHead)).toThrow("used unexpected head")
+  })
+})
+
 describe("credential cleanup", () => {
   test("removes copied browser state when Chrome exits during startup", async () => {
     const fixture = await createSubprocessFixture("#!/bin/sh\nexit 1\n")
@@ -178,10 +227,10 @@ describe("credential cleanup", () => {
     }
   })
 
-  for (const signal of ["SIGINT", "SIGTERM"] as const) {
-    test(`removes copied browser state on ${signal}`, async () => {
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    test(`removes copied browser state on ${signal}${signal === "SIGINT" ? " repeated" : ""}`, async () => {
       const fixture = await createSubprocessFixture(`#!/bin/sh
-trap 'kill "$child" 2>/dev/null; exit' INT TERM
+trap 'kill "$child" 2>/dev/null; exit' INT TERM HUP
 sleep 60 & child=$!
 wait "$child"
 `)
@@ -204,6 +253,10 @@ wait "$child"
         )
         await waitForCopiedProfile(fixture.runtime)
         process.kill(signal)
+        if (signal === "SIGINT") {
+          await Bun.sleep(50)
+          process.kill(signal)
+        }
         await process.exited
         expect(await readdir(fixture.runtime)).toEqual([])
       } finally {

--- a/.agents/skills/gh-stack/scripts/merge-stack.ts
+++ b/.agents/skills/gh-stack/scripts/merge-stack.ts
@@ -48,6 +48,11 @@ export interface MergePlan {
   baseRef: string
   entries: StackPullRequest[]
   expectedHeads: Record<number, string>
+  remainingEntries: Array<{
+    number: number
+    state: "open" | "closed"
+    mergedAt: string | null
+  }>
 }
 
 interface BrowserPreflight {
@@ -67,6 +72,8 @@ interface BrowserRequestResult {
   status: number
   message: string
 }
+
+class EnqueueRejectedError extends Error {}
 
 const usage = `Usage:
   bun .agents/skills/gh-stack/scripts/merge-stack.ts <pull-request> --yes [options]
@@ -169,8 +176,11 @@ export function parseArgs(argv: string[]): MergeStackArgs {
   if (yes === dryRun) {
     throw new Error("choose exactly one of --yes or --dry-run")
   }
-  if (repo && !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
-    throw new Error(`invalid repository: ${repo}`)
+  if (repo) {
+    const parts = repo.split("/")
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) || parts.some((part) => part === "." || part === "..")) {
+      throw new Error(`invalid repository: ${repo}`)
+    }
   }
 
   return {
@@ -215,6 +225,11 @@ export function createMergePlan(stack: StackResource, targetPullRequest: number)
     baseRef: stack.base.ref,
     entries,
     expectedHeads: Object.fromEntries(entries.map((pull) => [pull.number, pull.head.sha])),
+    remainingEntries: stack.pull_requests.slice(targetIndex + 1).map((pull) => ({
+      number: pull.number,
+      state: pull.state,
+      mergedAt: pull.merged_at,
+    })),
   }
 }
 
@@ -242,6 +257,37 @@ export function assertExpectedHeads(plan: MergePlan, current: StackResource): vo
   }
 }
 
+export function assertCompletedMerge(plan: MergePlan, stack: StackResource): void {
+  for (const entry of plan.entries) {
+    const merged = stack.pull_requests.find((pull) => pull.number === entry.number)
+    if (!merged?.merged_at) throw new Error(`pull request #${entry.number} did not merge`)
+    if (merged.head.sha !== plan.expectedHeads[entry.number]) {
+      throw new Error(`stack merged, but PR #${entry.number} used unexpected head ${merged.head.sha}`)
+    }
+  }
+
+  for (const expected of plan.remainingEntries) {
+    const current = stack.pull_requests.find((pull) => pull.number === expected.number)
+    if (!current || current.merged_at !== expected.mergedAt || current.state !== expected.state) {
+      throw new Error(`stack merged more than the requested range; inspect PR #${expected.number}`)
+    }
+  }
+}
+
+const timeoutMarker = Symbol("timeout")
+
+async function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof timeoutMarker> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<typeof timeoutMarker>((resolveTimeout) => {
+    timeout = setTimeout(() => resolveTimeout(timeoutMarker), timeoutMs)
+  })
+  try {
+    return await Promise.race([promise, deadline])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 async function command(args: string[], timeoutMs = 30_000): Promise<string> {
   const subprocess = Bun.spawn(args, {
     env: process.env,
@@ -253,12 +299,12 @@ async function command(args: string[], timeoutMs = 30_000): Promise<string> {
     new Response(subprocess.stderr).text(),
     subprocess.exited,
   ])
-  const result = await Promise.race([completion, Bun.sleep(timeoutMs).then(() => null)])
-  if (!result) {
+  const result = await raceWithTimeout(completion, timeoutMs)
+  if (result === timeoutMarker) {
     subprocess.kill("SIGTERM")
-    await Promise.race([subprocess.exited, Bun.sleep(500)])
+    await raceWithTimeout(subprocess.exited, 500)
     if (subprocess.exitCode === null) subprocess.kill("SIGKILL")
-    await Promise.race([subprocess.exited, Bun.sleep(1_500)])
+    await raceWithTimeout(subprocess.exited, 1_500)
     throw new Error(`${args.join(" ")} timed out after ${timeoutMs}ms`)
   }
   const [stdout, stderr, exitCode] = result
@@ -360,14 +406,24 @@ async function copyFileSnapshot(source: string, destination: string): Promise<bo
 async function copySqliteSnapshot(source: string, destination: string): Promise<boolean> {
   if (!(await exists(source))) return false
   const database = new Database(source, { readonly: true })
+  let serialized: Uint8Array
   try {
     database.query("SELECT COUNT(*) AS count FROM sqlite_master").get()
-    await mkdir(dirname(destination), { recursive: true, mode: 0o700 })
-    await writeFile(destination, database.serialize(), { mode: 0o600 })
-    return true
+    serialized = database.serialize()
   } finally {
     database.close()
   }
+
+  await mkdir(dirname(destination), { recursive: true, mode: 0o700 })
+  await writeFile(destination, serialized, { mode: 0o600 })
+  const snapshot = new Database(destination)
+  try {
+    snapshot.query("DELETE FROM cookies WHERE host_key <> 'github.com' AND host_key <> '.github.com'").run()
+    snapshot.exec("VACUUM")
+  } finally {
+    snapshot.close()
+  }
+  return true
 }
 
 class CdpSession {
@@ -452,10 +508,13 @@ class CdpSession {
       const payload = this.buffer.subarray(0, boundary).toString("utf8")
       this.buffer = this.buffer.subarray(boundary + 1)
       if (payload) {
-        const message = JSON.parse(payload) as {
-          id?: number
-          result?: unknown
-          error?: { message: string }
+        let message: { id?: number; result?: unknown; error?: { message: string } }
+        try {
+          message = JSON.parse(payload) as typeof message
+        } catch {
+          this.failPending(new Error("Chrome DevTools returned a malformed frame"))
+          this.close()
+          return
         }
         if (message.id) {
           const waiter = this.pending.get(message.id)
@@ -528,6 +587,7 @@ class BrowserHarness {
         } finally {
           process.off("SIGINT", onSigint)
           process.off("SIGTERM", onSigterm)
+          process.off("SIGHUP", onSighup)
         }
         if (errors.length) throw new AggregateError(errors, errors.map((error) => error.message).join("; "))
       })()
@@ -546,8 +606,10 @@ class BrowserHarness {
     }
     const onSigint = () => closeForSignal(130)
     const onSigterm = () => closeForSignal(143)
-    process.once("SIGINT", onSigint)
-    process.once("SIGTERM", onSigterm)
+    const onSighup = () => closeForSignal(129)
+    process.on("SIGINT", onSigint)
+    process.on("SIGTERM", onSigterm)
+    process.on("SIGHUP", onSighup)
 
     try {
       await chmod(tempRoot, 0o700)
@@ -577,6 +639,8 @@ class BrowserHarness {
           "--disable-gpu",
           "--disable-sync",
           "--disable-extensions",
+          "--disable-background-networking",
+          "--disable-component-update",
           "--no-first-run",
           "--no-default-browser-check",
           `--user-data-dir=${tempUserData}`,
@@ -613,13 +677,19 @@ class BrowserHarness {
     await this.cdp.request("Page.navigate", { url })
     for (let attempt = 0; attempt < 300; attempt += 1) {
       const evaluation = await this.cdp.request<RuntimeEvaluation>("Runtime.evaluate", {
-        expression: "JSON.stringify({ready:document.readyState,path:location.pathname})",
+        expression: "JSON.stringify({ready:document.readyState,path:location.pathname,title:document.title})",
         returnByValue: true,
       })
       const value = evaluation.result.value
       if (value) {
-        const state = JSON.parse(value) as { ready: string; path: string }
+        const state = JSON.parse(value) as { ready: string; path: string; title: string }
         if (state.ready === "complete" && state.path === expectedPath) return
+        if (
+          state.ready === "complete" &&
+          (state.path.startsWith("/login") || state.title.toLowerCase().includes("sign in"))
+        ) {
+          throw new Error("Chrome GitHub session is not authenticated")
+        }
       }
       await Bun.sleep(100)
     }
@@ -659,7 +729,7 @@ class BrowserHarness {
       const query = '?merge_method=' + config.method + '&bypass_requirements=false'
       const mergeBox = await getJson(prefix + config.targetPullRequest + '/page_data/merge_box' + query)
       if (mergeBox.error) return JSON.stringify({ error: 'Merge box: ' + mergeBox.error })
-      if (mergeBox.body?.pullRequest?.state !== 'OPEN') {
+      if ((mergeBox.body?.pullRequest?.state || mergeBox.body?.pull_request?.state) !== 'OPEN') {
         return JSON.stringify({ error: 'Target pull request is not open in the browser session' })
       }
       const requirements = mergeBox.body?.mergeRequirements || mergeBox.body?.merge_requirements || {}
@@ -763,10 +833,10 @@ class BrowserHarness {
 
 async function runUtility(args: string[], timeoutMs = 5_000): Promise<number | null> {
   const process = Bun.spawn(args, { stdout: "ignore", stderr: "ignore" })
-  const result = await Promise.race([process.exited, Bun.sleep(timeoutMs).then(() => null)])
-  if (result !== null) return result
+  const result = await raceWithTimeout(process.exited, timeoutMs)
+  if (result !== timeoutMarker) return result
   process.kill("SIGKILL")
-  await Promise.race([process.exited, Bun.sleep(500)])
+  await raceWithTimeout(process.exited, 500)
   return null
 }
 
@@ -777,10 +847,7 @@ async function stopChrome(process: ChildProcess, tempUserData: string): Promise<
     } catch {
       // The process may have exited between the exitCode check and kill.
     }
-    await Promise.race([
-      new Promise<void>((resolveExit) => process.once("exit", () => resolveExit())),
-      Bun.sleep(2_000),
-    ])
+    await raceWithTimeout(new Promise<void>((resolveExit) => process.once("exit", () => resolveExit())), 2_000)
   }
   if (process.exitCode === null) {
     try {
@@ -793,13 +860,13 @@ async function stopChrome(process: ChildProcess, tempUserData: string): Promise<
   await runUtility(["pkill", "-TERM", "-f", tempUserData])
   await Bun.sleep(200)
   await runUtility(["pkill", "-KILL", "-f", tempUserData])
-  await Promise.race([
+  await raceWithTimeout(
     new Promise<void>((resolveExit) => {
       if (process.exitCode !== null) resolveExit()
       else process.once("exit", () => resolveExit())
     }),
-    Bun.sleep(2_000),
-  ])
+    2_000
+  )
 
   const matchingProcesses = await runUtility(["pgrep", "-f", tempUserData])
   if (process.exitCode === null || matchingProcesses === 0 || matchingProcesses === null) {
@@ -827,12 +894,7 @@ async function waitForMerge(repo: string, plan: MergePlan, timeoutSeconds: numbe
     const stack = await ghJson<StackResource>(`repos/${repo}/stacks/${plan.stackNumber}`, remaining)
     const selected = plan.entries.map((entry) => stack.pull_requests.find((pull) => pull.number === entry.number))
     if (selected.every((entry) => entry?.merged_at)) {
-      const unexpectedHead = selected.find((entry) => entry && entry.head.sha !== plan.expectedHeads[entry.number])
-      if (unexpectedHead) {
-        throw new Error(
-          `stack merged, but PR #${unexpectedHead.number} used unexpected head ${unexpectedHead.head.sha}`
-        )
-      }
+      assertCompletedMerge(plan, stack)
       return stack
     }
     const closedWithoutMerge = selected.find((entry) => entry && entry.state === "closed" && !entry.merged_at)
@@ -896,13 +958,31 @@ async function main(): Promise<void> {
     console.error(
       "Heads and topology verified immediately before enqueue; GitHub exposes no expected-head CAS for this private route."
     )
-    const request = await browser.enqueue(repo, plan, args.method, preflight)
-    if (request.status < 200 || request.status >= 300) {
-      throw new Error(`GitHub rejected stack merge (HTTP ${request.status}): ${request.message}`)
+    let mergedStack: StackResource | undefined
+    try {
+      const request = await browser.enqueue(repo, plan, args.method, preflight)
+      if (request.status < 200 || request.status >= 300) {
+        throw new EnqueueRejectedError(`GitHub rejected stack merge (HTTP ${request.status}): ${request.message}`)
+      }
+      console.error(`GitHub accepted stack merge: ${request.message}`)
+    } catch (error) {
+      if (error instanceof EnqueueRejectedError) throw error
+      const enqueueError = error instanceof Error ? error : new Error(String(error))
+      console.error(
+        `Enqueue outcome unknown (${enqueueError.message}); the request may have reached GitHub. Watching stack #${plan.stackNumber} before allowing a retry.`
+      )
+      try {
+        mergedStack = await waitForMerge(repo, plan, args.timeoutSeconds)
+      } catch (watchError) {
+        const watch = watchError instanceof Error ? watchError : new Error(String(watchError))
+        throw new AggregateError(
+          [enqueueError, watch],
+          `enqueue outcome remains unknown; inspect stack #${plan.stackNumber} before retrying: ${watch.message}`
+        )
+      }
     }
-    console.error(`GitHub accepted stack merge: ${request.message}`)
 
-    const mergedStack = await waitForMerge(repo, plan, args.timeoutSeconds)
+    mergedStack ??= await waitForMerge(repo, plan, args.timeoutSeconds)
     const merged = plan.entries.map((entry) => {
       const current = mergedStack.pull_requests.find((pull) => pull.number === entry.number)!
       return { number: current.number, mergedAt: current.merged_at }


### PR DESCRIPTION
## Problem

Fable’s final adversarial review found two safety gaps and five hardening/test issues in the browser-backed stack merge wrapper: silent over-merge detection, repeated-signal cleanup, ambiguous enqueue outcomes, full-cookie blast radius, malformed CDP frames, lingering timeout races, and missing partial/resumed tests.

## Solution

- preserve and verify every PR above the selected target after completion
- absorb repeated `SIGINT` and handle `SIGTERM`/`SIGHUP` until cleanup finishes
- retain only `github.com` cookies and disable Chrome background networking
- watch the stack when enqueue delivery is ambiguous instead of permitting an unsafe retry
- bound/cancel command timers, reject malformed CDP frames safely, and improve login errors
- cover resumed, rejected, exact partial, over-merge, unexpected-head, startup, and signal paths

Review dispositions: findings 1–7 accepted and fixed; informational repo-validation, casing, and login diagnostics also fixed. The endpoint’s missing server-side expected-head CAS remains acknowledged/documented because GitHub’s web request exposes no such field.

## Test plan

- [x] focused wrapper tests — 13 pass
- [x] focused TypeScript check
- [x] Bun production build
- [x] repository pre-commit lint, typecheck, migration/Dockerfile checks, Astro checks, and API-doc check


## Fable re-check

Clean: all eight findings resolved. Fable re-ran the focused suite (13/13) and independently verified stack #1453’s partial merge: targeting #1451 merged exact heads #1450/#1451, left #1452 open, and retargeted it to `main`. The wrapper then merged #1452 separately.
