### PR TITLE
feat: subject-keyed regional flag mirror with layered bootstrap

### DIFF
--- a/apps/backend/src/db/migrations/20260720120000_feature_flag_subjects.sql
+++ b/apps/backend/src/db/migrations/20260720120000_feature_flag_subjects.sql
@@ -1,0 +1,37 @@
+-- Subject-keyed regional mirror of feature-flag overrides. Replaces the
+-- per-user `user_feature_flags` table so a flag can be attached to a whole
+-- workspace (subject_type='workspace', subject_id=workspace_id) or to one user
+-- (subject_type='user', subject_id=workos_user_id). Source of truth is the
+-- control plane, pushed here via POST /internal/feature-flags as one subject's
+-- raw overrides; the region stores each layer and resolves against the code
+-- registry (@threa/types FEATURE_FLAGS) at read time, so retired keys/values
+-- and undeclared scopes drop with no migration (INV-3: TEXT + code validation).
+--
+-- subject_id is NOT NULL and carries the workspace_id for workspace rows: a
+-- nullable user column would let Postgres' NULLs-are-distinct rule admit
+-- duplicate workspace rows for the same flag.
+--
+-- User rows key on workos_user_id, not the regional user_id (decision 2): the
+-- CP no longer has to resolve a regional user before writing, so a flag set for
+-- an invited-but-never-signed-in user is stored instead of silently dropped.
+
+CREATE TABLE feature_flag_overrides (
+    workspace_id TEXT NOT NULL,
+    subject_type TEXT NOT NULL,   -- 'workspace' | 'user' (code-validated, INV-3)
+    subject_id   TEXT NOT NULL,   -- workos_user_id, or workspace_id for workspace scope
+    flag_key     TEXT NOT NULL,
+    value        TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, subject_type, subject_id, flag_key)
+);
+
+-- Safe drop. The table is NOT provably empty — retired flags (board-view,
+-- sync-v2-cursor) were live per-user rollouts while it existed, and retirement
+-- only removes the registry entry, never the rows. But any surviving rows are
+-- overrides for keys no longer in FEATURE_FLAGS, so they are already inert (read
+-- paths filter through the registry) — nothing live reads them. They were also
+-- keyed by the regional user_id this design abandons for workos_user_id, so a
+-- backfill would carry nothing forward. Dropping removes latent stale rows and
+-- the CP re-populates the new table by sync.
+DROP TABLE user_feature_flags;

--- a/apps/backend/src/features/feature-flags/handlers.ts
+++ b/apps/backend/src/features/feature-flags/handlers.ts
@@ -6,11 +6,12 @@ import type { FeatureFlagService } from "./service"
 // Flag keys/values are not constrained to the registry here: the control
 // plane can deploy with a new key or value ahead of this region's release.
 // Unknown entries are stored and ignored at read time (resolveFeatureFlags
