### PR TITLE
feat: persist flag layers to IDB for first-render correctness

### DIFF
--- a/apps/frontend/src/components/workspace-settings/feature-flags-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/feature-flags-tab.tsx
@@ -25,14 +25,14 @@ export function FeatureFlagsTab({ workspaceId }: FeatureFlagsTabProps) {
         <p className="text-sm text-muted-foreground">No flags are set on your account.</p>
       ) : (
         <ul className="space-y-3">
-          {flags.map(({ key, value, defaultValue }) => (
+          {flags.map(({ key, value, defaultValue, scope }) => (
             <li key={key} className="flex items-center justify-between gap-3">
               <div>
                 <div className="font-mono text-sm">{key}</div>
                 <div className="text-xs text-muted-foreground">Default: {defaultValue}</div>
               </div>
               <Badge variant="secondary" className="font-mono">
-                {value}
+                {value} · {scope === "user" ? "you" : "workspace"}
               </Badge>
             </li>
           ))}

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -7,6 +7,7 @@ import type {
   ConversationDirective,
   E2eActor,
   EventType,
+  FeatureFlagLayers,
   JSONContent,
   NotificationLevel,
   SidebarConfig,
@@ -841,6 +842,13 @@ export interface CachedWorkspaceMetadata {
    */
   configuredToolCategories?: ToolPrivacyCategory[]
   /**
+   * Raw feature-flag override layers (workspace + user), resolved through the
+   * registry at read time. Persisted so a warm start paints the resolved value
+   * instead of the registry default for a frame. Optional for rows cached
+   * before the field shipped — absent reads as all defaults.
+   */
+  featureFlags?: FeatureFlagLayers
+  /**
    * Commands surfaced in the slash-command menu. `kind` defaults to "server"
    * for backwards compatibility with older cached rows; "client-action" items
    * carry a `clientActionId` the frontend dispatches on locally.
@@ -1339,6 +1347,11 @@ export class ThreaDatabase extends Dexie {
     this.version(39).stores({
       uploadJobs: "attachmentId, workspaceId",
     })
+
+    // v40: workspaceMetadata gains optional `featureFlags` (raw override layers)
+    // for first-render correctness. An unindexed value field on existing rows,
+    // so the bump only guards the added shape — no schema delta (see v37).
+    this.version(40).stores({})
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }

--- a/apps/frontend/src/hooks/use-feature-flags.test.tsx
+++ b/apps/frontend/src/hooks/use-feature-flags.test.tsx
@@ -1,10 +1,18 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
-import { describe, expect, it } from "vitest"
-import { type FeatureFlagLayers, type WorkspaceBootstrap } from "@threa/types"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  FEATURE_FLAG_DEFINITIONS,
+  type FeatureFlagDefinition,
+  type FeatureFlagKey,
+  type FeatureFlagLayers,
+  type WorkspaceBootstrap,
+} from "@threa/types"
+import { db } from "@/db"
+import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { workspaceKeys } from "./use-workspaces"
-import { useOverriddenFeatureFlags } from "./use-feature-flags"
+import { useFeatureFlag, useOverriddenFeatureFlags } from "./use-feature-flags"
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -12,12 +20,40 @@ function createWrapper(queryClient: QueryClient) {
   }
 }
 
-// The shipped registry is empty (no rollout in flight), so the per-flag hooks
-// (useFeatureFlag / useFeatureFlagWhenKnown) have no key to read and only the
-// overridden-flags view is exercisable end-to-end. The precedence the hooks
-// depend on is proven against the registry-parameterized resolver below — the
-// same function `useResolvedFeatureFlags` composes over — since a fake flag must
-// not enter FEATURE_FLAGS.
+// The shipped FEATURE_FLAGS is empty between rollouts, so inject a stand-in
+// registry (visible to the code-bound predicates + resolver, which read
+// FEATURE_FLAG_DEFINITIONS dynamically) and clear it after each test rather
+// than committing a fake flag to @threa/types. `warmStart` is default-on: the
+// case the persistence fix protects — a warm paint must not flash the default.
+const STANDIN_REGISTRY = {
+  warmStart: { values: ["off", "on"], scopes: ["workspace", "user"], default: "on" },
+  wsOnly: { values: ["off", "on"], scopes: ["workspace"], default: "off" },
+} as const satisfies Record<string, FeatureFlagDefinition>
+
+function injectRegistry() {
+  Object.assign(FEATURE_FLAG_DEFINITIONS, STANDIN_REGISTRY)
+}
+
+function resetRegistry() {
+  for (const key of Object.keys(STANDIN_REGISTRY)) delete FEATURE_FLAG_DEFINITIONS[key]
+}
+
+function cacheBootstrapLayers(queryClient: QueryClient, workspaceId: string, featureFlags: FeatureFlagLayers): void {
+  queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), { featureFlags } as WorkspaceBootstrap)
+}
+
+async function persistMetadataLayers(workspaceId: string, featureFlags: FeatureFlagLayers): Promise<void> {
+  await db.workspaceMetadata.put({
+    id: workspaceId,
+    workspaceId,
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    featureFlags,
+    _cachedAt: Date.now(),
+  })
+}
+
 describe("useOverriddenFeatureFlags", () => {
   it("returns no overridden flags before the bootstrap is cached", () => {
     const queryClient = new QueryClient()
@@ -40,5 +76,93 @@ describe("useOverriddenFeatureFlags", () => {
     // Empty registry: every override is inert, so nothing is surfaced (and the
     // layered shape does not crash the resolve).
     expect(result.current).toEqual([])
+  })
+})
+
+describe("feature flags — first render off persisted layers", () => {
+  beforeEach(async () => {
+    await db.workspaceMetadata.clear()
+    resetWorkspaceStoreCache()
+    injectRegistry()
+  })
+
+  afterEach(async () => {
+    resetRegistry()
+    await db.workspaceMetadata.clear()
+    resetWorkspaceStoreCache()
+  })
+
+  it("returns the persisted workspace value, not the registry default, on a warm start with an empty query cache", async () => {
+    // Warm start: no bootstrap in the query cache yet, but IDB metadata carries
+    // a workspace override of "off" for a default-ON flag. The old query-cache-
+    // only read would return the "on" default here.
+    const queryClient = new QueryClient()
+    await persistMetadataLayers("ws_1", { workspace: { warmStart: "off" }, user: {} })
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("off"))
+  })
+
+  it("prefers the live query cache over the persisted layers when both are present", async () => {
+    const queryClient = new QueryClient()
+    // IDB persisted "off"; the live (socket-patched) query cache says "on".
+    await persistMetadataLayers("ws_1", { workspace: { warmStart: "off" }, user: {} })
+    cacheBootstrapLayers(queryClient, "ws_1", { workspace: { warmStart: "on" }, user: {} })
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("on"))
+  })
+
+  it("treats a cached bootstrap with no layers as authoritative, not a fall-through to stale IDB", async () => {
+    // A bootstrap is cached but carries no featureFlags (older server / no
+    // overrides = all defaults). IDB still holds a stale "off". The present
+    // bootstrap must win: the flag resolves to its default "on", not the IDB value.
+    const queryClient = new QueryClient()
+    await persistMetadataLayers("ws_1", { workspace: { warmStart: "off" }, user: {} })
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), { featureFlags: undefined } as WorkspaceBootstrap)
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("on"))
+  })
+})
+
+describe("useOverriddenFeatureFlags — provenance", () => {
+  afterEach(() => {
+    resetRegistry()
+  })
+
+  it("labels a workspace-layer override with workspace scope", () => {
+    injectRegistry()
+    const queryClient = new QueryClient()
+    cacheBootstrapLayers(queryClient, "ws_1", { workspace: { wsOnly: "on" }, user: {} })
+
+    const { result } = renderHook(() => useOverriddenFeatureFlags("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    expect(result.current).toEqual([{ key: "wsOnly", value: "on", defaultValue: "off", scope: "workspace" }])
+  })
+
+  it("labels a user override with user scope, and user wins when both layers set the key", () => {
+    injectRegistry()
+    const queryClient = new QueryClient()
+    cacheBootstrapLayers(queryClient, "ws_1", { workspace: { warmStart: "off" }, user: { warmStart: "off" } })
+
+    const { result } = renderHook(() => useOverriddenFeatureFlags("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    // Both layers set warmStart=off (non-default); the user layer applies last,
+    // so the winning scope is "user".
+    expect(result.current).toEqual([{ key: "warmStart", value: "off", defaultValue: "on", scope: "user" }])
   })
 })

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -2,32 +2,57 @@ import { useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   defaultFeatureFlagValue,
-  FEATURE_FLAG_KEYS,
+  flagAllowsScope,
+  isFeatureFlagValue,
   resolveFeatureFlags,
   type FeatureFlagKey,
+  type FeatureFlagLayers,
   type FeatureFlags,
+  type FeatureFlagScope,
   type FeatureFlagValue,
   type WorkspaceBootstrap,
 } from "@threa/types"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useWorkspaceMetadata } from "@/stores/workspace-store"
 
 /**
- * The viewer's resolved flag map, or null until the bootstrap (with its raw
- * layers) is cached. Reads the bootstrap cache via the cache-only observer
- * pattern and resolves the workspace + user layers through the shared registry
- * resolver — the same one the backend runs — so a flag means the same thing on
- * both sides. The resolve is memoized on the layers reference (kept stable by
- * the query's structural sharing), so it runs on a real change, not per render.
+ * The viewer's raw override layers, preferring the live bootstrap query cache
+ * (kept socket-patched by chunk 3) and falling back to the layers persisted in
+ * `workspaceMetadata` when the query cache is still empty. The fallback is what
+ * makes a warm start correct: the coordinated-loading gate opens off IDB while
+ * the network bootstrap is still in flight, so without it every flag would read
+ * its registry default for a frame band. Returns null only when neither source
+ * has layers yet (a first cold load before any bootstrap).
  */
-function useResolvedFeatureFlags(workspaceId: string): FeatureFlags | null {
+function useFeatureFlagLayers(workspaceId: string): FeatureFlagLayers | null {
   const queryClient = useQueryClient()
-  const { data: layers } = useQuery({
+  const { data: cached } = useQuery({
     queryKey: workspaceKeys.bootstrap(workspaceId),
     queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
     enabled: false,
     staleTime: Infinity,
-    select: (bootstrap) => bootstrap?.featureFlags ?? null,
+    // Wrap so a cached bootstrap that carries no layers is still distinguishable
+    // from "no bootstrap": the former is authoritative (all defaults), the latter
+    // is the warm-start window where the persisted row must fill in.
+    select: (bootstrap) => (bootstrap ? { layers: bootstrap.featureFlags ?? null } : null),
   })
+  const persistedLayers = useWorkspaceMetadata(workspaceId)?.featureFlags ?? null
+  // A cached bootstrap wins even when its layers are null — an authoritative
+  // server snapshot with no overrides must not be shadowed by a stale IDB row.
+  // Fall back to the persisted row only when no bootstrap is cached at all.
+  return cached ? cached.layers : persistedLayers
+}
+
+/**
+ * The viewer's resolved flag map, or null until layers are available from the
+ * query cache or the persisted metadata row. Resolves the workspace + user
+ * layers through the shared registry resolver — the same one the backend runs —
+ * so a flag means the same thing on both sides. The resolve is memoized on the
+ * layers reference (kept stable by structural sharing / the store snapshot), so
+ * it runs on a real change, not per render.
+ */
+function useResolvedFeatureFlags(workspaceId: string): FeatureFlags | null {
+  const layers = useFeatureFlagLayers(workspaceId)
   return useMemo(() => (layers ? resolveFeatureFlags(layers) : null), [layers])
 }
 
@@ -62,24 +87,45 @@ export interface OverriddenFeatureFlag {
   key: FeatureFlagKey
   value: FeatureFlagValue
   defaultValue: FeatureFlagValue
+  /** Which layer supplied the winning value — "user" wins over "workspace". */
+  scope: FeatureFlagScope
 }
 
 /**
  * The viewer's feature flags that are set to a non-default value, for the
- * read-only flags view. Until the bootstrap is cached this returns `[]` —
- * same "unknown renders as default" stance as {@link useFeatureFlag}, which
- * here means showing nothing rather than leaking flag state.
+ * read-only flags view. Until layers are available this returns `[]` — same
+ * "unknown renders as default" stance as {@link useFeatureFlag}, which here
+ * means showing nothing rather than leaking flag state. Each row carries the
+ * winning scope so the tab can show whether a flag is on for the workspace or
+ * for this user.
  */
 export function useOverriddenFeatureFlags(workspaceId: string): OverriddenFeatureFlag[] {
-  const flags = useResolvedFeatureFlags(workspaceId)
-  return useMemo(() => listOverriddenFlags(flags), [flags])
+  const layers = useFeatureFlagLayers(workspaceId)
+  return useMemo(() => listOverriddenFlags(layers), [layers])
 }
 
-function listOverriddenFlags(flags: FeatureFlags | null | undefined): OverriddenFeatureFlag[] {
-  if (!flags) return []
-  return FEATURE_FLAG_KEYS.flatMap((key) => {
+function listOverriddenFlags(layers: FeatureFlagLayers | null): OverriddenFeatureFlag[] {
+  if (!layers) return []
+  const flags = resolveFeatureFlags(layers)
+  // Iterate the resolved map (registry-backed keys) rather than FEATURE_FLAG_KEYS
+  // so the injected-registry test seam sees flags — the resolver is the shared
+  // authority for which keys exist.
+  return (Object.keys(flags) as FeatureFlagKey[]).flatMap((key) => {
     const value = flags[key]
     const defaultValue = defaultFeatureFlagValue(key)
-    return value !== undefined && value !== defaultValue ? [{ key, value, defaultValue }] : []
+    if (value === defaultValue) return []
+    return [{ key, value, defaultValue, scope: winningScope(key, layers) }]
   })
+}
+
+// A non-default resolved value always came from a layer that contributed a valid
+// applied override; the user layer applies last, so it wins when both did. If the
+// user layer did not contribute, the workspace layer must have — hence the fallback.
+function winningScope(key: FeatureFlagKey, layers: FeatureFlagLayers): FeatureFlagScope {
+  return layerContributes(key, "user", layers.user) ? "user" : "workspace"
+}
+
+function layerContributes(key: FeatureFlagKey, scope: FeatureFlagScope, overrides: Record<string, string>): boolean {
+  const value = overrides[key]
+  return value !== undefined && flagAllowsScope(key, scope) && isFeatureFlagValue(key, value)
 }

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -4,6 +4,7 @@ import { QueryClient } from "@tanstack/react-query"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import {
+  applyReconnectBootstrapBatch,
   applyWorkspaceBootstrap,
   mergeReconnectWorkspaceBootstrap,
   registerWorkspaceSocketHandlers,
@@ -376,6 +377,41 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     const row = await db.streams.get("stream_arch_root")
     expect(row?.lastMessagePreview?.content).toBe("kept")
+  })
+
+  it("persists the bootstrap feature-flag layers to workspaceMetadata", async () => {
+    await applyWorkspaceBootstrap(
+      "ws_1",
+      makeBootstrap({ featureFlags: { workspace: { calls: "off" }, user: { newComposer: "on" } } }),
+      Date.now()
+    )
+
+    const stored = await db.workspaceMetadata.get("ws_1")
+    expect(stored?.featureFlags).toEqual({ workspace: { calls: "off" }, user: { newComposer: "on" } })
+  })
+
+  it("writes undefined featureFlags when the bootstrap omits them (old server)", async () => {
+    const bootstrap = makeBootstrap()
+    delete bootstrap.featureFlags
+
+    await applyWorkspaceBootstrap("ws_1", bootstrap, Date.now())
+
+    const stored = await db.workspaceMetadata.get("ws_1")
+    expect(stored?.featureFlags).toBeUndefined()
+  })
+
+  it("persists feature-flag layers on the reconnect apply path too", async () => {
+    await applyReconnectBootstrapBatch(
+      "ws_1",
+      makeBootstrap({ featureFlags: { workspace: { calls: "off" }, user: {} } }),
+      new Map(),
+      new Set(),
+      new Set(),
+      Date.now()
+    )
+
+    const stored = await db.workspaceMetadata.get("ws_1")
+    expect(stored?.featureFlags).toEqual({ workspace: { calls: "off" }, user: {} })
   })
 })
 
@@ -1477,6 +1513,40 @@ describe("registerWorkspaceSocketHandlers", () => {
     expect(cached?.featureFlags).toEqual({ workspace: { calls: "off" }, user: { newComposer: "on" } })
 
     cleanup()
+  })
+
+  it("writes the patched layers back to the persisted metadata row so a warm restart repaints the live value", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ featureFlags: { workspace: {}, user: {} } })
+    )
+    await db.workspaceMetadata.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      emojis: [],
+      emojiWeights: {},
+      commands: [],
+      featureFlags: { workspace: {}, user: {} },
+      _cachedAt: 1,
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => undefined,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+    })
+
+    emit("feature_flags:workspace_updated", { workspaceId: "ws_1", overrides: { calls: "off" } })
+
+    await vi.waitFor(async () => {
+      const persisted = await db.workspaceMetadata.get("ws_1")
+      expect(persisted?.featureFlags).toEqual({ workspace: { calls: "off" }, user: {} })
+    })
+
+    cleanup()
+    await db.workspaceMetadata.clear()
   })
 
   it("promotes newly created DMs for recipients without waiting for a workspace refetch", async () => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -20,6 +20,7 @@ import type {
   User,
   Bot,
   WorkspaceBootstrap,
+  FeatureFlagLayers,
   StreamMember,
   UserPreferences,
   SidebarConfig,
@@ -1518,24 +1519,28 @@ export function registerWorkspaceSocketHandlers(
 
   // Handle feature flags updated (a platform admin toggled a flag from the
   // backoffice). Two scope-routed events, each patching only its own raw layer
-  // and leaving the other intact; the hook re-resolves. Layers live only in the
-  // bootstrap query cache, like workspace settings (INV-53 via the guard).
+  // and leaving the other intact; the hook re-resolves (INV-53 via the guard).
+  // The patched layers are also written back to the persisted metadata row so a
+  // warm restart before the next bootstrap repaints the live value, not a stale
+  // one — the whole point of persisting layers is first-render correctness.
+  const patchFeatureFlagLayers = (nextLayers: (old: WorkspaceBootstrap) => FeatureFlagLayers) => {
+    const patched = updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
+      ...old,
+      featureFlags: nextLayers(old),
+    }))
+    if (!patched) return
+    const layers = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.featureFlags
+    if (layers) void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
+  }
+
   const handleFeatureFlagsUpdated = (payload: FeatureFlagsUpdatedPayload) => {
     if (payload.workspaceId !== workspaceId) return
-
-    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
-      ...old,
-      featureFlags: { workspace: old.featureFlags?.workspace ?? {}, user: payload.overrides },
-    }))
+    patchFeatureFlagLayers((old) => ({ workspace: old.featureFlags?.workspace ?? {}, user: payload.overrides }))
   }
 
   const handleFeatureFlagsWorkspaceUpdated = (payload: FeatureFlagsWorkspaceUpdatedPayload) => {
     if (payload.workspaceId !== workspaceId) return
-
-    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
-      ...old,
-      featureFlags: { workspace: payload.overrides, user: old.featureFlags?.user ?? {} },
-    }))
+    patchFeatureFlagLayers((old) => ({ workspace: payload.overrides, user: old.featureFlags?.user ?? {} }))
   }
 
   const handleBotCreated = (payload: { workspaceId: string; bot: Bot }) => {
@@ -2335,6 +2340,7 @@ export async function applyWorkspaceBootstrap(
           emojiWeights: bootstrap.emojiWeights,
           commands: bootstrap.commands,
           configuredToolCategories: bootstrap.configuredToolCategories,
+          featureFlags: bootstrap.featureFlags,
           _cachedAt: now,
         }),
       ])
