### PR TITLE
fix(calls): end an emptied call on explicit last-leave; hide dead calls

### DIFF
--- a/apps/backend/src/features/calls/repository.test.ts
+++ b/apps/backend/src/features/calls/repository.test.ts
@@ -74,6 +74,23 @@ describe("CallRepository — active-call glare + grace re-verification", () => {
     expect(sql).toContain("p.workspace_id = c.workspace_id")
   })
 
+  it("endActiveIfEmpty CASes active → ended only when no joined participant remains (explicit last-leave)", async () => {
+    const captured: Captured = { text: "" }
+    await CallRepository.endActiveIfEmpty(createQuerier(captured), {
+      workspaceId: "ws_1",
+      id: "call_1",
+      reason: "completed",
+    })
+    const sql = normalize(captured.text)
+    expect(sql).toContain("status = 'ended'")
+    expect(sql).toContain("ended_at = NOW()")
+    // Same CAS guard as enterGraceIfEmpty — a status flag AND a live-roster
+    // predicate (INV-20), so a concurrent join / double last-leave ends once.
+    expect(sql).toContain("c.status = 'active'")
+    expect(sql).toMatch(/NOT EXISTS \([^)]*call_participants p[\s\S]*status = 'joined'/)
+    expect(sql).toContain("p.workspace_id = c.workspace_id")
+  })
+
   it("enterGraceIfEmptyBatch cascades reaped emptiness with a workspace-correlated anti-join", async () => {
     const captured: Captured = { text: "" }
     await CallRepository.enterGraceIfEmptyBatch(createQuerier(captured), {

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -230,6 +230,35 @@ export const CallRepository = {
   },
 
   /**
+   * CAS `active → ended` on an explicit last-leave: end the call in the same tx
+   * as the leave instead of parking it in `empty_grace` for the 15s sweeper. The
+   * guard mirrors {@link enterGraceIfEmpty} — `status = 'active'` AND no joined
+   * participant (INV-20), a roster predicate not a bare flag — so a concurrent
+   * join wins the row and a double last-leave ends it exactly once (the loser
+   * gets `null`, not an error). Records `ended_reason` + `ended_at` so the
+   * caller's `appendCallEnded` reads the same summary the grace-end sweep
+   * produces. Grace is retained for disconnect-driven emptiness (the reaper);
+   * this is only the explicit-leave path.
+   */
+  async endActiveIfEmpty(
+    db: Querier,
+    params: { workspaceId: string; id: string; reason: CallEndedReason }
+  ): Promise<Call | null> {
+    const result = await db.query<CallRow>(sql`
+      UPDATE calls c SET
+        status = 'ended', ended_reason = ${params.reason}, ended_at = NOW(),
+        status_changed_at = NOW(), updated_at = NOW()
+      WHERE c.workspace_id = ${params.workspaceId} AND c.id = ${params.id} AND c.status = 'active'
+        AND NOT EXISTS (
+          SELECT 1 FROM call_participants p
+          WHERE p.workspace_id = c.workspace_id AND p.call_id = c.id AND p.status = 'joined'
+        )
+      RETURNING ${sql.raw(CALL_COLUMNS)}
+    `)
+    return result.rows[0] ? mapCall(result.rows[0]) : null
+  },
+
+  /**
    * Batch cascade for the endpoint reaper (INV-56): flip the named calls to
    * `empty_grace` (reason `reaped`) when their last joined participant just went
    * away. The `NOT EXISTS` re-verifies emptiness against the current

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -446,7 +446,7 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
 describe("CallService.leaveCall", () => {
   afterEach(() => mock.restore())
 
-  it("closes the endpoint, lefts the participant, and graces an emptied call", async () => {
+  it("ends an emptied call IN-TX on an explicit last-leave (skips grace) and appends stream:call_ended", async () => {
     stubTransaction()
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallEndpointRepository, "findById").mockResolvedValue(fakeEndpoint())
@@ -456,9 +456,17 @@ describe("CallService.leaveCall", () => {
       fakeParticipant({ status: "left" })
     )
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
-    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(null)
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(
+      fakeCall({ status: "ended", endedReason: "completed", endedAt: NOW })
+    )
+    // appendCallEndedForLeave's ctx reads (stream visibility + ever-participant set).
+    spyOn(streamsModule.StreamRepository, "findById").mockResolvedValue({ visibility: "public" } as never)
+    spyOn(CallParticipantRepository, "listUserIdsByCall").mockResolvedValue(new Map([["call_1", ["usr_a"]]]))
+    spyOn(CallInvitationRepository, "cancelRingingForCall").mockResolvedValue([])
     const bump = spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
-    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "ended", endedReason: "completed" }))
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
 
     const result = await makeService().leaveCall({
       workspaceId: "ws_1",
@@ -469,13 +477,47 @@ describe("CallService.leaveCall", () => {
 
     expect(close).toHaveBeenCalledWith(expect.anything(), "ws_1", "callep_1")
     expect(markLeft).toHaveBeenCalledTimes(1)
-    expect(grace).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ reason: "completed" }))
+    // The explicit last-leave ends the call directly — grace is only for the reaper path.
+    expect(end).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ reason: "completed" }))
+    expect(grace).not.toHaveBeenCalled()
+    // The end summary rides the outbox in the same tx (INV-4/7) so peers see the ended card.
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "stream:call_ended",
+      expect.objectContaining({ callId: "call_1", streamId: "stream_1" })
+    )
     // A leave bumps the roster version in the same tx (INV-66) so the departed tile isn't a ghost.
     expect(bump).toHaveBeenCalledWith(expect.anything(), "ws_1", "call_1")
-    expect(result.call.status).toBe("empty_grace")
+    expect(result.call.status).toBe("ended")
   })
 
-  it("does not grace a call that still has joined participants", async () => {
+  it("a lost end CAS (concurrent join / double last-leave) appends no call_ended and does not throw", async () => {
+    stubTransaction()
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallEndpointRepository, "findById").mockResolvedValue(fakeEndpoint())
+    spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant())
+    spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ status: "closed" }))
+    spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
+    // The CAS loses the row (a concurrent join revived it, or a sibling leave ended it first).
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(null)
+    const streamRead = spyOn(streamsModule.StreamRepository, "findById").mockResolvedValue({
+      visibility: "public",
+    } as never)
+    spyOn(CallInvitationRepository, "cancelRingingForCall").mockResolvedValue([])
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
+    const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
+
+    await makeService().leaveCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a", endpointId: "callep_1" })
+
+    expect(end).toHaveBeenCalledTimes(1)
+    // No ended row → no summary read, no call_ended emit (the winner already emitted it).
+    expect(streamRead).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalledWith(expect.anything(), "stream:call_ended", expect.anything())
+  })
+
+  it("does not end a call that still has joined participants", async () => {
     stubTransaction()
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallEndpointRepository, "findById").mockResolvedValue(fakeEndpoint())
@@ -483,12 +525,14 @@ describe("CallService.leaveCall", () => {
     spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ status: "closed" }))
     spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(2)
-    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(null)
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(null)
+    spyOn(CallInvitationRepository, "cancelRingingByInviter").mockResolvedValue([])
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
     spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
 
     await makeService().leaveCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a", endpointId: "callep_1" })
 
-    expect(grace).not.toHaveBeenCalled()
+    expect(end).not.toHaveBeenCalled()
   })
 
   it("rejects closing an endpoint owned by another participant", async () => {
@@ -524,9 +568,11 @@ describe("CallService.leaveCall", () => {
     spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ status: "closed" }))
     spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
-    spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(fakeCall({ status: "ended", endedReason: "completed" }))
+    spyOn(streamsModule.StreamRepository, "findById").mockResolvedValue({ visibility: "public" } as never)
+    spyOn(CallParticipantRepository, "listUserIdsByCall").mockResolvedValue(new Map([["call_1", ["usr_a"]]]))
     spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
-    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "ended", endedReason: "completed" }))
     const cancelAll = spyOn(CallInvitationRepository, "cancelRingingForCall").mockResolvedValue([
       { id: "callinv_1", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_peer", inviterUserId: "usr_a" },
     ] as never)
@@ -556,7 +602,7 @@ describe("CallService.leaveCall", () => {
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(2)
     spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
     spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
-    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(null)
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(null)
     const cancelByInviter = spyOn(CallInvitationRepository, "cancelRingingByInviter").mockResolvedValue([
       { id: "callinv_2", workspaceId: "ws_1", callId: "call_1", inviteeUserId: "usr_peer", inviterUserId: "usr_a" },
     ] as never)
@@ -564,8 +610,8 @@ describe("CallService.leaveCall", () => {
 
     await makeService().leaveCall({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a", endpointId: "callep_1" })
 
-    // The call lives on (others remain) — only the leaver's own ring is retracted.
-    expect(grace).not.toHaveBeenCalled()
+    // The call lives on (others remain) — only the leaver's own ring is retracted, never ended.
+    expect(end).not.toHaveBeenCalled()
     expect(cancelByInviter).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ callId: "call_1", inviterUserId: "usr_a" })
@@ -630,23 +676,35 @@ describe("CallService.leaveCallAsUser", () => {
     expect(emit).not.toHaveBeenCalled()
   })
 
-  it("closes the user's endpoints and emits participants_changed on a live call", async () => {
+  it("ends the emptied call in-tx on an explicit last-leave and emits stream:call_ended + participants_changed", async () => {
     stubTransaction()
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant())
     const closeByParticipant = spyOn(CallEndpointRepository, "closeByParticipant").mockResolvedValue([])
     spyOn(CallParticipantRepository, "markLeftIfNoLiveEndpoint").mockResolvedValue(fakeParticipant({ status: "left" }))
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
-    spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    const grace = spyOn(CallRepository, "enterGraceIfEmpty").mockResolvedValue(null)
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(
+      fakeCall({ status: "ended", endedReason: "completed", endedAt: NOW })
+    )
+    spyOn(streamsModule.StreamRepository, "findById").mockResolvedValue({ visibility: "public" } as never)
+    spyOn(CallParticipantRepository, "listUserIdsByCall").mockResolvedValue(new Map([["call_1", ["usr_a"]]]))
     spyOn(CallInvitationRepository, "cancelRingingForCall").mockResolvedValue([])
     spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(1)
     spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
-    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "empty_grace" }))
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall({ status: "ended", endedReason: "completed" }))
     const emit = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
 
     await makeService().leaveCallAsUser({ workspaceId: "ws_1", callId: "call_1", userId: "usr_a" })
 
     expect(closeByParticipant).toHaveBeenCalledWith(expect.anything(), "ws_1", "callp_1")
+    expect(end).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ reason: "completed" }))
+    expect(grace).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      "stream:call_ended",
+      expect.objectContaining({ callId: "call_1", streamId: "stream_1" })
+    )
     expect(emit).toHaveBeenCalledWith(
       expect.anything(),
       "call:participants_changed",
@@ -940,6 +998,8 @@ describe("CallService sweeps", () => {
     const grace = spyOn(CallRepository, "enterGraceIfEmptyBatch").mockResolvedValue([
       fakeCall({ status: "empty_grace" }),
     ])
+    // Disconnect-driven emptiness must NOT take the explicit-leave immediate-end path.
+    const end = spyOn(CallRepository, "endActiveIfEmpty").mockResolvedValue(null)
     const bumpBatch = spyOn(CallRepository, "bumpRosterVersionBatch").mockResolvedValue(undefined)
 
     const result = await makeService().reapLapsedEndpoints(NOW)
@@ -950,6 +1010,8 @@ describe("CallService sweeps", () => {
     expect(lock).toHaveBeenCalledWith(expect.anything(), ["call_1"])
     expect(markLeft).toHaveBeenCalledWith(expect.anything(), ["callp_a", "callp_b"])
     expect(grace).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ callIds: ["call_1"] }))
+    // The reaper keeps the grace window (its reconnect buffer) — never ends in-tx.
+    expect(end).not.toHaveBeenCalled()
     // The reap cascade bumps the roster version of every touched call in the same tx (INV-66).
     expect(bumpBatch).toHaveBeenCalledWith(expect.anything(), ["call_1"])
   })

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -444,12 +444,17 @@ export class CallService {
 
       const joined = await CallParticipantRepository.countJoined(client, params.workspaceId, params.callId)
       if (joined === 0 && call.status === "active") {
-        await CallRepository.enterGraceIfEmpty(client, {
+        // Explicit last-leave ends the call in THIS tx (not empty_grace + a ~45s
+        // sweep): the clicker is functionally the last one out, so skip the grace
+        // window that only serves disconnect-driven emptiness (the reaper still
+        // graces). The CAS returns null on a concurrent join / double last-leave,
+        // in which case there is nothing to append.
+        const ended = await CallRepository.endActiveIfEmpty(client, {
           workspaceId: params.workspaceId,
           id: params.callId,
-          graceDeadline: new Date(Date.now() + EMPTY_GRACE_MS),
           reason: "completed",
         })
+        if (ended) await this.appendCallEndedForLeave(client, ended)
         // The call is now empty: retract every outstanding ring in the same tx
         // (INV-7). Cancelling (not letting it lapse) is what prevents a
         // missed-call activity for a caller who hung up before an answer.
@@ -527,12 +532,14 @@ export class CallService {
 
       const joined = await CallParticipantRepository.countJoined(client, params.workspaceId, params.callId)
       if (joined === 0 && call.status === "active") {
-        await CallRepository.enterGraceIfEmpty(client, {
+        // Explicit last-leave ends the call in THIS tx (see {@link leaveCall}) —
+        // grace stays only for the disconnect/reaper path.
+        const ended = await CallRepository.endActiveIfEmpty(client, {
           workspaceId: params.workspaceId,
           id: params.callId,
-          graceDeadline: new Date(Date.now() + EMPTY_GRACE_MS),
           reason: "completed",
         })
+        if (ended) await this.appendCallEndedForLeave(client, ended)
         const cancelled = await CallInvitationRepository.cancelRingingForCall(client, {
           workspaceId: params.workspaceId,
           callId: params.callId,
@@ -1468,6 +1475,27 @@ export class CallService {
       event,
       callId: args.call.id,
       streamVisibility: args.streamVisibility,
+      memberUserIds,
+    })
+  }
+
+  /**
+   * Assemble the `call_ended` ctx for an explicit last-leave and append it in the
+   * caller's transaction (INV-4/7). Mirrors {@link appendCallsEnded}'s per-call
+   * reads — ever-participant set, host-stream visibility, member UserIds — for a
+   * single just-ended call. A missing stream row (a call always has a host stream)
+   * skips the append: there is nowhere to land the card.
+   */
+  private async appendCallEndedForLeave(client: PoolClient, call: Call): Promise<void> {
+    const stream = await StreamRepository.findById(client, call.streamId)
+    if (!stream) return
+    const participantUserIdsByCall = await CallParticipantRepository.listUserIdsByCall(client, call.workspaceId, [
+      call.id,
+    ])
+    const memberUserIds = await this.listStreamMemberUserIds(client, call.streamId)
+    await this.appendCallEnded(client, call, {
+      streamVisibility: stream.visibility,
+      participantUserIds: participantUserIdsByCall.get(call.id) ?? [],
       memberUserIds,
     })
   }

--- a/apps/backend/tests/integration/calls-leave-end.test.ts
+++ b/apps/backend/tests/integration/calls-leave-end.test.ts
@@ -1,0 +1,188 @@
+/**
+ * DB-backed leave/end lifecycle (chunk 2 — fix/calls-auto-end). Drives the real
+ * CallService against threa_test so the `endActiveIfEmpty` CAS, the in-tx
+ * `stream:call_ended` outbox write, and the FOR UPDATE serialization are
+ * exercised for real — not through mocks.
+ *
+ * Values are produced through the repo's own NOW()/status path and read back
+ * through the repo (INV-66); assertions are on event presence + payload content,
+ * not raw counts (INV-23). Control-plane only: no Cloudflare (channel calls never
+ * ring, and leave closes no CF session when none was minted).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { Visibilities } from "@threa/types"
+import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService } from "../../src/features/streams"
+import { CallService, CallRepository, ENDPOINT_LEASE_TTL_MS } from "../../src/features/calls"
+import { workspaceId as newWorkspaceId } from "../../src/lib/id"
+
+let pool: Pool
+let streams: StreamService
+let calls: CallService
+
+beforeAll(async () => {
+  pool = await setupTestDatabase()
+  streams = new StreamService(pool)
+  calls = new CallService({ pool })
+})
+
+afterAll(async () => {
+  await pool.end()
+})
+
+interface Scenario {
+  workspaceId: string
+  streamId: string
+  aUserId: string
+  bUserId: string
+}
+
+/** A fresh workspace + private channel with members A (creator) and B. */
+async function seedScenario(label: string): Promise<Scenario> {
+  const workspaceId = newWorkspaceId()
+  let aUserId = ""
+  let bUserId = ""
+  await withTransaction(pool, async (client) => {
+    await WorkspaceRepository.insert(client, {
+      id: workspaceId,
+      name: `Calls ${label}`,
+      slug: `calls-${label}-${workspaceId}`,
+      createdBy: workspaceId,
+    })
+    aUserId = (await addTestMember(client, workspaceId, `a-${label}`)).id
+    bUserId = (await addTestMember(client, workspaceId, `b-${label}`)).id
+  })
+  const channel = await streams.createChannel({
+    workspaceId,
+    slug: `calls-${label}-${workspaceId}`,
+    displayName: `Calls ${label}`,
+    createdBy: aUserId,
+    visibility: Visibilities.PRIVATE,
+    memberIds: [bUserId],
+  })
+  return { workspaceId, streamId: channel.id, aUserId, bUserId }
+}
+
+/** The `stream:call_ended` outbox payloads for a call (event presence + content). */
+async function callEndedRows(callId: string): Promise<Array<{ callId: string; streamId: string }>> {
+  const res = await pool.query<{ payload: { callId: string; streamId: string } }>(
+    `SELECT payload FROM outbox WHERE event_type = 'stream:call_ended' AND payload->>'callId' = $1`,
+    [callId]
+  )
+  return res.rows.map((r) => r.payload)
+}
+
+describe("calls — explicit last-leave ends promptly (fix/calls-auto-end)", () => {
+  test("leaveCall by the last participant ends the call in-tx and writes stream:call_ended", async () => {
+    const s = await seedScenario("leavecall")
+    const started = await calls.startCall({
+      workspaceId: s.workspaceId,
+      streamId: s.streamId,
+      userId: s.aUserId,
+      mode: "video",
+    })
+
+    await calls.leaveCall({
+      workspaceId: s.workspaceId,
+      callId: started.call.id,
+      userId: s.aUserId,
+      endpointId: started.endpoint.id,
+    })
+
+    const ended = await CallRepository.findById(pool, s.workspaceId, started.call.id)
+    expect(ended).toMatchObject({ status: "ended", endedReason: "completed" })
+    expect(ended?.endedAt).not.toBeNull()
+
+    const rows = await callEndedRows(started.call.id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ callId: started.call.id, streamId: s.streamId })
+  })
+
+  test("leaveCallAsUser by the last participant ends the call in-tx and writes stream:call_ended", async () => {
+    const s = await seedScenario("leaveasuser")
+    const started = await calls.startCall({
+      workspaceId: s.workspaceId,
+      streamId: s.streamId,
+      userId: s.aUserId,
+      mode: "video",
+    })
+
+    await calls.leaveCallAsUser({ workspaceId: s.workspaceId, callId: started.call.id, userId: s.aUserId })
+
+    const ended = await CallRepository.findById(pool, s.workspaceId, started.call.id)
+    expect(ended).toMatchObject({ status: "ended", endedReason: "completed" })
+
+    const rows = await callEndedRows(started.call.id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ callId: started.call.id, streamId: s.streamId })
+  })
+
+  test("a leave that still leaves others joined keeps the call active and writes no call_ended", async () => {
+    const s = await seedScenario("stayactive")
+    const started = await calls.startCall({
+      workspaceId: s.workspaceId,
+      streamId: s.streamId,
+      userId: s.aUserId,
+      mode: "video",
+    })
+    await calls.joinCall({ workspaceId: s.workspaceId, callId: started.call.id, userId: s.bUserId })
+
+    await calls.leaveCall({
+      workspaceId: s.workspaceId,
+      callId: started.call.id,
+      userId: s.aUserId,
+      endpointId: started.endpoint.id,
+    })
+
+    const after = await CallRepository.findById(pool, s.workspaceId, started.call.id)
+    expect(after?.status).toBe("active")
+    expect(await callEndedRows(started.call.id)).toHaveLength(0)
+  })
+
+  test("concurrent double last-leave ends exactly once, no error on the loser", async () => {
+    const s = await seedScenario("doubleleave")
+    const started = await calls.startCall({
+      workspaceId: s.workspaceId,
+      streamId: s.streamId,
+      userId: s.aUserId,
+      mode: "video",
+    })
+
+    // Two racing self-leaves for the same last participant (double-click / two
+    // devices). The call-row FOR UPDATE serializes them; the ended-guard + the CAS
+    // together end it once and no-op the loser.
+    const results = await Promise.allSettled([
+      calls.leaveCallAsUser({ workspaceId: s.workspaceId, callId: started.call.id, userId: s.aUserId }),
+      calls.leaveCallAsUser({ workspaceId: s.workspaceId, callId: started.call.id, userId: s.aUserId }),
+    ])
+    expect(results.map((r) => r.status)).toEqual(["fulfilled", "fulfilled"])
+
+    const ended = await CallRepository.findById(pool, s.workspaceId, started.call.id)
+    expect(ended?.status).toBe("ended")
+    // Exactly one end event — the CAS + status guard prevent a double append.
+    expect(await callEndedRows(started.call.id)).toHaveLength(1)
+  })
+
+  test("disconnect/reaper path still enters empty_grace, never immediate-end (regression guard)", async () => {
+    const s = await seedScenario("reapergrace")
+    const started = await calls.startCall({
+      workspaceId: s.workspaceId,
+      streamId: s.streamId,
+      userId: s.aUserId,
+      mode: "video",
+    })
+
+    // A socket drop is not a leave: the lease reaper cascades emptiness to
+    // empty_grace (its reconnect buffer), NOT to ended. Reap with a now past the
+    // fresh lease so the just-minted endpoint lapses.
+    await calls.reapLapsedEndpoints(new Date(Date.now() + ENDPOINT_LEASE_TTL_MS + 60_000))
+
+    const after = await CallRepository.findById(pool, s.workspaceId, started.call.id)
+    expect(after).toMatchObject({ status: "empty_grace", endedReason: "reaped" })
+    // Grace has not ended it yet, so no call_ended was written by the reaper.
+    expect(await callEndedRows(started.call.id)).toHaveLength(0)
+  })
+})

--- a/apps/frontend/src/stores/active-calls-store.test.ts
+++ b/apps/frontend/src/stores/active-calls-store.test.ts
@@ -67,6 +67,31 @@ describe("active-calls-store", () => {
     expect(getActiveCall("ws_1", "call_ghost")).toBeNull()
   })
 
+  it("count-0 reads as not-live (no Join for a dead call) but keeps the entry so a grace rejoin revives it", () => {
+    // A live call empties: participants_changed carries count 0. The liveness read
+    // must go null (the affordance gate) WITHOUT deleting the entry — a rejoin
+    // during grace re-populates it, which updateCallParticipants can only do when
+    // the entry still exists.
+    upsertActiveCall("ws_1", call({ participantCount: 2 }))
+    updateCallParticipants("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      participantCount: 0,
+      participantUserIds: [],
+    })
+    expect(getActiveCall("ws_1", "call_1")).toBeNull()
+
+    // The entry survived: a count-1 rejoin during grace revives it.
+    updateCallParticipants("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      participantCount: 1,
+      participantUserIds: ["usr_a"],
+    })
+    expect(getActiveCall("ws_1", "call_1")?.participantCount).toBe(1)
+    expect(getActiveCall("ws_1", "call_1")?.participantUserIds).toEqual(["usr_a"])
+  })
+
   it("re-seed preserves a known roster the workspace seed does not carry", () => {
     // The call is tracked (a `call_started` upsert) and then its roster is refined
     // by a participants_changed, mirroring the live sequence.

--- a/apps/frontend/src/stores/active-calls-store.ts
+++ b/apps/frontend/src/stores/active-calls-store.ts
@@ -47,6 +47,20 @@ function notify(key: string): void {
   for (const listener of keyListeners.get(key) ?? []) listener()
 }
 
+/**
+ * Liveness gate (chunk 2): a call reads as live/joinable ONLY while someone is
+ * still joined. A `participantCount === 0` entry is KEPT in the map (a rejoin
+ * during grace emits `call:participants_changed` with count 1 and must revive it
+ * via {@link updateCallParticipants}, which no-ops on a missing entry) but reads
+ * as not-live everywhere — no Join on the timeline card, no rejoin bar, no
+ * sidebar dot — so the UI never offers to join a functionally-dead call. The end
+ * signal (`stream:call_ended` → {@link removeActiveCall}) still deletes the entry;
+ * this only covers the count-0 window before it (or when that signal is missed).
+ */
+function isLive(entry: ActiveCallEntry): boolean {
+  return entry.participantCount > 0
+}
+
 function sameEntry(a: ActiveCallEntry | null, b: ActiveCallEntry | null): boolean {
   if (a === b) return true
   if (!a || !b) return false
@@ -84,7 +98,7 @@ function recomputeCall(workspaceId: string, callId: string): void {
 function recomputeRoot(workspaceId: string, rootStreamId: string): void {
   const key = rootKey(workspaceId, rootStreamId)
   const calls = [...(workspaces.get(workspaceId)?.values() ?? [])]
-    .filter((entry) => entry.rootStreamId === rootStreamId)
+    .filter((entry) => entry.rootStreamId === rootStreamId && isLive(entry))
     .sort((a, b) => a.callId.localeCompare(b.callId))
   const prev = rootSnapshots.get(key)
   if (calls.length === 0) {
@@ -180,9 +194,15 @@ export function removeActiveCall(workspaceId: string, callId: string): void {
   recompute(workspaceId, existing)
 }
 
-/** Non-reactive read of one live call by id (the card liveness gate). */
+/**
+ * Non-reactive read of one live call by id (the card liveness gate). Gated on
+ * {@link isLive}: a kept-but-empty (`participantCount === 0`) entry reads as null
+ * so no surface offers Join/Rejoin, while the entry survives for a grace-window
+ * revive.
+ */
 export function getActiveCall(workspaceId: string, callId: string): ActiveCallEntry | null {
-  return workspaces.get(workspaceId)?.get(callId) ?? null
+  const entry = workspaces.get(workspaceId)?.get(callId) ?? null
+  return entry && isLive(entry) ? entry : null
 }
 
 function subscribeKey(key: string, onChange: () => void): () => void {


### PR DESCRIPTION
**Chunk 2 of the calls UX overhaul stack** — stacked on #1470. Bug fix.

## The bug (corrected mechanics)
The earlier read ("the call never ends") was wrong. An emptied call *does* end — via `empty_grace` (`CALL_EMPTY_GRACE_MS`, ~45s) then a 15s sweeper → `stream:call_ended`. But a raw **socket drop** isn't a leave: the leaver lingers `joined` until the endpoint lease lapses (~45s) *before* grace starts. Worst case last-person-gone → ended ≈ **~105s**, and the whole time the timeline card shows a live **Join** for a functionally-dead call — the "we couldn't stop it" symptom from the live prod call.

## What changed
- **Server:** a new `endActiveIfEmpty` CAS (`active → ended`, guarded on `status='active'` + a workspace-correlated no-joined-participant anti-join, INV-20). The **explicit** leave paths (`leaveCall`/`leaveCallAsUser`) now end the call **in-tx** when their leave empties the roster, appending `call_ended` + the `stream:call_ended` outbox event in the **same transaction** (INV-4/7) — skipping grace. **Disconnect-driven** emptiness (the reaper) still enters `empty_grace` — that's the reconnect buffer, and the rejoin flow depends on it. Ring cancellation (`cancelRingingForCall` + `settleCancelledRings`) is preserved on the immediate-end path, so a hang-up-before-answer still can't become a `missed_call`.
- **Client:** `active-calls-store` gates joinability on `participantCount > 0` **without deleting the entry** — a dead call never shows a live Join / rejoin bar, yet a grace rejoin (`count → 1`) still revives it. One selector change (`isLive`) covers the timeline card, the rejoin bar, and the sidebar dot; the live in-call dock reads a *separate* store and is unaffected.

Concurrent double last-leave ends **exactly once** (`FOR UPDATE` + CAS loser → `null`, no throw).

## Testing
- Backend typecheck + `test:unit` (3450) green; frontend typecheck + tests (active-calls-store / call-card / rejoin-bar / sidebar) green.
- New **DB-backed integration test** (`tests/integration/calls-leave-end.test.ts`, real CAS/tx/outbox against `threa_test`, INV-66 values through the repo's own `NOW()`/status path): last-leave ends + writes `stream:call_ended` (both leave paths); leave-with-others-joined stays active; concurrent double last-leave ends once; reaper still enters `empty_grace`.
- **Adversarial verify pass** (Opus/xhigh, re-derived from the diff): verdict **SHIP**, no blockers/majors/minors. The 4 browser calls e2e flows (happy/decline/abandonment/rejoin) reasoned green per-test (happy-path end is now strictly faster); the browser spec runs in the end-of-stack harness pass (env contention deferred it here).

## Deferred (fast-follow)
Per plan §2(c): an explicit **"End call for everyone"** (host/admin) for the peer-socket-drop **ghost** case — where a peer closes their tab without leaving, keeping a `joined` ghost for the lease, so *your* leave isn't "last." The client safety net already hides the dead call; the ghost-lease tuning is a separate PR (no lease-TTL change here).

## Screenshots
Behavioral fix (live card → ended card, faster). The before/after ended-card shot lands in the end-of-stack harness pass with the UI chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787178789&installation_model_id=20758&pr_number=1472&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1472&signature=14b311949e924e1a712747c642d7330b0ef5df6f04b1459e5ac494f1fa48456f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->