### PR TITLE
fix: collapse safety-redacted trace sections to a one-line notice

### DIFF
--- a/apps/backend/src/features/attachments/image/service.test.ts
+++ b/apps/backend/src/features/attachments/image/service.test.ts
@@ -133,8 +133,10 @@ describe("ImageThumbnailService.generateThumbnail", () => {
       width: 1600,
       height: 800,
     })
-  })
+  }, 30_000)
 
+  // Building + re-encoding an animated GIF through sharp routinely blows
+  // bun's 5s default timeout on slower machines.
   it("caps a high-framerate GIF, dropping frames while staying animated", async () => {
     // 12 frames at 25ms = 40fps → downsampled below the 15fps cap.
     const gif = await buildAnimatedGif(12, 25)
@@ -157,7 +159,7 @@ describe("ImageThumbnailService.generateThumbnail", () => {
     // Still animated, but with fewer frames than the 40fps source.
     expect(meta.pages ?? 1).toBeGreaterThan(1)
     expect(meta.pages ?? 1).toBeLessThan(12)
-  })
+  }, 30_000)
 
   it("swaps width/height for EXIF orientations that rotate 90°", async () => {
     const rotated = await sharp({

--- a/apps/backend/src/features/public-api/sanitize.ts
+++ b/apps/backend/src/features/public-api/sanitize.ts
@@ -1,5 +1,6 @@
 import {
   PI_TOOL_TRACE_FORMAT,
+  PI_TOOL_TRACE_REDACTED_BODIES,
   PI_TOOL_TRACE_SECTION_LABELS,
   PiToolTraceSectionLabels,
   type PiToolTraceSectionLabel,
@@ -66,10 +67,10 @@ function sanitizeTraceSection(section: unknown): SafeTraceSection | null {
   if (!TRACE_SECTION_LABEL_SET.has(rawLabel)) return null
   const label = rawLabel as PiToolTraceSectionLabel
   if (label === PiToolTraceSectionLabels.ARGUMENTS) {
-    return { label, body: "Tool arguments omitted for safety.", lang: null }
+    return { label, body: PI_TOOL_TRACE_REDACTED_BODIES.ARGUMENTS, lang: null }
   }
   if (label === PiToolTraceSectionLabels.OUTPUT || label === PiToolTraceSectionLabels.ERROR_OUTPUT) {
-    return { label, body: "Tool output omitted for safety.", lang: null }
+    return { label, body: PI_TOOL_TRACE_REDACTED_BODIES.OUTPUT, lang: null }
   }
   const body = typeof item.body === "string" ? clampString(redactSensitiveText(item.body), TRACE_BODY_MAX_CHARS) : ""
   const lang = typeof item.lang === "string" ? clampString(item.lang, TRACE_LANG_MAX_CHARS) : null

--- a/apps/backend/src/lib/env.test.ts
+++ b/apps/backend/src/lib/env.test.ts
@@ -13,6 +13,9 @@ function setBaseEnv() {
   delete process.env.GITHUB_APP_ID
   delete process.env.GITHUB_APP_SLUG
   delete process.env.GITHUB_APP_PRIVATE_KEY
+  delete process.env.LINEAR_OAUTH_CLIENT_ID
+  delete process.env.LINEAR_OAUTH_CLIENT_SECRET
+  delete process.env.LINEAR_OAUTH_REDIRECT_URI
   delete process.env.WORKSPACE_INTEGRATIONS_SECRET
   delete process.env.MEDIACONVERT_ENABLED
   delete process.env.MEDIACONVERT_ROLE_ARN

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -464,9 +464,8 @@ describe("TraceStep", () => {
     )
 
     expect(screen.getByText("Editing file index.html")).toBeInTheDocument()
-    expect(screen.getByText("Arguments", { exact: false })).toBeInTheDocument()
-    expect(screen.getByText("Output", { exact: false })).toBeInTheDocument()
-    expect(screen.getAllByText("hidden for safety")).toHaveLength(2)
+    const notices = screen.getAllByText("hidden for safety").map((el) => el.parentElement?.textContent)
+    expect(notices).toEqual(["Arguments hidden for safety", "Output hidden for safety"])
     expect(screen.queryByRole("button", { name: /Arguments/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /Output/i })).not.toBeInTheDocument()
     expect(screen.queryByText(PI_TOOL_TRACE_REDACTED_BODIES.ARGUMENTS)).not.toBeInTheDocument()

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import {
   AgentReconsiderationDecisions,
   PI_TOOL_TRACE_FORMAT,
+  PI_TOOL_TRACE_REDACTED_BODIES,
   PiToolTraceSectionLabels,
   type AgentSessionStep,
 } from "@threa/types"
@@ -444,6 +445,32 @@ describe("TraceStep", () => {
     expect(screen.queryByText(/apps\/backend\/src\/foo\.ts/)).not.toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Output/i }))
     expect(screen.getByText(/apps\/backend\/src\/foo\.ts/)).toBeInTheDocument()
+  })
+
+  it("renders redacted sections as a one-line notice instead of a disclosure", () => {
+    const content = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Editing file index.html",
+      sections: [
+        { label: PiToolTraceSectionLabels.ARGUMENTS, body: PI_TOOL_TRACE_REDACTED_BODIES.ARGUMENTS, lang: null },
+        { label: PiToolTraceSectionLabels.OUTPUT, body: PI_TOOL_TRACE_REDACTED_BODIES.OUTPUT, lang: null },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <TraceStep step={createStep({ stepType: "tool_call", content })} workspaceId="ws_1" streamId="stream_1" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText("Editing file index.html")).toBeInTheDocument()
+    expect(screen.getByText("Arguments", { exact: false })).toBeInTheDocument()
+    expect(screen.getByText("Output", { exact: false })).toBeInTheDocument()
+    expect(screen.getAllByText("hidden for safety")).toHaveLength(2)
+    expect(screen.queryByRole("button", { name: /Arguments/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Output/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(PI_TOOL_TRACE_REDACTED_BODIES.ARGUMENTS)).not.toBeInTheDocument()
+    expect(screen.queryByText(PI_TOOL_TRACE_REDACTED_BODIES.OUTPUT)).not.toBeInTheDocument()
   })
 
   it("renders truncated structured Pi tool traces as a collapsed fallback", async () => {

--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom"
 import {
   AgentReconsiderationDecisions,
   PI_TOOL_TRACE_FORMAT,
+  PI_TOOL_TRACE_REDACTED_BODY_SET,
   PiToolTraceSectionLabels,
   type AgentSessionStep,
   type AgentStepType,
@@ -18,6 +19,7 @@ import {
   CircleSlash,
   Clock,
   ExternalLink,
+  EyeOff,
   Loader2,
   MessageSquareReply,
   type LucideIcon,
@@ -749,20 +751,35 @@ function ToolTraceContent({
       <div className="font-mono text-[12.5px] leading-snug break-words text-foreground/90">{headlineText}</div>
       {sections.length > 0 && (
         <div className="space-y-1.5">
-          {sections.map((section, i) => (
-            <ToolSectionDisclosure
-              key={`${section.label}-${i}`}
-              section={section}
-              defaultOpen={isError && section.label === PiToolTraceSectionLabels.ERROR_OUTPUT}
-              isError={
-                isError &&
-                (section.label === PiToolTraceSectionLabels.ERROR_OUTPUT ||
-                  section.label === PiToolTraceSectionLabels.DETAILS)
-              }
-            />
-          ))}
+          {sections.map((section, i) =>
+            PI_TOOL_TRACE_REDACTED_BODY_SET.has(section.body) ? (
+              <RedactedSectionNotice key={`${section.label}-${i}`} label={section.label} />
+            ) : (
+              <ToolSectionDisclosure
+                key={`${section.label}-${i}`}
+                section={section}
+                defaultOpen={isError && section.label === PiToolTraceSectionLabels.ERROR_OUTPUT}
+                isError={
+                  isError &&
+                  (section.label === PiToolTraceSectionLabels.ERROR_OUTPUT ||
+                    section.label === PiToolTraceSectionLabels.DETAILS)
+                }
+              />
+            )
+          )}
         </div>
       )}
+    </div>
+  )
+}
+
+function RedactedSectionNotice({ label }: { label: PiToolTraceSectionLabel }) {
+  return (
+    <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+      <EyeOff className="w-3 h-3 shrink-0" />
+      <span>
+        {label} <span className="italic">hidden for safety</span>
+      </span>
     </div>
   )
 }

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1246,6 +1246,17 @@ export const PiToolTraceSectionLabels = {
   DETAILS: "Details",
 } as const satisfies Record<string, PiToolTraceSectionLabel>
 
+// Exact bodies the backend substitutes for redacted trace sections
+// (public-api sanitize). The frontend matches on these to collapse the
+// section into a one-line "hidden for safety" notice.
+export const PI_TOOL_TRACE_REDACTED_BODIES = {
+  ARGUMENTS: "Tool arguments omitted for safety.",
+  OUTPUT: "Tool output omitted for safety.",
+} as const
+export const PI_TOOL_TRACE_REDACTED_BODY_SET: ReadonlySet<string> = new Set(
+  Object.values(PI_TOOL_TRACE_REDACTED_BODIES)
+)
+
 // 'archived' is the recoverable end state written when the linked scratchpad is
 // archived — stream:unarchived revives exactly these links back to 'active'.
 // 'ended' is terminal (normal shutdown) and is never revived.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -290,6 +290,8 @@ export {
   PI_TOOL_TRACE_SECTION_LABELS,
   type PiToolTraceSectionLabel,
   PiToolTraceSectionLabels,
+  PI_TOOL_TRACE_REDACTED_BODIES,
+  PI_TOOL_TRACE_REDACTED_BODY_SET,
   // Voice dictation draft-context cap (shared FE/gateway)
   VOICE_DRAFT_CONTEXT_MAX_CHARS,
   // Auth (social providers + magic auth)


### PR DESCRIPTION
## Problem

Pi tool trace steps whose Arguments/Output the sanitizer redacts (`sanitizeInvocationStepContent` in `apps/backend/src/features/public-api/sanitize.ts`) still rendered a full `ToolSectionDisclosure` — an uppercase toggle row plus a full-width body box — just to say "Tool arguments omitted for safety." Two such sections per tool call eat most of the trace dialog for zero information.

## Solution

Detect the redaction placeholder on the frontend and collapse the section to one greyed line — EyeOff icon + `Arguments hidden for safety` — instead of the disclosure.

- Redaction bodies centralized as `PI_TOOL_TRACE_REDACTED_BODIES` / `PI_TOOL_TRACE_REDACTED_BODY_SET` in `packages/types/src/constants.ts` (INV-33); the sanitizer now writes those constants, the frontend matches the exact strings. Exact-match on body over a new wire field — no schema change, historical persisted steps collapse too.
- Two pre-existing test problems surfaced by the full suites, fixed in-branch: `env.test.ts` didn't clear `LINEAR_OAUTH_*` in `setBaseEnv`, so a local `.env` with Linear creds failed 20 tests; the two animated-GIF thumbnail tests in `image/service.test.ts` blow bun's 5s default timeout on slower machines (sharp re-encode ≈13s) — now 30s.

## After

First two steps redacted (one-liner), third unredacted (disclosures unchanged):

![redacted-trace-after](https://seer.build/ws_vbyzjvdg6g/i/img_2k1c0znv7a/redacted-trace-after.webp)

_Real `TraceStep` mounted in a scratch Vite entry + Playwright; layout only, no live sockets._

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | `PI_TOOL_TRACE_REDACTED_BODIES` + `PI_TOOL_TRACE_REDACTED_BODY_SET` |
| `packages/types/src/index.ts` | export them |
| `apps/backend/src/features/public-api/sanitize.ts` | redaction bodies from the shared constants |
| `apps/frontend/src/components/trace/trace-step.tsx` | redacted sections render `RedactedSectionNotice` one-liner instead of `ToolSectionDisclosure` |
| `apps/frontend/src/components/trace/trace-step.test.tsx` | test: one-line notice, no toggle, placeholder body not rendered |
| `apps/backend/src/lib/env.test.ts` | hermeticity: delete `LINEAR_OAUTH_*` in `setBaseEnv` |
| `apps/backend/src/features/attachments/image/service.test.ts` | 30s timeouts on the two animated-GIF tests |

## Test plan

- [x] frontend `trace-step.test.tsx` — 22 pass
- [x] backend unit suite — 3446 pass, 0 fail
- [x] full monorepo typecheck — clean
- [ ] full frontend vitest run locally — reds are the known Node 25 localStorage/jsdom environment issue (verified: failing files pass in isolation); CI is authoritative

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787174344&installation_model_id=20758&pr_number=1469&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1469&signature=d7fa73812faddb79ee64bdf253270b01b9fc96fe53d6eaf0b6fceafcd3c12110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
