### PR TITLE
feat: send inline steer as a message and command

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -404,6 +404,7 @@ describe("BotInvocationRepository.claimOne", () => {
     // Bounded re-claim: a wedged invocation can't be picked up forever.
     expect(captured.text).toContain("attempts < ")
     expect(captured.text).toContain("attempts = attempts + 1")
+    expect(captured.text).toContain("CASE WHEN i.trigger = 'session-control' THEN 1 ELSE 0 END ASC")
     expect(captured.values).toContain(BOT_CLAIM_MAX_ATTEMPTS)
   })
 
@@ -501,6 +502,7 @@ describe("BotInvocationRepository.findBootstrapInvocations", () => {
     // advertised here is one a follow-up claim can actually win (no keyless
     // runtime is told sealed work is available it can't open).
     expect(availableQuery).toContain("w.recipient_key_id = ri.public_key_id")
+    expect(availableQuery).toContain("CASE WHEN i.trigger = 'session-control' THEN 1 ELSE 0 END ASC")
     // The owned-claims query must NOT be attempt-bounded: a runtime keeps its
     // own in-flight claim regardless of how many times it's been re-dispatched,
     // and it is never re-gated on wrap coverage (the claim already succeeded).

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -845,6 +845,8 @@ export const BotInvocationRepository = {
       maxAttempts: number
     }
   ): Promise<BotInvocation | null> {
+    // A composite message + steer shares one transaction timestamp; put the
+    // message invocation first when both capabilities are claimable.
     const result = await db.query<BotInvocationRow>(composeSql`WITH candidate AS (
         SELECT i.id FROM bot_invocations i
         WHERE i.workspace_id = ${params.workspaceId}
@@ -863,7 +865,7 @@ export const BotInvocationRepository = {
           AND (i.status = 'pending' OR (i.status = 'claimed' AND i.claim_expires_at < NOW()))
           AND i.attempts < ${params.maxAttempts}
           AND ${sealedStreamClaimGateSql(params.instanceId)}
-        ORDER BY i.created_at ASC, i.id ASC
+        ORDER BY i.created_at ASC, CASE WHEN i.trigger = 'session-control' THEN 1 ELSE 0 END ASC, i.id ASC
         FOR UPDATE OF i SKIP LOCKED
         LIMIT 1
       )
@@ -1002,6 +1004,7 @@ export const BotInvocationRepository = {
       maxAttempts: number
     }
   ): Promise<{ available: BotInvocation[]; ownedClaims: BotInvocation[] }> {
+    // Bootstrap order must match claimOne for same-timestamp message + steer rows.
     const [availableResult, ownedClaimsResult] = await Promise.all([
       db.query<BotInvocationRow>(composeSql`SELECT i.* FROM bot_invocations i
         WHERE i.workspace_id = ${params.workspaceId}
@@ -1014,7 +1017,7 @@ export const BotInvocationRepository = {
           AND i.attempts < ${params.maxAttempts}
           AND (${params.since}::timestamptz IS NULL OR i.created_at >= ${params.since})
           AND ${sealedStreamClaimGateSql(params.instanceId)}
-        ORDER BY i.created_at ASC, i.id ASC
+        ORDER BY i.created_at ASC, CASE WHEN i.trigger = 'session-control' THEN 1 ELSE 0 END ASC, i.id ASC
         LIMIT 200`),
       db.query<BotInvocationRow>(sql`SELECT * FROM bot_invocations
         WHERE workspace_id = ${params.workspaceId}

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -75,7 +75,14 @@ export class CommandAvailabilityService {
     streamId: string
     name: string
   }): Promise<ResolvedCommand | null> {
-    const commands = await this.resolveStreamCommands(params)
+    return withClient(this.deps.pool, (db) => this.resolveCommandInTransaction(db, params))
+  }
+
+  async resolveCommandInTransaction(
+    db: Querier,
+    params: { workspaceId: string; userId: string; streamId: string; name: string }
+  ): Promise<ResolvedCommand | null> {
+    const commands = await this.resolveStreamCommandsInTransaction(db, params)
     const lower = params.name.toLowerCase()
     return commands.find((command) => command.info.name.toLowerCase() === lower) ?? null
   }
@@ -85,42 +92,47 @@ export class CommandAvailabilityService {
     userId: string
     streamId: string
   }): Promise<ResolvedCommand[]> {
-    return withClient(this.deps.pool, async (client) => {
-      const stream = await checkStreamAccess(client, params.streamId, params.workspaceId, params.userId)
-      if (!stream || stream.archivedAt) return []
+    return withClient(this.deps.pool, (db) => this.resolveStreamCommandsInTransaction(db, params))
+  }
 
-      const commands: ResolvedCommand[] = []
+  private async resolveStreamCommandsInTransaction(
+    db: Querier,
+    params: { workspaceId: string; userId: string; streamId: string }
+  ): Promise<ResolvedCommand[]> {
+    const stream = await checkStreamAccess(db, params.streamId, params.workspaceId, params.userId)
+    if (!stream || stream.archivedAt) return []
 
-      for (const info of listServerCommandInfos(this.deps.commandRegistry)) {
-        if (await isServerCommandAvailableInStream(info.name, stream, client)) {
-          commands.push({ info, executionKind: CommandKinds.SERVER })
-        }
+    const commands: ResolvedCommand[] = []
+
+    for (const info of listServerCommandInfos(this.deps.commandRegistry)) {
+      if (await isServerCommandAvailableInStream(info.name, stream, db)) {
+        commands.push({ info, executionKind: CommandKinds.SERVER })
       }
+    }
 
-      for (const info of listClientActionCommandInfos()) {
-        if (isClientActionAvailableInStream(info, stream)) {
-          commands.push({ info, executionKind: CommandKinds.CLIENT_ACTION })
-        }
+    for (const info of listClientActionCommandInfos()) {
+      if (isClientActionAvailableInStream(info, stream)) {
+        commands.push({ info, executionKind: CommandKinds.CLIENT_ACTION })
       }
+    }
 
-      const runtimeTarget = await resolveRuntimeCommandTarget(client, {
-        workspaceId: params.workspaceId,
-        userId: params.userId,
-        stream,
-      })
-      if (runtimeTarget) {
-        for (const info of listSessionControlCommandInfos()) {
-          if (!runtimeTarget.advertisedCommandNames.has(info.name.toLowerCase())) continue
-          commands.push({
-            info: applyAdvertisedSuggestions(info, runtimeTarget),
-            executionKind: CommandKinds.BOT_RUNTIME,
-            runtime: runtimeTarget,
-          })
-        }
-      }
-
-      return dedupeCommands(commands)
+    const runtimeTarget = await resolveRuntimeCommandTarget(db, {
+      workspaceId: params.workspaceId,
+      userId: params.userId,
+      stream,
     })
+    if (runtimeTarget) {
+      for (const info of listSessionControlCommandInfos()) {
+        if (!runtimeTarget.advertisedCommandNames.has(info.name.toLowerCase())) continue
+        commands.push({
+          info: applyAdvertisedSuggestions(info, runtimeTarget),
+          executionKind: CommandKinds.BOT_RUNTIME,
+          runtime: runtimeTarget,
+        })
+      }
+    }
+
+    return dedupeCommands(commands)
   }
 }
 

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -3,6 +3,7 @@ import {
   BotInvocationCapabilities,
   BotRuntimeKinds,
   BotRuntimeStatuses,
+  BotTypes,
   CommandKinds,
   DISCUSS_WITH_ARIADNE_COMMAND,
   StreamTypes,
@@ -44,7 +45,7 @@ export interface RuntimeCommandTarget {
   responseStreamId: string
   targetInstanceId: string
   targetRuntimeSessionId: string
-  /** Whether a source-message invocation may use mention routing for dedupe. */
+  /** Whether this user may invoke the target through mention routing for dedupe. */
   supportsMentionable: boolean
   /** Lowercased canonical names the runtime currently advertises. */
   advertisedCommandNames: ReadonlySet<string>
@@ -219,7 +220,11 @@ async function resolveRuntimeCommandTarget(
     responseStreamId: stream.id,
     targetInstanceId: link.instanceId,
     targetRuntimeSessionId: link.runtimeSessionId,
-    supportsMentionable: botHasCapability(bot, BotInvocationCapabilities.MENTIONABLE),
+    // Mirror BotRepository.findInvocableByIds: the composite must choose the
+    // same trigger as the later message outbox so their idempotency keys match.
+    supportsMentionable:
+      botHasCapability(bot, BotInvocationCapabilities.MENTIONABLE) &&
+      (bot.type === BotTypes.SHARED || bot.ownerUserId === params.userId),
     advertisedCommandNames,
     advertisedThinkingLevels: resolveAdvertisedThinkingLevels(presence),
     advertisedModelSuggestions: resolveAdvertisedModelSuggestions(presence),

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -44,6 +44,8 @@ export interface RuntimeCommandTarget {
   responseStreamId: string
   targetInstanceId: string
   targetRuntimeSessionId: string
+  /** Whether a source-message invocation may use mention routing for dedupe. */
+  supportsMentionable: boolean
   /** Lowercased canonical names the runtime currently advertises. */
   advertisedCommandNames: ReadonlySet<string>
   /** Thinking levels the runtime supports for the current model. Empty = runtime did not advertise. */
@@ -217,6 +219,7 @@ async function resolveRuntimeCommandTarget(
     responseStreamId: stream.id,
     targetInstanceId: link.instanceId,
     targetRuntimeSessionId: link.runtimeSessionId,
+    supportsMentionable: botHasCapability(bot, BotInvocationCapabilities.MENTIONABLE),
     advertisedCommandNames,
     advertisedThinkingLevels: resolveAdvertisedThinkingLevels(presence),
     advertisedModelSuggestions: resolveAdvertisedModelSuggestions(presence),

--- a/apps/backend/src/features/commands/index.ts
+++ b/apps/backend/src/features/commands/index.ts
@@ -1,4 +1,4 @@
-export { createCommandHandlers } from "./handlers"
+export { createCommandHandlers, resolveRuntimeInvocationRouting } from "./handlers"
 
 export { CommandRegistry, parseCommand, isCommand } from "./registry"
 export type { Command, CommandContext, CommandResult } from "./registry"

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -991,6 +991,35 @@ describe("EventService.createMessage metadata propagation", () => {
     const insertParams = (MessageRepository.insert as any).mock.calls[0][1]
     expect(insertParams.metadata).toBeUndefined()
   })
+
+  it("runs the transactional callback for a newly created message", async () => {
+    const service = new EventService({} as any)
+    const onCreated = mock(async () => undefined)
+
+    await service.createMessageReturningConversation(baseParams, onCreated)
+
+    expect(onCreated).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ contentMarkdown: "hello" }))
+  })
+
+  it("does not repeat the transactional callback for an idempotent message retry", async () => {
+    const service = new EventService({} as any)
+    const existing = {
+      id: "msg_existing",
+      streamId: "stream_1",
+      contentMarkdown: "hello",
+      ciphertext: null,
+    }
+    spyOn(MessageRepository, "findByClientMessageId").mockResolvedValue(existing as any)
+    const onCreated = mock(async () => undefined)
+
+    const result = await service.createMessageReturningConversation(
+      { ...baseParams, clientMessageId: "temp_1" },
+      onCreated
+    )
+
+    expect(result.message.id).toBe("msg_existing")
+    expect(onCreated).not.toHaveBeenCalled()
+  })
 })
 
 describe("EventService.createMessage conversation declaration (Mechanism C)", () => {

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -466,12 +466,15 @@ export class EventService {
    * no directive was declared. The board composer surfaces it on the send
    * response so it can write an optimistic board card keyed by the real
    * conversation id (no temp-id swap), reconciled by the `conversation:*` echo.
+   * `onCreated` joins the same transaction and runs only for the winning insert.
    */
   async createMessageReturningConversation(
-    params: CreateMessageParams
+    params: CreateMessageParams,
+    onCreated?: (client: PoolClient, message: Message) => Promise<void>
   ): Promise<{ message: Message; conversationId?: string }> {
     try {
-      return await this._createMessageTxn(params)
+      const result = await this._createMessageTxn(params, onCreated)
+      return { message: result.message, ...(result.conversationId && { conversationId: result.conversationId }) }
     } catch (error) {
       // Concurrent duplicate: the txn rolled back (no orphaned stream_events/outbox),
       // and we return the already-committed message from the winning transaction.
@@ -485,13 +488,13 @@ export class EventService {
   async createMessageInTransaction(
     client: PoolClient,
     params: CreateMessageParams
-  ): Promise<{ message: Message; conversationId?: string }> {
+  ): Promise<{ message: Message; conversationId?: string; created: boolean }> {
     // Fast path for sequential retries: return the existing message without
     // writes. No conversation id — the first send already surfaced it; a retry
     // reconciles through the echo/refetch, not a fresh optimistic card.
     if (params.clientMessageId) {
       const existing = await MessageRepository.findByClientMessageId(client, params.streamId, params.clientMessageId)
-      if (existing) return { message: existing }
+      if (existing) return { message: existing, created: false }
     }
     // The enclave seals its E2E reply with the message AAD bound to a
     // server-minted id, so the caller can pass that same id here to keep the
@@ -836,11 +839,18 @@ export class EventService {
       })
     }
 
-    return { message, conversationId }
+    return { message, conversationId, created: true }
   }
 
-  private async _createMessageTxn(params: CreateMessageParams): Promise<{ message: Message; conversationId?: string }> {
-    return withTransaction(this.pool, (client) => this.createMessageInTransaction(client, params))
+  private async _createMessageTxn(
+    params: CreateMessageParams,
+    onCreated?: (client: PoolClient, message: Message) => Promise<void>
+  ): Promise<{ message: Message; conversationId?: string; created: boolean }> {
+    return withTransaction(this.pool, async (client) => {
+      const result = await this.createMessageInTransaction(client, params)
+      if (result.created) await onCreated?.(client, result.message)
+      return result
+    })
   }
 
   async editMessage(params: EditMessageParams): Promise<Message | null> {

--- a/apps/backend/src/features/messaging/handlers.steer.test.ts
+++ b/apps/backend/src/features/messaging/handlers.steer.test.ts
@@ -132,6 +132,7 @@ describe("message + steer composite send", () => {
         promptMarkdown: "/steer",
         metadata: {
           command: expect.objectContaining({ name: "steer", args: "", executionKind: "bot-runtime" }),
+          steeredMessage: true,
         },
       }),
     ])

--- a/apps/backend/src/features/messaging/handlers.steer.test.ts
+++ b/apps/backend/src/features/messaging/handlers.steer.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import { CommandKinds } from "@threa/types"
+import { createMessageHandlers, createMessageSchema } from "./handlers"
+import { SteeredMessageService } from "./steered-message-service"
+import { StreamEventRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+
+afterEach(() => mock.restore())
+
+describe("message + steer composite send", () => {
+  it("accepts the cleartext steer flag beside an E2E message and attachments", () => {
+    expect(
+      createMessageSchema.safeParse({
+        streamId: "stream_1",
+        ciphertext: "Y2lwaGVydGV4dA==",
+        envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "msg_1" },
+        e2eVersion: 2,
+        attachmentIds: ["att_1"],
+        steer: true,
+      }).success
+    ).toBe(true)
+  })
+
+  it("persists the authored message, then creates the normal turn, command event, and steer in one callback", async () => {
+    const order: string[] = []
+    const message = {
+      id: "msg_1",
+      streamId: "stream_1",
+      contentMarkdown: "/steer I want option 2",
+      ciphertext: null,
+    }
+    const eventService = {
+      createMessageReturningConversation: async (
+        params: { contentMarkdown: string },
+        onCreated?: (db: unknown, message: unknown) => Promise<void>
+      ) => {
+        order.push("message")
+        expect(params.contentMarkdown).toBe("/steer I want option 2")
+        await onCreated?.({ query: mock(async () => ({ rows: [], rowCount: 0 })) }, message)
+        return { message }
+      },
+    }
+    const commandAvailabilityService = {
+      resolveCommandInTransaction: mock(async () => ({
+        executionKind: CommandKinds.BOT_RUNTIME,
+        runtime: {
+          botId: "bot_1",
+          runtimeKind: "pi-local",
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+          responseStreamId: "stream_1",
+          targetInstanceId: "pi_1",
+          targetRuntimeSessionId: "session_1",
+        },
+      })),
+    }
+    const createInvocationInTransaction = mock(async (_db, params: { trigger: string }) => {
+      order.push(params.trigger === "active-scratchpad" ? "message-invocation" : "steer-invocation")
+      return { invocation: {}, wasNewlyInserted: true }
+    })
+    spyOn(StreamEventRepository, "insert").mockImplementation(async (_db, params) => {
+      order.push("command-event")
+      return {
+        id: "evt_command",
+        streamId: params.streamId,
+        sequence: 2n,
+        broadcastSequence: null,
+        eventType: params.eventType,
+        payload: params.payload,
+        actorId: params.actorId ?? null,
+        actorType: params.actorType ?? null,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      }
+    })
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+    const steeredMessageService = new SteeredMessageService({
+      commandAvailabilityService: commandAvailabilityService as never,
+      botRuntimeService: { createInvocationInTransaction } as never,
+    })
+    const handlers = createMessageHandlers({
+      pool: {} as Pool,
+      eventService: eventService as never,
+      streamService: {
+        resolveWritableMessageStream: mock(async () => ({ id: "stream_1", e2eEnabled: false })),
+      } as never,
+      commandRegistry: {} as never,
+      steeredMessageService,
+    })
+    const response = {
+      statusCode: 200,
+      body: undefined as unknown,
+      status(code: number) {
+        this.statusCode = code
+        return this
+      },
+      json(body: unknown) {
+        this.body = body
+        return this
+      },
+    }
+
+    await handlers.create(
+      {
+        user: { id: "usr_1" },
+        workspaceId: "ws_1",
+        body: {
+          streamId: "stream_1",
+          contentJson: {
+            type: "doc",
+            content: [{ type: "paragraph", content: [{ type: "text", text: "/steer I want option 2" }] }],
+          },
+          steer: true,
+          clientMessageId: "temp_1",
+        },
+      } as never,
+      response as never
+    )
+
+    expect(order).toEqual(["message", "message-invocation", "command-event", "steer-invocation"])
+    expect(createInvocationInTransaction.mock.calls.map((call: unknown[]) => call[1])).toEqual([
+      expect.objectContaining({
+        sourceMessageId: "msg_1",
+        trigger: "active-scratchpad",
+        promptMarkdown: "/steer I want option 2",
+      }),
+      expect.objectContaining({
+        sourceMessageId: "msg_1",
+        trigger: "session-control",
+        requiredCapability: "active-scratchpad",
+        promptMarkdown: "/steer",
+        metadata: {
+          command: expect.objectContaining({ name: "steer", args: "", executionKind: "bot-runtime" }),
+        },
+      }),
+    ])
+    expect(response.statusCode).toBe(201)
+  })
+})

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
-import type { Pool } from "pg"
+import type { Pool, PoolClient } from "pg"
 import { withTransaction } from "../../db"
 import type { EventService } from "./event-service"
 import type { StreamService } from "../streams"
@@ -22,6 +22,7 @@ import { collectAttachmentReferenceIds, parseMarkdown } from "@threa/prosemirror
 import { deriveContentMarkdown } from "./content"
 import type { JSONContent } from "@threa/types"
 import { messageMetadataSchema } from "./metadata-schema"
+import type { SteeredMessageService } from "./steered-message-service"
 
 // Fields shared by every create/update variant. Defining once keeps the
 // six schemas from drifting when a per-message option is added.
@@ -71,6 +72,7 @@ const contentJsonSchema = z.object({
 const createMessageJsonToStreamSchema = z.object({
   streamId: z.string().min(1, "streamId is required"),
   contentJson: contentJsonSchema,
+  steer: z.literal(true).optional(),
   ...commonMessageOptionsSchema,
 })
 
@@ -78,6 +80,7 @@ const createMessageJsonToStreamSchema = z.object({
 const createMessageMarkdownToStreamSchema = z.object({
   streamId: z.string().min(1, "streamId is required"),
   content: z.string().min(1, "content is required"),
+  steer: z.literal(true).optional(),
   ...commonMessageOptionsSchema,
 })
 
@@ -155,6 +158,7 @@ const createMessageE2eToStreamSchema = z.object({
   // the wire so the rows can be attached to the message.
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
+  steer: z.literal(true).optional(),
 })
 
 // Plaintext-only union (used by `normalizeContent` and the post-E2E-gate
@@ -282,9 +286,16 @@ interface Dependencies {
   eventService: EventService
   streamService: StreamService
   commandRegistry: CommandRegistry
+  steeredMessageService: SteeredMessageService
 }
 
-export function createMessageHandlers({ pool, eventService, streamService, commandRegistry }: Dependencies) {
+export function createMessageHandlers({
+  pool,
+  eventService,
+  streamService,
+  commandRegistry,
+  steeredMessageService,
+}: Dependencies) {
   return {
     async create(req: Request, res: Response) {
       const userId = req.user!.id
@@ -298,6 +309,11 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         target: "dmUserId" in data ? { dmUserId: data.dmUserId } : { streamId: data.streamId },
       })
       const streamId = stream.id
+      const insertSteeredInvocations =
+        "steer" in data && data.steer
+          ? (client: PoolClient, message: Message) =>
+              steeredMessageService.dispatchInTransaction(client, { workspaceId, streamId, userId, message })
+          : undefined
 
       // INV-E1: a plaintext request must not land in an E2E stream and an E2E
       // request must not land in a plaintext stream. Either direction would
@@ -323,19 +339,22 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         // without crashing on null content. Attachments still bind: the rows are
         // `e2e_only` ciphertext (no real content to gate on), and the same
         // workspace + shareable check the plaintext path runs covers them.
-        const message = await eventService.createMessage({
-          workspaceId,
-          streamId,
-          authorId: userId,
-          authorType: "user",
-          contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
-          contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
-          ciphertext: Buffer.from(data.ciphertext, "base64"),
-          envelope: data.envelope,
-          e2eVersion: data.e2eVersion,
-          attachmentIds: data.attachmentIds && data.attachmentIds.length > 0 ? data.attachmentIds : undefined,
-          clientMessageId: data.clientMessageId,
-        })
+        const { message } = await eventService.createMessageReturningConversation(
+          {
+            workspaceId,
+            streamId,
+            authorId: userId,
+            authorType: "user",
+            contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
+            contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+            ciphertext: Buffer.from(data.ciphertext, "base64"),
+            envelope: data.envelope,
+            e2eVersion: data.e2eVersion,
+            attachmentIds: data.attachmentIds && data.attachmentIds.length > 0 ? data.attachmentIds : undefined,
+            clientMessageId: data.clientMessageId,
+          },
+          insertSteeredInvocations
+        )
         return res.status(201).json({ message: serializeMessage(message) })
       }
 
@@ -402,19 +421,22 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       // `conversationId` is the id the declared directive assigned the message to
       // (a fresh mint for a board `new` post) — surfaced so the board composer can
       // slot an optimistic card keyed by the real id, reconciled by the echo.
-      const { message, conversationId } = await eventService.createMessageReturningConversation({
-        workspaceId,
-        streamId,
-        authorId: userId,
-        authorType: "user",
-        contentJson,
-        contentMarkdown,
-        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        clientMessageId: data.clientMessageId,
-        metadata: data.metadata,
-        conversation: data.conversation,
-        confirmedPrivacyWarning: data.confirmedPrivacyWarning,
-      })
+      const { message, conversationId } = await eventService.createMessageReturningConversation(
+        {
+          workspaceId,
+          streamId,
+          authorId: userId,
+          authorType: "user",
+          contentJson,
+          contentMarkdown,
+          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+          clientMessageId: data.clientMessageId,
+          metadata: data.metadata,
+          conversation: data.conversation,
+          confirmedPrivacyWarning: data.confirmedPrivacyWarning,
+        },
+        insertSteeredInvocations
+      )
 
       res.status(201).json({ message: serializeMessage(message), ...(conversationId && { conversationId }) })
     },

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -42,6 +42,7 @@ export type {
 } from "./event-service"
 
 export { createMessageHandlers } from "./handlers"
+export { SteeredMessageService } from "./steered-message-service"
 export {
   createMessageSchema,
   updateMessageSchema,

--- a/apps/backend/src/features/messaging/steered-message-service.test.ts
+++ b/apps/backend/src/features/messaging/steered-message-service.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, mock } from "bun:test"
-import { MessageErrorCodes } from "@threa/types"
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { CommandKinds, MessageErrorCodes } from "@threa/types"
+import { OutboxRepository } from "../../lib/outbox"
+import { StreamEventRepository } from "../streams"
 import { SteeredMessageService } from "./steered-message-service"
+
+afterEach(() => mock.restore())
 
 describe("SteeredMessageService", () => {
   it("fails before writing invocations when steer is unavailable", async () => {
@@ -21,5 +25,63 @@ describe("SteeredMessageService", () => {
       })
     ).rejects.toMatchObject({ status: 409, code: MessageErrorCodes.STEER_UNAVAILABLE })
     expect(createInvocationInTransaction).not.toHaveBeenCalled()
+  })
+
+  it("uses mention routing when the source mentions the active mentionable bot", async () => {
+    const createInvocationInTransaction = mock(async (_db: unknown, _params: unknown) => ({
+      invocation: {},
+      wasNewlyInserted: true,
+    }))
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const service = new SteeredMessageService({
+      commandAvailabilityService: {
+        resolveCommandInTransaction: mock(async () => ({
+          executionKind: CommandKinds.BOT_RUNTIME,
+          runtime: {
+            botId: "bot_1",
+            runtimeKind: "pi-local",
+            rootStreamId: "stream_1",
+            activeStreamId: "stream_1",
+            responseStreamId: "stream_1",
+            targetInstanceId: "pi_1",
+            targetRuntimeSessionId: "session_1",
+            supportsMentionable: true,
+          },
+        })),
+      } as never,
+      botRuntimeService: { createInvocationInTransaction } as never,
+    })
+
+    await service.dispatchInTransaction({} as never, {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      userId: "usr_1",
+      message: {
+        id: "msg_1",
+        contentMarkdown: "@pi /steer focus here",
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "mention", attrs: { id: "bot_1", slug: "pi", mentionType: "bot" } },
+                { type: "text", text: " /steer focus here" },
+              ],
+            },
+          ],
+        },
+      } as never,
+    })
+
+    expect(createInvocationInTransaction.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        actorId: "bot_1",
+        trigger: "mention",
+        requiredCapability: "mentionable",
+        mentionedActorSlugs: ["pi"],
+      })
+    )
   })
 })

--- a/apps/backend/src/features/messaging/steered-message-service.test.ts
+++ b/apps/backend/src/features/messaging/steered-message-service.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, mock } from "bun:test"
+import { MessageErrorCodes } from "@threa/types"
+import { SteeredMessageService } from "./steered-message-service"
+
+describe("SteeredMessageService", () => {
+  it("fails before writing invocations when steer is unavailable", async () => {
+    const createInvocationInTransaction = mock(async () => ({ invocation: {}, wasNewlyInserted: true }))
+    const service = new SteeredMessageService({
+      commandAvailabilityService: {
+        resolveCommandInTransaction: mock(async () => null),
+      } as never,
+      botRuntimeService: { createInvocationInTransaction } as never,
+    })
+
+    await expect(
+      service.dispatchInTransaction({} as never, {
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        userId: "usr_1",
+        message: { id: "msg_1", contentMarkdown: "hello /steer" } as never,
+      })
+    ).rejects.toMatchObject({ status: 409, code: MessageErrorCodes.STEER_UNAVAILABLE })
+    expect(createInvocationInTransaction).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/messaging/steered-message-service.ts
+++ b/apps/backend/src/features/messaging/steered-message-service.ts
@@ -1,0 +1,90 @@
+import { HttpError } from "@threa/backend-common"
+import { CommandKinds, MessageErrorCodes } from "@threa/types"
+import type { Querier } from "../../db"
+import { commandId as generateCommandId } from "../../lib/id"
+import type { BotRuntimeService } from "../bot-runtimes"
+import {
+  insertCommandDispatchedEvent,
+  resolveRuntimeInvocationRouting,
+  type CommandAvailabilityService,
+} from "../commands"
+import type { Message } from "./repository"
+
+export class SteeredMessageService {
+  constructor(
+    private readonly deps: {
+      commandAvailabilityService: CommandAvailabilityService
+      botRuntimeService: BotRuntimeService
+    }
+  ) {}
+
+  async dispatchInTransaction(
+    db: Querier,
+    params: { workspaceId: string; streamId: string; userId: string; message: Message }
+  ): Promise<void> {
+    const resolved = await this.deps.commandAvailabilityService.resolveCommandInTransaction(db, {
+      workspaceId: params.workspaceId,
+      userId: params.userId,
+      streamId: params.streamId,
+      name: "steer",
+    })
+    if (!resolved || resolved.executionKind !== CommandKinds.BOT_RUNTIME) {
+      throw new HttpError("Steer is not available in this stream", {
+        status: 409,
+        code: MessageErrorCodes.STEER_UNAVAILABLE,
+      })
+    }
+
+    const target = resolved.runtime
+    await this.deps.botRuntimeService.createInvocationInTransaction(db, {
+      workspaceId: params.workspaceId,
+      rootStreamId: target.rootStreamId,
+      activeStreamId: target.activeStreamId,
+      sourceMessageId: params.message.id,
+      responseStreamId: target.responseStreamId,
+      actorId: target.botId,
+      trigger: "active-scratchpad",
+      requiredCapability: "active-scratchpad",
+      promptMarkdown: params.message.contentMarkdown,
+      authorUserId: params.userId,
+      targetInstanceId: target.targetInstanceId,
+      targetRuntimeSessionId: target.targetRuntimeSessionId,
+      metadata: {},
+    })
+
+    const commandId = generateCommandId()
+    await insertCommandDispatchedEvent(db, {
+      workspaceId: params.workspaceId,
+      streamId: params.streamId,
+      userId: params.userId,
+      commandId,
+      name: "steer",
+      args: "",
+      executionKind: CommandKinds.BOT_RUNTIME,
+    })
+
+    const routing = resolveRuntimeInvocationRouting("steer", target.runtimeKind)
+    await this.deps.botRuntimeService.createInvocationInTransaction(db, {
+      workspaceId: params.workspaceId,
+      rootStreamId: target.rootStreamId,
+      activeStreamId: target.activeStreamId,
+      sourceMessageId: params.message.id,
+      responseStreamId: target.responseStreamId,
+      actorId: target.botId,
+      trigger: routing.trigger,
+      requiredCapability: routing.requiredCapability,
+      promptMarkdown: "/steer",
+      authorUserId: params.userId,
+      targetInstanceId: target.targetInstanceId,
+      targetRuntimeSessionId: target.targetRuntimeSessionId,
+      metadata: {
+        command: {
+          id: commandId,
+          name: "steer",
+          args: "",
+          executionKind: CommandKinds.BOT_RUNTIME,
+        },
+      },
+    })
+  }
+}

--- a/apps/backend/src/features/messaging/steered-message-service.ts
+++ b/apps/backend/src/features/messaging/steered-message-service.ts
@@ -110,6 +110,7 @@ export class SteeredMessageService {
           args: "",
           executionKind: CommandKinds.BOT_RUNTIME,
         },
+        steeredMessage: true,
       },
     })
   }

--- a/apps/backend/src/features/messaging/steered-message-service.ts
+++ b/apps/backend/src/features/messaging/steered-message-service.ts
@@ -1,5 +1,6 @@
 import { HttpError } from "@threa/backend-common"
-import { CommandKinds, MessageErrorCodes } from "@threa/types"
+import { collectMentionActorRefs } from "@threa/prosemirror"
+import { BotInvocationCapabilities, BotInvocationTriggers, CommandKinds, MessageErrorCodes } from "@threa/types"
 import type { Querier } from "../../db"
 import { commandId as generateCommandId } from "../../lib/id"
 import type { BotRuntimeService } from "../bot-runtimes"
@@ -9,6 +10,18 @@ import {
   type CommandAvailabilityService,
 } from "../commands"
 import type { Message } from "./repository"
+
+function collectMentionSlugs(content: Message["contentJson"]): string[] {
+  const slugs: string[] = []
+  const walk = (node: Message["contentJson"]): void => {
+    if (node.type === "mention" && typeof node.attrs?.slug === "string" && node.attrs.slug.length > 0) {
+      slugs.push(node.attrs.slug)
+    }
+    for (const child of node.content ?? []) walk(child)
+  }
+  walk(content)
+  return slugs
+}
 
 export class SteeredMessageService {
   constructor(
@@ -36,6 +49,18 @@ export class SteeredMessageService {
     }
 
     const target = resolved.runtime
+    const targetIsMentioned =
+      target.supportsMentionable &&
+      collectMentionActorRefs(params.message.contentJson).some(
+        (ref) => ref.actorType === "bot" && ref.actorId === target.botId
+      )
+    // Match the normal outbox route when the active bot is explicitly
+    // mentioned. Its later mention insert then hits the same idempotency key
+    // instead of delivering this source message a second time.
+    const messageTrigger = targetIsMentioned ? BotInvocationTriggers.MENTION : BotInvocationTriggers.ACTIVE_SCRATCHPAD
+    const messageCapability = targetIsMentioned
+      ? BotInvocationCapabilities.MENTIONABLE
+      : BotInvocationCapabilities.ACTIVE_SCRATCHPAD
     await this.deps.botRuntimeService.createInvocationInTransaction(db, {
       workspaceId: params.workspaceId,
       rootStreamId: target.rootStreamId,
@@ -43,10 +68,11 @@ export class SteeredMessageService {
       sourceMessageId: params.message.id,
       responseStreamId: target.responseStreamId,
       actorId: target.botId,
-      trigger: "active-scratchpad",
-      requiredCapability: "active-scratchpad",
+      trigger: messageTrigger,
+      requiredCapability: messageCapability,
       promptMarkdown: params.message.contentMarkdown,
       authorUserId: params.userId,
+      mentionedActorSlugs: targetIsMentioned ? collectMentionSlugs(params.message.contentJson) : undefined,
       targetInstanceId: target.targetInstanceId,
       targetRuntimeSessionId: target.targetRuntimeSessionId,
       metadata: {},

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -16,7 +16,7 @@ import { createWorkspaceHandlers, WorkspaceRepository } from "./features/workspa
 import { createWorkspaceMemberManagementHandlers } from "./features/workspace-members"
 import type { ControlPlaneClient } from "./lib/control-plane-client"
 import { createStreamHandlers, createStreamBriefHandlers, StreamBriefService } from "./features/streams"
-import { createMessageHandlers } from "./features/messaging"
+import { createMessageHandlers, SteeredMessageService } from "./features/messaging"
 import { createAttachmentHandlers } from "./features/attachments"
 import { createSearchHandlers } from "./features/search"
 import { createMemoHandlers } from "./features/memos"
@@ -280,6 +280,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const authHandlers = createAuthHandlers()
   const avatarUpload = createAvatarUploadMiddleware()
   const commandAvailabilityService = new CommandAvailabilityService({ pool, commandRegistry })
+  const steeredMessageService = new SteeredMessageService({ commandAvailabilityService, botRuntimeService })
   const boardViewService = new BoardViewService(pool)
   const workspace = createWorkspaceHandlers({
     workspaceService,
@@ -319,6 +320,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     eventService,
     streamService,
     commandRegistry,
+    steeredMessageService,
   })
   const attachment = createAttachmentHandlers({ attachmentService, streamService, storage, pool })
   const search = createSearchHandlers({ pool, searchService })

--- a/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
@@ -145,6 +145,7 @@ export function useCommandSuggestion({
         scope: cmd.scope,
         args: cmd.args,
         clientActionId: cmd.clientActionId,
+        ...(cmd.name === "steer" && { placement: "inline" as const }),
       }))
     return [
       ...(includeMemoSearch ? [MEMO_SLASH_ITEM] : []),

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1795,6 +1795,7 @@ function EditingMessageEvent({
         {!editingSurfaceTouch ? (
           <UnsentMessageEditForm
             messageId={event.id}
+            workspaceId={workspaceId}
             streamId={streamId}
             initialContentJson={payload.contentJson}
             onDone={stopEditing}
@@ -1804,6 +1805,7 @@ function EditingMessageEvent({
       {editingSurfaceTouch && (
         <UnsentMessageEditForm
           messageId={event.id}
+          workspaceId={workspaceId}
           streamId={streamId}
           initialContentJson={payload.contentJson}
           onDone={stopEditing}

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -458,6 +458,35 @@ describe("MessageInput", () => {
       })
     })
 
+    it("sends an inline steer as an unchanged message with its attachments", async () => {
+      const content = makeAttachmentDoc()
+      content.content![0].content![1].text = " I want option 2 /steer and also pizza"
+      mockComposerState.canSend = true
+      mockComposerState.content = content
+      vi.mocked(hooksModule.useStreamBootstrap).mockReturnValue({
+        data: {
+          commands: [{ name: "steer", description: "Steer", kind: "bot-runtime", scope: "stream" }],
+        },
+      } as unknown as ReturnType<typeof hooksModule.useStreamBootstrap>)
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        contentJson: content,
+        attachmentIds: ["attach_1"],
+        attachments: [
+          {
+            id: "attach_1",
+            filename: "pasted-image-1.png",
+            mimeType: "image/png",
+            sizeBytes: 1234,
+          },
+        ],
+        steer: true,
+      })
+    })
+
     it("should resolve the draft and clear attachments after sending", async () => {
       mockComposerState.canSend = true
       mockComposerState.content = makeDoc("Hello world")

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -27,7 +27,7 @@ import { STREAM_ICONS } from "@/lib/streams"
 import { useScheduleMessage, useStreamBootstrap } from "@/hooks"
 import { useWorkspaceMetadata } from "@/stores/workspace-store"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
-import { extractCommandNode, extractCommandFromRawText } from "@/lib/commands"
+import { extractCommandNode, extractCommandFromRawText, extractSteerDirective } from "@/lib/commands"
 import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quote-reply-context"
@@ -549,12 +549,34 @@ function MessageInputComponent({
       const liveContent = editorContent ?? composer.content
       const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
 
+      const steerDirective = availableCommandByName.has("steer") ? extractSteerDirective(normalizedContent) : null
+
+      // A bare `/steer` remains a command-only send. When any message content
+      // or attachment surrounds it, the authored content stays a normal message
+      // carrying `steer: true`; the backend writes the message and follow-up
+      // command in one transaction.
+      if (steerDirective && !steerDirective.hasMessageContent) {
+        composer.setContent(EMPTY_DOC)
+        composer.resolveDraft()
+        setExpanded(false)
+        try {
+          await queueCommand({ commandMarkdown: "/steer", commandName: "steer" })
+        } catch {
+          setError("Failed to queue command. Please try again.")
+        } finally {
+          composer.setIsSending(false)
+        }
+        return
+      }
+
       // Dispatch as a command when the editor produced a slashCommand node,
       // or when the message is raw text that matches an available slash command
       // (e.g. `/model ` with a trailing space that never became a node). Plain
       // text like "/s" that does not match a known command still sends normally.
-      const commandNode = extractCommandNode(normalizedContent)
-      const rawTextCommand = commandNode === null ? extractCommandFromRawText(normalizedContent) : null
+      // Embedded steer is the exception above: it stays on the message path.
+      const commandNode = steerDirective ? null : extractCommandNode(normalizedContent)
+      const rawTextCommand =
+        commandNode === null && !steerDirective ? extractCommandFromRawText(normalizedContent) : null
       const resolvedCommand =
         commandNode ?? (rawTextCommand ? (availableCommandByName.get(rawTextCommand.name) ?? null) : null)
       if (resolvedCommand !== null) {
@@ -615,7 +637,8 @@ function MessageInputComponent({
         return
       }
 
-      const attachments = extractUploadedAttachments(normalizedContent)
+      const messageContent = steerDirective?.content ?? normalizedContent
+      const attachments = extractUploadedAttachments(messageContent)
       const attachmentIds = attachments.map((attachment) => attachment.id)
 
       const contentJson = liveContent
@@ -629,9 +652,10 @@ function MessageInputComponent({
         setExpanded(false)
 
         const result = await sendMessage({
-          contentJson: normalizedContent,
+          contentJson: messageContent,
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
           attachments: attachments.length > 0 ? attachments : undefined,
+          ...(steerDirective && { steer: true as const }),
           // Armed by "Reply in conversation": file this send into the
           // conversation synchronously (Mechanism C). Cleared only on success —
           // a failed send keeps the filing armed alongside the restored content.

--- a/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
@@ -11,11 +11,14 @@ import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import type { Editor } from "@tiptap/react"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
+import { useStreamBootstrap } from "@/hooks/use-streams"
+import { useWorkspaceMetadata } from "@/stores/workspace-store"
 
 const MOD_KEY_NAME = navigator.platform?.toLowerCase().includes("mac") ? "Command" : "Control"
 
 interface UnsentMessageEditFormProps {
   messageId: string
+  workspaceId: string
   /** The stream this message belongs to — scopes the `/memo` picker. */
   streamId: string
   initialContentJson?: JSONContent
@@ -25,12 +28,19 @@ interface UnsentMessageEditFormProps {
 
 export function UnsentMessageEditForm({
   messageId,
+  workspaceId,
   streamId,
   initialContentJson,
   onDone,
   authorName,
 }: UnsentMessageEditFormProps) {
   const { saveEditedMessage, cancelEditing, deleteMessage } = usePendingMessages()
+  const metadata = useWorkspaceMetadata(workspaceId)
+  const { data: streamBootstrap } = useStreamBootstrap(workspaceId, streamId, { enabled: false })
+  const steerAvailable = useMemo(
+    () => (streamBootstrap?.commands ?? metadata?.commands ?? []).some((command) => command.name === "steer"),
+    [streamBootstrap?.commands, metadata?.commands]
+  )
   // Latch the surface at mount: input mode is live, so reading it directly would
   // flip drawer<->inline mid-edit and remount the editor, dropping unsaved text.
   const [isTouch] = useState(useInputMode() === "touch")
@@ -87,12 +97,12 @@ export function UnsentMessageEditForm({
     }
     setIsSaving(true)
     try {
-      await saveEditedMessage(messageId, contentJson)
+      await saveEditedMessage(messageId, contentJson, { steerAvailable })
       onDone()
     } finally {
       setIsSaving(false)
     }
-  }, [contentJson, initialMarkdown, messageId, saveEditedMessage, cancelEditing, onDone])
+  }, [contentJson, initialMarkdown, messageId, saveEditedMessage, cancelEditing, onDone, steerAvailable])
 
   const handleDelete = useCallback(async () => {
     await deleteMessage(messageId)
@@ -112,13 +122,13 @@ export function UnsentMessageEditForm({
       setDocEditorOpen(false)
       setIsSaving(true)
       try {
-        await saveEditedMessage(messageId, parseMarkdown(trimmed))
+        await saveEditedMessage(messageId, parseMarkdown(trimmed), { steerAvailable })
         onDone()
       } finally {
         setIsSaving(false)
       }
     },
-    [initialMarkdown, messageId, saveEditedMessage, cancelEditing, onDone]
+    [initialMarkdown, messageId, saveEditedMessage, cancelEditing, onDone, steerAvailable]
   )
 
   const handleDocEditorDismiss = useCallback((markdown: string) => {

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -310,7 +310,55 @@ describe("PendingMessagesContext", () => {
           retryCount: 0,
           retryAfter: 0,
           terminalFailure: undefined,
+          steer: undefined,
         })
+      )
+    })
+
+    it.each([
+      {
+        name: "clears steer when the token is removed",
+        existingSteer: true,
+        contentJson: {
+          type: "doc" as const,
+          content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "plain edit" }] }],
+        },
+        expectedSteer: undefined,
+      },
+      {
+        name: "sets steer when mixed content adds the token",
+        existingSteer: undefined,
+        contentJson: {
+          type: "doc" as const,
+          content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "redirect this /steer" }] }],
+        },
+        expectedSteer: true,
+      },
+      {
+        name: "does not turn a bare steer edit into a composite message",
+        existingSteer: undefined,
+        contentJson: {
+          type: "doc" as const,
+          content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "/steer" }] }],
+        },
+        expectedSteer: undefined,
+      },
+    ])("$name", async ({ existingSteer, contentJson, expectedSteer }) => {
+      mockGet.mockResolvedValue({ clientId: "temp_steer_edit", steer: existingSteer })
+      mockEventsGet.mockResolvedValue({
+        id: "temp_steer_edit",
+        payload: { contentMarkdown: "old" },
+        _status: "editing",
+      })
+      const { result } = renderHook(() => usePendingMessages(), { wrapper })
+
+      await act(async () => {
+        await result.current.saveEditedMessage("temp_steer_edit", contentJson)
+      })
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "temp_steer_edit",
+        expect.objectContaining({ steer: expectedSteer, terminalFailure: undefined })
       )
     })
   })

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -309,6 +309,7 @@ describe("PendingMessagesContext", () => {
           preEditStatus: undefined,
           retryCount: 0,
           retryAfter: 0,
+          terminalFailure: undefined,
         })
       )
     })

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -99,7 +99,12 @@ describe("PendingMessagesContext", () => {
         await result.current.retryMessage("temp_retry")
       })
 
-      expect(mockUpdate).toHaveBeenCalledWith("temp_retry", { retryCount: 0, retryAfter: 0 })
+      expect(mockUpdate).toHaveBeenCalledWith("temp_retry", {
+        retryCount: 0,
+        retryAfter: 0,
+        status: undefined,
+        terminalFailure: undefined,
+      })
       expect(mockEventsUpdate).toHaveBeenCalledWith("temp_retry", { _status: "pending" })
       expect(result.current.getStatus("temp_retry")).toBe("pending")
     })

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -323,6 +323,7 @@ describe("PendingMessagesContext", () => {
           type: "doc" as const,
           content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "plain edit" }] }],
         },
+        steerAvailable: true,
         expectedSteer: undefined,
       },
       {
@@ -332,7 +333,18 @@ describe("PendingMessagesContext", () => {
           type: "doc" as const,
           content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "redirect this /steer" }] }],
         },
