### PR TITLE
fix: order and dismiss local command failures

### DIFF
--- a/apps/backend/src/db/migrations/20260720233005_add_command_dispatch_idempotency.sql
+++ b/apps/backend/src/db/migrations/20260720233005_add_command_dispatch_idempotency.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS command_dispatches (
+    command_id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    stream_id TEXT NOT NULL,
+    client_command_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS command_dispatches_client_id_unique
+    ON command_dispatches (workspace_id, user_id, stream_id, client_command_id);

--- a/apps/backend/src/features/commands/events.ts
+++ b/apps/backend/src/features/commands/events.ts
@@ -59,6 +59,7 @@ export async function insertCommandDispatchedEvent(
     streamId: string
     userId: string
     commandId: string
+    clientCommandId?: string
     eventId?: string
     name: string
     args: string
@@ -71,6 +72,7 @@ export async function insertCommandDispatchedEvent(
     eventType: "command_dispatched",
     payload: {
       commandId: params.commandId,
+      ...(params.clientCommandId && { clientCommandId: params.clientCommandId }),
       name: params.name,
       args: params.args,
       status: "dispatched",

--- a/apps/backend/src/features/commands/events.ts
+++ b/apps/backend/src/features/commands/events.ts
@@ -59,13 +59,14 @@ export async function insertCommandDispatchedEvent(
     streamId: string
     userId: string
     commandId: string
+    eventId?: string
     name: string
     args: string
     executionKind?: "server" | "bot-runtime"
   }
 ): Promise<StreamEvent> {
   const evt = await StreamEventRepository.insert(db, {
-    id: eventId(),
+    id: params.eventId ?? eventId(),
     streamId: params.streamId,
     eventType: "command_dispatched",
     payload: {

--- a/apps/backend/src/features/commands/handlers.test.ts
+++ b/apps/backend/src/features/commands/handlers.test.ts
@@ -5,6 +5,7 @@ import { CommandKinds } from "@threa/types"
 import { createCommandHandlers } from "./handlers"
 import { CommandDispatchRepository } from "./repository"
 import { StreamEventRepository } from "../streams"
+import * as streamsModule from "../streams"
 
 function makePool(): Pool {
   const client = {
@@ -54,6 +55,7 @@ describe("command dispatch idempotency", () => {
   }
 
   it("replays a committed dispatch before rechecking runtime availability", async () => {
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1" } as never)
     spyOn(CommandDispatchRepository, "findByClientId").mockResolvedValue({
       commandId: "cmd_existing",
       eventId: event.id,
@@ -91,7 +93,32 @@ describe("command dispatch idempotency", () => {
     })
   })
 
+  it("refuses replay after stream access is revoked", async () => {
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue(null)
+    const findReplay = spyOn(CommandDispatchRepository, "findByClientId")
+    const handlers = createCommandHandlers({
+      pool: makePool(),
+      commandAvailabilityService: {} as never,
+      botRuntimeService: {} as never,
+    })
+    const req = {
+      user: { id: "usr_1" },
+      workspaceId: "ws_1",
+      body: { streamId: "stream_1", command: "/stop", clientCommandId: "temp_cmd_1" },
+    } as Request
+    const res = makeResponse()
+
+    await handlers.dispatch(req, res)
+
+    expect({ status: res.statusCode, body: res.body, replayReads: findReplay.mock.calls.length }).toEqual({
+      status: 404,
+      body: { success: false, error: "Stream not found" },
+      replayReads: 0,
+    })
+  })
+
   it("replays the winner when a concurrent request wins the idempotency claim", async () => {
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1" } as never)
     spyOn(CommandDispatchRepository, "findByClientId")
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ commandId: "cmd_existing", eventId: event.id })

--- a/apps/backend/src/features/commands/handlers.test.ts
+++ b/apps/backend/src/features/commands/handlers.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import type { Pool, PoolClient } from "pg"
+import { CommandKinds } from "@threa/types"
+import { createCommandHandlers } from "./handlers"
+import { CommandDispatchRepository } from "./repository"
+import { StreamEventRepository } from "../streams"
+
+function makePool(): Pool {
+  const client = {
+    query: mock(async () => ({ rows: [], rowCount: 0 })),
+    release: mock(() => undefined),
+  } as unknown as PoolClient
+  return { connect: mock(async () => client) } as unknown as Pool
+}
+
+function makeResponse() {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(body: unknown) {
+      this.body = body
+      return this
+    },
+  }
+  return response as typeof response & Response
+}
+
+describe("command dispatch idempotency", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  const event = {
+    id: "evt_existing",
+    streamId: "stream_1",
+    sequence: 7n,
+    broadcastSequence: null,
+    eventType: "command_dispatched" as const,
+    payload: {
+      commandId: "cmd_existing",
+      name: "stop",
+      args: "",
+      status: "dispatched" as const,
+      executionKind: CommandKinds.BOT_RUNTIME,
+    },
+    actorId: "usr_1",
+    actorType: "user" as const,
+    createdAt: new Date("2026-07-20T20:00:00.000Z"),
+  }
+
+  it("replays a committed dispatch before rechecking runtime availability", async () => {
+    spyOn(CommandDispatchRepository, "findByClientId").mockResolvedValue({
+      commandId: "cmd_existing",
+      eventId: event.id,
+    })
+    spyOn(StreamEventRepository, "findById").mockResolvedValue(event)
+    const resolveCommand = mock(async () => null)
+    const handlers = createCommandHandlers({
+      pool: makePool(),
+      commandAvailabilityService: {
+        resolveCommand,
+        listStreamCommands: mock(async () => []),
+        listWorkspaceCommands: mock(() => []),
+      } as never,
+      botRuntimeService: {} as never,
+    })
+    const req = {
+      user: { id: "usr_1" },
+      workspaceId: "ws_1",
+      body: { streamId: "stream_1", command: "/stop", clientCommandId: "temp_cmd_1" },
+    } as Request
+    const res = makeResponse()
+
+    await handlers.dispatch(req, res)
+
+    expect({ status: res.statusCode, body: res.body, availabilityCalls: resolveCommand.mock.calls.length }).toEqual({
+      status: 202,
+      body: {
+        success: true,
+        commandId: "cmd_existing",
+        command: "stop",
+        args: "",
+        event: { ...event, sequence: "7" },
+      },
+      availabilityCalls: 0,
+    })
+  })
+
+  it("replays the winner when a concurrent request wins the idempotency claim", async () => {
+    spyOn(CommandDispatchRepository, "findByClientId")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ commandId: "cmd_existing", eventId: event.id })
+    spyOn(CommandDispatchRepository, "claim").mockResolvedValue(false)
+    spyOn(StreamEventRepository, "findById").mockResolvedValue(event)
+    const handlers = createCommandHandlers({
+      pool: makePool(),
+      commandAvailabilityService: {
+        resolveCommand: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        listStreamCommands: mock(async () => []),
+        listWorkspaceCommands: mock(() => []),
+      } as never,
+      botRuntimeService: {} as never,
+    })
+    const req = {
+      user: { id: "usr_1" },
+      workspaceId: "ws_1",
+      body: { streamId: "stream_1", command: "/stop", clientCommandId: "temp_cmd_1" },
+    } as Request
+    const res = makeResponse()
+
+    await handlers.dispatch(req, res)
+
+    expect({ status: res.statusCode, commandId: (res.body as { commandId: string }).commandId }).toEqual({
+      status: 202,
+      commandId: "cmd_existing",
+    })
+  })
+})

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -3,17 +3,20 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import { serializeBigInt } from "@threa/backend-common"
 import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds, CommandKinds } from "@threa/types"
-import type { BotRuntimeKind } from "@threa/types"
-import { withTransaction } from "../../db"
-import { commandId as generateCommandId } from "../../lib/id"
+import type { BotRuntimeKind, CommandDispatchedPayload } from "@threa/types"
+import { withClient, withTransaction, type Querier } from "../../db"
+import { commandId as generateCommandId, eventId as generateEventId } from "../../lib/id"
 import { parseCommand } from "./registry"
 import type { CommandAvailabilityService } from "./availability"
 import type { BotRuntimeService } from "../bot-runtimes"
 import { buildRuntimeCommandInvocationMetadata, insertCommandDispatchedEvent } from "./events"
+import { CommandDispatchRepository } from "./repository"
+import { StreamEventRepository, type StreamEvent } from "../streams"
 
 const dispatchCommandSchema = z.object({
   command: z.string().min(1, "command is required"),
   streamId: z.string().min(1, "streamId is required"),
+  clientCommandId: z.string().min(1).max(255).optional(),
 })
 
 interface Dependencies {
@@ -51,6 +54,58 @@ export function resolveRuntimeInvocationRouting(
   }
 }
 
+interface ClaimedCommandDispatch {
+  commandId: string
+  command: string
+  args: string
+  event: StreamEvent
+}
+
+async function findCommandDispatchReplay(
+  db: Querier,
+  params: { workspaceId: string; userId: string; streamId: string; clientCommandId: string }
+): Promise<ClaimedCommandDispatch | null> {
+  const existing = await CommandDispatchRepository.findByClientId(db, params)
+  if (!existing) return null
+  const event = await StreamEventRepository.findById(db, existing.eventId)
+  if (!event) throw new Error("Command dispatch event missing after idempotency lookup")
+  const payload = event.payload as CommandDispatchedPayload
+  return { commandId: existing.commandId, command: payload.name, args: payload.args, event }
+}
+
+async function claimOrReplayCommandDispatch(
+  db: Querier,
+  params: {
+    workspaceId: string
+    userId: string
+    streamId: string
+    clientCommandId?: string
+    commandId: string
+    eventId: string
+  }
+): Promise<ClaimedCommandDispatch | null> {
+  if (!params.clientCommandId) return null
+
+  const claimed = await CommandDispatchRepository.claim(db, {
+    commandId: params.commandId,
+    workspaceId: params.workspaceId,
+    userId: params.userId,
+    streamId: params.streamId,
+    clientCommandId: params.clientCommandId,
+    eventId: params.eventId,
+  })
+  if (claimed) return null
+
+  const replay = await findCommandDispatchReplay(db, {
+    workspaceId: params.workspaceId,
+    userId: params.userId,
+    streamId: params.streamId,
+    clientCommandId: params.clientCommandId,
+  })
+  if (!replay) throw new Error("Command dispatch idempotency row missing after conflict")
+  return replay
+}
+
 export function createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService }: Dependencies) {
   return {
     /**
@@ -73,13 +128,26 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
         })
       }
 
-      const { command: commandString, streamId } = result.data
+      const { command: commandString, streamId, clientCommandId } = result.data
       const parsed = parseCommand(commandString)
       if (!parsed) {
         return res.status(400).json({
           success: false,
           error: "Invalid command format. Commands must start with / followed by a name.",
         })
+      }
+
+      if (clientCommandId) {
+        const replay = await withClient(pool, (client) =>
+          findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
+        )
+        if (replay) {
+          return res.status(202).json({
+            success: true,
+            ...replay,
+            event: serializeBigInt(replay.event),
+          })
+        }
       }
 
       const resolved = await commandAvailabilityService.resolveCommand({
@@ -106,35 +174,57 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
       }
 
       const cmdId = generateCommandId()
+      const evtId = generateEventId()
 
       if (resolved.executionKind === CommandKinds.SERVER) {
-        const event = await withTransaction(pool, (client) =>
-          insertCommandDispatchedEvent(client, {
+        const dispatch = await withTransaction(pool, async (client) => {
+          const replay = await claimOrReplayCommandDispatch(client, {
+            workspaceId,
+            userId,
+            streamId,
+            clientCommandId,
+            commandId: cmdId,
+            eventId: evtId,
+          })
+          if (replay) return replay
+
+          const event = await insertCommandDispatchedEvent(client, {
             workspaceId,
             streamId,
             userId,
             commandId: cmdId,
+            eventId: evtId,
             name: parsed.name,
             args: parsed.args,
             executionKind: CommandKinds.SERVER,
           })
-        )
+          return { commandId: cmdId, command: parsed.name, args: parsed.args, event }
+        })
 
         return res.status(202).json({
           success: true,
-          commandId: cmdId,
-          command: parsed.name,
-          args: parsed.args,
-          event: serializeBigInt(event),
+          ...dispatch,
+          event: serializeBigInt(dispatch.event),
         })
       }
 
-      const event = await withTransaction(pool, async (client) => {
-        const evt = await insertCommandDispatchedEvent(client, {
+      const dispatch = await withTransaction(pool, async (client) => {
+        const replay = await claimOrReplayCommandDispatch(client, {
+          workspaceId,
+          userId,
+          streamId,
+          clientCommandId,
+          commandId: cmdId,
+          eventId: evtId,
+        })
+        if (replay) return replay
+
+        const event = await insertCommandDispatchedEvent(client, {
           workspaceId,
           streamId,
           userId,
           commandId: cmdId,
+          eventId: evtId,
           name: parsed.name,
           args: parsed.args,
           executionKind: CommandKinds.BOT_RUNTIME,
@@ -162,15 +252,13 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           metadata,
         })
 
-        return evt
+        return { commandId: cmdId, command: parsed.name, args: parsed.args, event }
       })
 
       res.status(202).json({
         success: true,
-        commandId: cmdId,
-        command: parsed.name,
-        args: parsed.args,
-        event: serializeBigInt(event),
+        ...dispatch,
+        event: serializeBigInt(dispatch.event),
       })
     },
 

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -11,7 +11,7 @@ import type { CommandAvailabilityService } from "./availability"
 import type { BotRuntimeService } from "../bot-runtimes"
 import { buildRuntimeCommandInvocationMetadata, insertCommandDispatchedEvent } from "./events"
 import { CommandDispatchRepository } from "./repository"
-import { StreamEventRepository, type StreamEvent } from "../streams"
+import { checkStreamAccess, StreamEventRepository, type StreamEvent } from "../streams"
 
 const dispatchCommandSchema = z.object({
   command: z.string().min(1, "command is required"),
@@ -138,14 +138,23 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
       }
 
       if (clientCommandId) {
-        const replay = await withClient(pool, (client) =>
-          findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
-        )
-        if (replay) {
+        const replayCheck = await withClient(pool, async (client) => {
+          const accessible = (await checkStreamAccess(client, streamId, workspaceId, userId)) != null
+          return {
+            accessible,
+            replay: accessible
+              ? await findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
+              : null,
+          }
+        })
+        if (!replayCheck.accessible) {
+          return res.status(404).json({ success: false, error: "Stream not found" })
+        }
+        if (replayCheck.replay) {
           return res.status(202).json({
             success: true,
-            ...replay,
-            event: serializeBigInt(replay.event),
+            ...replayCheck.replay,
+            event: serializeBigInt(replayCheck.replay.event),
           })
         }
       }
@@ -193,6 +202,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
             streamId,
             userId,
             commandId: cmdId,
+            clientCommandId,
             eventId: evtId,
             name: parsed.name,
             args: parsed.args,
@@ -224,6 +234,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           streamId,
           userId,
           commandId: cmdId,
+          clientCommandId,
           eventId: evtId,
           name: parsed.name,
           args: parsed.args,

--- a/apps/backend/src/features/commands/index.ts
+++ b/apps/backend/src/features/commands/index.ts
@@ -1,7 +1,6 @@
 export { createCommandHandlers, resolveRuntimeInvocationRouting } from "./handlers"
 
 export { CommandRegistry, parseCommand, isCommand } from "./registry"
-export { CommandDispatchRepository } from "./repository"
 export type { Command, CommandContext, CommandResult } from "./registry"
 export { CommandAvailabilityService } from "./availability"
 export type { ResolvedCommand, RuntimeCommandTarget } from "./availability"

--- a/apps/backend/src/features/commands/index.ts
+++ b/apps/backend/src/features/commands/index.ts
@@ -1,6 +1,7 @@
 export { createCommandHandlers, resolveRuntimeInvocationRouting } from "./handlers"
 
 export { CommandRegistry, parseCommand, isCommand } from "./registry"
+export { CommandDispatchRepository } from "./repository"
 export type { Command, CommandContext, CommandResult } from "./registry"
 export { CommandAvailabilityService } from "./availability"
 export type { ResolvedCommand, RuntimeCommandTarget } from "./availability"

--- a/apps/backend/src/features/commands/repository.test.ts
+++ b/apps/backend/src/features/commands/repository.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { Querier } from "../../db"
+import { CommandDispatchRepository } from "./repository"
+
+function makeDb(rows: Record<string, unknown>[], rowCount = rows.length) {
+  const query = mock(() => Promise.resolve({ rows, rowCount }))
+  return { query, _query: query } as unknown as Querier & { _query: ReturnType<typeof mock> }
+}
+
+const params = {
+  commandId: "cmd_1",
+  workspaceId: "ws_1",
+  userId: "usr_1",
+  streamId: "stream_1",
+  clientCommandId: "temp_cmd_1",
+  eventId: "evt_1",
+}
+
+describe("CommandDispatchRepository", () => {
+  test("claims a new client command id", async () => {
+    const db = makeDb([{ command_id: "cmd_1" }], 1)
+
+    expect(await CommandDispatchRepository.claim(db, params)).toBe(true)
+  })
+
+  test("reports an existing client command id", async () => {
+    const db = makeDb([], 0)
+
+    expect(await CommandDispatchRepository.claim(db, params)).toBe(false)
+  })
+
+  test("finds an existing dispatch within its workspace, user, and stream scope", async () => {
+    const db = makeDb([{ command_id: "cmd_1", event_id: "evt_1" }])
+
+    expect(
+      await CommandDispatchRepository.findByClientId(db, {
+        workspaceId: params.workspaceId,
+        userId: params.userId,
+        streamId: params.streamId,
+        clientCommandId: params.clientCommandId,
+      })
+    ).toEqual({ commandId: "cmd_1", eventId: "evt_1" })
+  })
+})

--- a/apps/backend/src/features/commands/repository.ts
+++ b/apps/backend/src/features/commands/repository.ts
@@ -1,0 +1,54 @@
+import { sql, type Querier } from "../../db"
+
+interface CommandDispatchRow {
+  command_id: string
+  event_id: string
+}
+
+export interface CommandDispatchRecord {
+  commandId: string
+  eventId: string
+}
+
+export const CommandDispatchRepository = {
+  async claim(
+    db: Querier,
+    params: {
+      commandId: string
+      workspaceId: string
+      userId: string
+      streamId: string
+      clientCommandId: string
+      eventId: string
+    }
+  ): Promise<boolean> {
+    const result = await db.query<{ command_id: string }>(sql`
+      INSERT INTO command_dispatches (
+        command_id, workspace_id, user_id, stream_id, client_command_id, event_id
+      )
+      VALUES (
+        ${params.commandId}, ${params.workspaceId}, ${params.userId}, ${params.streamId},
+        ${params.clientCommandId}, ${params.eventId}
+      )
+      ON CONFLICT (workspace_id, user_id, stream_id, client_command_id) DO NOTHING
+      RETURNING command_id
+    `)
+    return result.rowCount === 1
+  },
+
+  async findByClientId(
+    db: Querier,
+    params: { workspaceId: string; userId: string; streamId: string; clientCommandId: string }
+  ): Promise<CommandDispatchRecord | null> {
+    const result = await db.query<CommandDispatchRow>(sql`
+      SELECT command_id, event_id
+      FROM command_dispatches
+      WHERE workspace_id = ${params.workspaceId}
+        AND user_id = ${params.userId}
+        AND stream_id = ${params.streamId}
+        AND client_command_id = ${params.clientCommandId}
+    `)
+    const row = result.rows[0]
+    return row ? { commandId: row.command_id, eventId: row.event_id } : null
+  },
+}

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react"
 import type { StreamEvent, CommandDispatchedPayload, CommandCompletedPayload, CommandFailedPayload } from "@threa/types"
-import { Loader2, CheckCircle, XCircle, ChevronRight } from "lucide-react"
+import { Loader2, CheckCircle, XCircle, ChevronRight, X } from "lucide-react"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { useFormattedDate } from "@/hooks"
 import { stripMarkdownToInline } from "@/lib/markdown"
+import { useCancelCommandDispatch } from "@/hooks/use-command-dispatch-queue"
 
 interface CommandEventProps {
   /** All events for this command, grouped by commandId */
@@ -24,10 +25,13 @@ export function CommandEvent({ events }: CommandEventProps) {
   const dispatchedEvent = events.find((e) => e.eventType === "command_dispatched")
   const completedEvent = events.find((e) => e.eventType === "command_completed")
   const failedEvent = events.find((e) => e.eventType === "command_failed")
+  const cancelCommand = useCancelCommandDispatch(dispatchedEvent?.streamId ?? "")
 
   if (!dispatchedEvent) return null
 
   const dispatchedPayload = dispatchedEvent.payload as CommandDispatchedPayload
+  const localStatus = (dispatchedEvent as StreamEvent & { _status?: string })._status
+  const canCancel = localStatus === "pending" || localStatus === "failed"
   let status: CommandStatus = "running"
   if (failedEvent) {
     status = "failed"
@@ -37,22 +41,35 @@ export function CommandEvent({ events }: CommandEventProps) {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger asChild>
-        <button className="flex w-full items-center gap-2 py-1.5 px-3 text-sm text-muted-foreground hover:bg-muted/50 rounded transition-colors">
-          <ChevronRight className={`h-3 w-3 transition-transform ${isOpen ? "rotate-90" : ""}`} />
-          <StatusIcon status={status} />
-          <span className="flex-1 text-left">
-            <code className="font-mono text-xs bg-muted text-primary font-bold px-1 py-0.5 rounded">
-              /{dispatchedPayload.name}
-            </code>
-            {dispatchedPayload.args && (
-              <span className="text-muted-foreground/70 ml-1">{truncateArgs(dispatchedPayload.args)}</span>
-            )}
-            <StatusLabel status={status} failedPayload={failedEvent?.payload as CommandFailedPayload | undefined} />
-          </span>
-          <span className="text-xs text-muted-foreground/50">{formatTime(new Date(dispatchedEvent.createdAt))}</span>
-        </button>
-      </CollapsibleTrigger>
+      <div className="flex items-center rounded hover:bg-muted/50">
+        <CollapsibleTrigger asChild>
+          <button className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pl-3 pr-1 text-sm text-muted-foreground transition-colors">
+            <ChevronRight className={`h-3 w-3 shrink-0 transition-transform ${isOpen ? "rotate-90" : ""}`} />
+            <StatusIcon status={status} />
+            <span className="min-w-0 flex-1 text-left">
+              <code className="font-mono text-xs bg-muted text-primary font-bold px-1 py-0.5 rounded">
+                /{dispatchedPayload.name}
+              </code>
+              {dispatchedPayload.args && (
+                <span className="text-muted-foreground/70 ml-1">{truncateArgs(dispatchedPayload.args)}</span>
+              )}
+              <StatusLabel status={status} failedPayload={failedEvent?.payload as CommandFailedPayload | undefined} />
+            </span>
+            <span className="text-xs text-muted-foreground/50">{formatTime(new Date(dispatchedEvent.createdAt))}</span>
+          </button>
+        </CollapsibleTrigger>
+        {canCancel && (
+          <button
+            type="button"
+            className="mr-1 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={status === "failed" ? "Remove failed command" : "Cancel pending command"}
+            title={status === "failed" ? "Remove failed command" : "Cancel pending command"}
+            onClick={() => void cancelCommand(dispatchedPayload.commandId)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
       <CollapsibleContent>
         <div className="ml-8 border-l border-muted pl-3 py-1 space-y-1">
           {events.map((event) => (

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -44,9 +44,9 @@ export function CommandEvent({ events }: CommandEventProps) {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div className="flex items-center rounded hover:bg-muted/50">
+      <div className="flex min-h-10 items-center rounded hover:bg-muted/50">
         <CollapsibleTrigger asChild>
-          <button className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pl-3 pr-1 text-sm text-muted-foreground transition-colors">
+          <button className="flex min-h-10 min-w-0 flex-1 items-center gap-2 py-1.5 pl-3 pr-1 text-sm text-muted-foreground transition-colors">
             <ChevronRight className={`h-3 w-3 shrink-0 transition-transform ${isOpen ? "rotate-90" : ""}`} />
             <StatusIcon status={status} />
             <span className="min-w-0 flex-1 text-left">

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -4,7 +4,7 @@ import { Loader2, CheckCircle, XCircle, ChevronRight, X } from "lucide-react"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { useFormattedDate } from "@/hooks"
 import { stripMarkdownToInline } from "@/lib/markdown"
-import { useCancelCommandDispatch } from "@/hooks/use-command-dispatch-queue"
+import { useCommandDispatchCancellation } from "@/hooks/use-command-dispatch-queue"
 
 interface CommandEventProps {
   /** All events for this command, grouped by commandId */
@@ -25,13 +25,16 @@ export function CommandEvent({ events }: CommandEventProps) {
   const dispatchedEvent = events.find((e) => e.eventType === "command_dispatched")
   const completedEvent = events.find((e) => e.eventType === "command_completed")
   const failedEvent = events.find((e) => e.eventType === "command_failed")
-  const cancelCommand = useCancelCommandDispatch(dispatchedEvent?.streamId ?? "")
+  const localStatus = (dispatchedEvent as (StreamEvent & { _status?: string }) | undefined)?._status
+  const cancellation = useCommandDispatchCancellation(
+    dispatchedEvent?.streamId ?? "",
+    (dispatchedEvent?.payload as CommandDispatchedPayload | undefined)?.commandId ?? "",
+    localStatus
+  )
 
   if (!dispatchedEvent) return null
 
   const dispatchedPayload = dispatchedEvent.payload as CommandDispatchedPayload
-  const localStatus = (dispatchedEvent as StreamEvent & { _status?: string })._status
-  const canCancel = localStatus === "pending" || localStatus === "failed"
   let status: CommandStatus = "running"
   if (failedEvent) {
     status = "failed"
@@ -58,13 +61,13 @@ export function CommandEvent({ events }: CommandEventProps) {
             <span className="text-xs text-muted-foreground/50">{formatTime(new Date(dispatchedEvent.createdAt))}</span>
           </button>
         </CollapsibleTrigger>
-        {canCancel && (
+        {cancellation.canCancel && (
           <button
             type="button"
             className="mr-1 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label={status === "failed" ? "Remove failed command" : "Cancel pending command"}
             title={status === "failed" ? "Remove failed command" : "Cancel pending command"}
-            onClick={() => void cancelCommand(dispatchedPayload.commandId)}
+            onClick={() => void cancellation.cancel()}
           >
             <X className="h-3.5 w-3.5" />
           </button>

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -27,6 +27,7 @@ export function CommandEvent({ events }: CommandEventProps) {
   const failedEvent = events.find((e) => e.eventType === "command_failed")
   const localStatus = (dispatchedEvent as (StreamEvent & { _status?: string }) | undefined)?._status
   const cancellation = useCommandDispatchCancellation(
+    (dispatchedEvent as (StreamEvent & { workspaceId?: string }) | undefined)?.workspaceId ?? "",
     dispatchedEvent?.streamId ?? "",
     (dispatchedEvent?.payload as CommandDispatchedPayload | undefined)?.commandId ?? "",
     localStatus

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -64,7 +64,7 @@ export function CommandEvent({ events }: CommandEventProps) {
         {cancellation.canCancel && (
           <button
             type="button"
-            className="mr-1 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="mr-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label={status === "failed" ? "Remove failed command" : "Cancel pending command"}
             title={status === "failed" ? "Remove failed command" : "Cancel pending command"}
             onClick={() => void cancellation.cancel()}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -36,7 +36,7 @@ import {
   type AgentActivitySummaryEntry,
 } from "@/contexts"
 import { useMessageService } from "@/contexts"
-import { useStreamEvents } from "@/stores/stream-store"
+import { orderStreamEvents, useStreamEvents } from "@/stores/stream-store"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
 import { useUser } from "@/auth"
 import { Button } from "@/components/ui/button"
@@ -880,13 +880,14 @@ export function StreamContent({
   // conversation" reads as noise next to the author who clearly is here.
   const displayEvents = useMemo(() => {
     if (!isThread) return events
-    return [...events]
-      .filter((e) => !THREAD_HIDDEN_EVENT_TYPES.has(e.eventType))
-      .sort((a, b) => {
+    return orderStreamEvents(
+      events.filter((event) => !THREAD_HIDDEN_EVENT_TYPES.has(event.eventType)),
+      (a, b) => {
         const timeDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
         if (timeDelta !== 0) return timeDelta
         return a.id.localeCompare(b.id)
-      })
+      }
+    )
   }, [events, isThread])
 
   // See remapSuppressedWatermark: a fresh thread member's watermark sits on a

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -409,8 +409,6 @@ export interface PendingOperation {
    * `enqueueDraftUpsert`); an op that never started can be reused in place.
    */
   startedAt?: number
-  /** True only while a command dispatch request is actively in flight. */
-  attempting?: boolean
 }
 
 export interface SyncCursor {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -407,6 +407,8 @@ export interface PendingOperation {
    * `enqueueDraftUpsert`); an op that never started can be reused in place.
    */
   startedAt?: number
+  /** True only while a command dispatch request is actively in flight. */
+  attempting?: boolean
 }
 
 export interface SyncCursor {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -189,6 +189,8 @@ export interface CachedEvent {
   // Optimistic sending state (for message_created events)
   _clientId?: string
   _status?: "pending" | "sent" | "failed" | "editing"
+  /** Persisted stream sequence visible when this optimistic row was created. */
+  _anchorSequenceNum?: number
   _cachedAt: number
   /**
    * Client wall-clock (ms) of the most recent socket-driven payload patch
@@ -1358,6 +1360,10 @@ export class ThreaDatabase extends Dexie {
     // for first-render correctness. An unindexed value field on existing rows,
     // so the bump only guards the added shape — no schema delta (see v37).
     this.version(40).stores({})
+
+    // v41: optimistic events gain an unindexed persisted-sequence anchor for
+    // clock-independent timeline ordering; existing rows need no migration.
+    this.version(41).stores({})
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { commandsApi } from "@/api"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { processOperationQueue } from "@/sync/operation-queue"
+import { processOperationQueue, reclaimStaleCommandAttempts } from "@/sync/operation-queue"
 import { cancelCommandDispatch } from "./use-command-dispatch-queue"
 
 const commandId = "temp_cmd_1"
 const streamId = "stream_1"
+const originalLocks = navigator.locks
 
 function commandEvent(id: string, eventType: "command_dispatched" | "command_failed"): CachedEvent {
   return {
@@ -23,6 +24,7 @@ function commandEvent(id: string, eventType: "command_dispatched" | "command_fai
     actorType: "user",
     createdAt: "2026-01-01T20:30:00.000Z",
     _status: "failed",
+    _anchorSequenceNum: 4,
     _cachedAt: 1,
   }
 }
@@ -32,6 +34,10 @@ describe("cancelCommandDispatch", () => {
     vi.restoreAllMocks()
     await db.events.clear()
     await db.pendingOperations.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "locks", { configurable: true, value: originalLocks })
   })
 
   it("removes the local command lifecycle and queued dispatch", async () => {
@@ -52,6 +58,49 @@ describe("cancelCommandDispatch", () => {
 
     expect(await db.events.where("streamId").equals(streamId).toArray()).toEqual([])
     expect(await db.pendingOperations.toArray()).toEqual([])
+  })
+
+  it("reclaims a crashed dispatch attempt after its Web Lock is released", async () => {
+    await db.pendingOperations.add({
+      id: "op_stale",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+      attempting: true,
+    })
+    const request = vi.fn(async (_name: string, callback: (lock: Lock) => Promise<boolean>) => callback({} as Lock))
+    Object.defineProperty(navigator, "locks", { configurable: true, value: { request } })
+
+    expect(await reclaimStaleCommandAttempts()).toBe(true)
+
+    expect((await db.pendingOperations.get("op_stale"))?.attempting).toBe(false)
+  })
+
+  it("preserves the ordering anchor when a dispatch fails permanently", async () => {
+    const dispatched = commandEvent(commandId, "command_dispatched")
+    dispatched._status = "pending"
+    await db.events.put(dispatched)
+    await db.pendingOperations.add({
+      id: "op_failed",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+    })
+    vi.spyOn(commandsApi, "dispatch").mockResolvedValue({ success: false, error: "Unknown command" })
+
+    await processOperationQueue(
+      { update: vi.fn(), delete: vi.fn() },
+      { add: vi.fn(), remove: vi.fn() },
+      undefined,
+      undefined,
+      () => true
+    )
+
+    expect((await db.events.get(`${commandId}:failed`))?._anchorSequenceNum).toBe(4)
   })
 
   it("refuses cancellation while a dispatch request is in flight", async () => {

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -4,6 +4,7 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { processOperationQueue } from "@/sync/operation-queue"
 import { cancelCommandDispatch } from "./use-command-dispatch-queue"
 
+const workspaceId = "ws_1"
 const commandId = "temp_cmd_1"
 const streamId = "stream_1"
 
@@ -49,10 +50,26 @@ describe("cancelCommandDispatch", () => {
       retryCount: 0,
     })
 
-    await cancelCommandDispatch(streamId, commandId)
+    await cancelCommandDispatch(workspaceId, streamId, commandId)
 
     expect(await db.events.where("streamId").equals(streamId).toArray()).toEqual([])
     expect(await db.pendingOperations.toArray()).toEqual([])
+  })
+
+  it("does not cancel a command from another workspace", async () => {
+    await db.events.put(commandEvent(commandId, "command_dispatched"))
+    await db.pendingOperations.add({
+      id: "op_other_workspace",
+      workspaceId,
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+    })
+
+    expect(await cancelCommandDispatch("ws_other", streamId, commandId)).toBe(false)
+    expect(await db.events.get(commandId)).toBeDefined()
+    expect(await db.pendingOperations.get("op_other_workspace")).toBeDefined()
   })
 
   it("preserves the ordering anchor when a dispatch fails permanently", async () => {
@@ -103,7 +120,7 @@ describe("cancelCommandDispatch", () => {
     )
 
     expect((await db.pendingOperations.get("op_retry"))?.startedAt).toBeDefined()
-    expect(await cancelCommandDispatch(streamId, commandId)).toBe(false)
+    expect(await cancelCommandDispatch(workspaceId, streamId, commandId)).toBe(false)
   })
 
   it("refuses cancellation while a dispatch request is in flight", async () => {
@@ -136,7 +153,7 @@ describe("cancelCommandDispatch", () => {
       command: "/thinking low",
       clientCommandId: commandId,
     })
-    expect(await cancelCommandDispatch(streamId, commandId)).toBe(false)
+    expect(await cancelCommandDispatch(workspaceId, streamId, commandId)).toBe(false)
     resolveDispatch({
       success: true,
       commandId: "cmd_confirmed",

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -1,12 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { commandsApi } from "@/api"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { processOperationQueue, reclaimStaleCommandAttempts } from "@/sync/operation-queue"
+import { processOperationQueue } from "@/sync/operation-queue"
 import { cancelCommandDispatch } from "./use-command-dispatch-queue"
 
 const commandId = "temp_cmd_1"
 const streamId = "stream_1"
-const originalLocks = navigator.locks
 
 function commandEvent(id: string, eventType: "command_dispatched" | "command_failed"): CachedEvent {
   return {
@@ -36,10 +35,6 @@ describe("cancelCommandDispatch", () => {
     await db.pendingOperations.clear()
   })
 
-  afterEach(() => {
-    Object.defineProperty(navigator, "locks", { configurable: true, value: originalLocks })
-  })
-
   it("removes the local command lifecycle and queued dispatch", async () => {
     await db.events.bulkPut([
       commandEvent(commandId, "command_dispatched"),
@@ -58,24 +53,6 @@ describe("cancelCommandDispatch", () => {
 
     expect(await db.events.where("streamId").equals(streamId).toArray()).toEqual([])
     expect(await db.pendingOperations.toArray()).toEqual([])
-  })
-
-  it("reclaims a crashed dispatch attempt after its Web Lock is released", async () => {
-    await db.pendingOperations.add({
-      id: "op_stale",
-      workspaceId: "ws_1",
-      type: "dispatch_command",
-      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
-      createdAt: 1,
-      retryCount: 0,
-      attempting: true,
-    })
-    const request = vi.fn(async (_name: string, callback: (lock: Lock) => Promise<boolean>) => callback({} as Lock))
-    Object.defineProperty(navigator, "locks", { configurable: true, value: { request } })
-
-    expect(await reclaimStaleCommandAttempts()).toBe(true)
-
-    expect((await db.pendingOperations.get("op_stale"))?.attempting).toBe(false)
   })
 
   it("preserves the ordering anchor when a dispatch fails permanently", async () => {
@@ -128,6 +105,11 @@ describe("cancelCommandDispatch", () => {
       () => true
     )
     await vi.waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledOnce())
+    expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", {
+      streamId,
+      command: "/thinking low",
+      clientCommandId: commandId,
+    })
     expect(await cancelCommandDispatch(streamId, commandId)).toBe(false)
     resolveDispatch({
       success: true,

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { commandsApi } from "@/api"
+import { db, sequenceToNum, type CachedEvent } from "@/db"
+import { processOperationQueue } from "@/sync/operation-queue"
+import { cancelCommandDispatch } from "./use-command-dispatch-queue"
+
+const commandId = "temp_cmd_1"
+const streamId = "stream_1"
+
+function commandEvent(id: string, eventType: "command_dispatched" | "command_failed"): CachedEvent {
+  return {
+    id,
+    workspaceId: "ws_1",
+    streamId,
+    sequence: id === commandId ? "1000" : "1001",
+    _sequenceNum: sequenceToNum(id === commandId ? "1000" : "1001"),
+    eventType,
+    payload:
+      eventType === "command_dispatched"
+        ? { commandId, name: "thinking", args: "low" }
+        : { commandId, error: "Unknown command" },
+    actorId: "user_1",
+    actorType: "user",
+    createdAt: "2026-01-01T20:30:00.000Z",
+    _status: "failed",
+    _cachedAt: 1,
+  }
+}
+
+describe("cancelCommandDispatch", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await db.events.clear()
+    await db.pendingOperations.clear()
+  })
+
+  it("removes the local command lifecycle and queued dispatch", async () => {
+    await db.events.bulkPut([
+      commandEvent(commandId, "command_dispatched"),
+      commandEvent(`${commandId}:failed`, "command_failed"),
+    ])
+    await db.pendingOperations.add({
+      id: "op_1",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+    })
+
+    await cancelCommandDispatch(streamId, commandId)
+
+    expect(await db.events.where("streamId").equals(streamId).toArray()).toEqual([])
+    expect(await db.pendingOperations.toArray()).toEqual([])
+  })
+
+  it("does not restore a command cancelled while its request is in flight", async () => {
+    await db.events.put(commandEvent(commandId, "command_dispatched"))
+    await db.pendingOperations.add({
+      id: "op_1",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+    })
+
+    let resolveDispatch!: (value: Awaited<ReturnType<typeof commandsApi.dispatch>>) => void
+    const dispatchResult = new Promise<Awaited<ReturnType<typeof commandsApi.dispatch>>>((resolve) => {
+      resolveDispatch = resolve
+    })
+    vi.spyOn(commandsApi, "dispatch").mockReturnValue(dispatchResult)
+
+    const processing = processOperationQueue(
+      { update: vi.fn(), delete: vi.fn() },
+      { add: vi.fn(), remove: vi.fn() },
+      undefined,
+      undefined,
+      () => true
+    )
+    await vi.waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledOnce())
+    await cancelCommandDispatch(streamId, commandId)
+    resolveDispatch({
+      success: true,
+      commandId: "cmd_confirmed",
+      command: "thinking",
+      args: "low",
+      event: {
+        id: "evt_confirmed",
+        streamId,
+        sequence: "10",
+        eventType: "command_dispatched",
+        payload: { commandId: "cmd_confirmed", name: "thinking", args: "low", status: "dispatched" },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: "2026-01-01T20:30:01.000Z",
+      },
+    })
+    await processing
+
+    expect(await db.events.toArray()).toEqual([])
+  })
+})

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -80,6 +80,32 @@ describe("cancelCommandDispatch", () => {
     expect((await db.events.get(`${commandId}:failed`))?._anchorSequenceNum).toBe(4)
   })
 
+  it("allows cancellation between idempotent retries", async () => {
+    const dispatched = commandEvent(commandId, "command_dispatched")
+    dispatched._status = "pending"
+    await db.events.put(dispatched)
+    await db.pendingOperations.add({
+      id: "op_retry",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId },
+      createdAt: 1,
+      retryCount: 0,
+    })
+    vi.spyOn(commandsApi, "dispatch").mockRejectedValue(new Error("offline"))
+
+    await processOperationQueue(
+      { update: vi.fn(), delete: vi.fn() },
+      { add: vi.fn(), remove: vi.fn() },
+      undefined,
+      undefined,
+      () => true
+    )
+
+    expect((await db.pendingOperations.get("op_retry"))?.startedAt).toBeUndefined()
+    expect(await cancelCommandDispatch(streamId, commandId)).toBe(true)
+  })
+
   it("refuses cancellation while a dispatch request is in flight", async () => {
     await db.events.put(commandEvent(commandId, "command_dispatched"))
     await db.pendingOperations.add({

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -80,7 +80,7 @@ describe("cancelCommandDispatch", () => {
     expect((await db.events.get(`${commandId}:failed`))?._anchorSequenceNum).toBe(4)
   })
 
-  it("allows cancellation between idempotent retries", async () => {
+  it("refuses cancellation after an ambiguous transient failure", async () => {
     const dispatched = commandEvent(commandId, "command_dispatched")
     dispatched._status = "pending"
     await db.events.put(dispatched)
@@ -102,8 +102,8 @@ describe("cancelCommandDispatch", () => {
       () => true
     )
 
-    expect((await db.pendingOperations.get("op_retry"))?.startedAt).toBeUndefined()
-    expect(await cancelCommandDispatch(streamId, commandId)).toBe(true)
+    expect((await db.pendingOperations.get("op_retry"))?.startedAt).toBeDefined()
+    expect(await cancelCommandDispatch(streamId, commandId)).toBe(false)
   })
 
   it("refuses cancellation while a dispatch request is in flight", async () => {

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -54,7 +54,7 @@ describe("cancelCommandDispatch", () => {
     expect(await db.pendingOperations.toArray()).toEqual([])
   })
 
-  it("does not restore a command cancelled while its request is in flight", async () => {
+  it("refuses cancellation while a dispatch request is in flight", async () => {
     await db.events.put(commandEvent(commandId, "command_dispatched"))
     await db.pendingOperations.add({
       id: "op_1",
@@ -79,7 +79,7 @@ describe("cancelCommandDispatch", () => {
       () => true
     )
     await vi.waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledOnce())
-    await cancelCommandDispatch(streamId, commandId)
+    expect(await cancelCommandDispatch(streamId, commandId)).toBe(false)
     resolveDispatch({
       success: true,
       commandId: "cmd_confirmed",
@@ -98,6 +98,6 @@ describe("cancelCommandDispatch", () => {
     })
     await processing
 
-    expect(await db.events.toArray()).toEqual([])
+    expect((await db.events.toArray()).map((event) => event.id)).toEqual(["evt_confirmed"])
   })
 })

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -6,6 +6,24 @@ import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { AuthorTypes, CommandKinds, type StreamEvent } from "@threa/types"
 
+export async function cancelCommandDispatch(streamId: string, commandId: string): Promise<void> {
+  await db.transaction("rw", [db.events, db.pendingOperations], async () => {
+    const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
+    const operationIds = operations
+      .filter((operation) => operation.payload.optimisticEventId === commandId)
+      .map((operation) => operation.id)
+    const dispatched = await db.events.get(commandId)
+    if (dispatched?.streamId !== streamId) return
+
+    await db.pendingOperations.bulkDelete(operationIds)
+    await db.events.bulkDelete([commandId, `${commandId}:failed`])
+  })
+}
+
+export function useCancelCommandDispatch(streamId: string) {
+  return useCallback((commandId: string) => cancelCommandDispatch(streamId, commandId), [streamId])
+}
+
 function parseCommandArgs(commandMarkdown: string): string {
   const trimmed = commandMarkdown.trim()
   const withoutSlash = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -65,32 +65,34 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
         throw new Error("Cannot dispatch command: user identity not resolved yet")
       }
 
-      const optimisticSequence = nextOptimisticSequence()
-      const optimisticEventId = `temp_cmd_${optimisticSequence}_${Math.random().toString(36).slice(2)}`
+      const optimisticEventId = `temp_cmd_${Date.now()}_${Math.random().toString(36).slice(2)}`
       const now = new Date().toISOString()
-      const optimisticEvent: StreamEvent = {
-        id: optimisticEventId,
-        streamId,
-        sequence: optimisticSequence,
-        eventType: "command_dispatched",
-        payload: {
-          commandId: optimisticEventId,
-          name: params.commandName,
-          args: parseCommandArgs(params.commandMarkdown),
-          status: "dispatched",
-          executionKind: CommandKinds.BOT_RUNTIME,
-        },
-        actorId: currentUserId,
-        actorType: AuthorTypes.USER,
-        createdAt: now,
-      }
 
       await db.transaction("rw", [db.events, db.pendingOperations], async () => {
-        const anchorSequence = await getLatestPersistedSequence(streamId)
+        const [anchorSequence, optimisticSequence] = await Promise.all([
+          getLatestPersistedSequence(streamId),
+          nextOptimisticSequence(streamId),
+        ])
+        const optimisticEvent: StreamEvent = {
+          id: optimisticEventId,
+          streamId,
+          sequence: optimisticSequence,
+          eventType: "command_dispatched",
+          payload: {
+            commandId: optimisticEventId,
+            name: params.commandName,
+            args: parseCommandArgs(params.commandMarkdown),
+            status: "dispatched",
+            executionKind: CommandKinds.BOT_RUNTIME,
+          },
+          actorId: currentUserId,
+          actorType: AuthorTypes.USER,
+          createdAt: now,
+        }
         await db.events.add({
           ...optimisticEvent,
           workspaceId,
-          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _sequenceNum: sequenceToNum(optimisticSequence),
           ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _status: "pending",
           _cachedAt: Date.now(),

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useUser } from "@/auth"
 import { db, sequenceToNum } from "@/db"
-import { enqueueOperation } from "@/sync/operation-queue"
+import { enqueueOperation, reclaimStaleCommandAttempts } from "@/sync/operation-queue"
+import { getLatestPersistedSequence } from "@/sync/stream-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { AuthorTypes, CommandKinds, type StreamEvent } from "@threa/types"
@@ -25,6 +26,7 @@ export async function cancelCommandDispatch(streamId: string, commandId: string)
 }
 
 export function useCommandDispatchCancellation(streamId: string, commandId: string, localStatus: string | undefined) {
+  const syncEngine = useOptionalSyncEngine()
   const operation = useLiveQuery(
     async () =>
       (await db.pendingOperations
@@ -35,6 +37,17 @@ export function useCommandDispatchCancellation(streamId: string, commandId: stri
     [commandId],
     undefined
   )
+  useEffect(() => {
+    if (!operation?.attempting) return
+    let active = true
+    void reclaimStaleCommandAttempts().then((reclaimed) => {
+      if (active && reclaimed) syncEngine?.kickOperationQueue()
+    })
+    return () => {
+      active = false
+    }
+  }, [operation?.attempting, syncEngine])
+
   const canCancel =
     localStatus === "failed" || (localStatus === "pending" && operation != null && !operation.attempting)
   const cancel = useCallback(() => cancelCommandDispatch(streamId, commandId), [commandId, streamId])
@@ -85,10 +98,12 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
       }
 
       await db.transaction("rw", [db.events, db.pendingOperations], async () => {
+        const anchorSequence = await getLatestPersistedSequence(streamId)
         await db.events.add({
           ...optimisticEvent,
           workspaceId,
           _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
           _status: "pending",
           _cachedAt: Date.now(),
         })

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -9,36 +9,78 @@ import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { AuthorTypes, CommandKinds, type StreamEvent } from "@threa/types"
 import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
 
-export async function cancelCommandDispatch(streamId: string, commandId: string): Promise<boolean> {
+/**
+ * Removes a cancellable optimistic command and its queued dispatch.
+ *
+ * @param workspaceId - Workspace that owns the command.
+ * @param streamId - Stream that owns the optimistic event.
+ * @param commandId - Optimistic command event identifier.
+ * @returns Whether the command was still cancellable and was removed.
+ * @example
+ * await cancelCommandDispatch("ws_123", "stream_123", "temp_cmd_123")
+ */
+export async function cancelCommandDispatch(
+  workspaceId: string,
+  streamId: string,
+  commandId: string
+): Promise<boolean> {
   return db.transaction("rw", [db.events, db.pendingOperations], async () => {
     const operations = (await db.pendingOperations.where("type").equals("dispatch_command").toArray()).filter(
-      (operation) => operation.payload.optimisticEventId === commandId
+      (operation) => operation.workspaceId === workspaceId && operation.payload.optimisticEventId === commandId
     )
     if (operations.some((operation) => operation.startedAt != null)) return false
 
     const dispatched = await db.events.get(commandId)
-    if (dispatched?.streamId !== streamId) return false
+    if (dispatched?.workspaceId !== workspaceId || dispatched.streamId !== streamId) return false
 
     await db.pendingOperations.bulkDelete(operations.map((operation) => operation.id))
-    await db.events.bulkDelete([commandId, `${commandId}:failed`])
+    const eventIds = [commandId, `${commandId}:failed`]
+    const events = await db.events.bulkGet(eventIds)
+    await db.events.bulkDelete(
+      eventIds.filter((_, index) => {
+        const event = events[index]
+        return event?.workspaceId === workspaceId && event.streamId === streamId
+      })
+    )
     return true
   })
 }
 
-export function useCommandDispatchCancellation(streamId: string, commandId: string, localStatus: string | undefined) {
+/**
+ * Observes whether a local command can be cancelled and exposes its cancellation action.
+ *
+ * @param workspaceId - Workspace that owns the command.
+ * @param streamId - Stream that owns the command.
+ * @param commandId - Optimistic command event identifier.
+ * @param localStatus - Current local optimistic status.
+ * @returns Reactive cancellation eligibility and callback.
+ * @example
+ * const { canCancel, cancel } = useCommandDispatchCancellation(workspaceId, streamId, commandId, status)
+ */
+export function useCommandDispatchCancellation(
+  workspaceId: string,
+  streamId: string,
+  commandId: string,
+  localStatus: string | undefined
+) {
   const operation = useLiveQuery(
     async () =>
       (await db.pendingOperations
         .where("type")
         .equals("dispatch_command")
-        .filter((candidate) => candidate.payload.optimisticEventId === commandId)
+        .filter(
+          (candidate) => candidate.workspaceId === workspaceId && candidate.payload.optimisticEventId === commandId
+        )
         .first()) ?? null,
-    [commandId],
+    [commandId, workspaceId],
     undefined
   )
   const canCancel =
     localStatus === "failed" || (localStatus === "pending" && operation != null && operation.startedAt == null)
-  const cancel = useCallback(() => cancelCommandDispatch(streamId, commandId), [commandId, streamId])
+  const cancel = useCallback(
+    () => cancelCommandDispatch(workspaceId, streamId, commandId),
+    [commandId, streamId, workspaceId]
+  )
   return { canCancel, cancel }
 }
 
@@ -50,6 +92,15 @@ function parseCommandArgs(commandMarkdown: string): string {
   return withoutSlash.slice(firstSpace).trim()
 }
 
+/**
+ * Creates optimistic command events and queues their durable dispatch operations.
+ *
+ * @param workspaceId - Workspace receiving the command.
+ * @param streamId - Stream receiving the command.
+ * @returns A callback that queues a slash command.
+ * @example
+ * const { queueCommand } = useCommandDispatchQueue(workspaceId, streamId)
+ */
 export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
   const user = useUser()
   const syncEngine = useOptionalSyncEngine()

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -1,27 +1,44 @@
 import { useCallback, useMemo } from "react"
+import { useLiveQuery } from "dexie-react-hooks"
 import { useUser } from "@/auth"
 import { db, sequenceToNum } from "@/db"
 import { enqueueOperation } from "@/sync/operation-queue"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { AuthorTypes, CommandKinds, type StreamEvent } from "@threa/types"
+import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
 
-export async function cancelCommandDispatch(streamId: string, commandId: string): Promise<void> {
-  await db.transaction("rw", [db.events, db.pendingOperations], async () => {
-    const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
-    const operationIds = operations
-      .filter((operation) => operation.payload.optimisticEventId === commandId)
-      .map((operation) => operation.id)
+export async function cancelCommandDispatch(streamId: string, commandId: string): Promise<boolean> {
+  return db.transaction("rw", [db.events, db.pendingOperations], async () => {
+    const operations = (await db.pendingOperations.where("type").equals("dispatch_command").toArray()).filter(
+      (operation) => operation.payload.optimisticEventId === commandId
+    )
+    if (operations.some((operation) => operation.attempting)) return false
+
     const dispatched = await db.events.get(commandId)
-    if (dispatched?.streamId !== streamId) return
+    if (dispatched?.streamId !== streamId) return false
 
-    await db.pendingOperations.bulkDelete(operationIds)
+    await db.pendingOperations.bulkDelete(operations.map((operation) => operation.id))
     await db.events.bulkDelete([commandId, `${commandId}:failed`])
+    return true
   })
 }
 
-export function useCancelCommandDispatch(streamId: string) {
-  return useCallback((commandId: string) => cancelCommandDispatch(streamId, commandId), [streamId])
+export function useCommandDispatchCancellation(streamId: string, commandId: string, localStatus: string | undefined) {
+  const operation = useLiveQuery(
+    async () =>
+      (await db.pendingOperations
+        .where("type")
+        .equals("dispatch_command")
+        .filter((candidate) => candidate.payload.optimisticEventId === commandId)
+        .first()) ?? null,
+    [commandId],
+    undefined
+  )
+  const canCancel =
+    localStatus === "failed" || (localStatus === "pending" && operation != null && !operation.attempting)
+  const cancel = useCallback(() => cancelCommandDispatch(streamId, commandId), [commandId, streamId])
+  return { canCancel, cancel }
 }
 
 function parseCommandArgs(commandMarkdown: string): string {
@@ -47,12 +64,13 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
         throw new Error("Cannot dispatch command: user identity not resolved yet")
       }
 
-      const optimisticEventId = `temp_cmd_${Date.now()}_${Math.random().toString(36).slice(2)}`
+      const optimisticSequence = nextOptimisticSequence()
+      const optimisticEventId = `temp_cmd_${optimisticSequence}_${Math.random().toString(36).slice(2)}`
       const now = new Date().toISOString()
       const optimisticEvent: StreamEvent = {
         id: optimisticEventId,
         streamId,
-        sequence: Date.now().toString(),
+        sequence: optimisticSequence,
         eventType: "command_dispatched",
         payload: {
           commandId: optimisticEventId,

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useUser } from "@/auth"
 import { db, sequenceToNum } from "@/db"
-import { enqueueOperation, reclaimStaleCommandAttempts } from "@/sync/operation-queue"
+import { enqueueOperation } from "@/sync/operation-queue"
 import { getLatestPersistedSequence } from "@/sync/stream-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
@@ -14,7 +14,7 @@ export async function cancelCommandDispatch(streamId: string, commandId: string)
     const operations = (await db.pendingOperations.where("type").equals("dispatch_command").toArray()).filter(
       (operation) => operation.payload.optimisticEventId === commandId
     )
-    if (operations.some((operation) => operation.attempting)) return false
+    if (operations.some((operation) => operation.startedAt != null)) return false
 
     const dispatched = await db.events.get(commandId)
     if (dispatched?.streamId !== streamId) return false
@@ -26,7 +26,6 @@ export async function cancelCommandDispatch(streamId: string, commandId: string)
 }
 
 export function useCommandDispatchCancellation(streamId: string, commandId: string, localStatus: string | undefined) {
-  const syncEngine = useOptionalSyncEngine()
   const operation = useLiveQuery(
     async () =>
       (await db.pendingOperations
@@ -37,19 +36,8 @@ export function useCommandDispatchCancellation(streamId: string, commandId: stri
     [commandId],
     undefined
   )
-  useEffect(() => {
-    if (!operation?.attempting) return
-    let active = true
-    void reclaimStaleCommandAttempts().then((reclaimed) => {
-      if (active && reclaimed) syncEngine?.kickOperationQueue()
-    })
-    return () => {
-      active = false
-    }
-  }, [operation?.attempting, syncEngine])
-
   const canCancel =
-    localStatus === "failed" || (localStatus === "pending" && operation != null && !operation.attempting)
+    localStatus === "failed" || (localStatus === "pending" && operation != null && operation.startedAt == null)
   const cancel = useCallback(() => cancelCommandDispatch(streamId, commandId), [commandId, streamId])
   return { canCancel, cancel }
 }
@@ -103,7 +91,7 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
           ...optimisticEvent,
           workspaceId,
           _sequenceNum: sequenceToNum(optimisticEvent.sequence),
-          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
+          ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _status: "pending",
           _cachedAt: Date.now(),
         })

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -6,7 +6,7 @@ import { db, sequenceToNum, type CachedStream, type PendingStreamCreation } from
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { StreamTypes, Visibilities, type ConversationDirective, type JSONContent, type StreamEvent } from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
-import { optimisticReplyCountUpdate } from "@/sync/stream-sync"
+import { getLatestPersistedSequence, optimisticReplyCountUpdate } from "@/sync/stream-sync"
 import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
 import { sealOutgoingMessage, type SealOutgoingMessageResult } from "@/lib/crypto/seal-send"
 import { reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
@@ -148,31 +148,35 @@ export function useQueueDraftMessage(workspaceId: string) {
 
       markPending(clientId)
 
-      await db.pendingMessages.add({
-        clientId,
-        workspaceId: params.workspaceId,
-        streamId: params.streamId,
-        content: contentMarkdown,
-        contentFormat: "markdown",
-        contentJson: input.contentJson,
-        attachmentIds: input.attachmentIds,
-        createdAt: Date.now(),
-        retryCount: 0,
-        streamCreation: params.streamCreation,
-        conversation: params.conversation,
-        draftId: params.draftId,
-        ...(e2eFields
-          ? { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
-          : {}),
-      })
+      await db.transaction("rw", [db.pendingMessages, db.events], async () => {
+        const anchorSequence = await getLatestPersistedSequence(params.streamId)
+        await db.pendingMessages.add({
+          clientId,
+          workspaceId: params.workspaceId,
+          streamId: params.streamId,
+          content: contentMarkdown,
+          contentFormat: "markdown",
+          contentJson: input.contentJson,
+          attachmentIds: input.attachmentIds,
+          createdAt: Date.now(),
+          retryCount: 0,
+          streamCreation: params.streamCreation,
+          conversation: params.conversation,
+          draftId: params.draftId,
+          ...(e2eFields
+            ? { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
+            : {}),
+        })
 
-      await db.events.add({
-        ...optimisticEvent,
-        workspaceId: params.workspaceId,
-        _sequenceNum: sequenceToNum(optimisticEvent.sequence),
-        _clientId: clientId,
-        _status: "pending",
-        _cachedAt: Date.now(),
+        await db.events.add({
+          ...optimisticEvent,
+          workspaceId: params.workspaceId,
+          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
+          _clientId: clientId,
+          _status: "pending",
+          _cachedAt: Date.now(),
+        })
       })
 
       // Surface the committed draft in the sidebar and quick switcher so the

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -7,6 +7,7 @@ import { serializeToMarkdown } from "@threa/prosemirror"
 import { StreamTypes, Visibilities, type ConversationDirective, type JSONContent, type StreamEvent } from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { optimisticReplyCountUpdate } from "@/sync/stream-sync"
+import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
 import { sealOutgoingMessage, type SealOutgoingMessageResult } from "@/lib/crypto/seal-send"
 import { reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { generateClientId } from "./use-stream-or-draft"
@@ -73,7 +74,7 @@ export function useQueueDraftMessage(workspaceId: string) {
       const clientId = generateClientId()
       const now = new Date().toISOString()
       const contentMarkdown = serializeToMarkdown(input.contentJson)
-      const optimisticSequence = Date.now().toString()
+      const optimisticSequence = nextOptimisticSequence()
 
       const optimisticEvent: StreamEvent = {
         id: clientId,

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -74,12 +74,11 @@ export function useQueueDraftMessage(workspaceId: string) {
       const clientId = generateClientId()
       const now = new Date().toISOString()
       const contentMarkdown = serializeToMarkdown(input.contentJson)
-      const optimisticSequence = "0"
 
       const optimisticEvent: StreamEvent = {
         id: clientId,
         streamId: params.streamId,
-        sequence: optimisticSequence,
+        sequence: "0",
         eventType: "message_created",
         payload: {
           messageId: clientId,

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -172,7 +172,7 @@ export function useQueueDraftMessage(workspaceId: string) {
           ...optimisticEvent,
           workspaceId: params.workspaceId,
           _sequenceNum: sequenceToNum(optimisticEvent.sequence),
-          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
+          ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _clientId: clientId,
           _status: "pending",
           _cachedAt: Date.now(),

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -74,7 +74,7 @@ export function useQueueDraftMessage(workspaceId: string) {
       const clientId = generateClientId()
       const now = new Date().toISOString()
       const contentMarkdown = serializeToMarkdown(input.contentJson)
-      const optimisticSequence = nextOptimisticSequence()
+      const optimisticSequence = "0"
 
       const optimisticEvent: StreamEvent = {
         id: clientId,
@@ -149,7 +149,10 @@ export function useQueueDraftMessage(workspaceId: string) {
       markPending(clientId)
 
       await db.transaction("rw", [db.pendingMessages, db.events], async () => {
-        const anchorSequence = await getLatestPersistedSequence(params.streamId)
+        const [anchorSequence, allocatedSequence] = await Promise.all([
+          getLatestPersistedSequence(params.streamId),
+          nextOptimisticSequence(params.streamId),
+        ])
         await db.pendingMessages.add({
           clientId,
           workspaceId: params.workspaceId,
@@ -171,7 +174,8 @@ export function useQueueDraftMessage(workspaceId: string) {
         await db.events.add({
           ...optimisticEvent,
           workspaceId: params.workspaceId,
-          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          sequence: allocatedSequence,
+          _sequenceNum: sequenceToNum(allocatedSequence),
           ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _clientId: clientId,
           _status: "pending",

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -34,6 +34,7 @@ import type {
   ToolPrivacyPolicy,
 } from "@threa/types"
 import { StreamTypes, Visibilities, CompanionModes } from "@threa/types"
+import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
 
 const DM_DRAFT_PREFIX = "draft_dm_"
 
@@ -588,7 +589,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
       // Use timestamp as sequence to ensure optimistic events sort after real events
       // Real events have low sequence numbers (1, 2, 3...), timestamps are ~13 digits
-      const optimisticSequence = Date.now().toString()
+      const optimisticSequence = nextOptimisticSequence()
 
       const optimisticEvent: StreamEvent = {
         id: clientId,

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -686,7 +686,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
           ...optimisticEvent,
           workspaceId,
           _sequenceNum: sequenceToNum(optimisticEvent.sequence),
-          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
+          ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _clientId: clientId,
           _status: "pending",
           _cachedAt: Date.now(),

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -588,14 +588,10 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
       const contentMarkdown = serializeToMarkdown(input.contentJson)
 
-      // Use timestamp as sequence to ensure optimistic events sort after real events
-      // Real events have low sequence numbers (1, 2, 3...), timestamps are ~13 digits
-      const optimisticSequence = "0"
-
       const optimisticEvent: StreamEvent = {
         id: clientId,
         streamId,
-        sequence: optimisticSequence,
+        sequence: "0",
         eventType: "message_created",
         payload: {
           messageId: clientId,

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -14,6 +14,7 @@ import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage, conversationTag } from "./use-queue-draft-message"
 import { useWorkspaceUsers, useWorkspaceStreams, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useSyncEngine } from "@/sync/sync-engine"
+import { getLatestPersistedSequence } from "@/sync/stream-sync"
 import { hasSeededDraftCache } from "@/stores/draft-store"
 import { getDraftMessageKey, purgeScopeDrafts, upsertLoadedDraft } from "./use-draft-message"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
@@ -665,6 +666,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
       // message stays one queue item so replay cannot dispatch the command
       // before the message reaches the server.
       await db.transaction("rw", [db.pendingMessages, db.events], async () => {
+        const anchorSequence = await getLatestPersistedSequence(streamId)
         await db.pendingMessages.add({
           clientId,
           workspaceId,
@@ -684,6 +686,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
           ...optimisticEvent,
           workspaceId,
           _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _anchorSequenceNum: sequenceToNum(anchorSequence ?? "0"),
           _clientId: clientId,
           _status: "pending",
           _cachedAt: Date.now(),

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -590,7 +590,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
       // Use timestamp as sequence to ensure optimistic events sort after real events
       // Real events have low sequence numbers (1, 2, 3...), timestamps are ~13 digits
-      const optimisticSequence = nextOptimisticSequence()
+      const optimisticSequence = "0"
 
       const optimisticEvent: StreamEvent = {
         id: clientId,
@@ -666,7 +666,10 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
       // message stays one queue item so replay cannot dispatch the command
       // before the message reaches the server.
       await db.transaction("rw", [db.pendingMessages, db.events], async () => {
-        const anchorSequence = await getLatestPersistedSequence(streamId)
+        const [anchorSequence, allocatedSequence] = await Promise.all([
+          getLatestPersistedSequence(streamId),
+          nextOptimisticSequence(streamId),
+        ])
         await db.pendingMessages.add({
           clientId,
           workspaceId,
@@ -685,7 +688,8 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         await db.events.add({
           ...optimisticEvent,
           workspaceId,
-          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          sequence: allocatedSequence,
+          _sequenceNum: sequenceToNum(allocatedSequence),
           ...(anchorSequence != null && { _anchorSequenceNum: sequenceToNum(anchorSequence) }),
           _clientId: clientId,
           _status: "pending",

--- a/apps/frontend/src/lib/optimistic-sequence.test.ts
+++ b/apps/frontend/src/lib/optimistic-sequence.test.ts
@@ -1,11 +1,28 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
+import { db } from "@/db"
 import { nextOptimisticSequence } from "./optimistic-sequence"
 
 describe("nextOptimisticSequence", () => {
-  it("stays monotonic when multiple sends share a millisecond", () => {
-    const first = BigInt(nextOptimisticSequence(1_000))
-    const second = BigInt(nextOptimisticSequence(1_000))
+  beforeEach(async () => {
+    await db.events.clear()
+  })
 
-    expect(second).toBe(first + 1n)
+  it("advances beyond the durable stream sequence when clocks tie or move backward", async () => {
+    await db.events.put({
+      id: "temp_existing",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1001",
+      _sequenceNum: 1001,
+      eventType: "message_created",
+      payload: {},
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      _status: "pending",
+      _cachedAt: 1,
+    })
+
+    expect(await nextOptimisticSequence("stream_1", 1000)).toBe("1002")
   })
 })

--- a/apps/frontend/src/lib/optimistic-sequence.test.ts
+++ b/apps/frontend/src/lib/optimistic-sequence.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+import { nextOptimisticSequence } from "./optimistic-sequence"
+
+describe("nextOptimisticSequence", () => {
+  it("stays monotonic when multiple sends share a millisecond", () => {
+    const first = BigInt(nextOptimisticSequence(1_000))
+    const second = BigInt(nextOptimisticSequence(1_000))
+
+    expect(second).toBe(first + 1n)
+  })
+})

--- a/apps/frontend/src/lib/optimistic-sequence.ts
+++ b/apps/frontend/src/lib/optimistic-sequence.ts
@@ -1,6 +1,10 @@
-let lastOptimisticSequence = 0
+import { db } from "@/db"
 
-export function nextOptimisticSequence(now = Date.now()): string {
-  lastOptimisticSequence = Math.max(now, lastOptimisticSequence + 1)
-  return lastOptimisticSequence.toString()
+export async function nextOptimisticSequence(streamId: string, now = Date.now()): Promise<string> {
+  const latest = await db.events
+    .where("[streamId+_sequenceNum]")
+    .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
+    .reverse()
+    .first()
+  return Math.max(now, (latest?._sequenceNum ?? 0) + 1).toString()
 }

--- a/apps/frontend/src/lib/optimistic-sequence.ts
+++ b/apps/frontend/src/lib/optimistic-sequence.ts
@@ -1,0 +1,6 @@
+let lastOptimisticSequence = 0
+
+export function nextOptimisticSequence(now = Date.now()): string {
+  lastOptimisticSequence = Math.max(now, lastOptimisticSequence + 1)
+  return lastOptimisticSequence.toString()
+}

--- a/apps/frontend/src/lib/optimistic-sequence.ts
+++ b/apps/frontend/src/lib/optimistic-sequence.ts
@@ -1,5 +1,15 @@
 import { db } from "@/db"
 
+/**
+ * Allocates an optimistic sequence after the latest locally cached event.
+ * Call this inside the same read-write events transaction that persists the event.
+ *
+ * @param streamId - Stream receiving the optimistic event.
+ * @param now - Clock value used as the minimum sequence.
+ * @returns A decimal sequence string unique within the serialized transaction.
+ * @example
+ * const sequence = await nextOptimisticSequence(streamId)
+ */
 export async function nextOptimisticSequence(streamId: string, now = Date.now()): Promise<string> {
   const latest = await db.events
     .where("[streamId+_sequenceNum]")

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { loadStreamEvents, shareEventIdentities } from "./stream-store"
+import { loadStreamEvents, orderStreamEvents, shareEventIdentities } from "./stream-store"
 import { bumpLaterOptimisticAnchors } from "@/sync/stream-sync"
 
 const WORKSPACE_ID = "ws_1"
@@ -229,6 +229,28 @@ describe("loadStreamEvents", () => {
       "evt_stream_slow_clock_2",
       "temp_slow",
       "evt_stream_slow_clock_3",
+    ])
+  })
+
+  it("preserves thread chronology while anchoring optimistic rows", () => {
+    const streamId = "stream_thread"
+    const first = makeRealEvent(streamId, "1")
+    first.createdAt = "2026-01-02T00:00:00.000Z"
+    const movedOlder = makeRealEvent(streamId, "2")
+    movedOlder.createdAt = "2026-01-01T00:00:00.000Z"
+    const future = makeRealEvent(streamId, "3")
+    future.createdAt = "2026-01-03T00:00:00.000Z"
+    const optimistic = makeOptimisticEvent(streamId, "temp_thread", "1000", "1990-01-01T00:00:00.000Z", 1)
+
+    const events = orderStreamEvents([first, movedOlder, future, optimistic], (a, b) =>
+      a.createdAt.localeCompare(b.createdAt)
+    )
+
+    expect(events.map((event) => event.id)).toEqual([
+      "evt_stream_thread_2",
+      "evt_stream_thread_1",
+      "temp_thread",
+      "evt_stream_thread_3",
     ])
   })
 

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -21,7 +21,12 @@ function makeRealEvent(streamId: string, sequence: string): CachedEvent {
   }
 }
 
-function makeOptimisticEvent(streamId: string, clientId: string, placeholderSeq: string): CachedEvent {
+function makeOptimisticEvent(
+  streamId: string,
+  clientId: string,
+  placeholderSeq: string,
+  createdAt = new Date(2026, 0, 2).toISOString()
+): CachedEvent {
   const sequenceNum = sequenceToNum(placeholderSeq)
   return {
     id: clientId,
@@ -33,7 +38,7 @@ function makeOptimisticEvent(streamId: string, clientId: string, placeholderSeq:
     payload: { messageId: clientId, contentMarkdown: clientId },
     actorId: "user_1",
     actorType: "user",
-    createdAt: new Date().toISOString(),
+    createdAt,
     _clientId: clientId,
     _status: "pending",
     _cachedAt: Date.now(),
@@ -156,32 +161,37 @@ describe("loadStreamEvents", () => {
     ])
   })
 
-  it("merges pending events that fell outside the count-capped window in ASC order", async () => {
-    // Defensive: if a pending event's _sequenceNum is somehow lower than the
-    // window of latest events, the merge step must still place it correctly
-    // by _sequenceNum rather than appending at the end.
+  it("merges optimistic events outside the count-capped window by createdAt", async () => {
     const streamId = "stream_fallback"
-
-    // Stuff the stream with > DEFAULT_IDB_EVENT_LIMIT (150) real events so the
-    // window cap matters. Insert one pending event with a deliberately low
-    // _sequenceNum (simulating a hypothetical alternative scheme).
     const reals: CachedEvent[] = []
     for (let i = 1; i <= 200; i++) {
       reals.push(makeRealEvent(streamId, String(i)))
     }
-    const lowPending = makeOptimisticEvent(streamId, "temp_low", "10")
-    await db.events.bulkPut([...reals, lowPending])
+    const oldPending = makeOptimisticEvent(streamId, "temp_old", "10", new Date(2026, 0, 1, 0, 0, 10).toISOString())
+    await db.events.bulkPut([...reals, oldPending])
 
     const events = await loadStreamEvents(streamId, null)
 
-    // Pending event must appear before the events with seq=11..200, between
-    // seq=10 and seq=51 (the floor of the latest 150 real events).
-    const ids = events.map((e) => e.id)
-    const lowIdx = ids.indexOf("temp_low")
-    expect(lowIdx).toBeGreaterThanOrEqual(0)
-    // It sorts by _sequenceNum=10, which falls before all reals in the window
-    // (seqs 51..200 — 200 reals capped to latest 150 = seqs 51..200).
-    expect(ids[0]).toBe("temp_low")
+    expect(events[0].id).toBe("temp_old")
+  })
+
+  it("lets a failed optimistic command move above newer persisted events", async () => {
+    const streamId = "stream_failed_command"
+    const failed = makeOptimisticEvent(streamId, "temp_cmd", "1714428000000", "2026-01-01T20:30:00.000Z")
+    failed.eventType = "command_dispatched"
+    failed._status = "failed"
+    failed.payload = { commandId: failed.id, name: "thinking", args: "low", status: "dispatched" }
+    const newer = makeRealEvent(streamId, "2")
+    newer.createdAt = "2026-01-01T21:13:00.000Z"
+    await db.events.bulkPut([makeRealEvent(streamId, "1"), failed, newer])
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((event) => event.id)).toEqual([
+      "evt_stream_failed_command_1",
+      "temp_cmd",
+      "evt_stream_failed_command_2",
+    ])
   })
 
   it("returns a large floored window fully ASC without an unsent merge", async () => {

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -261,7 +261,7 @@ describe("loadStreamEvents", () => {
     await db.events.bulkPut([makeRealEvent(streamId, "1"), first, second])
 
     await db.transaction("rw", db.events, async () => {
-      await bumpLaterOptimisticAnchors(streamId, first._sequenceNum, 2)
+      await bumpLaterOptimisticAnchors(streamId, first._sequenceNum, 2, first.id)
       await db.events.delete(first.id)
       await db.events.put(makeRealEvent(streamId, "2"))
     })
@@ -273,6 +273,17 @@ describe("loadStreamEvents", () => {
       "evt_stream_partial_ack_2",
       "temp_second",
     ])
+  })
+
+  it("bumps a deterministic later row when cross-tab optimistic sequences tie", async () => {
+    const streamId = "stream_cross_tab_tie"
+    const confirmed = makeOptimisticEvent(streamId, "temp_a", "1000", "2026-01-01T00:00:01.000Z", 1)
+    const later = makeOptimisticEvent(streamId, "temp_z", "1000", "2026-01-01T00:00:01.000Z", 1)
+    await db.events.bulkPut([confirmed, later])
+
+    await bumpLaterOptimisticAnchors(streamId, confirmed._sequenceNum, 2, confirmed.id)
+
+    expect((await db.events.get(later.id))?._anchorSequenceNum).toBe(2)
   })
 
   it("lets a failed optimistic command move above newer persisted events", async () => {

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -25,7 +25,8 @@ function makeOptimisticEvent(
   streamId: string,
   clientId: string,
   placeholderSeq: string,
-  createdAt = new Date(2026, 0, 2).toISOString()
+  createdAt = new Date(2026, 0, 2).toISOString(),
+  anchorSequenceNum?: number
 ): CachedEvent {
   const sequenceNum = sequenceToNum(placeholderSeq)
   return {
@@ -41,6 +42,7 @@ function makeOptimisticEvent(
     createdAt,
     _clientId: clientId,
     _status: "pending",
+    _anchorSequenceNum: anchorSequenceNum,
     _cachedAt: Date.now(),
   }
 }
@@ -167,7 +169,7 @@ describe("loadStreamEvents", () => {
     for (let i = 1; i <= 200; i++) {
       reals.push(makeRealEvent(streamId, String(i)))
     }
-    const oldPending = makeOptimisticEvent(streamId, "temp_old", "10", new Date(2026, 0, 1, 0, 0, 10).toISOString())
+    const oldPending = makeOptimisticEvent(streamId, "temp_old", "10", new Date(2026, 0, 1, 0, 0, 10).toISOString(), 10)
     await db.events.bulkPut([...reals, oldPending])
 
     const events = await loadStreamEvents(streamId, null)
@@ -179,8 +181,8 @@ describe("loadStreamEvents", () => {
     const streamId = "stream_same_millisecond"
     const createdAt = "2026-01-01T20:30:00.000Z"
     await db.events.bulkPut([
-      makeOptimisticEvent(streamId, "temp_z", "1000", createdAt),
-      makeOptimisticEvent(streamId, "temp_a", "1001", createdAt),
+      makeOptimisticEvent(streamId, "temp_z", "1000", createdAt, 0),
+      makeOptimisticEvent(streamId, "temp_a", "1001", createdAt, 0),
     ])
 
     const events = await loadStreamEvents(streamId, null)
@@ -188,9 +190,29 @@ describe("loadStreamEvents", () => {
     expect(events.map((event) => event.id)).toEqual(["temp_z", "temp_a"])
   })
 
+  it("starts a clock-skewed optimistic row after its observed persisted tail", async () => {
+    const streamId = "stream_slow_clock"
+    const optimistic = makeOptimisticEvent(streamId, "temp_slow", "1714428000000", "1990-01-01T00:00:00.000Z", 2)
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "1"),
+      makeRealEvent(streamId, "2"),
+      makeRealEvent(streamId, "3"),
+      optimistic,
+    ])
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((event) => event.id)).toEqual([
+      "evt_stream_slow_clock_1",
+      "evt_stream_slow_clock_2",
+      "temp_slow",
+      "evt_stream_slow_clock_3",
+    ])
+  })
+
   it("lets a failed optimistic command move above newer persisted events", async () => {
     const streamId = "stream_failed_command"
-    const failed = makeOptimisticEvent(streamId, "temp_cmd", "1714428000000", "2026-01-01T20:30:00.000Z")
+    const failed = makeOptimisticEvent(streamId, "temp_cmd", "1714428000000", "2036-01-01T20:30:00.000Z", 1)
     failed.eventType = "command_dispatched"
     failed._status = "failed"
     failed.payload = { commandId: failed.id, name: "thinking", args: "low", status: "dispatched" }

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -175,6 +175,19 @@ describe("loadStreamEvents", () => {
     expect(events[0].id).toBe("temp_old")
   })
 
+  it("preserves optimistic order when creation timestamps match", async () => {
+    const streamId = "stream_same_millisecond"
+    const createdAt = "2026-01-01T20:30:00.000Z"
+    await db.events.bulkPut([
+      makeOptimisticEvent(streamId, "temp_z", "1000", createdAt),
+      makeOptimisticEvent(streamId, "temp_a", "1001", createdAt),
+    ])
+
+    const events = await loadStreamEvents(streamId, null)
+
+    expect(events.map((event) => event.id)).toEqual(["temp_z", "temp_a"])
+  })
+
   it("lets a failed optimistic command move above newer persisted events", async () => {
     const streamId = "stream_failed_command"
     const failed = makeOptimisticEvent(streamId, "temp_cmd", "1714428000000", "2026-01-01T20:30:00.000Z")

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -212,6 +212,19 @@ describe("loadStreamEvents", () => {
     expect(events.map((event) => event.id)).toEqual(["temp_z", "temp_a"])
   })
 
+  it("places a legacy row older than all loaded history before that history", () => {
+    const streamId = "stream_legacy_oldest"
+    const legacy = makeOptimisticEvent(streamId, "temp_legacy", "1000", "1990-01-01T00:00:00.000Z")
+
+    const events = orderStreamEvents([makeRealEvent(streamId, "1"), makeRealEvent(streamId, "2"), legacy])
+
+    expect(events.map((event) => event.id)).toEqual([
+      "temp_legacy",
+      "evt_stream_legacy_oldest_1",
+      "evt_stream_legacy_oldest_2",
+    ])
+  })
+
   it("starts a clock-skewed optimistic row after its observed persisted tail", async () => {
     const streamId = "stream_slow_clock"
     const optimistic = makeOptimisticEvent(streamId, "temp_slow", "1714428000000", "1990-01-01T00:00:00.000Z", 2)

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { loadStreamEvents, shareEventIdentities } from "./stream-store"
+import { bumpLaterOptimisticAnchors } from "@/sync/stream-sync"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -177,6 +178,27 @@ describe("loadStreamEvents", () => {
     expect(events[0].id).toBe("temp_old")
   })
 
+  it("keeps an editing optimistic row at its anchor", async () => {
+    const streamId = "stream_editing"
+    const editing = makeOptimisticEvent(streamId, "temp_editing", "1000", "2026-01-01T00:00:01.000Z", 1)
+    editing._status = "editing"
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "1"),
+      makeRealEvent(streamId, "2"),
+      makeRealEvent(streamId, "3"),
+      editing,
+    ])
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((event) => event.id)).toEqual([
+      "evt_stream_editing_1",
+      "temp_editing",
+      "evt_stream_editing_2",
+      "evt_stream_editing_3",
+    ])
+  })
+
   it("preserves optimistic order when creation timestamps match", async () => {
     const streamId = "stream_same_millisecond"
     const createdAt = "2026-01-01T20:30:00.000Z"
@@ -207,6 +229,27 @@ describe("loadStreamEvents", () => {
       "evt_stream_slow_clock_2",
       "temp_slow",
       "evt_stream_slow_clock_3",
+    ])
+  })
+
+  it("keeps later optimistic sends after an earlier send confirms", async () => {
+    const streamId = "stream_partial_ack"
+    const first = makeOptimisticEvent(streamId, "temp_first", "1000", "2026-01-01T00:00:01.000Z", 1)
+    const second = makeOptimisticEvent(streamId, "temp_second", "1001", "2026-01-01T00:00:02.000Z", 1)
+    await db.events.bulkPut([makeRealEvent(streamId, "1"), first, second])
+
+    await db.transaction("rw", db.events, async () => {
+      await bumpLaterOptimisticAnchors(streamId, first._sequenceNum, 2)
+      await db.events.delete(first.id)
+      await db.events.put(makeRealEvent(streamId, "2"))
+    })
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((event) => event.id)).toEqual([
+      "evt_stream_partial_ack_1",
+      "evt_stream_partial_ack_2",
+      "temp_second",
     ])
   })
 

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useRef } from "react"
-import { db, type CachedEvent, type CachedStream } from "@/db"
+import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 
 /**
  * Cap the number of events loaded from IDB per stream when no sequence floor
@@ -64,30 +64,45 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
   return orderStreamEvents([...base, ...extra])
 }
 
-export function orderStreamEvents(events: CachedEvent[]): CachedEvent[] {
-  const optimistic: CachedEvent[] = []
-  const persisted: CachedEvent[] = []
+type OrderableStreamEvent = Pick<CachedEvent, "id" | "sequence" | "createdAt"> &
+  Partial<Pick<CachedEvent, "_sequenceNum" | "_anchorSequenceNum" | "_status">>
+
+function eventSequence(event: OrderableStreamEvent): number {
+  return event._sequenceNum ?? sequenceToNum(event.sequence)
+}
+
+export function orderStreamEvents<T extends OrderableStreamEvent>(
+  events: T[],
+  persistedComparator: (a: T, b: T) => number = (a, b) => eventSequence(a) - eventSequence(b)
+): T[] {
+  const optimistic: T[] = []
+  const persisted: T[] = []
 
   for (const event of events) {
     if (event._status != null) optimistic.push(event)
     else persisted.push(event)
   }
 
-  const anchor = (event: CachedEvent) => event._anchorSequenceNum ?? Number.POSITIVE_INFINITY
-  persisted.sort((a, b) => a._sequenceNum - b._sequenceNum)
-  optimistic.sort((a, b) => anchor(a) - anchor(b) || a._sequenceNum - b._sequenceNum || a.id.localeCompare(b.id))
+  const anchor = (event: OrderableStreamEvent) => event._anchorSequenceNum ?? Number.POSITIVE_INFINITY
+  persisted.sort(persistedComparator)
+  optimistic.sort((a, b) => anchor(a) - anchor(b) || eventSequence(a) - eventSequence(b) || a.id.localeCompare(b.id))
 
-  const ordered: CachedEvent[] = []
-  let persistedIndex = 0
+  const optimisticAfterPersistedIndex = new Map<number, T[]>()
   for (const optimisticEvent of optimistic) {
-    while (persistedIndex < persisted.length && persisted[persistedIndex]._sequenceNum <= anchor(optimisticEvent)) {
-      ordered.push(persisted[persistedIndex])
-      persistedIndex++
+    let afterIndex = -1
+    for (let i = 0; i < persisted.length; i++) {
+      if (eventSequence(persisted[i]) <= anchor(optimisticEvent)) afterIndex = i
     }
-    ordered.push(optimisticEvent)
+    const slot = optimisticAfterPersistedIndex.get(afterIndex) ?? []
+    slot.push(optimisticEvent)
+    optimisticAfterPersistedIndex.set(afterIndex, slot)
   }
 
-  return ordered.concat(persisted.slice(persistedIndex))
+  const ordered = [...(optimisticAfterPersistedIndex.get(-1) ?? [])]
+  for (let i = 0; i < persisted.length; i++) {
+    ordered.push(persisted[i], ...(optimisticAfterPersistedIndex.get(i) ?? []))
+  }
+  return ordered
 }
 
 /**

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -54,7 +54,7 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
   // very top and are usually already in `base`). Drive this off the `_status`
   // index — Dexie only indexes rows where the value is present, so this is the
   // handful of unsent rows app-wide, not an O(history) scan of the stream.
-  const unsentForStream = (await db.events.where("_status").anyOf(["pending", "failed"]).toArray()).filter(
+  const unsentForStream = (await db.events.where("_status").anyOf(["pending", "failed", "editing"]).toArray()).filter(
     (e) => e.streamId === streamId && (!hasFloor || e._sequenceNum >= fromSequenceNum)
   )
   if (unsentForStream.length === 0) return base

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -83,7 +83,18 @@ export function orderStreamEvents<T extends OrderableStreamEvent>(
     else persisted.push(event)
   }
 
-  const anchor = (event: OrderableStreamEvent) => event._anchorSequenceNum ?? Number.POSITIVE_INFINITY
+  const inferredAnchors = new Map<string, number>()
+  for (const optimisticEvent of optimistic) {
+    if (optimisticEvent._anchorSequenceNum != null) continue
+    const optimisticCreatedAt = Date.parse(optimisticEvent.createdAt)
+    const inferred = persisted.reduce<number | null>((current, persistedEvent) => {
+      if (Date.parse(persistedEvent.createdAt) > optimisticCreatedAt) return current
+      return Math.max(current ?? 0, eventSequence(persistedEvent))
+    }, null)
+    if (inferred != null) inferredAnchors.set(optimisticEvent.id, inferred)
+  }
+  const anchor = (event: OrderableStreamEvent) =>
+    event._anchorSequenceNum ?? inferredAnchors.get(event.id) ?? Number.POSITIVE_INFINITY
   persisted.sort(persistedComparator)
   optimistic.sort((a, b) => anchor(a) - anchor(b) || eventSequence(a) - eventSequence(b) || a.id.localeCompare(b.id))
 

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -71,9 +71,19 @@ function eventSequence(event: OrderableStreamEvent): number {
   return event._sequenceNum ?? sequenceToNum(event.sequence)
 }
 
+/**
+ * Interleaves optimistic stream events at their persisted sequence anchors.
+ *
+ * @param events - Persisted and optimistic events to order.
+ * @param persistedComparator - Optional chronology for persisted events, such as thread ordering.
+ * @returns A newly ordered event array.
+ * @example
+ * const ordered = orderStreamEvents(cachedEvents)
+ */
 export function orderStreamEvents<T extends OrderableStreamEvent>(
   events: T[],
-  persistedComparator: (a: T, b: T) => number = (a, b) => eventSequence(a) - eventSequence(b)
+  persistedComparator: (leftEvent: T, rightEvent: T) => number = (leftEvent, rightEvent) =>
+    eventSequence(leftEvent) - eventSequence(rightEvent)
 ): T[] {
   const optimistic: T[] = []
   const persisted: T[] = []
@@ -99,7 +109,12 @@ export function orderStreamEvents<T extends OrderableStreamEvent>(
   const anchor = (event: OrderableStreamEvent) =>
     event._anchorSequenceNum ?? inferredAnchors.get(event.id) ?? Number.POSITIVE_INFINITY
   persisted.sort(persistedComparator)
-  optimistic.sort((a, b) => anchor(a) - anchor(b) || eventSequence(a) - eventSequence(b) || a.id.localeCompare(b.id))
+  optimistic.sort(
+    (leftEvent, rightEvent) =>
+      anchor(leftEvent) - anchor(rightEvent) ||
+      eventSequence(leftEvent) - eventSequence(rightEvent) ||
+      leftEvent.id.localeCompare(rightEvent.id)
+  )
 
   const optimisticAfterPersistedIndex = new Map<number, T[]>()
   for (const optimisticEvent of optimistic) {

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -21,10 +21,10 @@ export function resetStreamStoreCache(): void {}
  *   - Without a floor: same range, but capped to the latest N events as a
  *     memory bound on initial pre-bootstrap load.
  *
- * Pending and failed optimistic events use placeholder sequences, so their
- * `createdAt` places them among server events while each source keeps its own
- * authoritative order. A pending send starts at the tail, then moves upward
- * naturally when newer server events arrive.
+ * Pending and failed optimistic events use the persisted sequence visible at
+ * creation as their anchor. A pending send starts at the tail, then moves
+ * upward naturally when newer server events arrive, without comparing client
+ * and server clocks.
  */
 export async function loadStreamEvents(streamId: string, fromSequenceNum: number | null): Promise<CachedEvent[]> {
   const hasFloor = fromSequenceNum != null
@@ -73,28 +73,21 @@ export function orderStreamEvents(events: CachedEvent[]): CachedEvent[] {
     else persisted.push(event)
   }
 
+  const anchor = (event: CachedEvent) => event._anchorSequenceNum ?? Number.POSITIVE_INFINITY
   persisted.sort((a, b) => a._sequenceNum - b._sequenceNum)
-  optimistic.sort((a, b) => {
-    const timeDiff = Date.parse(a.createdAt) - Date.parse(b.createdAt)
-    return timeDiff || a._sequenceNum - b._sequenceNum
-  })
+  optimistic.sort((a, b) => anchor(a) - anchor(b) || a._sequenceNum - b._sequenceNum || a.id.localeCompare(b.id))
 
   const ordered: CachedEvent[] = []
   let persistedIndex = 0
-  let optimisticIndex = 0
-  while (persistedIndex < persisted.length && optimisticIndex < optimistic.length) {
-    const persistedEvent = persisted[persistedIndex]
-    const optimisticEvent = optimistic[optimisticIndex]
-    if (Date.parse(optimisticEvent.createdAt) < Date.parse(persistedEvent.createdAt)) {
-      ordered.push(optimisticEvent)
-      optimisticIndex++
-    } else {
-      ordered.push(persistedEvent)
+  for (const optimisticEvent of optimistic) {
+    while (persistedIndex < persisted.length && persisted[persistedIndex]._sequenceNum <= anchor(optimisticEvent)) {
+      ordered.push(persisted[persistedIndex])
       persistedIndex++
     }
+    ordered.push(optimisticEvent)
   }
 
-  return ordered.concat(persisted.slice(persistedIndex), optimistic.slice(optimisticIndex))
+  return ordered.concat(persisted.slice(persistedIndex))
 }
 
 /**

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -177,7 +177,8 @@ export function shareEventIdentities(prev: CachedEvent[] | null, next: CachedEve
       old._cachedAt === row._cachedAt &&
       old._patchedAt === row._patchedAt &&
       old._status === row._status &&
-      old.sequence === row.sequence
+      old.sequence === row.sequence &&
+      old._anchorSequenceNum === row._anchorSequenceNum
     ) {
       if (allSame && prev[i] !== old) allSame = false
       return old

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -85,13 +85,16 @@ export function orderStreamEvents<T extends OrderableStreamEvent>(
 
   const inferredAnchors = new Map<string, number>()
   for (const optimisticEvent of optimistic) {
-    if (optimisticEvent._anchorSequenceNum != null) continue
+    if (optimisticEvent._anchorSequenceNum != null || persisted.length === 0) continue
     const optimisticCreatedAt = Date.parse(optimisticEvent.createdAt)
     const inferred = persisted.reduce<number | null>((current, persistedEvent) => {
       if (Date.parse(persistedEvent.createdAt) > optimisticCreatedAt) return current
       return Math.max(current ?? 0, eventSequence(persistedEvent))
     }, null)
-    if (inferred != null) inferredAnchors.set(optimisticEvent.id, inferred)
+    inferredAnchors.set(
+      optimisticEvent.id,
+      inferred ?? Math.max(0, Math.min(...persisted.map((persistedEvent) => eventSequence(persistedEvent))) - 1)
+    )
   }
   const anchor = (event: OrderableStreamEvent) =>
     event._anchorSequenceNum ?? inferredAnchors.get(event.id) ?? Number.POSITIVE_INFINITY

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -21,9 +21,10 @@ export function resetStreamStoreCache(): void {}
  *   - Without a floor: same range, but capped to the latest N events as a
  *     memory bound on initial pre-bootstrap load.
  *
- * Pending and failed optimistic events with placeholder sequences are merged
- * in and the full list re-sorted, so they always land in their natural slot
- * by `_sequenceNum` rather than being appended at the end of the array.
+ * Pending and failed optimistic events use placeholder sequences, so their
+ * `createdAt` places them among server events while each source keeps its own
+ * authoritative order. A pending send starts at the tail, then moves upward
+ * naturally when newer server events arrive.
  */
 export async function loadStreamEvents(streamId: string, fromSequenceNum: number | null): Promise<CachedEvent[]> {
   const hasFloor = fromSequenceNum != null
@@ -58,17 +59,42 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
   )
   if (unsentForStream.length === 0) return base
 
-  // Only now pay for de-duplication: a pending row inside the scanned range is
-  // already present in `base`, so drop those before merging.
   const loadedIds = new Set(base.map((e) => e.id))
   const extra = unsentForStream.filter((e) => !loadedIds.has(e.id))
-  if (extra.length === 0) return base
+  return orderStreamEvents([...base, ...extra])
+}
 
-  // Re-sort the spliced list so order is determined solely by `_sequenceNum`,
-  // not by which path a row arrived on.
-  const merged = [...base, ...extra]
-  merged.sort((a, b) => a._sequenceNum - b._sequenceNum)
-  return merged
+export function orderStreamEvents(events: CachedEvent[]): CachedEvent[] {
+  const optimistic: CachedEvent[] = []
+  const persisted: CachedEvent[] = []
+
+  for (const event of events) {
+    if (event._status != null) optimistic.push(event)
+    else persisted.push(event)
+  }
+
+  persisted.sort((a, b) => a._sequenceNum - b._sequenceNum)
+  optimistic.sort((a, b) => {
+    const timeDiff = Date.parse(a.createdAt) - Date.parse(b.createdAt)
+    return timeDiff || a._sequenceNum - b._sequenceNum
+  })
+
+  const ordered: CachedEvent[] = []
+  let persistedIndex = 0
+  let optimisticIndex = 0
+  while (persistedIndex < persisted.length && optimisticIndex < optimistic.length) {
+    const persistedEvent = persisted[persistedIndex]
+    const optimisticEvent = optimistic[optimisticIndex]
+    if (Date.parse(optimisticEvent.createdAt) < Date.parse(persistedEvent.createdAt)) {
+      ordered.push(optimisticEvent)
+      optimisticIndex++
+    } else {
+      ordered.push(persistedEvent)
+      persistedIndex++
+    }
+  }
+
+  return ordered.concat(persisted.slice(persistedIndex), optimistic.slice(optimisticIndex))
 }
 
 /**

--- a/apps/frontend/src/sync/operation-queue.test.ts
+++ b/apps/frontend/src/sync/operation-queue.test.ts
@@ -95,10 +95,19 @@ describe("processOperationQueue permanent-4xx handling", () => {
   it("retains the op for retry on a network error", async () => {
     await enqueueOperation(workspaceId, "send_scheduled_now", { id: schedId })
 
-    await process(scheduledServiceRejectingWith(new TypeError("Failed to fetch")))
+    const retryAt = await processOperationQueue(
+      messageService,
+      reactionService,
+      scheduledServiceRejectingWith(new TypeError("Failed to fetch")),
+      undefined,
+      () => true
+    )
 
     const [op] = await db.pendingOperations.toArray()
-    expect(op).toMatchObject({ type: "send_scheduled_now", retryCount: 1 })
+    expect({ operation: op, retryAt }).toMatchObject({
+      operation: { type: "send_scheduled_now", retryCount: 1 },
+      retryAt: expect.any(Number),
+    })
   })
 
   it("retains the op for retry on 429", async () => {

--- a/apps/frontend/src/sync/operation-queue.test.ts
+++ b/apps/frontend/src/sync/operation-queue.test.ts
@@ -108,6 +108,7 @@ describe("processOperationQueue permanent-4xx handling", () => {
       operation: { type: "send_scheduled_now", retryCount: 1 },
       retryAt: expect.any(Number),
     })
+    expect(retryAt).toBe(op?.retryAfter)
   })
 
   it("retains the op for retry on 429", async () => {

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -145,6 +145,7 @@ export async function processOperationQueue(
           await db.pendingOperations.update(next.id, {
             retryCount,
             retryAfter: Date.now() + getRetryDelay(retryCount),
+            ...(next.type === "dispatch_command" && { startedAt: undefined }),
           })
           skipped.add(next.id)
         }

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -51,26 +51,27 @@ async function reconcileRejectedOperation(op: PendingOperation): Promise<void> {
 }
 
 async function markCommandDispatchFailed(workspaceId: string, optimisticEventId: string, error: Error): Promise<void> {
-  const dispatched = await db.events.get(optimisticEventId)
-  if (!dispatched) return
-  const failedEvent: CachedEvent = {
-    id: `${optimisticEventId}:failed`,
-    workspaceId,
-    streamId: dispatched.streamId,
-    sequence: (Number(dispatched.sequence) + 1).toString(),
-    eventType: "command_failed",
-    payload: {
-      commandId: optimisticEventId,
-      error: error.message,
-    } satisfies CommandFailedPayload,
-    actorId: dispatched.actorId,
-    actorType: dispatched.actorType,
-    createdAt: new Date().toISOString(),
-    _sequenceNum: sequenceToNum((Number(dispatched.sequence) + 1).toString()),
-    _status: "failed",
-    _cachedAt: Date.now(),
-  }
   await db.transaction("rw", db.events, async () => {
+    const dispatched = await db.events.get(optimisticEventId)
+    if (!dispatched) return
+    const failedSequence = (Number(dispatched.sequence) + 1).toString()
+    const failedEvent: CachedEvent = {
+      id: `${optimisticEventId}:failed`,
+      workspaceId,
+      streamId: dispatched.streamId,
+      sequence: failedSequence,
+      eventType: "command_failed",
+      payload: {
+        commandId: optimisticEventId,
+        error: error.message,
+      } satisfies CommandFailedPayload,
+      actorId: dispatched.actorId,
+      actorType: dispatched.actorType,
+      createdAt: new Date().toISOString(),
+      _sequenceNum: sequenceToNum(failedSequence),
+      _status: "failed",
+      _cachedAt: Date.now(),
+    }
     await db.events.update(optimisticEventId, { _status: "failed" })
     await db.events.put(failedEvent)
   })
@@ -123,7 +124,11 @@ export async function processOperationQueue(
         // device, a coalescing replace of this op must carry its idempotency
         // lineage (writeId) forward instead of minting a fresh one — otherwise
         // a committed-but-unacked write reads as drift and splits server-side.
-        await db.pendingOperations.update(next.id, { startedAt: Date.now() })
+        const claimed = await db.pendingOperations.update(next.id, {
+          startedAt: Date.now(),
+          ...(next.type === "dispatch_command" && { attempting: true }),
+        })
+        if (claimed === 0) continue
         await executeOperation(next, messageService, reactionService, scheduledService, draftsService)
         await db.pendingOperations.delete(next.id)
       } catch (error) {
@@ -139,6 +144,7 @@ export async function processOperationQueue(
           await db.pendingOperations.update(next.id, {
             retryCount,
             retryAfter: Date.now() + getRetryDelay(retryCount),
+            ...(next.type === "dispatch_command" && { attempting: false }),
           })
           skipped.add(next.id)
         }

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -225,7 +225,8 @@ async function executeOperation(
         })
         if (!result.success) throw new ApiError(400, "COMMAND_DISPATCH_FAILED", result.error)
         await db.transaction("rw", db.events, async () => {
-          await db.events.delete(optimisticEventId).catch(() => undefined)
+          if (!(await db.events.get(optimisticEventId))) return
+          await db.events.delete(optimisticEventId)
           await db.events.put({
             ...result.event,
             workspaceId,

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -12,6 +12,8 @@ function getRetryDelay(retryCount: number): number {
   return 120_000
 }
 
+const OPERATION_QUEUE_LOCK = "threa-operation-queue"
+
 function generateId(): string {
   return `op_${Date.now()}_${Math.random().toString(36).slice(2)}`
 }
@@ -69,6 +71,7 @@ async function markCommandDispatchFailed(workspaceId: string, optimisticEventId:
       actorType: dispatched.actorType,
       createdAt: new Date().toISOString(),
       _sequenceNum: sequenceToNum(failedSequence),
+      _anchorSequenceNum: dispatched._anchorSequenceNum,
       _status: "failed",
       _cachedAt: Date.now(),
     }
@@ -101,6 +104,19 @@ export async function enqueueOperation(
  * Process pending operations from IDB. Called on socket connect/reconnect.
  * Uses Web Locks to prevent cross-tab double-processing.
  */
+export async function reclaimStaleCommandAttempts(): Promise<boolean> {
+  if (!navigator.locks) return false
+
+  return navigator.locks.request(OPERATION_QUEUE_LOCK, async () => {
+    await db.pendingOperations
+      .where("type")
+      .equals("dispatch_command")
+      .filter((operation) => operation.attempting === true)
+      .modify({ attempting: false })
+    return true
+  })
+}
+
 export async function processOperationQueue(
   messageService: MessageServiceLike,
   reactionService: ReactionServiceLike,
@@ -108,7 +124,15 @@ export async function processOperationQueue(
   draftsService: DraftsServiceLike | undefined,
   isOnline: () => boolean
 ): Promise<void> {
-  const processor = async () => {
+  const processor = async (ownsLock: boolean) => {
+    if (ownsLock) {
+      await db.pendingOperations
+        .where("type")
+        .equals("dispatch_command")
+        .filter((operation) => operation.attempting === true)
+        .modify({ attempting: false })
+    }
+
     const now = Date.now()
     const skipped = new Set<string>()
 
@@ -153,12 +177,12 @@ export async function processOperationQueue(
   }
 
   if (navigator.locks) {
-    await navigator.locks.request("threa-operation-queue", { ifAvailable: true }, async (lock) => {
+    await navigator.locks.request(OPERATION_QUEUE_LOCK, { ifAvailable: true }, async (lock) => {
       if (!lock) return
-      await processor()
+      await processor(true)
     })
   } else {
-    await processor()
+    await processor(false)
   }
 }
 
@@ -230,15 +254,17 @@ async function executeOperation(
           command: payload.command as string,
         })
         if (!result.success) throw new ApiError(400, "COMMAND_DISPATCH_FAILED", result.error)
-        await db.transaction("rw", db.events, async () => {
-          if (!(await db.events.get(optimisticEventId))) return
-          await db.events.delete(optimisticEventId)
-          await db.events.put({
-            ...result.event,
-            workspaceId,
-            _sequenceNum: sequenceToNum(result.event.sequence),
-            _cachedAt: Date.now(),
-          })
+        await db.transaction("rw", [db.events, db.pendingOperations], async () => {
+          if (await db.events.get(optimisticEventId)) {
+            await db.events.delete(optimisticEventId)
+            await db.events.put({
+              ...result.event,
+              workspaceId,
+              _sequenceNum: sequenceToNum(result.event.sequence),
+              _cachedAt: Date.now(),
+            })
+          }
+          await db.pendingOperations.delete(op.id)
         })
       } catch (error) {
         if (!isPermanentApiError(error)) throw error

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -145,7 +145,6 @@ export async function processOperationQueue(
           await db.pendingOperations.update(next.id, {
             retryCount,
             retryAfter: Date.now() + getRetryDelay(retryCount),
-            ...(next.type === "dispatch_command" && { startedAt: undefined }),
           })
           skipped.add(next.id)
         }
@@ -238,7 +237,8 @@ async function executeOperation(
             await bumpLaterOptimisticAnchors(
               optimistic.streamId,
               optimistic._sequenceNum,
-              sequenceToNum(result.event.sequence)
+              sequenceToNum(result.event.sequence),
+              optimistic.id
             )
             await db.events.delete(optimisticEventId)
             await db.events.put({

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -111,7 +111,7 @@ export async function processOperationQueue(
   scheduledService: ScheduledServiceLike | undefined,
   draftsService: DraftsServiceLike | undefined,
   isOnline: () => boolean
-): Promise<void> {
+): Promise<number | null> {
   const processor = async () => {
     const now = Date.now()
     const skipped = new Set<string>()
@@ -160,6 +160,11 @@ export async function processOperationQueue(
   } else {
     await processor()
   }
+
+  if (!isOnline()) return null
+  const remaining = await db.pendingOperations.toArray()
+  if (remaining.length === 0) return null
+  return remaining.reduce((next, operation) => Math.min(next, operation.retryAfter ?? Date.now()), Infinity)
 }
 
 async function executeOperation(

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -4,6 +4,7 @@ import type { CommandFailedPayload, ScheduleMessageInput, ScheduledMessageView }
 import { ApiError, commandsApi, isPermanentApiError } from "@/api"
 import { persistScheduledRows, removeScheduledRow, replaceLocalScheduledRow } from "@/hooks/use-scheduled"
 import { executeDraftDelete, executeDraftResolve, executeDraftUpsert, type DraftsServiceLike } from "./draft-sync"
+import { bumpLaterOptimisticAnchors } from "./stream-sync"
 
 function getRetryDelay(retryCount: number): number {
   if (retryCount <= 3) return 0
@@ -104,19 +105,6 @@ export async function enqueueOperation(
  * Process pending operations from IDB. Called on socket connect/reconnect.
  * Uses Web Locks to prevent cross-tab double-processing.
  */
-export async function reclaimStaleCommandAttempts(): Promise<boolean> {
-  if (!navigator.locks) return false
-
-  return navigator.locks.request(OPERATION_QUEUE_LOCK, async () => {
-    await db.pendingOperations
-      .where("type")
-      .equals("dispatch_command")
-      .filter((operation) => operation.attempting === true)
-      .modify({ attempting: false })
-    return true
-  })
-}
-
 export async function processOperationQueue(
   messageService: MessageServiceLike,
   reactionService: ReactionServiceLike,
@@ -124,15 +112,7 @@ export async function processOperationQueue(
   draftsService: DraftsServiceLike | undefined,
   isOnline: () => boolean
 ): Promise<void> {
-  const processor = async (ownsLock: boolean) => {
-    if (ownsLock) {
-      await db.pendingOperations
-        .where("type")
-        .equals("dispatch_command")
-        .filter((operation) => operation.attempting === true)
-        .modify({ attempting: false })
-    }
-
+  const processor = async () => {
     const now = Date.now()
     const skipped = new Set<string>()
 
@@ -148,10 +128,7 @@ export async function processOperationQueue(
         // device, a coalescing replace of this op must carry its idempotency
         // lineage (writeId) forward instead of minting a fresh one — otherwise
         // a committed-but-unacked write reads as drift and splits server-side.
-        const claimed = await db.pendingOperations.update(next.id, {
-          startedAt: Date.now(),
-          ...(next.type === "dispatch_command" && { attempting: true }),
-        })
+        const claimed = await db.pendingOperations.update(next.id, { startedAt: Date.now() })
         if (claimed === 0) continue
         await executeOperation(next, messageService, reactionService, scheduledService, draftsService)
         await db.pendingOperations.delete(next.id)
@@ -168,7 +145,6 @@ export async function processOperationQueue(
           await db.pendingOperations.update(next.id, {
             retryCount,
             retryAfter: Date.now() + getRetryDelay(retryCount),
-            ...(next.type === "dispatch_command" && { attempting: false }),
           })
           skipped.add(next.id)
         }
@@ -179,10 +155,10 @@ export async function processOperationQueue(
   if (navigator.locks) {
     await navigator.locks.request(OPERATION_QUEUE_LOCK, { ifAvailable: true }, async (lock) => {
       if (!lock) return
-      await processor(true)
+      await processor()
     })
   } else {
-    await processor(false)
+    await processor()
   }
 }
 
@@ -252,10 +228,17 @@ async function executeOperation(
         const result = await commandsApi.dispatch(workspaceId, {
           streamId: payload.streamId as string,
           command: payload.command as string,
+          clientCommandId: optimisticEventId,
         })
         if (!result.success) throw new ApiError(400, "COMMAND_DISPATCH_FAILED", result.error)
         await db.transaction("rw", [db.events, db.pendingOperations], async () => {
-          if (await db.events.get(optimisticEventId)) {
+          const optimistic = await db.events.get(optimisticEventId)
+          if (optimistic) {
+            await bumpLaterOptimisticAnchors(
+              optimistic.streamId,
+              optimistic._sequenceNum,
+              sequenceToNum(result.event.sequence)
+            )
             await db.events.delete(optimisticEventId)
             await db.events.put({
               ...result.event,

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -525,11 +525,48 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
       retryCount: 0,
     })
 
-    const bootstrap = makeBootstrap([makeEvent({ id: "evt_A", streamId, sequence: "100" })], streamId)
+    const bootstrap = makeBootstrap(
+      [makeEvent({ id: "evt_A", streamId, sequence: "100", createdAt: "2020-01-01T00:00:00.000Z" })],
+      streamId
+    )
     await applyStreamBootstrap("ws_1", streamId, bootstrap)
 
     expect((await db.events.get("temp_pending"))?._anchorSequenceNum).toBe(100)
     expect(await db.events.get("evt_A")).toBeDefined()
+  })
+
+  it("anchors a legacy failed row by its chronology during bootstrap", async () => {
+    const streamId = "stream_legacy_failed"
+    await db.events.put({
+      id: "temp_legacy_failed",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      eventType: "command_dispatched",
+      payload: { commandId: "temp_legacy_failed", name: "thinking", args: "low", status: "dispatched" },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: "2026-01-01T20:30:00.000Z",
+      _status: "failed",
+      _cachedAt: 1,
+    })
+    const before = makeEvent({
+      id: "evt_before",
+      streamId,
+      sequence: "100",
+      createdAt: "2026-01-01T20:00:00.000Z",
+    })
+    const after = makeEvent({
+      id: "evt_after",
+      streamId,
+      sequence: "101",
+      createdAt: "2026-01-01T21:00:00.000Z",
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([before, after], streamId))
+
+    expect((await db.events.get("temp_legacy_failed"))?._anchorSequenceNum).toBe(100)
   })
 
   it("collapses an optimistic row when the bootstrap carries its server copy (reload-during-send race)", async () => {

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -569,6 +569,51 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect((await db.events.get("temp_legacy_failed"))?._anchorSequenceNum).toBe(100)
   })
 
+  it("collapses an optimistic command when bootstrap carries its idempotent server copy", async () => {
+    const streamId = "stream_command_reload"
+    await db.events.put({
+      id: "temp_command",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      _anchorSequenceNum: 10,
+      eventType: "command_dispatched",
+      payload: { commandId: "temp_command", name: "stop", args: "", status: "dispatched" },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: "2026-01-01T20:30:00.000Z",
+      _status: "pending",
+      _cachedAt: 1,
+    })
+    await db.pendingOperations.add({
+      id: "op_command",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/stop", optimisticEventId: "temp_command" },
+      createdAt: 1,
+      retryCount: 0,
+      startedAt: 2,
+    })
+    const serverCopy = makeEvent({ id: "evt_command", streamId, sequence: "11" })
+    serverCopy.eventType = "command_dispatched"
+    serverCopy.payload = {
+      commandId: "cmd_1",
+      clientCommandId: "temp_command",
+      name: "stop",
+      args: "",
+      status: "dispatched",
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([serverCopy], streamId))
+
+    expect({
+      server: (await db.events.get("evt_command"))?.id,
+      optimistic: await db.events.get("temp_command"),
+      operation: await db.pendingOperations.get("op_command"),
+    }).toEqual({ server: "evt_command", optimistic: undefined, operation: undefined })
+  })
+
   it("collapses an optimistic row when the bootstrap carries its server copy (reload-during-send race)", async () => {
     const streamId = "stream_reload_race"
 

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { QueryClient } from "@tanstack/react-query"
 import type { Socket } from "socket.io-client"
-import { db } from "@/db"
+import { db, type CachedEvent } from "@/db"
 import {
   applyStreamBootstrap,
   detectSequenceGap,
@@ -586,6 +586,13 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
       _status: "pending",
       _cachedAt: 1,
     })
+    await db.events.put({
+      ...((await db.events.get("temp_command")) as CachedEvent),
+      id: "temp_command:failed",
+      eventType: "command_failed",
+      payload: { commandId: "temp_command", error: "Timed out" },
+      _status: "failed",
+    })
     await db.pendingOperations.add({
       id: "op_command",
       workspaceId: "ws_1",
@@ -610,8 +617,9 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect({
       server: (await db.events.get("evt_command"))?.id,
       optimistic: await db.events.get("temp_command"),
+      failed: await db.events.get("temp_command:failed"),
       operation: await db.pendingOperations.get("op_command"),
-    }).toEqual({ server: "evt_command", optimistic: undefined, operation: undefined })
+    }).toEqual({ server: "evt_command", optimistic: undefined, failed: undefined, operation: undefined })
   })
 
   it("collapses an optimistic row when the bootstrap carries its server copy (reload-during-send race)", async () => {
@@ -1298,6 +1306,7 @@ describe("registerStreamSocketHandlers — E2E send reconciliation seeds the dec
     await db.events.clear()
     await db.streams.clear()
     await db.pendingMessages.clear()
+    await db.pendingOperations.clear()
     clearDecryptCache()
   })
 
@@ -1365,6 +1374,63 @@ describe("registerStreamSocketHandlers — E2E send reconciliation seeds the dec
     expect(cached?.status).toBe("decrypted")
     expect(cached?.value?.contentMarkdown).toBe("secret")
     expect(cached?.value?.contentJson).toEqual(plaintextJson)
+
+    cleanup()
+  })
+
+  it("removes a failed command sidecar when the live server event confirms the command", async () => {
+    const streamId = "stream_command_echo"
+    const optimistic = {
+      id: "temp_command_echo",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      eventType: "command_dispatched" as const,
+      payload: { commandId: "temp_command_echo", name: "stop", args: "", status: "dispatched" },
+      actorId: "user_1",
+      actorType: "user" as const,
+      createdAt: new Date().toISOString(),
+      _status: "failed" as const,
+      _cachedAt: Date.now(),
+    }
+    await db.events.bulkPut([
+      optimistic,
+      {
+        ...optimistic,
+        id: "temp_command_echo:failed",
+        eventType: "command_failed",
+        payload: { commandId: "temp_command_echo", error: "Timed out" },
+      },
+    ])
+
+    const { socket, emit } = createTestSocket()
+    const queryClient = new QueryClient()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("command:dispatched", {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: "evt_command_echo",
+        streamId,
+        sequence: "1000",
+        eventType: "command_dispatched",
+        payload: {
+          commandId: "cmd_echo",
+          clientCommandId: "temp_command_echo",
+          name: "stop",
+          args: "",
+          status: "dispatched",
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    expect(await db.events.bulkGet(["temp_command_echo", "temp_command_echo:failed"])).toEqual([undefined, undefined])
+    expect(await db.events.get("evt_command_echo")).toBeDefined()
 
     cleanup()
   })

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -528,7 +528,7 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     const bootstrap = makeBootstrap([makeEvent({ id: "evt_A", streamId, sequence: "100" })], streamId)
     await applyStreamBootstrap("ws_1", streamId, bootstrap)
 
-    expect(await db.events.get("temp_pending")).toBeDefined()
+    expect((await db.events.get("temp_pending"))?._anchorSequenceNum).toBe(100)
     expect(await db.events.get("evt_A")).toBeDefined()
   })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -87,6 +87,14 @@ export function toCachedStreamBootstrap(
   }
 }
 
+async function resolveUnknownOptimisticAnchors(streamId: string, anchorSequence: number): Promise<void> {
+  await db.events
+    .where("_status")
+    .anyOf(["pending", "failed", "editing"])
+    .filter((event) => event.streamId === streamId && event._anchorSequenceNum == null)
+    .modify({ _anchorSequenceNum: anchorSequence })
+}
+
 export async function bumpLaterOptimisticAnchors(
   streamId: string,
   confirmedOptimisticSequence: number,
@@ -353,6 +361,8 @@ async function writeBootstrapEventsAndStream(
     if (toWrite.length > 0) {
       await db.events.bulkPut(toWrite)
     }
+    const bootstrapTail = bootstrap.events.reduce((max, event) => Math.max(max, sequenceToNum(event.sequence)), 0)
+    await resolveUnknownOptimisticAnchors(streamId, bootstrapTail)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
@@ -868,6 +878,8 @@ export function registerStreamSocketHandlers(
         carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
       }
 
+      await resolveUnknownOptimisticAnchors(streamId, Math.max(0, sequenceToNum(newEvent.sequence) - 1))
+
       // Add the real event BEFORE deleting the optimistic one so that
       // Dexie live-query observers never see a frame with neither event.
       const eventToStore = carriedConversationId
@@ -1169,6 +1181,7 @@ export function registerStreamSocketHandlers(
       if (onSequenceGap) {
         gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), payload.event)
       }
+      await resolveUnknownOptimisticAnchors(streamId, Math.max(0, sequenceToNum(payload.event.sequence) - 1))
       await db.events.put({
         ...payload.event,
         workspaceId,

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -92,7 +92,7 @@ export async function getLatestPersistedSequence(streamId: string): Promise<stri
     .where("[streamId+_sequenceNum]")
     .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
     .reverse()
-    .filter((event) => event._status !== "pending" && event._status !== "failed")
+    .filter((event) => event._status == null)
     .first()
 
   return latestEvent?.sequence ?? null
@@ -121,7 +121,7 @@ export async function getPersistedTail(streamId: string): Promise<PersistedTail>
     .where("[streamId+_sequenceNum]")
     .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
     .reverse()
-    .filter((event) => event._status !== "pending" && event._status !== "failed")
+    .filter((event) => event._status == null)
     .limit(TAIL_SCAN_LIMIT)
     .toArray()
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -87,6 +87,23 @@ export function toCachedStreamBootstrap(
   }
 }
 
+export async function bumpLaterOptimisticAnchors(
+  streamId: string,
+  confirmedOptimisticSequence: number,
+  confirmedPersistedSequence: number
+): Promise<void> {
+  await db.events
+    .where("_status")
+    .anyOf(["pending", "failed", "editing"])
+    .filter(
+      (event) =>
+        event.streamId === streamId &&
+        event._sequenceNum > confirmedOptimisticSequence &&
+        (event._anchorSequenceNum ?? -1) < confirmedPersistedSequence
+    )
+    .modify({ _anchorSequenceNum: confirmedPersistedSequence })
+}
+
 export async function getLatestPersistedSequence(streamId: string): Promise<string | null> {
   const latestEvent = await db.events
     .where("[streamId+_sequenceNum]")
@@ -342,6 +359,7 @@ async function writeBootstrapEventsAndStream(
     // liveQuery frame never shows neither copy. Deleting the outbox row also
     // stops the queue from replaying a send the server already committed.
     for (const { realEvent, optimistic } of optimisticSwaps) {
+      await bumpLaterOptimisticAnchors(streamId, optimistic._sequenceNum, sequenceToNum(realEvent.sequence))
       await db.events.delete(optimistic.id)
       await db.pendingMessages.delete(optimistic.id)
       const plaintext = readPlaintextContent(optimistic.payload)
@@ -835,8 +853,9 @@ export function registerStreamSocketHandlers(
       // BEFORE writing the real event, so we can carry forward state the server
       // event doesn't itself carry.
       let carriedConversationId: string | undefined
+      let optimistic: CachedEvent | undefined
       if (newPayload.clientMessageId) {
-        const optimistic = await db.events.get(newPayload.clientMessageId)
+        optimistic = await db.events.get(newPayload.clientMessageId)
         optimisticPlaintext = readPlaintextContent(optimistic?.payload)
         // A board reply tags its optimistic event with the conversation it
         // attaches to; the server `message:created` does NOT carry that (the
@@ -865,6 +884,9 @@ export function registerStreamSocketHandlers(
       })
 
       if (newPayload.clientMessageId) {
+        if (optimistic) {
+          await bumpLaterOptimisticAnchors(streamId, optimistic._sequenceNum, sequenceToNum(newEvent.sequence))
+        }
         await db.events.delete(newPayload.clientMessageId).catch(() => {})
         await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
       }

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -88,6 +88,11 @@ export function toCachedStreamBootstrap(
 }
 
 async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> {
+  const unresolved = (await db.events.where("_status").anyOf(["pending", "failed", "editing"]).toArray()).filter(
+    (event) => event.streamId === streamId && event._anchorSequenceNum == null
+  )
+  if (unresolved.length === 0) return
+
   const persistedEvents = await db.events
     .where("[streamId+_sequenceNum]")
     .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
@@ -95,20 +100,16 @@ async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> 
     .toArray()
   if (persistedEvents.length === 0) return
 
-  await db.events
-    .where("_status")
-    .anyOf(["pending", "failed", "editing"])
-    .filter((event) => event.streamId === streamId && event._anchorSequenceNum == null)
-    .modify((event) => {
-      const optimisticCreatedAt = Date.parse(event.createdAt)
-      const anchor = persistedEvents.reduce<number | null>((current, persisted) => {
-        if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return current
-        return Math.max(current ?? 0, persisted._sequenceNum)
-      }, null)
-      if (anchor == null) return
-      event._anchorSequenceNum = anchor
-      event._cachedAt = Date.now()
-    })
+  const now = Date.now()
+  const resolved = unresolved.flatMap((event) => {
+    const optimisticCreatedAt = Date.parse(event.createdAt)
+    const anchor = persistedEvents.reduce<number | null>((current, persisted) => {
+      if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return current
+      return Math.max(current ?? 0, persisted._sequenceNum)
+    }, null)
+    return anchor == null ? [] : [{ ...event, _anchorSequenceNum: anchor, _cachedAt: now }]
+  })
+  if (resolved.length > 0) await db.events.bulkPut(resolved)
 }
 
 export async function bumpLaterOptimisticAnchors(
@@ -343,7 +344,7 @@ async function writeBootstrapEventsAndStream(
     )
     const optimisticCommandSwaps = commandDispatchedWithClientId.flatMap(({ realEvent }, index) => {
       const optimistic = optimisticCommandRows[index]
-      return optimistic ? [{ realEvent, optimistic }] : []
+      return optimistic?._status != null ? [{ realEvent, optimistic }] : []
     })
 
     const toWrite: CachedEvent[] = []
@@ -1243,7 +1244,8 @@ export function registerStreamSocketHandlers(
         payload.event.eventType === "command_dispatched"
           ? (payload.event.payload as { clientCommandId?: string }).clientCommandId
           : undefined
-      const optimisticCommand = commandClientId ? await db.events.get(commandClientId) : undefined
+      const commandCandidate = commandClientId ? await db.events.get(commandClientId) : undefined
+      const optimisticCommand = commandCandidate?._status != null ? commandCandidate : undefined
       await db.events.put({
         ...payload.event,
         workspaceId,
@@ -1251,15 +1253,13 @@ export function registerStreamSocketHandlers(
         _cachedAt: now,
       })
       await resolveUnknownOptimisticAnchors(streamId)
-      if (commandClientId) {
-        if (optimisticCommand) {
-          await bumpLaterOptimisticAnchors(
-            streamId,
-            optimisticCommand._sequenceNum,
-            sequenceToNum(payload.event.sequence),
-            optimisticCommand.id
-          )
-        }
+      if (commandClientId && optimisticCommand) {
+        await bumpLaterOptimisticAnchors(
+          streamId,
+          optimisticCommand._sequenceNum,
+          sequenceToNum(payload.event.sequence),
+          optimisticCommand.id
+        )
         await db.events.delete(commandClientId)
         const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
         await db.pendingOperations.bulkDelete(

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -87,12 +87,22 @@ export function toCachedStreamBootstrap(
   }
 }
 
-async function resolveUnknownOptimisticAnchors(streamId: string, anchorSequence: number): Promise<void> {
+async function resolveUnknownOptimisticAnchors(
+  streamId: string,
+  persistedEvents: Array<Pick<StreamEvent, "sequence" | "createdAt">>
+): Promise<void> {
   await db.events
     .where("_status")
     .anyOf(["pending", "failed", "editing"])
     .filter((event) => event.streamId === streamId && event._anchorSequenceNum == null)
-    .modify({ _anchorSequenceNum: anchorSequence })
+    .modify((event) => {
+      const optimisticCreatedAt = Date.parse(event.createdAt)
+      event._anchorSequenceNum = persistedEvents.reduce((anchor, persisted) => {
+        if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return anchor
+        return Math.max(anchor, sequenceToNum(persisted.sequence))
+      }, 0)
+      event._cachedAt = Date.now()
+    })
 }
 
 export async function bumpLaterOptimisticAnchors(
@@ -109,7 +119,10 @@ export async function bumpLaterOptimisticAnchors(
         event._sequenceNum > confirmedOptimisticSequence &&
         (event._anchorSequenceNum ?? -1) < confirmedPersistedSequence
     )
-    .modify({ _anchorSequenceNum: confirmedPersistedSequence })
+    .modify((event) => {
+      event._anchorSequenceNum = confirmedPersistedSequence
+      event._cachedAt = Date.now()
+    })
 }
 
 export async function getLatestPersistedSequence(streamId: string): Promise<string | null> {
@@ -361,8 +374,7 @@ async function writeBootstrapEventsAndStream(
     if (toWrite.length > 0) {
       await db.events.bulkPut(toWrite)
     }
-    const bootstrapTail = bootstrap.events.reduce((max, event) => Math.max(max, sequenceToNum(event.sequence)), 0)
-    await resolveUnknownOptimisticAnchors(streamId, bootstrapTail)
+    await resolveUnknownOptimisticAnchors(streamId, bootstrap.events)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
@@ -878,7 +890,7 @@ export function registerStreamSocketHandlers(
         carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
       }
 
-      await resolveUnknownOptimisticAnchors(streamId, Math.max(0, sequenceToNum(newEvent.sequence) - 1))
+      await resolveUnknownOptimisticAnchors(streamId, [newEvent])
 
       // Add the real event BEFORE deleting the optimistic one so that
       // Dexie live-query observers never see a frame with neither event.
@@ -1181,7 +1193,7 @@ export function registerStreamSocketHandlers(
       if (onSequenceGap) {
         gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), payload.event)
       }
-      await resolveUnknownOptimisticAnchors(streamId, Math.max(0, sequenceToNum(payload.event.sequence) - 1))
+      await resolveUnknownOptimisticAnchors(streamId, [payload.event])
       await db.events.put({
         ...payload.event,
         workspaceId,

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -426,7 +426,7 @@ async function writeBootstrapEventsAndStream(
         sequenceToNum(realEvent.sequence),
         optimistic.id
       )
-      await db.events.delete(optimistic.id)
+      await db.events.bulkDelete([optimistic.id, `${optimistic.id}:failed`])
       const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
       await db.pendingOperations.bulkDelete(
         operations
@@ -1262,7 +1262,7 @@ export function registerStreamSocketHandlers(
           sequenceToNum(payload.event.sequence),
           optimisticCommand.id
         )
-        await db.events.delete(commandClientId)
+        await db.events.bulkDelete([commandClientId, `${commandClientId}:failed`])
         const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
         await db.pendingOperations.bulkDelete(
           operations

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -107,7 +107,9 @@ async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> 
       if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return current
       return Math.max(current ?? 0, persisted._sequenceNum)
     }, null)
-    return anchor == null ? [] : [{ ...event, _anchorSequenceNum: anchor, _cachedAt: now }]
+    const resolvedAnchor =
+      anchor ?? Math.max(0, Math.min(...persistedEvents.map((persisted) => persisted._sequenceNum)) - 1)
+    return [{ ...event, _anchorSequenceNum: resolvedAnchor, _cachedAt: now }]
   })
   if (resolved.length > 0) await db.events.bulkPut(resolved)
 }

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -87,20 +87,26 @@ export function toCachedStreamBootstrap(
   }
 }
 
-async function resolveUnknownOptimisticAnchors(
-  streamId: string,
-  persistedEvents: Array<Pick<StreamEvent, "sequence" | "createdAt">>
-): Promise<void> {
+async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> {
+  const persistedEvents = await db.events
+    .where("[streamId+_sequenceNum]")
+    .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
+    .filter((event) => event._status == null)
+    .toArray()
+  if (persistedEvents.length === 0) return
+
   await db.events
     .where("_status")
     .anyOf(["pending", "failed", "editing"])
     .filter((event) => event.streamId === streamId && event._anchorSequenceNum == null)
     .modify((event) => {
       const optimisticCreatedAt = Date.parse(event.createdAt)
-      event._anchorSequenceNum = persistedEvents.reduce((anchor, persisted) => {
-        if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return anchor
-        return Math.max(anchor, sequenceToNum(persisted.sequence))
-      }, 0)
+      const anchor = persistedEvents.reduce<number | null>((current, persisted) => {
+        if (Date.parse(persisted.createdAt) > optimisticCreatedAt) return current
+        return Math.max(current ?? 0, persisted._sequenceNum)
+      }, null)
+      if (anchor == null) return
+      event._anchorSequenceNum = anchor
       event._cachedAt = Date.now()
     })
 }
@@ -108,7 +114,8 @@ async function resolveUnknownOptimisticAnchors(
 export async function bumpLaterOptimisticAnchors(
   streamId: string,
   confirmedOptimisticSequence: number,
-  confirmedPersistedSequence: number
+  confirmedPersistedSequence: number,
+  confirmedOptimisticId: string
 ): Promise<void> {
   await db.events
     .where("_status")
@@ -116,7 +123,8 @@ export async function bumpLaterOptimisticAnchors(
     .filter(
       (event) =>
         event.streamId === streamId &&
-        event._sequenceNum > confirmedOptimisticSequence &&
+        (event._sequenceNum > confirmedOptimisticSequence ||
+          (event._sequenceNum === confirmedOptimisticSequence && event.id.localeCompare(confirmedOptimisticId) > 0)) &&
         (event._anchorSequenceNum ?? -1) < confirmedPersistedSequence
     )
     .modify((event) => {
@@ -323,6 +331,20 @@ async function writeBootstrapEventsAndStream(
       return optimistic ? [{ realEvent, optimistic }] : []
     })
     const optimisticByRealEventId = new Map(optimisticSwaps.map((s) => [s.realEvent.id, s.optimistic] as const))
+    const commandDispatchedWithClientId = bootstrap.events
+      .filter((event) => event.eventType === "command_dispatched")
+      .map((event) => ({
+        realEvent: event,
+        clientCommandId: (event.payload as { clientCommandId?: string }).clientCommandId,
+      }))
+      .filter((pair): pair is { realEvent: StreamEvent; clientCommandId: string } => !!pair.clientCommandId)
+    const optimisticCommandRows = await db.events.bulkGet(
+      commandDispatchedWithClientId.map((pair) => pair.clientCommandId)
+    )
+    const optimisticCommandSwaps = commandDispatchedWithClientId.flatMap(({ realEvent }, index) => {
+      const optimistic = optimisticCommandRows[index]
+      return optimistic ? [{ realEvent, optimistic }] : []
+    })
 
     const toWrite: CachedEvent[] = []
     for (const e of bootstrap.events) {
@@ -374,20 +396,40 @@ async function writeBootstrapEventsAndStream(
     if (toWrite.length > 0) {
       await db.events.bulkPut(toWrite)
     }
-    await resolveUnknownOptimisticAnchors(streamId, bootstrap.events)
+    await resolveUnknownOptimisticAnchors(streamId)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
     // liveQuery frame never shows neither copy. Deleting the outbox row also
     // stops the queue from replaying a send the server already committed.
     for (const { realEvent, optimistic } of optimisticSwaps) {
-      await bumpLaterOptimisticAnchors(streamId, optimistic._sequenceNum, sequenceToNum(realEvent.sequence))
+      await bumpLaterOptimisticAnchors(
+        streamId,
+        optimistic._sequenceNum,
+        sequenceToNum(realEvent.sequence),
+        optimistic.id
+      )
       await db.events.delete(optimistic.id)
       await db.pendingMessages.delete(optimistic.id)
       const plaintext = readPlaintextContent(optimistic.payload)
       if (plaintext && isEncryptedPayload(realEvent.payload)) {
         seedDecryption(realEvent.id, plaintext)
       }
+    }
+    for (const { realEvent, optimistic } of optimisticCommandSwaps) {
+      await bumpLaterOptimisticAnchors(
+        streamId,
+        optimistic._sequenceNum,
+        sequenceToNum(realEvent.sequence),
+        optimistic.id
+      )
+      await db.events.delete(optimistic.id)
+      const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
+      await db.pendingOperations.bulkDelete(
+        operations
+          .filter((operation) => operation.payload.optimisticEventId === optimistic.id)
+          .map((operation) => operation.id)
+      )
     }
   }
 
@@ -890,8 +932,6 @@ export function registerStreamSocketHandlers(
         carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
       }
 
-      await resolveUnknownOptimisticAnchors(streamId, [newEvent])
-
       // Add the real event BEFORE deleting the optimistic one so that
       // Dexie live-query observers never see a frame with neither event.
       const eventToStore = carriedConversationId
@@ -906,10 +946,16 @@ export function registerStreamSocketHandlers(
         _sequenceNum: sequenceToNum(newEvent.sequence),
         _cachedAt: now,
       })
+      await resolveUnknownOptimisticAnchors(streamId)
 
       if (newPayload.clientMessageId) {
         if (optimistic) {
-          await bumpLaterOptimisticAnchors(streamId, optimistic._sequenceNum, sequenceToNum(newEvent.sequence))
+          await bumpLaterOptimisticAnchors(
+            streamId,
+            optimistic._sequenceNum,
+            sequenceToNum(newEvent.sequence),
+            optimistic.id
+          )
         }
         await db.events.delete(newPayload.clientMessageId).catch(() => {})
         await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
@@ -1186,20 +1232,42 @@ export function registerStreamSocketHandlers(
     // Same transactional shape as handleMessageCreated: dedupe, gap-read, and
     // put must be atomic, or a concurrent append can land between the gap read
     // and this write and make the cursor lie in either direction.
-    await db.transaction("rw", [db.events], async () => {
+    await db.transaction("rw", [db.events, db.pendingOperations], async () => {
       const existing = await db.events.get(payload.event.id)
       if (existing) return
       // Tail-gap check must read the latest BEFORE this write advances it.
       if (onSequenceGap) {
         gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), payload.event)
       }
-      await resolveUnknownOptimisticAnchors(streamId, [payload.event])
+      const commandClientId =
+        payload.event.eventType === "command_dispatched"
+          ? (payload.event.payload as { clientCommandId?: string }).clientCommandId
+          : undefined
+      const optimisticCommand = commandClientId ? await db.events.get(commandClientId) : undefined
       await db.events.put({
         ...payload.event,
         workspaceId,
         _sequenceNum: sequenceToNum(payload.event.sequence),
         _cachedAt: now,
       })
+      await resolveUnknownOptimisticAnchors(streamId)
+      if (commandClientId) {
+        if (optimisticCommand) {
+          await bumpLaterOptimisticAnchors(
+            streamId,
+            optimisticCommand._sequenceNum,
+            sequenceToNum(payload.event.sequence),
+            optimisticCommand.id
+          )
+        }
+        await db.events.delete(commandClientId)
+        const operations = await db.pendingOperations.where("type").equals("dispatch_command").toArray()
+        await db.pendingOperations.bulkDelete(
+          operations
+            .filter((operation) => operation.payload.optimisticEventId === commandClientId)
+            .map((operation) => operation.id)
+        )
+      }
     })
     if (gapAfterSequence !== null) {
       onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -185,6 +185,7 @@ export class SyncEngine {
   /** Max behind-head among heartbeats received while the grace timer is armed. */
   private pendingHeartbeatHead: bigint | null = null
   private heartbeatCleanup: (() => void) | null = null
+  private operationQueueRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
@@ -478,13 +479,25 @@ export class SyncEngine {
    */
   kickOperationQueue(): void {
     if (!this.deps.messageService) return
+    if (this.operationQueueRetryTimer) {
+      clearTimeout(this.operationQueueRetryTimer)
+      this.operationQueueRetryTimer = null
+    }
     void processOperationQueue(
       this.deps.messageService,
       this.deps.reactionService ?? { add: async () => {}, remove: async () => {} },
       this.deps.scheduledService,
       this.deps.draftsService,
       () => this.socket !== null && !this.isDestroyed
-    )
+    ).then((retryAt) => {
+      if (retryAt === null || this.isDestroyed || !this.socket) return
+      if (this.operationQueueRetryTimer) clearTimeout(this.operationQueueRetryTimer)
+      const delay = Math.max(0, retryAt - Date.now())
+      this.operationQueueRetryTimer = setTimeout(() => {
+        this.operationQueueRetryTimer = null
+        this.kickOperationQueue()
+      }, delay)
+    })
   }
 
   /**
@@ -605,6 +618,8 @@ export class SyncEngine {
     this.isDestroyed = true
     this.cleanupAllHandlers()
     this.subscribedStreams.clear()
+    if (this.operationQueueRetryTimer) clearTimeout(this.operationQueueRetryTimer)
+    this.operationQueueRetryTimer = null
     this.socket = null
     // Dispose without flushing or splicing — destroy can be an account switch
     // that repoints the shared db proxy, and neither the cursor nor buffered

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -400,6 +400,21 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     expect(stored?.featureFlags).toBeUndefined()
   })
 
+  it("applies stream bootstraps inside the reconnect batch transaction", async () => {
+    const streamId = "stream_reconnect_batch"
+
+    await applyReconnectBootstrapBatch(
+      "ws_1",
+      makeBootstrap({ streams: [{ ...makeStreamBootstrap(streamId).stream, lastMessagePreview: null }] }),
+      new Map([[streamId, makeStreamBootstrap(streamId)]]),
+      new Set(),
+      new Set(),
+      Date.now()
+    )
+
+    expect((await db.streams.get(streamId))?.id).toBe(streamId)
+  })
+
   it("persists feature-flag layers on the reconnect apply path too", async () => {
     await applyReconnectBootstrapBatch(
       "ws_1",

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2528,6 +2528,7 @@ export async function applyReconnectBootstrapBatch(
       db.workspaceMetadata,
       db.events,
       db.pendingMessages,
+      db.pendingOperations,
     ],
     async () => {
       await Promise.all([

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1880,6 +1880,7 @@ export interface DispatchCommandError {
 
 export interface CommandDispatchedPayload {
   commandId: string
+  clientCommandId?: string
   name: string
   args: string
   status: "dispatched"

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1861,6 +1861,7 @@ export interface MarkAllAsReadResponse {
 export interface DispatchCommandInput {
   command: string
   streamId: string
+  clientCommandId?: string
 }
 
 export interface DispatchCommandResponse {


### PR DESCRIPTION
## Problem

Failed or pending optimistic slash-command rows remained at the live tail instead of aging upward as server events arrived. They could not be safely dismissed, and retries, socket echoes, reloads, clock skew, or multiple tabs could duplicate execution or leave stale lifecycle rows.

## Solution

- Order optimistic events by persisted sequence anchors while preserving server ordering, thread chronology, partial acknowledgements, legacy rows, and deterministic cross-tab ties.
- Add accessible cancel/remove controls for locally cancellable command rows, with workspace-scoped transactional cleanup of queued operations and lifecycle events.
- Correlate HTTP, socket, and bootstrap command acknowledgements through `clientCommandId`, replacing optimistic rows and failed sidecars atomically.
- Persist backend command-dispatch idempotency claims so ambiguous retries cannot execute a command twice; replay remains gated by current stream access.
- Make local operation claiming race-safe and automatically schedule transient retries while the sync connection remains active.

### Key design decisions

**Persisted anchors instead of client/server timestamps**  
New optimistic events capture the latest persisted sequence. This avoids clock-skew ordering errors while allowing old failures to move upward naturally.

**Durable command idempotency**  
The backend claims `(workspace_id, client_command_id)` in the same transaction as event and runtime dispatch. Concurrent or later retries replay the committed event without invoking the command again.

**Conservative cancellation after ambiguous requests**  
Once a request may have reached the server, the local command remains non-cancellable and is reconciled through idempotent retry, socket echo, or bootstrap.

## Files changed

| Area | Change |
| --- | --- |
| Backend command handlers/repository | Access-gated idempotent claim and replay |
| Database migration | Durable workspace-scoped command dispatch ledger |
| Frontend event store/sync | Anchor ordering plus HTTP, socket, and bootstrap reconciliation |
| Operation queue/sync engine | Atomic claims and scheduled transient retries |
| Command timeline/hooks | Workspace-scoped cancel/remove controls |
| Tests | Ordering, clock skew, threads, cross-tab ties, cancellation races, replay, access, and reconciliation regressions |

## Test plan

- [x] 100 relevant frontend regression tests
- [x] Backend command handler and repository tests
- [x] Full monorepo typecheck
- [x] All workspace lint checks
- [x] Dockerfile checks
- [x] 230 migration checks
- [x] Generated API documentation check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787169073&installation_model_id=20758&pr_number=1466&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1466&signature=a371b37e6a8cbbbe61ddc0c270af851363c5f20f73792cf685c4fc5dddac8628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->