### PR TITLE
fix: close activity and feature flag test races

### DIFF
--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -114,7 +114,7 @@ function mapRowToActivity(row: ActivityRow): Activity {
 function conflictClauseFor(activityType: string) {
   if (activityType === ActivityTypes.REACTION) {
     return sql.raw(
-      "ON CONFLICT (user_id, message_id, actor_id, emoji) WHERE activity_type = 'reaction' DO UPDATE SET id = user_activity.id"
+      "ON CONFLICT (user_id, message_id, actor_id, emoji) WHERE activity_type = 'reaction' DO UPDATE SET read_at = COALESCE(user_activity.read_at, EXCLUDED.read_at)"
     )
   }
   if (activityType === ActivityTypes.SAVED_REMINDER || activityType === ActivityTypes.MISSED_CALL) {
@@ -123,7 +123,7 @@ function conflictClauseFor(activityType: string) {
     return sql.raw("")
   }
   return sql.raw(
-    "ON CONFLICT (user_id, message_id, activity_type, actor_id) WHERE activity_type NOT IN ('reaction', 'saved_reminder') DO UPDATE SET id = user_activity.id"
+    "ON CONFLICT (user_id, message_id, activity_type, actor_id) WHERE activity_type NOT IN ('reaction', 'saved_reminder') DO UPDATE SET read_at = COALESCE(user_activity.read_at, EXCLUDED.read_at)"
   )
 }
 

--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -3,7 +3,7 @@ import { Pool } from "pg"
 import { withTransaction } from "./setup"
 import { StreamService, StreamEventRepository, StreamMemberRepository } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
-import { ActivityService } from "../../src/features/activity"
+import { ActivityRepository, ActivityService } from "../../src/features/activity"
 import { streamId, userId, workspaceId } from "../../src/lib/id"
 import { setupTestDatabase, testMessageContent } from "./setup"
 
@@ -717,6 +717,17 @@ describe("Unread Counts", () => {
 
       const events = await StreamEventRepository.list(pool, testStreamId)
       await streamService.markAsRead(testWorkspaceId, testStreamId, readerId, events[0].id)
+
+      // A notification worker that resolved before the read can commit its stale unread insert afterward.
+      await ActivityRepository.insertBatch(pool, {
+        workspaceId: testWorkspaceId,
+        userIds: [readerId],
+        activityType: "message",
+        streamId: testStreamId,
+        messageId: message.id,
+        actorId: authorId,
+        actorType: "user",
+      })
 
       const activities = await activityService.processMessageNotifications({
         workspaceId: testWorkspaceId,

--- a/apps/frontend/src/hooks/use-feature-flags.test.tsx
+++ b/apps/frontend/src/hooks/use-feature-flags.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook, waitFor } from "@testing-library/react"
+import { cleanup, renderHook, waitFor } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
@@ -88,6 +88,7 @@ describe("feature flags — first render off persisted layers", () => {
   })
 
   afterEach(async () => {
+    cleanup()
     resetRegistry()
     await db.workspaceMetadata.clear()
     resetWorkspaceStoreCache()
@@ -138,6 +139,7 @@ describe("feature flags — first render off persisted layers", () => {
 
 describe("useOverriddenFeatureFlags — provenance", () => {
   afterEach(() => {
+    cleanup()
     resetRegistry()
   })
 


### PR DESCRIPTION
## Problem

Recent CI exposed two independent races. Backend notification dedupe could preserve a stale unread activity after the recipient had already read the message; frontend feature-flag tests deleted injected registry entries while mounted Dexie-backed hooks could still rerender, producing a post-test `undefined.default` exception.

## Solution

- Make `ActivityRepository` conflict updates preserve monotonic `read_at`: duplicates can promote unread → read, never read → unread.
- Make the unread integration case deterministic by committing a stale unread insert after the watermark update before replaying notification processing.
- Explicitly unmount feature-flag hooks before deleting injected registry entries or invalidating reactive stores.

Reviewed recent CI failures beyond these two: the attachment-hook race was already fixed by #1281; production config fixtures by #1433; latest Browser E2E red was a control-plane web-server boot timeout, not a recurring test assertion.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/activity/repository.ts` | Promote duplicate activities to read without allowing demotion |
| `apps/backend/tests/integration/unread-counts.test.ts` | Deterministically cover stale notification insertion after a read |
| `apps/frontend/src/hooks/use-feature-flags.test.tsx` | Cleanup mounted hooks before mutating the stand-in registry |

## Test plan

- [x] `bun scripts/test-silent.ts backend-integration tests/integration/unread-counts.test.ts` — 17 pass
- [x] Feature-flag tests with `--sequence.hooks=stack`, `list`, and `parallel` — 21 pass
- [x] Pre-commit lint, monorepo typecheck, Dockerfile/migration checks, OpenAPI check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787171781&installation_model_id=20758&pr_number=1467&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1467&signature=5feac8f1f217e5a2574b832192444c1bfc2c8da06ad2400fa70c9f7727e1d288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->