@@ -2584,6 +2590,7 @@ export async function applyReconnectBootstrapBatch(
           emojiWeights: finalBootstrap.emojiWeights,
           commands: finalBootstrap.commands,
           configuredToolCategories: finalBootstrap.configuredToolCategories,
+          featureFlags: finalBootstrap.featureFlags,
           _cachedAt: now,
         }),
       ])


### PR DESCRIPTION
## What

PR 4 of the workspace-feature-flags stack — closes the original "flags load after first render" complaint.

Stacked on #1457. Plan: `docs/plans/workspace-feature-flags.md`.

## Why

Warm starts open the loading gate off IndexedDB while the bootstrap query cache is still empty, so flags read as their registry default for a frame band — wrong for a default-on flag, which paints on then flips.

## Changes

- Persist the raw `FeatureFlagLayers` onto the `CachedWorkspaceMetadata` IDB row (the row the gate already blocks on) at **both** `applyWorkspaceBootstrap` sites — cold and reconnect. Dexie v40 bump (unindexed optional field, no data migration).
- The flag hook falls back to the persisted layers when the query cache has no bootstrap, preferring the live socket-patched cache when present. A cached bootstrap is treated as **authoritative even when it carries no layers** (older server / no overrides = all defaults), so a stale IDB row can never shadow a present snapshot.
- Socket toggles (`feature_flags:updated` / `:workspace_updated`) now also write the patched layers back to the metadata row, so a warm restart after a mid-session backoffice toggle repaints the live value, not a stale one.
- Read-only flags tab shows provenance — "workspace" vs "you".

Gate readiness is unchanged: `featureFlags` rides the metadata row the gate already waits on, and a presence check would wrongly never open for rows cached before this shipped (their fall-to-default is the documented one-warm-start residual).

## Review

Reviewed by Opus xhigh adversarial verify (memoization stability, both persistence paths, provenance, gate reasoning all confirmed; mutation-tested the headline warm-start guard) **and** GPT-5.6 Sol. Two Sol findings folded in: a cached-bootstrap-without-layers must beat stale IDB (fixed + guarded by a test that fails on the old read), and socket toggles now persist to IDB. 4651 frontend + 134 types tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787157818&installation_model_id=20758&pr_number=1459&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1459&signature=3490aa87a0bc8d4c978c8d336ab0db47f266f049ab5cc3fe1242166616a9258a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->