### PR TITLE
feat(calls): release calls — callsEnabled defaults on

### DIFF
--- a/apps/frontend/src/components/user-profile/user-profile-modal.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.tsx
@@ -19,7 +19,7 @@ import { useCallLaunch } from "@/components/call"
 import { useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useAuth } from "@/auth"
-import { getAvatarUrl, resolveActiveStatus, type User } from "@threa/types"
+import { DEFAULT_WORKSPACE_SETTINGS, getAvatarUrl, resolveActiveStatus, type User } from "@threa/types"
 import { getInitials } from "@/lib/initials"
 import { formatStatusClearLabel } from "@/lib/status"
 
@@ -115,7 +115,7 @@ export function UserProfileModal({ userId, open, onOpenChange }: UserProfileModa
   const messageHref = workspaceId ? `/w/${workspaceId}/s/${messageStreamId}` : undefined
 
   const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
-  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
+  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? DEFAULT_WORKSPACE_SETTINGS.callsEnabled
   const { launch: launchCall, callActive } = useCallLaunch()
 
   if (!user) return null

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -61,7 +61,13 @@ import { useInputMode } from "@/hooks/use-input-mode"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
 import { InviteActorButton, InviteBotButton } from "@/components/encryption"
-import { BotRuntimeStatuses, CompanionModes, LabelableResourceTypes, StreamTypes } from "@threa/types"
+import {
+  BotRuntimeStatuses,
+  CompanionModes,
+  DEFAULT_WORKSPACE_SETTINGS,
+  LabelableResourceTypes,
+  StreamTypes,
+} from "@threa/types"
 import { getStreamName, getStreamTypeLabel, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { StreamSheet } from "@/components/stream-sheet"
 import { StreamContextSurface, StreamContextGallery, useStreamGallery } from "@/components/stream-context"
@@ -225,7 +231,7 @@ export function StreamPage() {
   const activeBotPresence = useActiveBotPresence(workspaceId, streamId)
 
   const bootstrap = useCachedWorkspaceBootstrap(workspaceId ?? "")
-  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? false
+  const callsEnabled = bootstrap?.workspaceSettings?.callsEnabled ?? DEFAULT_WORKSPACE_SETTINGS.callsEnabled
   const { launch: launchCall, callActive } = useCallLaunch()
 
   const isThread = stream?.type === StreamTypes.THREAD
@@ -718,8 +724,7 @@ export function StreamPage() {
           </div>
           <div className="flex items-center gap-1 ml-1">
             {stream && !isDraft && (isChannel || isDm) && callsEnabled && (
-              // Dark feature: rendered only when the workspace `callsEnabled`
-              // setting is on, so an off workspace shows no calls surface at all.
+              // A workspace that has switched calls off shows no calls surface at all.
               <Button
                 variant="ghost"
                 size="icon"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -311,9 +311,9 @@ Calls media routes through a **Cloudflare Realtime (SFU) app**, one **per enviro
 
 - **Boot behavior**: the pair is co-presence-validated at startup (both set or both absent, INV-11). When absent, the backend boots normally but every calls HTTP/socket surface answers **503 `CALLS_UNAVAILABLE`** — deploying without them **disables calls and breaks nothing** else. A single one of the two set fails boot loudly.
 
-- **Per-workspace flag**: even with the app configured, calls stay dark until the `callsEnabled` workspace setting is turned on (default off).
+- **Per-workspace kill switch**: `callsEnabled` is **on by default**. Turning it off makes every calls surface answer as if the feature does not exist — the way to stop calls in one workspace without a deploy, which matters because the media plane is a third-party dependency.
 
-- **M1 exit gate**: the SFU is a content-level media processor from the first shipped call. Do **not** flip `callsEnabled` on in prod until Cloudflare's DPA / processor-register entry is in place — see the plan's `GDPR (v1)` section (`docs/plans/voice-video-calls.md`).
+- **Outstanding GDPR item**: the SFU is a content-level media processor from the first real call. Calls were released pre-launch by an explicit product decision (2026-07-20); Cloudflare's DPA / processor-register entry is still **not** in place and must land before the product carries external users. See the plan's `GDPR (v1)` section (`docs/plans/voice-video-calls.md`).
 
 ### Control-Plane
 

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -54,7 +54,7 @@ Two rules for using it:
 | offline                                                                        | Composing offline, queued operations, connection status                                                                                         | `sw.ts`, `sync/operation-queue.ts`                                             |
 | [ai-companions](public/ai-companions.md) ✅                                    | Personas, companion mode, mentions, in-timeline activity card, agent traces                                                                     | `features/agents`, `docs/core-concepts.md`                                     |
 | [custom-personas](public/custom-personas.md) ✅                                | Fork/edit personas (workspace + personal scopes, visibility rules), the editor, test-drive, revisions, attached knowledge files                 | `features/agents`, `components/persona-editor/`                                |
-| [calls](calls.md) ✅ (M1, flag-gated)                                          | 1:1 DM voice/video via the Cloudflare Realtime SFU: header start, ring, docked call, timeline card, rejoin; flag `callsEnabled` + CF app        | `features/calls`, `apps/frontend/src/calls`, `docs/plans/voice-video-calls.md` |
+| [calls](calls.md) ✅ (M1, released)                                            | 1:1 DM voice/video via the Cloudflare Realtime SFU: header start, ring, docked call, timeline card, rejoin; `callsEnabled` kill switch + CF app | `features/calls`, `apps/frontend/src/calls`, `docs/plans/voice-video-calls.md` |
 
 ## Concepts
 

--- a/docs/features/calls.md
+++ b/docs/features/calls.md
@@ -127,11 +127,13 @@ Calls are gated by **two independent switches**, both required:
      boot loudly. Absent ⇒ the backend boots fine but every calls surface answers
      **503 `CALLS_UNAVAILABLE`**. Resolved in `apps/backend/src/lib/env.ts`
      (`config.cloudflareRealtime.enabled`), consumed only by the CF proxy.
-2. **`callsEnabled`** workspace setting (default **off**,
-   `packages/types/src/workspace-settings.ts`) — even with the CF app configured,
-   calls stay dark per-workspace until an admin flips it. The frontend renders no
+2. **`callsEnabled`** workspace setting (default **on**,
+   `packages/types/src/workspace-settings.ts`) — a per-workspace kill switch rather
+   than a rollout gate: an admin can shut calls off without a deploy, which matters
+   because the media plane is a third-party dependency. The frontend renders no
    calls surface (`stream.tsx`, `user-profile-modal.tsx`) when off; the backend
-   handlers + gateway reject when off.
+   handlers + gateway reject when off. There is no settings UI for it yet — it is
+   changed via `PATCH /api/workspaces/:id/workspace-settings` (WORKSPACE_ADMIN).
 
 ## Operational notes
 
@@ -219,10 +221,12 @@ and STT ship with transcription).
   by construction (there is no server-side audio path) and by the `RealtimeMediaApi`
   seam being the only media boundary.
 
-## Flag-flip checklist
+## Release state
 
-Preconditions to turn `callsEnabled` on in an environment. Most are **unchecked** —
-this is the honest M1-exit state, not a claim of readiness.
+Calls were **released on by default** on 2026-07-20 by an explicit pre-launch product
+decision, ahead of the items below. The list is kept because the unchecked entries are
+still genuinely outstanding — it is the honest state of the feature, not a gate that
+was satisfied.
 
 - [x] Schema + state machines + CF proxy + `/calls` gateway shipped (PRs 0.1–0.2).
 - [x] 1:1 DM lifecycle: ring, dock, mute/camera, timeline card, rejoin bar, sweeper
@@ -262,5 +266,5 @@ this is the honest M1-exit state, not a claim of readiness.
       media both directions; what remains is the same flow driven by the shipped
       frontend transport in a real session (dev stack + dev app, two browsers).
 
-Until the CF-app, live-spike, and DPA-register items are checked, `callsEnabled`
-stays off everywhere.
+The DPA-register entry is the one that still carries real weight: it must land before
+the product carries external users.

--- a/packages/types/src/workspace-settings.ts
+++ b/packages/types/src/workspace-settings.ts
@@ -76,11 +76,11 @@ export interface WorkspaceSettings {
    */
   billingTimezone: string
   /**
-   * Feature flag for voice/video calls (dark feature, default OFF). Off ⇒ the
-   * calls HTTP/socket surfaces answer as if the feature does not exist
+   * Kill switch for voice/video calls, on by default. Off ⇒ the calls
+   * HTTP/socket surfaces answer as if the feature does not exist
    * (`CALLS_DISABLED`, 404-style) per the house convention for gated features.
-   * Flipped on per-workspace during rollout; the M1 exit gate requires the
-   * Cloudflare DPA/processor-register entry before enabling it in prod.
+   * Calls depend on a third-party SFU, so an admin needs a way to shut them off
+   * without a deploy; that is the only job this setting still has.
    */
   callsEnabled: boolean
   createdAt: string
@@ -96,7 +96,7 @@ export const DEFAULT_WORKSPACE_SETTINGS: Omit<WorkspaceSettings, "workspaceId" |
   maxPendingFollowUps: DEFAULT_MAX_PENDING_FOLLOW_UPS,
   defaultCompanionPersonaId: null,
   billingTimezone: "UTC",
-  callsEnabled: false,
+  callsEnabled: true,
 }
 
 /** Partial update — only provided fields are changed. */

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -43,7 +43,7 @@ async function setUpDmPair(browser: Browser): Promise<DmPair> {
   const workspaceId = ownerPage.url().match(/\/w\/([^/]+)/)?.[1]
   if (!workspaceId) throw new Error("Could not resolve workspaceId from owner URL")
 
-  // Flip the workspace `callsEnabled` dark-feature flag on (admin-only; owner is admin).
+  // Assert calls on explicitly (they default on) so the test is independent of the default.
   await expectApiOk(
     await ownerPage.request.patch(`/api/workspaces/${workspaceId}/workspace-settings`, {
       data: { callsEnabled: true },


### PR DESCRIPTION
## Summary

Calls shipped dark behind the per-workspace `callsEnabled` setting, which has **no settings UI** — only `PATCH /api/workspaces/:id/workspace-settings` (WORKSPACE_ADMIN). In practice that made the feature unreachable from the app on any device. Pre-launch decision: release it.

`callsEnabled` stays, demoted from rollout gate to **kill switch**, and now defaults **on**. The media plane is a third-party dependency (Cloudflare Realtime SFU), so an admin needs a way to stop calls in one workspace without a deploy — that is the setting's only remaining job.

## Design decisions

- **Flip the default rather than delete the flag.** Deleting it would have released the feature too, but would also have thrown away the ability to shut calls off without shipping — not a trade worth making for a feature that depends on an external provider.
- **Frontend fallbacks now read `DEFAULT_WORKSPACE_SETTINGS.callsEnabled`** instead of a hardcoded `?? false`, so the default lives in exactly one place (INV-33). Previously a stale cached bootstrap would have hidden calls even after the release.
- **Docs corrected rather than quietly left stale.** `docs/deployment.md` and `docs/features/calls.md` both instructed operators *not* to enable calls in prod. That instruction is now wrong, so it is rewritten — but the outstanding **Cloudflare DPA / processor-register entry is recorded as still outstanding**, not deleted. It must land before the product carries external users.

## File changes

- `packages/types/src/workspace-settings.ts` — default `false` → `true`; comment rewritten from "dark feature" to kill switch.
- `apps/frontend/src/pages/stream.tsx`, `apps/frontend/src/components/user-profile/user-profile-modal.tsx` — fallback reads the shared default.
- `docs/deployment.md`, `docs/features/calls.md`, `docs/features/INVENTORY.md` — release state, kill-switch framing, DPA item retained.
- `tests/browser/calls.spec.ts` — comment only; the spec still sets the flag explicitly so it does not depend on the default.

## Verification

- Backend: 159 tests (calls + workspace-settings) pass.
- Frontend: 170 tests across 21 files (pages, user-profile, calls, call components, stores) pass.
- Full monorepo typecheck: 0 errors. Pre-commit lint/migrations/API-docs checks pass.
- No test pinned the old default, so nothing needed loosening to accommodate the change.

## Follow-ups (not in this PR)

- **No settings UI** for the kill switch — it is still API-only. Worth a small toggle in workspace settings.
- The repo has a real `feature-flags` system (`apps/backend/src/features/feature-flags`, backoffice-managed, registry in `packages/types/src/feature-flags.ts`) that calls did not use. It is **per-user** today; making it workspace-scoped is the better long-term home for gates like this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787136271&installation_id=129946197&pr_number=1454&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1454&signature=8e215e1b63389f5a61984a881048a06888384a97fbc7d3457962d2dd8932df87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->