+        steerAvailable: true,
         expectedSteer: true,
+      },
+      {
+        name: "does not arm steer when the command is unavailable",
+        existingSteer: undefined,
+        contentJson: {
+          type: "doc" as const,
+          content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "mention /steer" }] }],
+        },
+        steerAvailable: false,
+        expectedSteer: undefined,
       },
       {
         name: "does not turn a bare steer edit into a composite message",
@@ -341,9 +353,10 @@ describe("PendingMessagesContext", () => {
           type: "doc" as const,
           content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "/steer" }] }],
         },
+        steerAvailable: true,
         expectedSteer: undefined,
       },
-    ])("$name", async ({ existingSteer, contentJson, expectedSteer }) => {
+    ])("$name", async ({ existingSteer, contentJson, steerAvailable, expectedSteer }) => {
       mockGet.mockResolvedValue({ clientId: "temp_steer_edit", steer: existingSteer })
       mockEventsGet.mockResolvedValue({
         id: "temp_steer_edit",
@@ -353,7 +366,7 @@ describe("PendingMessagesContext", () => {
       const { result } = renderHook(() => usePendingMessages(), { wrapper })
 
       await act(async () => {
-        await result.current.saveEditedMessage("temp_steer_edit", contentJson)
+        await result.current.saveEditedMessage("temp_steer_edit", contentJson, { steerAvailable })
       })
 
       expect(mockUpdate).toHaveBeenCalledWith(

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -290,7 +290,13 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
       // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
       // Cast through unknown to bypass the broken type inference.
       type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-      await (db.pendingMessages.update as unknown as UpdateFn)(id, { retryCount: 0, retryAfter: 0, ...patch })
+      await (db.pendingMessages.update as unknown as UpdateFn)(id, {
+        retryCount: 0,
+        retryAfter: 0,
+        status: undefined,
+        terminalFailure: undefined,
+        ...patch,
+      })
       await db.events.update(id, { _status: "pending" })
       markPending(id)
       notifyQueue()

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -219,6 +219,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
           preEditStatus: undefined,
           retryCount: 0,
           retryAfter: 0,
+          terminalFailure: undefined,
         })
 
         // Update the optimistic event's payload so the timeline reflects the edit

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -3,6 +3,7 @@ import { db } from "@/db"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { ConversationIntents, type JSONContent } from "@threa/types"
 import { deleteOptimisticBoardPost } from "@/stores/board-store"
+import { extractSteerDirective } from "@/lib/commands"
 
 type MessageStatus = "pending" | "failed" | "editing"
 /** Status the message had before the user entered editing mode */
@@ -206,6 +207,8 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
   const saveEditedMessage = useCallback(
     async (id: string, contentJson: JSONContent) => {
       const contentMarkdown = serializeToMarkdown(contentJson).trim()
+      const steerDirective = extractSteerDirective(contentJson)
+      const steer = steerDirective?.hasMessageContent === true ? true : undefined
 
       const updated = await db.transaction("rw", db.pendingMessages, db.events, async () => {
         const existing = await db.pendingMessages.get(id)
@@ -220,6 +223,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
           retryCount: 0,
           retryAfter: 0,
           terminalFailure: undefined,
+          steer,
         })
 
         // Update the optimistic event's payload so the timeline reflects the edit

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -17,7 +17,7 @@ interface PendingMessagesContextValue {
   /** Put a pending/failed message into editing mode so the queue skips it */
   markEditing: (id: string) => Promise<void>
   /** Save edits to an unsent message, return it to pending, and kick the queue */
-  saveEditedMessage: (id: string, contentJson: JSONContent) => Promise<void>
+  saveEditedMessage: (id: string, contentJson: JSONContent, options?: { steerAvailable?: boolean }) => Promise<void>
   /** Cancel editing and return message to its previous queue state */
   cancelEditing: (id: string) => Promise<void>
   /**
@@ -205,9 +205,9 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
   }, [])
 
   const saveEditedMessage = useCallback(
-    async (id: string, contentJson: JSONContent) => {
+    async (id: string, contentJson: JSONContent, options?: { steerAvailable?: boolean }) => {
       const contentMarkdown = serializeToMarkdown(contentJson).trim()
-      const steerDirective = extractSteerDirective(contentJson)
+      const steerDirective = options?.steerAvailable ? extractSteerDirective(contentJson) : null
       const steer = steerDirective?.hasMessageContent === true ? true : undefined
 
       const updated = await db.transaction("rw", db.pendingMessages, db.events, async () => {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -288,6 +288,8 @@ export interface PendingMessage {
   contentJson?: JSONContent
   /** Attachment IDs to include with the message */
   attachmentIds?: string[]
+  /** Persist this message and dispatch `/steer` atomically on the server. */
+  steer?: true
   createdAt: number // timestamp for ordering
   retryCount: number
   /** Timestamp before which this message should not be retried (exponential backoff) */
@@ -303,6 +305,8 @@ export interface PendingMessage {
    *   `status` and sets `confirmedPrivacyWarning: true`.
    */
   status?: "editing" | "blocked-privacy"
+  /** Permanent rejection: keep the failed row for manual Retry, but do not auto-replay it. */
+  terminalFailure?: boolean
   /** Original queue state before entering editing mode; used to cancel stale edits on startup. */
   preEditStatus?: "pending" | "failed"
   /**

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -11,6 +11,8 @@ import * as draftStoreModule from "@/stores/draft-store"
 import * as boardStoreModule from "@/stores/board-store"
 import * as useDraftMessageModule from "./use-draft-message"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MessageErrorCodes } from "@threa/types"
+import { ApiError } from "@/api/client"
 import { createElement, type ReactNode } from "react"
 
 const mockCreate = vi.fn()
@@ -33,6 +35,9 @@ interface MockPendingMessage {
   contentFormat: string
   contentJson?: { type: string; content: Array<{ type: string; content?: Array<{ type: string; text: string }> }> }
   attachmentIds?: string[]
+  steer?: true
+  status?: "editing" | "blocked-privacy"
+  terminalFailure?: boolean
   createdAt: number
   retryCount: number
   retryAfter?: number
@@ -188,6 +193,32 @@ describe("useMessageQueue", () => {
     expect(mockMarkSent).toHaveBeenCalledWith("temp_abc")
   })
 
+  it("forwards atomic steer on the message request", async () => {
+    mockPendingMessages = [
+      {
+        clientId: "temp_steer",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "I want option 2",
+        contentFormat: "markdown",
+        steer: true,
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      "ws_1",
+      "stream_1",
+      expect.objectContaining({ clientMessageId: "temp_steer", steer: true })
+    )
+  })
+
   it("should mark message as failed and increment retryCount when API call fails", async () => {
     mockCreate.mockRejectedValue(new Error("Network error"))
     mockPendingMessages = [
@@ -214,6 +245,59 @@ describe("useMessageQueue", () => {
     })
     expect(mockEventsUpdate).toHaveBeenCalledWith("temp_fail", { _status: "failed" })
     expect(mockMarkFailed).toHaveBeenCalledWith("temp_fail")
+  })
+
+  it("parks a message when its atomic steer is no longer available", async () => {
+    mockCreate.mockRejectedValue(
+      new ApiError(409, MessageErrorCodes.STEER_UNAVAILABLE, "Steer is not available in this stream")
+    )
+    mockPendingMessages = [
+      {
+        clientId: "temp_steer_gone",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Please handle this /steer",
+        contentFormat: "markdown",
+        steer: true,
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith("temp_steer_gone", {
+      terminalFailure: true,
+      retryAfter: undefined,
+    })
+    expect(mockEventsUpdate).toHaveBeenCalledWith("temp_steer_gone", { _status: "failed" })
+    expect(mockMarkFailed).toHaveBeenCalledWith("temp_steer_gone")
+  })
+
+  it("does not auto-retry a permanently failed send", async () => {
+    mockPendingMessages = [
+      {
+        clientId: "temp_permanent",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Please handle this /steer",
+        contentFormat: "markdown",
+        steer: true,
+        terminalFailure: true,
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
   })
 
   it("should retry high-retry-count messages (no max retry cap) with backoff", async () => {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -10,7 +10,7 @@ import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
 import { reconcileOptimisticBoardPost } from "@/stores/board-store"
 import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
-import { StreamTypes, ShareErrorCodes, draftStreamScope } from "@threa/types"
+import { MessageErrorCodes, ShareErrorCodes, StreamTypes, draftStreamScope } from "@threa/types"
 import type { PendingMessage } from "@/db"
 import type {
   AttachmentSummary,
@@ -204,6 +204,7 @@ export function useMessageQueue(): void {
           // (which clears the status); the drain loop must skip them so they
           // don't churn through retries the user hasn't authorized yet.
           m.status !== "blocked-privacy" &&
+          m.terminalFailure !== true &&
           (m.retryAfter ?? 0) <= now
       )
       if (!next) break
@@ -241,6 +242,7 @@ export function useMessageQueue(): void {
             e2eVersion: next.e2eVersion,
             attachmentIds: next.attachmentIds,
             clientMessageId: next.clientId,
+            ...(next.steer && { steer: true }),
           })
         } else {
           const contentJson = next.contentJson ?? parseMarkdown(next.content)
@@ -250,6 +252,7 @@ export function useMessageQueue(): void {
             attachmentIds: next.attachmentIds,
             clientMessageId: next.clientId,
             confirmedPrivacyWarning: next.confirmedPrivacyWarning,
+            ...(next.steer && { steer: true }),
             // A board reply declares its conversation so the send attaches it
             // synchronously (in the message's transaction) instead of waiting on
             // the async extractor; omitted on ordinary sends.
@@ -322,6 +325,20 @@ export function useMessageQueue(): void {
           ])
           markFailed(next.clientId)
           surfacePrivacyBlockToast(next.clientId, { retryMessage, deleteMessage })
+          skippedIds.add(next.clientId)
+          continue
+        }
+
+        if (ApiError.isApiError(err) && err.code === MessageErrorCodes.STEER_UNAVAILABLE) {
+          type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
+          await Promise.all([
+            (db.pendingMessages.update as unknown as UpdateFn)(next.clientId, {
+              terminalFailure: true,
+              retryAfter: undefined,
+            }),
+            db.events.update(next.clientId, { _status: "failed" }),
+          ])
+          markFailed(next.clientId)
           skippedIds.add(next.clientId)
           continue
         }

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -231,6 +231,26 @@ describe("useStreamOrDraft real stream send", () => {
     })
   })
 
+  it("keeps steer on the same durable message queue item", async () => {
+    const { result } = await mountRealStreamSend()
+
+    await act(async () => {
+      await result.current.sendMessage({
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "I want option 2" }] }],
+        },
+        steer: true,
+      })
+    })
+
+    expect((await db.pendingMessages.toArray()).find((message) => message.content === "I want option 2")).toMatchObject(
+      {
+        steer: true,
+      }
+    )
+  })
+
   it("forwards a conversation directive to the pending row and tags the optimistic payload (reply in conversation)", async () => {
     const { result } = await mountRealStreamSend()
 
@@ -471,8 +491,29 @@ describe("useStreamOrDraft draft DM send", () => {
 describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
   const CREATED_AT = "2026-03-31T10:00:00Z"
 
-  function seedScratchpad(streamOverrides: Record<string, unknown>): string {
+  async function seedScratchpad(streamOverrides: Record<string, unknown>): Promise<string> {
     const streamId = "stream_pad_1"
+    const stream = {
+      id: streamId,
+      workspaceId: "ws_1",
+      type: "scratchpad" as const,
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private" as const,
+      parentStreamId: null,
+      parentMessageId: null,
+      rootStreamId: null,
+      companionMode: "on" as const,
+      companionPersonaId: null,
+      createdBy: "member_1",
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+      archivedAt: null,
+      lastMessagePreview: null,
+      _cachedAt: Date.now(),
+      ...streamOverrides,
+    }
     seedWorkspaceCache("ws_1", {
       workspace: {
         id: "ws_1",
@@ -509,29 +550,7 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
           _cachedAt: Date.now(),
         },
       ],
-      streams: [
-        {
-          id: streamId,
-          workspaceId: "ws_1",
-          type: "scratchpad" as const,
-          displayName: null,
-          slug: null,
-          description: null,
-          visibility: "private" as const,
-          parentStreamId: null,
-          parentMessageId: null,
-          rootStreamId: null,
-          companionMode: "on" as const,
-          companionPersonaId: null,
-          createdBy: "member_1",
-          createdAt: CREATED_AT,
-          updatedAt: CREATED_AT,
-          archivedAt: null,
-          lastMessagePreview: null,
-          _cachedAt: Date.now(),
-          ...streamOverrides,
-        },
-      ],
+      streams: [stream],
       memberships: [
         {
           id: `ws_1:${streamId}`,
@@ -569,6 +588,7 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
       },
       metadata: { id: "ws_1", workspaceId: "ws_1", emojis: [], emojiWeights: {}, commands: [], _cachedAt: Date.now() },
     })
+    await db.streams.put(stream)
     return streamId
   }
 
@@ -596,7 +616,11 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
     } as never)
     vi.spyOn(messageEnvelope, "sealStreamName").mockResolvedValue({ ciphertext: "Y3Q=", envelope: { v: 1 } as never })
 
-    const streamId = seedScratchpad({ e2eEnabled: true, sealedNameCiphertext: "old_ct", sealedNameEnvelope: { v: 0 } })
+    const streamId = await seedScratchpad({
+      e2eEnabled: true,
+      sealedNameCiphertext: "old_ct",
+      sealedNameEnvelope: { v: 0 },
+    })
     const update = vi.fn().mockImplementation(async (_ws: string, id: string, data: Record<string, unknown>) => ({
       id,
       workspaceId: "ws_1",
@@ -646,7 +670,7 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
 
   it("renames a plaintext scratchpad by writing displayName directly (no sealing)", async () => {
     const sealSpy = vi.spyOn(messageEnvelope, "sealStreamName")
-    const streamId = seedScratchpad({ e2eEnabled: false })
+    const streamId = await seedScratchpad({ e2eEnabled: false })
     const update = vi.fn().mockImplementation(async (_ws: string, id: string, data: Record<string, unknown>) => ({
       id,
       workspaceId: "ws_1",

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -139,6 +139,8 @@ export interface SendMessageInput {
   attachmentIds?: string[]
   /** Full attachment info for optimistic UI - required when attachmentIds is provided */
   attachments?: AttachmentSummary[]
+  /** Persist the message first, then dispatch `/steer` in the same server transaction. */
+  steer?: true
   /**
    * Files the send into a conversation synchronously ("Reply in conversation",
    * Mechanism C). Only meaningful on real streams — draft paths ignore it, since
@@ -658,29 +660,33 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
       markPending(clientId)
 
-      // Durable enqueue: the background message queue (useMessageQueue) picks
-      // this up and sends it.
-      await db.pendingMessages.add({
-        clientId,
-        workspaceId,
-        streamId,
-        content: contentMarkdown,
-        contentFormat: "markdown",
-        contentJson: input.contentJson,
-        attachmentIds: input.attachmentIds,
-        conversation: input.conversation,
-        createdAt: Date.now(),
-        retryCount: 0,
-        ...(e2eFields ?? {}),
-      })
+      // The durable send and its optimistic row appear together. A steered
+      // message stays one queue item so replay cannot dispatch the command
+      // before the message reaches the server.
+      await db.transaction("rw", [db.pendingMessages, db.events], async () => {
+        await db.pendingMessages.add({
+          clientId,
+          workspaceId,
+          streamId,
+          content: contentMarkdown,
+          contentFormat: "markdown",
+          contentJson: input.contentJson,
+          attachmentIds: input.attachmentIds,
+          conversation: input.conversation,
+          steer: input.steer,
+          createdAt: Date.now(),
+          retryCount: 0,
+          ...(e2eFields ?? {}),
+        })
 
-      await db.events.add({
-        ...optimisticEvent,
-        workspaceId,
-        _sequenceNum: sequenceToNum(optimisticEvent.sequence),
-        _clientId: clientId,
-        _status: "pending",
-        _cachedAt: Date.now(),
+        await db.events.add({
+          ...optimisticEvent,
+          workspaceId,
+          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _clientId: clientId,
+          _status: "pending",
+          _cachedAt: Date.now(),
+        })
       })
 
       notifyQueue()

--- a/apps/frontend/src/lib/commands.test.ts
+++ b/apps/frontend/src/lib/commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import type { JSONContent } from "@threa/types"
-import { extractCommandNode, extractCommandFromRawText } from "./commands"
+import { extractCommandNode, extractCommandFromRawText, extractSteerDirective } from "./commands"
 
 describe("extractCommandNode", () => {
   it("extracts name + clientActionId from the first slashCommand node", () => {
@@ -126,6 +126,97 @@ describe("extractCommandNode", () => {
       ],
     }
     expect(extractCommandNode(doc)?.name).toBe("help")
+  })
+})
+
+describe("extractSteerDirective", () => {
+  it("detects a structural steer command at the start of a message without changing it", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "slashCommand", attrs: { name: "steer", clientActionId: null } },
+            { type: "text", text: " I want option 2" },
+          ],
+        },
+      ],
+    }
+
+    expect(extractSteerDirective(doc)).toEqual({ content: doc, hasMessageContent: true })
+  })
+
+  it("finds standalone raw steer tokens at the end, middle, and across paragraphs", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "I want option 2 /steer" }] },
+        { type: "paragraph", content: [{ type: "text", text: "Yes./steer and also pizza" }] },
+      ],
+    }
+
+    expect(extractSteerDirective(doc)).toEqual({ content: doc, hasMessageContent: true })
+  })
+
+  it("detects a steer token split across formatting marks", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "/ste", marks: [{ type: "bold" }] },
+            { type: "text", text: "er" },
+            { type: "text", text: " keep the attachment" },
+          ],
+        },
+      ],
+    }
+
+    expect(extractSteerDirective(doc)).toEqual({ content: doc, hasMessageContent: true })
+  })
+
+  it("treats a trailing-newline steer as a command with no message", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "/steer" }] }, { type: "paragraph" }],
+    }
+
+    expect(extractSteerDirective(doc)?.hasMessageContent).toBe(false)
+  })
+
+  it("keeps attachments as normal message content", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "attachmentReference", attrs: { id: "att_1", filename: "image.png" } },
+            { type: "text", text: " /steer" },
+          ],
+        },
+      ],
+    }
+
+    const extracted = extractSteerDirective(doc)
+    expect(extracted?.hasMessageContent).toBe(true)
+    expect(extracted?.content.content?.[0].content?.[0].type).toBe("attachmentReference")
+  })
+
+  it("does not match paths, URLs, or longer command names", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "https://example.com/steer /steer-more foo/steer" }],
+        },
+      ],
+    }
+
+    expect(extractSteerDirective(doc)).toBeNull()
   })
 })
 

--- a/apps/frontend/src/lib/commands.test.ts
+++ b/apps/frontend/src/lib/commands.test.ts
@@ -159,6 +159,70 @@ describe("extractSteerDirective", () => {
     expect(extractSteerDirective(doc)).toEqual({ content: doc, hasMessageContent: true })
   })
 
+  it("detects steer in later list items and nested block paragraphs", () => {
+    const listDoc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "prep the release" }] }],
+            },
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "/steer start with tests" }] }],
+            },
+          ],
+        },
+      ],
+    }
+    const quoteDoc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "context" }] },
+            { type: "paragraph", content: [{ type: "text", text: "/steer use this" }] },
+          ],
+        },
+      ],
+    }
+
+    expect(extractSteerDirective(listDoc)).toEqual({ content: listDoc, hasMessageContent: true })
+    expect(extractSteerDirective(quoteDoc)).toEqual({ content: quoteDoc, hasMessageContent: true })
+  })
+
+  it("detects a structural steer node inside a list item", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "context" }] }],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "slashCommand", attrs: { name: "steer", clientActionId: null } }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractSteerDirective(doc)).toEqual({ content: doc, hasMessageContent: true })
+  })
+
   it("detects a steer token split across formatting marks", () => {
     const doc: JSONContent = {
       type: "doc",

--- a/apps/frontend/src/lib/commands.ts
+++ b/apps/frontend/src/lib/commands.ts
@@ -42,13 +42,17 @@ export interface ExtractedSteerDirective {
 const RAW_STEER_PATTERN = /(^|[^\p{L}\p{N}_/])\/steer(?=$|[^\p{L}\p{N}_/-])/iu
 const RAW_STEER_PATTERN_GLOBAL = new RegExp(RAW_STEER_PATTERN.source, "giu")
 const INLINE_CONTENT_PLACEHOLDER = "\uFFFC"
+const INLINE_CONTENT_CONTAINERS = new Set(["paragraph", "heading", "codeBlock"])
 
 function steerDetectionText(node: JSONContent): string {
   if (node.type === "text") return node.text ?? ""
   if (node.type === "slashCommand") return `/${String(node.attrs?.name ?? "")}`
   if (node.type === "hardBreak") return "\n"
   if (node.content) {
-    const separator = node.type === "doc" ? "\n" : ""
+    // Keep adjacent inline nodes contiguous so formatting-split tokens still
+    // match, but separate every block container so list/quote boundaries do
+    // not glue the preceding word to a following `/steer`.
+    const separator = INLINE_CONTENT_CONTAINERS.has(node.type ?? "") ? "" : "\n"
     return node.content.map(steerDetectionText).join(separator)
   }
   return ["doc", "paragraph"].includes(node.type ?? "") ? "" : INLINE_CONTENT_PLACEHOLDER

--- a/apps/frontend/src/lib/commands.ts
+++ b/apps/frontend/src/lib/commands.ts
@@ -34,6 +34,39 @@ export interface RawTextCommand {
   args: string
 }
 
+export interface ExtractedSteerDirective {
+  content: JSONContent
+  hasMessageContent: boolean
+}
+
+const RAW_STEER_PATTERN = /(^|[^\p{L}\p{N}_/])\/steer(?=$|[^\p{L}\p{N}_/-])/iu
+const RAW_STEER_PATTERN_GLOBAL = new RegExp(RAW_STEER_PATTERN.source, "giu")
+const INLINE_CONTENT_PLACEHOLDER = "\uFFFC"
+
+function steerDetectionText(node: JSONContent): string {
+  if (node.type === "text") return node.text ?? ""
+  if (node.type === "slashCommand") return `/${String(node.attrs?.name ?? "")}`
+  if (node.type === "hardBreak") return "\n"
+  if (node.content) {
+    const separator = node.type === "doc" ? "\n" : ""
+    return node.content.map(steerDetectionText).join(separator)
+  }
+  return ["doc", "paragraph"].includes(node.type ?? "") ? "" : INLINE_CONTENT_PLACEHOLDER
+}
+
+/**
+ * Detect `/steer` wherever it appears in a message. The authored document is
+ * preserved as the normal message; a separate steer command follows it. A
+ * plain-text projection is used only to distinguish a bare command from a
+ * message and to match tokens split across formatting marks.
+ */
+export function extractSteerDirective(content: JSONContent): ExtractedSteerDirective | null {
+  const text = steerDetectionText(content)
+  if (!RAW_STEER_PATTERN.test(text)) return null
+  const withoutSteer = text.replace(RAW_STEER_PATTERN_GLOBAL, "$1")
+  return { content, hasMessageContent: withoutSteer.trim().length > 0 }
+}
+
 /**
  * Walk the content tree and return the first `slashCommand` node's attrs as
  * `{ name, clientActionId }`, or null when no command node is present.

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -243,6 +243,12 @@ describe("verdictCandidateText", () => {
     expect(verdictCandidateText(makeSteerInvocation("no abcde"))).toBe("no abcde")
   })
 
+  test("strips an embedded steer directive from an ordinary swept message", () => {
+    expect(
+      verdictCandidateText(makeInvocation({ trigger: "active-scratchpad", promptMarkdown: "/steer yes abcde" }))
+    ).toBe("yes abcde")
+  })
+
   test("other session-control commands never carry a verdict", () => {
     const model = makeInvocation({
       trigger: "session-control",

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -243,10 +243,10 @@ describe("verdictCandidateText", () => {
     expect(verdictCandidateText(makeSteerInvocation("no abcde"))).toBe("no abcde")
   })
 
-  test("strips an embedded steer directive from an ordinary swept message", () => {
-    expect(
-      verdictCandidateText(makeInvocation({ trigger: "active-scratchpad", promptMarkdown: "/steer yes abcde" }))
-    ).toBe("yes abcde")
+  test("strips an embedded steer directive anywhere in an ordinary swept message", () => {
+    for (const promptMarkdown of ["/steer yes abcde", "yes /steer abcde", "yes abcde /steer"]) {
+      expect(verdictCandidateText(makeInvocation({ trigger: "active-scratchpad", promptMarkdown }))).toBe("yes abcde")
+    }
   })
 
   test("other session-control commands never carry a verdict", () => {

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -41,6 +41,7 @@ const MODEL_SUGGESTIONS = modelSuggestions()
 
 /** "y abcde" / "yes abcde" / "n abcde" / "no abcde". The id alphabet skips 'l' (Claude Code's convention). */
 export const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
+const EMBEDDED_STEER_RE = /(^|[^\p{L}\p{N}_/])\/steer(?=$|[^\p{L}\p{N}_/-])/giu
 
 // Delegation-queue backstop poll. The /bot socket pushes delegation:available,
 // so like WS_BACKSTOP_POLL_MS in the SDK this is only insurance against a
@@ -103,8 +104,11 @@ export function verdictCandidateText(invocation: ClaimedInvocation): string | nu
   // Embedded steer is now persisted as an ordinary source message plus an
   // empty structured steer invocation. When that source message is swept while
   // busy, retain the old permission-reply behavior by testing its text without
-  // the leading directive.
-  return invocation.promptMarkdown.replace(/^\s*\/steer(?:\s+|$)/i, "").trim()
+  // the embedded directive, regardless of where the user placed it.
+  return invocation.promptMarkdown
+    .replace(EMBEDDED_STEER_RE, "$1")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim()
 }
 
 export function buildInstructions(permissionRelay: boolean, channelActive = true): string {

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -98,8 +98,13 @@ export function parsePermissionVerdict(text: string): PermissionVerdict | null {
  */
 export function verdictCandidateText(invocation: ClaimedInvocation): string | null {
   const command = parseSessionControlCommand(invocation)
-  if (!command) return invocation.promptMarkdown
-  return command.name === "steer" ? command.args : null
+  if (command) return command.name === "steer" ? command.args : null
+
+  // Embedded steer is now persisted as an ordinary source message plus an
+  // empty structured steer invocation. When that source message is swept while
+  // busy, retain the old permission-reply behavior by testing its text without
+  // the leading directive.
+  return invocation.promptMarkdown.replace(/^\s*\/steer(?:\s+|$)/i, "").trim()
 }
 
 export function buildInstructions(permissionRelay: boolean, channelActive = true): string {

--- a/extensions/pi-remote/src/threa-remote.sealed.test.ts
+++ b/extensions/pi-remote/src/threa-remote.sealed.test.ts
@@ -213,16 +213,18 @@ describe("sealed attachments (inbound)", () => {
       throw new Error(`unexpected fetch: ${url}`)
     }) as typeof fetch)
 
-    let lines: string[]
+    let lines: { contextLines: string[]; sourceLines: string[] }
     try {
       lines = await __testing.downloadSealedContextAttachments([ref], [], invocation() as never, dir)
     } finally {
       fetchSpy.mockRestore()
     }
 
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toContain("notes.md (text/markdown, 14 bytes)")
-    expect(lines[0]).toContain("[attached to the source message]")
+    expect(lines.contextLines).toHaveLength(1)
+    expect(lines.contextLines[0]).toContain("notes.md (text/markdown, 14 bytes)")
+    expect(lines.contextLines[0]).toContain("[attached to the source message]")
+    expect(lines.sourceLines).toHaveLength(1)
+    expect(lines.sourceLines[0]).not.toContain("[attached to the source message]")
     const localPath = join(dir, ".threa-attachments", "binv_1", "notes.md")
     expect(new TextDecoder().decode(readFileSync(localPath))).toBe("inbound secret")
   })
@@ -250,15 +252,48 @@ describe("sealed attachments (inbound)", () => {
       throw new Error(`unexpected fetch: ${url}`)
     }) as typeof fetch)
 
-    let lines: string[]
+    let lines: { contextLines: string[]; sourceLines: string[] }
     try {
       lines = await __testing.downloadSealedContextAttachments([ref], [ref], invocation() as never, dir)
     } finally {
       fetchSpy.mockRestore()
     }
 
-    expect(lines).toHaveLength(1)
+    expect(lines.contextLines).toHaveLength(1)
+    expect(lines.sourceLines).toHaveLength(1)
     expect(urlFetches).toBe(1)
+  })
+
+  test("keeps history-only attachments out of steer context", async () => {
+    __testing.setConfigForTesting(BASE_CONFIG)
+    const dir = tempDir()
+    const encrypted = await encryptAttachmentBytes(new Uint8Array([9]))
+    const ref: AttachmentRef = {
+      attachmentId: "att_history",
+      key: encrypted.key,
+      iv: encrypted.iv,
+      filename: "old.txt",
+      mimeType: "text/plain",
+      sizeBytes: 1,
+    }
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes("/attachments/att_history/url")) {
+        return jsonResponse({ data: { url: "https://signed.example/att_history" } })
+      }
+      if (url.startsWith("https://signed.example/")) return new Response(encrypted.ciphertext)
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch)
+
+    let lines: { contextLines: string[]; sourceLines: string[] }
+    try {
+      lines = await __testing.downloadSealedContextAttachments([], [ref], invocation() as never, dir)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+
+    expect(lines.contextLines).toHaveLength(1)
+    expect(lines.sourceLines).toEqual([])
   })
 })
 

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -168,6 +168,24 @@ describe("Pi remote trace safety", () => {
     expect(__testing.resolveSessionControlCommand(invocation)).toBeNull()
   })
 
+  test("preserves non-steer command fallback for active-scratchpad messages", () => {
+    const invocation = {
+      id: "binv_1",
+      activeStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "/model openai-codex/gpt-5.6-sol",
+      claimToken: "claim",
+      claimExpiresAt: null,
+      requiredCapability: "active-scratchpad",
+    }
+    expect(__testing.resolveSessionControlCommand(invocation)).toEqual({
+      id: "msg_1",
+      name: "model",
+      args: "openai-codex/gpt-5.6-sol",
+      executionKind: "bot-runtime",
+    })
+  })
+
   test("formats Pi mid-turn steers like normal user messages", () => {
     expect(__testing.formatSteerPrompt("I want option 2")).toBe("I want option 2")
     expect(

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -155,22 +155,29 @@ describe("Pi remote trace safety", () => {
     })
   })
 
-  test("falls back to parsing prompt for active-scratchpad invocations", () => {
+  test("does not mistake an active-scratchpad message for a session-control command", () => {
     const invocation = {
       id: "binv_1",
       activeStreamId: "stream_1",
       sourceMessageId: "msg_1",
-      promptMarkdown: "/model ",
+      promptMarkdown: "/steer I want option 2",
       claimToken: "claim",
       claimExpiresAt: null,
       requiredCapability: "active-scratchpad",
     }
-    expect(__testing.resolveSessionControlCommand(invocation)).toEqual({
-      id: "msg_1",
-      name: "model",
-      args: "",
-      executionKind: "bot-runtime",
-    })
+    expect(__testing.resolveSessionControlCommand(invocation)).toBeNull()
+  })
+
+  test("formats Pi mid-turn steers like normal user messages", () => {
+    expect(__testing.formatSteerPrompt("I want option 2")).toBe("I want option 2")
+    expect(
+      __testing.formatSteerPrompt(
+        "Look at this image",
+        "Attachments saved into this session's working directory — read them from these paths:\n- image.png → /tmp/image.png"
+      )
+    ).toBe(
+      "Look at this image\n\nAttachments saved into this session's working directory — read them from these paths:\n- image.png → /tmp/image.png"
+    )
   })
 
   test("does not treat mention invocations as session-control commands", () => {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -87,7 +87,6 @@ const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000
 const MAX_RETRY_ATTEMPTS = 3
 const PI_TOOL_TRACE_FORMAT = "pi_tool_trace"
 const SESSION_CONTROL_CAPABILITY = "session-control"
-const ACTIVE_SCRATCHPAD_CAPABILITY = "active-scratchpad"
 const SESSION_CONTROL_COMMANDS = [
   "compact",
   "model",
@@ -210,6 +209,8 @@ type ClaimedInvocation = {
   sealing?: SealingState
   /** Decrypted prior-message context, pre-formatted for the prompt (no plaintext fetch on E2E). */
   sealedContextText?: string
+  /** Decrypted attachment paths to include in a concise mid-turn steer. */
+  sealedSteerContextText?: string
   /** Present on a session-control claim on an E2E stream: SSK wraps to seal the command ack. */
   sealedAck?: unknown
 }
@@ -1640,6 +1641,25 @@ function formatInvocationContext(
   ].join("\n")
 }
 
+function formatSteerPrompt(promptMarkdown: string, attachmentContext = ""): string {
+  return [promptMarkdown.trim() || "(empty message)", attachmentContext].filter(Boolean).join("\n\n")
+}
+
+function formatSteerAttachmentContext(
+  messages: StreamMessage[],
+  sourceMessageId: string,
+  downloadedAttachments: Map<string, string>
+): string {
+  const source = messages.find((message) => message.id === sourceMessageId)
+  const lines = (source?.attachments ?? []).flatMap((attachment) => {
+    const path = downloadedAttachments.get(attachment.id)
+    return path ? [`- ${attachment.filename} (${attachment.mimeType}, ${attachment.sizeBytes} bytes) → ${path}`] : []
+  })
+  return lines.length > 0
+    ? ["Attachments saved into this session's working directory — read them from these paths:", ...lines].join("\n")
+    : ""
+}
+
 function safeFilename(filename: string): string {
   return filename.replace(/[\\/:*?"<>|]/g, "_").slice(0, 180) || "attachment"
 }
@@ -1743,8 +1763,8 @@ async function fetchInvocationContext(
   invocation: ClaimedInvocation,
   cwd: string,
   sessionLink: RuntimeSessionLink | undefined
-): Promise<{ context: string; cursor?: string }> {
-  if (!config) return { context: "" }
+): Promise<{ context: string; steerContext: string; cursor?: string }> {
+  if (!config) return { context: "", steerContext: "" }
   const cursor = sessionLink?.streamCursors?.[invocation.activeStreamId]
   const query = cursor ? `after=${encodeURIComponent(cursor)}&limit=50` : "limit=12"
   const body = await request<{ data: StreamMessage[] }>(
@@ -1765,6 +1785,7 @@ async function fetchInvocationContext(
 
   return {
     context: formatInvocationContext(orderedMessages, invocation.sourceMessageId, downloadedAttachments),
+    steerContext: formatSteerAttachmentContext(orderedMessages, invocation.sourceMessageId, downloadedAttachments),
     cursor: sourceIncluded ? orderedMessages.at(-1)?.sequence : undefined,
   }
 }
@@ -1873,6 +1894,13 @@ async function hydrateSealedClaim(
       promptMarkdown: opened.promptMarkdown,
       sealing: opened.sealing,
       sealedContextText: contextBlocks.join("\n\n"),
+      sealedSteerContextText:
+        attachmentLines.length > 0
+          ? [
+              "Attachments saved into this session's working directory — read them from these paths:",
+              ...attachmentLines,
+            ].join("\n")
+          : "",
     }
   } catch (error) {
     return fail(scrubSealedError(error))
@@ -1938,10 +1966,7 @@ function parseSessionControlCommand(promptMarkdown: string): { name: string; arg
 function resolveSessionControlCommand(invocation: ClaimedInvocation): RuntimeCommandMetadata | null {
   const runtimeCommand = getRuntimeCommand(invocation)
   if (runtimeCommand) return runtimeCommand
-  const canParseFromPrompt =
-    invocation.requiredCapability === SESSION_CONTROL_CAPABILITY ||
-    invocation.requiredCapability === ACTIVE_SCRATCHPAD_CAPABILITY
-  if (!canParseFromPrompt) return null
+  if (invocation.requiredCapability !== SESSION_CONTROL_CAPABILITY) return null
   const parsed = parseSessionControlCommand(invocation.promptMarkdown)
   if (!parsed) return null
   return {
@@ -2043,23 +2068,28 @@ async function completeInvocationWithMarkdown(
 async function buildInvocationPrompt(
   invocation: ClaimedInvocation,
   ctx: ExtensionContext
-): Promise<{ prompt: string; cursor?: string; context: string }> {
+): Promise<{ prompt: string; steerPrompt: string; cursor?: string; context: string }> {
   // A sealed turn never touches the plaintext messages API — its context is
   // what was already decrypted at claim time (the server would only return
   // ciphertext placeholders anyway; inbound files were decrypted from the
   // payload refs during hydration).
   const sealed = invocation.sealing !== undefined
-  const { context, cursor } = sealed
-    ? { context: invocation.sealedContextText ?? "", cursor: undefined }
+  const { context, steerContext, cursor } = sealed
+    ? {
+        context: invocation.sealedContextText ?? "",
+        steerContext: invocation.sealedSteerContextText ?? "",
+        cursor: undefined,
+      }
     : await fetchInvocationContext(invocation, ctx.cwd, getCurrentSessionLink(ctx)).catch(
-        (error): { context: string; cursor?: string } => {
+        (error): { context: string; steerContext: string; cursor?: string } => {
           ctx.ui.notify(`Threa remote context fetch failed: ${summarizeError(error)}`, "warning")
-          return { context: "" }
+          return { context: "", steerContext: "" }
         }
       )
   return {
     context,
     cursor,
+    steerPrompt: formatSteerPrompt(invocation.promptMarkdown, steerContext),
     prompt: [
       `Remote Threa invocation ${invocation.id}.`,
       `Source message: ${invocation.sourceMessageId}`,
@@ -2113,10 +2143,11 @@ async function injectInvocation(
   invocation: ClaimedInvocation,
   steer: boolean
 ): Promise<void> {
-  const { prompt, cursor, context } = await buildInvocationPrompt(invocation, ctx)
+  const { prompt, steerPrompt, cursor, context } = await buildInvocationPrompt(invocation, ctx)
+  const deliveredPrompt = steer ? steerPrompt : prompt
   if (!pending) {
     beginPendingInvocation(invocation, cursor)
-    pendingInvocationPrompt = prompt
+    pendingInvocationPrompt = deliveredPrompt
     await recordTraceStep("context_received", formatInvocationTrace(invocation, context), "Loaded context…")
   } else {
     steeredInvocations.push({ invocation, cursor })
@@ -2128,7 +2159,7 @@ async function injectInvocation(
     )
   }
   setRemoteStatus(ctx, `Threa remote: running ${pending.id}`)
-  pi.sendUserMessage(prompt, steer ? { deliverAs: "steer" } : undefined)
+  pi.sendUserMessage(deliveredPrompt, steer ? { deliverAs: "steer" } : undefined)
 }
 
 function compactSession(ctx: ExtensionContext, customInstructions?: string): Promise<void> {
@@ -2448,18 +2479,19 @@ async function runSteerCommand(
   }
 
   const steeredInvocation = { ...invocation, promptMarkdown: steerText }
-  const { prompt, cursor, context } = await buildInvocationPrompt(steeredInvocation, ctx)
+  const { prompt, steerPrompt, cursor, context } = await buildInvocationPrompt(steeredInvocation, ctx)
   const shouldSteer = pending !== undefined || !ctx.isIdle()
+  const deliveredPrompt = shouldSteer ? steerPrompt : prompt
   if (!pending) {
     beginPendingInvocation(invocation, cursor)
-    pendingInvocationPrompt = prompt
+    pendingInvocationPrompt = deliveredPrompt
     await recordTraceStep("context_received", formatInvocationTrace(steeredInvocation, context), "Loaded context…")
   } else {
     steeredInvocations.push({ invocation, cursor })
     await recordTraceStep("steer", formatInvocationTrace(steeredInvocation, context), "Steering…")
   }
   setRemoteStatus(ctx, `Threa remote: running ${pending?.id ?? invocation.id}`)
-  pi.sendUserMessage(prompt, shouldSteer ? { deliverAs: "steer" } : undefined)
+  pi.sendUserMessage(deliveredPrompt, shouldSteer ? { deliverAs: "steer" } : undefined)
 }
 
 /**
@@ -3308,6 +3340,7 @@ export const __testing = {
   buildRuntimeCapabilities,
   getRuntimeCommand,
   parseSessionControlCommand,
+  formatSteerPrompt,
   resolveSessionControlCommand,
   normalizeThinkingLevel,
   migrateSessionState,

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -1719,9 +1719,10 @@ async function downloadSealedContextAttachments(
   historyRefs: readonly AttachmentRef[],
   invocation: ClaimedInvocation,
   cwd: string
-): Promise<string[]> {
+): Promise<{ contextLines: string[]; sourceLines: string[] }> {
   const seen = new Set<string>()
-  const lines: string[] = []
+  const contextLines: string[] = []
+  const sourceLines: string[] = []
   for (const { refs, isSource } of [
     { refs: promptRefs, isSource: true },
     { refs: historyRefs, isSource: false },
@@ -1731,14 +1732,15 @@ async function downloadSealedContextAttachments(
       seen.add(ref.attachmentId)
       try {
         const path = await downloadSealedAttachment(ref, invocation, cwd)
-        const marker = isSource ? " [attached to the source message]" : ""
-        lines.push(`- ${ref.filename} (${ref.mimeType}, ${ref.sizeBytes} bytes) → ${path}${marker}`)
+        const line = `- ${ref.filename} (${ref.mimeType}, ${ref.sizeBytes} bytes) → ${path}`
+        contextLines.push(isSource ? `${line} [attached to the source message]` : line)
+        if (isSource) sourceLines.push(line)
       } catch (error) {
         console.warn(`Failed to download sealed Threa attachment ${ref.attachmentId}: ${String(error)}`)
       }
     }
   }
-  return lines
+  return { contextLines, sourceLines }
 }
 
 async function downloadContextAttachments(
@@ -1881,10 +1883,10 @@ async function hydrateSealedClaim(
     )
     const contextBlocks = [
       historyLines.length > 0 ? ["Recent Threa stream context (oldest first):", ...historyLines].join("\n") : "",
-      attachmentLines.length > 0
+      attachmentLines.contextLines.length > 0
         ? [
             "Attachments saved into this session's working directory — read them from these paths:",
-            ...attachmentLines,
+            ...attachmentLines.contextLines,
           ].join("\n")
         : "",
     ].filter(Boolean)
@@ -1895,10 +1897,10 @@ async function hydrateSealedClaim(
       sealing: opened.sealing,
       sealedContextText: contextBlocks.join("\n\n"),
       sealedSteerContextText:
-        attachmentLines.length > 0
+        attachmentLines.sourceLines.length > 0
           ? [
               "Attachments saved into this session's working directory — read them from these paths:",
-              ...attachmentLines,
+              ...attachmentLines.sourceLines,
             ].join("\n")
           : "",
     }
@@ -1966,9 +1968,15 @@ function parseSessionControlCommand(promptMarkdown: string): { name: string; arg
 function resolveSessionControlCommand(invocation: ClaimedInvocation): RuntimeCommandMetadata | null {
   const runtimeCommand = getRuntimeCommand(invocation)
   if (runtimeCommand) return runtimeCommand
-  if (invocation.requiredCapability !== SESSION_CONTROL_CAPABILITY) return null
   const parsed = parseSessionControlCommand(invocation.promptMarkdown)
   if (!parsed) return null
+  if (invocation.requiredCapability !== SESSION_CONTROL_CAPABILITY) {
+    // Legacy/API clients can still post bare session commands as normal
+    // scratchpad messages. Preserve that fallback for every command except
+    // steer: embedded steer deliberately creates a normal `/steer …` message
+    // plus a separate structured session-control invocation.
+    if (invocation.requiredCapability !== "active-scratchpad" || parsed.name === "steer") return null
+  }
   return {
     id: invocation.sourceMessageId,
     name: parsed.name,

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -887,6 +887,38 @@ describe("steer into the running turn (native steer support)", () => {
     ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
   })
 
+  test("an empty composite steer closes silently when its message is already running", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_message", sourceMessageId: "msg_composite" }))
+    ;(client as unknown as { claim: () => Promise<null> }).claim = async () => null
+    const composite = makeSteerInvocation("")
+    composite.sourceMessageId = "msg_composite"
+    composite.metadata = { ...composite.metadata, steeredMessage: true }
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(composite)
+
+    expect(steered).toEqual([])
+    const close = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(close?.body.noResponse).toBe(true)
+    expect(close?.body.finalMessageMarkdown).toBeUndefined()
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_message")
+  })
+
   test("empty steer still closes a swept foldless control command instead of stranding its claim", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -881,6 +881,17 @@ export class RemoteSession {
       // The sweep can still have claimed foldless invocations (a queued control
       // command in the double-command race) — close them or they hang to TTL.
       await Promise.all(swept.map((item) => this.completeNoResponse(item)))
+      if (invocation.metadata?.steeredMessage === true) {
+        // An embedded-steer pair carries its text on the normal message. If
+        // that companion is already running (or an interceptor consumed it),
+        // the empty control half is only a barrier — do not post a false
+        // "nothing to steer" acknowledgement.
+        await this.completeTurn(invocation, {
+          noResponse: true,
+          metadata: { "remote.invocationId": invocation.id, "remote.sessionControl": "true", "remote.steered": "true" },
+        })
+        return
+      }
       // A sweep that only consumed intercepted replies did real work (a verdict
       // reached its pending prompt) — "nothing to steer with" would misread as
       // the reply having been lost.

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -406,6 +406,8 @@ export interface CreateMessageInputJson {
   attachmentIds?: string[]
   /** Client-generated idempotency key to prevent duplicate sends on retry */
   clientMessageId?: string
+  /** Persist this message first, then dispatch `/steer` in the same transaction. */
+  steer?: true
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
   /** Declare the message's conversation (see {@link ConversationDirective}); omit to let the extractor infer. */
@@ -445,6 +447,8 @@ export interface CreateMessageInputMarkdown {
   attachmentIds?: string[]
   /** Client-generated idempotency key to prevent duplicate sends on retry */
   clientMessageId?: string
+  /** Persist this message first, then dispatch `/steer` in the same transaction. */
+  steer?: true
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
 }
@@ -482,6 +486,8 @@ export interface CreateMessageInputE2e {
   attachmentIds?: string[]
   /** Client-generated idempotency key to prevent duplicate sends on retry */
   clientMessageId?: string
+  /** Persist this message first, then dispatch `/steer` in the same transaction. */
+  steer?: true
 }
 
 /**

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1103,6 +1103,10 @@ export const ShareErrorCodes = {
   E2E_SHARING_NOT_ALLOWED: "SHARE_E2E_NOT_ALLOWED",
 } as const
 
+export const MessageErrorCodes = {
+  STEER_UNAVAILABLE: "STEER_UNAVAILABLE",
+} as const
+
 // Inter-service authentication header (control-plane ↔ regional backend ↔ workspace-router)
 export const INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key"
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -247,6 +247,7 @@ export {
   type ShareFlavor,
   ShareFlavors,
   ShareErrorCodes,
+  MessageErrorCodes,
   // Inter-service authentication
   INTERNAL_API_KEY_HEADER,
   ENCLAVE_CALLBACK_TOKEN_HEADER,


### PR DESCRIPTION
## Problem

Remote scratchpad messages containing `/steer` were routed as command-only sends, so surrounding prose and attachments could be dropped. A trailing newline could also leave a purple command token without dispatching it. Pi then injected claimed follow-ups with the full remote-invocation wrapper instead of a normal steering message.

## Solution

Treat embedded `/steer` as a normal message plus an atomic steer command.

- `extractSteerDirective` detects structural or raw `/steer` tokens at any position, across paragraphs and formatting marks, while preserving authored `contentJson`.
- One `PendingMessage` carries `steer: true`; plaintext and E2E queue drains send one request, including attachment ids.
- `SteeredMessageService` writes the message invocation, `command_dispatched` event, and targeted steer invocation inside the message transaction. Idempotent message retries skip the callback; same-timestamp claims put the message before session control.
- Permanently unavailable steer sends remain visible as failed messages and wait for manual Retry instead of replaying forever.
- Pi no longer double-parses the normal `/steer` message as session control, while legacy non-steer command fallback remains. Mid-turn steers receive concise message text plus source-message attachment paths.
- Claude Code channels preserve permission-verdict replies and close the empty control half of a composite steer without posting a false acknowledgement.

## Files

| Area | Change |
| ---- | ------ |
| `apps/frontend/src/lib/commands.ts`, `message-input.tsx` | Detect embedded steer, preserve the message, expose `/steer` inline |
| `apps/frontend/src/hooks/use-stream-or-draft.ts`, `use-message-queue.ts` | Persist and replay one steered-message queue item; park permanent rejection |
| `apps/backend/src/features/messaging/steered-message-service.ts` | Compose message + normal invocation + command event + steer invocation in one transaction; dedupe active-bot mentions |
| `apps/backend/src/features/bot-runtimes/repository.ts` | Deterministic message-before-command ordering for same-timestamp invocations |
| `extensions/pi-remote/src/threa-remote.ts` | Concise mid-turn formatting, source-only attachment paths, unambiguous command resolution |
| `extensions/remote-session/src/session.ts`, `extensions/claude-code-remote/src/channel-server.ts` | Preserve permission verdicts and silently close an empty composite control barrier |
| `packages/types/src/` | `steer?: true` request contract and shared `STEER_UNAVAILABLE` code |

## Test plan

- [x] Frontend focused suites — 103 tests
- [x] Backend focused suites — 72 tests
- [x] Pi remote plaintext + sealed suites — 103 tests
- [x] Remote-session suite — 119 tests
- [x] Claude Code remote suite — 102 tests
- [x] `bun run typecheck` plus extension typechecks — clean
- [x] Commit hooks — repository lint, migration checks, Dockerfile checks, OpenAPI check
- [x] Multi-model adversarial review — 15 findings fixed; final Fable sign-off clean; code-format exclusion disputed because `/steer` anywhere is explicit

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Allow `/steer` anywhere in a remote scratchpad message without sacrificing the message body, formatting, attachments, E2E payload, or deterministic runtime delivery.

## What Was Built

### Composer and durable queue

- Detect structural and raw steer tokens at prefix, suffix, middle, multiline, and formatting boundaries.
- Preserve the original message; use a cleartext `steer: true` request flag.
- Keep message and steer in one durable queue item for offline replay.
- Surface `/steer` in inline command autocomplete.

### Atomic backend composition

- Validate steer against the stream's live runtime command set on the caller-owned transaction.
- Persist the message first.
- Create the normal source-message invocation so claim hydration downloads plaintext or sealed attachments; use mention routing when needed to share the outbox idempotency key.
- Insert the command event and targeted steer invocation before commit.
- Skip composite writes on idempotent message retries.
- Keep bootstrap and claim ordering identical when transaction timestamps tie.

### Runtime delivery

- Treat active-scratchpad `/steer` text as message content unless structured command metadata says otherwise; preserve non-steer command fallback.
- Use concise text for Pi mid-turn steering and include only locally downloaded source attachment paths, including sealed attachments.
- Retain the existing full wrapper for idle Pi turns that start a new remote response.
- Preserve Claude Code permission verdict interception for prefix, middle, and suffix `/steer` placement.
- Mark the empty control half as a composite barrier so remote-session closes it without a misleading acknowledgement after the message is already running or intercepted.

## Design Decisions

- **One message request over two frontend queues:** independent message and command queues cannot guarantee server transaction or ordering.
- **Preserve `/steer` in authored content:** the message remains exactly what the user sent; the command is an additional action.
- **Normal invocation carries attachments:** command invocations have no source-message attachment context, especially on E2E streams.
- **Manual retry for stale runtime availability:** a 409 rolls back the transaction and leaves one visible failed message instead of silently posting without steering or retrying forever.

## Schema Changes

None. `PendingMessage.steer` and `terminalFailure` are optional, unindexed IndexedDB fields; the server request change is additive.

## What's NOT Included

- Searching attachment contents for `/steer`.
- Changing non-steer slash-command semantics.
- Installing the updated Pi extension into a local user configuration.

## Status

- [x] Frontend detection and queueing
- [x] Atomic backend transaction and idempotency
- [x] Plaintext/E2E attachment path preservation
- [x] Pi formatting correction
- [x] Focused tests, lint, and monorepo typecheck

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787157960&installation_model_id=20758&pr_number=1460&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1460&signature=735908dbb28e0ec5cec652cf0536cc4cfc346a302754b9f4b15cf06519920bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

