### PR TITLE
feat(calls): mobile 4-mode global call drawer

### DIFF
--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { Mic, MicOff, PhoneOff, Video, VideoOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useCallManager } from "./call-manager-context"
+import { useCallCameraOn, useCallMode, useCallMuted } from "./call-store-hooks"
+
+// The mute / camera / leave triple, one component each so the compact bar and the
+// (later) desktop pill share one implementation instead of re-inlining the manager
+// wiring + INV-63 error toasts (success stays silent). Icon-only, 9x9 like CallControls.
+
+export function MuteButton() {
+  const manager = useCallManager()
+  const muted = useCallMuted()
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={cn("h-9 w-9", muted && "text-destructive")}
+      aria-label={muted ? "Unmute" : "Mute"}
+      aria-pressed={muted}
+      onClick={() => manager.setMuted(!muted)}
+    >
+      {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+    </Button>
+  )
+}
+
+export function CameraButton() {
+  const manager = useCallManager()
+  const cameraOn = useCallCameraOn()
+  const mode = useCallMode()
+  if (mode === "audio_only") return null
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-9 w-9"
+      aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
+      aria-pressed={cameraOn}
+      onClick={() => void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))}
+    >
+      {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+    </Button>
+  )
+}
+
+export function LeaveButton() {
+  const manager = useCallManager()
+  const [leaving, setLeaving] = useState(false)
+  return (
+    <Button
+      variant="destructive"
+      size="icon"
+      className="h-9 w-9"
+      aria-label="Leave call"
+      disabled={leaving}
+      onClick={() => {
+        setLeaving(true)
+        void manager.leaveCall().catch(() => {
+          setLeaving(false)
+          toast.error("Couldn't leave the call")
+        })
+      }}
+    >
+      <PhoneOff className="h-4 w-4" />
+    </Button>
+  )
+}

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -278,42 +278,43 @@ describe("CallDock — pre-join permission taxonomy", () => {
   })
 })
 
