### PR TITLE
fix: scope sidebar agent activity to exact streams

### DIFF
--- a/apps/backend/src/features/agents/companion/session.test.ts
+++ b/apps/backend/src/features/agents/companion/session.test.ts
@@ -306,7 +306,7 @@ describe("per-stream session concurrency (roadmap 3.2)", () => {
     )
     spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([])
     spyOn(StreamEventRepository, "insert").mockResolvedValue({} as any)
-    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const outboxSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const base = {
       pool: {} as any,
@@ -323,7 +323,12 @@ describe("per-stream session concurrency (roadmap 3.2)", () => {
       work
     )
     const threadResult = await withCompanionSession(
-      { ...base, triggerMessageId: "msg_thread", streamId: "stream_thread_under_channel" },
+      {
+        ...base,
+        triggerMessageId: "msg_thread",
+        streamId: "stream_thread_under_channel",
+        rootStreamId: "stream_channel",
+      },
       work
     )
 
@@ -333,6 +338,16 @@ describe("per-stream session concurrency (roadmap 3.2)", () => {
     expect(insertSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ streamId: "stream_thread_under_channel" })
+    )
+    expect(outboxSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      "agent_session:started",
+      expect.objectContaining({ streamId: "stream_thread_under_channel", rootStreamId: "stream_channel" })
+    )
+    expect(outboxSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      "agent_session:completed",
+      expect.objectContaining({ streamId: "stream_thread_under_channel", rootStreamId: "stream_channel" })
     )
   })
 

--- a/apps/backend/src/features/agents/companion/session.ts
+++ b/apps/backend/src/features/agents/companion/session.ts
@@ -30,6 +30,7 @@ export async function withCompanionSession(
     pool: Pool
     triggerMessageId: string
     streamId: string
+    rootStreamId?: string
     personaId: string
     personaName: string
     workspaceId: string
@@ -57,6 +58,7 @@ export async function withCompanionSession(
     pool,
     triggerMessageId,
     streamId,
+    rootStreamId = streamId,
     personaId,
     personaName,
     workspaceId,
@@ -129,6 +131,7 @@ export async function withCompanionSession(
     await OutboxRepository.insert(db, "agent_session:started", {
       workspaceId,
       streamId,
+      rootStreamId,
       event: streamEvent,
     })
 
@@ -191,6 +194,7 @@ export async function withCompanionSession(
         await OutboxRepository.insert(db, "agent_session:completed", {
           workspaceId,
           streamId,
+          rootStreamId,
           event: streamEvent,
         })
         completionCommitted = true
@@ -272,6 +276,7 @@ export async function withCompanionSession(
           await OutboxRepository.insert(db, "agent_session:interrupted", {
             workspaceId,
             streamId,
+            rootStreamId,
             event: streamEvent,
           })
         } else {
@@ -292,6 +297,7 @@ export async function withCompanionSession(
           await OutboxRepository.insert(db, "agent_session:failed", {
             workspaceId,
             streamId,
+            rootStreamId,
             event: streamEvent,
           })
         }

--- a/apps/backend/src/features/agents/message-mutation-outbox-handler.test.ts
+++ b/apps/backend/src/features/agents/message-mutation-outbox-handler.test.ts
@@ -5,7 +5,7 @@ import type { ProcessResult } from "@threa/backend-common"
 import * as cursorLockModule from "@threa/backend-common"
 import { OutboxRepository } from "../../lib/outbox"
 import { MessageVersionRepository } from "../messaging"
-import { StreamEventRepository } from "../streams"
+import { StreamEventRepository, StreamRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { AgentMessageMutationHandler } from "./message-mutation-outbox-handler"
 import { AgentSessionRepository, SessionStatuses } from "./session-repository"
@@ -913,6 +913,10 @@ describe("AgentMessageMutationHandler", () => {
   })
 
   it("deletes invoking sessions and cascades deletion for stored and event-sourced session messages", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_thread_1",
+      rootStreamId: "stream_root_1",
+    } as any)
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([
       {
         id: 1n,
@@ -1057,6 +1061,7 @@ describe("AgentMessageMutationHandler", () => {
       expect.objectContaining({
         workspaceId: "ws_1",
         streamId: "stream_thread_1",
+        rootStreamId: "stream_root_1",
       })
     )
     expect(eventService.deleteMessage).toHaveBeenCalledTimes(2)

--- a/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
+++ b/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
@@ -9,7 +9,7 @@ import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxE
 import { JobQueues, type QueueManager } from "../../lib/queue"
 import type { EventService } from "../messaging"
 import { MessageVersionRepository } from "../messaging"
-import { StreamEventRepository } from "../streams"
+import { StreamEventRepository, StreamRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { AgentSessionRepository, SessionStatuses, type AgentSession } from "./session-repository"
 
@@ -379,9 +379,11 @@ export class AgentMessageMutationHandler extends DebouncedOutboxHandler {
         actorType: AuthorTypes.PERSONA,
       })
 
+      const stream = await StreamRepository.findById(db, updated.streamId)
       await OutboxRepository.insert(db, "agent_session:deleted", {
         workspaceId,
         streamId: updated.streamId,
+        rootStreamId: stream?.rootStreamId ?? stream?.id,
         event: serializeBigInt(streamEvent),
       })
 

--- a/apps/backend/src/features/agents/orphan-session-cleanup.ts
+++ b/apps/backend/src/features/agents/orphan-session-cleanup.ts
@@ -71,6 +71,7 @@ export async function failSessionWithLifecycle(
       await OutboxRepository.insert(tx, "agent_session:failed", {
         workspaceId: stream.workspaceId,
         streamId,
+        rootStreamId: stream.rootStreamId ?? stream.id,
         event: streamEvent,
       })
     }
@@ -78,7 +79,7 @@ export async function failSessionWithLifecycle(
   })
 
   // Live-update an open trace dialog (session room) the way the in-process
-  // `trace.notifyFailed()` does — the outbox only reaches the stream room.
+  // `trace.notifyFailed()` does — the outbox does not reach the session room.
   if (won && stream) {
     io.to(`ws:${stream.workspaceId}:agent_session:${sessionId}`).emit("agent_session:failed", { sessionId })
   }

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -450,6 +450,7 @@ export class PersonaAgent {
         pool,
         triggerMessageId: messageId,
         streamId: sessionStreamId,
+        rootStreamId: stream.rootStreamId ?? stream.id,
         personaId: persona.id,
         personaName: persona.name,
         workspaceId,

--- a/apps/backend/src/features/enclave-runtimes/claim-service.ts
+++ b/apps/backend/src/features/enclave-runtimes/claim-service.ts
@@ -497,7 +497,12 @@ export class EnclaveClaimService {
         actorId: ARIADNE_AGENT_ID,
         actorType: "persona",
       })
-      await OutboxRepository.insert(tx, "agent_session:started", { workspaceId, streamId, event: startedEvent })
+      await OutboxRepository.insert(tx, "agent_session:started", {
+        workspaceId,
+        streamId,
+        rootStreamId: triggerStream.rootStreamId ?? triggerStream.id,
+        event: startedEvent,
+      })
       return created
     })
     if (!session) return completeAsNoOp("another session is running for this stream")

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -728,6 +728,7 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
           await OutboxRepository.insert(tx, "agent_session:completed", {
             workspaceId: stream.workspaceId,
             streamId: session.streamId,
+            rootStreamId: stream.rootStreamId ?? stream.id,
             event: completedEvent,
           })
         }
@@ -735,8 +736,8 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
       })
 
       // Live-update an open trace dialog (session room) the way the in-process
-      // `trace.notifyCompleted()` does — the outbox broadcast only reaches the
-      // stream room, so the dialog wouldn't otherwise transition until a refetch.
+      // `trace.notifyCompleted()` does — the outbox broadcast does not reach the
+      // session room, so the dialog wouldn't otherwise transition until a refetch.
       if (committed && stream) {
         io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:completed", { sessionId: id })
       }

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1348,6 +1348,7 @@ export function createPublicApiHandlers({
           await OutboxRepository.insert(client, "agent_session:started", {
             workspaceId: req.workspaceId!,
             streamId: invocation.responseStreamId,
+            rootStreamId: invocation.rootStreamId,
             event: streamEvent,
           })
         })
@@ -1602,13 +1603,14 @@ export function createPublicApiHandlers({
         await OutboxRepository.insert(client, "agent_session:completed", {
           workspaceId: stream.workspaceId,
           streamId: session.streamId,
+          rootStreamId: stream.rootStreamId ?? stream.id,
           event: streamEvent,
         })
         return { message, sessionFinalized: true }
       })
 
       // Live-update an open trace dialog (session room) the way the enclave/in-process
-      // completes do — the outbox broadcast only reaches the stream room, so the
+      // completes do — the outbox broadcast does not reach the session room, so the
       // dialog wouldn't otherwise transition until a refetch.
       if (sessionFinalized) {
         io.to(`ws:${stream.workspaceId}:agent_session:${session.id}`).emit("agent_session:completed", {
@@ -1783,6 +1785,7 @@ export function createPublicApiHandlers({
             await OutboxRepository.insert(client, "agent_session:completed", {
               workspaceId: req.workspaceId!,
               streamId: completed.responseStreamId,
+              rootStreamId: completed.rootStreamId,
               event: streamEvent,
             })
             return { completed, message, sessionFinalized: true, synthesizedSteps }

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -60,6 +60,34 @@ describe("resolveDeliveryGroups — enclave re-wrap nudges", () => {
   })
 })
 
+describe("resolveDeliveryGroups — agent sessions", () => {
+  it("routes thread lifecycle events to the thread and its access root", () => {
+    expect(
+      resolveDeliveryGroups(
+        event("agent_session:started", {
+          workspaceId: "ws_1",
+          streamId: "stream_thread",
+          rootStreamId: "stream_root",
+          event: {},
+        })
+      )
+    ).toEqual([streamGroup("stream_thread"), streamGroup("stream_root")])
+  })
+
+  it("does not duplicate a root session's delivery group", () => {
+    expect(
+      resolveDeliveryGroups(
+        event("agent_session:completed", {
+          workspaceId: "ws_1",
+          streamId: "stream_root",
+          rootStreamId: "stream_root",
+          event: {},
+        })
+      )
+    ).toEqual([streamGroup("stream_root")])
+  })
+})
+
 describe("resolveDeliveryGroups — agent_config:updated (user-scoped-personas)", () => {
   it("routes a personal persona's update to its owner's room only, never the workspace", () => {
     const groups = resolveDeliveryGroups(

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -330,6 +330,21 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
     return groups
   }
 
+  if (
+    isOneOfOutboxEventType(event, [
+      "agent_session:started",
+      "agent_session:completed",
+      "agent_session:failed",
+      "agent_session:interrupted",
+      "agent_session:deleted",
+    ])
+  ) {
+    const { streamId, rootStreamId } = event.payload as { streamId: string; rootStreamId?: string }
+    return rootStreamId && rootStreamId !== streamId
+      ? [streamGroup(streamId), streamGroup(rootStreamId)]
+      : [streamGroup(streamId)]
+  }
+
   // Permission-scoped events (e.g. invitation lifecycle → members:write) go to
   // their scope's delivery group instead of the whole-workspace fallthrough.
   const permissionScopedGroup = PERMISSION_GROUP_BY_EVENT.get(event.eventType)

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -585,26 +585,16 @@ export interface CommandFailedOutboxPayload extends StreamScopedPayload {
   event: StreamEvent
 }
 
-// Agent session event payloads (stream-scoped - visible to all stream members)
-export interface AgentSessionStartedOutboxPayload extends StreamScopedPayload {
+interface AgentSessionOutboxPayload extends StreamScopedPayload {
+  rootStreamId?: string
   event: StreamEvent
 }
 
-export interface AgentSessionCompletedOutboxPayload extends StreamScopedPayload {
-  event: StreamEvent
-}
-
-export interface AgentSessionFailedOutboxPayload extends StreamScopedPayload {
-  event: StreamEvent
-}
-
-export interface AgentSessionInterruptedOutboxPayload extends StreamScopedPayload {
-  event: StreamEvent
-}
-
-export interface AgentSessionDeletedOutboxPayload extends StreamScopedPayload {
-  event: StreamEvent
-}
+export type AgentSessionStartedOutboxPayload = AgentSessionOutboxPayload
+export type AgentSessionCompletedOutboxPayload = AgentSessionOutboxPayload
+export type AgentSessionFailedOutboxPayload = AgentSessionOutboxPayload
+export type AgentSessionInterruptedOutboxPayload = AgentSessionOutboxPayload
+export type AgentSessionDeletedOutboxPayload = AgentSessionOutboxPayload
 
 // Read state event payloads (author-scoped - only visible to the user marking as read)
 export interface StreamReadOutboxPayload extends WorkspaceScopedPayload {

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -397,16 +397,13 @@ export function StreamItem({
   const hasUnread = unreadCount > 0
   const preview = stream.lastMessagePreview
   const isVirtualDraft = isDraftId(stream.id)
-  // Activity is keyed by sidebar root (a thread session projects to its channel),
-  // so a thread row must look up its root, not its own id, or it never lights.
-  const agentActivityStreamId =
-    stream.type === StreamTypes.THREAD && stream.rootStreamId ? stream.rootStreamId : stream.id
-  const agentSessions = useAgentActivityForStream(workspaceId, agentActivityStreamId)
+  const agentSessions = useAgentActivityForStream(workspaceId, stream.id)
   const agentActive = agentSessions.length > 0
-  // A live call keys on the sidebar root too (a call is anchored to a channel/DM
+  // A live call keys on the sidebar root (a call is anchored to a channel/DM
   // root; threads carry no calls in v1). The call dot wins the slot over the
   // agent dot (roadmap 1.4).
-  const callActive = useActiveCallsForStream(workspaceId, agentActivityStreamId).length > 0
+  const callStreamId = stream.type === StreamTypes.THREAD && stream.rootStreamId ? stream.rootStreamId : stream.id
+  const callActive = useActiveCallsForStream(workspaceId, callStreamId).length > 0
 
   useUrgencyTracking(itemRef, stream.id, stream.urgency, scrollContainerRef)
 

--- a/apps/frontend/src/stores/agent-activity-store.test.ts
+++ b/apps/frontend/src/stores/agent-activity-store.test.ts
@@ -24,21 +24,29 @@ function session(overrides: Partial<ActiveAgentSession>): ActiveAgentSession {
 describe("agent-activity-store", () => {
   beforeEach(() => __resetAgentActivityStore())
 
-  it("seeds by root and reads back the running sessions", () => {
-    seedAgentActivity(WS, [session({ sessionId: "s1", rootStreamId: "stream_a" })])
+  it("seeds by stream and reads back the running sessions", () => {
+    seedAgentActivity(WS, [session({ sessionId: "s1", streamId: "stream_a" })])
     expect(getAgentActivityForStream(WS, "stream_a").map((s) => s.sessionId)).toEqual(["s1"])
     expect(getAgentActivityForStream(WS, "stream_b")).toEqual([])
   })
 
   it("re-seed replaces the set, dropping entries whose end was missed (reconnect)", () => {
-    seedAgentActivity(WS, [session({ sessionId: "s1", rootStreamId: "stream_a" })])
+    seedAgentActivity(WS, [session({ sessionId: "s1", streamId: "stream_a" })])
     // Reconnect bootstrap no longer lists s1 → it must clear.
-    seedAgentActivity(WS, [session({ sessionId: "s2", rootStreamId: "stream_c" })])
+    seedAgentActivity(WS, [session({ sessionId: "s2", streamId: "stream_c" })])
     expect(getAgentActivityForStream(WS, "stream_a")).toEqual([])
     expect(getAgentActivityForStream(WS, "stream_c").map((s) => s.sessionId)).toEqual(["s2"])
   })
 
-  it("orders multiple sessions on a root by most recently started", () => {
+  it("keeps thread activity separate from its parent stream", () => {
+    seedAgentActivity(WS, [
+      session({ sessionId: "thread_session", streamId: "stream_thread", rootStreamId: "stream_parent" }),
+    ])
+    expect(getAgentActivityForStream(WS, "stream_parent")).toEqual([])
+    expect(getAgentActivityForStream(WS, "stream_thread").map((s) => s.sessionId)).toEqual(["thread_session"])
+  })
+
+  it("orders multiple sessions in a stream by most recently started", () => {
     seedAgentActivity(WS, [
       session({
         sessionId: "old",
@@ -70,9 +78,9 @@ describe("agent-activity-store", () => {
     expect(getAgentActivityForStream(WS, "stream_a")).toEqual([])
   })
 
-  it("moving a session to a new root clears the old root's snapshot", () => {
-    upsertAgentSession(WS, session({ sessionId: "s1", rootStreamId: "stream_a" }))
-    upsertAgentSession(WS, session({ sessionId: "s1", rootStreamId: "stream_b" }))
+  it("moving a session to a new stream clears the old stream's snapshot", () => {
+    upsertAgentSession(WS, session({ sessionId: "s1", streamId: "stream_a" }))
+    upsertAgentSession(WS, session({ sessionId: "s1", streamId: "stream_b" }))
     expect(getAgentActivityForStream(WS, "stream_a")).toEqual([])
     expect(getAgentActivityForStream(WS, "stream_b").map((s) => s.sessionId)).toEqual(["s1"])
   })

--- a/apps/frontend/src/stores/agent-activity-store.ts
+++ b/apps/frontend/src/stores/agent-activity-store.ts
@@ -3,14 +3,15 @@ import type { ActiveAgentSession } from "@threa/types"
 
 /**
  * Ephemeral, non-persisted store of the agent sessions running RIGHT NOW,
- * keyed by their sidebar root so a stream row can paint an "agent working"
- * state. Seeded from the workspace bootstrap (`activeAgentSessions`) and, on
+ * keyed by their exact stream so a stream row can paint an "agent working"
+ * state without inheriting activity from a parent or child. Seeded from the
+ * workspace bootstrap (`activeAgentSessions`) and, on
  * reconnect, re-seeded as the authoritative running set (INV-53) — the seed
  * REPLACES the workspace's entries, so any entry whose end signal was missed is
  * dropped at the next reconnect. Live starts/ends fold in from the
  * `agent_session:*` room events (see workspace-sync). Removal is by session id
- * (root-agnostic) so a terminal event always clears reliably regardless of which
- * root resolved it.
+ * (stream-agnostic) so a terminal event always clears reliably regardless of
+ * which room delivered it.
  *
  * Not in IDB: this is transient presence, not durable state — a cold reload
  * re-derives it from the fresh bootstrap.
@@ -19,15 +20,15 @@ import type { ActiveAgentSession } from "@threa/types"
 // workspaceId -> sessionId -> session
 const workspaces = new Map<string, Map<string, ActiveAgentSession>>()
 
-// `${workspaceId}:${rootStreamId}` -> listeners subscribed to that row
+// `${workspaceId}:${streamId}` -> listeners subscribed to that row
 const keyListeners = new Map<string, Set<() => void>>()
 // Content-stable snapshot per key (referential stability for useSyncExternalStore)
 const keySnapshots = new Map<string, ActiveAgentSession[]>()
 
 const EMPTY: readonly ActiveAgentSession[] = Object.freeze([])
 
-function subKey(workspaceId: string, rootStreamId: string): string {
-  return `${workspaceId}:${rootStreamId}`
+function subKey(workspaceId: string, streamId: string): string {
+  return `${workspaceId}:${streamId}`
 }
 
 function sameSnapshot(a: readonly ActiveAgentSession[], b: readonly ActiveAgentSession[]): boolean {
@@ -38,11 +39,11 @@ function sameSnapshot(a: readonly ActiveAgentSession[], b: readonly ActiveAgentS
   return true
 }
 
-/** Recompute the cached snapshot for one root key and notify iff its content changed. */
-function recomputeKey(workspaceId: string, rootStreamId: string): void {
-  const key = subKey(workspaceId, rootStreamId)
+/** Recompute the cached snapshot for one stream key and notify iff its content changed. */
+function recomputeKey(workspaceId: string, streamId: string): void {
+  const key = subKey(workspaceId, streamId)
   const sessions = [...(workspaces.get(workspaceId)?.values() ?? [])]
-    .filter((entry) => entry.rootStreamId === rootStreamId)
+    .filter((entry) => entry.streamId === streamId)
     // Most-recently-started first: the row's primary label picks [0].
     .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
 
@@ -60,17 +61,17 @@ function recomputeKey(workspaceId: string, rootStreamId: string): void {
 /** Replace the whole running set for a workspace (bootstrap / reconnect re-seed). */
 export function seedAgentActivity(workspaceId: string, sessions: ActiveAgentSession[]): void {
   const previous = workspaces.get(workspaceId)
-  const affectedRoots = new Set<string>()
-  for (const entry of previous?.values() ?? []) affectedRoots.add(entry.rootStreamId)
+  const affectedStreams = new Set<string>()
+  for (const entry of previous?.values() ?? []) affectedStreams.add(entry.streamId)
 
   const next = new Map<string, ActiveAgentSession>()
   for (const session of sessions) {
     next.set(session.sessionId, { ...session })
-    affectedRoots.add(session.rootStreamId)
+    affectedStreams.add(session.streamId)
   }
   workspaces.set(workspaceId, next)
 
-  for (const root of affectedRoots) recomputeKey(workspaceId, root)
+  for (const streamId of affectedStreams) recomputeKey(workspaceId, streamId)
 }
 
 /** Add or refresh one running session (live `started`/`progress`). */
@@ -90,19 +91,19 @@ export function upsertAgentSession(workspaceId: string, session: ActiveAgentSess
     return
   }
   ws.set(session.sessionId, { ...session })
-  if (existing && existing.rootStreamId !== session.rootStreamId) {
-    recomputeKey(workspaceId, existing.rootStreamId)
+  if (existing && existing.streamId !== session.streamId) {
+    recomputeKey(workspaceId, existing.streamId)
   }
-  recomputeKey(workspaceId, session.rootStreamId)
+  recomputeKey(workspaceId, session.streamId)
 }
 
-/** Remove a session by id on any terminal signal (root-agnostic). */
+/** Remove a session by id on any terminal signal. */
 export function removeAgentSession(workspaceId: string, sessionId: string): void {
   const ws = workspaces.get(workspaceId)
   const existing = ws?.get(sessionId)
   if (!ws || !existing) return
   ws.delete(sessionId)
-  recomputeKey(workspaceId, existing.rootStreamId)
+  recomputeKey(workspaceId, existing.streamId)
 }
 
 /** True if a session with this id is already tracked in the workspace. */
@@ -110,25 +111,24 @@ export function hasAgentSession(workspaceId: string, sessionId: string): boolean
   return workspaces.get(workspaceId)?.has(sessionId) ?? false
 }
 
-/** Non-reactive read of a root's running sessions (most recent first). */
-export function getAgentActivityForStream(workspaceId: string, rootStreamId: string): readonly ActiveAgentSession[] {
-  return keySnapshots.get(subKey(workspaceId, rootStreamId)) ?? EMPTY
+/** Non-reactive read of a stream's running sessions (most recent first). */
+export function getAgentActivityForStream(workspaceId: string, streamId: string): readonly ActiveAgentSession[] {
+  return keySnapshots.get(subKey(workspaceId, streamId)) ?? EMPTY
 }
 
 /**
- * The agent sessions running in `rootStreamId` (or any of its threads), most
- * recently started first; empty when idle. Reactive per-row read for the
- * sidebar — subscribes only to this root's slice, so an unrelated stream's
- * activity change re-renders nothing here.
+ * The agent sessions running directly in `streamId`, most recently started
+ * first; empty when idle. Reactive per-row read for the sidebar — subscribes
+ * only to this stream's slice, so parent and thread activity stay independent.
  */
 export function useAgentActivityForStream(
   workspaceId: string | undefined,
-  rootStreamId: string | undefined
+  streamId: string | undefined
 ): readonly ActiveAgentSession[] {
   const subscribe = useCallback(
     (onChange: () => void) => {
-      if (!workspaceId || !rootStreamId) return () => {}
-      const key = subKey(workspaceId, rootStreamId)
+      if (!workspaceId || !streamId) return () => {}
+      const key = subKey(workspaceId, streamId)
       let set = keyListeners.get(key)
       if (!set) {
         set = new Set()
@@ -140,11 +140,11 @@ export function useAgentActivityForStream(
         if (set.size === 0) keyListeners.delete(key)
       }
     },
-    [workspaceId, rootStreamId]
+    [workspaceId, streamId]
   )
   const getSnapshot = useCallback(
-    () => (workspaceId && rootStreamId ? getAgentActivityForStream(workspaceId, rootStreamId) : EMPTY),
-    [workspaceId, rootStreamId]
+    () => (workspaceId && streamId ? getAgentActivityForStream(workspaceId, streamId) : EMPTY),
+    [workspaceId, streamId]
   )
   return useSyncExternalStore(subscribe, getSnapshot)
 }

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2324,7 +2324,7 @@ describe("agent-activity sidebar socket handlers", () => {
   it("upserts on started (wrapped outbox shape), resolving the channel root, and removes on the flat session-room completed shape", async () => {
     await putStream("stream_ch", null)
     const queryClient = new QueryClient()
-    const { socket, emit, emitAsync } = createTestSocket()
+    const { socket, emitAsync } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
     await emitAsync("agent_session:started", {
@@ -2335,8 +2335,8 @@ describe("agent-activity sidebar socket handlers", () => {
 
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_1"])
 
-    // Flat session-room shape (trace dialog open on the shared socket) — must not throw.
-    expect(() => emit("agent_session:completed", { sessionId: "sess_1" })).not.toThrow()
+    // Flat session-room shape (trace dialog open on the shared socket).
+    await emitAsync("agent_session:completed", { sessionId: "sess_1" })
     expect(getAgentActivityForStream("ws_1", "stream_ch")).toEqual([])
 
     cleanup()
@@ -2366,6 +2366,27 @@ describe("agent-activity sidebar socket handlers", () => {
     expect(getAgentActivityForStream("ws_1", "stream_ch")).toEqual([])
     expect(getAgentActivityForStream("ws_1", "stream_thr").map((s) => s.sessionId)).toEqual(["sess_thr"])
 
+    cleanup()
+  })
+
+  it("preserves lifecycle order when a terminal event arrives during started root resolution", async () => {
+    await putStream("stream_ch", null)
+    const queryClient = new QueryClient()
+    const { socket, emit, emitAsync } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("agent_session:started", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_race", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
+    })
+    await emitAsync("agent_session:completed", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_race" } },
+    })
+
+    expect(getAgentActivityForStream("ws_1", "stream_ch")).toEqual([])
     cleanup()
   })
 

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2342,7 +2342,7 @@ describe("agent-activity sidebar socket handlers", () => {
     cleanup()
   })
 
-  it("resolves a thread session to its channel root and honors the cross-workspace guard", async () => {
+  it("keeps a thread session on the thread and honors the cross-workspace guard", async () => {
     await putStream("stream_ch", null)
     await putStream("stream_thr", "stream_ch")
     const queryClient = new QueryClient()
@@ -2354,7 +2354,8 @@ describe("agent-activity sidebar socket handlers", () => {
       streamId: "stream_thr",
       event: { payload: { sessionId: "sess_thr", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_thr"])
+    expect(getAgentActivityForStream("ws_1", "stream_ch")).toEqual([])
+    expect(getAgentActivityForStream("ws_1", "stream_thr").map((s) => s.sessionId)).toEqual(["sess_thr"])
 
     // Different workspace — ignored.
     await emitAsync("agent_session:started", {
@@ -2362,7 +2363,8 @@ describe("agent-activity sidebar socket handlers", () => {
       streamId: "stream_ch",
       event: { payload: { sessionId: "sess_other", personaName: "X", startedAt: "2026-07-16T00:00:00.000Z" } },
     })
-    expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_thr"])
+    expect(getAgentActivityForStream("ws_1", "stream_ch")).toEqual([])
+    expect(getAgentActivityForStream("ws_1", "stream_thr").map((s) => s.sessionId)).toEqual(["sess_thr"])
 
     cleanup()
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1194,58 +1194,65 @@ export function registerWorkspaceSocketHandlers(
     return stream.rootStreamId ?? stream.id
   }
 
-  const handleAgentSessionStartedActivity = async (payload: {
-    workspaceId: string
-    streamId: string
-    event: StreamEvent
-  }) => {
-    if (payload.workspaceId !== workspaceId) return
-    const inner = payload.event.payload as AgentSessionStartedPayload
-    const rootStreamId = await resolveRootStreamId(payload.streamId)
-    if (!rootStreamId) return
-    upsertAgentSession(workspaceId, {
-      sessionId: inner.sessionId,
-      streamId: payload.streamId,
-      rootStreamId,
-      personaName: inner.personaName,
-      startedAt: inner.startedAt,
+  let agentActivityQueue = Promise.resolve()
+  const enqueueAgentActivity = (task: () => void | Promise<void>): Promise<void> => {
+    const run = agentActivityQueue.then(task)
+    agentActivityQueue = run.catch((error) => {
+      console.error("Failed to update sidebar agent activity", error)
     })
+    return run
   }
 
-  const handleAgentSessionProgressActivity = async (payload: AgentSessionProgressPayload) => {
-    if (payload.workspaceId !== workspaceId) return
-    // Progress arrives per step, but only for the stream/parent rooms this viewer
-    // has joined (trace-emitter emits to streamRoom + parentRoom, never workspace-
-    // wide). Once the session is tracked, nothing the sidebar renders changes —
-    // skip the IDB lookup and the no-op upsert entirely.
-    if (hasAgentSession(workspaceId, payload.sessionId)) return
-    const rootStreamId = await resolveRootStreamId(payload.streamId)
-    if (!rootStreamId) return
-    upsertAgentSession(workspaceId, {
-      sessionId: payload.sessionId,
-      streamId: payload.streamId,
-      rootStreamId,
-      personaName: payload.personaName,
-      // Progress carries no start time; anchor sort order to arrival.
-      startedAt: new Date().toISOString(),
+  const handleAgentSessionStartedActivity = (payload: { workspaceId: string; streamId: string; event: StreamEvent }) =>
+    enqueueAgentActivity(async () => {
+      if (payload.workspaceId !== workspaceId) return
+      const inner = payload.event.payload as AgentSessionStartedPayload
+      const rootStreamId = await resolveRootStreamId(payload.streamId)
+      if (!rootStreamId) return
+      upsertAgentSession(workspaceId, {
+        sessionId: inner.sessionId,
+        streamId: payload.streamId,
+        rootStreamId,
+        personaName: inner.personaName,
+        startedAt: inner.startedAt,
+      })
     })
-  }
 
-  const handleAgentActivityStarted = async (payload: AgentActivityStartedPayload) => {
-    const rootStreamId = await resolveRootStreamId(payload.threadStreamId)
-    if (!rootStreamId) return
-    upsertAgentSession(workspaceId, {
-      sessionId: payload.sessionId,
-      streamId: payload.threadStreamId,
-      rootStreamId,
-      personaName: payload.personaName,
-      startedAt: new Date().toISOString(),
+  const handleAgentSessionProgressActivity = (payload: AgentSessionProgressPayload) =>
+    enqueueAgentActivity(async () => {
+      if (payload.workspaceId !== workspaceId) return
+      // Progress arrives per step, but only for the stream/parent rooms this viewer
+      // has joined (trace-emitter emits to streamRoom + parentRoom, never workspace-
+      // wide). Once the session is tracked, nothing the sidebar renders changes —
+      // skip the IDB lookup and the no-op upsert entirely.
+      if (hasAgentSession(workspaceId, payload.sessionId)) return
+      const rootStreamId = await resolveRootStreamId(payload.streamId)
+      if (!rootStreamId) return
+      upsertAgentSession(workspaceId, {
+        sessionId: payload.sessionId,
+        streamId: payload.streamId,
+        rootStreamId,
+        personaName: payload.personaName,
+        // Progress carries no start time; anchor sort order to arrival.
+        startedAt: new Date().toISOString(),
+      })
     })
-  }
 
-  const handleAgentActivityEnded = (payload: AgentActivityEndedPayload) => {
-    removeAgentSession(workspaceId, payload.sessionId)
-  }
+  const handleAgentActivityStarted = (payload: AgentActivityStartedPayload) =>
+    enqueueAgentActivity(async () => {
+      const rootStreamId = await resolveRootStreamId(payload.threadStreamId)
+      if (!rootStreamId) return
+      upsertAgentSession(workspaceId, {
+        sessionId: payload.sessionId,
+        streamId: payload.threadStreamId,
+        rootStreamId,
+        personaName: payload.personaName,
+        startedAt: new Date().toISOString(),
+      })
+    })
+
+  const handleAgentActivityEnded = (payload: AgentActivityEndedPayload) =>
+    enqueueAgentActivity(() => removeAgentSession(workspaceId, payload.sessionId))
 
   // agent_session:completed/failed reach this socket in two shapes: the
   // stream-scoped outbox form `{ workspaceId, streamId, event }`, and a flat
@@ -1258,11 +1265,12 @@ export function registerWorkspaceSocketHandlers(
     streamId?: string
     event?: StreamEvent
     sessionId?: string
-  }) => {
-    if (payload.workspaceId !== undefined && payload.workspaceId !== workspaceId) return
-    const sessionId = (payload.event?.payload as { sessionId?: string } | undefined)?.sessionId ?? payload.sessionId
-    if (sessionId) removeAgentSession(workspaceId, sessionId)
-  }
+  }) =>
+    enqueueAgentActivity(() => {
+      if (payload.workspaceId !== undefined && payload.workspaceId !== workspaceId) return
+      const sessionId = (payload.event?.payload as { sessionId?: string } | undefined)?.sessionId ?? payload.sessionId
+      if (sessionId) removeAgentSession(workspaceId, sessionId)
+    })
 
   // Handle stream display name updated (from auto-naming service)
   const handleStreamDisplayNameUpdated = (payload: StreamDisplayNameUpdatedPayload) => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1185,15 +1185,9 @@ export function registerWorkspaceSocketHandlers(
   }
 
   // Sidebar agent-activity: keep the running-session store live for stream rows
-  // the viewer isn't currently looking at. The sync engine joins every member
-  // stream's room, so these events arrive here for all of them. Root resolution
-  // rides the local streams cache (`db.streams` carries `rootStreamId`): a
-  // root-level session resolves to its own row; a thread session resolves to the
-  // channel row once the thread is cached (channel-mention threads are cached via
-  // their `stream:created`, which fans out to the parent room). An unresolved
-  // stream (uncached thread) is skipped — the next bootstrap/reconnect re-seed
-  // carries it. Terminal signals remove by session id (root-agnostic), so an end
-  // always clears regardless of which root resolved it.
+  // the viewer isn't currently looking at. Indicators key on the exact stream;
+  // the resolved root is retained for access metadata. An uncached stream is
+  // skipped until the next bootstrap/reconnect re-seed.
   const resolveRootStreamId = async (streamId: string): Promise<string | null> => {
     const stream = await db.streams.get(streamId)
     if (!stream) return null
@@ -1223,7 +1217,7 @@ export function registerWorkspaceSocketHandlers(
     // Progress arrives per step, but only for the stream/parent rooms this viewer
     // has joined (trace-emitter emits to streamRoom + parentRoom, never workspace-
     // wide). Once the session is tracked, nothing the sidebar renders changes —
-    // skip the IDB root lookup and the no-op upsert entirely.
+    // skip the IDB lookup and the no-op upsert entirely.
     if (hasAgentSession(workspaceId, payload.sessionId)) return
     const rootStreamId = await resolveRootStreamId(payload.streamId)
     if (!rootStreamId) return
@@ -1258,7 +1252,7 @@ export function registerWorkspaceSocketHandlers(
   // session-room form `{ sessionId }` (trace-emitter/orphan-cleanup/enclave/
   // public-api) delivered whenever the trace dialog holds the session room open
   // on this same shared socket. Read the id from either and remove by it —
-  // removal is root-agnostic and a no-op for an id this workspace never tracked.
+  // removal is stream-agnostic and a no-op for an id this workspace never tracked.
   const handleAgentSessionEndedActivity = (payload: {
     workspaceId?: string
     streamId?: string

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1658,9 +1658,9 @@ export interface WorkspaceBootstrap {
    */
   syncHead?: string
   /**
-   * Agent sessions currently RUNNING in streams the viewer can access, resolved
-   * to their sidebar root (`rootStreamId`) so the sidebar can paint an
-   * "agent working" state cold (INV-62: access-filtered server-side; a session in
+   * Agent sessions currently RUNNING in streams the viewer can access. The
+   * sidebar keys indicators by the session's exact `streamId`; `rootStreamId`
+   * remains the access boundary (INV-62: access-filtered server-side; a session in
    * a stream the viewer can't see is omitted). Live starts/ends ride the
    * `agent_session:*` room events; this seeds the store and, on reconnect,
    * re-seeds it as the authoritative running set (INV-53). Optional: payloads
@@ -1689,9 +1689,9 @@ export interface WorkspaceBootstrap {
 /**
  * One running agent session, projected for the sidebar activity indicator.
  * `streamId` is the session's own stream (a channel/scratchpad/DM root, or a
- * thread); `rootStreamId` is the non-thread ancestor whose sidebar row lights up
- * (`COALESCE(streams.root_stream_id, streams.id)`). `personaName` is the
- * persona or bot display name driving the session.
+ * thread) whose sidebar row lights up; `rootStreamId` is its non-thread ancestor
+ * used for access filtering (`COALESCE(streams.root_stream_id, streams.id)`).
+ * `personaName` is the persona or bot display name driving the session.
  */
 export interface ActiveAgentSession {
   sessionId: string


### PR DESCRIPTION
## Problem

Sidebar agent activity was indexed by `rootStreamId`, so parent sessions appeared active on thread rows and thread sessions collapsed into the parent row.

## Solution

- Index sidebar activity snapshots and subscriptions by exact `streamId`.
- Route thread agent lifecycle outbox events to both the exact thread and its access root so unopened thread rows stay live without leaking across access boundaries.
- Serialize asynchronous sidebar lifecycle handlers so terminal events cannot race root resolution and resurrect stale indicators.
- Keep root-based call lookup unchanged.

## Files

| Area | Change |
| ---- | ------ |
| Frontend agent activity store/sidebar | Exact-stream indexing and row lookup. |
| Workspace sync | Ordered started/progress/terminal handling with parent/thread isolation coverage. |
| Outbox delivery | Thread lifecycle fan-out to thread + access-root groups. |
| Agent runtimes | Carry `rootStreamId` through companion, public API, enclave, orphan, and deletion lifecycle events. |

## Test plan

- [x] Agent activity store — 7 passed
- [x] Stream item — 25 passed
- [x] Workspace sync agent lifecycle — 4 passed
- [x] Outbox delivery groups — 34 passed
- [x] Companion session lifecycle — 8 passed
- [x] Message mutation lifecycle — 13 passed
- [x] Repository lint, typecheck, migration, Dockerfile, and OpenAPI commit checks

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787174262&installation_model_id=20758&pr_number=1468&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1468&signature=4d4558c538e29c8136f848c28b0abb48239535b499fc7ef33c891e51c70923e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->