### PR TITLE
fix(calls): camera/source picker + mobile front/back flip

### DIFF
--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -7,6 +7,7 @@ import {
   type CallSocket,
 } from "./call-manager"
 import type { MediaTransport } from "./media-transport"
+import { AUDIO_CAPTURE_CONSTRAINTS, VIDEO_CAPTURE_CONSTRAINTS } from "./config"
 import { ApiError } from "@/api/client"
 import { getCallState, clearCallState, resetCallStoreCache, type CallRosterParticipant } from "@/stores/call-store"
 import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
@@ -488,6 +489,82 @@ describe("CallManager", () => {
     expect(getCallState().local.devices.selectedInputId).toBe("dev-b")
   })
 
+  // ── camera selection + mobile flip ──────────────────────────────────────────
+
+  it("switchCameraDevice writes selectedCameraId and recaptures video with the exact deviceId", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    await manager.setCameraOn(true)
+
+    await manager.switchCameraDevice("cam-2")
+
+    expect(getCallState().local.devices.selectedCameraId).toBe("cam-2")
+    expect(getCallState().local.devices.facingMode).toBeNull()
+    // Recaptures mic+camera in one stream (iOS rule) with the chosen camera; the
+    // whole constraints object is asserted in one comparison (INV-24).
+    expect(lastAcquireConstraints(deps)).toEqual({
+      audio: AUDIO_CAPTURE_CONSTRAINTS,
+      video: { ...VIDEO_CAPTURE_CONSTRAINTS, deviceId: { exact: "cam-2" } },
+    })
+    // The video track was republished (not dropped) and the call stays up.
+    expect(transport._events.filter((e) => e === "publish:camera").length).toBeGreaterThanOrEqual(2)
+    expect(manager.isActive()).toBe(true)
+  })
+
+  it("switchCameraDevice with the camera off stores the pref and applies it on the next setCameraOn", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    // Join defaults to camera-off, so the switch only records the preference.
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    await manager.switchCameraDevice("cam-9")
+
+    expect(getCallState().local.devices.selectedCameraId).toBe("cam-9")
+    // No recapture while the camera is off — only the join's mic acquisition ran.
+    expect(deps.acquireUserMedia).toHaveBeenCalledTimes(1)
+    expect(transport._events).not.toContain("publish:camera")
+
+    await manager.setCameraOn(true)
+    expect(lastAcquireConstraints(deps)).toEqual({
+      audio: AUDIO_CAPTURE_CONSTRAINTS,
+      video: { ...VIDEO_CAPTURE_CONSTRAINTS, deviceId: { exact: "cam-9" } },
+    })
+  })
+
+  it("flipCamera toggles facingMode, clears the deviceId pref, and recaptures video", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    // Seed an explicit device pref, then turn the camera on with it.
+    await manager.switchCameraDevice("cam-1")
+    await manager.setCameraOn(true)
+
+    await manager.flipCamera()
+
+    // First flip goes to the back camera and clears the explicit deviceId.
+    expect(getCallState().local.devices.facingMode).toBe("environment")
+    expect(getCallState().local.devices.selectedCameraId).toBeNull()
+    expect(lastAcquireConstraints(deps)).toEqual({
+      audio: AUDIO_CAPTURE_CONSTRAINTS,
+      video: { ...VIDEO_CAPTURE_CONSTRAINTS, facingMode: "environment" },
+    })
+
+    // A second flip toggles back to the front camera.
+    await manager.flipCamera()
+    expect(getCallState().local.devices.facingMode).toBe("user")
+    expect(lastAcquireConstraints(deps)).toEqual({
+      audio: AUDIO_CAPTURE_CONSTRAINTS,
+      video: { ...VIDEO_CAPTURE_CONSTRAINTS, facingMode: "user" },
+    })
+  })
+
   it("iOS mid-call recapture failure rolls back to the prior capture with a typed error", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
@@ -731,4 +808,10 @@ function getMicTrack(transport: MediaTransport): MediaStreamTrack {
   const publish = transport.publish as unknown as ReturnType<typeof vi.fn>
   const micCall = publish.mock.calls.find((c: unknown[]) => c[0] === "mic")
   return micCall?.[1] as MediaStreamTrack
+}
+
+/** The constraints of the most recent getUserMedia acquisition. */
+function lastAcquireConstraints(deps: CallManagerDeps): MediaStreamConstraints {
+  const acquire = deps.acquireUserMedia as unknown as ReturnType<typeof vi.fn>
+  return acquire.mock.calls.at(-1)?.[0] as MediaStreamConstraints
 }

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -204,6 +204,19 @@ function refKey(ref: PeerTrackRef): string {
 }
 
 /**
+ * A capture+publish request: the mic is always captured, the camera optionally.
+ * `inputDeviceId` selects the mic; `cameraDeviceId`/`facingMode` select the
+ * camera (deviceId wins when both are present, and the two are mutually
+ * exclusive by construction — see {@link CallDeviceState.facingMode}).
+ */
+interface CaptureOpts {
+  camera: boolean
+  inputDeviceId?: string | null
+  cameraDeviceId?: string | null
+  facingMode?: "user" | "environment" | null
+}
+
+/**
  * The command surface UI components drive (INV-15: components never touch
  * `MediaTransport` or sockets). `CallManager` implements it; tests inject a fake
  * through the `CallManagerProvider`. State is read from the call-store, never
@@ -215,6 +228,8 @@ export interface CallController {
   setMuted(muted: boolean): void
   setCameraOn(on: boolean): Promise<void>
   switchInputDevice(deviceId: string): Promise<void>
+  switchCameraDevice(deviceId: string): Promise<void>
+  flipCamera(): Promise<void>
   setOutputDevice(deviceId: string): Promise<void>
   getVideoStream(endpointId: string): MediaStream | null
 }
@@ -501,9 +516,13 @@ export class CallManager implements CallController {
       if (on) {
         // Turning the camera on re-acquires mic+camera as ONE stream (iOS single-
         // active-capture): a camera-only gUM while the mic is live would mute it.
+        // Apply the stored camera selection (desktop deviceId or mobile facingMode).
+        const devices = getCallState().local.devices
         await this.doCaptureAndPublish(session, {
           camera: true,
-          inputDeviceId: getCallState().local.devices.selectedInputId,
+          inputDeviceId: devices.selectedInputId,
+          cameraDeviceId: devices.selectedCameraId,
+          facingMode: devices.facingMode,
         })
       } else if (session.cameraTrack) {
         // Camera off fully stops the track (kills the LED) and unpublishes; the
@@ -527,6 +546,82 @@ export class CallManager implements CallController {
       await this.doCaptureAndPublish(session, { camera: session.cameraTrack != null, inputDeviceId: deviceId })
       patchCallLocal({ devices: { ...getCallState().local.devices, selectedInputId: deviceId } })
     })
+    await this.refreshDevices()
+  }
+
+  /**
+   * Switch which camera the call publishes. Stores the selection regardless (a
+   * camera-off call applies it on the next {@link setCameraOn}); when the camera
+   * is live, recaptures mic+camera as ONE stream (iOS single-active-capture) on
+   * the new device and republishes video — audio and the call stay up. Clears any
+   * facingMode flip pref, since an explicit device wins over front/back.
+   */
+  async switchCameraDevice(deviceId: string): Promise<void> {
+    const session = this.session
+    if (!session) return
+    if (session.mode === "audio_only") return
+    const prev = getCallState().local.devices
+    patchCallLocal({
+      devices: { ...prev, selectedCameraId: deviceId, facingMode: null },
+    })
+    if (!session.cameraTrack) return
+    try {
+      await this.serializeCapture(session, async () => {
+        await this.doCaptureAndPublish(session, {
+          camera: true,
+          inputDeviceId: getCallState().local.devices.selectedInputId,
+          cameraDeviceId: deviceId,
+        })
+      })
+    } catch (err) {
+      // Capture failed (e.g. camera in use); the old feed is still live, so
+      // restore the pref that reflects it rather than leaving the tried device highlighted.
+      patchCallLocal({
+        devices: {
+          ...getCallState().local.devices,
+          selectedCameraId: prev.selectedCameraId,
+          facingMode: prev.facingMode,
+        },
+      })
+      throw err
+    }
+    await this.refreshDevices()
+  }
+
+  /**
+   * Mobile front/back flip: toggle `facingMode` (defaulting the first flip to the
+   * back camera) and clear the explicit deviceId. Recaptures+republishes video
+   * when the camera is live; otherwise the pref applies on the next
+   * {@link setCameraOn}.
+   */
+  async flipCamera(): Promise<void> {
+    const session = this.session
+    if (!session) return
+    if (session.mode === "audio_only") return
+    const prev = getCallState().local.devices
+    const facingMode: "user" | "environment" = prev.facingMode === "environment" ? "user" : "environment"
+    patchCallLocal({
+      devices: { ...prev, facingMode, selectedCameraId: null },
+    })
+    if (!session.cameraTrack) return
+    try {
+      await this.serializeCapture(session, async () => {
+        await this.doCaptureAndPublish(session, {
+          camera: true,
+          inputDeviceId: getCallState().local.devices.selectedInputId,
+          facingMode,
+        })
+      })
+    } catch (err) {
+      patchCallLocal({
+        devices: {
+          ...getCallState().local.devices,
+          facingMode: prev.facingMode,
+          selectedCameraId: prev.selectedCameraId,
+        },
+      })
+      throw err
+    }
     await this.refreshDevices()
   }
 
@@ -686,18 +781,27 @@ export class CallManager implements CallController {
     return run
   }
 
-  private captureAndPublish(
-    session: CallSession,
-    opts: { camera: boolean; inputDeviceId?: string | null }
-  ): Promise<void> {
+  private captureAndPublish(session: CallSession, opts: CaptureOpts): Promise<void> {
     return this.serializeCapture(session, () => this.doCaptureAndPublish(session, opts))
   }
 
-  private buildCaptureConstraints(opts: { camera: boolean; inputDeviceId?: string | null }): MediaStreamConstraints {
+  private buildCaptureConstraints(opts: CaptureOpts): MediaStreamConstraints {
     const audio: MediaTrackConstraints = opts.inputDeviceId
       ? { ...AUDIO_CAPTURE_CONSTRAINTS, deviceId: { exact: opts.inputDeviceId } }
       : AUDIO_CAPTURE_CONSTRAINTS
-    return opts.camera ? { audio, video: VIDEO_CAPTURE_CONSTRAINTS } : { audio }
+    if (!opts.camera) return { audio }
+    return { audio, video: this.buildVideoConstraints(opts) }
+  }
+
+  /**
+   * Camera constraints with the caller's selection applied. An explicit
+   * `cameraDeviceId` (desktop picker) wins over `facingMode` (mobile flip); with
+   * neither, the unmodified capture defaults let the browser pick a camera.
+   */
+  private buildVideoConstraints(opts: CaptureOpts): MediaTrackConstraints {
+    if (opts.cameraDeviceId) return { ...VIDEO_CAPTURE_CONSTRAINTS, deviceId: { exact: opts.cameraDeviceId } }
+    if (opts.facingMode) return { ...VIDEO_CAPTURE_CONSTRAINTS, facingMode: opts.facingMode }
+    return VIDEO_CAPTURE_CONSTRAINTS
   }
 
   /**
@@ -714,10 +818,7 @@ export class CallManager implements CallController {
    *
    * Always run through {@link serializeCapture}, never called directly.
    */
-  private async doCaptureAndPublish(
-    session: CallSession,
-    opts: { camera: boolean; inputDeviceId?: string | null }
-  ): Promise<void> {
+  private async doCaptureAndPublish(session: CallSession, opts: CaptureOpts): Promise<void> {
     const constraints = this.buildCaptureConstraints(opts)
     const prev = session.captureConstraints
 
@@ -1093,13 +1194,20 @@ export class CallManager implements CallController {
     if (!session) return
     const devices = await this.deps.enumerateDevices().catch(() => [] as MediaDeviceInfo[])
     const current = getCallState().local.devices
+    // A live camera resolves a bare deviceId/facingMode capture to a concrete
+    // device only its track knows; reflect that so the picker highlights the
+    // actual active camera. Falls back to the prior value when no camera is live.
+    // `|| null` not `?? null`: a granted track can report deviceId "" (permission
+    // quirk) — treat empty as "unknown" so it can't clobber a real selection.
+    const liveCameraId = session.cameraTrack?.getSettings?.().deviceId || null
     const next: CallDeviceState = {
       inputs: devices.filter((d) => d.kind === "audioinput"),
       outputs: devices.filter((d) => d.kind === "audiooutput"),
       cameras: devices.filter((d) => d.kind === "videoinput"),
       selectedInputId: current.selectedInputId,
       selectedOutputId: current.selectedOutputId,
-      selectedCameraId: current.selectedCameraId,
+      selectedCameraId: liveCameraId ?? current.selectedCameraId,
+      facingMode: current.facingMode,
     }
     setCallDevices(next)
   }

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act } from "@testing-library/react"
+import { render, screen, userEvent } from "@/test"
+import * as useMobileModule from "@/hooks/use-mobile"
+import { clearCallState, setCallSession, setCallPhase, setCallDevices, type CallDeviceState } from "@/stores/call-store"
+import type { CallController } from "@/calls/call-manager"
+import { CallControls, DevicePickerMenu } from "./call-controls"
+import { CallManagerProvider } from "./call-manager-context"
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function device(deviceId: string, label: string, kind: MediaDeviceKind): MediaDeviceInfo {
+  return { deviceId, label, kind, groupId: "grp", toJSON: () => ({}) } as MediaDeviceInfo
+}
+
+function makeDevices(overrides: Partial<CallDeviceState> = {}): CallDeviceState {
+  return {
+    inputs: [],
+    outputs: [],
+    cameras: [],
+    selectedInputId: null,
+    selectedOutputId: null,
+    selectedCameraId: null,
+    facingMode: null,
+    ...overrides,
+  }
+}
+
+function renderPicker(manager: CallController, devices: CallDeviceState) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <DevicePickerMenu devices={devices} />
+    </CallManagerProvider>
+  )
+}
+
+function renderControls(manager: CallController) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <CallControls />
+    </CallManagerProvider>
+  )
+}
+
+function enterVideoCall(overrides: Partial<CallDeviceState> = {}) {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallDevices(makeDevices(overrides))
+  })
+}
+
+beforeEach(() => {
+  clearCallState()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("DevicePickerMenu — camera group", () => {
+  it("renders the camera group and switches camera on select", async () => {
+    const manager = makeManager()
+    renderPicker(
+      manager,
+      makeDevices({
+        cameras: [device("cam-front", "Front camera", "videoinput"), device("cam-back", "Back camera", "videoinput")],
+        selectedCameraId: "cam-front",
+      })
+    )
+
+    await userEvent.click(screen.getByLabelText("Devices"))
+    expect(await screen.findByText("Camera")).toBeInTheDocument()
+    await userEvent.click(await screen.findByRole("menuitemradio", { name: "Back camera" }))
+
+    expect(manager.switchCameraDevice).toHaveBeenCalledWith("cam-back")
+  })
+
+  it("labels unlabeled cameras with a Camera N fallback", async () => {
+    renderPicker(
+      makeManager(),
+      makeDevices({ cameras: [device("c1", "", "videoinput"), device("c2", "", "videoinput")] })
+    )
+
+    await userEvent.click(screen.getByLabelText("Devices"))
+    expect(await screen.findByRole("menuitemradio", { name: "Camera 1" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitemradio", { name: "Camera 2" })).toBeInTheDocument()
+  })
+
+  it("omits the camera group when there are no cameras", async () => {
+    renderPicker(makeManager(), makeDevices({ inputs: [device("m1", "Mic 1", "audioinput")] }))
+
+    await userEvent.click(screen.getByLabelText("Devices"))
+    expect(await screen.findByText("Microphone")).toBeInTheDocument()
+    expect(screen.queryByText("Camera")).toBeNull()
+  })
+})
+
+describe("CallControls — mobile flip", () => {
+  function forceMobile(value: boolean) {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(value)
+  }
+
+  it("shows the flip control on mobile with multiple cameras and dispatches flipCamera", async () => {
+    forceMobile(true)
+    const manager = makeManager()
+    renderControls(manager)
+    enterVideoCall({ cameras: [device("c1", "Front", "videoinput"), device("c2", "Back", "videoinput")] })
+
+    await userEvent.click(screen.getByLabelText("Flip camera"))
+    expect(manager.flipCamera).toHaveBeenCalled()
+  })
+
+  it("hides the flip control on desktop even with multiple cameras", () => {
+    forceMobile(false)
+    renderControls(makeManager())
+    enterVideoCall({ cameras: [device("c1", "Front", "videoinput"), device("c2", "Back", "videoinput")] })
+
+    expect(screen.queryByLabelText("Flip camera")).toBeNull()
+  })
+
+  it("hides the flip control on mobile with only one camera", () => {
+    forceMobile(true)
+    renderControls(makeManager())
+    enterVideoCall({ cameras: [device("c1", "Front", "videoinput")] })
+
+    expect(screen.queryByLabelText("Flip camera")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { toast } from "sonner"
-import { Mic, MicOff, Video, VideoOff, PhoneOff, Settings, Signal } from "lucide-react"
+import { Mic, MicOff, Video, VideoOff, PhoneOff, Settings, Signal, SwitchCamera } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
 import { useCallManager } from "./call-manager-context"
 import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMode, useCallMuted } from "./call-store-hooks"
@@ -21,15 +22,16 @@ import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMode, useCa
 // speaker picker where the API is absent rather than showing a dead control.
 const OUTPUT_SELECTION_SUPPORTED = typeof HTMLMediaElement !== "undefined" && "setSinkId" in HTMLMediaElement.prototype
 
-function deviceLabel(device: MediaDeviceInfo, index: number): string {
-  return device.label || `Device ${index + 1}`
+function deviceLabel(device: MediaDeviceInfo, index: number, fallbackPrefix = "Device"): string {
+  return device.label || `${fallbackPrefix} ${index + 1}`
 }
 
 export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
   const manager = useCallManager()
+  const hasCameras = devices.cameras.length > 0
   const hasInputs = devices.inputs.length > 0
   const hasOutputs = OUTPUT_SELECTION_SUPPORTED && devices.outputs.length > 0
-  if (!hasInputs && !hasOutputs) return null
+  if (!hasCameras && !hasInputs && !hasOutputs) return null
 
   return (
     <DropdownMenu>
@@ -39,6 +41,24 @@ export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="center" className="max-w-[280px]">
+        {hasCameras && (
+          <>
+            <DropdownMenuLabel>Camera</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={devices.selectedCameraId ?? undefined}
+              onValueChange={(id) =>
+                void manager.switchCameraDevice(id).catch(() => toast.error("Couldn't switch camera"))
+              }
+            >
+              {devices.cameras.map((d, i) => (
+                <DropdownMenuRadioItem key={d.deviceId} value={d.deviceId} className="truncate">
+                  {deviceLabel(d, i, "Camera")}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+        {hasCameras && (hasInputs || hasOutputs) && <DropdownMenuSeparator />}
         {hasInputs && (
           <>
             <DropdownMenuLabel>Microphone</DropdownMenuLabel>
@@ -138,10 +158,15 @@ export function CallControls() {
   const mode = useCallMode()
   const devices = useCallDevices()
   const diagnostics = useCallDiagnostics()
+  const isMobile = useIsMobile()
   const [leaving, setLeaving] = useState(false)
 
   const toggleCamera = () => {
     void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))
+  }
+
+  const flipCamera = () => {
+    void manager.flipCamera().catch(() => toast.error("Couldn't flip the camera"))
   }
 
   const leave = () => {
@@ -174,6 +199,11 @@ export function CallControls() {
           onClick={toggleCamera}
         >
           {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+        </Button>
+      )}
+      {isMobile && mode !== "audio_only" && devices.cameras.length > 1 && (
+        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Flip camera" onClick={flipCamera}>
+          <SwitchCamera className="h-4 w-4" />
         </Button>
       )}
       <DevicePickerMenu devices={devices} />

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -72,6 +72,8 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     setMuted: vi.fn(),
     setCameraOn: vi.fn(async () => {}),
     switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
     ...overrides,

--- a/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
@@ -77,6 +77,8 @@ function makeManager(): CallController {
     setMuted: vi.fn(),
     setCameraOn: vi.fn(async () => {}),
     switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
   }

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -37,6 +37,15 @@ export interface CallDeviceState {
   selectedInputId: string | null
   selectedOutputId: string | null
   selectedCameraId: string | null
+  /**
+   * Mobile front/back flip preference. A flip sets this and clears
+   * `selectedCameraId`; picking an explicit device sets that and clears this. They
+   * are not permanently exclusive, though: once a facingMode capture lands,
+   * `refreshDevices` reflects the resulting device back into `selectedCameraId`
+   * (so the picker highlights it), leaving both set. Capture precedence is
+   * deviceId → facingMode → default, so an explicit device always wins next.
+   */
+  facingMode: "user" | "environment" | null
 }
 
 export interface CallLocalState {
@@ -99,6 +108,7 @@ const EMPTY_DEVICES: CallDeviceState = {
   selectedInputId: null,
   selectedOutputId: null,
   selectedCameraId: null,
+  facingMode: null,
 }
 
 function idleState(): CallState {

--- a/docs/plans/calls-ux-overhaul.md
+++ b/docs/plans/calls-ux-overhaul.md
@@ -1,0 +1,108 @@
+# Calls UX overhaul — plan
+
+Status: **draft, awaiting ratification**. Owner: Kris. Design source: Seer `calls-ux-cb8f33` (v7) — light/dark, 4-mode global drawer, Speaker↔Grid, desktop top/side dock.
+
+Voice/video calls shipped (stack #1410→#1424, released #1454, migrated to the `calls` feature flag default-on in #1461). Live prod use surfaced two bugs and a thin in-call UX. This overhaul fixes the bugs and rebuilds the call surface into one snap-resize system shared across mobile (drawer) and desktop (dock).
+
+## Locked design decisions (from the Seer exploration)
+
+- **One surface, snap modes.** Mobile = a **global** drawer pulled from the top; desktop = its **twin**, a resizable dock docked **top** or **side** (user config). Both snap between discrete sizes and follow the user across streams (call is app-chrome, not stream content — already mounts once at app root).
+  - Mobile modes: **Tab** (live dot + timer only) → **Bar** (timer + current speaker + mute/camera/leave) → **Tiny gallery** (speaker pinned + flip + device menu) → **Fullscreen**.
+  - Desktop **Top** dock snaps: Tab → Bar → Gallery → Fullscreen (drag bottom edge). **Side** dock snaps: Rail → Panel → Wide → Fullscreen (drag left edge). Config picks top (narrow window) or side (widescreen).
+- **Light + dark.** Call chrome (tab/bar/dock/controls) uses theme tokens and follows light/dark. Video tiles + the fullscreen stage keep a near-black bed in both themes (a light backdrop behind a live feed reads as broken). Hang-up stays destructive-red; live dot + speaking ring stay primary-amber in both.
+- **Speaker ↔ Grid.** Segmented switch in the fully-open/fullscreen view. Grid = equal tiles. Speaker = active speaker large + the rest as a filmstrip. Mobile filmstrip is bottom-only. Desktop offers **bottom** or **side** filmstrip (screen-shape choice). Layout choice persists.
+- **Camera / source picker.** Desktop: a device menu with **Camera / Microphone / Speaker** groups, each listing every device (webcams, capture cards, virtual cams). Mobile: one-tap **front/back flip** + the full device sheet one tap deeper.
+- **Self-view** is a small draggable PiP in Speaker; an equal tile in Grid. Camera-off shows avatar-initials (theme-aware surface).
+
+## Non-negotiable constraints
+
+- Gate every new surface on the **`calls` feature flag** via the current subject-keyed read path — never re-introduce the bespoke `callsEnabled` boolean. (Confirm exact hook API in grounding before writing chunk 1.)
+- Reuse the existing outbox/socket delivery (INV-4/7) for the auto-end event — no ad-hoc publish.
+- Media objects never go through React state (current call code attaches `srcObject` by ref on `mediaEpoch` bumps) — preserve that.
+- Persist user prefs (layout, dock position, filmstrip side) client-side (localStorage), keyed so they survive reload; do not add columns for these.
+- INV-25 comments, INV-63 toasts, INV-14 Shadcn primitives, INV-40 Link-vs-button all apply.
+
+## PR stack (bottom → top, linear; gh-stack)
+
+Bug fixes first, per Kris. Build order: **camera-picker → call-end** (camera is unambiguous; call-end has a lifecycle-semantics fork awaiting Kris's confirm), then 3 lays the shared foundation and 4–6 build the surfaces.
+
+### 1 · `fix/calls-camera-picker` — pick & switch camera / input source
+
+**Bug:** camera is grabbed at random and can't be changed; the device menu lists only mic + speaker; `cameras[]`/`selectedCameraId` are scaffolded but dead; no `facingMode`/flip.
+
+- Wire `selectedCameraId` into `CallDeviceState`; thread a video `deviceId` (`{ exact }`) through `setCameraOn`/`doCaptureAndPublish`; add `switchCameraDevice(deviceId)` to the controller and a mobile front/back flip (`facingMode` toggle, or deviceId cycle where facingMode is unsupported); republish the video track on switch without dropping the call.
+- **Desktop:** add a **Camera** group to `DevicePickerMenu` (above Microphone/Speaker), listing `devices.cameras`.
+- **Mobile:** a first-class **flip** control (front/back) on the bar; the full camera/mic/speaker list behind the device button.
+- **Tests:** switching camera updates `selectedCameraId` and re-publishes with the new deviceId; picker renders camera devices; flip toggles facingMode. Use scoped `spyOn`, no `mock.module` (INV-48).
+- **Acceptance:** in a live call, open devices → pick a different camera → feed switches; on mobile, flip swaps front/back.
+- **Screenshots:** desktop device menu with camera group open; mobile flip.
+
+### 2 · `fix/calls-auto-end` — end an emptied call promptly + never show a dead call as live
+
+**Corrected understanding (grounding):** the call _does_ end today, but slowly. An emptied roster → `empty_grace` (`CALL_EMPTY_GRACE_MS`, default **45 s**) → a 15 s sweeper flips `empty_grace → ended` and emits `stream:call_ended` (outbox). A raw socket **drop** is not a leave — the participant lingers `joined` until the endpoint lease lapses (`ENDPOINT_LEASE_TTL_MS`, **45 s**) before grace even starts. Worst case last-person-gone → ended ≈ lease + grace + sweep (~105 s). During all of that the timeline card shows a live **Join** for a functionally-dead call — the "we couldn't stop it" symptom.
+
+**Semantics fork (awaiting Kris — default in bold):**
+
+- **(a) Explicit last-leave ends immediately.** When a user clicks _Leave_ and they are the last `joined` participant, transition `active → ended` in that same tx and emit `stream:call_ended` — skip grace. Grace stays only for disconnect-driven emptiness (the reconnect buffer it was designed for). **Default: yes.**
+- **(b) Client safety net.** In `active-calls-store`, treat a call in grace / `participantCount === 0` as not-live: hide the Join affordance and the rejoin bar, show "Call ended". Never render a live Join for a dead call. **Default: yes.**
+- **(c) Ghost from a peer's socket-drop** (peer closed the tab without leaving): they stay `joined` for the lease TTL, so _your_ leave isn't "last" and the call lingers. Options: shorten the disconnect→empty path, or add an explicit **"End call for everyone"** for the workspace-admin/host. **Default: add the client safety net now + file ghost-lease tuning as a fast-follow; do NOT change lease TTL in this PR.**
+
+**Build (once ratified):**
+
+- Server: in `leaveCall` / `leaveCallAsUser` empty branches (`service.ts:445-460`, `:528-535`), when the leave is explicit and `countJoined === 0`, call `appendCallEnded` (transition to `ended`, reason `completed`) in-tx instead of `enterGraceIfEmpty`; keep grace for the reaper path (`service.ts:1326-1329`). CAS on status/roster-version, not a bare flag (INV-20/66).
+- Client: `active-calls-store.updateCallParticipants` + the card/rejoin-bar liveness gate treat count-0 / grace as ended.
+- **Tests:** explicit last-leave ends now + emits `stream:call_ended` (assert event content, INV-23); disconnect path still enters grace (unchanged); concurrent double-leave ends once (race, produce the value via the repo's own NOW()/version path, INV-66); client hides a count-0 call.
+- **Acceptance:** 2-party call, both click Leave → card gone within one event, no ~45 s ghost.
+- **Screenshots:** live card → ended card, before/after timing note.
+
+### 3 · `feat/calls-ui-foundation` — theme-aware chrome + shared primitives + state model
+
+Foundation for 4–6; minimal user-visible change (existing dock keeps working).
+
+- **Light/dark is nearly free already:** grounding confirms the current call chrome uses theme tokens (`bg-background`, `text-muted-foreground`, `bg-muted`, `ring-primary`, `text-destructive`) — no hardcoded dark, no `dark:` variants; the only fixed colors are the on-video caption gradient (`call-tile.tsx:88-94`, intentionally white-on-scrim). So this chunk's theming job is to keep that discipline in the **new** surfaces: chrome (tab/bar/dock frame/controls/segmented toggle) on theme tokens; video tiles + the fullscreen **stage bed** stay near-black in both themes (a fixed dark surface token, not `--background`), captions white-on-scrim.
+- Extract shared primitives: `CallTile` (video + camera-off avatar + name/mute + speaking ring), `CallControlBar` (mic/camera/flip/devices/diagnostics/leave + a screen-share **slot** rendered disabled/hidden — see Deferred), `LayoutToggle` (Speaker/Grid segmented, Shadcn).
+- **State model** on the call store: `surfaceMode` (`tab|bar|gallery|fullscreen`), `layout` (`speaker|grid`), `dockPosition` (`top|side`), `filmstripSide` (`bottom|side`) — persisted to localStorage; selectors in `call-store-hooks`.
+- **Tests:** store defaults + persistence roundtrip (integer/string prefs, read back through the store — no hand-crafted fixtures); tile renders camera-off avatar; control bar renders the flip + device buttons; light/dark snapshot of the bar via the real-component harness.
+- **Acceptance:** existing call still works; toggling OS theme reflows the bar; no regression in the current dock.
+
+### 4 · `feat/calls-mobile-drawer` — 4-mode global drawer
+
+- Replace the mobile collapsed-pill / expand path with the drawer: Tab → Bar → Tiny gallery → Fullscreen, driven by `surfaceMode`.
+- Drag from the top handle; **snap to nearest detent on release** with a velocity bias; chat stays live behind Tab/Bar/Tiny-gallery; Fullscreen is opaque with a chevron/flick to collapse.
+- Global: renders at app root regardless of active stream (Tab visible on any screen while a call is live).
+- Desktop path unchanged in this chunk (still the current dock until chunk 6).
+- **Tests:** mode transitions update `surfaceMode`; snap picks nearest; drawer renders on a non-call stream; controls present per mode (Tab = timer only; Bar adds mute/cam/leave; Tiny gallery adds flip/devices). Mount real components (INV-39).
+- **Acceptance:** on a phone viewport, pull the tab through all four modes and back; call visible across stream navigation.
+- **Screenshots:** the four modes (emulated phone) + the tab on another stream.
+
+### 5 · `feat/calls-speaker-grid` — Speaker/Grid layouts
+
+- `LayoutToggle` switches `layout`; render **Grid** (equal, responsive 2×2→3×3) and **Speaker** (active speaker + filmstrip).
+- Mobile Speaker filmstrip = bottom. Desktop Speaker filmstrip = **bottom or side** per `filmstripSide`; a control to switch it. Self-view = draggable PiP in Speaker, equal tile in Grid.
+- Active-speaker selection reuses the existing analyser signal.
+- **Tests:** toggle updates `layout` + persists; grid renders N tiles; speaker renders one large + filmstrip; desktop filmstrip side switches.
+- **Acceptance:** in fullscreen, switch Speaker↔Grid; on desktop switch filmstrip bottom↔side; choices persist across reload.
+- **Screenshots:** mobile Speaker + Grid; desktop Grid / Speaker-bottom / Speaker-side.
+
+### 6 · `feat/calls-desktop-dock` — resizable top/side dock
+
+- Desktop surface becomes the resizable dock: **Top** (snaps Tab→Bar→Gallery→Fullscreen, drag bottom edge) or **Side** (snaps Rail→Panel→Wide→Fullscreen, drag left edge), `dockPosition` config with a small top/side switch; persists.
+- Drag-resize with the same snap physics as mobile; Side pushes content (no overlap) like the old right rail; Fullscreen covers the content area; sidebar nav stays live and switching streams keeps the dock.
+- **Tests:** resize snaps to nearest detent; dock-position switch persists; side dock reflows content (no overlap); fullscreen covers content not the sidebar.
+- **Acceptance:** on desktop, drag the dock through its snaps in both orientations; switch top↔side; layout persists.
+- **Screenshots:** top dock (Gallery snap) + side dock (Panel snap) + the top/side config.
+
+## Deferred (binding — do not build)
+
+- Screen-share (net-new; the control bar reserves a disabled slot only).
+- Recording, reactions, virtual/blurred backgrounds, per-tile hover menus (pin/mirror/fill), raise-hand.
+- Per-workspace feature-flag **admin UI** (separate initiative; the flag system already gates calls).
+- CF DPA / processor-register entry (ops gate, tracked in the calls plan, not code).
+- Server-persisted layout prefs (client localStorage only for now).
+
+## Process
+
+- **build-feature** per-chunk rhythm: brief → Opus/medium implement → Opus/xhigh adversarial verify → fix loop → `/gh-stack` + `/create-pr` → `/code-review`. Screenshots in every PR body (real-component harness / emulated viewports) and posted to the Threa channel.
+- **gh-stack** for the whole chain (`gh stack init` bottom→top, `submit --auto`, `sync --prune` after merges). Never hand-rolled branches.
+- After the last chunk: whole-stack top-model review, then an **adversarial GPT-5.6 (Sol)** external pass; fold surviving findings; report per-PR links.
+- Local gates before any merge: `bun run typecheck`, `bun run test:unit`, relevant `test:e2e` / `test:browser`.


### PR DESCRIPTION
**Chunk 1 of the calls UX overhaul stack** (`docs/plans/calls-ux-overhaul.md`). Bug fix first, per the plan.

## The bug
In a live call the camera was grabbed at random with **no way to switch it**: the device menu listed only microphone + speaker, `cameras[]`/`selectedCameraId` were scaffolded but dead (nothing ever wrote the selection), capture always used the constant `VIDEO_CAPTURE_CONSTRAINTS` with no `deviceId`/`facingMode`, and there was no front/back flip. (Reported from a live prod call — one party couldn't change cameras.)

## What changed
- **Engine (`calls/call-manager.ts`)**: video capture now takes a `deviceId`/`facingMode` with precedence `cameraDeviceId → facingMode → default`. New `switchCameraDevice(deviceId)` and `flipCamera()` on the `CallController` re-acquire and **republish the video track via `replaceTrack`** — no SDP renegotiation, audio and the call stay up, the old track is stopped (no camera-LED leak). `refreshDevices` reflects the live camera track's `getSettings().deviceId` so the picker highlights the actually-active camera. A failed switch (camera in use) surfaces `toast.error`, keeps the call up, and **restores the prior selection** so the menu doesn't lie about which camera is live.
- **Desktop (`components/call/call-controls.tsx`)**: a **Camera** radio group in `DevicePickerMenu` (above Microphone/Speaker), listing every video input; unlabeled cameras read "Camera N".
- **Mobile**: a first-class **front/back flip** button (`SwitchCamera`), gated to `isMobile && mode !== "audio_only" && cameras.length > 1`.
- **Store (`stores/call-store.ts`)**: added `facingMode` to `CallDeviceState` (required-with-null; typecheck enforces every constructor sets it).

Client-only; no backend changes. Gated implicitly by the existing `calls` flag (this is in-call UI).

## Testing
- `apps/frontend` typecheck clean; **68 calls tests pass** (call-manager, call-controls, call-dock, call-store, active-calls, user-profile-modal), including new engine tests (switch writes `selectedCameraId` + recaptures with `deviceId.exact`; switch-while-off stores the pref; flip toggles `facingMode`) and new picker/flip component tests (real components mounted, INV-39; scoped `spyOn`, INV-48).
- Ran through an **adversarial verify pass** (separate Opus/xhigh agent, re-derived from the diff): verdict **SHIP**, no blockers/majors. Two MINORs it surfaced were folded in here (empty-string `deviceId` clobber → `|| null`; stale pref after a failed switch → restore-on-catch). One coverage NIT remains: the live-track `getSettings()` branch in `refreshDevices` isn't unit-covered (the fake track has no `getSettings`); it's a self-healing cosmetic path.

## Screenshots
The visual here is the Camera group in the device menu + the mobile flip button. Hero screenshots for the whole stack (device menu, drawer modes, dock) are captured in one dev-test-stack harness pass once the UI chunks land, and will be added to each PR + posted in the design channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787176958&installation_model_id=20758&pr_number=1470&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1470&signature=17793996cbf33cfdc479ab03af579d9ad99458a6894061cd269dbdc690b5be45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->