-describe("CallDock — collapsed + mobile", () => {
-  function forceMobile() {
-    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+describe("CallDock — mobile drawer vs desktop dock", () => {
+  function forceMobile(value: boolean) {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(value)
   }
 
-  it("auto-collapses to a pill on mobile and offers mute, camera, and leave", async () => {
-    forceMobile()
+  it("renders the mobile drawer (Tab) on a phone, not the desktop dock", () => {
+    forceMobile(true)
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.getByTestId("mobile-call-drawer")).toBeInTheDocument()
+    // Tab is timer-only: no dock chevron and no tiles until it is opened.
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Collapse call")).toBeNull()
+    expect(screen.queryByTestId("call-tile")).toBeNull()
+  })
+
+  it("renders the desktop dock, not the drawer, on a wide viewport", () => {
+    forceMobile(false)
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.queryByTestId("mobile-call-drawer")).toBeNull()
+    expect(screen.getByTestId("call-tile")).toBeInTheDocument()
+    expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
+  })
+
+  it("opens the drawer's compact controls when the Tab pill is tapped", async () => {
+    forceMobile(true)
     const manager = makeManager()
     renderDock(manager)
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
-
-    // Collapsed: the expanded body (CallControls' diagnostics) is not mounted.
-    expect(screen.getByLabelText("Expand call")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Connection diagnostics")).toBeNull()
-
-    await userEvent.click(screen.getByLabelText("Turn camera on"))
-    expect(manager.setCameraOn).toHaveBeenCalledWith(true)
-
-    await userEvent.click(screen.getByLabelText("Mute"))
-    expect(manager.setMuted).toHaveBeenCalledWith(true)
-
+    await userEvent.click(screen.getByRole("button", { name: "Expand call" }))
     await userEvent.click(screen.getByLabelText("Leave call"))
     expect(manager.leaveCall).toHaveBeenCalled()
   })
 
-  it("reflects camera-live state in the collapsed pill", () => {
-    forceMobile()
-    renderDock(makeManager())
-    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
-    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
-    act(() => patchCallLocal({ cameraOn: true }))
-    expect(screen.getByLabelText("Turn camera off")).toBeInTheDocument()
-  })
-
-  it("surfaces a capture error indicator while collapsed", () => {
-    forceMobile()
+  it("keeps the capture error visible on the mobile Tab", () => {
+    forceMobile(true)
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -37,6 +37,7 @@ export const RING_ABOVE_DOCK_BOTTOM =
   "bottom-[calc(var(--composer-height,5rem)_+_5.5rem)] sm:bottom-[calc(max(1rem,env(safe-area-inset-bottom))_+_4.5rem)]"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
+import { MobileCallDrawer } from "./mobile-call-drawer"
 import { PreJoinGate } from "./pre-join-gate"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 
@@ -97,8 +98,9 @@ export function CallDock() {
     if (launching || joining) setCollapsed(false)
   }, [launching, joining])
 
-  // On connect, reset the sticky flag: desktop opens the full dock; a phone
-  // auto-collapses to a pill so the panel never covers the composer.
+  // On connect, reset the sticky flag so the desktop dock opens full. Mobile
+  // renders the top drawer (driven by `surfaceMode`, not this flag), so the value
+  // is inert there — kept only to govern the desktop dock's collapse.
   useEffect(() => {
     if (inCall) setCollapsed(isMobile)
   }, [inCall, isMobile])
@@ -119,6 +121,8 @@ export function CallDock() {
   const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
 
   if (inCall) {
+    // Mobile gets the 4-mode global top drawer; desktop keeps the dock (chunk 6).
+    if (isMobile) return <MobileCallDrawer workspaceId={workspaceId} streamId={streamIdForLabel} />
     return (
       <ActiveCallDock
         workspaceId={workspaceId}

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -49,6 +49,10 @@ export function useCallStreamId(): string | null {
   return useCallSelector((s) => s.streamId)
 }
 
+export function useCallConnectedAt(): number | null {
+  return useCallSelector((s) => s.connectedAt)
+}
+
 export function useCallMode(): CallMode | null {
   return useCallSelector((s) => s.mode)
 }

--- a/apps/frontend/src/components/call/call-tile.tsx
+++ b/apps/frontend/src/components/call/call-tile.tsx
@@ -13,6 +13,10 @@ interface CallTileProps {
   participant: CallRosterParticipant
   workspaceId: string | null
   isSelf: boolean
+  /** Near-black `--call-stage` bed (mobile drawer / fullscreen), not the default `bg-muted` chrome tile. */
+  stage?: boolean
+  /** Fill the parent (fullscreen active speaker) instead of the default `aspect-video`. */
+  fill?: boolean
 }
 
 /**
@@ -22,7 +26,7 @@ interface CallTileProps {
  * ref-driven (`useSpeakingLevelRef`) so the analyser's per-frame level never
  * re-renders the tile, let alone the dock.
  */
-export function CallTile({ participant, workspaceId, isSelf }: CallTileProps) {
+export function CallTile({ participant, workspaceId, isSelf, stage = false, fill = false }: CallTileProps) {
   const users = useWorkspaceUsers(workspaceId ?? undefined)
   const user = users.find((u) => u.id === participant.userId)
   const name = user?.name ?? "Unknown"
@@ -56,7 +60,12 @@ export function CallTile({ participant, workspaceId, isSelf }: CallTileProps) {
 
   return (
     <div
-      className={cn("relative aspect-video overflow-hidden rounded-md bg-muted", reconnecting && "opacity-50")}
+      className={cn(
+        "relative overflow-hidden rounded-md",
+        fill ? "h-full w-full" : "aspect-video",
+        stage ? "bg-call-stage" : "bg-muted",
+        reconnecting && "opacity-50"
+      )}
       data-testid="call-tile"
       data-user-id={participant.userId}
     >
@@ -78,7 +87,7 @@ export function CallTile({ participant, workspaceId, isSelf }: CallTileProps) {
         data-testid="call-tile-video"
       />
       {!hasVideo && (
-        <div className="flex h-full w-full items-center justify-center">
+        <div className={cn("flex h-full w-full items-center justify-center", stage && "bg-call-stage-2")}>
           <Avatar className="h-12 w-12">
             {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
             <AvatarFallback>{getInitials(name)}</AvatarFallback>

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
 import { cn } from "@/lib/utils"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { useCallSurfaceMode } from "./call-store-hooks"
 import { useWorkspaceUserPreferences } from "@/stores/workspace-store"
 import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/stores/incoming-call-store"
 import { installRingAudioWarmup, startRing, stopRing } from "@/calls/ring-tone"
@@ -50,6 +52,8 @@ function fireLocalRingNotification(call: IncomingCall): void {
 export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   const calls = useIncomingCalls()
   const { launch, callActive } = useCallLaunch()
+  const isMobile = useIsMobile()
+  const surfaceMode = useCallSurfaceMode()
   const [searchParams, setSearchParams] = useSearchParams()
   const notifiedRef = useRef<Set<string>>(new Set())
   // Per-attempt mute (INV-... scoped so a fresh ring rings again). State, not a
@@ -153,11 +157,16 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
 
   if (calls.length === 0) return null
 
+  // The `callActive` lift clears the desktop bottom dock. On mobile the in-call
+  // surface is the TOP drawer, so the bottom is free — lift only in mobile
+  // fullscreen (where the drawer's bottom control bar would otherwise be covered).
+  const liftAboveDock = callActive && (!isMobile || surfaceMode === "full")
+
   return (
     <div
       className={cn(
         "pointer-events-none fixed right-4 z-50 flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
-        callActive ? RING_ABOVE_DOCK_BOTTOM : DOCK_BOTTOM
+        liftAboveDock ? RING_ABOVE_DOCK_BOTTOM : DOCK_BOTTOM
       )}
     >
       {calls.map((call) => (

--- a/apps/frontend/src/components/call/mobile-call-drawer-snap.test.ts
+++ b/apps/frontend/src/components/call/mobile-call-drawer-snap.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { nearestMode } from "./mobile-call-drawer-snap"
+
+// Detents (px): min 44, compact 80, standard 248, full-snap 420.
+// Midpoints: min|compact 62, compact|standard 164, standard|full 334.
+
+describe("nearestMode — nearest detent (no flick)", () => {
+  it("snaps to the detent at each resting height", () => {
+    expect(nearestMode(44, 0)).toBe("min")
+    expect(nearestMode(80, 0)).toBe("compact")
+    expect(nearestMode(248, 0)).toBe("standard")
+    expect(nearestMode(500, 0)).toBe("full")
+  })
+
+  it("resolves each midpoint to the correct side", () => {
+    expect(nearestMode(61, 0)).toBe("min")
+    expect(nearestMode(63, 0)).toBe("compact")
+    expect(nearestMode(163, 0)).toBe("compact")
+    expect(nearestMode(165, 0)).toBe("standard")
+    expect(nearestMode(333, 0)).toBe("standard")
+    expect(nearestMode(335, 0)).toBe("full")
+  })
+})
+
+describe("nearestMode — velocity flick bias", () => {
+  it("a fast downward flick advances one detent in the drag direction", () => {
+    // Near the tab but flicked down fast → jumps up to compact.
+    expect(nearestMode(50, 1)).toBe("compact")
+    // At standard, flicked down → jumps to full even without dragging all the way.
+    expect(nearestMode(248, 1)).toBe("full")
+  })
+
+  it("a fast upward flick drops one detent in the drag direction", () => {
+    // Near standard, flicked up fast → drops to compact.
+    expect(nearestMode(240, -1)).toBe("compact")
+    // At compact, flicked up → drops to the tab.
+    expect(nearestMode(80, -1)).toBe("min")
+  })
+
+  it("velocity below the flick threshold falls back to nearest", () => {
+    expect(nearestMode(240, -0.2)).toBe("standard")
+    expect(nearestMode(90, 0.2)).toBe("compact")
+  })
+})

--- a/apps/frontend/src/components/call/mobile-call-drawer-snap.ts
+++ b/apps/frontend/src/components/call/mobile-call-drawer-snap.ts
@@ -1,0 +1,70 @@
+import type { CallSurfaceMode } from "@/stores/call-store"
+
+/**
+ * Drag/snap physics for the mobile call drawer, factored out as pure functions so
+ * the detent logic is unit-testable without a real pointer drag.
+ *
+ * The drawer hangs from the top and grows DOWNWARD, so a larger height = a larger
+ * surface mode. Heights are the resting pixel size of each mode's chrome; `full`
+ * renders at `100dvh` but for snapping we only need a representative anchor well
+ * past `standard` (any drag beyond the standard↔full midpoint lands on full).
+ */
+
+export const DRAWER_MIN_HEIGHT = 44
+export const DRAWER_COMPACT_HEIGHT = 80
+export const DRAWER_STANDARD_HEIGHT = 248
+/** Snap anchor for `full` (rendered at 100dvh); crossing the standard↔full midpoint snaps to full. */
+export const DRAWER_FULL_SNAP_HEIGHT = 420
+
+/** A flick faster than this (px/ms, magnitude) biases the snap one detent in its direction. */
+export const FLICK_VELOCITY = 0.5
+
+const MODES: readonly CallSurfaceMode[] = ["min", "compact", "standard", "full"]
+const HEIGHTS: readonly number[] = [
+  DRAWER_MIN_HEIGHT,
+  DRAWER_COMPACT_HEIGHT,
+  DRAWER_STANDARD_HEIGHT,
+  DRAWER_FULL_SNAP_HEIGHT,
+]
+
+function nearestIndex(heightPx: number): number {
+  let idx = 0
+  let best = Infinity
+  for (let i = 0; i < HEIGHTS.length; i++) {
+    const d = Math.abs(HEIGHTS[i] - heightPx)
+    if (d < best) {
+      best = d
+      idx = i
+    }
+  }
+  return idx
+}
+
+/**
+ * The mode to settle on when a drag ends at `heightPx` with `velocityPxPerMs`
+ * (positive = growing/downward). Nearest detent by distance, then a fast flick
+ * jumps to the next detent in the flick direction (so a quick pull past a small
+ * threshold advances even if the finger didn't travel the whole way).
+ */
+export function nearestMode(heightPx: number, velocityPxPerMs: number): CallSurfaceMode {
+  const idx = nearestIndex(heightPx)
+
+  if (velocityPxPerMs > FLICK_VELOCITY) {
+    const nextUp = HEIGHTS.findIndex((h) => h > heightPx)
+    const target = nextUp === -1 ? HEIGHTS.length - 1 : nextUp
+    return MODES[Math.max(idx, target)]
+  }
+
+  if (velocityPxPerMs < -FLICK_VELOCITY) {
+    let nextDown = 0
+    for (let i = HEIGHTS.length - 1; i >= 0; i--) {
+      if (HEIGHTS[i] < heightPx) {
+        nextDown = i
+        break
+      }
+    }
+    return MODES[Math.min(idx, nextDown)]
+  }
+
+  return MODES[idx]
+}

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, fireEvent } from "@testing-library/react"
+import { render, screen, userEvent } from "@/test"
+import * as authModule from "@/auth"
+import * as useMobileModule from "@/hooks/use-mobile"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import {
+  clearCallState,
+  getCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  setCallDevices,
+  setCallSurfaceMode,
+  setCallCaptureError,
+  type CallDeviceState,
+  type CallRosterParticipant,
+  type CallSurfaceMode,
+} from "@/stores/call-store"
+import type { CallController } from "@/calls/call-manager"
+import { MobileCallDrawer } from "./mobile-call-drawer"
+import { CallManagerProvider } from "./call-manager-context"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_self",
+    participantStatus: "joined",
+    endpointId: "callep_self",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function device(deviceId: string, label: string): MediaDeviceInfo {
+  return { deviceId, label, kind: "videoinput", groupId: "grp", toJSON: () => ({}) } as MediaDeviceInfo
+}
+
+function makeDevices(overrides: Partial<CallDeviceState> = {}): CallDeviceState {
+  return {
+    inputs: [],
+    outputs: [],
+    cameras: [],
+    selectedInputId: null,
+    selectedOutputId: null,
+    selectedCameraId: null,
+    facingMode: null,
+    ...overrides,
+  }
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+function renderDrawer(manager: CallController = makeManager(), streamId = "stream_1") {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <MobileCallDrawer workspaceId={WORKSPACE_ID} streamId={streamId} />
+    </CallManagerProvider>
+  )
+}
+
+function enterConnected(roster: CallRosterParticipant[], mode: "video" | "audio_only" = "video") {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode })
+    setCallPhase("connected")
+    setCallRoster(roster, 1)
+  })
+}
+
+function setMode(m: CallSurfaceMode) {
+  act(() => setCallSurfaceMode(m))
+}
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  seedUsers()
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("MobileCallDrawer — mode rendering", () => {
+  it("Tab (min): timer only, no controls", () => {
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("min")
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
+    expect(screen.queryByLabelText("Mute")).toBeNull()
+    expect(screen.queryByLabelText("Leave call")).toBeNull()
+  })
+
+  it("Bar (compact): adds mute, camera, and leave", () => {
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("compact")
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    // Full control extras are not in the compact bar.
+    expect(screen.queryByLabelText("Connection diagnostics")).toBeNull()
+  })
+
+  it("Tiny gallery (standard): adds a tile grid, flip, and the device menu", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    renderDrawer()
+    enterConnected([
+      participant({ userId: "usr_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+    ])
+    act(() => setCallDevices(makeDevices({ cameras: [device("c1", "Front"), device("c2", "Back")] })))
+    setMode("standard")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Flip camera")).toBeInTheDocument()
+    expect(screen.getByLabelText("Devices")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+  })
+
+  it("Fullscreen (full): shows the stage, collapse chevron, ch5 layout seam, and full controls", () => {
+    renderDrawer()
+    enterConnected([
+      participant({ userId: "usr_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+    ])
+    act(() => setCallDevices(makeDevices({ cameras: [device("c1", "Front")] })))
+    setMode("full")
+    expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
+    expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Devices")).toBeInTheDocument()
+    expect(screen.getAllByTestId("call-tile").length).toBeGreaterThan(0)
+  })
+})
+
+describe("MobileCallDrawer — mode transitions", () => {
+  it("tapping the Tab pill steps up to compact", async () => {
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("min")
+    await userEvent.click(screen.getByRole("button", { name: "Expand call" }))
+    expect(getCallState().surfaceMode).toBe("compact")
+  })
+
+  it("the fullscreen collapse chevron lowers it to standard", async () => {
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("full")
+    await userEvent.click(screen.getByLabelText("Collapse call"))
+    expect(getCallState().surfaceMode).toBe("standard")
+  })
+})
+
+describe("MobileCallDrawer — capture error visible in every mode", () => {
+  const modes: CallSurfaceMode[] = ["min", "compact", "standard", "full"]
+  for (const m of modes) {
+    it(`surfaces the capture error in ${m} mode`, () => {
+      renderDrawer()
+      enterConnected([participant({ userId: "usr_self" })])
+      act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
+      setMode(m)
+      expect(screen.getByTestId("call-capture-error")).toBeInTheDocument()
+    })
+  }
+})
+
+describe("MobileCallDrawer — global", () => {
+  it("renders from call-store state even when the stream is not in the route/cache", () => {
+    // A streamId that matches no cached stream (name falls back to "Call"): the
+    // drawer reads the call store, not the route, so it still shows.
+    renderDrawer(makeManager(), "stream_not_in_cache")
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("min")
+    expect(screen.getByTestId("mobile-call-drawer")).toBeInTheDocument()
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+  })
+
+  it("dispatches leave to the manager from the bar (success stays silent — INV-63)", async () => {
+    const manager = makeManager()
+    renderDrawer(manager)
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("compact")
+    await userEvent.click(screen.getByLabelText("Leave call"))
+    expect(manager.leaveCall).toHaveBeenCalled()
+  })
+})
+
+describe("MobileCallDrawer — drag settles (no wedge)", () => {
+  // jsdom has neither setPointerCapture nor a real layout; stub both so the drag
+  // handlers run. The drawer measures its own height on pointerdown.
+  function primeDrag(startHeightPx: number) {
+    const drawer = screen.getByTestId("mobile-call-drawer")
+    drawer.getBoundingClientRect = () =>
+      ({
+        height: startHeightPx,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect
+    const handle = screen.getByTestId("call-drawer-handle")
+    handle.setPointerCapture = vi.fn()
+    return handle
+  }
+
+  it("dragging past the standard→full threshold keeps the handle mounted and settles to full", () => {
+    renderDrawer()
+    enterConnected([
+      participant({ userId: "usr_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+    ])
+    setMode("standard")
+    const handle = primeDrag(248)
+    // Drag down ~120px → height ~368 (> the 334 standard↔full midpoint) → content
+    // crosses into fullscreen mid-drag. Before the fix the handle unmounted here
+    // and pointerup could never fire (drawer wedged).
+    fireEvent.pointerDown(handle, { clientY: 300, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientY: 420, pointerId: 1 })
+    expect(screen.getByTestId("mobile-call-drawer")).toHaveAttribute("data-mode", "full")
+    expect(screen.getByTestId("call-drawer-handle")).toBeInTheDocument()
+    fireEvent.pointerUp(handle, { clientY: 420, pointerId: 1 })
+    expect(getCallState().surfaceMode).toBe("full")
+  })
+
+  it("a pointercancel mid-drag settles instead of wedging", () => {
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("compact")
+    const handle = primeDrag(80)
+    fireEvent.pointerDown(handle, { clientY: 100, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientY: 300, pointerId: 1 }) // dragged down toward standard/full
+    fireEvent.pointerCancel(handle, { clientY: 300, pointerId: 1 })
+    // The cancel must settle (onPointerUp ran): surfaceMode moved off the starting
+    // "compact" to the dragged-toward region. Exact detent depends on the (near-
+    // instant jsdom) velocity/flick, so assert it settled, not the precise mode.
+    // Before the fix, pointercancel was unhandled → surfaceMode stayed "compact".
+    expect(["standard", "full"]).toContain(getCallState().surfaceMode)
+  })
+})

--- a/apps/frontend/src/components/call/mobile-call-drawer.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
+import { ChevronUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+import {
+  setCallSurfaceMode,
+  type CallCaptureErrorInfo,
+  type CallRosterParticipant,
+  type CallSurfaceMode,
+} from "@/stores/call-store"
+import { CallTile } from "./call-tile"
+import { CallControls } from "./call-controls"
+import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
+import { DRAWER_MIN_HEIGHT, nearestMode } from "./mobile-call-drawer-snap"
+
+const REDUCED_MOTION =
+  typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+
+/** Per-mode frame classes (width/border/radius); `min` is the floating pill, the rest are full-width. */
+const FRAME_CLASS: Record<CallSurfaceMode, string> = {
+  min: "w-fit rounded-b-2xl border border-t-0",
+  compact: "w-full border-b",
+  standard: "w-full border-b",
+  full: "w-full",
+}
+
+/** Resting CSS height per mode; `min` is the intrinsic pill, `full` fills below the status bar. */
+const RESTING_HEIGHT: Record<CallSurfaceMode, string> = {
+  min: "auto",
+  compact: "80px",
+  standard: "248px",
+  full: "calc(100dvh - env(safe-area-inset-top))",
+}
+
+function viewportHeight(): number {
+  if (typeof window === "undefined") return DRAWER_MIN_HEIGHT
+  return window.visualViewport?.height ?? window.innerHeight
+}
+
+/** mm:ss, or h:mm:ss past an hour. */
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const mm = h > 0 ? String(m).padStart(2, "0") : String(m)
+  const ss = String(s).padStart(2, "0")
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
+}
+
+function CallTimer({ connectedAt, className }: { connectedAt: number | null; className?: string }) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  const elapsed = connectedAt == null ? 0 : now - connectedAt
+  return (
+    <span className={cn("font-mono text-sm tabular-nums", className)} aria-label="Call duration">
+      {formatElapsed(elapsed)}
+    </span>
+  )
+}
+
+function captureErrorText(code: CallCaptureErrorInfo["code"]): string {
+  return code === "capture_rollback_failed"
+    ? "Your microphone stopped working and couldn't be restored. Try leaving and rejoining."
+    : "Couldn't switch your microphone or camera. Your previous device is still active."
+}
+
+function CaptureErrorBanner({ error }: { error: CallCaptureErrorInfo }) {
+  return (
+    <p
+      className="mx-3 mt-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
+      role="alert"
+      data-testid="call-capture-error"
+    >
+      {captureErrorText(error.code)}
+    </p>
+  )
+}
+
+function GrabHandle({
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+}: {
+  onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label="Resize call"
+      data-testid="call-drawer-handle"
+      className="flex shrink-0 touch-none cursor-grab items-center justify-center py-2 active:cursor-grabbing"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      <span className="h-1 w-10 rounded-full bg-muted-foreground/40" aria-hidden />
+    </div>
+  )
+}
+
+interface ViewProps {
+  workspaceId: string | null
+  connectedAt: number | null
+  currentUserId: string | null
+  roster: CallRosterParticipant[]
+  speakerName: string | null
+  title: string
+}
+
+function TabView({
+  connectedAt,
+  captureError,
+}: {
+  connectedAt: number | null
+  captureError: CallCaptureErrorInfo | null
+}) {
+  return (
+    <button
+      type="button"
+      aria-label="Expand call"
+      onClick={() => setCallSurfaceMode("compact")}
+      className="flex items-center justify-center gap-2 px-4 py-1.5"
+    >
+      {captureError ? (
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-destructive"
+          role="alert"
+          data-testid="call-capture-error"
+          aria-label="Microphone or camera problem — expand the call to see details"
+        />
+      ) : (
+        <span
+          className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
+          aria-hidden
+        />
+      )}
+      <CallTimer connectedAt={connectedAt} />
+    </button>
+  )
+}
+
+function BarView({ connectedAt, speakerName }: ViewProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <CallTimer connectedAt={connectedAt} />
+        {speakerName && <span className="truncate text-xs text-muted-foreground">{speakerName}</span>}
+      </div>
+      <div className="flex shrink-0 items-center gap-1.5">
+        <MuteButton />
+        <CameraButton />
+        <LeaveButton />
+      </div>
+    </div>
+  )
+}
+
+function TinyGalleryView({ workspaceId, connectedAt, currentUserId, roster, speakerName }: ViewProps) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  const self = joined.find((p) => p.userId === currentUserId) ?? null
+  const peer = joined.find((p) => p.userId !== currentUserId) ?? null
+  const tiles = [peer, self].filter((p): p is CallRosterParticipant => p !== null)
+
+  return (
+    <div className="flex h-full flex-col gap-2 p-3">
+      <div className="flex flex-col">
+        <CallTimer connectedAt={connectedAt} />
+        {speakerName && <span className="truncate text-xs text-muted-foreground">{speakerName}</span>}
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-hidden">
+        {tiles.map((p) => (
+          <div key={p.userId} className={cn("min-h-0", p === peer && "rounded-md ring-2 ring-primary")}>
+            <CallTile participant={p} workspaceId={workspaceId} isSelf={p.userId === currentUserId} stage />
+          </div>
+        ))}
+      </div>
+      <div className="shrink-0">
+        <CallControls />
+      </div>
+    </div>
+  )
+}
+
+/** Draggable self-view PiP, constrained to the stage. Defaults to the top-right. */
+function SelfPip({ participant, workspaceId }: { participant: CallRosterParticipant; workspaceId: string | null }) {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+  const drag = useRef<{ dx: number; dy: number } | null>(null)
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const box = e.currentTarget.getBoundingClientRect()
+    drag.current = { dx: e.clientX - box.left, dy: e.clientY - box.top }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    const stage = e.currentTarget.parentElement
+    if (!d || !stage) return
+    const bounds = stage.getBoundingClientRect()
+    const box = e.currentTarget.getBoundingClientRect()
+    const x = Math.min(Math.max(e.clientX - d.dx - bounds.left, 0), Math.max(bounds.width - box.width, 0))
+    const y = Math.min(Math.max(e.clientY - d.dy - bounds.top, 0), Math.max(bounds.height - box.height, 0))
+    setPos({ x, y })
+  }
+  const onPointerUp = () => {
+    drag.current = null
+  }
+
+  return (
+    <div
+      className="absolute h-24 w-16 touch-none overflow-hidden rounded-lg shadow-lg"
+      style={pos ? { left: pos.x, top: pos.y } : { right: 12, top: 12 }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      data-testid="call-self-pip"
+    >
+      <CallTile participant={participant} workspaceId={workspaceId} isSelf stage fill />
+    </div>
+  )
+}
+
+function FullscreenView({ workspaceId, connectedAt, currentUserId, roster, title }: ViewProps) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  const self = joined.find((p) => p.userId === currentUserId) ?? null
+  const peer = joined.find((p) => p.userId !== currentUserId) ?? null
+  const pinned = peer ?? self
+  const selfPip = self && self !== pinned ? self : null
+  const filmstrip = joined.filter((p) => p !== pinned && p !== selfPip)
+
+  return (
+    <div className="flex h-full flex-col bg-call-stage text-white">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          aria-label="Collapse call"
+          onClick={() => setCallSurfaceMode("standard")}
+          className="flex h-9 w-9 items-center justify-center rounded-md text-white/80 hover:bg-white/10 hover:text-white"
+        >
+          <ChevronUp className="h-5 w-5" />
+        </button>
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium">{title}</span>
+          <CallTimer connectedAt={connectedAt} className="text-white/70" />
+        </div>
+        {/* ch5 seam: <LayoutToggle/> (Speaker/Grid) mounts here and switches the stage
+            between this speaker+filmstrip layout and an equal-tile Grid. */}
+        <div data-testid="call-layout-slot" className="ml-auto" />
+      </div>
+
+      <div className="relative min-h-0 flex-1">
+        {pinned && (
+          <CallTile
+            participant={pinned}
+            workspaceId={workspaceId}
+            isSelf={pinned.userId === currentUserId}
+            stage
+            fill
+          />
+        )}
+        {selfPip && <SelfPip participant={selfPip} workspaceId={workspaceId} />}
+      </div>
+
+      {filmstrip.length > 0 && (
+        <div className="flex shrink-0 gap-2 overflow-x-auto px-3 py-2">
+          {filmstrip.map((p) => (
+            <div key={p.userId} className="h-20 w-32 shrink-0">
+              <CallTile participant={p} workspaceId={workspaceId} isSelf={p.userId === currentUserId} stage fill />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="shrink-0 px-3 pb-3 pt-1">
+        <CallControls />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The mobile in-call surface: a global top drawer that snaps through four modes
+ * (Tab → Bar → Tiny gallery → Fullscreen) driven by `surfaceMode`. Rendered by
+ * {@link CallDock} only on a mobile viewport for the connected phase; it reads the
+ * call store, not the route, so the Tab stays visible across stream navigation.
+ * Desktop keeps the existing dock (chunk 6 replaces it).
+ */
+export function MobileCallDrawer({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
+  const surfaceMode = useCallSurfaceMode()
+  const roster = useCallRoster()
+  const connectedAt = useCallConnectedAt()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const users = useWorkspaceUsers(workspaceId ?? undefined)
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  const title = name ?? "Call"
+
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const [dragHeight, setDragHeight] = useState<number | null>(null)
+  const drag = useRef<{
+    startY: number
+    startHeight: number
+    height: number
+    velocity: number
+    lastY: number
+    lastT: number
+  } | null>(null)
+
+  const contentMode: CallSurfaceMode = dragging && dragHeight != null ? nearestMode(dragHeight, 0) : surfaceMode
+
+  const speaker = roster.find((p) => p.participantStatus === "joined" && p.userId !== currentUserId) ?? null
+  const speakerName = speaker ? (users.find((u) => u.id === speaker.userId)?.name ?? null) : null
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const startHeight = drawerRef.current?.getBoundingClientRect().height ?? DRAWER_MIN_HEIGHT
+    drag.current = {
+      startY: e.clientY,
+      startHeight,
+      height: startHeight,
+      velocity: 0,
+      lastY: e.clientY,
+      lastT: performance.now(),
+    }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    setDragHeight(startHeight)
+    setDragging(true)
+  }
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    if (!d) return
+    const now = performance.now()
+    const next = Math.min(Math.max(d.startHeight + (e.clientY - d.startY), DRAWER_MIN_HEIGHT), viewportHeight())
+    const dt = now - d.lastT
+    if (dt > 0) d.velocity = (e.clientY - d.lastY) / dt
+    d.lastY = e.clientY
+    d.lastT = now
+    d.height = next
+    setDragHeight(next)
+  }
+  const onPointerUp = () => {
+    const d = drag.current
+    drag.current = null
+    setDragging(false)
+    setDragHeight(null)
+    if (d) setCallSurfaceMode(nearestMode(d.height, d.velocity))
+  }
+
+  const viewProps: ViewProps = { workspaceId, connectedAt, currentUserId, roster, speakerName, title }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50" style={{ paddingTop: "env(safe-area-inset-top)" }}>
+      <div
+        ref={drawerRef}
+        data-testid="mobile-call-drawer"
+        data-mode={contentMode}
+        className={cn(
+          "pointer-events-auto mx-auto flex flex-col overflow-hidden bg-background shadow-lg",
+          FRAME_CLASS[contentMode],
+          !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
+        )}
+        style={{ height: dragging && dragHeight != null ? `${dragHeight}px` : RESTING_HEIGHT[contentMode] }}
+      >
+        {contentMode !== "min" && captureError && <CaptureErrorBanner error={captureError} />}
+        <div className="min-h-0 flex-1 overflow-hidden">
+          {contentMode === "min" && <TabView connectedAt={connectedAt} captureError={captureError} />}
+          {contentMode === "compact" && <BarView {...viewProps} />}
+          {contentMode === "standard" && <TinyGalleryView {...viewProps} />}
+          {contentMode === "full" && <FullscreenView {...viewProps} />}
+        </div>
+        {/* Keep the handle mounted while dragging even once the content crosses into
+            `full`: it holds the pointer capture + the pointerup/cancel settle, so
+            unmounting it mid-drag would strand `dragging` true and wedge the drawer. */}
+        {(dragging || contentMode !== "full") && (
+          <GrabHandle onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/stores/call-store.test.ts
+++ b/apps/frontend/src/stores/call-store.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url"
 import {
   getCallState,
   setCallSession,
+  setCallPhase,
   setCallRoster,
   setCallSurfaceMode,
   registerCallHangup,
@@ -78,6 +79,23 @@ describe("call-store", () => {
 
     resetCallStoreCache()
     expect(getCallState().surfaceMode).toBe("min")
+  })
+
+  it("connectedAt: stamped once on connect, preserved across reconnects, cleared on teardown", () => {
+    setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    expect(getCallState().connectedAt).toBeNull()
+
+    setCallPhase("connected")
+    const stamped = getCallState().connectedAt
+    expect(typeof stamped).toBe("number")
+
+    // A reconnect blip must not reset the clock.
+    setCallPhase("reconnecting")
+    setCallPhase("connected")
+    expect(getCallState().connectedAt).toBe(stamped)
+
+    resetCallStoreCache()
+    expect(getCallState().connectedAt).toBeNull()
   })
 
   it("unregistering the hangup makes reset a plain state drop", () => {

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -86,6 +86,12 @@ export interface CallState {
   phase: CallPhase
   /** Unified surface size ({@link CallSurfaceMode}); "min" until a surface steps it up. */
   surfaceMode: CallSurfaceMode
+  /**
+   * `Date.now()` at the first "connected" transition — the in-call timer anchor.
+   * Stamped once and preserved across reconnects (a blip must not reset the clock);
+   * reset to null on a new session and on teardown.
+   */
+  connectedAt: number | null
   callId: string | null
   workspaceId: string | null
   streamId: string | null
@@ -125,6 +131,7 @@ function idleState(): CallState {
   return {
     phase: "idle",
     surfaceMode: "min",
+    connectedAt: null,
     callId: null,
     workspaceId: null,
     streamId: null,
@@ -170,7 +177,9 @@ export function registerCallHangup(hangup: () => void): () => void {
 
 export function setCallPhase(phase: CallPhase): void {
   if (state.phase === phase) return
-  setState({ ...state, phase })
+  // Stamp the timer anchor on the first connect; keep it across reconnects.
+  const connectedAt = phase === "connected" ? (state.connectedAt ?? Date.now()) : state.connectedAt
+  setState({ ...state, phase, connectedAt })
 }
 
 export function setCallSurfaceMode(surfaceMode: CallSurfaceMode): void {
@@ -179,7 +188,7 @@ export function setCallSurfaceMode(surfaceMode: CallSurfaceMode): void {
 }
 
 export function setCallSession(args: { callId: string; workspaceId: string; streamId: string; mode: CallMode }): void {
-  setState({ ...state, ...args, phase: "joining" })
+  setState({ ...state, ...args, phase: "joining", connectedAt: null })
 }
 
 export function setCallRoster(roster: CallRosterParticipant[], rosterVersion: number): void {


### PR DESCRIPTION
**Chunk 4 of the calls UX overhaul stack** — stacked on #1474. The core mobile surface, per the approved Seer design (calls-ux-cb8f33 v7).

Replaces the mobile bottom pill/dock with a **global top drawer** that snaps through four sizes. Desktop is untouched (chunk 6 replaces the desktop dock).

## Modes (drag the handle; snaps to the nearest on release)
- **Tab** (`min`) — a live amber dot + the call **timer**, nothing else. The global "you're in a call" anchor: visible on **any** stream/screen while a call is live. Tap → Bar.
- **Bar** (`compact`) — timer + current speaker + mute / camera / leave.
- **Tiny gallery** (`standard`) — timer/speaker line, a 2-up tile grid (peer pinned), + flip + device menu + leave.
- **Fullscreen** (`full`) — near-black stage: active speaker, a draggable self-PiP, a bottom filmstrip, a collapse chevron. (Speaker↔Grid toggle lands in chunk 5 at the `call-layout-slot` seam.)

Chat stays live behind Tab/Bar/Tiny-gallery (the drawer only covers the top slice); Fullscreen is opaque below the status bar. Capture-error is visible in **every** mode.

## Under the hood
- Pure `nearestMode(height, velocity)` snap helper (velocity-biased, clamped, ≤1 detent per flick) — unit-tested; the drawer height follows the finger 1:1 during a drag (transition off), snaps on release, respects `prefers-reduced-motion`.
- New store `connectedAt` (stamp-once, reconnect-preserving) drives the timer.
- `CallTile` gains opt-in `stage`/`fill` props (default `false` → **desktop dock renders byte-for-byte unchanged**, verified). Chrome uses theme tokens; video beds use the `--call-stage*` tokens (near-black in both light & dark). Camera-off tiles show avatar initials.
- Incoming-ring overlay position is now mobile-aware (the in-call surface moved to the top, so the bottom-dock lift only applies on desktop / mobile-fullscreen).

## Review + testing
- **Adversarial verify** (Opus/xhigh) verdict FIX-THEN-SHIP → the two findings are folded in and regression-tested: the grab handle now stays mounted through a drag that crosses into fullscreen, and a `pointercancel` settles the drag (previously the handle unmounted mid-gesture and **wedged the drawer** — a real bug that broke the pull-to-fullscreen flow). Snap math, desktop-unchanged, timer lifecycle, global rendering, and pointer-events-behind all verified clean.
- Frontend typecheck clean; drawer/snap/dock/store/tile suites green (incl. the new drag-into-fullscreen + pointercancel regression tests).

## Screenshots
Real-app shots of the four modes (mobile viewport, fake-CF two-user call) are being captured via the `calls` Playwright harness and will be added here + posted in the design channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787181886&installation_model_id=20758&pr_number=1475&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1475&signature=a96716404ff66acd20211c2689fdcef6cedc33bf06e2c40721124e074d97b722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->