### PR TITLE
feat(calls): UI foundation — surface-mode state, prefs, stage tokens, layout toggle

### DIFF
--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -4,6 +4,7 @@ import {
   getCallState,
   type CallState,
   type CallPhase,
+  type CallSurfaceMode,
   type CallRosterParticipant,
   type CallDeviceState,
   type CallDiagnostics,
@@ -38,6 +39,10 @@ function useCallSelector<T>(selector: (s: CallState) => T, isEqual: (a: T, b: T)
 
 export function useCallPhase(): CallPhase {
   return useCallSelector((s) => s.phase)
+}
+
+export function useCallSurfaceMode(): CallSurfaceMode {
+  return useCallSelector((s) => s.surfaceMode)
 }
 
 export function useCallStreamId(): string | null {

--- a/apps/frontend/src/components/call/layout-toggle.test.tsx
+++ b/apps/frontend/src/components/call/layout-toggle.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { render, screen, userEvent } from "@/test"
+import { getCallPrefs, setCallLayout, __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import { LayoutToggle } from "./layout-toggle"
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetCallPrefsForTests()
+})
+
+describe("LayoutToggle", () => {
+  it("renders both options and reflects the current layout", () => {
+    render(<LayoutToggle />)
+
+    const speaker = screen.getByRole("radio", { name: "Speaker" })
+    const grid = screen.getByRole("radio", { name: "Grid" })
+
+    expect(speaker).toHaveAttribute("aria-checked", "true")
+    expect(grid).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("reflects a non-default layout", () => {
+    setCallLayout("grid")
+    render(<LayoutToggle />)
+
+    expect(screen.getByRole("radio", { name: "Grid" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "Speaker" })).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("writes the layout via setCallLayout on click", async () => {
+    render(<LayoutToggle />)
+
+    await userEvent.click(screen.getByRole("radio", { name: "Grid" }))
+
+    expect(getCallPrefs().layout).toBe("grid")
+    expect(screen.getByRole("radio", { name: "Grid" })).toHaveAttribute("aria-checked", "true")
+  })
+})

--- a/apps/frontend/src/components/call/layout-toggle.tsx
+++ b/apps/frontend/src/components/call/layout-toggle.tsx
@@ -1,0 +1,38 @@
+import { LayoutGrid, Users } from "lucide-react"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { cn } from "@/lib/utils"
+import { useCallPrefs, setCallLayout } from "@/stores/call-prefs-store"
+
+const ITEM_CLASS =
+  "min-w-0 gap-1.5 rounded-[0.3125rem] px-2.5 text-xs font-medium text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm [&_svg]:size-3.5"
+
+interface LayoutToggleProps {
+  /** Restyle for a dark call-stage header (ch5); merged over the default chrome styling. */
+  className?: string
+}
+
+export function LayoutToggle({ className }: LayoutToggleProps) {
+  const { layout } = useCallPrefs()
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      role="radiogroup"
+      value={layout}
+      onValueChange={(next) => {
+        if (next === "speaker" || next === "grid") setCallLayout(next)
+      }}
+      aria-label="Call layout"
+      className={cn("shrink-0 gap-0.5 rounded-md bg-muted p-0.5", className)}
+    >
+      <ToggleGroupItem value="speaker" aria-label="Speaker" title="Speaker layout" className={cn(ITEM_CLASS, "h-7")}>
+        <Users aria-hidden="true" />
+        <span>Speaker</span>
+      </ToggleGroupItem>
+      <ToggleGroupItem value="grid" aria-label="Grid" title="Grid layout" className={cn(ITEM_CLASS, "h-7")}>
+        <LayoutGrid aria-hidden="true" />
+        <span>Grid</span>
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -236,6 +236,13 @@ html[data-input="mouse"] .message-hover-wash:hover {
     --conversation-6: 22 70% 47%;
     --conversation-7: 245 50% 58%;
     --conversation-8: 88 45% 34%;
+
+    /* Call stage — the near-black bed behind live video + the fullscreen stage.
+       Fixed dark in BOTH themes (a light backdrop behind a feed reads as broken),
+       so the same values are set under .dark below. */
+    --call-stage: 30 15% 8%;
+    --call-stage-2: 30 12% 13%;
+    --call-stage-border: 30 10% 20%;
   }
 
   .dark {
@@ -307,6 +314,11 @@ html[data-input="mouse"] .message-hover-wash:hover {
     --conversation-6: 24 75% 60%;
     --conversation-7: 245 60% 72%;
     --conversation-8: 88 40% 52%;
+
+    /* Call stage — same near-black as :root; theme-stable so video never flips light. */
+    --call-stage: 30 15% 8%;
+    --call-stage-2: 30 12% 13%;
+    --call-stage-border: 30 10% 20%;
   }
 }
 

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  getCallPrefs,
+  setCallLayout,
+  setCallDockPosition,
+  setCallFilmstripSide,
+  __resetCallPrefsForTests,
+} from "./call-prefs-store"
+
+const STORAGE_KEY = "threa:callPrefs:v1"
+const DEFAULTS = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom" }
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetCallPrefsForTests()
+})
+
+describe("call-prefs-store", () => {
+  it("defaults when storage is empty", () => {
+    expect(getCallPrefs()).toEqual(DEFAULTS)
+  })
+
+  it("a set persists to localStorage and reads back through the store", () => {
+    setCallLayout("grid")
+    setCallDockPosition("top")
+    setCallFilmstripSide("side")
+
+    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side" })
+
+    // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
+    __resetCallPrefsForTests()
+    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side" })
+  })
+
+  it("falls back to defaults on malformed JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json")
+    __resetCallPrefsForTests()
+    expect(getCallPrefs()).toEqual(DEFAULTS)
+  })
+
+  it("falls back per-field on an out-of-range persisted value", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "grid", dockPosition: "diagonal" }))
+    __resetCallPrefsForTests()
+    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "side", filmstripSide: "bottom" })
+  })
+})

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -1,0 +1,109 @@
+import { useSyncExternalStore } from "react"
+
+/**
+ * User-scoped call layout preferences, persisted to localStorage and read
+ * synchronously at module import so the first render reflects the saved choice.
+ * Unlike {@link import("./call-store").CallState} these survive a call ending —
+ * they're a preference, not live call state.
+ *
+ * INV-9 exception (module singleton): a synchronous source of truth readable from
+ * any surface without context plumbing; `useSyncExternalStore` consumers detach on
+ * unmount. All localStorage access is best-effort — private mode / quota / malformed
+ * JSON fall safe to defaults rather than throwing.
+ */
+
+export type CallLayout = "speaker" | "grid"
+export type CallDockPosition = "top" | "side"
+export type CallFilmstripSide = "bottom" | "side"
+
+export interface CallPrefs {
+  layout: CallLayout
+  dockPosition: CallDockPosition
+  filmstripSide: CallFilmstripSide
+}
+
+const DEFAULT_PREFS: CallPrefs = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom" }
+const STORAGE_KEY = "threa:callPrefs:v1"
+
+const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
+const isDockPosition = (v: unknown): v is CallDockPosition => v === "top" || v === "side"
+const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
+
+function readPersisted(): CallPrefs {
+  if (typeof localStorage === "undefined") return { ...DEFAULT_PREFS }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_PREFS }
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return { ...DEFAULT_PREFS }
+    const p = parsed as Record<string, unknown>
+    return {
+      layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
+      dockPosition: isDockPosition(p.dockPosition) ? p.dockPosition : DEFAULT_PREFS.dockPosition,
+      filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
+    }
+  } catch {
+    return { ...DEFAULT_PREFS }
+  }
+}
+
+function persist(next: CallPrefs): void {
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Quota / private mode: the in-memory value still holds for this tab.
+  }
+}
+
+let prefs: CallPrefs = readPersisted()
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of listeners) listener()
+}
+
+function update(patch: Partial<CallPrefs>): void {
+  const next = { ...prefs, ...patch }
+  if (
+    next.layout === prefs.layout &&
+    next.dockPosition === prefs.dockPosition &&
+    next.filmstripSide === prefs.filmstripSide
+  ) {
+    return
+  }
+  prefs = next
+  persist(next)
+  notify()
+}
+
+export function getCallPrefs(): CallPrefs {
+  return prefs
+}
+
+export function setCallLayout(layout: CallLayout): void {
+  update({ layout })
+}
+
+export function setCallDockPosition(dockPosition: CallDockPosition): void {
+  update({ dockPosition })
+}
+
+export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {
+  update({ filmstripSide })
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useCallPrefs(): CallPrefs {
+  return useSyncExternalStore(subscribe, getCallPrefs, getCallPrefs)
+}
+
+/** Test-only: re-read from (possibly test-seeded) localStorage and drop listeners. */
+export function __resetCallPrefsForTests(): void {
+  prefs = readPersisted()
+  listeners.clear()
+}

--- a/apps/frontend/src/stores/call-store.test.ts
+++ b/apps/frontend/src/stores/call-store.test.ts
@@ -6,6 +6,7 @@ import {
   getCallState,
   setCallSession,
   setCallRoster,
+  setCallSurfaceMode,
   registerCallHangup,
   resetCallStoreCache,
   clearCallState,
@@ -67,6 +68,16 @@ describe("call-store", () => {
     // And that it's actually invoked inside flushModuleStoreCaches, not just imported.
     const flushBody = source.slice(source.indexOf("function flushModuleStoreCaches"))
     expect(flushBody).toContain("resetCallStoreCache()")
+  })
+
+  it("surfaceMode: defaults to min, sets, and resets to min on teardown", () => {
+    expect(getCallState().surfaceMode).toBe("min")
+
+    setCallSurfaceMode("full")
+    expect(getCallState().surfaceMode).toBe("full")
+
+    resetCallStoreCache()
+    expect(getCallState().surfaceMode).toBe("min")
   })
 
   it("unregistering the hangup makes reset a plain state drop", () => {

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -10,6 +10,14 @@ import type { CallMode, PublishedTrackKind } from "@/calls/config"
 
 export type CallPhase = "idle" | "joining" | "connected" | "reconnecting"
 
+/**
+ * Unified surface size for the call UI. One enum, four steps; each surface maps a
+ * step to its own presentation (mobile Tab/Bar/Tiny-gallery/Fullscreen; desktop-top
+ * Tab/Bar/Gallery/Fullscreen; desktop-side Rail/Panel/Wide/Fullscreen). Ephemeral —
+ * defaults to "min" ("opens minimal") and resets to "min" on teardown, like the roster.
+ */
+export type CallSurfaceMode = "min" | "compact" | "standard" | "full"
+
 export interface CallPublishedTrack {
   kind: PublishedTrackKind
   trackName: string
@@ -76,6 +84,8 @@ export interface CallCaptureErrorInfo {
 
 export interface CallState {
   phase: CallPhase
+  /** Unified surface size ({@link CallSurfaceMode}); "min" until a surface steps it up. */
+  surfaceMode: CallSurfaceMode
   callId: string | null
   workspaceId: string | null
   streamId: string | null
@@ -114,6 +124,7 @@ const EMPTY_DEVICES: CallDeviceState = {
 function idleState(): CallState {
   return {
     phase: "idle",
+    surfaceMode: "min",
     callId: null,
     workspaceId: null,
     streamId: null,
@@ -160,6 +171,11 @@ export function registerCallHangup(hangup: () => void): () => void {
 export function setCallPhase(phase: CallPhase): void {
   if (state.phase === phase) return
   setState({ ...state, phase })
+}
+
+export function setCallSurfaceMode(surfaceMode: CallSurfaceMode): void {
+  if (state.surfaceMode === surfaceMode) return
+  setState({ ...state, surfaceMode })
 }
 
 export function setCallSession(args: { callId: string; workspaceId: string; streamId: string; mode: CallMode }): void {

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -67,6 +67,11 @@ export default {
         activity: {
           people: "hsl(var(--activity-people))",
         },
+        "call-stage": {
+          DEFAULT: "hsl(var(--call-stage))",
+          2: "hsl(var(--call-stage-2))",
+          border: "hsl(var(--call-stage-border))",
+        },
       },
       borderRadius: {
         modal: "16px",


### PR DESCRIPTION
**Chunk 3 of the calls UX overhaul stack** — stacked on #1472. Shared scaffolding for the drawer (ch4), Speaker/Grid (ch5), and desktop dock (ch6). **No user-visible change** — the current dock is untouched; this only adds pieces the later chunks read.

## What's here
- **`CallSurfaceMode`** (`"min" | "compact" | "standard" | "full"`) on the call store + `setCallSurfaceMode` + `useCallSurfaceMode`. One unified size step; each surface maps it to its own presentation (mobile Tab/Bar/Tiny-gallery/Fullscreen; desktop-top Tab/Bar/Gallery/Fullscreen; desktop-side Rail/Panel/Wide/Fullscreen). Ephemeral — resets to `"min"` on teardown, like the roster.
- **`call-prefs-store`** — localStorage-persisted `{ layout, dockPosition, filmstripSide }`, read synchronously at import (first render reflects the saved choice), **fail-safe per-field** to defaults (private mode / quota / malformed JSON never throw). `useSyncExternalStore` with a stable snapshot.
- **`--call-stage` / `--call-stage-2` / `--call-stage-border`** tokens — identical values in `:root` and `.dark`, so the video bed stays near-black in **both** themes (a light backdrop behind a live feed reads as broken); mapped in `tailwind.config.js` as `bg-call-stage` etc.
- **`LayoutToggle`** — Shadcn `ToggleGroup` Speaker/Grid segmented control bound to the layout pref (radio semantics: `role=radiogroup` + `aria-checked`).

## Testing
`apps/frontend` typecheck clean; **15 new/adjacent call tests** green (surfaceMode default/set/reset; prefs defaults/persist-roundtrip/malformed/out-of-range; LayoutToggle render/reflect/click — real component, INV-39). Full frontend suite green (a first run flaked two unrelated suites under parallelism; both pass in isolation).

Reviewed by the coordinator (this is scaffolding — the heavier adversarial + Sol passes run on the whole stack once the UI chunks land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787179741&installation_model_id=20758&pr_number=1474&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1474&signature=9d97c2419930a5e1129198b68c4d553ec5f48f5aa1860c191f205384ba2b065f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->