### PR TITLE
feat(cli): richer text output, memos/attachments list, download, skill print

### DIFF
--- a/.agents/skills/threa-cli/SKILL.md
+++ b/.agents/skills/threa-cli/SKILL.md
@@ -43,7 +43,7 @@ Two things you cannot do this way, by design of the API: an `@user-slug` will no
 
 ## Payloads name their authors
 
-Read results already carry author identity, so you seldom need a second call to name who said what. Message rows carry `author: { id, type, name, slug? }` (a bot or persona author has no slug and its name comes from `authorDisplayName`). Conversations carry a `participants` array parallel to `participantIds` with each participant's name and slug. Stream members carry name and slug. Use these fields directly instead of listing users per id.
+Read results already carry author identity, so you seldom need a second call to name who said what. Message rows carry `author: { id, type, name, slug? }` (a bot or persona author has no slug and its name comes from `authorDisplayName`). Conversations carry a `participants` array parallel to `participantIds` with each participant's name and slug. Stream members carry name and slug. Message search results, attachment rows, and conversations also carry `stream: { id, name?, type? }` — and `rootStream` when the stream is a thread — so you can name the scope without a `streams read`. Use these fields directly instead of listing users or streams per id.
 
 ## Search memory before asking a human
 
@@ -86,7 +86,8 @@ One `search` command covers all three kinds; pick with `--what`, and pass only t
 
 - **`--what messages`**, default full-text: you know the words that appear in the message. Add `--semantic` when you know the idea but not the wording, or `--exact` to match the query as a literal phrase. Query required.
 - **`--what memos`**: search workspace memory (see the memory section). Query optional and semantic; an empty query browses recent memos.
-- **`--what attachments`**: search files by filename or extracted content, then `threa attachments get <id>` (tool `get_attachment`) for the full extracted text, or `threa attachments get <id> --url` (tool `get_attachment_download_url`) only when you need the raw bytes. Query required.
+- **`--what attachments`**: search files by filename or extracted content, then `threa attachments get <id>` (tool `get_attachment`) for the full extracted text, or `threa attachments get <id> --url` (tool `get_attachment_download_url`) only when you need the raw bytes' URL. Query optional; omit it to browse the most recent attachments. `threa attachments download <id> [dest]` fetches the bytes to disk — a directory dest names the file after the attachment (`name (1).ext` on conflict), a file dest is written as given.
+- **Recent-first browsing**: `threa memos list` and `threa attachments list` (both take repeatable `--stream` and `--limit`) are shorthand for a query-less search — use them for "what's new here" instead of inventing a query.
 - **`messages find-by-metadata`**: you want messages by a reference you stamped at send time, not by text. It is exact key/value AND-containment, the right tool for dedup and external-id lookup.
 
 ## Paging