-// filters them).
+// filters them). subjectType IS constrained — it selects the storage layer.
 const syncSchema = z.object({
   workspaceId: z.string().min(1),
-  workosUserId: z.string().min(1),
-  flags: z.record(z.string().min(1), z.string().min(1)),
+  subjectType: z.enum(["workspace", "user"]),
+  subjectId: z.string().min(1),
+  overrides: z.record(z.string().min(1), z.string().min(1)),
 })
 
 interface Dependencies {
@@ -19,7 +20,7 @@ interface Dependencies {
 
 export function createFeatureFlagHandlers({ featureFlagService }: Dependencies) {
   return {
-    /** CP fan-out endpoint: replace one user's flag snapshot in this region. */
+    /** CP fan-out endpoint: replace one subject's flag overrides in this region. */
     async sync(req: Request, res: Response, next: NextFunction) {
       const result = syncSchema.safeParse(req.body)
       if (!result.success) {

--- a/apps/backend/src/features/feature-flags/index.ts
+++ b/apps/backend/src/features/feature-flags/index.ts
@@ -1,3 +1,3 @@
 export { createFeatureFlagHandlers } from "./handlers"
 export { FeatureFlagService, type ApplyFeatureFlagSyncInput } from "./service"
-export { UserFeatureFlagRepository, type UserFeatureFlagRecord } from "./repository"
+export { FeatureFlagOverrideRepository } from "./repository"

--- a/apps/backend/src/features/feature-flags/repository.test.ts
+++ b/apps/backend/src/features/feature-flags/repository.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { QueryConfig, QueryResult } from "pg"
+import type { Querier } from "../../db"
+import { FeatureFlagOverrideRepository } from "./repository"
+
+const WORKSPACE_ID = "ws_1"
+const WORKOS_USER_ID = "workos_user_1"
+
+interface Captured {
+  text: string | null
+  values: unknown[] | null
+}
+
+function createQuerier(captured: Captured, rows: unknown[]): Querier {
+  return {
+    query: mock(async (q) => {
+      const config = q as QueryConfig
+      captured.text = config.text
+      captured.values = config.values ?? []
+      return { rows, rowCount: rows.length } as QueryResult
+    }),
+  }
+}
+
+describe("FeatureFlagOverrideRepository.findLayers", () => {
+  it("partitions workspace and user rows from one query, keeping both for the same flag", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [
+      { subject_type: "workspace", flag_key: "calls", value: "off" },
+      { subject_type: "user", flag_key: "calls", value: "on" },
+      { subject_type: "user", flag_key: "newComposer", value: "on" },
+    ])
+
+    const layers = await FeatureFlagOverrideRepository.findLayers(db, WORKSPACE_ID, WORKOS_USER_ID)
+
+    expect(layers).toEqual({
+      workspace: { calls: "off" },
+      user: { calls: "on", newComposer: "on" },
+    })
+    // One round trip: workspace_id, the workspace-scope subject_id (= workspace
+    // id), and the user-scope subject_id (= workos user id).
+    expect((db.query as ReturnType<typeof mock>).mock.calls.length).toBe(1)
+    expect(captured.values).toEqual([WORKSPACE_ID, WORKSPACE_ID, WORKOS_USER_ID])
+  })
+
+  it("returns empty layers when the subject has no rows", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    const layers = await FeatureFlagOverrideRepository.findLayers(db, WORKSPACE_ID, WORKOS_USER_ID)
+
+    expect(layers).toEqual({ workspace: {}, user: {} })
+  })
+})

--- a/apps/backend/src/features/feature-flags/repository.ts
+++ b/apps/backend/src/features/feature-flags/repository.ts
@@ -1,49 +1,76 @@
+import type { FeatureFlagLayers, FeatureFlagScope } from "@threa/types"
 import { sql, type Querier } from "../../db"
 
-interface UserFeatureFlagRow {
+interface OverrideRow {
+  subject_type: string
   flag_key: string
   value: string
 }
 
-export interface UserFeatureFlagRecord {
-  flagKey: string
-  value: string
-}
-
-export const UserFeatureFlagRepository = {
-  /** Stored flag rows for one user. Merge with registry defaults in the service. */
-  async findForUser(db: Querier, workspaceId: string, userId: string): Promise<UserFeatureFlagRecord[]> {
-    const result = await db.query<UserFeatureFlagRow>(sql`
-      SELECT flag_key, value
-      FROM user_feature_flags
-      WHERE workspace_id = ${workspaceId} AND user_id = ${userId}
+export const FeatureFlagOverrideRepository = {
+  /**
+   * The workspace layer and this user's layer in one query (INV-30/INV-56):
+   * the workspace's own rows (`subject_id = workspace_id`) plus the user's rows
+   * (`subject_id = workos_user_id`). Partitioned into the two records by
+   * subject_type; merge with registry defaults in the service.
+   */
+  async findLayers(db: Querier, workspaceId: string, workosUserId: string): Promise<FeatureFlagLayers> {
+    const result = await db.query<OverrideRow>(sql`
+      SELECT subject_type, flag_key, value
+      FROM feature_flag_overrides
+      WHERE workspace_id = ${workspaceId}
+        AND (
+          (subject_type = 'workspace' AND subject_id = ${workspaceId})
+          OR (subject_type = 'user' AND subject_id = ${workosUserId})
+        )
     `)
-    return result.rows.map((row) => ({ flagKey: row.flag_key, value: row.value }))
+    const layers: FeatureFlagLayers = { workspace: {}, user: {} }
+    for (const row of result.rows) {
+      if (row.subject_type === "workspace") layers.workspace[row.flag_key] = row.value
+      else if (row.subject_type === "user") layers.user[row.flag_key] = row.value
+    }
+    return layers
+  },
+
+  /** The workspace layer alone, for workspace-scoped reads that carry no user. */
+  async findWorkspaceOverrides(db: Querier, workspaceId: string): Promise<Record<string, string>> {
+    const result = await db.query<OverrideRow>(sql`
+      SELECT subject_type, flag_key, value
+      FROM feature_flag_overrides
+      WHERE workspace_id = ${workspaceId} AND subject_type = 'workspace' AND subject_id = ${workspaceId}
+    `)
+    return Object.fromEntries(result.rows.map((row) => [row.flag_key, row.value]))
   },
 
   /**
-   * Replace one user's flag rows with a control-plane snapshot: upsert every
+   * Replace one subject's flag rows with a control-plane snapshot: upsert every
    * key in the snapshot, delete the rest. Two set-based statements (INV-56),
    * race-safe via ON CONFLICT (INV-20) — concurrent syncs converge on the
    * last writer without check-then-act.
    */
-  async replaceForUser(db: Querier, workspaceId: string, userId: string, flags: Record<string, string>): Promise<void> {
-    const flagKeys = Object.keys(flags)
-    const values = flagKeys.map((key) => flags[key])
+  async replaceForSubject(
+    db: Querier,
+    workspaceId: string,
+    subjectType: FeatureFlagScope,
+    subjectId: string,
+    overrides: Record<string, string>
+  ): Promise<void> {
+    const flagKeys = Object.keys(overrides)
+    const values = flagKeys.map((key) => overrides[key])
 
     await db.query(
-      `DELETE FROM user_feature_flags
-       WHERE workspace_id = $1 AND user_id = $2 AND flag_key <> ALL($3::text[])`,
-      [workspaceId, userId, flagKeys]
+      `DELETE FROM feature_flag_overrides
+       WHERE workspace_id = $1 AND subject_type = $2 AND subject_id = $3 AND flag_key <> ALL($4::text[])`,
+      [workspaceId, subjectType, subjectId, flagKeys]
     )
     if (flagKeys.length === 0) return
     await db.query(
-      `INSERT INTO user_feature_flags (workspace_id, user_id, flag_key, value)
-       SELECT $1, $2, * FROM unnest($3::text[], $4::text[])
-       ON CONFLICT (workspace_id, user_id, flag_key) DO UPDATE SET
+      `INSERT INTO feature_flag_overrides (workspace_id, subject_type, subject_id, flag_key, value)
+       SELECT $1, $2, $3, * FROM unnest($4::text[], $5::text[])
+       ON CONFLICT (workspace_id, subject_type, subject_id, flag_key) DO UPDATE SET
          value = EXCLUDED.value,
          updated_at = NOW()`,
-      [workspaceId, userId, flagKeys, values]
+      [workspaceId, subjectType, subjectId, flagKeys, values]
     )
   },
 }

--- a/apps/backend/src/features/feature-flags/service.test.ts
+++ b/apps/backend/src/features/feature-flags/service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { PoolClient } from "pg"
 import { FEATURE_FLAG_KEYS, defaultFeatureFlags } from "@threa/types"
 import { FeatureFlagService } from "./service"
-import { UserFeatureFlagRepository } from "./repository"
+import { FeatureFlagOverrideRepository } from "./repository"
 import { UserRepository } from "../workspaces"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -18,23 +18,23 @@ function setupTransaction() {
 describe("FeatureFlagService.getFlags", () => {
   afterEach(() => mock.restore())
 
-  it("defaults every registry flag to its first declared value when nothing is stored", async () => {
-    spyOn(UserFeatureFlagRepository, "findForUser").mockResolvedValue([])
+  it("defaults every registry flag when nothing is stored", async () => {
+    spyOn(FeatureFlagOverrideRepository, "findLayers").mockResolvedValue({ workspace: {}, user: {} })
     const service = new FeatureFlagService({} as any)
 
-    const flags = await service.getFlags(WORKSPACE_ID, USER_ID)
+    const flags = await service.getFlags(WORKSPACE_ID, WORKOS_USER_ID)
 
     expect(flags).toEqual(defaultFeatureFlags())
   })
 
-  it("ignores stored rows whose key is no longer in the registry", async () => {
-    spyOn(UserFeatureFlagRepository, "findForUser").mockResolvedValue([
-      { flagKey: "retired-flag-not-in-registry", value: "on" },
-      { flagKey: "another-retired-flag", value: "off" },
-    ])
+  it("ignores stored overrides whose key is no longer in the registry", async () => {
+    spyOn(FeatureFlagOverrideRepository, "findLayers").mockResolvedValue({
+      workspace: { "retired-workspace-flag": "on" },
+      user: { "retired-user-flag": "off" },
+    })
     const service = new FeatureFlagService({} as any)
 
-    const flags = await service.getFlags(WORKSPACE_ID, USER_ID)
+    const flags = await service.getFlags(WORKSPACE_ID, WORKOS_USER_ID)
 
     expect(flags).toEqual(defaultFeatureFlags())
     expect(Object.keys(flags)).toEqual([...FEATURE_FLAG_KEYS])
@@ -44,44 +44,69 @@ describe("FeatureFlagService.getFlags", () => {
 describe("FeatureFlagService.applySync", () => {
   afterEach(() => mock.restore())
 
-  it("replaces the user's rows and broadcasts the resolved snapshot in one transaction", async () => {
+  it("writes the user layer and broadcasts the raw user overrides in one transaction", async () => {
     setupTransaction()
     spyOn(UserRepository, "findByWorkosUserIdInWorkspace").mockResolvedValue({ id: USER_ID } as any)
-    const replace = spyOn(UserFeatureFlagRepository, "replaceForUser").mockResolvedValue()
-    spyOn(UserFeatureFlagRepository, "findForUser").mockResolvedValue([])
+    const replace = spyOn(FeatureFlagOverrideRepository, "replaceForSubject").mockResolvedValue()
     const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
     const service = new FeatureFlagService({} as any)
 
-    const applied = await service.applySync({
+    await service.applySync({
       workspaceId: WORKSPACE_ID,
-      workosUserId: WORKOS_USER_ID,
-      flags: {},
+      subjectType: "user",
+      subjectId: WORKOS_USER_ID,
+      overrides: { newComposer: "on" },
     })
 
-    expect(applied).toBe(true)
-    expect(replace).toHaveBeenCalledWith({}, WORKSPACE_ID, USER_ID, {})
-    // User-scoped broadcast carrying the full resolved map (INV-7: same transaction).
+    // Storage keys on the workos id (decision 2), not the regional user id.
+    expect(replace).toHaveBeenCalledWith({}, WORKSPACE_ID, "user", WORKOS_USER_ID, { newComposer: "on" })
+    // User-scoped broadcast carrying the raw user layer, routed to the regional user.
     expect(insert).toHaveBeenCalledWith({}, "feature_flags:updated", {
       workspaceId: WORKSPACE_ID,
       targetUserId: USER_ID,
-      featureFlags: defaultFeatureFlags(),
+      overrides: { newComposer: "on" },
     })
   })
 
-  it("skips without writing when the WorkOS user has no regional row yet", async () => {
+  it("still writes the user layer when the WorkOS user has no regional row yet, skipping only the broadcast", async () => {
+    setupTransaction()
     spyOn(UserRepository, "findByWorkosUserIdInWorkspace").mockResolvedValue(null)
-    const replace = spyOn(UserFeatureFlagRepository, "replaceForUser").mockResolvedValue()
+    const replace = spyOn(FeatureFlagOverrideRepository, "replaceForSubject").mockResolvedValue()
     const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
     const service = new FeatureFlagService({} as any)
 
-    const applied = await service.applySync({
+    await service.applySync({
       workspaceId: WORKSPACE_ID,
-      workosUserId: WORKOS_USER_ID,
-      flags: {},
+      subjectType: "user",
+      subjectId: WORKOS_USER_ID,
+      overrides: { newComposer: "on" },
     })
 
-    expect(applied).toBe(false)
-    expect(replace).not.toHaveBeenCalled()
+    // The write lands regardless — the decision-2 fix (the old code dropped it).
+    expect(replace).toHaveBeenCalledWith({}, WORKSPACE_ID, "user", WORKOS_USER_ID, { newComposer: "on" })
     expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("writes the workspace layer and emits the workspace-scoped event, resolving no user", async () => {
+    setupTransaction()
+    const findUser = spyOn(UserRepository, "findByWorkosUserIdInWorkspace")
+    const replace = spyOn(FeatureFlagOverrideRepository, "replaceForSubject").mockResolvedValue()
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new FeatureFlagService({} as any)
+
+    await service.applySync({
+      workspaceId: WORKSPACE_ID,
+      subjectType: "workspace",
+      subjectId: WORKSPACE_ID,
+      overrides: { calls: "off" },
+    })
+
+    expect(replace).toHaveBeenCalledWith({}, WORKSPACE_ID, "workspace", WORKSPACE_ID, { calls: "off" })
+    expect(insert).toHaveBeenCalledWith({}, "feature_flags:workspace_updated", {
+      workspaceId: WORKSPACE_ID,
+      overrides: { calls: "off" },
+    })
+    // Workspace scope routes to the workspace room; no regional-user lookup happens.
+    expect(findUser).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/feature-flags/service.ts
+++ b/apps/backend/src/features/feature-flags/service.ts
@@ -1,75 +1,109 @@
 import type { Pool } from "pg"
-import { resolveFeatureFlags, type FeatureFlagKey, type FeatureFlagValue, type FeatureFlags } from "@threa/types"
+import {
+  resolveFeatureFlags,
+  type FeatureFlagKey,
+  type FeatureFlagLayers,
+  type FeatureFlagScope,
+  type FeatureFlagValue,
+  type FeatureFlags,
+} from "@threa/types"
 import { withTransaction } from "../../db"
 import { logger } from "../../lib/logger"
 import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
-import { UserFeatureFlagRepository } from "./repository"
-
-function toOverrideRecord(rows: { flagKey: string; value: string }[]): Record<string, string> {
-  return Object.fromEntries(rows.map((row) => [row.flagKey, row.value]))
-}
+import { FeatureFlagOverrideRepository } from "./repository"
 
 export interface ApplyFeatureFlagSyncInput {
   workspaceId: string
-  workosUserId: string
-  /** Full resolved snapshot from the control plane — replaces stored rows wholesale. */
-  flags: Record<string, string>
+  subjectType: FeatureFlagScope
+  /** workos_user_id for user scope, workspace_id for workspace scope. */
+  subjectId: string
+  /** That subject's raw overrides from the control plane — replaces stored rows wholesale. */
+  overrides: Record<string, string>
 }
 
 /**
- * Regional read/write surface for per-user feature flags. The control plane
- * owns the data and pushes snapshots through `applySync`; everything else in
- * the backend resolves flags via `getFlags`/`getFlag`, which mirror the
+ * Regional read/write surface for feature flags. The control plane owns the
+ * data and pushes one subject's overrides through `applySync`; everything else
+ * in the backend resolves flags via `getFlags`/`getFlag`, which mirror the
  * frontend's bootstrap-backed lookup so a flag means the same thing on both
- * sides of the stack.
+ * sides of the stack. Reads key on `workos_user_id` — the same id storage keys
+ * on — so no path joins to the regional user row (that lookup is only needed to
+ * route the user-scoped broadcast).
  */
 export class FeatureFlagService {
   constructor(private pool: Pool) {}
 
-  /** The user's resolved flags: registry defaults (first value) + stored snapshot. */
-  async getFlags(workspaceId: string, userId: string): Promise<FeatureFlags> {
-    // Single query, INV-30
-    const rows = await UserFeatureFlagRepository.findForUser(this.pool, workspaceId, userId)
-    return resolveFeatureFlags({ workspace: {}, user: toOverrideRecord(rows) })
+  /** Raw stored layers for one user in one workspace — the bootstrap wire shape. */
+  async getFlagLayers(workspaceId: string, workosUserId: string): Promise<FeatureFlagLayers> {
+    return FeatureFlagOverrideRepository.findLayers(this.pool, workspaceId, workosUserId)
+  }
+
+  /** The user's resolved flags: registry defaults + workspace layer + user layer. */
+  async getFlags(workspaceId: string, workosUserId: string): Promise<FeatureFlags> {
+    return resolveFeatureFlags(await this.getFlagLayers(workspaceId, workosUserId))
   }
 
   /** Backend-side flag lookup — the counterpart of the frontend's `useFeatureFlag`. */
-  async getFlag<K extends FeatureFlagKey>(workspaceId: string, userId: string, key: K): Promise<FeatureFlagValue<K>> {
-    const flags = await this.getFlags(workspaceId, userId)
+  async getFlag<K extends FeatureFlagKey>(
+    workspaceId: string,
+    workosUserId: string,
+    key: K
+  ): Promise<FeatureFlagValue<K>> {
+    const flags = await this.getFlags(workspaceId, workosUserId)
     return flags[key]
   }
 
   /**
-   * Apply a control-plane snapshot and broadcast the user's new resolved
-   * flags to their live sessions. Row replacement and the outbox event commit
-   * together (INV-7), so a session can never observe the broadcast without
-   * the rows that back it.
-   *
-   * Returns false when the WorkOS user has no regional user row yet (flag set
-   * before first sign-in). Safe to drop: the regional state already equals the
-   * default the snapshot would mostly encode, and the next backoffice change
-   * re-syncs after the user exists.
+   * A workspace-scoped flag resolved from the workspace layer + default only,
+   * no user. For gates that have no user in scope (a workspace-only flag never
+   * depends on one), so nothing has to fabricate or look one up.
    */
-  async applySync(input: ApplyFeatureFlagSyncInput): Promise<boolean> {
-    const user = await UserRepository.findByWorkosUserIdInWorkspace(this.pool, input.workspaceId, input.workosUserId)
-    if (!user) {
-      logger.warn(
-        { workspaceId: input.workspaceId, workosUserId: input.workosUserId },
-        "Feature flag sync skipped: no regional user for WorkOS id"
-      )
-      return false
+  async getWorkspaceFlag<K extends FeatureFlagKey>(workspaceId: string, key: K): Promise<FeatureFlagValue<K>> {
+    const workspace = await FeatureFlagOverrideRepository.findWorkspaceOverrides(this.pool, workspaceId)
+    return resolveFeatureFlags({ workspace, user: {} })[key]
+  }
+
+  /**
+   * Apply a control-plane snapshot for one subject and broadcast the changed
+   * layer to live sessions. The row replacement always lands — no regional-user
+   * resolution gates the write, which is the decision-2 fix (an invited-but-
+   * never-signed-in user's flags used to be dropped, not just their broadcast).
+   *
+   * The broadcast is best-effort and separate from the write: the outbox event
+   * carries the raw layer that changed (a workspace layer cannot be resolved
+   * server-side — each recipient has their own user layer). For user scope it is
+   * routed to the regional user's room, so it needs the regional user id; if the
+   * user has no regional row yet, the write still commits and only the broadcast
+   * is skipped (nobody is connected to receive it). Write + outbox commit in one
+   * transaction (INV-7).
+   */
+  async applySync(input: ApplyFeatureFlagSyncInput): Promise<void> {
+    const { workspaceId, subjectType, subjectId, overrides } = input
+
+    if (subjectType === "workspace") {
+      await withTransaction(this.pool, async (client) => {
+        await FeatureFlagOverrideRepository.replaceForSubject(client, workspaceId, "workspace", subjectId, overrides)
+        await OutboxRepository.insert(client, "feature_flags:workspace_updated", { workspaceId, overrides })
+      })
+      return
     }
 
+    const user = await UserRepository.findByWorkosUserIdInWorkspace(this.pool, workspaceId, subjectId)
     await withTransaction(this.pool, async (client) => {
-      await UserFeatureFlagRepository.replaceForUser(client, input.workspaceId, user.id, input.flags)
-      const rows = await UserFeatureFlagRepository.findForUser(client, input.workspaceId, user.id)
-      await OutboxRepository.insert(client, "feature_flags:updated", {
-        workspaceId: input.workspaceId,
-        targetUserId: user.id,
-        featureFlags: resolveFeatureFlags({ workspace: {}, user: toOverrideRecord(rows) }),
-      })
+      await FeatureFlagOverrideRepository.replaceForSubject(client, workspaceId, "user", subjectId, overrides)
+      if (user) {
+        await OutboxRepository.insert(client, "feature_flags:updated", {
+          workspaceId,
+          targetUserId: user.id,
+          overrides,
+        })
+      } else {
+        logger.info(
+          { workspaceId, workosUserId: subjectId },
+          "Feature flag sync stored without broadcast: no regional user for WorkOS id yet"
+        )
+      }
     })
-    return true
   }
 }

--- a/apps/backend/src/features/workspaces/handlers.test.ts
+++ b/apps/backend/src/features/workspaces/handlers.test.ts
@@ -39,7 +39,7 @@ function makeDeps(archivedStreams: unknown[]) {
     streamService,
     userPreferencesService: { getPreferences: async () => ({}) },
     workspaceSettingsService: { getSettings: async () => ({}) },
-    featureFlagService: { getFlags: async () => ({}) },
+    featureFlagService: { getFlagLayers: async () => ({ workspace: {}, user: {} }) },
     platformAdminService: { hasAccess: async () => false },
     sidebarConfigService: { getConfig: async () => ({}) },
     boardViewService: { list: async () => [] },
@@ -100,5 +100,24 @@ describe("workspace bootstrap handler", () => {
     expect(getJson().data.archivedStreams).toEqual([archivedChannel, { ...archivedDm, displayName: "Peer Name" }])
     // Active streams list stays a separate contract (empty here).
     expect(getJson().data.streams).toEqual([])
+  })
+
+  it("emits the viewer's feature-flag layers, not a resolved map", async () => {
+    spyOn(SyncLogRepository, "getHeadAndRetainedFrom").mockResolvedValue({ head: 0n, retainedFrom: 0n } as never)
+    spyOn(BotRepository, "listVisibleTo").mockResolvedValue([] as never)
+    spyOn(AgentSessionRepository, "listRunningByWorkspace").mockResolvedValue([] as never)
+
+    const deps = makeDeps([])
+    // Override the default empty-layers mock so the assertion has something to bite on.
+    ;(deps as any).featureFlagService.getFlagLayers = async () => ({
+      workspace: { calls: "off" },
+      user: { newComposer: "on" },
+    })
+    const handlers = createWorkspaceHandlers(deps)
+    const { req, res, getJson } = makeReqRes()
+
+    await handlers.bootstrap(req, res)
+
+    expect(getJson().data.featureFlags).toEqual({ workspace: { calls: "off" }, user: { newComposer: "on" } })
   })
 })

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -191,7 +191,7 @@ export function createWorkspaceHandlers({
         workspaceService.getEmojiWeights(workspaceId, userId),
         userPreferencesService.getPreferences(workspaceId, userId),
         workspaceSettingsService.getSettings(workspaceId),
-        featureFlagService.getFlags(workspaceId, userId),
+        featureFlagService.getFlagLayers(workspaceId, req.user!.workosUserId),
         platformAdminService.hasAccess(workspaceId, req.user!.workosUserId),
         sidebarConfigService.getConfig(workspaceId, userId),
         boardViewService.list(workspaceId, userId),

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -9,7 +9,6 @@ import type {
   UserPreferences,
   SidebarConfig,
   WorkspaceSettings,
-  FeatureFlags,
   LastMessagePreview,
   Bot as WireBot,
   BotInvocationCapability,
@@ -72,6 +71,7 @@ export type OutboxEventType =
   | "sidebar_config:updated"
   | "workspace_settings:updated"
   | "feature_flags:updated"
+  | "feature_flags:workspace_updated"
   | "agent_config:updated"
   | "budget:alert"
   | "stream:member_joined"
@@ -715,11 +715,20 @@ export interface AgentConfigUpdatedOutboxPayload extends WorkspaceScopedPayload 
   persona: PersonaListItem
 }
 
-// Feature flags event payload (user-scoped — flags are per user). Carries the
-// full resolved map so the frontend replaces its bootstrap field wholesale.
+// Feature flags event payload (user-scoped). Carries the user layer's raw
+// overrides — the frontend patches its user layer and re-resolves. A resolved
+// map cannot be broadcast because each recipient has their own workspace layer.
 export interface FeatureFlagsUpdatedOutboxPayload extends WorkspaceScopedPayload {
   targetUserId: string
-  featureFlags: FeatureFlags
+  overrides: Record<string, string>
+}
+
+// Workspace-scope feature flags event payload (workspace-scoped — falls through
+// to the workspace room). Carries the workspace layer's raw overrides; the
+// frontend patches its workspace layer and re-resolves against its own user
+// layer, which the server cannot do on its behalf.
+export interface FeatureFlagsWorkspaceUpdatedOutboxPayload extends WorkspaceScopedPayload {
+  overrides: Record<string, string>
 }
 
 export interface InvitationSentOutboxPayload extends WorkspaceScopedPayload {
@@ -1159,6 +1168,7 @@ export interface OutboxEventPayloadMap {
   "sidebar_config:updated": SidebarConfigUpdatedOutboxPayload
   "workspace_settings:updated": WorkspaceSettingsUpdatedOutboxPayload
   "feature_flags:updated": FeatureFlagsUpdatedOutboxPayload
+  "feature_flags:workspace_updated": FeatureFlagsWorkspaceUpdatedOutboxPayload
   "agent_config:updated": AgentConfigUpdatedOutboxPayload
   "budget:alert": BudgetAlertOutboxPayload
   "invitation:sent": InvitationSentOutboxPayload

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { defaultFeatureFlags, type WorkspaceBootstrap } from "@threa/types"
+import { type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { WorkspaceSettingsDialog } from "./workspace-settings-dialog"
 import * as generalTabModule from "./general-tab"
@@ -80,7 +80,7 @@ describe("WorkspaceSettingsDialog", () => {
   describe("feature flags tab", () => {
     it("hides the tab when there are no overridden flags", async () => {
       const queryClient = new QueryClient()
-      seedBootstrapFlags(queryClient, defaultFeatureFlags())
+      seedBootstrapFlags(queryClient, { workspace: {}, user: {} })
 
       renderDialog("/w/ws_1?ws-settings=general", queryClient)
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -2,13 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
-import {
-  DEFAULT_SIDEBAR_CONFIG,
-  defaultFeatureFlags,
-  type JSONContent,
-  type Stream,
-  type WorkspaceBootstrap,
-} from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, type JSONContent, type Stream, type WorkspaceBootstrap } from "@threa/types"
 import { db, type CachedDraft } from "@/db"
 import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
 import { resetDraftStoreCache } from "@/stores/draft-store"
@@ -145,7 +139,7 @@ function makeReloadBootstrap(archivedStreams: Stream[], streams: Stream[] = []):
     activityCounts: {},
     unreadActivityCount: 0,
     mutedStreamIds: [],
-    featureFlags: defaultFeatureFlags(),
+    featureFlags: { workspace: {}, user: {} },
     sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       workspaceId,
@@ -546,10 +540,9 @@ describe("useAllDrafts archived-root persistence across reload (the whole-featur
     await applyWorkspaceBootstrap(workspaceId, makeReloadBootstrap([archivedRoot], [activeRoot]), Date.now())
 
     const { wrapper } = createWrapper()
-    const { result } = renderHook(
-      () => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }),
-      { wrapper }
-    )
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
 
     await waitFor(() => {
       expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_control"])

--- a/apps/frontend/src/hooks/use-feature-flags.test.tsx
+++ b/apps/frontend/src/hooks/use-feature-flags.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
 import { describe, expect, it } from "vitest"
-import { defaultFeatureFlags, type WorkspaceBootstrap } from "@threa/types"
+import { type FeatureFlagLayers, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useOverriddenFeatureFlags } from "./use-feature-flags"
 
@@ -12,10 +12,12 @@ function createWrapper(queryClient: QueryClient) {
   }
 }
 
-// The registry is currently empty (no rollout in flight), so there is never a
-// non-default flag to surface. The per-flag hooks (useFeatureFlag /
-// useFeatureFlagWhenKnown) return with the next flag added to FEATURE_FLAGS;
-// until then only the overridden-flags view is exercisable.
+// The shipped registry is empty (no rollout in flight), so the per-flag hooks
+// (useFeatureFlag / useFeatureFlagWhenKnown) have no key to read and only the
+// overridden-flags view is exercisable end-to-end. The precedence the hooks
+// depend on is proven against the registry-parameterized resolver below — the
+// same function `useResolvedFeatureFlags` composes over — since a fake flag must
+// not enter FEATURE_FLAGS.
 describe("useOverriddenFeatureFlags", () => {
   it("returns no overridden flags before the bootstrap is cached", () => {
     const queryClient = new QueryClient()
@@ -26,16 +28,17 @@ describe("useOverriddenFeatureFlags", () => {
     expect(result.current).toEqual([])
   })
 
-  it("returns no overridden flags when the bootstrap carries the default map", () => {
+  it("consumes the layered bootstrap shape and drops keys not in the registry", () => {
     const queryClient = new QueryClient()
-    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
-      featureFlags: defaultFeatureFlags(),
-    } as WorkspaceBootstrap)
+    const layers: FeatureFlagLayers = { workspace: { calls: "off" }, user: { newComposer: "on" } }
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), { featureFlags: layers } as WorkspaceBootstrap)
 
     const { result } = renderHook(() => useOverriddenFeatureFlags("ws_1"), {
       wrapper: createWrapper(queryClient),
     })
 
+    // Empty registry: every override is inert, so nothing is surfaced (and the
+    // layered shape does not crash the resolve).
     expect(result.current).toEqual([])
   })
 })

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   defaultFeatureFlagValue,
   FEATURE_FLAG_KEYS,
+  resolveFeatureFlags,
   type FeatureFlagKey,
   type FeatureFlags,
   type FeatureFlagValue,
@@ -11,11 +12,30 @@ import {
 import { workspaceKeys } from "@/hooks/use-workspaces"
 
 /**
+ * The viewer's resolved flag map, or null until the bootstrap (with its raw
+ * layers) is cached. Reads the bootstrap cache via the cache-only observer
+ * pattern and resolves the workspace + user layers through the shared registry
+ * resolver — the same one the backend runs — so a flag means the same thing on
+ * both sides. The resolve is memoized on the layers reference (kept stable by
+ * the query's structural sharing), so it runs on a real change, not per render.
+ */
+function useResolvedFeatureFlags(workspaceId: string): FeatureFlags | null {
+  const queryClient = useQueryClient()
+  const { data: layers } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap) => bootstrap?.featureFlags ?? null,
+  })
+  return useMemo(() => (layers ? resolveFeatureFlags(layers) : null), [layers])
+}
+
+/**
  * The current viewer's value for a feature flag once it has actually been
  * delivered, or null while it is still unknown (no bootstrap cached yet).
- * Reads the bootstrap cache via the cache-only observer pattern; the
- * `feature_flags:updated` socket event keeps the value live, so a backoffice
- * change flips this hook without a reload.
+ * The `feature_flags:updated` / `feature_flags:workspace_updated` socket events
+ * keep the layers live, so a backoffice change flips this hook without a reload.
  *
  * Most callers want {@link useFeatureFlag} instead — reach for this variant
  * only when "not yet delivered" must be distinguished from "set to the
@@ -25,21 +45,14 @@ export function useFeatureFlagWhenKnown<K extends FeatureFlagKey>(
   workspaceId: string,
   key: K
 ): FeatureFlagValue<K> | null {
-  const queryClient = useQueryClient()
-  const { data } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-    select: (bootstrap) => bootstrap?.featureFlags?.[key] ?? null,
-  })
-  return data ?? null
+  const flags = useResolvedFeatureFlags(workspaceId)
+  return flags?.[key] ?? null
 }
 
 /**
- * The current viewer's value for a feature flag. Returns the flag's default
- * (first declared value) until the bootstrap is cached — "unknown yet" and
- * "default" render the same.
+ * The current viewer's value for a feature flag. Returns the flag's declared
+ * default until the bootstrap is cached — "unknown yet" and "default" render
+ * the same.
  */
 export function useFeatureFlag<K extends FeatureFlagKey>(workspaceId: string, key: K): FeatureFlagValue<K> {
   return useFeatureFlagWhenKnown(workspaceId, key) ?? defaultFeatureFlagValue(key)
@@ -58,15 +71,8 @@ export interface OverriddenFeatureFlag {
  * here means showing nothing rather than leaking flag state.
  */
 export function useOverriddenFeatureFlags(workspaceId: string): OverriddenFeatureFlag[] {
-  const queryClient = useQueryClient()
-  const { data } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-    select: (bootstrap) => bootstrap?.featureFlags ?? null,
-  })
-  return useMemo(() => listOverriddenFlags(data), [data])
+  const flags = useResolvedFeatureFlags(workspaceId)
+  return useMemo(() => listOverriddenFlags(flags), [flags])
 }
 
 function listOverriddenFlags(flags: FeatureFlags | null | undefined): OverriddenFeatureFlag[] {

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -5,13 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
 import type { CreateStreamInput } from "@/api"
-import {
-  DEFAULT_SIDEBAR_CONFIG,
-  DEFAULT_WORKSPACE_SETTINGS,
-  defaultFeatureFlags,
-  type Stream,
-  type WorkspaceBootstrap,
-} from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, DEFAULT_WORKSPACE_SETTINGS, type Stream, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useCreateStream } from "./use-streams"
 import * as syncEngineModule from "@/sync/sync-engine"
@@ -109,7 +103,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },
-    featureFlags: defaultFeatureFlags(),
+    featureFlags: { workspace: {}, user: {} },
     workspaceSettings: {
       ...DEFAULT_WORKSPACE_SETTINGS,
       workspaceId: "ws_1",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -7,7 +7,6 @@ import { clearAllCachedData, db } from "@/db"
 import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_WORKSPACE_SETTINGS,
-  defaultFeatureFlags,
   type StreamMember,
   type WorkspaceBootstrap,
 } from "@threa/types"
@@ -118,7 +117,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },
-    featureFlags: defaultFeatureFlags(),
+    featureFlags: { workspace: {}, user: {} },
     workspaceSettings: {
       ...DEFAULT_WORKSPACE_SETTINGS,
       workspaceId: "ws_1",

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -11,7 +11,6 @@ import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
   DEFAULT_WORKSPACE_SETTINGS,
-  defaultFeatureFlags,
   DEFAULT_SIDEBAR_CONFIG,
   type WorkspaceBootstrap,
   type StreamBootstrap,
@@ -149,7 +148,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       createdAt: now,
       updatedAt: now,
     },
-    featureFlags: defaultFeatureFlags(),
+    featureFlags: { workspace: {}, user: {} },
     workspaceSettings: {
       ...DEFAULT_WORKSPACE_SETTINGS,
       workspaceId: "ws_1",

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -18,7 +18,6 @@ import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_QUICK_LINKS,
   SIDEBAR_CONFIG_VERSION,
-  defaultFeatureFlags,
   type LabelAssignment,
   type SavedMessageView,
   type ScheduledMessageView,
@@ -59,7 +58,7 @@ function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBo
     activityCounts: {},
     unreadActivityCount: 0,
     mutedStreamIds: [],
-    featureFlags: defaultFeatureFlags(),
+    featureFlags: { workspace: {}, user: {} },
     sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       workspaceId: "ws_1",
@@ -362,7 +361,12 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     await db.streams.put({
       ...archivedRoot,
-      lastMessagePreview: { authorId: "user_1", authorType: "user", content: "kept", createdAt: "2026-01-01T00:00:00Z" },
+      lastMessagePreview: {
+        authorId: "user_1",
+        authorType: "user",
+        content: "kept",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
       _cachedAt: fetchStartedAt - 1000,
     })
 
@@ -1424,9 +1428,12 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 
-  it("applies feature_flags:updated to the bootstrap cache", () => {
+  it("patches only the user layer on feature_flags:updated, leaving the workspace layer intact", () => {
     const queryClient = new QueryClient()
-    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ featureFlags: { workspace: { calls: "off" }, user: {} } })
+    )
 
     const { socket, emit } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
@@ -1438,11 +1445,36 @@ describe("registerWorkspaceSocketHandlers", () => {
     emit("feature_flags:updated", {
       workspaceId: "ws_1",
       targetUserId: "member_1",
-      featureFlags: defaultFeatureFlags(),
+      overrides: { newComposer: "on" },
     })
 
     const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
-    expect(cached?.featureFlags).toEqual(defaultFeatureFlags())
+    expect(cached?.featureFlags).toEqual({ workspace: { calls: "off" }, user: { newComposer: "on" } })
+
+    cleanup()
+  })
+
+  it("patches only the workspace layer on feature_flags:workspace_updated, leaving the user layer intact", () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ featureFlags: { workspace: {}, user: { newComposer: "on" } } })
+    )
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => undefined,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+    })
+
+    emit("feature_flags:workspace_updated", {
+      workspaceId: "ws_1",
+      overrides: { calls: "off" },
+    })
+
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached?.featureFlags).toEqual({ workspace: { calls: "off" }, user: { newComposer: "on" } })
 
     cleanup()
   })
@@ -1796,7 +1828,12 @@ describe("registerWorkspaceSocketHandlers", () => {
   it("preserves an existing row's lastMessagePreview on stream:unarchived", async () => {
     await db.streams.put({
       ...makeStream("stream_unarch2", { archivedAt: "2026-01-01T00:00:00Z" }),
-      lastMessagePreview: { authorId: "member_1", authorType: "user", content: "kept", createdAt: "2026-01-01T00:00:00Z" },
+      lastMessagePreview: {
+        authorId: "member_1",
+        authorType: "user",
+        content: "kept",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
       _cachedAt: Date.now(),
     })
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -24,7 +24,6 @@ import type {
   UserPreferences,
   SidebarConfig,
   WorkspaceSettings,
-  FeatureFlags,
   LastMessagePreview,
   Activity,
   AgentSessionStartedPayload,
@@ -238,7 +237,14 @@ interface WorkspaceSettingsUpdatedPayload {
 interface FeatureFlagsUpdatedPayload {
   workspaceId: string
   targetUserId: string
-  featureFlags: FeatureFlags
+  /** The user layer's raw overrides; the client re-resolves against its own workspace layer. */
+  overrides: Record<string, string>
+}
+
+interface FeatureFlagsWorkspaceUpdatedPayload {
+  workspaceId: string
+  /** The workspace layer's raw overrides; the client re-resolves against its own user layer. */
+  overrides: Record<string, string>
 }
 
 /**
@@ -1510,13 +1516,26 @@ export function registerWorkspaceSocketHandlers(
     updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({ ...old, workspaceSettings: payload.settings }))
   }
 
-  // Handle feature flags updated (a platform admin toggled a flag for this
-  // user from the backoffice). User-scoped event carrying the full resolved
-  // map; lives only in the bootstrap query cache, like workspace settings.
+  // Handle feature flags updated (a platform admin toggled a flag from the
+  // backoffice). Two scope-routed events, each patching only its own raw layer
+  // and leaving the other intact; the hook re-resolves. Layers live only in the
+  // bootstrap query cache, like workspace settings (INV-53 via the guard).
   const handleFeatureFlagsUpdated = (payload: FeatureFlagsUpdatedPayload) => {
     if (payload.workspaceId !== workspaceId) return
 
-    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({ ...old, featureFlags: payload.featureFlags }))
+    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
+      ...old,
+      featureFlags: { workspace: old.featureFlags?.workspace ?? {}, user: payload.overrides },
+    }))
+  }
+
+  const handleFeatureFlagsWorkspaceUpdated = (payload: FeatureFlagsWorkspaceUpdatedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+
+    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
+      ...old,
+      featureFlags: { workspace: payload.overrides, user: old.featureFlags?.user ?? {} },
+    }))
   }
 
   const handleBotCreated = (payload: { workspaceId: string; bot: Bot }) => {
@@ -2066,6 +2085,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("sidebar_config:updated", handleSidebarConfigUpdated)
   socket.on("workspace_settings:updated", handleWorkspaceSettingsUpdated)
   socket.on("feature_flags:updated", handleFeatureFlagsUpdated)
+  socket.on("feature_flags:workspace_updated", handleFeatureFlagsWorkspaceUpdated)
   socket.on("bot:created", handleBotCreated)
   socket.on("bot:updated", handleBotUpdated)
   socket.on("agent_config:updated", handleAgentConfigUpdated)
@@ -2134,6 +2154,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("sidebar_config:updated", handleSidebarConfigUpdated)
     socket.off("workspace_settings:updated", handleWorkspaceSettingsUpdated)
     socket.off("feature_flags:updated", handleFeatureFlagsUpdated)
+    socket.off("feature_flags:workspace_updated", handleFeatureFlagsWorkspaceUpdated)
     socket.off("bot:created", handleBotCreated)
     socket.off("bot:updated", handleBotUpdated)
     socket.off("agent_config:updated", handleAgentConfigUpdated)

--- a/docs/plans/workspace-feature-flags.md
+++ b/docs/plans/workspace-feature-flags.md
@@ -21,9 +21,14 @@ Three distinct problems, one of which is the stated ask:
    starts paint fully while flags are still `undefined` and read as registry defaults.
    Default-off degrades politely; default-on paints wrong then flips.
 
-**Timing.** `FEATURE_FLAGS = {}` and the CP rejects unregistered keys on write, so
-both flag tables are provably empty in every environment. No backfill, no dual-read
-window. This is the cheapest this change will ever be.
+**Timing.** `FEATURE_FLAGS = {}` today, so there are no _live_ flag values to migrate.
+The tables are not empty in history — `board-view` and `sync-v2-cursor` were per-user
+rollouts, and retiring a flag only drops the registry entry, never the rows — but any
+surviving rows are overrides for keys no longer in the registry, hence inert (read paths
+filter through the registry). The CP table ALTERs in place (rows re-keyed to
+`subject_type='user'`); the regional table drops (its inert rows carry nothing forward and
+the region re-syncs). So no live value migrates and no dual-read window is needed. This is
+the cheapest this change will ever be.
 
 ## Ratified decisions
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -41,7 +41,7 @@ import type {
 } from "./domain"
 import type { UserPreferences } from "./preferences"
 import type { WorkspaceSettings } from "./workspace-settings"
-import type { FeatureFlags } from "./feature-flags"
+import type { FeatureFlagLayers } from "./feature-flags"
 import type { SidebarConfig } from "./sidebar"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "./tool-privacy"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
@@ -1616,10 +1616,14 @@ export interface WorkspaceBootstrap {
   /** Workspace-wide settings (e.g. the default working schedule members inherit). */
   workspaceSettings: WorkspaceSettings
   /**
-   * The viewer's resolved feature flags (defaults + backoffice-managed
-   * per-user overrides). Kept live by the `feature_flags:updated` socket event.
+   * The viewer's raw feature-flag layers (workspace + user overrides); the
+   * client resolves them against the code registry, so a flag means the same
+   * thing here as on the backend. Kept live by the `feature_flags:updated`
+   * (user layer) and `feature_flags:workspace_updated` (workspace layer) socket
+   * events. Optional per the post-v1 bootstrap convention — absent reads as all
+   * registry defaults.
    */
-  featureFlags: FeatureFlags
+  featureFlags?: FeatureFlagLayers
   /**
    * True when the viewer holds a control-plane platform-admin grant (synced
    * to the regional `platform_admin_access` mirror). Gates UI links into the


### PR DESCRIPTION
## What

PR 3 of the workspace-feature-flags stack. The regional half: subject-keyed mirror, layered bootstrap, and scope-routed socket delivery.

Stacked on #1456. Plan: `docs/plans/workspace-feature-flags.md`.

## Changes

- **Migration**: create subject-keyed `feature_flag_overrides` (PK `(workspace_id, subject_type, subject_id, flag_key)`), drop `user_feature_flags`. The drop is safe — surviving rows are inert overrides for retired flags (`board-view`, `sync-v2-cursor`), nothing live reads them, and they were keyed by the regional `user_id` this design abandons.
- **Repository** `FeatureFlagOverrideRepository`: `findLayers` (one query partitioning workspace/user rows), `findWorkspaceOverrides`, `replaceForSubject`.
- **Service**: `getFlagLayers` (bootstrap), `getFlags`/`getFlag` (user-taking, for chunk 5), `getWorkspaceFlag` (user-less workspace read, for calls' `assertAvailable`). `applySync` replaces one subject's rows **unconditionally** inside the transaction and resolves the regional user only for broadcast routing — so the write always lands and the user-scoped broadcast is best-effort. This fixes the old silent drop for a user who hasn't signed into the region yet (decision 2).
- **Delivery** splits by audience: `feature_flags:updated` (user-scoped) carries the user layer; new `feature_flags:workspace_updated` (workspace-scoped) carries the workspace layer. One event type can't route both ways through the static `USER_SCOPED_EVENTS` list, and the two layers have genuinely different recipients.
- **Bootstrap**: `WorkspaceBootstrap.featureFlags` is now optional `FeatureFlagLayers`; the handler emits raw layers.
- **Frontend** (minimum to stay green): the hook resolves layers through the shared resolver — `useFeatureFlag` signature unchanged — and the two socket handlers each patch only their own layer. IDB persistence + first-render gating is PR 4.

`getFlags`/`getFlag`/`getWorkspaceFlag` are caller-less until PR 5's calls gates — kept as the committed read API, same "present, registry empty between rollouts" shape the feature is built around.

## Verification

Reviewed locally: Opus implement → xhigh adversarial verify (write-vs-broadcast split, two-event routing, findLayers partition, and layer-patching all re-derived and confirmed; migration justification corrected from a false "provably empty" premise). 86 backend + 4644 frontend + 134 types tests green, typecheck + `check:migrations` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787155678&installation_model_id=20758&pr_number=1457&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1457&signature=1296c8e3f7c06dd2652e70d2a579e7f19907889495892ae9c9765b55c39e0c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->