### PR TITLE
feat(calls): Speaker/Grid layouts with bottom/side filmstrip

### DIFF
--- a/apps/frontend/src/components/call/call-stage-layout.test.tsx
+++ b/apps/frontend/src/components/call/call-stage-layout.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { useState } from "react"
+import { render, screen, userEvent, within } from "@/test"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { clearCallState, type CallRosterParticipant } from "@/stores/call-store"
+import type { CallFilmstripSide, CallLayout } from "@/stores/call-prefs-store"
+import type { CallController } from "@/calls/call-manager"
+import { CallStageLayout } from "./call-stage-layout"
+import { CallManagerProvider } from "./call-manager-context"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_self",
+    participantStatus: "joined",
+    endpointId: "callep_self",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_a", workosUserId: "workos_a", slug: "a", name: "Grace" }),
+      user({ id: "usr_b", workosUserId: "workos_b", slug: "b", name: "Linus" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+/** A controlled host holding the view-only pin, mirroring the mobile drawer's FullscreenView. */
+function Host({
+  layout,
+  filmstripSide = "bottom",
+  participants,
+}: {
+  layout: CallLayout
+  filmstripSide?: CallFilmstripSide
+  participants: CallRosterParticipant[]
+}) {
+  const [pinnedUserId, setPinnedUserId] = useState<string | null>(null)
+  return (
+    <CallManagerProvider manager={makeManager()}>
+      <CallStageLayout
+        layout={layout}
+        filmstripSide={filmstripSide}
+        participants={participants}
+        currentUserId="usr_self"
+        workspaceId={WORKSPACE_ID}
+        pinnedUserId={pinnedUserId}
+        onPin={setPinnedUserId}
+      />
+    </CallManagerProvider>
+  )
+}
+
+const THREE = [
+  participant({ userId: "usr_self", endpointId: "callep_self" }),
+  participant({ userId: "usr_a", endpointId: "callep_a" }),
+  participant({ userId: "usr_b", endpointId: "callep_b" }),
+]
+
+/** The large speaker tile is the direct-child CallTile of the stage-main region (the PiP's is nested). */
+function bigTileUserId(): string | null {
+  const main = screen.getByTestId("call-stage-main")
+  return main.querySelector(":scope > [data-testid='call-tile']")?.getAttribute("data-user-id") ?? null
+}
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  seedUsers()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("CallStageLayout — grid", () => {
+  it("renders one equal tile per participant", () => {
+    render(<Host layout="grid" participants={THREE} />)
+    expect(screen.getByTestId("call-stage-grid")).toBeInTheDocument()
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(3)
+    // No self-PiP in grid; the self tile is just another tile.
+    expect(screen.queryByTestId("call-self-pip")).toBeNull()
+  })
+
+  it("ignores non-joined participants", () => {
+    render(
+      <Host
+        layout="grid"
+        participants={[
+          participant({ userId: "usr_self" }),
+          participant({ userId: "usr_a", endpointId: "callep_a", participantStatus: "left" }),
+        ]}
+      />
+    )
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(1)
+  })
+})
+
+describe("CallStageLayout — speaker", () => {
+  it("renders one large tile, a filmstrip of the rest, and the self PiP", () => {
+    render(<Host layout="speaker" participants={THREE} />)
+    // Default speaker = first joined non-self peer (usr_a).
+    expect(bigTileUserId()).toBe("usr_a")
+    expect(screen.getByTestId("call-self-pip")).toBeInTheDocument()
+    // Filmstrip holds the remaining peer (usr_b) — not the speaker, not self.
+    const strip = screen.getByTestId("call-filmstrip")
+    const stripUsers = within(strip)
+      .getAllByTestId("call-tile")
+      .map((t) => t.getAttribute("data-user-id"))
+    expect(stripUsers).toEqual(["usr_b"])
+  })
+
+  it("solo self: self is the large tile, no filmstrip, no PiP", () => {
+    render(<Host layout="speaker" participants={[participant({ userId: "usr_self" })]} />)
+    expect(bigTileUserId()).toBe("usr_self")
+    expect(screen.queryByTestId("call-filmstrip")).toBeNull()
+    expect(screen.queryByTestId("call-self-pip")).toBeNull()
+  })
+
+  it("filmstripSide places the strip: bottom = row, side = column", () => {
+    const { rerender } = render(<Host layout="speaker" filmstripSide="bottom" participants={THREE} />)
+    const bottom = screen.getByTestId("call-stage-speaker")
+    expect(bottom).toHaveAttribute("data-filmstrip-side", "bottom")
+    expect(bottom.className).toContain("flex-col")
+    expect(screen.getByTestId("call-filmstrip").className).toContain("overflow-x-auto")
+
+    rerender(<Host layout="speaker" filmstripSide="side" participants={THREE} />)
+    const side = screen.getByTestId("call-stage-speaker")
+    expect(side).toHaveAttribute("data-filmstrip-side", "side")
+    expect(side.className).toContain("flex-row")
+    expect(screen.getByTestId("call-filmstrip").className).toContain("overflow-y-auto")
+  })
+
+  it("tapping a filmstrip tile pins that user as the large speaker", async () => {
+    render(<Host layout="speaker" participants={THREE} />)
+    expect(bigTileUserId()).toBe("usr_a")
+
+    // usr_b is in the filmstrip; pin them.
+    await userEvent.click(screen.getByRole("button", { name: "Pin Linus" }))
+
+    expect(bigTileUserId()).toBe("usr_b")
+    // usr_a now takes the filmstrip slot.
+    const stripUsers = within(screen.getByTestId("call-filmstrip"))
+      .getAllByTestId("call-tile")
+      .map((t) => t.getAttribute("data-user-id"))
+    expect(stripUsers).toEqual(["usr_a"])
+  })
+})

--- a/apps/frontend/src/components/call/call-stage-layout.tsx
+++ b/apps/frontend/src/components/call/call-stage-layout.tsx
@@ -1,0 +1,163 @@
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
+import { cn } from "@/lib/utils"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+import type { CallRosterParticipant } from "@/stores/call-store"
+import type { CallFilmstripSide, CallLayout } from "@/stores/call-prefs-store"
+import { CallTile } from "./call-tile"
+
+interface CallStageLayoutProps {
+  layout: CallLayout
+  /** Speaker filmstrip placement: horizontal row (`bottom`) or vertical column (`side`). */
+  filmstripSide: CallFilmstripSide
+  participants: CallRosterParticipant[]
+  currentUserId: string | null
+  workspaceId: string | null
+  /** View-only local pin (not the store): overrides the default speaker. `null` = default. */
+  pinnedUserId: string | null
+  onPin: (userId: string) => void
+}
+
+/** grid-cols by participant count: 1 up, 2×2 up to 4, 3×3 (scrolls) beyond. */
+function gridColsClass(count: number): string {
+  if (count <= 1) return "grid-cols-1"
+  if (count <= 4) return "grid-cols-2"
+  return "grid-cols-3"
+}
+
+/** Draggable self-view PiP, constrained to the stage. Defaults to the top-right. */
+function SelfPip({ participant, workspaceId }: { participant: CallRosterParticipant; workspaceId: string | null }) {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+  const drag = useRef<{ dx: number; dy: number } | null>(null)
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const box = e.currentTarget.getBoundingClientRect()
+    drag.current = { dx: e.clientX - box.left, dy: e.clientY - box.top }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    const stage = e.currentTarget.parentElement
+    if (!d || !stage) return
+    const bounds = stage.getBoundingClientRect()
+    const box = e.currentTarget.getBoundingClientRect()
+    const x = Math.min(Math.max(e.clientX - d.dx - bounds.left, 0), Math.max(bounds.width - box.width, 0))
+    const y = Math.min(Math.max(e.clientY - d.dy - bounds.top, 0), Math.max(bounds.height - box.height, 0))
+    setPos({ x, y })
+  }
+  const onPointerUp = () => {
+    drag.current = null
+  }
+
+  return (
+    <div
+      className="absolute h-24 w-16 touch-none overflow-hidden rounded-lg shadow-lg"
+      style={pos ? { left: pos.x, top: pos.y } : { right: 12, top: 12 }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      data-testid="call-self-pip"
+    >
+      <CallTile participant={participant} workspaceId={workspaceId} isSelf stage fill />
+    </div>
+  )
+}
+
+/**
+ * The in-call stage: Grid (equal responsive tiles) or Speaker (active speaker large
+ * + draggable self-PiP + filmstrip). Shared by the mobile drawer's Fullscreen and
+ * (chunk 6) the desktop dock's Fullscreen/Wide. Renders the stage region only; the
+ * caller owns the header (with {@link import("./layout-toggle").LayoutToggle}) and controls.
+ *
+ * Active speaker is pin-based, not audio-driven: v1 has no per-remote speaking level,
+ * so the default is the first joined non-self peer and a tap pins any tile. Auto-switch
+ * on the analyser signal is a follow-up once remote levels exist.
+ */
+export function CallStageLayout({
+  layout,
+  filmstripSide,
+  participants,
+  currentUserId,
+  workspaceId,
+  pinnedUserId,
+  onPin,
+}: CallStageLayoutProps) {
+  const users = useWorkspaceUsers(workspaceId ?? undefined)
+  const joined = participants.filter((p) => p.participantStatus === "joined")
+  const self = joined.find((p) => p.userId === currentUserId) ?? null
+  const nameFor = (userId: string) => users.find((u) => u.id === userId)?.name ?? "participant"
+
+  if (layout === "grid") {
+    return (
+      <div
+        className={cn(
+          // Row floor so a large group scrolls rather than compressing to slivers.
+          "grid min-h-0 flex-1 auto-rows-[minmax(7rem,1fr)] gap-2 overflow-y-auto bg-call-stage p-3",
+          gridColsClass(joined.length)
+        )}
+        data-testid="call-stage-grid"
+      >
+        {joined.map((p) => (
+          <button
+            key={p.userId}
+            type="button"
+            onClick={() => onPin(p.userId)}
+            aria-label={`Pin ${nameFor(p.userId)}`}
+            data-testid="call-grid-tile"
+            className="min-h-0 overflow-hidden rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <CallTile participant={p} workspaceId={workspaceId} isSelf={p.userId === currentUserId} stage fill />
+          </button>
+        ))}
+      </div>
+    )
+  }
+
+  const defaultSpeaker = joined.find((p) => p.userId !== currentUserId) ?? self
+  const speaker = joined.find((p) => p.userId === pinnedUserId) ?? defaultSpeaker
+  const selfPip = self && self !== speaker ? self : null
+  const filmstrip = joined.filter((p) => p !== speaker && p !== selfPip)
+
+  return (
+    <div
+      className={cn("flex min-h-0 flex-1 bg-call-stage", filmstripSide === "side" ? "flex-row" : "flex-col")}
+      data-testid="call-stage-speaker"
+      data-filmstrip-side={filmstripSide}
+    >
+      <div className="relative min-h-0 flex-1" data-testid="call-stage-main">
+        {speaker && (
+          <CallTile
+            participant={speaker}
+            workspaceId={workspaceId}
+            isSelf={speaker.userId === currentUserId}
+            stage
+            fill
+          />
+        )}
+        {selfPip && <SelfPip participant={selfPip} workspaceId={workspaceId} />}
+      </div>
+
+      {filmstrip.length > 0 && (
+        <div
+          className={cn(
+            "flex shrink-0 gap-2",
+            filmstripSide === "side" ? "flex-col overflow-y-auto px-2 py-3" : "overflow-x-auto px-3 py-2"
+          )}
+          data-testid="call-filmstrip"
+        >
+          {filmstrip.map((p) => (
+            <button
+              key={p.userId}
+              type="button"
+              onClick={() => onPin(p.userId)}
+              aria-label={`Pin ${nameFor(p.userId)}`}
+              data-testid="call-filmstrip-tile"
+              className="h-20 w-32 shrink-0 overflow-hidden rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <CallTile participant={p} workspaceId={workspaceId} isSelf={p.userId === currentUserId} stage fill />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -17,6 +17,7 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
+import { getCallPrefs, __resetCallPrefsForTests } from "@/stores/call-prefs-store"
 import type { CallController } from "@/calls/call-manager"
 import { MobileCallDrawer } from "./mobile-call-drawer"
 import { CallManagerProvider } from "./call-manager-context"
@@ -143,6 +144,8 @@ function setMode(m: CallSurfaceMode) {
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
   seedUsers()
   vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
 })
@@ -202,6 +205,33 @@ describe("MobileCallDrawer — mode rendering", () => {
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
     expect(screen.getByLabelText("Devices")).toBeInTheDocument()
     expect(screen.getAllByTestId("call-tile").length).toBeGreaterThan(0)
+  })
+})
+
+describe("MobileCallDrawer — fullscreen layout switch (ch5)", () => {
+  it("mounts the LayoutToggle and switches Speaker↔Grid, persisting the pref", async () => {
+    renderDrawer()
+    enterConnected([
+      participant({ userId: "usr_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+      participant({ userId: "usr_third", endpointId: "callep_third" }),
+    ])
+    setMode("full")
+
+    const speaker = screen.getByRole("radio", { name: "Speaker" })
+    const grid = screen.getByRole("radio", { name: "Grid" })
+    expect(speaker).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByTestId("call-stage-speaker")).toBeInTheDocument()
+    expect(screen.getByTestId("call-filmstrip")).toBeInTheDocument()
+
+    await userEvent.click(grid)
+    expect(getCallPrefs().layout).toBe("grid")
+    expect(screen.getByTestId("call-stage-grid")).toBeInTheDocument()
+    expect(screen.queryByTestId("call-stage-speaker")).toBeNull()
+
+    await userEvent.click(speaker)
+    expect(getCallPrefs().layout).toBe("speaker")
+    expect(screen.getByTestId("call-filmstrip")).toBeInTheDocument()
   })
 })
 

--- a/apps/frontend/src/components/call/mobile-call-drawer.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.tsx
@@ -10,9 +10,12 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
+import { useCallPrefs } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
+import { CallStageLayout } from "./call-stage-layout"
 import { CallControls } from "./call-controls"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
 import { DRAWER_MIN_HEIGHT, nearestMode } from "./mobile-call-drawer-snap"
 
@@ -192,51 +195,10 @@ function TinyGalleryView({ workspaceId, connectedAt, currentUserId, roster, spea
   )
 }
 
-/** Draggable self-view PiP, constrained to the stage. Defaults to the top-right. */
-function SelfPip({ participant, workspaceId }: { participant: CallRosterParticipant; workspaceId: string | null }) {
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
-  const drag = useRef<{ dx: number; dy: number } | null>(null)
-
-  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
-    const box = e.currentTarget.getBoundingClientRect()
-    drag.current = { dx: e.clientX - box.left, dy: e.clientY - box.top }
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }
-  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
-    const d = drag.current
-    const stage = e.currentTarget.parentElement
-    if (!d || !stage) return
-    const bounds = stage.getBoundingClientRect()
-    const box = e.currentTarget.getBoundingClientRect()
-    const x = Math.min(Math.max(e.clientX - d.dx - bounds.left, 0), Math.max(bounds.width - box.width, 0))
-    const y = Math.min(Math.max(e.clientY - d.dy - bounds.top, 0), Math.max(bounds.height - box.height, 0))
-    setPos({ x, y })
-  }
-  const onPointerUp = () => {
-    drag.current = null
-  }
-
-  return (
-    <div
-      className="absolute h-24 w-16 touch-none overflow-hidden rounded-lg shadow-lg"
-      style={pos ? { left: pos.x, top: pos.y } : { right: 12, top: 12 }}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      data-testid="call-self-pip"
-    >
-      <CallTile participant={participant} workspaceId={workspaceId} isSelf stage fill />
-    </div>
-  )
-}
-
 function FullscreenView({ workspaceId, connectedAt, currentUserId, roster, title }: ViewProps) {
-  const joined = roster.filter((p) => p.participantStatus === "joined")
-  const self = joined.find((p) => p.userId === currentUserId) ?? null
-  const peer = joined.find((p) => p.userId !== currentUserId) ?? null
-  const pinned = peer ?? self
-  const selfPip = self && self !== pinned ? self : null
-  const filmstrip = joined.filter((p) => p !== pinned && p !== selfPip)
+  const { layout } = useCallPrefs()
+  // View-only pin (not the store): overrides the default speaker until the call ends.
+  const [pinnedUserId, setPinnedUserId] = useState<string | null>(null)
 
   return (
     <div className="flex h-full flex-col bg-call-stage text-white">
@@ -253,33 +215,20 @@ function FullscreenView({ workspaceId, connectedAt, currentUserId, roster, title
           <span className="truncate text-sm font-medium">{title}</span>
           <CallTimer connectedAt={connectedAt} className="text-white/70" />
         </div>
-        {/* ch5 seam: <LayoutToggle/> (Speaker/Grid) mounts here and switches the stage
-            between this speaker+filmstrip layout and an equal-tile Grid. */}
-        <div data-testid="call-layout-slot" className="ml-auto" />
-      </div>
-
-      <div className="relative min-h-0 flex-1">
-        {pinned && (
-          <CallTile
-            participant={pinned}
-            workspaceId={workspaceId}
-            isSelf={pinned.userId === currentUserId}
-            stage
-            fill
-          />
-        )}
-        {selfPip && <SelfPip participant={selfPip} workspaceId={workspaceId} />}
-      </div>
-
-      {filmstrip.length > 0 && (
-        <div className="flex shrink-0 gap-2 overflow-x-auto px-3 py-2">
-          {filmstrip.map((p) => (
-            <div key={p.userId} className="h-20 w-32 shrink-0">
-              <CallTile participant={p} workspaceId={workspaceId} isSelf={p.userId === currentUserId} stage fill />
-            </div>
-          ))}
+        <div data-testid="call-layout-slot" className="ml-auto">
+          <LayoutToggle className="bg-white/10" />
         </div>
-      )}
+      </div>
+
+      <CallStageLayout
+        layout={layout}
+        filmstripSide="bottom"
+        participants={roster}
+        currentUserId={currentUserId}
+        workspaceId={workspaceId}
+        pinnedUserId={pinnedUserId}
+        onPin={setPinnedUserId}
+      />
 
       <div className="shrink-0 px-3 pb-3 pt-1">
         <CallControls />


### PR DESCRIPTION
**Chunk 5 of the calls UX overhaul stack** — stacked on #1475. Adds the **Speaker ↔ Grid** switch to the fully-open call view.

## What's here
- **`CallStageLayout`** — a reusable stage: **Grid** (equal responsive tiles, 1 → 2×2 → 3×3, with a row floor so large groups scroll instead of compressing) or **Speaker** (active speaker large + a draggable **self-PiP** + a filmstrip placed **bottom or side**). It owns the `SelfPip` (moved out of the drawer, not duplicated — INV-38). Camera-off tiles show avatar initials on the dark `--call-stage` bed. Shared by the mobile drawer (wired here) and the desktop dock (chunk 6).
- **Active speaker = pin-based** (deterministic): tap any filmstrip/grid tile to pin them; default is the first peer. v1 has no per-remote speaking level, so there's no fake audio-driven switch (analyser auto-select is a flagged follow-up once remote levels exist); a departed pin falls back cleanly.
- The mobile drawer's **Fullscreen** now mounts `LayoutToggle` in its header seam and delegates the stage to `CallStageLayout` (mobile is always bottom-filmstrip; the bottom/side choice is desktop → chunk 6). `TinyGalleryView` (standard mode) is unchanged.

## Review + testing
- **Adversarial verify** (Opus/xhigh) verdict **SHIP** — no correctness defects (solo/empty-filmstrip, departed-pin fallback, the SelfPip move-not-duplicate, and the PiP drag-parent all verified clean). Two LOW polish notes; the grid-scroll one is folded in here.
- Frontend typecheck + lint clean; `CallStageLayout` / drawer / layout-toggle / call-prefs tests green (28 focused; 84 across the call components — desktop dock unregressed).

## Screenshots
Mobile Speaker + Grid shots land in the batched harness pass (with the drawer + dock) — added here + posted in the design channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787182843&installation_model_id=20758&pr_number=1476&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1476&signature=2d2efd39360ba2693d9100aaa7aa37476fe129ff231031b2142866ae0e317870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->