--- a/apps/backend/src/features/attachments/repository.ts
+++ b/apps/backend/src/features/attachments/repository.ts
@@ -445,7 +445,8 @@ export const AttachmentRepository = {
     opts: {
       workspaceId: string
       streamIds: string[]
-      query: string
+      /** Omitted = recent-first browse (no text filter). */
+      query?: string
       contentTypes?: ExtractionContentType[]
       safetyStatuses?: AttachmentSafetyStatus[]
       limit?: number
@@ -455,7 +456,8 @@ export const AttachmentRepository = {
 
     if (streamIds.length === 0) return []
 
-    const searchPattern = `%${query}%`
+    const hasQuery = query !== undefined
+    const searchPattern = `%${query ?? ""}%`
     const hasSafetyStatusFilter = Boolean(safetyStatuses?.length)
 
     // Use separate queries to avoid nested sql template issues
@@ -476,7 +478,8 @@ export const AttachmentRepository = {
           AND a.stream_id = ANY(${streamIds})
           AND (${!hasSafetyStatusFilter} OR a.safety_status = ANY(${safetyStatuses ?? []}))
           AND (
-            a.filename ILIKE ${searchPattern}
+            ${!hasQuery}
+            OR a.filename ILIKE ${searchPattern}
             OR e.summary ILIKE ${searchPattern}
             OR e.full_text ILIKE ${searchPattern}
           )
@@ -503,7 +506,8 @@ export const AttachmentRepository = {
         AND a.stream_id = ANY(${streamIds})
         AND (${!hasSafetyStatusFilter} OR a.safety_status = ANY(${safetyStatuses ?? []}))
         AND (
-          a.filename ILIKE ${searchPattern}
+          ${!hasQuery}
+          OR a.filename ILIKE ${searchPattern}
           OR e.summary ILIKE ${searchPattern}
           OR e.full_text ILIKE ${searchPattern}
         )

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -803,7 +803,8 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     path: "/api/v1/workspaces/{workspaceId}/attachments/search",
     operationId: "searchAttachments",
     summary: "Search attachments",
-    description: "Search accessible attachments by filename or extracted content.",
+    description:
+      "Search accessible attachments by filename or extracted content. Omit query to browse the most recent attachments.",
     tags: ["Attachments"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_READ],
     parameters: [workspaceIdParam],

--- a/apps/backend/src/features/public-api/schemas.test.ts
+++ b/apps/backend/src/features/public-api/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { createRuntimeSessionSchema, upsertPresenceSchema } from "./schemas"
+import { createRuntimeSessionSchema, searchAttachmentsSchema, upsertPresenceSchema } from "./schemas"
 
 const BASE = {
   runtimeKind: "pi-local" as const,
@@ -94,5 +94,17 @@ describe("createRuntimeSessionSchema runtimeKind", () => {
     expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "pi-local", labelName: "   " }).success).toBe(
       false
     )
+  })
+})
+
+describe("searchAttachmentsSchema query", () => {
+  it("allows omitting query for a recent-first browse", () => {
+    const parsed = searchAttachmentsSchema.parse({})
+    expect(parsed.query).toBeUndefined()
+    expect(parsed.limit).toBe(20)
+  })
+
+  it("rejects an empty-string query", () => {
+    expect(searchAttachmentsSchema.safeParse({ query: "" }).success).toBe(false)
   })
 })

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -56,7 +56,7 @@ export const searchMemosSchema = z.object({
 })
 
 export const searchAttachmentsSchema = z.object({
-  query: z.string().min(1, "query is required"),
+  query: z.string().min(1).optional(),
   streams: z.array(z.string()).optional(),
   contentTypes: z.array(z.enum(EXTRACTION_CONTENT_TYPES)).optional(),
   limit: z.coerce.number().int().min(1).max(PUBLIC_ATTACHMENT_SEARCH_MAX_LIMIT).optional().default(20),

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -634,7 +634,7 @@
         "operationId": "searchAttachments",
         "summary": "Search attachments",
         "tags": ["Attachments"],
-        "description": "Search accessible attachments by filename or extracted content.",
+        "description": "Search accessible attachments by filename or extracted content. Omit query to browse the most recent attachments.",
         "security": [{ "apiKey": ["attachments:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -665,7 +665,7 @@
                   },
                   "limit": { "default": 20, "type": "integer", "minimum": 1, "maximum": 50 }
                 },
-                "required": ["query", "limit"],
+                "required": ["limit"],
                 "additionalProperties": false
               }
             }

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -634,7 +634,7 @@
         "operationId": "searchAttachments",
         "summary": "Search attachments",
         "tags": ["Attachments"],
-        "description": "Search accessible attachments by filename or extracted content.",
+        "description": "Search accessible attachments by filename or extracted content. Omit query to browse the most recent attachments.",
         "security": [{ "apiKey": ["attachments:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -665,7 +665,7 @@
                   },
                   "limit": { "default": 20, "type": "integer", "minimum": 1, "maximum": 50 }
                 },
-                "required": ["query", "limit"],
+                "required": ["limit"],
                 "additionalProperties": false
               }
             }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,8 +72,12 @@ threa search invoice --what attachments             # search attachments by name
 threa conversations list --stream #eng --status active
 threa conversations read conv_123 --limit 50
 threa messages find-by-metadata github.pr=org/repo#42 --stream #eng
+threa memos list --stream #eng                      # browse recent memos, newest first
 threa memos get memo_123
+threa attachments list --stream #eng                # browse recent attachments, newest first
 threa attachments get att_123 --url                 # --url returns a short-lived signed download URL
+threa attachments download att_123 ./               # download bytes; dir dest names it after the file
+threa skill print                                   # print the threa-cli agent skill to stdout
 
 # writes
 threa messages send #eng "Deploy is green"          # post markdown (content `-` reads stdin)
@@ -109,7 +113,7 @@ Claim tokens are persisted to `~/.threa/state.json` (mode 0600), keyed by worksp
 
 ### Agent skill
 
-`threa skill install` copies the `threa-cli` skill into `~/.claude/skills/threa-cli/`, so Claude Code sessions in any project on this machine load it on demand. The skill teaches ref forms, the JSON output and exit-code contract, search selection, and the delegation loop. Re-run after pulling a newer checkout. The in-repo copy at `.agents/skills/threa-cli/SKILL.md` is the source of truth.
+`threa skill install` copies the `threa-cli` skill into `~/.claude/skills/threa-cli/`, so Claude Code sessions in any project on this machine load it on demand. The skill teaches ref forms, the JSON output and exit-code contract, search selection, and the delegation loop. Re-run after pulling a newer checkout. The in-repo copy at `.agents/skills/threa-cli/SKILL.md` is the source of truth. `threa skill print` writes the same markdown to stdout for any other destination.
 
 ### The two Threa MCP servers (do not confuse the sends)
 
@@ -166,8 +170,8 @@ The scopes on the key decide which areas work. A key without a scope does not ge
 | `messages:read`     | `streams read` (messages leg), `conversations read`, `conversations list`, `messages find-by-metadata` |
 | `messages:search`   | `search --what messages`                                                                               |
 | `messages:write`    | `messages send`, `messages edit`, `messages delete`                                                    |
-| `memos:read`        | `search --what memos`, `memos get`                                                                     |
-| `attachments:read`  | `search --what attachments`, `attachments get`                                                         |
+| `memos:read`        | `search --what memos`, `memos list`, `memos get`                                                       |
+| `attachments:read`  | `search --what attachments`, `attachments list`, `attachments get`, `attachments download`             |
 | `labels:read`       | `labels list`                                                                                          |
 | `labels:write`      | `labels add`, `labels remove`                                                                          |
 | `delegations:read`  | `delegations list`                                                                                     |

--- a/packages/cli/src/commands/attachments.ts
+++ b/packages/cli/src/commands/attachments.ts
@@ -1,5 +1,37 @@
-import { getAttachment, getAttachmentDownloadUrl } from "../ops"
-import { boolFlag, UsageError, type NounSpec, type VerbSpec } from "../output"
+import { existsSync, statSync } from "node:fs"
+import { basename, extname, join } from "node:path"
+import { getAttachment, getAttachmentDownloadUrl, search } from "../ops"
+import { arrayFlag, boolFlag, intFlag, UsageError, type NounSpec, type VerbSpec } from "../output"
+import { renderSearchResult } from "./search"
+
+const listVerb: VerbSpec = {
+  name: "list",
+  summary: "List the most recent attachments, optionally scoped to streams",
+  usage: "threa attachments list [--stream ref]... [--limit n]",
+  help:
+    "threa attachments list [flags]\n\n" +
+    "Browse accessible attachments, newest first (a query-less attachment search). Filter by content with " +
+    "`threa search --what attachments`.\n\n" +
+    "Flags:\n" +
+    "  --stream ref   limit to a source stream (stream_ id or #slug); repeatable\n" +
+    "  --limit n      max results, <= 50 (default 20)\n" +
+    "  --json         force JSON output\n" +
+    "  --help         show this help",
+  options: {
+    stream: { type: "string", multiple: true },
+    limit: { type: "string" },
+  },
+  run: (ctx, _positionals, values) =>
+    search(ctx.client, ctx.resolver, {
+      what: "attachments",
+      stream_ids: arrayFlag(values, "stream"),
+      limit: intFlag(values, "limit"),
+    }),
+  render: (payload) => {
+    const rows = (payload as { data?: Array<Record<string, unknown>> }).data ?? []
+    return rows.map(renderSearchResult).join("\n") || "(no attachments)"
+  },
+}
 
 const getVerb: VerbSpec = {
   name: "get",
@@ -23,8 +55,59 @@ const getVerb: VerbSpec = {
   },
 }
 
+/**
+ * Directory destinations name the file after the attachment and never clobber:
+ * an existing `report.pdf` yields `report (1).pdf`, Chrome-style. An explicit
+ * file destination is taken literally and overwritten.
+ */
+export function resolveDownloadTarget(destination: string, filename: string): string {
+  const isDir = destination.endsWith("/") || (existsSync(destination) && statSync(destination).isDirectory())
+  if (!isDir) return destination
+  const ext = extname(filename)
+  const stem = basename(filename, ext)
+  let candidate = join(destination, filename)
+  for (let n = 1; existsSync(candidate); n++) {
+    candidate = join(destination, `${stem} (${n})${ext}`)
+  }
+  return candidate
+}
+
+const downloadVerb: VerbSpec = {
+  name: "download",
+  summary: "Download an attachment's raw bytes to a local file",
+  usage: "threa attachments download <id> [destination]",
+  help:
+    "threa attachments download <id> [destination] [flags]\n\n" +
+    "Download the attachment's raw bytes via its signed URL. destination defaults to the current directory. " +
+    "A directory destination names the file after the attachment and picks `name (1).ext` on conflict; an " +
+    "explicit file path is written as given (overwriting).\n\n" +
+    "Flags:\n" +
+    "  --json    force JSON output\n" +
+    "  --help    show this help",
+  options: {},
+  run: async (ctx, positionals) => {
+    const id = positionals[0]
+    if (!id) throw new UsageError("attachments download requires a <id> (an att_ id)")
+    const [meta, urlResp] = await Promise.all([
+      getAttachment(ctx.client, id) as Promise<{ data?: { filename?: string } }>,
+      getAttachmentDownloadUrl(ctx.client, id) as Promise<{ data?: { url?: string } }>,
+    ])
+    const url = urlResp.data?.url
+    if (!url) throw new Error(`no download URL returned for ${id}`)
+    const target = resolveDownloadTarget(positionals[1] ?? ".", meta.data?.filename ?? id)
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`download failed: HTTP ${response.status}`)
+    const bytes = await Bun.write(target, response)
+    return { downloaded: true, id, path: target, sizeBytes: bytes }
+  },
+  render: (payload) => {
+    const p = payload as { id?: string; path?: string; sizeBytes?: number }
+    return `downloaded ${p.id ?? "?"} → ${p.path ?? "?"} (${p.sizeBytes ?? 0} bytes)`
+  },
+}
+
 export const attachmentsNoun: NounSpec = {
   name: "attachments",
-  summary: "Get an attachment's text or a signed download URL",
-  verbs: [getVerb],
+  summary: "List attachments, get one's text or URL, or download its bytes",
+  verbs: [listVerb, getVerb, downloadVerb],
 }

