### PR TITLE
feat: add harness-backed /kick session control

### DIFF
--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -423,7 +423,17 @@ export class BotRuntimeService {
         ...(params.runtimeKind === "pi-local"
           ? {
               supportsSessionControlCommands: true,
-              sessionControlCommands: ["compact", "model", "thinking", "skill", "reload", "shell", "steer", "stop"],
+              sessionControlCommands: [
+                "compact",
+                "model",
+                "thinking",
+                "skill",
+                "reload",
+                "shell",
+                "steer",
+                "stop",
+                "kick",
+              ],
             }
           : {}),
       },

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -5,7 +5,7 @@ import type { CommandRegistry } from "./registry"
 // long-lived linked session (Pi, the Claude Code channel). Each runtime sees only
 // the subset it advertises in `capabilities.sessionControlCommands`, so a command
 // it doesn't advertise never surfaces for it (e.g. `skill` is Pi-only; `run` is
-// Claude-channel-only; `compact`/`reload` are advertised by both).
+// Claude-channel-only; `compact`/`reload`/`kick` are advertised by both).
 export const SESSION_CONTROL_COMMAND_NAMES = [
   "compact",
   "model",
@@ -15,6 +15,7 @@ export const SESSION_CONTROL_COMMAND_NAMES = [
   "shell",
   "steer",
   "stop",
+  "kick",
   "run",
   "carry-on",
 ] as const
@@ -103,6 +104,12 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
     {
       name: "stop",
       description: "Stop the current turn in the linked session",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+    },
+    {
+      name: "kick",
+      description: "Nudge the linked session to continue",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
     },

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -29,8 +29,8 @@ export function resolveRuntimeInvocationRouting(
   trigger: (typeof BotInvocationTriggers)[keyof typeof BotInvocationTriggers]
   requiredCapability: (typeof BotInvocationCapabilities)[keyof typeof BotInvocationCapabilities]
 } {
-  if (commandName === "steer" || commandName === "stop" || commandName === "carry-on") {
-    // steer/stop/carry-on must reach the runtime mid-turn. Pi advertises
+  if (commandName === "steer" || commandName === "stop" || commandName === "kick" || commandName === "carry-on") {
+    // steer/stop/kick/carry-on must reach the runtime mid-turn. Pi advertises
     // `active-scratchpad` while busy, so it claims them there. The Claude Code
     // channel instead advertises ONLY `session-control` while busy (so a normal
     // `active-scratchpad` follow-up stays queued behind the running turn) — route

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -3,8 +3,8 @@ import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds } fro
 import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
-  it("routes steer/stop/carry-on to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "carry-on"]) {
+  it("routes steer/stop/kick/carry-on to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
+    for (const name of ["steer", "stop", "kick", "carry-on"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -12,8 +12,8 @@ describe("resolveRuntimeInvocationRouting", () => {
     }
   })
 
-  it("routes steer/stop/carry-on to session-control for the Claude Code channel (so a busy channel still claims interrupts)", () => {
-    for (const name of ["steer", "stop", "carry-on"]) {
+  it("routes steer/stop/kick/carry-on to session-control for the Claude Code channel (so a busy channel still claims control)", () => {
+    for (const name of ["steer", "stop", "kick", "carry-on"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.CLAUDE_CODE_CHANNEL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,

--- a/apps/backend/tests/e2e/commands.test.ts
+++ b/apps/backend/tests/e2e/commands.test.ts
@@ -189,7 +189,7 @@ async function createLinkedPiSession(
       supportsActiveScratchpad: true,
       supportsPersistentSessions: true,
       supportsSessionControlCommands: true,
-      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload", "steer", "stop"],
+      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload", "steer", "stop", "kick"],
       thinkingLevels: ["off", "minimal", "low", "medium", "high"],
       modelSuggestions: [
         { value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
@@ -227,6 +227,7 @@ describe("Stream-scoped Pi session-control commands", () => {
     expect(linkedNames).toContain("reload")
     expect(linkedNames).toContain("steer")
     expect(linkedNames).toContain("stop")
+    expect(linkedNames).toContain("kick")
 
     // /thinking suggestions reflect the runtime's advertised levels, not a backend-hardcoded list.
     const thinkingCommand = linkedCommands.find((c) => c.name === "thinking")

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -2,7 +2,8 @@
 
 Status: **implemented + tmux mechanics live-verified** on `feat/harness-steer`, 2026-06-26.
 Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`, `reload` —
-later joined by `thinking` and `carry-on` (quota carry-on; see `docs/quota-carry-on.md`). The
+later joined by `thinking`, `carry-on` (quota carry-on; see `docs/quota-carry-on.md`), and
+`kick` (an Enter nudge routed through harnessd). The
 genuinely-novel tmux paths ($TMUX_PANE inheritance, Esc interrupt, `/model`) are verified against
 Claude Code v2.1.193 (and live testing found + fixed two bugs — see the checklist); the full
 dispatch round-trip through a real scratchpad is still only unit-tested.
@@ -113,6 +114,7 @@ Notes:
 | Command             | Key sequence                                                                                                                             | Channel bookkeeping                                                                                                                                                                                                                                                                                                                                     |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **stop**            | `Escape`                                                                                                                                 | Complete every in-flight invocation (interrupted), ack the stop invocation: "Stopped Claude."                                                                                                                                                                                                                                                           |
+| **kick**            | `harnessd kick <runtime-session-id>` → `Enter`                                                                                           | Nudge a managed pane past a blocking prompt, then acknowledge the command.                                                                                                                                                                                                                                                                              |
 | **steer `<text>`**  | Turn in flight: `Ctrl-U` + bracketed paste + `Enter` (Claude's native mid-turn steering, **no Escape**). Idle: the interrupt path below. | Turn in flight: record a `steer` step on the RUNNING invocation's trace, fold queued msgs + steer text into the injected block, close swept msgs `noResponse`, complete /steer immediately — the running turn keeps its trace and its `reply` answers the steer. Idle: drain + one combined turn under the /steer invocation (original semantics below) |
 | **model `<alias>`** | `typeLine("/model <alias>")`                                                                                                             | Ack "Model set to `<alias>`." (best-effort)                                                                                                                                                                                                                                                                                                             |
 | **compact**         | `typeLine("/compact")`                                                                                                                   | Ack                                                                                                                                                                                                                                                                                                                                                     |
@@ -192,7 +194,7 @@ The channel advertises in its `bot:hello` / presence `capabilities` **only when 
   "supportsActiveScratchpad": true,
   "supportsPersistentSessions": true,
   "supportsSessionControlCommands": true,
-  "sessionControlCommands": ["stop", "steer", "model", "thinking", "compact", "run", "reload"],
+  "sessionControlCommands": ["stop", "steer", "kick", "model", "thinking", "compact", "run", "reload"],
   "modelSuggestions": [
     { "value": "opus", "label": "Opus", "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks" },
     // …built-in aliases (default/opus/sonnet/haiku) plus models discovered from the
@@ -207,7 +209,9 @@ inside tmux (no pane), it advertises none of this, so the UI never shows a comma
 actuated — fail-safe. `resolveAdvertisedSessionControlCommandNames` (`availability.ts:257`)
 already intersects with the canonical name list, so only what the channel advertises shows up.
 
-Commands chosen for v1: **stop, steer, model, compact, run, reload**. `reload` maps to Claude
+Commands chosen for v1: **stop, steer, model, compact, run, reload**. `/kick` was added later for
+harness-managed Pi and Claude sessions; it sends `Enter` to the recorded tmux pane, matching the
+manual nudge used to accept blocking harness prompts. `reload` maps to Claude
 Code's `/reload-skills` (v2.1.152+) — picks up skills + custom commands added on disk mid-session;
 verified live ("16 skills available"). Newly `claude mcp add`'d MCP servers still can't hot-reload
 (Claude Code limitation — restart only); `/reload-plugins` is reachable via the generic `run`.
@@ -284,7 +288,6 @@ covered by their feature-folder suites.
 
 ## Bonus: harness CLI ergonomics (optional)
 
-To "improve the harness" for manual use, add `threa-harnessd stop|steer|keys <ref> [text]` verbs
-that reuse `tmux.ts` against an inventory agent's recorded `tmuxSession:tmuxWindow`. Not on the
-Threa-UI path (the channel sends keys directly via its own pane — no cross-process dependency at
-runtime), but handy from a terminal.
+To "improve the harness" for manual use, add `threa-harnessd stop|kick|steer|keys <ref> [text]` verbs
+that reuse `tmux.ts` against an inventory agent's recorded window/pane ids. `/kick` now
+uses that CLI path from both linked runtimes; the other verbs remain terminal-only helpers.

--- a/docs/plans/harness-daemon.md
+++ b/docs/plans/harness-daemon.md
@@ -47,7 +47,7 @@ Tracked fields:
 
 - id/name/runtime/status
 - worktree/branch
-- tmux session/window
+- tmux session/window plus stable pane id for key injection
 - scratchpad URL when available from Pi pane capture or Claude pre-link
 - command used to spawn
 - runtime instance/session IDs needed to reattach the same scratchpad

--- a/extensions/bot-runtime-client/src/harness-kick.test.ts
+++ b/extensions/bot-runtime-client/src/harness-kick.test.ts
@@ -6,19 +6,17 @@ describe("runHarnessKick", () => {
     const calls: unknown[][] = []
     const result = runHarnessKick(" ccs_1 ", {
       entrypoint: "/repo/extensions/harness-daemon/src/index.ts",
+      bunExecutable: "/opt/bun/bin/bun",
       exists: () => true,
-      spawnSync: ((command: string[], options: unknown) => {
-        calls.push([command, options])
-        return { exitCode: 0, stdout: Buffer.from("kicked"), stderr: Buffer.from("") }
-      }) as typeof Bun.spawnSync,
+      spawnSync: (executable, args, options) => {
+        calls.push([executable, args, options])
+        return { status: 0, stdout: "kicked", stderr: "" }
+      },
     })
 
     expect(result).toEqual({ ok: true })
     expect(calls).toEqual([
-      [
-        [process.execPath, "/repo/extensions/harness-daemon/src/index.ts", "kick", "ccs_1"],
-        { stdout: "pipe", stderr: "pipe" },
-      ],
+      ["/opt/bun/bin/bun", ["/repo/extensions/harness-daemon/src/index.ts", "kick", "ccs_1"], { encoding: "utf8" }],
     ])
   })
 
@@ -26,14 +24,27 @@ describe("runHarnessKick", () => {
     const result = runHarnessKick("ccs_missing", {
       entrypoint: "/repo/index.ts",
       exists: () => true,
-      spawnSync: (() => ({
-        exitCode: 1,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from("harnessd: no agent found for ccs_missing\n"),
-      })) as unknown as typeof Bun.spawnSync,
+      spawnSync: () => ({
+        status: 1,
+        stdout: "",
+        stderr: "harnessd: no agent found for ccs_missing\n",
+      }),
     })
 
     expect(result).toEqual({ ok: false, error: "harnessd: no agent found for ccs_missing" })
+  })
+
+  it("reports a missing Bun executable", () => {
+    const result = runHarnessKick("ccs_1", {
+      entrypoint: "/repo/index.ts",
+      exists: () => true,
+      spawnSync: () => ({
+        status: null,
+        error: new Error("spawnSync /missing/bun ENOENT"),
+      }),
+    })
+
+    expect(result).toEqual({ ok: false, error: "spawnSync /missing/bun ENOENT" })
   })
 
   it("does not spawn without a runtime session id or harnessd entrypoint", () => {

--- a/extensions/bot-runtime-client/src/harness-kick.test.ts
+++ b/extensions/bot-runtime-client/src/harness-kick.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test"
+import { runHarnessKick } from "./harness-kick"
+
+describe("runHarnessKick", () => {
+  it("runs harnessd kick against the runtime session id", () => {
+    const calls: unknown[][] = []
+    const result = runHarnessKick(" ccs_1 ", {
+      entrypoint: "/repo/extensions/harness-daemon/src/index.ts",
+      exists: () => true,
+      spawnSync: ((command: string[], options: unknown) => {
+        calls.push([command, options])
+        return { exitCode: 0, stdout: Buffer.from("kicked"), stderr: Buffer.from("") }
+      }) as typeof Bun.spawnSync,
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(calls).toEqual([
+      [
+        [process.execPath, "/repo/extensions/harness-daemon/src/index.ts", "kick", "ccs_1"],
+        { stdout: "pipe", stderr: "pipe" },
+      ],
+    ])
+  })
+
+  it("fails loudly when the runtime is not in harnessd inventory", () => {
+    const result = runHarnessKick("ccs_missing", {
+      entrypoint: "/repo/index.ts",
+      exists: () => true,
+      spawnSync: (() => ({
+        exitCode: 1,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from("harnessd: no agent found for ccs_missing\n"),
+      })) as unknown as typeof Bun.spawnSync,
+    })
+
+    expect(result).toEqual({ ok: false, error: "harnessd: no agent found for ccs_missing" })
+  })
+
+  it("does not spawn without a runtime session id or harnessd entrypoint", () => {
+    expect(runHarnessKick("", { entrypoint: "/repo/index.ts", exists: () => true })).toEqual({
+      ok: false,
+      error: "Runtime session id is missing.",
+    })
+    expect(runHarnessKick("ccs_1", { entrypoint: "/missing/index.ts", exists: () => false })).toEqual({
+      ok: false,
+      error: "Harness daemon entrypoint not found: /missing/index.ts",
+    })
+  })
+})

--- a/extensions/bot-runtime-client/src/harness-kick.ts
+++ b/extensions/bot-runtime-client/src/harness-kick.ts
@@ -1,0 +1,43 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+export interface HarnessKickResult {
+  ok: boolean
+  error?: string
+}
+
+interface RunHarnessKickOptions {
+  entrypoint?: string
+  exists?: (path: string) => boolean
+  spawnSync?: typeof Bun.spawnSync
+}
+
+export function harnessDaemonEntrypoint(): string {
+  return (
+    process.env.THREA_HARNESSD_ENTRYPOINT?.trim() ||
+    join(import.meta.dir, "..", "..", "harness-daemon", "src", "index.ts")
+  )
+}
+
+/** Ask harnessd to nudge one managed runtime's tmux pane with Enter. */
+export function runHarnessKick(runtimeSessionId: string, options: RunHarnessKickOptions = {}): HarnessKickResult {
+  const ref = runtimeSessionId.trim()
+  if (!ref) return { ok: false, error: "Runtime session id is missing." }
+
+  const entrypoint = options.entrypoint ?? harnessDaemonEntrypoint()
+  if (!(options.exists ?? existsSync)(entrypoint)) {
+    return { ok: false, error: `Harness daemon entrypoint not found: ${entrypoint}` }
+  }
+
+  try {
+    const result = (options.spawnSync ?? Bun.spawnSync)([process.execPath, entrypoint, "kick", ref], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    if (result.exitCode === 0) return { ok: true }
+    const detail = result.stderr.toString().trim() || result.stdout.toString().trim()
+    return { ok: false, error: detail || `Harness daemon exited ${result.exitCode}.` }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/extensions/bot-runtime-client/src/harness-kick.ts
+++ b/extensions/bot-runtime-client/src/harness-kick.ts
@@ -1,21 +1,33 @@
+import { spawnSync as nodeSpawnSync } from "node:child_process"
 import { existsSync } from "node:fs"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 export interface HarnessKickResult {
   ok: boolean
   error?: string
 }
 
+interface HarnessSpawnResult {
+  status: number | null
+  stdout?: string | Buffer | null
+  stderr?: string | Buffer | null
+  error?: Error
+}
+
+type HarnessSpawnSync = (executable: string, args: string[], options: { encoding: "utf8" }) => HarnessSpawnResult
+
 interface RunHarnessKickOptions {
   entrypoint?: string
+  bunExecutable?: string
   exists?: (path: string) => boolean
-  spawnSync?: typeof Bun.spawnSync
+  spawnSync?: HarnessSpawnSync
 }
 
 export function harnessDaemonEntrypoint(): string {
   return (
     process.env.THREA_HARNESSD_ENTRYPOINT?.trim() ||
-    join(import.meta.dir, "..", "..", "harness-daemon", "src", "index.ts")
+    join(dirname(fileURLToPath(import.meta.url)), "..", "..", "harness-daemon", "src", "index.ts")
   )
 }
 
@@ -30,13 +42,14 @@ export function runHarnessKick(runtimeSessionId: string, options: RunHarnessKick
   }
 
   try {
-    const result = (options.spawnSync ?? Bun.spawnSync)([process.execPath, entrypoint, "kick", ref], {
-      stdout: "pipe",
-      stderr: "pipe",
+    const bunExecutable = (options.bunExecutable ?? process.env.THREA_HARNESSD_BUN_BIN?.trim()) || "bun"
+    const result = (options.spawnSync ?? nodeSpawnSync)(bunExecutable, [entrypoint, "kick", ref], {
+      encoding: "utf8",
     })
-    if (result.exitCode === 0) return { ok: true }
-    const detail = result.stderr.toString().trim() || result.stdout.toString().trim()
-    return { ok: false, error: detail || `Harness daemon exited ${result.exitCode}.` }
+    if (result.error) return { ok: false, error: result.error.message }
+    if (result.status === 0) return { ok: true }
+    const detail = String(result.stderr ?? "").trim() || String(result.stdout ?? "").trim()
+    return { ok: false, error: detail || `Harness daemon exited ${result.status ?? "without a status"}.` }
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) }
   }

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -1,4 +1,5 @@
 export { BotRuntimeTransport } from "./transport"
+export { harnessDaemonEntrypoint, runHarnessKick, type HarnessKickResult } from "./harness-kick"
 export {
   BotSupervisorTransport,
   type BotSessionRestoredPayload,

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -109,6 +109,8 @@ The flag is required for the scratchpad to link at all: the server checks its pa
 
 Open the scratchpad in Threa and type a message. No `@`-mention needed: the bot is the scratchpad's active actor, so every message you post is forwarded to your Claude Code session. The presence pill shows **Available** / **Working**. Claude's answer posts back as a `BOT` message.
 
+For harness-managed sessions, `/kick` asks harnessd to send Enter to the session's recorded tmux pane. Use it to accept or move past a blocking Claude Code prompt without opening the terminal.
+
 ## Permission relay
 
 Away from the terminal, a tool that needs approval would normally stall the session. With `THREA_PERMISSION_RELAY=1` (default), the approval prompt is posted into the scratchpad as a message:

--- a/extensions/claude-code-remote/install-local.ts
+++ b/extensions/claude-code-remote/install-local.ts
@@ -26,13 +26,31 @@ const VENDORED = [
   {
     dep: "@threa/bot-runtime-client",
     src: resolve(here, "../bot-runtime-client"),
-    files: ["index.ts", "transport.ts", "types.ts", "ws-hint.ts", "crypto.ts", "sealed.ts"],
+    files: [
+      "index.ts",
+      "transport.ts",
+      "types.ts",
+      "ws-hint.ts",
+      "crypto.ts",
+      "sealed.ts",
+      "supervisor.ts",
+      "harness-kick.ts",
+    ],
     dir: "bot-runtime-client",
   },
   {
     dep: "@threa/remote-session",
     src: resolve(here, "../remote-session"),
-    files: ["index.ts", "session.ts", "client.ts", "identity.ts", "attachments.ts", "lifecycle.ts"],
+    files: [
+      "index.ts",
+      "session.ts",
+      "client.ts",
+      "identity.ts",
+      "attachments.ts",
+      "lifecycle.ts",
+      "delegation-client.ts",
+      "delegation-runner.ts",
+    ],
     dir: "remote-session",
   },
 ]

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -1,7 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
-import type { BotRuntimeTransport } from "@threa/bot-runtime-client"
+import { runHarnessKick, type BotRuntimeTransport } from "@threa/bot-runtime-client"
 import {
   DelegationClient,
   DelegationRunner,
@@ -32,8 +32,19 @@ export const CHANNEL_SOURCE = "threa-channel"
 // to Claude Code's `/reload-skills` (pick up skills + custom commands added on
 // disk this session — `/reload-plugins` is reachable via `run` for the plugin
 // case); Threa's canonical `thinking` maps to Claude Code's `/effort`;
-// `carry-on` queues text for the quota carry-on resume (see carry-on.ts).
-const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "thinking", "compact", "run", "reload", "carry-on"] as const
+// `carry-on` queues text for the quota carry-on resume (see carry-on.ts);
+// `kick` asks harnessd to press Enter in this managed session's pane.
+const SESSION_CONTROL_COMMANDS = [
+  "stop",
+  "steer",
+  "kick",
+  "model",
+  "thinking",
+  "compact",
+  "run",
+  "reload",
+  "carry-on",
+] as const
 // Model options for the composer's arg picker: built-in /model aliases plus
 // whatever the local client's own picker cache discovers (see model-catalog).
 // Resolved once at startup — new models arrive with the next spawned session.
@@ -139,12 +150,19 @@ export function buildInstructions(permissionRelay: boolean, channelActive = true
 export async function runClaudeCommand(
   name: string,
   args: string,
-  carryOn?: CarryOnController
+  carryOn?: CarryOnController,
+  runtimeSessionId?: string
 ): Promise<{ ok: boolean; message: string }> {
   switch (name) {
     case "carry-on": {
       if (!carryOn) return { ok: false, message: "Quota carry-on is unavailable for this session." }
       return carryOn.enqueue(args)
+    }
+    case "kick": {
+      if (!runtimeSessionId) throw new Error("Harness kick is unavailable for this session.")
+      const result = runHarnessKick(runtimeSessionId)
+      if (!result.ok) throw new Error(`Could not kick the session: ${result.error}`)
+      return { ok: true, message: "Kicked the linked Claude Code session." }
     }
     case "model": {
       const alias = args.trim()
@@ -196,7 +214,8 @@ async function runSlash(slash: string): Promise<{ ok: boolean; message: string }
  * controller needs the constructed session, which needs this actuator first.
  */
 export function createClaudeSessionControl(
-  carryOn: () => CarryOnController | undefined = () => undefined
+  carryOn: () => CarryOnController | undefined = () => undefined,
+  runtimeSessionId?: string
 ): SessionControlActuator | undefined {
   if (!tmuxAvailable()) return undefined
   return {
@@ -219,7 +238,7 @@ export function createClaudeSessionControl(
       if (absorbed !== undefined) return true
       return steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`)
     },
-    runCommand: (name, args) => runClaudeCommand(name, args, carryOn()),
+    runCommand: (name, args) => runClaudeCommand(name, args, carryOn(), runtimeSessionId),
   }
 }
 
@@ -299,7 +318,7 @@ export class ChannelServer {
       },
       delegate: {
         deliverTurn: (turn) => this.deliverToClaude(turn),
-        sessionControl: createClaudeSessionControl(() => this.carryOn),
+        sessionControl: createClaudeSessionControl(() => this.carryOn, config.runtimeSessionId),
         onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay
           ? { interceptClaimed: (invocation: ClaimedInvocation) => this.interceptVerdict(invocation) }

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -219,7 +219,9 @@ export function createClaudeSessionControl(
 ): SessionControlActuator | undefined {
   if (!tmuxAvailable()) return undefined
   return {
-    commands: [...SESSION_CONTROL_COMMANDS],
+    commands: runtimeSessionId
+      ? [...SESSION_CONTROL_COMMANDS]
+      : SESSION_CONTROL_COMMANDS.filter((command) => command !== "kick"),
     modelSuggestions: MODEL_SUGGESTIONS,
     thinkingLevels: [...THINKING_LEVELS],
     interrupt: () => {

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -33,7 +33,17 @@ describe("createClaudeSessionControl", () => {
     withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
       const actuator = createClaudeSessionControl()
       expect(actuator).toBeDefined()
-      expect(actuator!.commands).toEqual(["stop", "steer", "model", "thinking", "compact", "run", "reload", "carry-on"])
+      expect(actuator!.commands).toEqual([
+        "stop",
+        "steer",
+        "kick",
+        "model",
+        "thinking",
+        "compact",
+        "run",
+        "reload",
+        "carry-on",
+      ])
       expect(actuator!.thinkingLevels).toEqual(["low", "medium", "high", "xhigh", "max", "ultracode"])
       expect(actuator!.modelSuggestions!.map((suggestion) => suggestion.value)).toContain("opus")
       expect(actuator!.modelSuggestions!.every((suggestion) => suggestion.label)).toBe(true)
@@ -44,6 +54,10 @@ describe("createClaudeSessionControl", () => {
 })
 
 describe("runClaudeCommand validation (paths that never touch tmux)", () => {
+  it("fails loudly when /kick has no harness-managed runtime identity", async () => {
+    expect(runClaudeCommand("kick", "")).rejects.toThrow("Harness kick is unavailable for this session.")
+  })
+
   it("gives usage help for /model without an argument", async () => {
     const outcome = await runClaudeCommand("model", "")
     expect(outcome.ok).toBe(false)

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -31,7 +31,7 @@ describe("createClaudeSessionControl", () => {
 
   it("advertises the full command set with effort levels and display-labelled models inside tmux", () => {
     withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
-      const actuator = createClaudeSessionControl()
+      const actuator = createClaudeSessionControl(undefined, "ccs-one")
       expect(actuator).toBeDefined()
       expect(actuator!.commands).toEqual([
         "stop",
@@ -49,6 +49,21 @@ describe("createClaudeSessionControl", () => {
       expect(actuator!.modelSuggestions!.every((suggestion) => suggestion.label)).toBe(true)
       // Native mid-turn steering: without this the SDK falls back to interrupt+redeliver.
       expect(typeof actuator!.steer).toBe("function")
+    })
+  })
+
+  it("does not advertise /kick without a harness runtime identity", () => {
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
+      expect(createClaudeSessionControl()!.commands).toEqual([
+        "stop",
+        "steer",
+        "model",
+        "thinking",
+        "compact",
+        "run",
+        "reload",
+        "carry-on",
+      ])
     })
   })
 })

--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -1,6 +1,6 @@
 # harness-daemon
 
-Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. Run `threa-harnessd help` for the full command list.
+Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). Run `threa-harnessd help` for the full command list.
 
 ## `up` (alias `resume-active`)
 

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -16,6 +16,7 @@ Usage:
   threa-harnessd install-watch [--tmux <session>]
   threa-harnessd install-boot-resume [--tmux <session>]
   threa-harnessd stop <agent-id-or-name>
+  threa-harnessd kick <agent-id-or-name-or-runtime-session-id>
   threa-harnessd interrupt <agent-id-or-name>
   threa-harnessd steer <agent-id-or-name> [follow-up text]
   threa-harnessd keys <agent-id-or-name> <tmux send-keys tokens...>
@@ -29,6 +30,7 @@ Examples:
   threa-harnessd watch-unarchived --tmux threa-agents
   threa-harnessd install-watch
   threa-harnessd do spawn a pi agent for long chat performance
+  threa-harnessd kick fix-sidebar
   threa-harnessd interrupt fix-sidebar
   threa-harnessd steer fix-sidebar "also update the tests"
   threa-harnessd keys fix-sidebar /compact Enter

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -89,6 +89,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
       tmuxSession: result.tmuxSession,
       tmuxWindow: result.tmuxWindow,
       tmuxWindowId: result.tmuxWindowId,
+      tmuxPaneId: result.tmuxPaneId,
       scratchpadUrl: result.scratchpadUrl,
       instanceId: result.instanceId,
       runtimeSessionId: result.runtimeSessionId,
@@ -460,6 +461,7 @@ export async function reviveAgent(
       tmuxSession: result.tmuxSession,
       tmuxWindow: result.tmuxWindow,
       tmuxWindowId: result.tmuxWindowId,
+      tmuxPaneId: result.tmuxPaneId,
       status: "online",
       updatedAt: now(),
       lastOutput: result.output.slice(-4000),
@@ -521,30 +523,45 @@ export function listAgents(): void {
 
 export function stopAgent(ref: string): void {
   const agent = findAgent(ref)
-  const target = tmuxTarget(agent)
+  const target = tmuxWindowTarget(agent)
   const result = output(["tmux", "kill-window", "-t", target], { allowFailure: true })
   if (result.exitCode !== 0) die(result.stderr.trim() || `tmux kill-window failed for ${target}`)
   upsertAgent({ ...agent, status: "stopped", updatedAt: now() })
   console.log(`harnessd: stopped ${agent.name} (${target})`)
 }
 
-/** Window id when recorded (durable across renames/collisions), else the legacy session:name target. */
-function tmuxTarget(agent: ManagedAgent): string {
+function tmuxWindowTarget(agent: ManagedAgent): string {
   if (agent.tmuxWindowId) return agent.tmuxWindowId
   if (agent.tmuxSession && agent.tmuxWindow) return `${agent.tmuxSession}:${agent.tmuxWindow}`
-  return die(`${agent.name} has no tmux target recorded`)
+  return die(`${agent.name} has no tmux window recorded`)
+}
+
+function tmuxKeyTarget(agent: ManagedAgent): string {
+  if (agent.tmuxPaneId) return agent.tmuxPaneId
+  const window = tmuxWindowTarget(agent)
+  const result = output(["tmux", "list-panes", "-t", window, "-F", "#{pane_id}"], { allowFailure: true })
+  const panes = result.stdout.split("\n").filter(Boolean)
+  if (result.exitCode === 0 && panes.length === 1) return panes[0]!
+  return die(`${agent.name} has no unambiguous tmux pane recorded; restart the managed session`)
+}
+
+/** Nudge the managed agent's TUI with Enter (e.g. accept a blocking prompt). */
+export function kickAgent(ref: string, send: typeof sendKeys = sendKeys): void {
+  const target = tmuxKeyTarget(findAgent(ref))
+  send(target, ["Enter"])
+  console.log(`harnessd: kicked ${target}`)
 }
 
 /** Send Esc to interrupt the agent's current turn (Claude Code / Pi) without killing the window. */
 export function interruptAgent(ref: string): void {
-  const target = tmuxTarget(findAgent(ref))
+  const target = tmuxKeyTarget(findAgent(ref))
   sendKeys(target, ["Escape"])
   console.log(`harnessd: interrupted ${target}`)
 }
 
 /** Interrupt the current turn, then (if given) type a follow-up and submit it. */
 export function steerAgent(ref: string, text: string): void {
-  const target = tmuxTarget(findAgent(ref))
+  const target = tmuxKeyTarget(findAgent(ref))
   sendKeys(target, ["Escape"])
   if (text) {
     // Esc restores the interrupted message into the input box; clear it (Ctrl-U)
@@ -557,10 +574,10 @@ export function steerAgent(ref: string, text: string): void {
   console.log(`harnessd: steered ${target}`)
 }
 
-/** Raw `tmux send-keys` passthrough to the agent's window (tokens follow tmux rules). */
+/** Raw `tmux send-keys` passthrough to the agent's pane (tokens follow tmux rules). */
 export function sendKeysToAgent(ref: string, keys: string[]): void {
   if (keys.length === 0) die("keys requires at least one key or token")
-  const target = tmuxTarget(findAgent(ref))
+  const target = tmuxKeyTarget(findAgent(ref))
   sendKeys(target, keys)
   console.log(`harnessd: sent keys to ${target}`)
 }
@@ -568,7 +585,7 @@ export function sendKeysToAgent(ref: string, keys: string[]): void {
 export function attachAgent(ref: string): void {
   const agent = findAgent(ref)
   if (!agent.tmuxSession) die(`${agent.name} has no tmux session recorded`)
-  const target = tmuxTarget(agent)
+  const target = tmuxWindowTarget(agent)
   if (process.env.TMUX) {
     const result = Bun.spawnSync(["tmux", "switch-client", "-t", target], { stdout: "inherit", stderr: "pipe" })
     if (result.exitCode !== 0) die(result.stderr.toString().trim() || `tmux switch-client failed for ${target}`)

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -8,6 +8,7 @@ import {
   inferAndRun,
   installBootResumeAgent,
   interruptAgent,
+  kickAgent,
   listAgents,
   resumeActive,
   sendKeysToAgent,
@@ -38,6 +39,7 @@ async function main(): Promise<void> {
     return installBootResumeAgent(parseResume(args))
   }
   if (command === "stop") return stopAgent(args[0] ?? die("stop requires an agent id or name"))
+  if (command === "kick") return kickAgent(args[0] ?? die("kick requires an agent id, name, or runtime session id"))
   if (command === "interrupt") return interruptAgent(args[0] ?? die("interrupt requires an agent id or name"))
   if (command === "steer")
     return steerAgent(args[0] ?? die("steer requires an agent id or name"), args.slice(1).join(" "))

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -17,6 +17,7 @@ interface ManagedAgentRow {
   tmux_session: string | null
   tmux_window: string | null
   tmux_window_id: string | null
+  tmux_pane_id: string | null
   scratchpad_url: string | null
   instance_id: string | null
   runtime_session_id: string | null
@@ -46,6 +47,8 @@ function openInventory(): Database {
       branch TEXT,
       tmux_session TEXT,
       tmux_window TEXT,
+      tmux_window_id TEXT,
+      tmux_pane_id TEXT,
       scratchpad_url TEXT,
       instance_id TEXT,
       runtime_session_id TEXT,
@@ -57,11 +60,11 @@ function openInventory(): Database {
       probe_backoff_until TEXT
     )
   `)
-  // Inventories predating the window-id column: CREATE TABLE IF NOT EXISTS
-  // won't extend an existing table, so add the column in place.
+  // CREATE TABLE IF NOT EXISTS won't extend an existing inventory, so add new columns in place.
   const columns = db.query("PRAGMA table_info(managed_agents)").all() as Array<{ name: string }>
   const added: Array<[string, string]> = [
     ["tmux_window_id", "TEXT"],
+    ["tmux_pane_id", "TEXT"],
     ["instance_id", "TEXT"],
     ["runtime_session_id", "TEXT"],
     ["probe_failures", "INTEGER"],
@@ -86,6 +89,7 @@ function rowToAgent(row: ManagedAgentRow): ManagedAgent {
     tmuxSession: row.tmux_session ?? undefined,
     tmuxWindow: row.tmux_window ?? undefined,
     tmuxWindowId: row.tmux_window_id ?? undefined,
+    tmuxPaneId: row.tmux_pane_id ?? undefined,
     scratchpadUrl: row.scratchpad_url ?? undefined,
     instanceId: row.instance_id ?? undefined,
     runtimeSessionId: row.runtime_session_id ?? undefined,
@@ -116,9 +120,9 @@ export function upsertAgent(agent: ManagedAgent): void {
       `
       INSERT INTO managed_agents (
         id, name, runtime, status, worktree, branch, tmux_session, tmux_window,
-        tmux_window_id, scratchpad_url, instance_id, runtime_session_id, command_json,
+        tmux_window_id, tmux_pane_id, scratchpad_url, instance_id, runtime_session_id, command_json,
         created_at, updated_at, last_output, probe_failures, probe_backoff_until
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         runtime = excluded.runtime,
@@ -128,6 +132,7 @@ export function upsertAgent(agent: ManagedAgent): void {
         tmux_session = excluded.tmux_session,
         tmux_window = excluded.tmux_window,
         tmux_window_id = excluded.tmux_window_id,
+        tmux_pane_id = excluded.tmux_pane_id,
         scratchpad_url = excluded.scratchpad_url,
         instance_id = excluded.instance_id,
         runtime_session_id = excluded.runtime_session_id,
@@ -147,6 +152,7 @@ export function upsertAgent(agent: ManagedAgent): void {
       agent.tmuxSession ?? null,
       agent.tmuxWindow ?? null,
       agent.tmuxWindowId ?? null,
+      agent.tmuxPaneId ?? null,
       agent.scratchpadUrl ?? null,
       agent.instanceId ?? null,
       agent.runtimeSessionId ?? null,
@@ -164,7 +170,15 @@ export function upsertAgent(agent: ManagedAgent): void {
 
 export function findAgent(ref: string): ManagedAgent {
   const agents = readInventory()
-  const matches = agents.filter((agent) => agent.id === ref || agent.name === ref)
+  const byId = agents.find((agent) => agent.id === ref)
+  if (byId) return byId
+
+  const byRuntimeSession = agents
+    .filter((agent) => agent.runtimeSessionId === ref)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  if (byRuntimeSession[0]) return byRuntimeSession[0]
+
+  const matches = agents.filter((agent) => agent.name === ref)
   if (matches.length === 0) die(`no agent found for ${ref}`)
   if (matches.length > 1) die(`multiple agents match ${ref}; use id`)
   return matches[0]

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -265,6 +265,7 @@ test("reconstructs the current Claude channel launch with stable runtime identit
   expect(command).toContain("'THREA_RUNTIME_SESSION_ID=ccs-one'")
   expect(command).toContain("'THREA_DEFAULT_LABEL=coding'")
   expect(command).toContain("'THREA_HARNESSD_ENTRYPOINT=")
+  expect(command).toContain(`'THREA_HARNESSD_BUN_BIN=${process.execPath}'`)
   expect(command).toContain("'THREA_COLD_START_IF_ARCHIVED=wait'")
   expect(command).toContain("'THREA_COLD_START_IF_MISSING=error'")
   expect(command).toContain("'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'")
@@ -275,10 +276,12 @@ test("reconstructs the current Claude channel launch with stable runtime identit
 
 test("Pi revival reuses an exact recorded session id bound to the expected root", () => {
   expect(piLaunchArgs("pi", "019f-session")).toEqual(["pi", "--session-id", "019f-session"])
-  expect(piLaunchCommand("pi", "019f-session")).toContain("'THREA_HARNESSD_ENTRYPOINT=")
-  expect(piResumeCommand("pi", "019f-session", "stream_expected")).toContain(
-    "'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'"
-  )
+  const launch = piLaunchCommand("pi", "019f-session")
+  expect(launch).toContain("'THREA_HARNESSD_ENTRYPOINT=")
+  expect(launch).toContain(`'THREA_HARNESSD_BUN_BIN=${process.execPath}'`)
+  const resume = piResumeCommand("pi", "019f-session", "stream_expected")
+  expect(resume).toContain(`'THREA_HARNESSD_BUN_BIN=${process.execPath}'`)
+  expect(resume).toContain("'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'")
 })
 
 test("classifies active, archived, inaccessible, and unavailable scratchpads", async () => {

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -13,14 +13,15 @@ import {
 } from "./resume"
 import { launchAgentPlist } from "./boot"
 import { parseResume, parseSpawn } from "./cli"
-import { restoredSessionMatches, reviveAgent, type ReviveDeps, type ReviveOutcome } from "./commands"
-import { readInventory, upsertAgent } from "./inventory"
+import { kickAgent, restoredSessionMatches, reviveAgent, type ReviveDeps, type ReviveOutcome } from "./commands"
+import { findAgent, readInventory, upsertAgent } from "./inventory"
 import { acquireProcessLock } from "./lock"
 import {
   claudeLaunchArgs,
   claudeLaunchCommand,
   normalizeChannelMcpConfig,
   piLaunchArgs,
+  piLaunchCommand,
   piResumeCommand,
 } from "./spawners"
 import type { ManagedAgent, ResumeOptions } from "./types"
@@ -79,6 +80,7 @@ test("migrates legacy inventory and persists runtime identity", () => {
     const managed = agent({
       instanceId: "cc-one",
       runtimeSessionId: "ccs-one",
+      tmuxPaneId: "%8",
       probeFailures: 3,
       probeBackoffUntil: "2026-07-20T12:00:00.000Z",
     })
@@ -87,6 +89,45 @@ test("migrates legacy inventory and persists runtime identity", () => {
     const cleared = { ...managed, probeFailures: undefined, probeBackoffUntil: undefined }
     upsertAgent(cleared)
     expect(readInventory()).toEqual([cleared])
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("resolves slash-command kicks by the latest matching runtime session id", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  process.env.THREA_HARNESSD_INVENTORY = join(
+    mkdtempSync(join(tmpdir(), "harnessd-kick-inventory-")),
+    "inventory.sqlite"
+  )
+  try {
+    upsertAgent(agent({ id: "old", runtimeSessionId: "ccs-one" }))
+    upsertAgent(
+      agent({
+        id: "current",
+        runtimeSessionId: "ccs-one",
+        updatedAt: "2026-07-02T00:00:00.000Z",
+        tmuxWindowId: "@7",
+        tmuxPaneId: "%8",
+      })
+    )
+    expect(findAgent("ccs-one").id).toBe("current")
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("kick sends Enter to the managed tmux pane", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  const dir = mkdtempSync(join(tmpdir(), "harnessd-kick-"))
+  process.env.THREA_HARNESSD_INVENTORY = join(dir, "inventory.sqlite")
+  try {
+    const sent: Array<{ target: string; keys: string[] }> = []
+    upsertAgent(agent({ runtimeSessionId: "ccs-one", tmuxWindowId: "@7", tmuxPaneId: "%8" }))
+    kickAgent("ccs-one", (target, keys) => sent.push({ target, keys }))
+    expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
   } finally {
     if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
     else process.env.THREA_HARNESSD_INVENTORY = previousPath
@@ -223,6 +264,7 @@ test("reconstructs the current Claude channel launch with stable runtime identit
   expect(command).toContain("'THREA_INSTANCE_ID=cc-one'")
   expect(command).toContain("'THREA_RUNTIME_SESSION_ID=ccs-one'")
   expect(command).toContain("'THREA_DEFAULT_LABEL=coding'")
+  expect(command).toContain("'THREA_HARNESSD_ENTRYPOINT=")
   expect(command).toContain("'THREA_COLD_START_IF_ARCHIVED=wait'")
   expect(command).toContain("'THREA_COLD_START_IF_MISSING=error'")
   expect(command).toContain("'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'")
@@ -233,6 +275,7 @@ test("reconstructs the current Claude channel launch with stable runtime identit
 
 test("Pi revival reuses an exact recorded session id bound to the expected root", () => {
   expect(piLaunchArgs("pi", "019f-session")).toEqual(["pi", "--session-id", "019f-session"])
+  expect(piLaunchCommand("pi", "019f-session")).toContain("'THREA_HARNESSD_ENTRYPOINT=")
   expect(piResumeCommand("pi", "019f-session", "stream_expected")).toContain(
     "'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'"
   )
@@ -633,6 +676,7 @@ test("up starts an eligible agent and records it online", async () => {
       tmuxSession: "threa-agents",
       tmuxWindow: "repair",
       tmuxWindowId: "@7",
+      tmuxPaneId: "%8",
       scratchpadUrl: managed.scratchpadUrl,
       instanceId: managed.instanceId,
       runtimeSessionId: managed.runtimeSessionId,
@@ -647,6 +691,7 @@ test("up starts an eligible agent and records it online", async () => {
     expect.objectContaining({
       status: "online",
       tmuxWindowId: "@7",
+      tmuxPaneId: "%8",
       instanceId: "cc-one",
       runtimeSessionId: "ccs-one",
     }),
@@ -673,6 +718,7 @@ test("a scratchpad archived during launch is killed, not recorded online", async
       tmuxSession: "threa-agents",
       tmuxWindow: "repair",
       tmuxWindowId: "@7",
+      tmuxPaneId: "%8",
       scratchpadUrl: managed.scratchpadUrl,
       instanceId: managed.instanceId,
       runtimeSessionId: managed.runtimeSessionId,
@@ -704,6 +750,7 @@ test("a persist failure after launch kills the window instead of leaving it untr
       tmuxSession: "threa-agents",
       tmuxWindow: "repair",
       tmuxWindowId: "@7",
+      tmuxPaneId: "%8",
       scratchpadUrl: managed.scratchpadUrl,
       instanceId: managed.instanceId,
       runtimeSessionId: managed.runtimeSessionId,

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -21,8 +21,21 @@ export function piLaunchArgs(piBin: string, runtimeSessionId: string): string[] 
   return [piBin, "--session-id", runtimeSessionId]
 }
 
+function harnessDaemonEnvironment(): string {
+  return `THREA_HARNESSD_ENTRYPOINT=${process.env.THREA_HARNESSD_ENTRYPOINT || join(import.meta.dir, "index.ts")}`
+}
+
+export function piLaunchCommand(piBin: string, runtimeSessionId: string): string {
+  return ["env", harnessDaemonEnvironment(), ...piLaunchArgs(piBin, runtimeSessionId)].map(shellQuote).join(" ")
+}
+
 export function piResumeCommand(piBin: string, runtimeSessionId: string, expectedRootStreamId: string): string {
-  return ["env", `THREA_EXPECTED_ROOT_STREAM_ID=${expectedRootStreamId}`, ...piLaunchArgs(piBin, runtimeSessionId)]
+  return [
+    "env",
+    harnessDaemonEnvironment(),
+    `THREA_EXPECTED_ROOT_STREAM_ID=${expectedRootStreamId}`,
+    ...piLaunchArgs(piBin, runtimeSessionId),
+  ]
     .map(shellQuote)
     .join(" ")
 }
@@ -147,22 +160,17 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
     const partial: Partial<SpawnResult> = { worktree, branch, tmuxSession: session, runtimeSessionId }
     try {
       const window = pickTmuxWindow(session, options.name)
-      const windowId = createWindow(
-        session,
-        window,
-        worktree,
-        piLaunchArgs(piBin, runtimeSessionId).map(shellQuote).join(" ")
-      )
-      Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId })
+      const { windowId, paneId } = createWindow(session, window, worktree, piLaunchCommand(piBin, runtimeSessionId))
+      Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Pi in tmux ${session}:${window} (${windowId})`)
 
       if (!options.noRemote) {
         await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000))
-        sendKeys(windowId, ["/remote-control", "Enter"])
+        sendKeys(paneId, ["/remote-control", "Enter"])
         await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_REMOTE_WAIT_MS ?? 6000))
       }
 
-      const outputText = capturePane(windowId)
+      const outputText = capturePane(paneId)
       const link = readPiRemoteSession(runtimeSessionId)
       return {
         worktree,
@@ -170,6 +178,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
         tmuxSession: session,
         tmuxWindow: window,
         tmuxWindowId: windowId,
+        tmuxPaneId: paneId,
         scratchpadUrl: link?.scratchpadUrl ?? firstScratchpadUrl(outputText),
         instanceId: link?.instanceId,
         runtimeSessionId,
@@ -190,7 +199,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "pi", name: agent.name })
     ensureTmuxSession(session, true)
     const window = pickTmuxWindow(session, agent.name)
-    const windowId = createWindow(
+    const { windowId, paneId } = createWindow(
       session,
       window,
       agent.worktree,
@@ -201,13 +210,14 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
       )
     )
     await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000))
-    const output = capturePane(windowId)
+    const output = capturePane(paneId)
     return {
       worktree: agent.worktree,
       branch: agent.branch ?? agent.name,
       tmuxSession: session,
       tmuxWindow: window,
       tmuxWindowId: windowId,
+      tmuxPaneId: paneId,
       scratchpadUrl: agent.scratchpadUrl,
       instanceId: agent.instanceId,
       runtimeSessionId: agent.runtimeSessionId,
@@ -278,19 +288,20 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
       })
 
       const window = pickTmuxWindow(session, options.name)
-      const windowId = createWindow(session, window, worktree, claudeLaunchCommand(args, identity, config))
-      Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId })
+      const { windowId, paneId } = createWindow(session, window, worktree, claudeLaunchCommand(args, identity, config))
+      Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Claude Code in tmux ${session}:${window} (${windowId})`)
 
-      if (!options.noAutoAccept) await this.acceptBootPrompts(windowId)
+      if (!options.noAutoAccept) await this.acceptBootPrompts(paneId)
 
-      const outputText = capturePane(windowId)
+      const outputText = capturePane(paneId)
       return {
         worktree,
         branch,
         tmuxSession: session,
         tmuxWindow: window,
         tmuxWindowId: windowId,
+        tmuxPaneId: paneId,
         scratchpadUrl: scratchpadUrl ?? firstScratchpadUrl(outputText),
         instanceId: identity.instanceId,
         runtimeSessionId: identity.runtimeSessionId,
@@ -322,7 +333,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     ensureTmuxSession(session, true)
     const noYolo = recordedNoYolo(agent)
     const window = pickTmuxWindow(session, agent.name)
-    const windowId = createWindow(
+    const { windowId, paneId } = createWindow(
       session,
       window,
       agent.worktree,
@@ -337,18 +348,19 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     )
     console.log(`harnessd: resumed Claude Code in tmux ${session}:${window} (${windowId})`)
     try {
-      await this.acceptBootPrompts(windowId)
-      sendKeys(windowId, ["/remote-control", "Enter"])
+      await this.acceptBootPrompts(paneId)
+      sendKeys(paneId, ["/remote-control", "Enter"])
       await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_REMOTE_WAIT_MS ?? 2000))
-      sendKeys(windowId, ["/rc", "Enter"])
+      sendKeys(paneId, ["/rc", "Enter"])
       await Bun.sleep(500)
-      const output = capturePane(windowId)
+      const output = capturePane(paneId)
       return {
         worktree: agent.worktree,
         branch: agent.branch ?? agent.name,
         tmuxSession: session,
         tmuxWindow: window,
         tmuxWindowId: windowId,
+        tmuxPaneId: paneId,
         scratchpadUrl: agent.scratchpadUrl,
         instanceId: identity.instanceId,
         runtimeSessionId: identity.runtimeSessionId,
@@ -400,12 +412,12 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
    * dialog still open (which left the channel half-wired often enough that the
    * old two-blind-Enters approach needed constant retuning).
    */
-  private async acceptBootPrompts(windowId: string): Promise<void> {
+  private async acceptBootPrompts(paneId: string): Promise<void> {
     const deadline = Date.now() + Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000)
     while (Date.now() < deadline) {
-      const text = capturePane(windowId)
+      const text = capturePane(paneId)
       if (BOOT_DIALOG_RE.test(text)) {
-        sendKeys(windowId, ["Enter"])
+        sendKeys(paneId, ["Enter"])
         await Bun.sleep(1000)
         continue
       }
@@ -504,6 +516,7 @@ export function claudeLaunchCommand(
     THREA_RUNTIME_SESSION_ID: identity.runtimeSessionId,
     THREA_DISPLAY_NAME: process.env.THREA_DISPLAY_NAME || config.displayName || "Claude Code",
     THREA_DEFAULT_LABEL: process.env.THREA_DEFAULT_LABEL || config.defaultLabel || "coding",
+    THREA_HARNESSD_ENTRYPOINT: process.env.THREA_HARNESSD_ENTRYPOINT || join(import.meta.dir, "index.ts"),
     THREA_COLD_START_IF_ARCHIVED: coldStartIfArchived,
     THREA_COLD_START_IF_MISSING: coldStartIfMissing,
     ...(expectedRootStreamId ? { THREA_EXPECTED_ROOT_STREAM_ID: expectedRootStreamId } : {}),

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -21,18 +21,21 @@ export function piLaunchArgs(piBin: string, runtimeSessionId: string): string[] 
   return [piBin, "--session-id", runtimeSessionId]
 }
 
-function harnessDaemonEnvironment(): string {
-  return `THREA_HARNESSD_ENTRYPOINT=${process.env.THREA_HARNESSD_ENTRYPOINT || join(import.meta.dir, "index.ts")}`
+function harnessDaemonEnvironment(): string[] {
+  return [
+    `THREA_HARNESSD_ENTRYPOINT=${process.env.THREA_HARNESSD_ENTRYPOINT || join(import.meta.dir, "index.ts")}`,
+    `THREA_HARNESSD_BUN_BIN=${process.env.THREA_HARNESSD_BUN_BIN || process.execPath}`,
+  ]
 }
 
 export function piLaunchCommand(piBin: string, runtimeSessionId: string): string {
-  return ["env", harnessDaemonEnvironment(), ...piLaunchArgs(piBin, runtimeSessionId)].map(shellQuote).join(" ")
+  return ["env", ...harnessDaemonEnvironment(), ...piLaunchArgs(piBin, runtimeSessionId)].map(shellQuote).join(" ")
 }
 
 export function piResumeCommand(piBin: string, runtimeSessionId: string, expectedRootStreamId: string): string {
   return [
     "env",
-    harnessDaemonEnvironment(),
+    ...harnessDaemonEnvironment(),
     `THREA_EXPECTED_ROOT_STREAM_ID=${expectedRootStreamId}`,
     ...piLaunchArgs(piBin, runtimeSessionId),
   ]
@@ -517,6 +520,7 @@ export function claudeLaunchCommand(
     THREA_DISPLAY_NAME: process.env.THREA_DISPLAY_NAME || config.displayName || "Claude Code",
     THREA_DEFAULT_LABEL: process.env.THREA_DEFAULT_LABEL || config.defaultLabel || "coding",
     THREA_HARNESSD_ENTRYPOINT: process.env.THREA_HARNESSD_ENTRYPOINT || join(import.meta.dir, "index.ts"),
+    THREA_HARNESSD_BUN_BIN: process.env.THREA_HARNESSD_BUN_BIN || process.execPath,
     THREA_COLD_START_IF_ARCHIVED: coldStartIfArchived,
     THREA_COLD_START_IF_MISSING: coldStartIfMissing,
     ...(expectedRootStreamId ? { THREA_EXPECTED_ROOT_STREAM_ID: expectedRootStreamId } : {}),

--- a/extensions/harness-daemon/src/tmux.ts
+++ b/extensions/harness-daemon/src/tmux.ts
@@ -65,19 +65,23 @@ export function pickTmuxWindow(session: string, name: string): string {
 /**
  * Create a window at the session's first free index (the `session:` target —
  * no `-a`, which inserts relative to the *current* window and fails when the
- * next index is taken) and return its window id. The id is the durable handle
- * for steer/keys/stop: names can collide or be renamed, `@n` ids cannot.
+ * next index is taken) and return its stable window + initial pane ids.
  * Detached (`-d`) so spawning into the user's attached session never yanks
  * focus away from what they're doing.
  */
-export function createWindow(session: string, name: string, cwd: string, command: string): string {
+export function createWindow(
+  session: string,
+  name: string,
+  cwd: string,
+  command: string
+): { windowId: string; paneId: string } {
   const result = output([
     "tmux",
     "new-window",
     "-d",
     "-P",
     "-F",
-    "#{window_id}",
+    "#{window_id} #{pane_id}",
     "-t",
     `${session}:`,
     "-n",
@@ -86,9 +90,9 @@ export function createWindow(session: string, name: string, cwd: string, command
     cwd,
     command,
   ])
-  const windowId = result.stdout.trim()
-  if (!windowId) die("tmux new-window did not return a window id")
-  return windowId
+  const [windowId, paneId] = result.stdout.trim().split(/\s+/)
+  if (!windowId || !paneId) die("tmux new-window did not return window and pane ids")
+  return { windowId, paneId }
 }
 
 export function capturePane(target: string, lines = 30): string {

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -10,8 +10,10 @@ export interface ManagedAgent {
   branch?: string
   tmuxSession?: string
   tmuxWindow?: string
-  /** Stable tmux window id (`@n`) — the durable target for steer/keys/stop; names can collide or be renamed. */
+  /** Stable tmux window id (`@n`) for window lifecycle; names can collide or be renamed. */
   tmuxWindowId?: string
+  /** Stable tmux pane id (`%n`) for key injection; avoids whichever split is active in the window. */
+  tmuxPaneId?: string
   scratchpadUrl?: string
   instanceId?: string
   runtimeSessionId?: string
@@ -57,6 +59,7 @@ export interface SpawnResult {
   tmuxSession: string
   tmuxWindow: string
   tmuxWindowId: string
+  tmuxPaneId: string
   scratchpadUrl?: string
   instanceId?: string
   runtimeSessionId?: string

--- a/extensions/pi-remote/README.md
+++ b/extensions/pi-remote/README.md
@@ -35,6 +35,8 @@ bun run extensions/pi-remote/install-local.ts
 
 Then run `/reload` in Pi. Pass a different target dir as the first argument if needed.
 
+For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt.
+
 The script rebuilds `~/.pi/agent/extensions/threa-remote` from scratch each time, so re-running it is the supported way to update.
 
 ### Why a script and not `cp -R` + `bun install`

--- a/extensions/pi-remote/install-local.ts
+++ b/extensions/pi-remote/install-local.ts
@@ -21,7 +21,16 @@ const extensionsDir = join(homedir(), ".pi", "agent", "extensions")
 const dest = process.argv[2] ?? join(extensionsDir, "threa-remote")
 
 // The runtime files of bot-runtime-client (its tests are not needed at runtime).
-const VENDOR_FILES = ["index.ts", "transport.ts", "types.ts", "ws-hint.ts", "crypto.ts", "sealed.ts"]
+const VENDOR_FILES = [
+  "index.ts",
+  "transport.ts",
+  "types.ts",
+  "ws-hint.ts",
+  "crypto.ts",
+  "sealed.ts",
+  "supervisor.ts",
+  "harness-kick.ts",
+]
 
 // 1. Clean any prior install — both the legacy single-file form and the dir form.
 rmSync(join(extensionsDir, "threa-remote.ts"), { force: true })

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -96,7 +96,18 @@ describe("Pi remote trace safety", () => {
   test("advertises session-control command capabilities", () => {
     expect(__testing.buildRuntimeCapabilities()).toMatchObject({
       supportsSessionControlCommands: true,
-      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload", "shell", "steer", "stop", "carry-on"],
+      sessionControlCommands: [
+        "compact",
+        "model",
+        "thinking",
+        "skill",
+        "reload",
+        "shell",
+        "steer",
+        "stop",
+        "kick",
+        "carry-on",
+      ],
     })
   })
 
@@ -127,6 +138,7 @@ describe("Pi remote trace safety", () => {
       args: "check the failing test first",
     })
     expect(__testing.parseSessionControlCommand("/stop")).toEqual({ name: "stop", args: "" })
+    expect(__testing.parseSessionControlCommand("/kick")).toEqual({ name: "kick", args: "" })
   })
 
   test("rejects prompts that do not look like session-control commands", () => {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -24,6 +24,7 @@ import {
   openSealedTurnContext,
   parseSealedAckContext,
   parseSealedTurnContext,
+  runHarnessKick,
   scrubSealedError,
   sealReply,
   sealStep,
@@ -97,6 +98,7 @@ const SESSION_CONTROL_COMMANDS = [
   "shell",
   "steer",
   "stop",
+  "kick",
   "carry-on",
 ] as const
 type PiSessionControlCommandName = (typeof SESSION_CONTROL_COMMANDS)[number]
@@ -2489,6 +2491,12 @@ async function runCarryOnCommand(invocation: ClaimedInvocation, args: string, ct
   await completeInvocationWithMarkdown(invocation, `Queued — the retry${retryAt} folds it in.`, ctx)
 }
 
+async function runKickCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
+  const result = runHarnessKick(getRuntimeSessionId(ctx))
+  if (!result.ok) throw new Error(result.error ?? "Harness daemon kick failed.")
+  await completeInvocationWithMarkdown(invocation, "Kicked the linked Pi session.", ctx)
+}
+
 async function runStopCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
   const hadPendingRemoteInvocation = pending !== undefined
   const wasBusy = !ctx.isIdle()
@@ -2610,6 +2618,9 @@ async function handleSessionControlInvocation(
         return
       case "stop":
         await runStopCommand(invocation, ctx)
+        return
+      case "kick":
+        await runKickCommand(invocation, ctx)
         return
       case "carry-on":
         await runCarryOnCommand(invocation, command.args, ctx)

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -44,6 +44,7 @@ function makeFakeClient() {
   const calls = {
     sendMessage: [] as Array<{ streamId: string; body: Record<string, unknown> }>,
     complete: [] as Array<{ id: string; body: Record<string, unknown> }>,
+    fail: [] as Array<{ id: string; body: Record<string, unknown> }>,
   }
   const client = {
     sendMessage: async (streamId: string, body: Record<string, unknown>) => {
@@ -51,6 +52,9 @@ function makeFakeClient() {
     },
     complete: async (id: string, body: Record<string, unknown>) => {
       calls.complete.push({ id, body })
+    },
+    fail: async (id: string, body: Record<string, unknown>) => {
+      calls.fail.push({ id, body })
     },
     uploadAttachment: async () => {
       throw new Error("unexpected upload in test")
@@ -728,6 +732,42 @@ describe("session control via the actuator", () => {
 
     expect(ran).toEqual([{ name: "model", args: "opus" }])
     expect(calls.complete[0]?.body.finalMessageMarkdown).toBe("Set model to `opus`.")
+  })
+
+  test("a failed actuator command fails the invocation instead of completing it", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["kick"],
+        interrupt: () => true,
+        runCommand: async () => {
+          throw new Error("harnessd could not find the runtime")
+        },
+      },
+    })
+    const invocation = makeInvocation({
+      id: "binv_kick",
+      trigger: "session-control",
+      promptMarkdown: "/kick",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_kick", name: "kick", args: "" } },
+    })
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(invocation)
+
+    expect(calls.complete).toEqual([])
+    expect(calls.fail).toEqual([
+      {
+        id: "binv_kick",
+        body: {
+          instanceId: "rt-test",
+          claimToken: "tok",
+          errorMessage: "harnessd could not find the runtime",
+        },
+      },
+    ])
   })
 
   test("steer without native steer support interrupts and posts a supersede note carrying the steer text", async () => {


### PR DESCRIPTION
## Problem

A linked Pi or Claude Code session can stop on a local confirmation prompt while its Threa messages remain queued. Recovery required opening tmux or asking another agent to send Enter. Existing stream-scoped controls had no harness-level nudge, and window-targeted key injection could hit the wrong split pane.

## Solution

Add `/kick` as a runtime-advertised stream command for harness-managed Pi and Claude sessions.

- Backend catalog/listing recognizes `kick`; dispatch stays claimable while busy (`active-scratchpad` for Pi, `session-control` for Claude).
- Both runtimes call `runHarnessKick(runtimeSessionId)`; the Node-compatible helper launches harnessd with the spawner-injected Bun executable, then harnessd resolves the newest matching inventory row and sends `Enter`.
- Harness inventory now persists the spawned `%pane_id` separately from the `@window_id`; key injection targets the exact pane. Legacy rows are accepted only when their window has one unambiguous pane.
- Harness failures fail the invocation instead of producing `command_completed`.
- Standalone Pi/Claude installers vendor the new helper and all modules re-exported by their vendored package entrypoints.

`/kick` is a nudge, not a restart. A fully offline runtime cannot claim a slash command; use `threa-harnessd kick|up` from the host for that case.

## Files

| Area | Change |
| --- | --- |
| `apps/backend/src/features/commands/` | Catalog, busy routing, and command tests for `/kick` |
| `extensions/bot-runtime-client/src/harness-kick.ts` | Synchronous harnessd bridge keyed by runtime session id (**new**) |
| `extensions/harness-daemon/src/` | `kick` CLI verb, runtime-session lookup, stable pane persistence/targeting |
| `extensions/pi-remote/src/threa-remote.ts` | Advertise and execute `/kick` |
| `extensions/claude-code-remote/src/channel-server.ts` | Advertise and execute `/kick`; propagate harness failures |
| `extensions/*/install-local.ts` | Keep standalone vendored installs resolvable |
| `docs/` + extension READMEs | Document nudge semantics and harness/pane path |

## Test plan

- [x] Root lint + typecheck hooks — all workspaces clean
- [x] Backend command routing — 3 pass
- [x] Backend command E2E — 6 pass
- [x] `bot-runtime-client` — 57 pass
- [x] `harness-daemon` — 43 pass
- [x] `pi-remote` — 100 pass
- [x] `claude-code-remote` — 103 pass
- [x] `remote-session` — 119 pass
- [x] Standalone Claude install + typecheck
- [x] Live Node-hosted tmux split-pane check — `/kick` launched Bun harnessd and reached the recorded agent pane, not the active unrelated pane
- [x] Multi-model review — stable pane targeting, failed Claude kick lifecycle, and Node-hosted Pi launch boundary fixed; Fable post-fix verification clean

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Expose the manual harness “kick” as `/kick` in linked Pi and Claude scratchpads. Preserve its established meaning: send Enter to the managed TUI so a blocking prompt can advance.

## What Was Built

### Command surface and dispatch

- Add `kick` to the canonical runtime command catalog.
- Surface it only when the linked runtime advertises it.
- Route it through the mid-turn claim path for both runtime kinds.

### Runtime bridge

- Pi and Claude advertise `/kick` and invoke a shared `runHarnessKick` helper with their stable runtime session id.
- The Node-compatible helper executes the local harnessd entrypoint with the Bun executable injected by the spawner.
- Command failure remains visible as `command_failed`.

### Harness targeting

- Add `threa-harnessd kick <id|name|runtime-session-id>`.
- Resolve runtime-session ids to the newest inventory row.
- Store window ids for lifecycle operations and pane ids for key injection.
- For pre-upgrade inventory rows, resolve only a single-pane window; reject ambiguous splits.

### Packaging and docs

- Vendor `harness-kick.ts` in standalone installs.
- Include pre-existing entrypoint re-exports that standalone installs also require.
- Document `/kick` as an Enter nudge, not restart behavior.

## Design Decisions

- **Enter over restart:** matches the existing manual “kick” operation and avoids destroying live turn/session state.
- **Harnessd over direct pane injection in each runtime:** one inventory authority resolves the managed target.
- **Pane id over window id:** `tmux send-keys -t @window` follows the active split and can execute unrelated input.
- **Runtime claim over a new backend supervisor protocol:** reuses session-control delivery and command lifecycle; fully offline recovery remains a host-level operation.

## Schema Changes

No application database migration. Harnessd’s local SQLite inventory gains additive `tmux_pane_id`, migrated in place.

## What's NOT Included

- Runtime restart semantics.
- Slash-command recovery for a fully offline/dead runtime.
- Frontend-specific command code; the existing dynamic command UI renders the backend descriptor.

## Status

- [x] Backend listing and routing
- [x] Pi execution
- [x] Claude execution
- [x] Harness CLI and pane targeting
- [x] Packaging, docs, tests, live tmux verification

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787156638&installation_model_id=20758&pr_number=1458&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1458&signature=85406d4ec4ae796d6760305a9d812861d6321d9986b8097bbfe9c2e8a94acb93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

