### PR TITLE
feat: subject-key feature flags in the control plane

### DIFF
--- a/apps/backoffice/src/api/backoffice.ts
+++ b/apps/backoffice/src/api/backoffice.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceInvitableRole, WorkspaceRoleSlug } from "@threa/types"
+import type { FeatureFlagScope, WorkspaceInvitableRole, WorkspaceRoleSlug } from "@threa/types"
 import { api } from "./client"
 
 /**
@@ -118,7 +118,9 @@ export interface WaitlistOverview {
 }
 
 export interface WorkspaceFeatureFlagOverride {
-  workosUserId: string
+  subjectType: FeatureFlagScope
+  /** Workspace id for workspace scope, workos_user_id for user scope. */
+  subjectId: string
   flagKey: string
   value: string
   updatedAt: string
@@ -126,14 +128,18 @@ export interface WorkspaceFeatureFlagOverride {
 
 export interface WorkspaceFeatureFlagDefinition {
   key: string
-  /** Declared values for the flag; the first one is the default. */
+  /** Declared values for the flag. */
   values: string[]
+  /** The flag's explicit default, resolved when no override applies. */
+  default: string
+  /** Subjects that may carry an override for this flag. */
+  scopes: FeatureFlagScope[]
 }
 
 export interface WorkspaceFeatureFlags {
   /** Flags currently in the code registry (@threa/types FEATURE_FLAGS). */
   flags: WorkspaceFeatureFlagDefinition[]
-  /** Stored per-user overrides; absence of an override means the default value. */
+  /** Stored overrides; absence of an override for a subject means the default value. */
   overrides: WorkspaceFeatureFlagOverride[]
 }
 
@@ -233,10 +239,10 @@ export function getWorkspaceFeatureFlags(workspaceId: string): Promise<Workspace
   return api.get<WorkspaceFeatureFlags>(`/api/backoffice/workspaces/${encodeURIComponent(workspaceId)}/feature-flags`)
 }
 
-/** Setting a flag to its default (first declared) value clears the override. */
+/** Setting a flag to its explicit default value clears the override. */
 export function setWorkspaceFeatureFlag(
   workspaceId: string,
-  params: { workosUserId: string; flagKey: string; value: string }
+  params: { subjectType: FeatureFlagScope; subjectId: string; flagKey: string; value: string }
 ): Promise<void> {
   return api.put<void>(`/api/backoffice/workspaces/${encodeURIComponent(workspaceId)}/feature-flags`, params)
 }