--- a/packages/cli/src/commands/conversations.ts
+++ b/packages/cli/src/commands/conversations.ts
@@ -1,9 +1,11 @@
 import { listConversations, readConversation } from "../ops"
 import {
-  cursorFooter,
   enumFlag,
+  fmtTimestamp,
   intFlag,
   renderList,
+  snippet,
+  streamLabel,
   stringFlag,
   UsageError,
   type NounSpec,
@@ -41,11 +43,36 @@ const listVerb: VerbSpec = {
       limit: intFlag(values, "limit"),
     }),
   render: (payload) =>
-    renderList<{ id?: string; status?: string; title?: string; summary?: string }>(
-      payload,
-      (c) => `${c.id ?? "?"}  ${c.status ?? "?"}  ${c.title ?? c.summary ?? ""}`.trimEnd(),
-      { empty: "(no conversations)", cursorFlag: "cursor" }
-    ),
+    renderList<ConversationRow>(payload, renderConversationRow, {
+      empty: "(no conversations)",
+      cursorFlag: "cursor",
+    }),
+}
+
+interface ConversationRow {
+  id?: string
+  status?: string
+  topicSummary?: string | null
+  summary?: string | null
+  messageCount?: number
+  lastActivityAt?: string
+  stream?: { id?: string; name?: string }
+  rootStream?: { id?: string; name?: string }
+  streamId?: string
+}
+
+function renderConversationRow(c: ConversationRow): string {
+  const header = [
+    c.id ?? "?",
+    c.status ?? "?",
+    c.messageCount !== undefined ? `${c.messageCount} msgs` : undefined,
+    fmtTimestamp(c.lastActivityAt) || undefined,
+    streamLabel(c) || undefined,
+  ]
+    .filter(Boolean)
+    .join("  ")
+  const topic = snippet(c.topicSummary ?? c.summary ?? "")
+  return topic ? `${header}\n  ${topic}` : header
 }
 
 const readVerb: VerbSpec = {
@@ -75,22 +102,40 @@ const readVerb: VerbSpec = {
   },
   render: (payload) => {
     const p = payload as {
-      conversation?: { id?: string; status?: string; title?: string }
+      conversation?: ConversationRow & { createdAt?: string }
       messages?: {
-        data?: Array<{ author?: { name?: string }; contentMarkdown?: string; content?: string }>
+        data?: Array<{
+          author?: { name?: string }
+          authorDisplayName?: string
+          contentMarkdown?: string
+          content?: string
+          createdAt?: string
+        }>
         hasMore?: boolean
       }
     }
     const lines: string[] = []
-    if (p.conversation)
+    const c = p.conversation
+    if (c) {
       lines.push(
-        `conversation: ${p.conversation.id ?? "?"}  ${p.conversation.status ?? ""}  ${p.conversation.title ?? ""}`.trimEnd()
+        [c.id ?? "?", c.status ?? "?", streamLabel(c) || undefined].filter(Boolean).join("  "),
+        [
+          fmtTimestamp(c.createdAt) && `created ${fmtTimestamp(c.createdAt)}`,
+          fmtTimestamp(c.lastActivityAt) && `last activity ${fmtTimestamp(c.lastActivityAt)}`,
+          c.messageCount !== undefined && `${c.messageCount} messages`,
+        ]
+          .filter(Boolean)
+          .join(" · ")
       )
+      const topic = snippet(c.topicSummary ?? c.summary ?? "")
+      if (topic) lines.push(`topic: ${topic}`)
+    }
     const msgs = p.messages?.data ?? []
     lines.push(`messages: ${msgs.length}${p.messages?.hasMore ? " (more)" : ""}`)
     for (const m of msgs) {
-      const body = (m.contentMarkdown ?? m.content ?? "").replace(/\s+/g, " ").trim()
-      lines.push(`  ${m.author?.name ?? "?"}: ${body.slice(0, 120)}`)
+      const who = m.author?.name ?? m.authorDisplayName ?? "?"
+      const ts = fmtTimestamp(m.createdAt)
+      lines.push(`  ${ts ? `[${ts}] ` : ""}${who}: ${snippet(m.contentMarkdown ?? m.content ?? "", 120)}`)
     }
     return lines.join("\n")
   },

--- a/packages/cli/src/commands/memos.ts
+++ b/packages/cli/src/commands/memos.ts
@@ -1,5 +1,35 @@
-import { getMemo } from "../ops"
-import { UsageError, type NounSpec, type VerbSpec } from "../output"
+import { getMemo, search } from "../ops"
+import { arrayFlag, intFlag, UsageError, type NounSpec, type VerbSpec } from "../output"
+import { renderSearchResult } from "./search"
+
+const listVerb: VerbSpec = {
+  name: "list",
+  summary: "List the most recent memos, optionally scoped to streams",
+  usage: "threa memos list [--stream ref]... [--limit n]",
+  help:
+    "threa memos list [flags]\n\n" +
+    "Browse preserved workspace memos, newest first (a query-less memo search). Filter further with " +
+    "`threa search --what memos`.\n\n" +
+    "Flags:\n" +
+    "  --stream ref   limit to a source stream (stream_ id or #slug); repeatable\n" +
+    "  --limit n      max results, <= 100 (default 20)\n" +
+    "  --json         force JSON output\n" +
+    "  --help         show this help",
+  options: {
+    stream: { type: "string", multiple: true },
+    limit: { type: "string" },
+  },
+  run: (ctx, _positionals, values) =>
+    search(ctx.client, ctx.resolver, {
+      what: "memos",
+      stream_ids: arrayFlag(values, "stream"),
+      limit: intFlag(values, "limit"),
+    }),
+  render: (payload) => {
+    const rows = (payload as { data?: Array<Record<string, unknown>> }).data ?? []
+    return rows.map(renderSearchResult).join("\n") || "(no memos)"
+  },
+}
 
 const getVerb: VerbSpec = {
   name: "get",
@@ -8,7 +38,7 @@ const getVerb: VerbSpec = {
   help:
     "threa memos get <id>\n\n" +
     "Retrieve one memo by id, with its source stream and the source messages it was extracted from " +
-    "(provenance). Find memos in the first place with `threa search --what memos`.\n\n" +
+    "(provenance). Find memos in the first place with `threa memos list` or `threa search --what memos`.\n\n" +
     "Flags:\n" +
     "  --json    force JSON output\n" +
     "  --help    show this help",
@@ -22,6 +52,6 @@ const getVerb: VerbSpec = {
 
 export const memosNoun: NounSpec = {
   name: "memos",
-  summary: "Get a memo by id",
-  verbs: [getVerb],
+  summary: "List memos and get one by id",
+  verbs: [listVerb, getVerb],
 }

--- a/packages/cli/src/commands/renders.test.ts
+++ b/packages/cli/src/commands/renders.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, expect, spyOn, test } from "bun:test"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { run } from "../cli"
+import { fetchByPath, jsonResponse, TEST_CONFIG } from "../test-support"
+import { resolveDownloadTarget } from "./attachments"
+
+const fetchSpy = spyOn(globalThis, "fetch")
+
+afterEach(() => {
+  fetchSpy.mockReset()
+})
+
+const TS_RE = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}/
+
+const USERS = { data: [{ id: "usr_k", name: "Kris", slug: "kris", email: "k@x.io", role: "admin" }] }
+const STREAMS: Record<string, unknown> = {
+  stream_root: { id: "stream_root", type: "channel", displayName: "engineering" },
+  stream_thread: { id: "stream_thread", type: "thread", displayName: "deploy plan", rootStreamId: "stream_root" },
+}
+
+function workspaceFetch(overrides: (path: string) => Response | undefined): typeof fetch {
+  return fetchByPath((path) => {
+    const custom = overrides(path)
+    if (custom) return custom
+    if (path.endsWith("/users")) return jsonResponse(200, USERS)
+    const streamId = path.split("/").pop()!
+    if (path.includes("/streams/") && STREAMS[streamId]) return jsonResponse(200, { data: STREAMS[streamId] })
+    return jsonResponse(404, { error: "unexpected", code: "NOT_FOUND" })
+  })
+}
+
+test("search --what messages renders timestamp, stream scope, author, and a content snippet", async () => {
+  fetchSpy.mockImplementation(
+    workspaceFetch((path) =>
+      path.endsWith("/messages/search")
+        ? jsonResponse(200, {
+            data: [
+              {
+                id: "msg_1",
+                streamId: "stream_thread",
+                authorId: "usr_k",
+                authorType: "user",
+                content: "WebSocket   error\nacross lines",
+                createdAt: "2026-07-19T12:02:00.000Z",
+                rank: 0.9,
+              },
+            ],
+          })
+        : undefined
+    )
+  )
+
+  const result = await run(["search", "ws error", "--what", "messages"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  const [header, body] = result.stdout.split("\n")
+  expect(header).toContain("msg_1")
+  expect(header).toMatch(TS_RE)
+  expect(header).toContain("engineering › deploy plan")
+  expect(header).toContain("Kris")
+  expect(body).toBe("  WebSocket error across lines")
+})
+
+test("conversations list renders status, message count, activity time, and stream scope", async () => {
+  fetchSpy.mockImplementation(
+    workspaceFetch((path) =>
+      path.endsWith("/conversations")
+        ? jsonResponse(200, {
+            data: [
+              {
+                id: "conv_1",
+                streamId: "stream_thread",
+                rootStreamId: "stream_root",
+                status: "active",
+                messageCount: 12,
+                topicSummary: "Deploy ordering",
+                lastActivityAt: "2026-07-19T12:02:00.000Z",
+                participantIds: [],
+              },
+            ],
+            hasMore: false,
+            cursor: null,
+          })
+        : undefined
+    )
+  )
+
+  const result = await run(["conversations", "list"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  const [header, body] = result.stdout.split("\n")
+  expect(header).toContain("conv_1")
+  expect(header).toContain("active")
+  expect(header).toContain("12 msgs")
+  expect(header).toMatch(TS_RE)
+  expect(header).toContain("engineering › deploy plan")
+  expect(body).toBe("  Deploy ordering")
+})
+
+test("memos list browses via a query-less memo search and renders scope + title", async () => {
+  fetchSpy.mockImplementation(
+    workspaceFetch((path) =>
+      path.endsWith("/memos/search")
+        ? jsonResponse(200, {
+            data: [
+              {
+                memo: {
+                  id: "memo_1",
+                  title: "Deploy order",
+                  abstract: "Regions before control plane.",
+                  knowledgeType: "procedure",
+                  createdAt: "2026-07-19T12:02:00.000Z",
+                },
+                distance: 0,
+                sourceStream: { id: "stream_thread", type: "thread", name: "deploy plan" },
+                rootStream: { id: "stream_root", type: "channel", name: "engineering" },
+              },
+            ],
+          })
+        : undefined
+    )
+  )
+
+  const result = await run(["memos", "list", "--limit", "5"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  const searchCall = fetchSpy.mock.calls.find((c) => String(c[0]).endsWith("/memos/search"))!
+  const body = JSON.parse(String((searchCall[1] as RequestInit).body)) as Record<string, unknown>
+  expect(body.query).toBeUndefined()
+  expect(body.limit).toBe(5)
+  const [header, abstract] = result.stdout.split("\n")
+  expect(header).toContain("memo_1")
+  expect(header).toContain("procedure")
+  expect(header).toContain("engineering › deploy plan")
+  expect(abstract).toBe("  Deploy order — Regions before control plane.")
+})
+
+test("attachments list browses query-less and renders filename, mime, and stream", async () => {
+  fetchSpy.mockImplementation(
+    workspaceFetch((path) =>
+      path.endsWith("/attachments/search")
+        ? jsonResponse(200, {
+            data: [
+              {
+                id: "att_1",
+                filename: "report.pdf",
+                mimeType: "application/pdf",
+                contentType: "document",
+                summary: "Q2 numbers",
+                streamId: "stream_root",
+                createdAt: "2026-07-19T12:02:00.000Z",
+              },
+            ],
+          })
+        : undefined
+    )
+  )
+
+  const result = await run(["attachments", "list", "--stream", "stream_root"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  const searchCall = fetchSpy.mock.calls.find((c) => String(c[0]).endsWith("/attachments/search"))!
+  const body = JSON.parse(String((searchCall[1] as RequestInit).body)) as Record<string, unknown>
+  expect(body.query).toBeUndefined()
+  expect(body.streams).toEqual(["stream_root"])
+  const [header, summary] = result.stdout.split("\n")
+  expect(header).toContain("att_1")
+  expect(header).toContain("report.pdf")
+  expect(header).toContain("application/pdf")
+  expect(header).toContain("engineering")
+  expect(summary).toBe("  Q2 numbers")
+})
+
+test("attachments download writes the signed-URL bytes under the attachment's filename", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "threa-dl-"))
+  fetchSpy.mockImplementation(
+    fetchByPath((path) => {
+      if (path.endsWith("/attachments/att_1"))
+        return jsonResponse(200, { data: { id: "att_1", filename: "notes.txt" } })
+      if (path.endsWith("/attachments/att_1/url"))
+        return jsonResponse(200, { data: { url: "https://files.example/signed/notes.txt", expiresIn: 900 } })
+      if (path.startsWith("/signed/")) return new Response("hello bytes")
+      return jsonResponse(404, { error: "unexpected", code: "NOT_FOUND" })
+    })
+  )
+
+  const result = await run(["attachments", "download", "att_1", dir], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain(`downloaded att_1 → ${join(dir, "notes.txt")}`)
+  expect(await Bun.file(join(dir, "notes.txt")).text()).toBe("hello bytes")
+})
+
+test("resolveDownloadTarget picks Chrome-style ` (n)` names on conflict, but honors explicit file paths", () => {
+  const dir = mkdtempSync(join(tmpdir(), "threa-dl-conflict-"))
+  writeFileSync(join(dir, "report.pdf"), "existing")
+  writeFileSync(join(dir, "report (1).pdf"), "existing too")
+
+  expect(resolveDownloadTarget(dir, "report.pdf")).toBe(join(dir, "report (2).pdf"))
+  expect(resolveDownloadTarget(join(dir, "report.pdf"), "ignored.pdf")).toBe(join(dir, "report.pdf"))
+  expect(resolveDownloadTarget(join(dir, "fresh.pdf"), "ignored.pdf")).toBe(join(dir, "fresh.pdf"))
+})
+
+test("skill print writes the skill markdown to stdout", async () => {
+  const result = await run(["skill", "print"], { config: TEST_CONFIG })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain("threa")
+  expect(result.stdout.length).toBeGreaterThan(500)
+  expect(fetchSpy).not.toHaveBeenCalled()
+})

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,5 +1,14 @@
 import { search, SEARCH_WHATS, type SearchArgs, type SearchWhat } from "../ops"
-import { arrayFlag, intFlag, stringFlag, UsageError, type CommandSpec } from "../output"
+import {
+  arrayFlag,
+  fmtTimestamp,
+  intFlag,
+  snippet,
+  streamLabel,
+  stringFlag,
+  UsageError,
+  type CommandSpec,
+} from "../output"
 import { EXTRACTION_CONTENT_TYPES, KNOWLEDGE_TYPES, MEMO_SCOPES, MEMO_TYPES, STREAM_TYPES } from "../tools/constants"
 
 export const searchCommand: CommandSpec = {
@@ -9,8 +18,8 @@ export const searchCommand: CommandSpec = {
   help:
     "threa search [query] --what messages|memos|attachments [flags]\n\n" +
     "One search routed by --what. Only the filters valid for the chosen --what are accepted; passing another " +
-    "is an error naming the offending flag. query is required for messages and attachments; for memos it is " +
-    "optional (omit it to browse the most recent memos).\n\n" +
+    "is an error naming the offending flag. query is required for messages; for memos and attachments it is " +
+    "optional (omit it to browse the most recent, newest first).\n\n" +
     "Common flags:\n" +
     "  --what w         messages | memos | attachments (required)\n" +
     "  --stream ref     limit to a source stream (stream_ id or #slug); repeatable\n" +
@@ -84,11 +93,56 @@ export const searchCommand: CommandSpec = {
     const p = payload as { data?: Array<Record<string, unknown>> }
     const rows = p.data ?? []
     if (rows.length === 0) return "(no results)"
-    return rows
-      .map((r) => {
-        const id = r.id ?? (r.memo as { id?: string } | undefined)?.id ?? "?"
-        return String(id)
-      })
-      .join("\n")
+    return rows.map(renderSearchResult).join("\n")
   },
+}
+
+function joinFields(fields: Array<string | undefined>): string {
+  return fields.filter(Boolean).join("  ")
+}
+
+export function renderSearchResult(r: Record<string, unknown>): string {
+  if (r.memo && typeof r.memo === "object") return renderMemoResult(r)
+  if (typeof r.filename === "string") return renderAttachmentResult(r)
+  return renderMessageResult(r)
+}
+
+function renderMessageResult(r: Record<string, unknown>): string {
+  const author = r.author as { name?: string; slug?: string } | undefined
+  const who = author?.name ?? (typeof r.authorDisplayName === "string" ? r.authorDisplayName : undefined)
+  const header = joinFields([
+    String(r.id ?? "?"),
+    fmtTimestamp(r.createdAt),
+    streamLabel(r as Parameters<typeof streamLabel>[0]),
+    who,
+  ])
+  return `${header}\n  ${snippet(r.content)}`
+}
+
+function renderMemoResult(r: Record<string, unknown>): string {
+  const memo = r.memo as Record<string, unknown>
+  const source = (r.sourceStream ?? null) as { name?: string | null } | null
+  const root = (r.rootStream ?? null) as { name?: string | null } | null
+  const scope = [root?.name, source?.name].filter((n): n is string => Boolean(n))
+  const scopeLabel = scope[0] === scope[1] ? scope[0] : scope.join(" › ")
+  const header = joinFields([
+    String(memo.id ?? "?"),
+    typeof memo.knowledgeType === "string" ? memo.knowledgeType : undefined,
+    fmtTimestamp(memo.createdAt),
+    scopeLabel || undefined,
+  ])
+  const title = typeof memo.title === "string" ? memo.title : ""
+  return `${header}\n  ${snippet(`${title}${title && memo.abstract ? " — " : ""}${String(memo.abstract ?? "")}`)}`
+}
+
+function renderAttachmentResult(r: Record<string, unknown>): string {
+  const header = joinFields([
+    String(r.id ?? "?"),
+    String(r.filename ?? "?"),
+    typeof r.mimeType === "string" ? r.mimeType : undefined,
+    fmtTimestamp(r.createdAt),
+    streamLabel(r as Parameters<typeof streamLabel>[0]),
+  ])
+  const summary = snippet(r.summary)
+  return summary ? `${header}\n  ${summary}` : header
 }

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from "node:fs"
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { stringFlag, UsageError, type CommandSpec } from "../output"
@@ -10,27 +10,32 @@ const SKILL_SOURCE = resolve(import.meta.dir, "../../../..", ".agents/skills", S
 
 export const skillCommand: CommandSpec = {
   name: "skill",
-  usage: "threa skill install [--target dir]",
-  summary: "Install the threa-cli agent skill into ~/.claude/skills",
+  usage: "threa skill install [--target dir] | threa skill print",
+  summary: "Install the threa-cli agent skill into ~/.claude/skills, or print it",
   help:
-    "threa skill install [flags]\n\n" +
-    "Copies the threa-cli skill (how an agent uses this CLI well) into the global Claude Code\n" +
-    "skills directory so every session on this machine can load it, in any project.\n\n" +
+    "threa skill install [flags]\n" +
+    "threa skill print\n\n" +
+    "install copies the threa-cli skill (how an agent uses this CLI well) into the global Claude Code\n" +
+    "skills directory so every session on this machine can load it, in any project.\n" +
+    "print writes the skill markdown to stdout — pipe it wherever a skills directory is not the target.\n\n" +
     "Flags:\n" +
-    "  --target dir   destination skills directory (default ~/.claude/skills)\n" +
+    "  --target dir   install: destination skills directory (default ~/.claude/skills)\n" +
     "  --help         show this help",
   options: {
     target: { type: "string" },
   },
   run: async (_ctx, positionals, values) => {
     const sub = positionals[0]
-    if (sub !== "install") {
-      throw new UsageError(`skill supports one subcommand: install (got "${sub ?? ""}")`)
+    if (sub !== "install" && sub !== "print") {
+      throw new UsageError(`skill supports two subcommands: install, print (got "${sub ?? ""}")`)
     }
     if (!existsSync(SKILL_SOURCE)) {
       throw new UsageError(
         `Skill source not found at ${SKILL_SOURCE}. Run threa from a Threa repo checkout (the skill ships in .agents/skills/${SKILL_NAME}).`
       )
+    }
+    if (sub === "print") {
+      return { skill: SKILL_NAME, source: SKILL_SOURCE, content: readFileSync(SKILL_SOURCE, "utf8") }
     }
     const targetRoot = stringFlag(values, "target") ?? join(homedir(), ".claude", "skills")
     const destination = join(targetRoot, SKILL_NAME, "SKILL.md")
@@ -39,7 +44,8 @@ export const skillCommand: CommandSpec = {
     return { installed: true, skill: SKILL_NAME, source: SKILL_SOURCE, destination }
   },
   render: (payload) => {
-    const p = payload as { destination?: string }
+    const p = payload as { destination?: string; content?: string }
+    if (typeof p.content === "string") return p.content
     return `installed ${SKILL_NAME} → ${p.destination ?? "?"}\nRe-run after pulling a newer checkout to refresh it.`
   },
   noConfig: true,

--- a/packages/cli/src/enrich.test.ts
+++ b/packages/cli/src/enrich.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, spyOn, test } from "bun:test"
 import { ThreaApiClient } from "./api-client"
-import { enrichConversation, enrichMessages } from "./enrich"
+import { enrichConversation, enrichMessages, enrichStreamContext } from "./enrich"
 import { RefResolver } from "./resolver"
 import { TEST_CONFIG, fetchByPath, jsonResponse } from "./test-support"
 
@@ -81,6 +81,54 @@ test("enrichConversation mirrors participantIds into a participants array with n
     { id: "bot_x" },
   ])
   expect(enriched.participantIds).toEqual(["usr_p", "usr_k", "bot_x"])
+})
+
+const STREAMS: Record<string, unknown> = {
+  stream_root: { id: "stream_root", type: "channel", displayName: "engineering" },
+  stream_thread: { id: "stream_thread", type: "thread", displayName: "deploy plan", rootStreamId: "stream_root" },
+}
+
+function streamFetch(path: string) {
+  const id = path.split("/").pop()!
+  const stream = STREAMS[id]
+  return stream ? jsonResponse(200, { data: stream }) : jsonResponse(404, { error: "nope", code: "NOT_FOUND" })
+}
+
+test("enrichStreamContext attaches stream and rootStream refs for thread rows", async () => {
+  fetchSpy.mockImplementation(fetchByPath(streamFetch))
+  const resolver = makeResolver()
+
+  const rows = [
+    { id: "msg_1", streamId: "stream_thread" },
+    { id: "msg_2", streamId: "stream_root" },
+  ]
+  const enriched = (await enrichStreamContext(rows, resolver)) as Array<Record<string, unknown>>
+
+  expect(enriched[0]!.stream).toEqual({ id: "stream_thread", name: "deploy plan", type: "thread" })
+  expect(enriched[0]!.rootStream).toEqual({ id: "stream_root", name: "engineering", type: "channel" })
+  expect(enriched[1]!.stream).toEqual({ id: "stream_root", name: "engineering", type: "channel" })
+  expect(enriched[1]!.rootStream).toBeUndefined()
+  // Deduped: stream_thread + stream_root fetched once each.
+  expect(fetchSpy.mock.calls.length).toBe(2)
+})
+
+test("enrichStreamContext uses a row's own rootStreamId (conversations) and degrades to bare ids on fetch failure", async () => {
+  fetchSpy.mockImplementation(fetchByPath(() => jsonResponse(500, { error: "boom", code: "INTERNAL" })))
+  const resolver = makeResolver()
+
+  const rows = [{ id: "conv_1", streamId: "stream_thread", rootStreamId: "stream_root" }]
+  const enriched = (await enrichStreamContext(rows, resolver)) as Array<Record<string, unknown>>
+
+  expect(enriched[0]!.stream).toEqual({ id: "stream_thread" })
+  expect(enriched[0]!.rootStream).toEqual({ id: "stream_root" })
+})
+
+test("enrichStreamContext passes rows without streamId through untouched", async () => {
+  const resolver = makeResolver()
+  const rows = [{ id: "memo_1" }]
+
+  expect(await enrichStreamContext(rows, resolver)).toEqual(rows)
+  expect(fetchSpy).not.toHaveBeenCalled()
 })
 
 test("enrichConversation degrades to the raw conversation when the users fetch fails", async () => {

--- a/packages/cli/src/enrich.ts
+++ b/packages/cli/src/enrich.ts
@@ -1,4 +1,4 @@
-import type { RefResolver } from "./resolver"
+import type { RefResolver, ResolverStreamInfo } from "./resolver"
 
 type UsersById = Map<string, { name: string; slug: string }>
 
@@ -47,6 +47,60 @@ export async function enrichMessages(rows: unknown, resolver: RefResolver): Prom
   const usersById = await loadUsersById(resolver)
   if (!usersById) return rows
   return rows.map((row) => enrichOne(row, usersById))
+}
+
+export interface StreamRef {
+  id: string
+  name?: string
+  type?: string
+}
+
+function toStreamRef(info: ResolverStreamInfo | null, id: string): StreamRef {
+  const ref: StreamRef = { id }
+  if (info?.displayName ?? info?.slug) ref.name = info.displayName ?? info.slug
+  if (info?.type) ref.type = info.type
+  return ref
+}
+
+/**
+ * Additively attach `stream: {id, name?, type?}` (and `rootStream` when the row's
+ * stream is a thread) to rows carrying a `streamId`. Stream infos come from
+ * per-id GET /streams/{id}, deduped and cached in the resolver; a failed lookup
+ * degrades to a bare `{id}` ref. Rows without a streamId pass through untouched.
+ */
+export async function enrichStreamContext(rows: unknown, resolver: RefResolver): Promise<unknown> {
+  if (!Array.isArray(rows)) return rows
+  const streamIds = new Set<string>()
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue
+    const { streamId, rootStreamId } = row as { streamId?: unknown; rootStreamId?: unknown }
+    if (typeof streamId === "string") streamIds.add(streamId)
+    if (typeof rootStreamId === "string") streamIds.add(rootStreamId)
+  }
+  if (streamIds.size === 0) return rows
+
+  const infos = new Map<string, ResolverStreamInfo | null>()
+  await Promise.all([...streamIds].map(async (id) => infos.set(id, await resolver.streamInfo(id))))
+  const rootIds = new Set<string>()
+  for (const [id, info] of infos) {
+    if (info?.rootStreamId && info.rootStreamId !== id && !infos.has(info.rootStreamId)) {
+      rootIds.add(info.rootStreamId)
+    }
+  }
+  await Promise.all([...rootIds].map(async (id) => infos.set(id, await resolver.streamInfo(id))))
+
+  return rows.map((row) => {
+    if (!row || typeof row !== "object") return row
+    const r = row as { streamId?: unknown; rootStreamId?: unknown } & Record<string, unknown>
+    if (typeof r.streamId !== "string") return row
+    const info = infos.get(r.streamId) ?? null
+    const out: Record<string, unknown> = { ...r, stream: toStreamRef(info, r.streamId) }
+    const rootId = typeof r.rootStreamId === "string" ? r.rootStreamId : info?.rootStreamId
+    if (rootId && rootId !== r.streamId) {
+      out.rootStream = toStreamRef(infos.get(rootId) ?? null, rootId)
+    }
+    return out
+  })
 }
 
 /**

--- a/packages/cli/src/ops.ts
+++ b/packages/cli/src/ops.ts
@@ -1,6 +1,6 @@
 import type { ThreaApiClient } from "./api-client"
 import type { ThreaConfig } from "./config"
-import { enrichConversation, enrichMessages } from "./enrich"
+import { enrichConversation, enrichMessages, enrichStreamContext } from "./enrich"
 import type { RefResolver } from "./resolver"
 import type { TokenStore } from "./token-store"
 import {
@@ -125,8 +125,8 @@ export async function listConversations(
   const response = await client.get<PagedEnvelope<unknown>>(
     `/conversations${buildQuery({ streamId, status: p.status, after: p.cursor, limit: p.limit })}`
   )
-  const data = await Promise.all(response.data.map((c) => enrichConversation(c, resolver)))
-  return { ...response, data }
+  const withParticipants = await Promise.all(response.data.map((c) => enrichConversation(c, resolver)))
+  return { ...response, data: await enrichStreamContext(withParticipants, resolver) }
 }
 
 export interface ReadConversationParams {
@@ -147,8 +147,12 @@ export async function readConversation(
       `/conversations/${id}/messages${buildQuery({ after: p.cursor, limit: p.limit })}`
     ),
   ])
+  const [conversation] = (await enrichStreamContext(
+    [await enrichConversation(conversationResp.data, resolver)],
+    resolver
+  )) as unknown[]
   return {
-    conversation: await enrichConversation(conversationResp.data, resolver),
+    conversation,
     messages: {
       data: await enrichMessages(messagesResp.data, resolver),
       hasMore: messagesResp.hasMore ?? false,
@@ -232,10 +236,17 @@ export async function search(client: ThreaApiClient, resolver: RefResolver, args
   }
 
   const query = args.query
-  if ((what === "messages" || what === "attachments") && (query === undefined || query.trim() === "")) {
+  if (what === "messages" && (query === undefined || query.trim() === "")) {
     throw new ToolInputError(
       "INVALID_ARGUMENT",
-      `search what="${what}" requires a non-empty query. Only what="memos" allows an empty query (recent-first browse).`
+      `search what="messages" requires a non-empty query. Omitting the query (recent-first browse) is only ` +
+        `supported for what="memos" and what="attachments".`
+    )
+  }
+  if (what === "attachments" && query !== undefined && query.trim() === "") {
+    throw new ToolInputError(
+      "INVALID_ARGUMENT",
+      `search what="attachments" got a blank query. Pass a non-empty query, or omit it entirely to browse the most recent attachments.`
     )
   }
 
@@ -258,7 +269,8 @@ export async function search(client: ThreaApiClient, resolver: RefResolver, args
       after: args.after,
       limit: args.limit,
     })
-    return { ...response, data: await enrichMessages(response.data, resolver) }
+    const data = await enrichStreamContext(await enrichMessages(response.data, resolver), resolver)
+    return { ...response, data }
   }
   if (what === "memos") {
     const streams = args.stream_ids ? await resolver.resolveStreams(args.stream_ids) : undefined
@@ -276,12 +288,13 @@ export async function search(client: ThreaApiClient, resolver: RefResolver, args
     })
   }
   const streams = args.stream_ids ? await resolver.resolveStreams(args.stream_ids) : undefined
-  return client.post("/attachments/search", {
+  const response = await client.post<PagedEnvelope<unknown>>("/attachments/search", {
     query,
     streams,
     contentTypes: args.content_types,
     limit: args.limit,
   })
+  return { ...response, data: await enrichStreamContext(response.data, resolver) }
 }
 
 export interface SendMessageParams {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -185,6 +185,39 @@ export function enumArrayFlag<T extends string>(
   return arr as T[]
 }
 
+/** ISO datetime → local `YYYY-MM-DD HH:mm` for human text output; "" when absent/invalid. */
+export function fmtTimestamp(iso: unknown): string {
+  if (typeof iso !== "string") return ""
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  const p = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+interface RenderStreamRef {
+  id?: string
+  name?: string
+}
+
+/** `root › stream` scope label from enriched stream refs; falls back to ids, "" when unenriched. */
+export function streamLabel(row: {
+  stream?: RenderStreamRef
+  rootStream?: RenderStreamRef
+  streamId?: unknown
+}): string {
+  const name = row.stream?.name ?? row.stream?.id ?? (typeof row.streamId === "string" ? row.streamId : undefined)
+  if (!name) return ""
+  const root = row.rootStream?.name ?? row.rootStream?.id
+  return root && root !== name ? `${root} › ${name}` : name
+}
+
+/** Collapses whitespace and truncates for one-line previews. */
+export function snippet(text: unknown, max = 160): string {
+  if (typeof text !== "string") return ""
+  const collapsed = text.replace(/\s+/g, " ").trim()
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed
+}
+
 export function cursorFooter(p: { hasMore?: boolean; cursor?: string | null }, flag: string): string[] {
   return p.hasMore && p.cursor ? [`… more (--${flag} ${p.cursor})`] : []
 }

--- a/packages/cli/src/resolver.ts
+++ b/packages/cli/src/resolver.ts
@@ -15,6 +15,14 @@ interface ResolverStream {
   displayName?: string | null
 }
 
+export interface ResolverStreamInfo {
+  id: string
+  type?: string
+  displayName?: string
+  slug?: string
+  rootStreamId?: string
+}
+
 interface CacheEntry<T> {
   value: T
   expires: number
@@ -38,6 +46,7 @@ export class RefResolver {
   private readonly ttlMs: number
   private readonly now: () => number
   private readonly channelCache = new Map<string, CacheEntry<string>>()
+  private readonly streamInfoCache = new Map<string, CacheEntry<ResolverStreamInfo | null>>()
   private allUsersCache?: CacheEntry<ResolverUser[]>
   private allUsersInFlight?: Promise<ResolverUser[]>
 
@@ -80,6 +89,21 @@ export class RefResolver {
       })
     this.allUsersInFlight = inFlight
     return inFlight
+  }
+
+  /** A stream's display info by id, for additive enrichment. Non-fatal: null on any fetch error (cached too). */
+  async streamInfo(streamId: string): Promise<ResolverStreamInfo | null> {
+    const hit = this.streamInfoCache.get(streamId)
+    if (hit && hit.expires > this.now()) return hit.value
+    let value: ResolverStreamInfo | null = null
+    try {
+      const resp = await this.client.get<{ data: ResolverStreamInfo }>(`/streams/${encodeURIComponent(streamId)}`)
+      value = resp.data ?? null
+    } catch {
+      value = null
+    }
+    this.streamInfoCache.set(streamId, { value, expires: this.now() + this.ttlMs })
+    return value
   }
 
   private async resolveUserSlug(slug: string): Promise<string> {

--- a/packages/cli/src/tools/search.ts
+++ b/packages/cli/src/tools/search.ts
@@ -24,11 +24,12 @@ export function registerSearchTools(server: McpServer, client: ThreaApiClient, r
         "the query in double quotes) to match a literal phrase, stream_ids, memo_type (message vs. conversation " +
         "source), knowledge_type, tags, scope (user = private to this key's user, stream, workspace), " +
         "before/after (ISO-8601 datetimes), limit (≤100, default 20).\n" +
-        "- what: 'attachments' — search accessible attachments by filename or extracted content. Filters: query " +
-        "(required), stream_ids, content_types (chart, table, diagram, screenshot, photo, document, other), " +
-        "limit (≤50, default 20).\n" +
+        "- what: 'attachments' — search accessible attachments by filename or extracted content. query is " +
+        "OPTIONAL — leave it empty to browse the most recent attachments. Filters: query, stream_ids, " +
+        "content_types (chart, table, diagram, screenshot, photo, document, other), limit (≤50, default 20).\n" +
         "stream_ids maps to the API's source-stream scope; each entry accepts a stream_ id or `#channel-slug`. " +
-        "For what='messages', result rows carry author { id, type, name, slug? }. " +
+        "For what='messages', result rows carry author { id, type, name, slug? }; message, attachment, and " +
+        "conversation rows carry stream { id, name?, type? } and, for threads, rootStream. " +
         "Results are the search envelope { data: [...] }. For " +
         "exact metadata lookup use find_messages_by_metadata; for a memo's source provenance use get_memo.",
       inputSchema: {


### PR DESCRIPTION
## Problem

The CLI's text mode is too thin to be useful to a human. `threa search` prints bare ids (`msg_01KY0…`, one per line) even though the payload carries content, timestamps, and stream ids; `conversations list` prints `id status` and reads a `title` field that doesn't exist on the wire (it's `topicSummary`). There's no way to browse memos or attachments without inventing a search query, no way to get attachment bytes to disk short of `--url` + curl, and the agent skill can only be installed into `~/.claude/skills`, not printed.

## Solution

Enrich rows client-side, render them densely, and add the missing verbs.

- **Stream-scope enrichment** — `enrichStreamContext` (`packages/cli/src/enrich.ts`) additively attaches `stream: {id, name?, type?}` and, for threads, `rootStream` to any row carrying `streamId`, resolving names via per-id `GET /streams/{id}` deduped through a new 5-min `RefResolver.streamInfo` cache. Same non-fatal pattern as the existing author enrichment: a failed lookup degrades to a bare `{id}`. Applied to message search results, attachment search results, and conversations (list + read) — JSON output gains the fields too, so the MCP head benefits.
- **Renders** — `search` prints per-what two-line rows: `id  local-time  root › stream  author` + collapsed 160-char snippet (filename/mime for attachments, title — abstract for memos). `conversations list` shows status, `N msgs`, last activity, scope, topic; `conversations read` gets a created/last-activity/count header and per-message `[time] author:` lines. Helpers `fmtTimestamp`/`streamLabel`/`snippet` live in `output.ts`.
- **`threa memos list` / `threa attachments list`** — recent-first browse (`--stream` repeatable, `--limit`), routed through the existing `search` op with no query. For attachments that required a one-line backend loosening: `searchAttachmentsSchema.query` is now optional (blank string still rejected) and `AttachmentRepository.searchWithExtractions` skips the ILIKE block when query is absent — same `(${!flag} OR …)` shape the safety-status filter already uses. Backwards-compatible, no API version bump; OpenAPI regenerated.
- **`threa attachments download <id> [dest]`** — fetches metadata + signed URL in parallel, streams the bytes with `Bun.write`. Directory dest names the file after the attachment with Chrome-style ` (1)` conflict suffixes (`resolveDownloadTarget`); an explicit file dest is written as given (overwrite, curl `-o` semantics). Plain streaming over parallel ranged requests — S3 serves a single stream fine at these sizes.
- **`threa skill print`** — SKILL.md to stdout for piping anywhere; `install` unchanged.
- MCP `search` tool description + threa-cli SKILL.md + CLI README updated to match.

Not included: `--before/--after` on attachment browse (repo query has no time filters today), and DM streams still render as "Direct message" (the wire hides the counterpart).

## Files

| File | Change |
| ---- | ------ |
| `packages/cli/src/enrich.ts` | `enrichStreamContext` additive stream/rootStream refs |
| `packages/cli/src/resolver.ts` | cached `streamInfo(id)` lookup |
| `packages/cli/src/output.ts` | `fmtTimestamp`, `streamLabel`, `snippet` render helpers |
| `packages/cli/src/ops.ts` | enrichment wiring; attachments query now optional, messages-only requirement |
| `packages/cli/src/commands/search.ts` | per-what rich renders (exported `renderSearchResult`) |
| `packages/cli/src/commands/conversations.ts` | list/read renders: temporal + scope + counts |
| `packages/cli/src/commands/memos.ts` | **new** `list` verb |
| `packages/cli/src/commands/attachments.ts` | **new** `list` + `download` verbs, `resolveDownloadTarget` |
| `packages/cli/src/commands/skill.ts` | **new** `print` subcommand |
| `packages/cli/src/commands/renders.test.ts` | **new** render/browse/download/print coverage |
| `apps/backend/src/features/public-api/schemas.ts` | `searchAttachmentsSchema.query` optional |
| `apps/backend/src/features/attachments/repository.ts` | query-less browse path in `searchWithExtractions` |
| `apps/backend/src/features/public-api/routes.ts` | endpoint description mentions browse |
| `.agents/skills/threa-cli/SKILL.md`, `packages/cli/README.md` | doc updates |
| `docs/public-api/*.json` | regenerated spec |

## Test plan

- [x] `packages/cli` — 148 pass (10 new: enrichStreamContext ×3, renders/browse/download/conflict/print)
- [x] backend `public-api/` + `attachments/` + `agents/tools/attachment-tools` suites — 366 pass (2 new schema tests)
- [x] pre-commit: full monorepo lint + typecheck + OpenAPI check green
- [x] live against prod workspace: message search render, conversations list/read, memos list, skill print, `attachments download` twice (got `pasted-image-1.png` then `pasted-image-1 (1).png`)
- [ ] live `attachments list` — needs the backend change deployed (prod still requires query); verified via unit tests + schema tests
- Note: `public-api/schemas.test.ts` fails when run standalone (pre-existing routes.ts module-init cycle, also fails on main); passes in folder/suite runs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787167518&installation_model_id=20758&pr_number=1465&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1465&signature=1ad2cc5ac802634342acef9341fe34cd40a17e82ec0b574a2f80a6f68aa00c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->