--- a/apps/backoffice/src/pages/workspace-detail-flags.test.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-flags.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, screen, waitFor, within, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { WorkspaceDetailFlagsPage } from "./workspace-detail-flags"
+import type { WorkspaceFeatureFlags, WorkspaceMember } from "@/api/backoffice"
+
+const WORKSPACE_ID = "ws_abc"
+const MEMBER_ID = "workos_user_1"
+
+// A flag whose explicit default is NOT its first declared value — the case the
+// backoffice reconstructed wrongly as values[0] before the wire type carried
+// `default` (chunk-5 `calls` is exactly this shape).
+function callsFlags(overrides: WorkspaceFeatureFlags["overrides"] = []): WorkspaceFeatureFlags {
+  return {
+    flags: [{ key: "calls", values: ["off", "on"], default: "on", scopes: ["workspace", "user"] }],
+    overrides,
+  }
+}
+
+function workspaceOverride(value: string): WorkspaceFeatureFlags["overrides"][number] {
+  return {
+    subjectType: "workspace",
+    subjectId: WORKSPACE_ID,
+    flagKey: "calls",
+    value,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+const MEMBERS: WorkspaceMember[] = [
+  {
+    workosUserId: MEMBER_ID,
+    email: "alice@example.com",
+    firstName: "Alice",
+    lastName: null,
+    status: "active",
+    roleSlugs: [],
+    lastEventAt: new Date().toISOString(),
+  },
+]
+
+interface FetchConfig {
+  flags: WorkspaceFeatureFlags
+  onPut?: (body: unknown) => void
+}
+
+function installFetch({ flags, onPut }: FetchConfig): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString()
+      const method = init?.method ?? "GET"
+      if (url.includes("/feature-flags") && method === "PUT") {
+        onPut?.(init?.body ? JSON.parse(init.body as string) : undefined)
+        return new Response(null, { status: 204 })
+      }
+      if (url.includes("/feature-flags")) {
+        return new Response(JSON.stringify(flags), { status: 200, headers: { "Content-Type": "application/json" } })
+      }
+      if (url.includes("/members")) {
+        return new Response(JSON.stringify({ members: MEMBERS }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    })
+  )
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/workspaces/${WORKSPACE_ID}/flags`]}>
+        <Routes>
+          <Route path="/workspaces/:id/flags" element={<WorkspaceDetailFlagsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe("WorkspaceDetailFlagsPage default handling", () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("shows the explicit default (not values[0]) and marks the (default) option on it", async () => {
+    installFetch({ flags: callsFlags() })
+    renderPage()
+
+    const [workspaceSelect] = await screen.findAllByLabelText<HTMLSelectElement>("calls")
+    // No override → resolves to the flag's explicit default "on", not values[0] "off".
+    expect(workspaceSelect.value).toBe("on")
+    // The (default) suffix rides the explicit default, not the first-declared value.
+    expect(within(workspaceSelect).getByRole("option", { name: "on (default)" })).toBeInTheDocument()
+    expect(within(workspaceSelect).getByRole("option", { name: "off" })).toBeInTheDocument()
+    // At its default, the control is not highlighted as a deviation.
+    expect(workspaceSelect.className).not.toContain("emerald")
+  })
+
+  it("shows a member the inherited workspace value without a false deviation highlight", async () => {
+    // Workspace set to the non-default "off"; the member has no personal override.
+    installFetch({ flags: callsFlags([workspaceOverride("off")]) })
+    renderPage()
+
+    const [workspaceSelect, memberSelect] = await screen.findAllByLabelText<HTMLSelectElement>("calls")
+    // Workspace deviates from the default → highlighted.
+    expect(workspaceSelect.value).toBe("off")
+    expect(workspaceSelect.className).toContain("emerald")
+    // Member inherits the workspace value (off), and is NOT falsely highlighted —
+    // they match their inherited baseline, they haven't deviated from it.
+    expect(memberSelect.value).toBe("off")
+    expect(memberSelect.className).not.toContain("emerald")
+  })
+
+  it("clears the override when set back to the explicit default", async () => {
+    const puts: unknown[] = []
+    installFetch({ flags: callsFlags([workspaceOverride("off")]), onPut: (body) => puts.push(body) })
+    renderPage()
+
+    const [workspaceSelect] = await screen.findAllByLabelText<HTMLSelectElement>("calls")
+    expect(workspaceSelect.value).toBe("off")
+
+    await userEvent.selectOptions(workspaceSelect, "on")
+
+    // The PUT carries the explicit default; the optimistic cache clears the
+    // override (defaultValue === value), agreeing with the server's clear.
+    await waitFor(() => expect(puts).toHaveLength(1))
+    expect(puts[0]).toEqual({
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+      flagKey: "calls",
+      value: "on",
+    })
+    await waitFor(() => expect(workspaceSelect.value).toBe("on"))
+    expect(workspaceSelect.className).not.toContain("emerald")
+  })
+})

--- a/apps/backoffice/src/pages/workspace-detail-flags.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-flags.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useParams } from "react-router-dom"
+import type { FeatureFlagScope } from "@threa/types"
 import { Section } from "@/components/layout/section"
 import { InlineBanner } from "@/components/inline-banner"
 import { Label } from "@/components/ui/label"
@@ -19,6 +20,14 @@ function memberDisplayName(m: WorkspaceMember): string {
   const parts = [m.firstName, m.lastName].filter((x): x is string => !!x && x.length > 0)
   if (parts.length > 0) return parts.join(" ")
   return m.email ?? m.workosUserId
+}
+
+interface SetVars {
+  subjectType: FeatureFlagScope
+  subjectId: string
+  flagKey: string
+  value: string
+  defaultValue: string
 }
 
 export function WorkspaceDetailFlagsPage() {
@@ -44,10 +53,11 @@ export function WorkspaceDetailFlagsPage() {
   })
 
   const setMutation = useMutation({
-    mutationFn: (vars: { workosUserId: string; flagKey: string; value: string; defaultValue: string }) => {
+    mutationFn: (vars: SetVars) => {
       if (!id) throw new Error("Missing workspace id")
       return setWorkspaceFeatureFlag(id, {
-        workosUserId: vars.workosUserId,
+        subjectType: vars.subjectType,
+        subjectId: vars.subjectId,
         flagKey: vars.flagKey,
         value: vars.value,
       })
@@ -59,14 +69,17 @@ export function WorkspaceDetailFlagsPage() {
       // default value clears the override (only deviations are stored).
       queryClient.setQueryData<WorkspaceFeatureFlags>(backofficeKeys.workspaceFeatureFlags(id), (prev) => {
         if (!prev) return prev
-        const rest = prev.overrides.filter((o) => !(o.workosUserId === vars.workosUserId && o.flagKey === vars.flagKey))
+        const rest = prev.overrides.filter(
+          (o) => !(o.subjectType === vars.subjectType && o.subjectId === vars.subjectId && o.flagKey === vars.flagKey)
+        )
         if (vars.value === vars.defaultValue) return { ...prev, overrides: rest }
         return {
           ...prev,
           overrides: [
             ...rest,
             {
-              workosUserId: vars.workosUserId,
+              subjectType: vars.subjectType,
+              subjectId: vars.subjectId,
               flagKey: vars.flagKey,
               value: vars.value,
               updatedAt: new Date().toISOString(),
@@ -78,20 +91,20 @@ export function WorkspaceDetailFlagsPage() {
   })
 
   const setError = readApiError(setMutation.error)
-  const busyKey = setMutation.isPending
-    ? `${setMutation.variables?.workosUserId}:${setMutation.variables?.flagKey}`
-    : null
+  const v = setMutation.variables
+  const busyKey = setMutation.isPending && v ? `${v.subjectType}:${v.subjectId}:${v.flagKey}` : null
 
   return (
     <div className="flex flex-col gap-10">
       <Section
         label="Feature flags"
-        description="Per-member rollout switches. Each flag's first declared value is the default; setting a different value propagates to the member's live sessions within seconds. Flags are temporary — retire the key from FEATURE_FLAGS once the rollout is done."
+        description="Workspace-wide and per-member rollout switches. Each flag has an explicit default; a user override wins over the workspace value, which wins over that default. Setting a value propagates to live sessions within seconds. Flags are temporary — retire the key from FEATURE_FLAGS once the rollout is done."
       >
         {setError ? <InlineBanner tone="error">Couldn't update flag: {setError}</InlineBanner> : null}
         <FlagsBody
           loading={flagsQ.isLoading || membersQ.isLoading}
           error={flagsQ.error ?? membersQ.error}
+          workspaceId={id}
           flags={flagsQ.data}
           members={membersQ.data}
           busyKey={busyKey}
@@ -102,9 +115,92 @@ export function WorkspaceDetailFlagsPage() {
   )
 }
 
+/** One subject's row of flag controls — a control appears only for flags that declare this scope. */
+function SubjectFlagRow({
+  subjectType,
+  subjectId,
+  title,
+  subtitle,
+  flags,
+  overrides,
+  busyKey,
+  onSet,
+}: {
+  subjectType: FeatureFlagScope
+  subjectId: string
+  title: string
+  subtitle: string | null
+  flags: WorkspaceFeatureFlagDefinition[]
+  overrides: WorkspaceFeatureFlags["overrides"]
+  busyKey: string | null
+  onSet: (vars: SetVars) => void
+}) {
+  const scoped = flags.filter((flag) => flag.scopes.includes(subjectType))
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-4 py-4 pl-1 pr-3">
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate text-sm font-medium text-foreground">{title}</span>
+        {subtitle ? <span className="truncate text-xs text-muted-foreground">{subtitle}</span> : null}
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-4">
+        {scoped.map((flag) => {
+          // A member with no override of its own inherits the workspace override
+          // (else the flag default); the workspace row inherits the flag default.
+          // The emerald highlight marks deviation from THIS baseline, so an
+          // inheriting member stays unmarked even when the workspace is non-default.
+          const workspaceValue = overrides.find((o) => o.subjectType === "workspace" && o.flagKey === flag.key)?.value
+          const inheritedValue = subjectType === "user" ? (workspaceValue ?? flag.default) : flag.default
+          const ownOverride = overrides.find(
+            (o) => o.subjectType === subjectType && o.subjectId === subjectId && o.flagKey === flag.key
+          )?.value
+          const value = ownOverride ?? inheritedValue
+          const deviates = value !== inheritedValue
+          const controlId = `flag-${subjectType}-${subjectId}-${flag.key}`
+          const busy = busyKey === `${subjectType}:${subjectId}:${flag.key}`
+          return (
+            <div key={flag.key} className="flex items-center gap-2">
+              <Label htmlFor={controlId} className="font-mono text-xs text-muted-foreground">
+                {flag.key}
+              </Label>
+              <select
+                id={controlId}
+                value={value}
+                disabled={busy}
+                onChange={(e) =>
+                  onSet({
+                    subjectType,
+                    subjectId,
+                    flagKey: flag.key,
+                    value: e.target.value,
+                    defaultValue: flag.default,
+                  })
+                }
+                className={cn(
+                  "h-8 rounded-input border border-input bg-background px-2 font-mono text-xs",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                  deviates && "border-emerald-500/50 bg-emerald-500/10"
+                )}
+              >
+                {flag.values.map((val) => (
+                  <option key={val} value={val}>
+                    {val}
+                    {val === flag.default ? " (default)" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )
+        })}
+      </div>
+    </li>
+  )
+}
+
 function FlagsBody({
   loading,
   error,
+  workspaceId,
   flags,
   members,
   busyKey,
@@ -112,10 +208,11 @@ function FlagsBody({
 }: {
   loading: boolean
   error: unknown
+  workspaceId: string | undefined
   flags: WorkspaceFeatureFlags | undefined
   members: WorkspaceMember[] | undefined
   busyKey: string | null
-  onSet: (vars: { workosUserId: string; flagKey: string; value: string; defaultValue: string }) => void
+  onSet: (vars: SetVars) => void
 }) {
   if (loading) {
     return <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">Loading feature flags…</div>
@@ -130,7 +227,7 @@ function FlagsBody({
     )
   }
 
-  if (!flags || flags.flags.length === 0) {
+  if (!flags || flags.flags.length === 0 || !workspaceId) {
     return (
       <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">
         No flags in the registry — add a key to FEATURE_FLAGS in @threa/types to start a rollout.
@@ -138,70 +235,41 @@ function FlagsBody({
     )
   }
 
-  if (!members || members.length === 0) {
-    return (
-      <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">
-        No members to flag — the WorkOS membership mirror is empty for this workspace.
-      </div>
-    )
-  }
-
-  const valueFor = (workosUserId: string, flag: WorkspaceFeatureFlagDefinition): string =>
-    flags.overrides.find((o) => o.workosUserId === workosUserId && o.flagKey === flag.key)?.value ?? flag.values[0]
-
   return (
-    <ul className="divide-y border-y">
-      {members.map((member) => (
-        <li key={member.workosUserId} className="flex flex-wrap items-center justify-between gap-4 py-4 pl-1 pr-3">
-          <div className="flex min-w-0 flex-col gap-1">
-            <span className="truncate text-sm font-medium text-foreground">{memberDisplayName(member)}</span>
-            {member.email ? <span className="truncate text-xs text-muted-foreground">{member.email}</span> : null}
-          </div>
-          <div className="flex shrink-0 flex-wrap items-center gap-4">
-            {flags.flags.map((flag) => {
-              const value = valueFor(member.workosUserId, flag)
-              const isDefault = value === flag.values[0]
-              const busy = busyKey === `${member.workosUserId}:${flag.key}`
-              return (
-                <div key={flag.key} className="flex items-center gap-2">
-                  <Label
-                    htmlFor={`flag-${member.workosUserId}-${flag.key}`}
-                    className="font-mono text-xs text-muted-foreground"
-                  >
-                    {flag.key}
-                  </Label>
-                  <select
-                    id={`flag-${member.workosUserId}-${flag.key}`}
-                    value={value}
-                    disabled={busy}
-                    onChange={(e) =>
-                      onSet({
-                        workosUserId: member.workosUserId,
-                        flagKey: flag.key,
-                        value: e.target.value,
-                        defaultValue: flag.values[0],
-                      })
-                    }
-                    className={cn(
-                      "h-8 rounded-input border border-input bg-background px-2 font-mono text-xs",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      "disabled:cursor-not-allowed disabled:opacity-50",
-                      !isDefault && "border-emerald-500/50 bg-emerald-500/10"
-                    )}
-                  >
-                    {flag.values.map((v, idx) => (
-                      <option key={v} value={v}>
-                        {v}
-                        {idx === 0 ? " (default)" : ""}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )
-            })}
-          </div>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col gap-6">
+      <ul className="divide-y border-y">
+        <SubjectFlagRow
+          subjectType="workspace"
+          subjectId={workspaceId}
+          title="Entire workspace"
+          subtitle="Workspace-wide default — a member override below wins."
+          flags={flags.flags}
+          overrides={flags.overrides}
+          busyKey={busyKey}
+          onSet={onSet}
+        />
+      </ul>
+      {members && members.length > 0 ? (
+        <ul className="divide-y border-y">
+          {members.map((member) => (
+            <SubjectFlagRow
+              key={member.workosUserId}
+              subjectType="user"
+              subjectId={member.workosUserId}
+              title={memberDisplayName(member)}
+              subtitle={member.email}
+              flags={flags.flags}
+              overrides={flags.overrides}
+              busyKey={busyKey}
+              onSet={onSet}
+            />
+          ))}
+        </ul>
+      ) : (
+        <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">
+          No members to flag — the WorkOS membership mirror is empty for this workspace.
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/control-plane/src/db/migrations/016_feature_flag_subjects.sql
+++ b/apps/control-plane/src/db/migrations/016_feature_flag_subjects.sql
@@ -1,0 +1,23 @@
+-- Re-key feature_flag_overrides on (subject_type, subject_id) so a row can
+-- describe a whole workspace, not just a user. `subject_type` is TEXT validated
+-- in code (INV-3): 'workspace' rows carry the workspace id in `subject_id`,
+-- 'user' rows carry the workos_user_id. `subject_id` is NOT NULL — a nullable
+-- user column would let Postgres' NULLs-are-distinct rule permit duplicate
+-- workspace rows. ALTER (not drop-and-recreate) is correct whether or not the
+-- table is empty; existing rows backfill to the old user-scoped meaning.
+
+ALTER TABLE feature_flag_overrides
+    ADD COLUMN subject_type TEXT,
+    ADD COLUMN subject_id TEXT;
+
+UPDATE feature_flag_overrides
+    SET subject_type = 'user', subject_id = workos_user_id;
+
+ALTER TABLE feature_flag_overrides
+    ALTER COLUMN subject_type SET NOT NULL,
+    ALTER COLUMN subject_id SET NOT NULL;
+
+ALTER TABLE feature_flag_overrides
+    DROP CONSTRAINT feature_flag_overrides_pkey,
+    ADD PRIMARY KEY (workspace_id, subject_type, subject_id, flag_key),
+    DROP COLUMN workos_user_id;

--- a/apps/control-plane/src/features/feature-flags/handlers.ts
+++ b/apps/control-plane/src/features/feature-flags/handlers.ts
@@ -1,13 +1,15 @@
 import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import { HttpError } from "@threa/backend-common"
-import { FEATURE_FLAG_DEFINITIONS, FEATURE_FLAG_KEYS } from "@threa/types"
+import { FEATURE_FLAG_DEFINITIONS, FEATURE_FLAG_KEYS, FEATURE_FLAG_SCOPES } from "@threa/types"
 import type { ControlPlaneFeatureFlagService } from "./service"
 
 const setFlagSchema = z.object({
-  workosUserId: z.string().min(1),
+  subjectType: z.enum(FEATURE_FLAG_SCOPES),
+  /** Workspace id for workspace scope, workos_user_id for user scope. */
+  subjectId: z.string().min(1),
   flagKey: z.string().min(1),
-  /** Must be one of the flag's declared values; the default (first) value clears the override. */
+  /** Must be one of the flag's declared values; the flag's explicit default clears the override. */
   value: z.string().min(1),
 })
 
@@ -18,9 +20,9 @@ interface Dependencies {
 export function createFeatureFlagHandlers({ featureFlagService }: Dependencies) {
   return {
     /**
-     * Registry (key + declared values, first value is the default) plus the
-     * stored per-user overrides. The backoffice renders the member × flag
-     * grid from these two lists.
+     * Registry (key + declared values + each flag's explicit default + declared
+     * scopes) plus the stored overrides. The backoffice renders the workspace
+     * row and the member × flag grid from these two lists.
      */
     async listWorkspaceFlags(req: Request, res: Response) {
       const id = req.params.id
@@ -29,9 +31,15 @@ export function createFeatureFlagHandlers({ featureFlagService }: Dependencies) 
       }
       const overrides = await featureFlagService.listWorkspaceOverrides(id)
       res.json({
-        flags: FEATURE_FLAG_KEYS.map((key) => ({ key, values: FEATURE_FLAG_DEFINITIONS[key].values })),
+        flags: FEATURE_FLAG_KEYS.map((key) => ({
+          key,
+          values: FEATURE_FLAG_DEFINITIONS[key].values,
+          default: FEATURE_FLAG_DEFINITIONS[key].default,
+          scopes: FEATURE_FLAG_DEFINITIONS[key].scopes,
+        })),
         overrides: overrides.map((o) => ({
-          workosUserId: o.workosUserId,
+          subjectType: o.subjectType,
+          subjectId: o.subjectId,
           flagKey: o.flagKey,
           value: o.value,
           updatedAt: o.updatedAt.toISOString(),
@@ -50,7 +58,8 @@ export function createFeatureFlagHandlers({ featureFlagService }: Dependencies) 
       }
       await featureFlagService.setFlag({
         workspaceId: id,
-        workosUserId: parsed.data.workosUserId,
+        subjectType: parsed.data.subjectType,
+        subjectId: parsed.data.subjectId,
         flagKey: parsed.data.flagKey,
         value: parsed.data.value,
       })

--- a/apps/control-plane/src/features/feature-flags/repository.ts
+++ b/apps/control-plane/src/features/feature-flags/repository.ts
@@ -1,14 +1,17 @@
 import type { Querier } from "@threa/backend-common"
+import type { FeatureFlagScope } from "@threa/types"
 
 export interface FeatureFlagOverrideRow {
-  workos_user_id: string
+  subject_type: FeatureFlagScope
+  subject_id: string
   flag_key: string
   value: string
   updated_at: Date
 }
 
 export interface FeatureFlagOverrideRecord {
-  workosUserId: string
+  subjectType: FeatureFlagScope
+  subjectId: string
   flagKey: string
   value: string
   updatedAt: Date
@@ -16,7 +19,8 @@ export interface FeatureFlagOverrideRecord {
 
 function mapRow(row: FeatureFlagOverrideRow): FeatureFlagOverrideRecord {
   return {
-    workosUserId: row.workos_user_id,
+    subjectType: row.subject_type,
+    subjectId: row.subject_id,
     flagKey: row.flag_key,
     value: row.value,
     updatedAt: row.updated_at,
@@ -26,7 +30,7 @@ function mapRow(row: FeatureFlagOverrideRow): FeatureFlagOverrideRecord {
 export const FeatureFlagOverrideRepository = {
   async listByWorkspace(db: Querier, workspaceId: string): Promise<FeatureFlagOverrideRecord[]> {
     const result = await db.query<FeatureFlagOverrideRow>(
-      `SELECT workos_user_id, flag_key, value, updated_at
+      `SELECT subject_type, subject_id, flag_key, value, updated_at
        FROM feature_flag_overrides
        WHERE workspace_id = $1`,
       [workspaceId]
@@ -34,12 +38,17 @@ export const FeatureFlagOverrideRepository = {
     return result.rows.map(mapRow)
   },
 
-  async listForUser(db: Querier, workspaceId: string, workosUserId: string): Promise<FeatureFlagOverrideRecord[]> {
+  async listForSubject(
+    db: Querier,
+    workspaceId: string,
+    subjectType: FeatureFlagScope,
+    subjectId: string
+  ): Promise<FeatureFlagOverrideRecord[]> {
     const result = await db.query<FeatureFlagOverrideRow>(
-      `SELECT workos_user_id, flag_key, value, updated_at
+      `SELECT subject_type, subject_id, flag_key, value, updated_at
        FROM feature_flag_overrides
-       WHERE workspace_id = $1 AND workos_user_id = $2`,
-      [workspaceId, workosUserId]
+       WHERE workspace_id = $1 AND subject_type = $2 AND subject_id = $3`,
+      [workspaceId, subjectType, subjectId]
     )
     return result.rows.map(mapRow)
   },
@@ -47,27 +56,27 @@ export const FeatureFlagOverrideRepository = {
   /** Race-safe upsert (INV-20) — concurrent admin writes converge on last write. */
   async setOverride(
     db: Querier,
-    params: { workspaceId: string; workosUserId: string; flagKey: string; value: string }
+    params: { workspaceId: string; subjectType: FeatureFlagScope; subjectId: string; flagKey: string; value: string }
   ): Promise<void> {
     await db.query(
-      `INSERT INTO feature_flag_overrides (workspace_id, workos_user_id, flag_key, value)
-       VALUES ($1, $2, $3, $4)
-       ON CONFLICT (workspace_id, workos_user_id, flag_key) DO UPDATE SET
+      `INSERT INTO feature_flag_overrides (workspace_id, subject_type, subject_id, flag_key, value)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (workspace_id, subject_type, subject_id, flag_key) DO UPDATE SET
          value = EXCLUDED.value,
          updated_at = NOW()`,
-      [params.workspaceId, params.workosUserId, params.flagKey, params.value]
+      [params.workspaceId, params.subjectType, params.subjectId, params.flagKey, params.value]
     )
   },
 
-  /** Remove an override (revert the flag to its default: the first declared value). */
+  /** Remove an override (revert the flag to its explicit default). */
   async deleteOverride(
     db: Querier,
-    params: { workspaceId: string; workosUserId: string; flagKey: string }
+    params: { workspaceId: string; subjectType: FeatureFlagScope; subjectId: string; flagKey: string }
   ): Promise<void> {
     await db.query(
       `DELETE FROM feature_flag_overrides
-       WHERE workspace_id = $1 AND workos_user_id = $2 AND flag_key = $3`,
-      [params.workspaceId, params.workosUserId, params.flagKey]
+       WHERE workspace_id = $1 AND subject_type = $2 AND subject_id = $3 AND flag_key = $4`,
+      [params.workspaceId, params.subjectType, params.subjectId, params.flagKey]
     )
   },
 }

--- a/apps/control-plane/src/features/feature-flags/service.test.ts
+++ b/apps/control-plane/src/features/feature-flags/service.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { HttpError } from "@threa/backend-common"
-import { defaultFeatureFlags } from "@threa/types"
-import { ControlPlaneFeatureFlagService } from "./service"
+import * as backendCommon from "@threa/backend-common"
+import { HttpError, OutboxRepository } from "@threa/backend-common"
+import { FEATURE_FLAG_DEFINITIONS, type FeatureFlagDefinition } from "@threa/types"
+import { ControlPlaneFeatureFlagService, OUTBOX_FEATURE_FLAGS_SYNC } from "./service"
 import { FeatureFlagOverrideRepository } from "./repository"
 import { WorkspaceRegistryRepository } from "../workspaces"
 import type { RegionalClient } from "../../lib/regional-client"
@@ -9,50 +10,226 @@ import type { RegionalClient } from "../../lib/regional-client"
 const WORKSPACE_ID = "ws_1"
 const WORKOS_USER_ID = "workos_user_1"
 
+// The shipped FEATURE_FLAGS is empty between rollouts, so inject a stand-in
+// registry (visible to the code-bound predicates, which read
+// FEATURE_FLAG_DEFINITIONS dynamically) and clear it after each test rather
+// than committing a fake flag to @threa/types.
+const STANDIN_REGISTRY = {
+  wsOnly: { values: ["off", "on"], scopes: ["workspace"], default: "off" },
+  userOnly: { values: ["off", "on"], scopes: ["user"], default: "off" },
+  both: { values: ["off", "shadow", "active"], scopes: ["workspace", "user"], default: "off" },
+} as const satisfies Record<string, FeatureFlagDefinition>
+
+function injectRegistry() {
+  Object.assign(FEATURE_FLAG_DEFINITIONS, STANDIN_REGISTRY)
+}
+
+function resetRegistry() {
+  for (const key of Object.keys(STANDIN_REGISTRY)) delete FEATURE_FLAG_DEFINITIONS[key]
+}
+
 function makeService(regionalClient: Partial<RegionalClient> = {}) {
   return new ControlPlaneFeatureFlagService({ pool: {} as any, regionalClient: regionalClient as RegionalClient })
 }
 
+function stubWrite(): {
+  setOverride: ReturnType<typeof spyOn>
+  deleteOverride: ReturnType<typeof spyOn>
+  insert: ReturnType<typeof spyOn>
+} {
+  spyOn(WorkspaceRegistryRepository, "findById").mockResolvedValue({ id: WORKSPACE_ID, region: "eu" } as any)
+  spyOn(backendCommon, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: unknown) => unknown) =>
+    fn({})) as typeof backendCommon.withTransaction)
+  return {
+    setOverride: spyOn(FeatureFlagOverrideRepository, "setOverride").mockResolvedValue(),
+    deleteOverride: spyOn(FeatureFlagOverrideRepository, "deleteOverride").mockResolvedValue(),
+    insert: spyOn(OutboxRepository, "insert").mockResolvedValue({} as any),
+  }
+}
+
+async function expectHttpError(promise: Promise<unknown>, code: string, status = 400): Promise<void> {
+  try {
+    await promise
+    throw new Error(`expected HttpError ${code}`)
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpError)
+    expect({ code: (err as HttpError).code, status: (err as HttpError).status }).toEqual({ code, status })
+  }
+}
+
 describe("ControlPlaneFeatureFlagService.setFlag", () => {
-  afterEach(() => mock.restore())
+  afterEach(() => {
+    resetRegistry()
+    mock.restore()
+  })
 
   it("rejects keys that are not in the registry", async () => {
-    const service = makeService()
+    await expectHttpError(
+      makeService().setFlag({
+        workspaceId: WORKSPACE_ID,
+        subjectType: "user",
+        subjectId: WORKOS_USER_ID,
+        flagKey: "nope",
+        value: "on",
+      }),
+      "UNKNOWN_FLAG"
+    )
+  })
 
-    await expect(
-      service.setFlag({ workspaceId: WORKSPACE_ID, workosUserId: WORKOS_USER_ID, flagKey: "nope", value: "on" })
-    ).rejects.toThrow(HttpError)
+  it("writes a subject_type='workspace' row keyed by the workspace id for a workspace-scope set", async () => {
+    injectRegistry()
+    const { setOverride, insert } = stubWrite()
+
+    await makeService().setFlag({
+      workspaceId: WORKSPACE_ID,
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+      flagKey: "wsOnly",
+      value: "on",
+    })
+
+    expect(setOverride).toHaveBeenCalledWith(
+      {},
+      { workspaceId: WORKSPACE_ID, subjectType: "workspace", subjectId: WORKSPACE_ID, flagKey: "wsOnly", value: "on" }
+    )
+    expect(insert).toHaveBeenCalledWith({}, OUTBOX_FEATURE_FLAGS_SYNC, {
+      workspaceId: WORKSPACE_ID,
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+    })
+  })
+
+  it("writes a subject_type='user' row for a user-scope set", async () => {
+    injectRegistry()
+    const { setOverride, insert } = stubWrite()
+
+    await makeService().setFlag({
+      workspaceId: WORKSPACE_ID,
+      subjectType: "user",
+      subjectId: WORKOS_USER_ID,
+      flagKey: "userOnly",
+      value: "on",
+    })
+
+    expect(setOverride).toHaveBeenCalledWith(
+      {},
+      { workspaceId: WORKSPACE_ID, subjectType: "user", subjectId: WORKOS_USER_ID, flagKey: "userOnly", value: "on" }
+    )
+    expect(insert).toHaveBeenCalledWith({}, OUTBOX_FEATURE_FLAGS_SYNC, {
+      workspaceId: WORKSPACE_ID,
+      subjectType: "user",
+      subjectId: WORKOS_USER_ID,
+    })
+  })
+
+  it("rejects a user-scope write to a workspace-only flag", async () => {
+    injectRegistry()
+    await expectHttpError(
+      makeService().setFlag({
+        workspaceId: WORKSPACE_ID,
+        subjectType: "user",
+        subjectId: WORKOS_USER_ID,
+        flagKey: "wsOnly",
+        value: "on",
+      }),
+      "FLAG_SCOPE_NOT_ALLOWED"
+    )
+  })
+
+  it("rejects a workspace-scope write whose subjectId is not the workspace id", async () => {
+    injectRegistry()
+    await expectHttpError(
+      makeService().setFlag({
+        workspaceId: WORKSPACE_ID,
+        subjectType: "workspace",
+        subjectId: WORKOS_USER_ID,
+        flagKey: "wsOnly",
+        value: "on",
+      }),
+      "INVALID_SUBJECT"
+    )
+  })
+
+  it("rejects a workspace-scope write to a user-only flag", async () => {
+    injectRegistry()
+    await expectHttpError(
+      makeService().setFlag({
+        workspaceId: WORKSPACE_ID,
+        subjectType: "workspace",
+        subjectId: WORKSPACE_ID,
+        flagKey: "userOnly",
+        value: "on",
+      }),
+      "FLAG_SCOPE_NOT_ALLOWED"
+    )
+  })
+
+  it("clears the override (delete, no write) when set to the default value at either scope", async () => {
+    injectRegistry()
+    const { setOverride, deleteOverride } = stubWrite()
+
+    await makeService().setFlag({
+      workspaceId: WORKSPACE_ID,
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+      flagKey: "wsOnly",
+      value: "off",
+    })
+    await makeService().setFlag({
+      workspaceId: WORKSPACE_ID,
+      subjectType: "user",
+      subjectId: WORKOS_USER_ID,
+      flagKey: "userOnly",
+      value: "off",
+    })
+
+    expect(setOverride).not.toHaveBeenCalled()
+    expect(deleteOverride).toHaveBeenCalledWith(
+      {},
+      { workspaceId: WORKSPACE_ID, subjectType: "workspace", subjectId: WORKSPACE_ID, flagKey: "wsOnly" }
+    )
+    expect(deleteOverride).toHaveBeenCalledWith(
+      {},
+      { workspaceId: WORKSPACE_ID, subjectType: "user", subjectId: WORKOS_USER_ID, flagKey: "userOnly" }
+    )
   })
 })
 
 describe("ControlPlaneFeatureFlagService.syncToRegion", () => {
-  afterEach(() => mock.restore())
+  afterEach(() => {
+    resetRegistry()
+    mock.restore()
+  })
 
-  it("pushes the user's resolved snapshot to the workspace's region, dropping retired overrides", async () => {
+  it("pushes the subject's raw overrides filtered by registry and scope, not a resolved map", async () => {
+    injectRegistry()
     spyOn(WorkspaceRegistryRepository, "findById").mockResolvedValue({ id: WORKSPACE_ID, region: "eu" } as any)
-    // A stored override whose key is no longer in the registry resolves away,
-    // so the snapshot pushed to the region is the bare defaults.
-    spyOn(FeatureFlagOverrideRepository, "listForUser").mockResolvedValue([
-      { workosUserId: WORKOS_USER_ID, flagKey: "retired-flag", value: "on", updatedAt: new Date() },
+    spyOn(FeatureFlagOverrideRepository, "listForSubject").mockResolvedValue([
+      { subjectType: "workspace", subjectId: WORKSPACE_ID, flagKey: "wsOnly", value: "on", updatedAt: new Date() },
+      // userOnly is user-scoped, so a workspace row for it is inert.
+      { subjectType: "workspace", subjectId: WORKSPACE_ID, flagKey: "userOnly", value: "on", updatedAt: new Date() },
+      // retired key: no longer in the registry.
+      { subjectType: "workspace", subjectId: WORKSPACE_ID, flagKey: "retired", value: "on", updatedAt: new Date() },
     ])
     const sync = mock(() => Promise.resolve())
-    const service = makeService({ syncUserFeatureFlags: sync } as any)
+    const service = makeService({ syncFeatureFlags: sync } as any)
 
-    await service.syncToRegion({ workspaceId: WORKSPACE_ID, workosUserId: WORKOS_USER_ID })
+    await service.syncToRegion({ workspaceId: WORKSPACE_ID, subjectType: "workspace", subjectId: WORKSPACE_ID })
 
     expect(sync).toHaveBeenCalledWith("eu", {
       workspaceId: WORKSPACE_ID,
-      workosUserId: WORKOS_USER_ID,
-      flags: defaultFeatureFlags(),
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+      overrides: { wsOnly: "on" },
     })
   })
 
   it("skips quietly when the workspace is gone from the registry", async () => {
     spyOn(WorkspaceRegistryRepository, "findById").mockResolvedValue(null)
     const sync = mock(() => Promise.resolve())
-    const service = makeService({ syncUserFeatureFlags: sync } as any)
+    const service = makeService({ syncFeatureFlags: sync } as any)
 
-    await service.syncToRegion({ workspaceId: WORKSPACE_ID, workosUserId: WORKOS_USER_ID })
+    await service.syncToRegion({ workspaceId: WORKSPACE_ID, subjectType: "user", subjectId: WORKOS_USER_ID })
 
     expect(sync).not.toHaveBeenCalled()
   })

--- a/apps/control-plane/src/features/feature-flags/service.ts
+++ b/apps/control-plane/src/features/feature-flags/service.ts
@@ -2,10 +2,10 @@ import type { Pool } from "pg"
 import { HttpError, withTransaction, logger, OutboxRepository } from "@threa/backend-common"
 import {
   defaultFeatureFlagValue,
+  flagAllowsScope,
   isFeatureFlagKey,
   isFeatureFlagValue,
-  resolveFeatureFlags,
-  type FeatureFlags,
+  type FeatureFlagScope,
 } from "@threa/types"
 import { FeatureFlagOverrideRepository, type FeatureFlagOverrideRecord } from "./repository"
 import { WorkspaceRegistryRepository } from "../workspaces"
@@ -14,13 +14,14 @@ import type { RegionalClient } from "../../lib/regional-client"
 export const OUTBOX_FEATURE_FLAGS_SYNC = "feature_flags_sync"
 
 /**
- * Outbox payload for the regional fan-out. Carries only identity — the
- * handler re-reads the overrides at delivery time and pushes a full snapshot,
- * so rapid changes collapse to the latest state and replays are idempotent.
+ * Outbox payload for the regional fan-out. Carries only the subject identity —
+ * the handler re-reads that subject's overrides at delivery time, so rapid
+ * changes collapse to the latest state and replays are idempotent.
  */
 export interface FeatureFlagsSyncPayload extends Record<string, unknown> {
   workspaceId: string
-  workosUserId: string
+  subjectType: FeatureFlagScope
+  subjectId: string
 }
 
 interface Dependencies {
@@ -28,15 +29,20 @@ interface Dependencies {
   regionalClient: RegionalClient
 }
 
-function toOverrideRecord(rows: { flagKey: string; value: string }[]): Record<string, string> {
-  return Object.fromEntries(rows.map((row) => [row.flagKey, row.value]))
+/** A stored override still backed by the code registry — live key, declared value, and a scope the flag allows. */
+function isLiveOverride(record: FeatureFlagOverrideRecord): boolean {
+  return (
+    isFeatureFlagKey(record.flagKey) &&
+    isFeatureFlagValue(record.flagKey, record.value) &&
+    flagAllowsScope(record.flagKey, record.subjectType)
+  )
 }
 
 /**
- * Source of truth for per-user feature flags. Backoffice admins set values
- * here; every write emits a durable outbox event that pushes the user's
- * resolved flag snapshot to the workspace's regional backend, which in turn
- * broadcasts it to the user's live sessions.
+ * Source of truth for feature flag overrides. Backoffice admins set values
+ * here — at workspace or user scope; every write emits a durable outbox event
+ * that pushes that subject's raw overrides to the workspace's regional backend,
+ * which resolves them against the same registry and broadcasts to live sessions.
  */
 export class ControlPlaneFeatureFlagService {
   private pool: Pool
@@ -48,59 +54,69 @@ export class ControlPlaneFeatureFlagService {
   }
 
   /**
-   * All overrides stored for a workspace, filtered to keys/values still in
-   * the code registry so the backoffice never renders retired flags.
+   * All overrides stored for a workspace, filtered to keys/values/scopes still
+   * in the code registry so the backoffice never renders retired flags.
    */
   async listWorkspaceOverrides(workspaceId: string): Promise<FeatureFlagOverrideRecord[]> {
     const rows = await FeatureFlagOverrideRepository.listByWorkspace(this.pool, workspaceId)
-    return rows.filter((row) => isFeatureFlagKey(row.flagKey) && isFeatureFlagValue(row.flagKey, row.value))
+    return rows.filter(isLiveOverride)
   }
 
   /**
-   * Set one user's flag to a declared value. Choosing the default (first
-   * declared) value clears the override — only deviations from default are
-   * stored, mirroring workspace-settings. The override write and the fan-out
-   * outbox event commit atomically (INV-7).
+   * Set one subject's flag to a declared value. Choosing the flag's explicit
+   * default clears the override — only deviations from default are stored,
+   * mirroring workspace-settings. The override write and the fan-out outbox
+   * event commit atomically (INV-7).
    */
-  async setFlag(params: { workspaceId: string; workosUserId: string; flagKey: string; value: string }): Promise<void> {
-    const { flagKey, value } = params
+  async setFlag(params: {
+    workspaceId: string
+    subjectType: FeatureFlagScope
+    subjectId: string
+    flagKey: string
+    value: string
+  }): Promise<void> {
+    const { workspaceId, subjectType, subjectId, flagKey, value } = params
     if (!isFeatureFlagKey(flagKey)) {
       throw new HttpError("Unknown feature flag", { status: 400, code: "UNKNOWN_FLAG" })
+    }
+    if (!flagAllowsScope(flagKey, subjectType)) {
+      throw new HttpError("Feature flag does not allow this scope", { status: 400, code: "FLAG_SCOPE_NOT_ALLOWED" })
+    }
+    // The workspace layer is a single row keyed by the workspace itself; a
+    // subjectId other than the workspace id would orphan a second, unreadable
+    // workspace override (the PK permits it). Reject rather than normalize (INV-11).
+    if (subjectType === "workspace" && subjectId !== workspaceId) {
+      throw new HttpError("Workspace-scope override must target the workspace itself", {
+        status: 400,
+        code: "INVALID_SUBJECT",
+      })
     }
     if (!isFeatureFlagValue(flagKey, value)) {
       throw new HttpError("Value is not declared for this feature flag", { status: 400, code: "UNKNOWN_FLAG_VALUE" })
     }
-    const workspace = await WorkspaceRegistryRepository.findById(this.pool, params.workspaceId)
+    const workspace = await WorkspaceRegistryRepository.findById(this.pool, workspaceId)
     if (!workspace) {
       throw new HttpError("Workspace not found", { status: 404, code: "NOT_FOUND" })
     }
 
     await withTransaction(this.pool, async (client) => {
       if (value === defaultFeatureFlagValue(flagKey)) {
-        await FeatureFlagOverrideRepository.deleteOverride(client, {
-          workspaceId: params.workspaceId,
-          workosUserId: params.workosUserId,
-          flagKey,
-        })
+        await FeatureFlagOverrideRepository.deleteOverride(client, { workspaceId, subjectType, subjectId, flagKey })
       } else {
-        await FeatureFlagOverrideRepository.setOverride(client, {
-          workspaceId: params.workspaceId,
-          workosUserId: params.workosUserId,
-          flagKey,
-          value,
-        })
+        await FeatureFlagOverrideRepository.setOverride(client, { workspaceId, subjectType, subjectId, flagKey, value })
       }
       await OutboxRepository.insert(client, OUTBOX_FEATURE_FLAGS_SYNC, {
-        workspaceId: params.workspaceId,
-        workosUserId: params.workosUserId,
+        workspaceId,
+        subjectType,
+        subjectId,
       } satisfies FeatureFlagsSyncPayload)
     })
   }
 
   /**
-   * Outbox handler: push one user's resolved flag snapshot to the workspace's
-   * region. Reads current state (not event-time state) so the last event to
-   * drain always leaves the region consistent with the control plane.
+   * Outbox handler: push one subject's raw overrides to the workspace's region.
+   * Reads current state (not event-time state) and filters through the registry
+   * so retired flags never reach the region; the region resolves the layers.
    */
   async syncToRegion(payload: FeatureFlagsSyncPayload): Promise<void> {
     const workspace = await WorkspaceRegistryRepository.findById(this.pool, payload.workspaceId)
@@ -109,16 +125,18 @@ export class ControlPlaneFeatureFlagService {
       logger.warn({ workspaceId: payload.workspaceId }, "Feature flag sync skipped: workspace not in registry")
       return
     }
-    const flags = await this.resolveForUser(payload.workspaceId, payload.workosUserId)
-    await this.regionalClient.syncUserFeatureFlags(workspace.region, {
+    const rows = await FeatureFlagOverrideRepository.listForSubject(
+      this.pool,
+      payload.workspaceId,
+      payload.subjectType,
+      payload.subjectId
+    )
+    const overrides = Object.fromEntries(rows.filter(isLiveOverride).map((row) => [row.flagKey, row.value]))
+    await this.regionalClient.syncFeatureFlags(workspace.region, {
       workspaceId: payload.workspaceId,
-      workosUserId: payload.workosUserId,
-      flags,
+      subjectType: payload.subjectType,
+      subjectId: payload.subjectId,
+      overrides,
     })
-  }
-
-  private async resolveForUser(workspaceId: string, workosUserId: string): Promise<FeatureFlags> {
-    const overrides = await FeatureFlagOverrideRepository.listForUser(this.pool, workspaceId, workosUserId)
-    return resolveFeatureFlags({ workspace: {}, user: toOverrideRecord(overrides) })
   }
 }

--- a/apps/control-plane/src/lib/regional-client.ts
+++ b/apps/control-plane/src/lib/regional-client.ts
@@ -1,4 +1,5 @@
 import { logger, INTERNAL_API_KEY_HEADER, type WorkosMembershipStatus } from "@threa/backend-common"
+import type { FeatureFlagScope } from "@threa/types"
 import type { RegionConfig } from "../config"
 
 const REGIONAL_REQUEST_TIMEOUT_MS = 15_000
@@ -174,13 +175,14 @@ export class RegionalClient {
   }
 
   /**
-   * Push one user's resolved feature-flag snapshot to the regional backend.
-   * Full-snapshot semantics keep the call idempotent and replay-safe — the
-   * region replaces the user's rows wholesale.
+   * Push one subject's raw feature-flag overrides to the regional backend. The
+   * region stores each layer separately and resolves at read. Full-snapshot
+   * semantics keep the call idempotent and replay-safe — the region replaces
+   * that subject's rows wholesale.
    */
-  async syncUserFeatureFlags(
+  async syncFeatureFlags(
     region: string,
-    data: { workspaceId: string; workosUserId: string; flags: Record<string, string> }
+    data: { workspaceId: string; subjectType: FeatureFlagScope; subjectId: string; overrides: Record<string, string> }
   ): Promise<void> {
     await this.postInternal(region, "/internal/feature-flags", data, "Regional feature flag sync")
   }

--- a/docs/plans/workspace-feature-flags.md
+++ b/docs/plans/workspace-feature-flags.md
@@ -211,6 +211,18 @@ first load after a flag ships; unavoidable without blocking paint on the network
 so no migration can carry a live value across; any enabled workspace must be re-enabled
 by hand in the backoffice.
 
+## Known boundary — no per-user opt-out below a workspace override
+
+Storage keeps only deviations from a flag's default (`setFlag` deletes the override when
+the chosen value equals `defaultFeatureFlagValue`). So for a both-scoped flag whose
+workspace override differs from the default, an individual user cannot be pinned back to
+a value that equals the default — selecting it clears the override and the user re-inherits
+the workspace value. The enable direction (user on, over a default-off / workspace-silent
+flag) is unaffected, which is the motivating use case. Nothing in this stack is both-scoped
+(`calls` is workspace-only), so this is latent. Lifting it means an explicit inherit/reset
+action that stores every concrete override rather than clearing on default — a stack-wide
+semantics change, deferred until a both-scoped flag needs per-user opt-out.
+
 ## Not building
 
 - localStorage mirror for flags (IDB + the existing gate covers it).


### PR DESCRIPTION
## What

PR 2 of the workspace-feature-flags stack. Re-keys the control-plane `feature_flag_overrides` table so a row can describe a whole workspace, not just a user.

Stacked on #1455. Plan: `docs/plans/workspace-feature-flags.md`.

## Changes

- **Migration 016** (`ALTER`, in place): add `subject_type`/`subject_id`, backfill existing rows to `subject_type='user'` / `subject_id=workos_user_id`, swap PK to `(workspace_id, subject_type, subject_id, flag_key)`, drop `workos_user_id`. `subject_id` is NOT NULL — a nullable user column would let NULLs-are-distinct permit duplicate workspace rows.
- **Repository**: subject-keyed (`listByWorkspace`, `listForSubject`, `setOverride`, `deleteOverride`).
- **Service** `setFlag({subjectType, subjectId, …})`: new 400 `FLAG_SCOPE_NOT_ALLOWED` when a flag doesn't declare that scope, checked before the write and before the default-clears-override path. Outbox payload is identity-only `{workspaceId, subjectType, subjectId}`; `syncToRegion` pushes the subject's **raw overrides** filtered through the registry (key + value + declared scope), not a resolved map — so a workspace change is one write regardless of member count.
- **Backoffice**: a workspace-scope row above the member grid; cells render only for scopes a flag declares.
- Removed a dead `resolveForUser`/`listLayersForUser` chain (INV-38) — the region resolves now, the CP never does.

## Deploy safety

The regional sync envelope changed (`{workspaceId, workosUserId, flags}` → `{workspaceId, subjectType, subjectId, overrides}`). The regional receiver for the new shape lands in PR 3. This PR is nonetheless **safe to deploy alone**: the flag registry is empty (`FEATURE_FLAGS = {}`), so every `setFlag` rejects with `UNKNOWN_FLAG` and no `feature_flags_sync` outbox event ever fires — the new body never reaches a region. Once the registry is non-empty (PR 5), the region (PR 3) is already deployed. General principle for any future envelope change: deploy the region before the control plane.

## Verification

Reviewed locally: Opus implement → xhigh adversarial verify. Migration executed on a scratch Postgres (seeded + empty + re-run): backfill correct, atomic, re-run fails cleanly with no partial mutation, PK rejects duplicate workspace rows. `bun test src/` 39 pass, typecheck clean, `check:migrations` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787153306&installation_id=129946197&pr_number=1456&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1456&signature=16faf8ed22314bd1957af428ee6caf3d70ca26f2d6100293dc7d3c7886ee9c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->