### PR TITLE
feat(calls): desktop resizable dock — top or side, snapping, pushes content

### DIFF
--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -543,7 +543,16 @@ export class CallManager implements CallController {
     // Recapture the whole stream (mic + camera if live) so iOS single-active-
     // capture never mutes the surviving track; serialized on the capture chain.
     await this.serializeCapture(session, async () => {
-      await this.doCaptureAndPublish(session, { camera: session.cameraTrack != null, inputDeviceId: deviceId })
+      // Thread the CURRENT camera selection through the recapture — a mic change
+      // that re-acquires the live video track must keep the chosen camera, not
+      // silently revert to the browser default.
+      const devices = getCallState().local.devices
+      await this.doCaptureAndPublish(session, {
+        camera: session.cameraTrack != null,
+        inputDeviceId: deviceId,
+        cameraDeviceId: devices.selectedCameraId,
+        facingMode: devices.facingMode,
+      })
       patchCallLocal({ devices: { ...getCallState().local.devices, selectedInputId: deviceId } })
     })
     await this.refreshDevices()

--- a/apps/frontend/src/components/call/call-capture-error.tsx
+++ b/apps/frontend/src/components/call/call-capture-error.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils"
+import type { CallCaptureErrorInfo } from "@/stores/call-store"
+
+export function captureErrorText(code: CallCaptureErrorInfo["code"]): string {
+  return code === "capture_rollback_failed"
+    ? "Your microphone stopped working and couldn't be restored. Try leaving and rejoining."
+    : "Couldn't switch your microphone or camera. Your previous device is still active."
+}
+
+/**
+ * In-surface banner for a mid-call capture failure. Shared by the mobile drawer
+ * and the desktop dock (INV-35); the caller supplies surface-specific margins via
+ * `className`.
+ */
+export function CaptureErrorBanner({ error, className }: { error: CallCaptureErrorInfo; className?: string }) {
+  return (
+    <p
+      className={cn("rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive", className)}
+      role="alert"
+      data-testid="call-capture-error"
+    >
+      {captureErrorText(error.code)}
+    </p>
+  )
+}

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -17,6 +17,7 @@ import {
   bumpCallMediaEpoch,
   type CallRosterParticipant,
 } from "@/stores/call-store"
+import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
 import { CallCaptureError, type CallController } from "@/calls/call-manager"
 import { CallDock } from "./call-dock"
 import { CallManagerProvider } from "./call-manager-context"
@@ -133,6 +134,8 @@ function enterConnectedCall(roster: CallRosterParticipant[]) {
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
   seedUsers()
   vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
 })
@@ -264,16 +267,16 @@ describe("CallDock — pre-join permission taxonomy", () => {
     expect(manager.startCall).not.toHaveBeenCalled()
   })
 
-  it("re-expands the pre-join gate on a fresh launch after a collapse", async () => {
+  it("shows the pre-join gate on a fresh launch after the prior call was minimized", async () => {
     const startCall = vi.fn(() => new Promise<void>(() => {}))
     renderDock(makeManager({ startCall }))
+    // Enter a connected call, then minimize the desktop dock to its Rail.
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
-    await userEvent.click(screen.getByLabelText("Collapse call"))
+    await userEvent.click(screen.getByLabelText("Minimize call"))
     expect(screen.getByLabelText("Expand call")).toBeInTheDocument()
+    // Call ends; a fresh launch must surface the pre-join gate, not stay hidden.
     act(() => setCallPhase("idle"))
     await userEvent.click(screen.getByText("launch"))
-    // Without resetting `collapsed` on the launch, the gate stays hidden behind
-    // the pill and this spinner never appears.
     expect(await screen.findByText("Joining…")).toBeInTheDocument()
   })
 })
@@ -299,8 +302,9 @@ describe("CallDock — mobile drawer vs desktop dock", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     expect(screen.queryByTestId("mobile-call-drawer")).toBeNull()
+    expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
     expect(screen.getByTestId("call-tile")).toBeInTheDocument()
-    expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
   })
 
   it("opens the drawer's compact controls when the Tab pill is tapped", async () => {

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,25 +1,12 @@
 import { useEffect, useState, type ReactNode } from "react"
-import { toast } from "sonner"
-import { AlertTriangle, ChevronDown, ChevronUp, Mic, MicOff, PhoneOff, Video, VideoOff } from "lucide-react"
+import { ChevronDown, ChevronUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SidePanel, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { useStreamName } from "@/hooks/use-stream-name"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { cn } from "@/lib/utils"
-import { useCallManager } from "./call-manager-context"
+import { getCallState, setCallSurfaceMode } from "@/stores/call-store"
 import { useCallLaunch } from "./call-launch-context"
-import {
-  useCallActiveElsewhere,
-  useCallCameraOn,
-  useCallCaptureError,
-  useCallMode,
-  useCallMuted,
-  useCallPhase,
-  useCallRoster,
-  useCallStreamId,
-  useCallWorkspaceId,
-} from "./call-store-hooks"
+import { useCallActiveElsewhere, useCallPhase, useCallStreamId, useCallWorkspaceId } from "./call-store-hooks"
 
 // Bottom-anchored call surfaces clear the iOS home indicator on desktop (app
 // convention — see message-composer.tsx) and, on a phone, sit a composer-height
@@ -35,9 +22,8 @@ export const DOCK_BOTTOM =
 // live at the dock's bottom edge).
 export const RING_ABOVE_DOCK_BOTTOM =
   "bottom-[calc(var(--composer-height,5rem)_+_5.5rem)] sm:bottom-[calc(max(1rem,env(safe-area-inset-bottom))_+_4.5rem)]"
-import { CallTile } from "./call-tile"
-import { CallControls } from "./call-controls"
 import { MobileCallDrawer } from "./mobile-call-drawer"
+import { DesktopCallDock } from "./desktop-call-dock"
 import { PreJoinGate } from "./pre-join-gate"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 
@@ -98,11 +84,11 @@ export function CallDock() {
     if (launching || joining) setCollapsed(false)
   }, [launching, joining])
 
-  // On connect, reset the sticky flag so the desktop dock opens full. Mobile
-  // renders the top drawer (driven by `surfaceMode`, not this flag), so the value
-  // is inert there — kept only to govern the desktop dock's collapse.
+  // On connect, open the desktop dock to a visible size — `min` (the Rail/Tab) is
+  // too minimal a default. Mobile keeps its Tab (min). `surfaceMode` is shared but
+  // only one surface renders per session, so this doesn't fight the drawer.
   useEffect(() => {
-    if (inCall) setCollapsed(isMobile)
+    if (inCall && !isMobile && getCallState().surfaceMode === "min") setCallSurfaceMode("compact")
   }, [inCall, isMobile])
 
   // Nothing to show: idle with no launch in flight. Surface the cross-tab chip if
@@ -121,16 +107,9 @@ export function CallDock() {
   const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
 
   if (inCall) {
-    // Mobile gets the 4-mode global top drawer; desktop keeps the dock (chunk 6).
+    // Mobile gets the 4-mode global top drawer; desktop gets the resizable dock.
     if (isMobile) return <MobileCallDrawer workspaceId={workspaceId} streamId={streamIdForLabel} />
-    return (
-      <ActiveCallDock
-        workspaceId={workspaceId}
-        streamId={streamIdForLabel}
-        collapsed={collapsed}
-        onToggle={() => setCollapsed((c) => !c)}
-      />
-    )
+    return <DesktopCallDock workspaceId={workspaceId} streamId={streamIdForLabel} />
   }
 
   // Joining / permission gate.
@@ -146,130 +125,4 @@ export function CallDock() {
 
 function JoiningBody() {
   return <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Connecting…</div>
-}
-
-function ActiveCallDock({
-  workspaceId,
-  streamId,
-  collapsed,
-  onToggle,
-}: {
-  workspaceId: string | null
-  streamId: string | null
-  collapsed: boolean
-  onToggle: () => void
-}) {
-  const roster = useCallRoster()
-  const captureError = useCallCaptureError()
-  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
-  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
-  const title = name ?? "Call"
-
-  const participants = roster.filter((p) => p.participantStatus === "joined")
-
-  if (collapsed) return <CollapsedDock title={title} onToggle={onToggle} />
-
-  return (
-    <DockFrame>
-      <DockHeader title={title} collapsed={collapsed} onToggle={onToggle} />
-      <div className="flex flex-col gap-3 p-3">
-        {captureError && (
-          <p
-            className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
-            role="alert"
-            data-testid="call-capture-error"
-          >
-            {captureError.code === "capture_rollback_failed"
-              ? "Your microphone stopped working and couldn't be restored. Try leaving and rejoining."
-              : "Couldn't switch your microphone or camera. Your previous device is still active."}
-          </p>
-        )}
-        <div
-          className={cn(
-            "grid max-h-[50vh] gap-2 overflow-y-auto",
-            participants.length > 1 ? "grid-cols-2" : "grid-cols-1"
-          )}
-        >
-          {participants.map((p) => (
-            <CallTile
-              key={p.userId}
-              participant={p}
-              workspaceId={workspaceId}
-              isSelf={!!currentUserId && p.userId === currentUserId}
-            />
-          ))}
-        </div>
-        <CallControls />
-      </div>
-    </DockFrame>
-  )
-}
-
-function CollapsedDock({ title, onToggle }: { title: string; onToggle: () => void }) {
-  const manager = useCallManager()
-  const muted = useCallMuted()
-  const cameraOn = useCallCameraOn()
-  const mode = useCallMode()
-  const captureError = useCallCaptureError()
-  return (
-    <div
-      className={cn(
-        "fixed right-4 z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl",
-        DOCK_BOTTOM
-      )}
-    >
-      {captureError && (
-        // Compact mirror of the expanded banner — a recapture failure must stay
-        // visible while collapsed. The full message is on expand.
-        <span
-          className="flex h-8 w-8 items-center justify-center rounded-full text-destructive"
-          role="alert"
-          data-testid="call-capture-error"
-          aria-label="Microphone or camera problem — expand the call to see details"
-        >
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-        </span>
-      )}
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-label="Expand call"
-        aria-expanded={false}
-        className="max-w-[140px] truncate text-sm font-medium"
-      >
-        {title}
-      </button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className={cn("h-8 w-8", muted && "text-destructive")}
-        aria-label={muted ? "Unmute" : "Mute"}
-        aria-pressed={muted}
-        onClick={() => manager.setMuted(!muted)}
-      >
-        {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
-      </Button>
-      {mode !== "audio_only" && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
-          aria-pressed={cameraOn}
-          onClick={() => void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))}
-        >
-          {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
-        </Button>
-      )}
-      <Button
-        variant="destructive"
-        size="icon"
-        className="h-8 w-8"
-        aria-label="Leave call"
-        onClick={() => void manager.leaveCall().catch(() => toast.error("Couldn't leave the call"))}
-      >
-        <PhoneOff className="h-4 w-4" />
-      </Button>
-    </div>
-  )
 }

--- a/apps/frontend/src/components/call/call-timer.tsx
+++ b/apps/frontend/src/components/call/call-timer.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { cn } from "@/lib/utils"
+
+/** mm:ss, or h:mm:ss past an hour. */
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const mm = h > 0 ? String(m).padStart(2, "0") : String(m)
+  const ss = String(s).padStart(2, "0")
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
+}
+
+/**
+ * Live call-duration readout, ticking once a second off `connectedAt`. Shared by
+ * the mobile drawer and the desktop dock (INV-35) — both surfaces show it.
+ */
+export function CallTimer({ connectedAt, className }: { connectedAt: number | null; className?: string }) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  const elapsed = connectedAt == null ? 0 : now - connectedAt
+  return (
+    <span className={cn("font-mono text-sm tabular-nums", className)} aria-label="Call duration">
+      {formatElapsed(elapsed)}
+    </span>
+  )
+}

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -1,0 +1,387 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, fireEvent } from "@testing-library/react"
+import { render, screen, userEvent } from "@/test"
+import * as authModule from "@/auth"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import {
+  clearCallState,
+  getCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  setCallSurfaceMode,
+  setCallCaptureError,
+  type CallRosterParticipant,
+  type CallSurfaceMode,
+} from "@/stores/call-store"
+import {
+  getCallPrefs,
+  setCallDockPosition,
+  __resetCallPrefsForTests,
+  type CallDockPosition,
+} from "@/stores/call-prefs-store"
+import type { CallController } from "@/calls/call-manager"
+import { DesktopCallDock } from "./desktop-call-dock"
+import { CallManagerProvider } from "./call-manager-context"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_self",
+    participantStatus: "joined",
+    endpointId: "callep_self",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+function renderDock(manager: CallController = makeManager()) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <DesktopCallDock workspaceId={WORKSPACE_ID} streamId="stream_1" />
+    </CallManagerProvider>
+  )
+}
+
+function enterConnected(roster: CallRosterParticipant[]) {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallRoster(roster, 1)
+  })
+}
+
+function setMode(m: CallSurfaceMode) {
+  act(() => setCallSurfaceMode(m))
+}
+
+function setPosition(p: CallDockPosition) {
+  act(() => setCallDockPosition(p))
+}
+
+const TWO_PEERS: CallRosterParticipant[] = [
+  participant({ userId: "usr_self" }),
+  participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+]
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
+  document.documentElement.removeAttribute("style")
+  seedUsers()
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("DesktopCallDock — side dock presentations", () => {
+  it("min renders the Rail: restore chevron + timer, no controls", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("side")
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-mode", "min")
+    expect(dock).toHaveAttribute("data-position", "side")
+    expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Mute")).toBeNull()
+  })
+
+  it("compact renders the Panel: tile grid, controls, minimize, and the Top/Side toggle", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setPosition("side")
+    setMode("compact")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "compact")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Side" })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
+  })
+
+  it("standard renders the Wide gallery: tiles + controls", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setPosition("side")
+    setMode("standard")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+  })
+})
+
+describe("DesktopCallDock — top dock presentations", () => {
+  it("min renders the Tab: timer only, tap to expand", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("top")
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-mode", "min")
+    expect(dock).toHaveAttribute("data-position", "top")
+    expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Mute")).toBeNull()
+  })
+
+  it("compact renders the Bar: timer + mute/camera/leave + the Top/Side toggle", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("top")
+    setMode("compact")
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
+  })
+
+  it("standard renders the Gallery: tiles row + controls + minimize", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setPosition("top")
+    setMode("standard")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
+  })
+})
+
+describe("DesktopCallDock — dock-position toggle", () => {
+  it("switches orientation and persists, preserving surfaceMode", async () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setPosition("side")
+    setMode("compact")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-position", "side")
+
+    await userEvent.click(screen.getByRole("radio", { name: "Top" }))
+    expect(getCallPrefs().dockPosition).toBe("top")
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-position", "top")
+    // surfaceMode is preserved across the re-orientation.
+    expect(dock).toHaveAttribute("data-mode", "compact")
+    expect(getCallState().surfaceMode).toBe("compact")
+  })
+})
+
+describe("DesktopCallDock — fullscreen", () => {
+  it("mounts the ch5 stage, LayoutToggle, and the desktop filmstrip-side toggle", () => {
+    renderDock()
+    enterConnected([
+      participant({ userId: "usr_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+      participant({ userId: "usr_third", endpointId: "callep_third" }),
+    ])
+    setPosition("side")
+    setMode("full")
+    expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
+    expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
+    expect(screen.getByTestId("call-stage-speaker")).toBeInTheDocument()
+    expect(screen.getByTestId("call-filmstrip-side-toggle")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+  })
+
+  it("the filmstrip-side toggle writes and persists filmstripSide", async () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("full")
+    expect(getCallPrefs().filmstripSide).toBe("bottom")
+    await userEvent.click(screen.getByRole("radio", { name: "Filmstrip side" }))
+    expect(getCallPrefs().filmstripSide).toBe("side")
+    expect(screen.getByTestId("call-stage-speaker")).toHaveAttribute("data-filmstrip-side", "side")
+  })
+
+  it("the collapse control lowers fullscreen to standard", async () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("full")
+    await userEvent.click(screen.getByLabelText("Collapse call"))
+    expect(getCallState().surfaceMode).toBe("standard")
+  })
+})
+
+describe("DesktopCallDock — content push var", () => {
+  function insetRight() {
+    return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
+  }
+  function insetTop() {
+    return document.documentElement.style.getPropertyValue("--call-dock-inset-top")
+  }
+
+  it("reserves the resting side width and no top inset when docked to the side", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("side")
+    setMode("compact")
+    expect(insetRight()).toBe("320px")
+    expect(insetTop()).toBe("0px")
+    setMode("standard")
+    expect(insetRight()).toBe("520px")
+  })
+
+  it("reserves the resting top height and no side inset when docked to the top", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("top")
+    setMode("standard")
+    expect(insetTop()).toBe("220px")
+    expect(insetRight()).toBe("0px")
+  })
+
+  it("drops both insets to 0 in fullscreen (the dock overlays, not pushes)", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("side")
+    setMode("full")
+    expect(insetRight()).toBe("0px")
+    expect(insetTop()).toBe("0px")
+  })
+
+  it("resets both insets to 0 when the dock unmounts", () => {
+    const { unmount } = renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("side")
+    setMode("compact")
+    expect(insetRight()).toBe("320px")
+    unmount()
+    expect(insetRight()).toBe("0px")
+    expect(insetTop()).toBe("0px")
+  })
+})
+
+describe("DesktopCallDock — capture error", () => {
+  it("surfaces a mid-call capture error banner in the Panel", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("side")
+    setMode("compact")
+    act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
+    expect(screen.getByTestId("call-capture-error")).toHaveTextContent(/couldn't be restored/i)
+  })
+})
+
+describe("DesktopCallDock — drag settles (no wedge)", () => {
+  // jsdom has neither setPointerCapture nor a real layout; stub the rects the
+  // handlers read so the drag physics run (the panel measures itself + the root).
+  function stubRect(el: HTMLElement, box: Partial<DOMRect>) {
+    el.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}), ...box }) as DOMRect
+  }
+
+  it("dragging the side handle past the wide→full threshold keeps the handle mounted and settles to full", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setPosition("side")
+    setMode("standard")
+    const dock = screen.getByTestId("desktop-call-dock")
+    stubRect(dock, { width: 520 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
+    const handle = screen.getByTestId("call-dock-handle")
+    handle.setPointerCapture = vi.fn()
+    // Drag the left edge leftward ~300px → width ~820 (> the 520↔900 midpoint 710)
+    // → crosses into fullscreen mid-drag; the handle must stay mounted.
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 200, pointerId: 1 })
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "full")
+    expect(screen.getByTestId("call-dock-handle")).toBeInTheDocument()
+    fireEvent.pointerUp(handle, { clientX: 200, pointerId: 1 })
+    expect(getCallState().surfaceMode).toBe("full")
+  })
+
+  it("a pointercancel mid-drag settles instead of wedging", () => {
+    renderDock()
+    enterConnected([participant({ userId: "usr_self" })])
+    setPosition("top")
+    setMode("compact")
+    const dock = screen.getByTestId("desktop-call-dock")
+    stubRect(dock, { height: 72 })
+    stubRect(dock.parentElement as HTMLElement, { height: 800 })
+    const handle = screen.getByTestId("call-dock-handle")
+    handle.setPointerCapture = vi.fn()
+    fireEvent.pointerDown(handle, { clientY: 100, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientY: 500, pointerId: 1 })
+    fireEvent.pointerCancel(handle, { clientY: 500, pointerId: 1 })
+    // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
+    expect(["standard", "full"]).toContain(getCallState().surfaceMode)
+  })
+})

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -348,7 +348,7 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
       ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}), ...box }) as DOMRect
   }
 
-  it("dragging the side handle past the wide→full threshold keeps the handle mounted and settles to full", () => {
+  it("dragging the side handle past the wide→full threshold caps the preview at standard and settles to full", () => {
     renderDock()
     enterConnected(TWO_PEERS)
     setPosition("side")
@@ -358,14 +358,18 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
     stubRect(dock.parentElement as HTMLElement, { width: 900 })
     const handle = screen.getByTestId("call-dock-handle")
     handle.setPointerCapture = vi.fn()
-    // Drag the left edge leftward ~300px → width ~820 (> the 520↔900 midpoint 710)
-    // → crosses into fullscreen mid-drag; the handle must stay mounted.
+    // Drag the left edge leftward ~300px → width ~820 (past the full threshold).
     fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
     fireEvent.pointerMove(handle, { clientX: 200, pointerId: 1 })
-    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "full")
+    // Mid-drag the preview caps at `standard` (the fullscreen stage never mounts
+    // during a drag — that thrash is what hung the capture harness), and the handle
+    // stays mounted so the settle can fire.
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
     expect(screen.getByTestId("call-dock-handle")).toBeInTheDocument()
     fireEvent.pointerUp(handle, { clientX: 200, pointerId: 1 })
     expect(getCallState().surfaceMode).toBe("full")
+    // The handle is still mounted at rest-fullscreen (drag back out of fullscreen).
+    expect(screen.getByTestId("call-dock-handle")).toBeInTheDocument()
   })
 
   it("a pointercancel mid-drag settles instead of wedging", () => {

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -43,19 +43,27 @@ const REDUCED_MOTION =
   typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
 
 const MODES: readonly CallSurfaceMode[] = ["min", "compact", "standard", "full"]
+const MODE_INDEX: Record<CallSurfaceMode, number> = { min: 0, compact: 1, standard: 2, full: 3 }
 
-/** Resting sizes (px) of the min/compact/standard steps; `full` is the content dimension, measured per drag. */
+/** The 3 pushing step sizes (px) — min/compact/standard; `full` = the whole content region. */
 const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
 const TOP_STEP_SIZES: readonly number[] = [44, 72, 220]
 
-// Resting size (px) per mode for the dock panel AND the content-push inset it
-// reserves. `full` overlays (inset 0). Both are clamped to the measured content
-// region at render so a narrow window / wide sidebar can't push the panel over the
-// sidebar or collapse the timeline to nothing (the content region is the ceiling).
-const SIDE_RESTING: Record<CallSurfaceMode, number> = { min: 56, compact: 320, standard: 520, full: 0 }
-const TOP_RESTING: Record<CallSurfaceMode, number> = { min: 44, compact: 72, standard: 220, full: 0 }
-const SIDE_INSET: Record<CallSurfaceMode, number> = { min: 56, compact: 320, standard: 520, full: 0 }
-const TOP_INSET: Record<CallSurfaceMode, number> = { min: 44, compact: 72, standard: 220, full: 0 }
+// Always leave this much of the conversation beside/below a pushing dock, so a
+// narrow window / wide sidebar can't collapse the timeline to nothing.
+const MIN_CONTENT = 320
+
+/**
+ * The 4 snap detents [min, compact, standard, full] for a given axis ceiling (the
+ * measured content region). The pushing steps are capped to `ceil - MIN_CONTENT`
+ * (leaving timeline) and `full` is the whole ceiling — guaranteeing a NON-DECREASING
+ * list even on a tiny window (so the snap never sees an unsorted/duplicate-final
+ * detent), and the inset a pushing mode reserves never exceeds `ceil - MIN_CONTENT`.
+ */
+function dockDetents(steps: readonly number[], ceil: number): number[] {
+  const cap = Math.max(steps[0], ceil - MIN_CONTENT)
+  return [steps[0], Math.min(steps[1], cap), Math.min(steps[2], cap), ceil]
+}
 
 interface DockViewProps {
   workspaceId: string | null
@@ -313,7 +321,7 @@ function TopGalleryView({ workspaceId, currentUserId, roster, captureError, titl
 }
 
 /** Fullscreen (both orientations): the ch5 stage with a permanent header of call controls/toggles. */
-function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title }: DockViewProps) {
+function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title, captureError }: DockViewProps) {
   const { layout, filmstripSide } = useCallPrefs()
   const joined = roster.filter((p) => p.participantStatus === "joined")
   // View-only pin (not the store): overrides the default speaker until the call ends.
@@ -321,6 +329,7 @@ function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, t
 
   return (
     <div className="flex h-full w-full flex-col bg-call-stage text-white">
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className="flex items-center gap-2 px-3 py-2">
         <button
           type="button"
@@ -472,10 +481,13 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const ceilW = content.w || Infinity
   const ceilH = content.h || Infinity
 
-  // Content push: reserve the resting size (clamped to the content region) on :root
-  // so the main content region (AppShell's <main>) reflows. Fullscreen overlays → 0.
-  const insetRight = isSide ? Math.min(SIDE_INSET[surfaceMode], ceilW) : 0
-  const insetTop = isSide ? 0 : Math.min(TOP_INSET[surfaceMode], ceilH)
+  const detentsW = dockDetents(SIDE_STEP_SIZES, ceilW)
+  const detentsH = dockDetents(TOP_STEP_SIZES, ceilH)
+
+  // Content push: reserve the pushing mode's detent (which already leaves MIN_CONTENT)
+  // on :root so the main content region (AppShell's <main>) reflows. Fullscreen → 0.
+  const insetRight = isSide && surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
+  const insetTop = !isSide && surfaceMode !== "full" ? detentsH[MODE_INDEX[surfaceMode]] : 0
   useEffect(() => {
     const root = document.documentElement
     root.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
@@ -535,17 +547,26 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     drag.current = null
     setDragging(false)
     setDragSize(null)
-    if (d) setCallSurfaceMode(MODES[nearestStep(d.size, d.velocity, [...stepSizes, d.full])])
+    if (d) {
+      // A pause before release means the drag stopped — don't flick on stale velocity.
+      const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
+      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(stepSizes, d.full))])
+    }
   }
 
   const speaker = roster.find((p) => p.participantStatus === "joined" && p.userId !== currentUserId) ?? null
   const speakerName = speaker ? (users.find((u) => u.id === speaker.userId)?.name ?? null) : null
 
   const dragFull = drag.current?.full ?? stepSizes[stepSizes.length - 1]
-  const contentMode: CallSurfaceMode =
-    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, [...stepSizes, dragFull])] : surfaceMode
+  const dragMode =
+    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(stepSizes, dragFull))] : null
+  // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
+  // thrashes the drag) — the preview caps at `standard`; fullscreen mounts on release.
+  const cappedDragMode = dragMode === "full" ? "standard" : dragMode
+  const contentMode: CallSurfaceMode = cappedDragMode ?? surfaceMode
+  const detents = isSide ? detentsW : detentsH
 
-  const restingFull = !dragging && contentMode === "full"
+  const restingFull = !dragging && surfaceMode === "full"
   let positionClass: string
   let sizeStyle: CSSProperties
   if (restingFull) {
@@ -553,11 +574,11 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     sizeStyle = {}
   } else if (isSide) {
     positionClass = "inset-y-0 right-0"
-    const w = dragging && dragSize != null ? dragSize : Math.min(SIDE_RESTING[contentMode], ceilW)
+    const w = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
     sizeStyle = { width: `${w}px` }
   } else {
     positionClass = "inset-x-0 top-0"
-    const h = dragging && dragSize != null ? dragSize : Math.min(TOP_RESTING[contentMode], ceilH)
+    const h = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
     sizeStyle = { height: `${h}px` }
   }
 
@@ -592,17 +613,15 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         style={sizeStyle}
       >
         <DockBody dockPosition={dockPosition} mode={contentMode} view={view} />
-        {/* Keep the handle mounted while dragging even after the content crosses into
-            `full`: it holds the pointer capture + the pointerup/cancel settle, so
-            unmounting it mid-drag would strand `dragging` true and wedge the dock. */}
-        {(dragging || contentMode !== "full") && (
-          <DockResizeHandle
-            orientation={dockPosition}
-            onPointerDown={onPointerDown}
-            onPointerMove={onPointerMove}
-            onPointerUp={onPointerUp}
-          />
-        )}
+        {/* Always mounted — including at rest-fullscreen — so it holds the pointer
+            capture/settle through a drag into full AND lets you drag back OUT of
+            fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}
+        <DockResizeHandle
+          orientation={dockPosition}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+        />
       </div>
     </div>
   )

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,0 +1,609 @@
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronLeft,
+  Minimize2,
+  PanelBottom,
+  PanelRight,
+  PanelTop,
+  Users,
+} from "lucide-react"
+import { getAvatarUrl } from "@threa/types"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { cn } from "@/lib/utils"
+import { getInitials } from "@/lib/initials"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+import {
+  setCallSurfaceMode,
+  type CallCaptureErrorInfo,
+  type CallRosterParticipant,
+  type CallSurfaceMode,
+} from "@/stores/call-store"
+import {
+  useCallPrefs,
+  setCallDockPosition,
+  setCallFilmstripSide,
+  type CallDockPosition,
+} from "@/stores/call-prefs-store"
+import { CallTile } from "./call-tile"
+import { CallControls } from "./call-controls"
+import { CallStageLayout } from "./call-stage-layout"
+import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { CallTimer } from "./call-timer"
+import { CaptureErrorBanner } from "./call-capture-error"
+import { LayoutToggle } from "./layout-toggle"
+import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
+import { nearestStep } from "./mobile-call-drawer-snap"
+
+const REDUCED_MOTION =
+  typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+
+const MODES: readonly CallSurfaceMode[] = ["min", "compact", "standard", "full"]
+
+/** Resting sizes (px) of the min/compact/standard steps; `full` is the content dimension, measured per drag. */
+const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
+const TOP_STEP_SIZES: readonly number[] = [44, 72, 220]
+
+// Resting size (px) per mode for the dock panel AND the content-push inset it
+// reserves. `full` overlays (inset 0). Both are clamped to the measured content
+// region at render so a narrow window / wide sidebar can't push the panel over the
+// sidebar or collapse the timeline to nothing (the content region is the ceiling).
+const SIDE_RESTING: Record<CallSurfaceMode, number> = { min: 56, compact: 320, standard: 520, full: 0 }
+const TOP_RESTING: Record<CallSurfaceMode, number> = { min: 44, compact: 72, standard: 220, full: 0 }
+const SIDE_INSET: Record<CallSurfaceMode, number> = { min: 56, compact: 320, standard: 520, full: 0 }
+const TOP_INSET: Record<CallSurfaceMode, number> = { min: 44, compact: 72, standard: 220, full: 0 }
+
+interface DockViewProps {
+  workspaceId: string | null
+  connectedAt: number | null
+  currentUserId: string | null
+  roster: CallRosterParticipant[]
+  users: ReturnType<typeof useWorkspaceUsers>
+  captureError: CallCaptureErrorInfo | null
+  title: string
+  speakerName: string | null
+}
+
+function DockPositionToggle({ dark = false }: { dark?: boolean }) {
+  const { dockPosition } = useCallPrefs()
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      role="radiogroup"
+      value={dockPosition}
+      onValueChange={(next) => {
+        if (next === "top" || next === "side") setCallDockPosition(next)
+      }}
+      aria-label="Dock position"
+      data-testid="call-dock-position-toggle"
+      className={cn("shrink-0 gap-0.5 rounded-md p-0.5", dark ? "bg-white/10" : "bg-muted")}
+    >
+      <ToggleGroupItem value="top" aria-label="Top" title="Dock to the top" className="h-7 px-2 [&_svg]:size-3.5">
+        <PanelTop aria-hidden="true" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="side" aria-label="Side" title="Dock to the side" className="h-7 px-2 [&_svg]:size-3.5">
+        <PanelRight aria-hidden="true" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}
+
+function FilmstripSideToggle() {
+  const { filmstripSide } = useCallPrefs()
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      role="radiogroup"
+      value={filmstripSide}
+      onValueChange={(next) => {
+        if (next === "bottom" || next === "side") setCallFilmstripSide(next)
+      }}
+      aria-label="Filmstrip position"
+      data-testid="call-filmstrip-side-toggle"
+      className="shrink-0 gap-0.5 rounded-md bg-white/10 p-0.5"
+    >
+      <ToggleGroupItem
+        value="bottom"
+        aria-label="Filmstrip bottom"
+        title="Filmstrip along the bottom"
+        className="h-7 px-2 [&_svg]:size-3.5"
+      >
+        <PanelBottom aria-hidden="true" />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="side"
+        aria-label="Filmstrip side"
+        title="Filmstrip down the side"
+        className="h-7 px-2 [&_svg]:size-3.5"
+      >
+        <PanelRight aria-hidden="true" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}
+
+function MinimizeButton() {
+  return (
+    <button
+      type="button"
+      aria-label="Minimize call"
+      onClick={() => setCallSurfaceMode("min")}
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      <Minimize2 className="h-4 w-4" />
+    </button>
+  )
+}
+
+/** Title + Top/Side toggle + minimize, shared by the side Panel/Wide and the top Gallery. */
+function DockHeaderBar({ title }: { title: string }) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+      <DockPositionToggle />
+      <MinimizeButton />
+    </div>
+  )
+}
+
+function RailAvatars({ roster, users, workspaceId }: Pick<DockViewProps, "roster" | "users" | "workspaceId">) {
+  const joined = roster.filter((p) => p.participantStatus === "joined").slice(0, 4)
+  return (
+    <div className="flex flex-col items-center gap-1.5 overflow-hidden">
+      {joined.map((p) => {
+        const u = users.find((x) => x.id === p.userId)
+        const url = u?.avatarUrl && workspaceId ? getAvatarUrl(workspaceId, u.avatarUrl, 64) : undefined
+        return (
+          <Avatar key={p.userId} className="h-8 w-8">
+            {url && <AvatarImage src={url} alt={u?.name ?? "participant"} />}
+            <AvatarFallback className="text-xs">{getInitials(u?.name ?? "?")}</AvatarFallback>
+          </Avatar>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Side `min`: a 56px icon strip — restore chevron, live/error dot, avatars, timer. */
+function SideRailView({ roster, users, workspaceId, connectedAt, captureError }: DockViewProps) {
+  return (
+    <div className="flex h-full w-full flex-col items-center gap-2 border-l bg-background py-3">
+      <button
+        type="button"
+        aria-label="Expand call"
+        onClick={() => setCallSurfaceMode("compact")}
+        className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      {captureError ? (
+        <span
+          className="flex h-5 w-5 items-center justify-center text-destructive"
+          role="alert"
+          data-testid="call-capture-error"
+          aria-label="Microphone or camera problem — expand the call to see details"
+        >
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+        </span>
+      ) : (
+        <span
+          className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
+          aria-hidden
+        />
+      )}
+      <RailAvatars roster={roster} users={users} workspaceId={workspaceId} />
+      <div className="mt-auto">
+        <CallTimer connectedAt={connectedAt} className="text-xs" />
+      </div>
+    </div>
+  )
+}
+
+/** Side `compact`/`standard`: header + tile grid + controls (the panel width does the sizing). */
+function SideTilesView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  return (
+    <div className="flex h-full w-full flex-col border-l bg-background">
+      <DockHeaderBar title={title} />
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
+        {joined.map((p) => (
+          <CallTile
+            key={p.userId}
+            participant={p}
+            workspaceId={workspaceId}
+            isSelf={!!currentUserId && p.userId === currentUserId}
+          />
+        ))}
+      </div>
+      <div className="shrink-0 border-t p-2">
+        <CallControls />
+      </div>
+    </div>
+  )
+}
+
+/** Top `min`: a thin bar — live/error dot + timer, tap to expand. */
+function TopTabView({ connectedAt, captureError }: DockViewProps) {
+  return (
+    <button
+      type="button"
+      aria-label="Expand call"
+      onClick={() => setCallSurfaceMode("compact")}
+      className="flex h-full w-full items-center justify-center gap-2 border-b bg-background px-4"
+    >
+      {captureError ? (
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-destructive"
+          role="alert"
+          data-testid="call-capture-error"
+          aria-label="Microphone or camera problem — expand the call to see details"
+        />
+      ) : (
+        <span
+          className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
+          aria-hidden
+        />
+      )}
+      <CallTimer connectedAt={connectedAt} />
+    </button>
+  )
+}
+
+/** Top `compact`: timer + speaker + controls, horizontal. */
+function TopBarView({ connectedAt, speakerName, captureError }: DockViewProps) {
+  return (
+    <div className="flex h-full w-full items-center gap-3 border-b bg-background px-4">
+      {captureError && (
+        <span
+          className="flex h-8 w-8 shrink-0 items-center justify-center text-destructive"
+          role="alert"
+          data-testid="call-capture-error"
+          aria-label="Microphone or camera problem"
+        >
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+        </span>
+      )}
+      <div className="flex min-w-0 flex-col">
+        <CallTimer connectedAt={connectedAt} />
+        {speakerName && <span className="truncate text-xs text-muted-foreground">{speakerName}</span>}
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        <MuteButton />
+        <CameraButton />
+        <LeaveButton />
+        <DockPositionToggle />
+        <MinimizeButton />
+      </div>
+    </div>
+  )
+}
+
+/** Top `standard`: header + a tiles row + controls. */
+function TopGalleryView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  return (
+    <div className="flex h-full w-full flex-col border-b bg-background">
+      <DockHeaderBar title={title} />
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <div className="flex min-h-0 flex-1 items-stretch gap-2 overflow-x-auto px-3 py-2">
+        {joined.map((p) => (
+          <div key={p.userId} className="aspect-video h-full shrink-0">
+            <CallTile
+              participant={p}
+              workspaceId={workspaceId}
+              isSelf={!!currentUserId && p.userId === currentUserId}
+              stage
+              fill
+            />
+          </div>
+        ))}
+      </div>
+      <div className="shrink-0 border-t p-2">
+        <CallControls />
+      </div>
+    </div>
+  )
+}
+
+/** Fullscreen (both orientations): the ch5 stage with a permanent header of call controls/toggles. */
+function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title }: DockViewProps) {
+  const { layout, filmstripSide } = useCallPrefs()
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  // View-only pin (not the store): overrides the default speaker until the call ends.
+  const [pinnedUserId, setPinnedUserId] = useState<string | null>(null)
+
+  return (
+    <div className="flex h-full w-full flex-col bg-call-stage text-white">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          aria-label="Collapse call"
+          onClick={() => setCallSurfaceMode("standard")}
+          className="flex h-9 w-9 items-center justify-center rounded-md text-white/80 hover:bg-white/10 hover:text-white"
+        >
+          <ChevronDown className="h-5 w-5" />
+        </button>
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium">{title}</span>
+          <CallTimer connectedAt={connectedAt} className="text-white/70" />
+        </div>
+        <span className="ml-2 flex shrink-0 items-center gap-1 text-xs text-white/70" aria-label="Participants in call">
+          <Users className="h-3.5 w-3.5" aria-hidden />
+          {joined.length}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          {layout === "speaker" && <FilmstripSideToggle />}
+          <div data-testid="call-layout-slot">
+            <LayoutToggle className="bg-white/10" />
+          </div>
+          <DockPositionToggle dark />
+        </div>
+      </div>
+
+      <CallStageLayout
+        layout={layout}
+        filmstripSide={filmstripSide}
+        participants={roster}
+        currentUserId={currentUserId}
+        workspaceId={workspaceId}
+        pinnedUserId={pinnedUserId}
+        onPin={setPinnedUserId}
+      />
+
+      <div className="shrink-0 px-3 pb-3 pt-1">
+        <CallControls />
+      </div>
+    </div>
+  )
+}
+
+function DockBody({
+  dockPosition,
+  mode,
+  view,
+}: {
+  dockPosition: CallDockPosition
+  mode: CallSurfaceMode
+  view: DockViewProps
+}) {
+  if (mode === "full") return <DockFullscreenView {...view} />
+  if (dockPosition === "side") {
+    if (mode === "min") return <SideRailView {...view} />
+    return <SideTilesView {...view} />
+  }
+  if (mode === "min") return <TopTabView {...view} />
+  if (mode === "compact") return <TopBarView {...view} />
+  return <TopGalleryView {...view} />
+}
+
+function DockResizeHandle({
+  orientation,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+}: {
+  orientation: CallDockPosition
+  onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
+}) {
+  const side = orientation === "side"
+  return (
+    <div
+      role="separator"
+      aria-orientation={side ? "vertical" : "horizontal"}
+      aria-label="Resize call"
+      data-testid="call-dock-handle"
+      className={cn(
+        "absolute z-10 flex touch-none items-center justify-center",
+        side ? "inset-y-0 left-0 w-2 cursor-col-resize" : "inset-x-0 bottom-0 h-2 cursor-row-resize"
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      <span className={cn("rounded-full bg-muted-foreground/40", side ? "h-10 w-1" : "h-1 w-10")} aria-hidden />
+    </div>
+  )
+}
+
+interface DragState {
+  start: number
+  startSize: number
+  size: number
+  velocity: number
+  last: number
+  lastT: number
+  full: number
+}
+
+/**
+ * The desktop in-call surface: a resizable dock, docked to the top or the side
+ * (`dockPosition` pref), snapping through the four {@link CallSurfaceMode} steps
+ * with the same physics as the mobile drawer ({@link nearestStep}). It pushes the
+ * conversation aside via `--call-dock-inset-right`/`--call-dock-inset-top` (the
+ * main content region reserves the inset) rather than overlaying it, until
+ * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
+ * the connected phase; reads the call store, not the route, so it survives stream
+ * navigation.
+ */
+export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
+  const { dockPosition } = useCallPrefs()
+  const surfaceMode = useCallSurfaceMode()
+  const roster = useCallRoster()
+  const connectedAt = useCallConnectedAt()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const users = useWorkspaceUsers(workspaceId ?? undefined)
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  const title = name ?? "Call"
+
+  const isSide = dockPosition === "side"
+
+  const rootRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const drag = useRef<DragState | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const [dragSize, setDragSize] = useState<number | null>(null)
+  // The dock root spans the content region (left = sidebar width → right:0); its
+  // measured size is the ceiling for the panel + inset so a narrow window / wide
+  // sidebar can never push the panel over the sidebar or squash the timeline to 0.
+  const [content, setContent] = useState<{ w: number; h: number }>({ w: Infinity, h: Infinity })
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el) return
+    const measure = () => setContent({ w: el.clientWidth, h: el.clientHeight })
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  // Ceilings from the measured content region; 0 means "not laid out yet" (initial
+  // render / jsdom) → treat as unbounded so we never clamp to nothing.
+  const ceilW = content.w || Infinity
+  const ceilH = content.h || Infinity
+
+  // Content push: reserve the resting size (clamped to the content region) on :root
+  // so the main content region (AppShell's <main>) reflows. Fullscreen overlays → 0.
+  const insetRight = isSide ? Math.min(SIDE_INSET[surfaceMode], ceilW) : 0
+  const insetTop = isSide ? 0 : Math.min(TOP_INSET[surfaceMode], ceilH)
+  useEffect(() => {
+    const root = document.documentElement
+    root.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
+    root.style.setProperty("--call-dock-inset-top", `${insetTop}px`)
+  }, [insetRight, insetTop])
+  useEffect(
+    () => () => {
+      const root = document.documentElement
+      root.style.setProperty("--call-dock-inset-right", "0px")
+      root.style.setProperty("--call-dock-inset-top", "0px")
+    },
+    []
+  )
+
+  const stepSizes = isSide ? SIDE_STEP_SIZES : TOP_STEP_SIZES
+  const minStep = stepSizes[0]
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const panel = panelRef.current?.getBoundingClientRect()
+    const root = rootRef.current?.getBoundingClientRect()
+    const full = (isSide ? root?.width : root?.height) ?? stepSizes[stepSizes.length - 1]
+    const startSize = (isSide ? panel?.width : panel?.height) ?? stepSizes[1]
+    const pointer = isSide ? e.clientX : e.clientY
+    drag.current = {
+      start: pointer,
+      startSize,
+      size: startSize,
+      velocity: 0,
+      last: pointer,
+      lastT: performance.now(),
+      full,
+    }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    setDragSize(startSize)
+    setDragging(true)
+  }
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    if (!d) return
+    const pointer = isSide ? e.clientX : e.clientY
+    // Side grows as the pointer moves left; top grows as it moves down.
+    const grow = isSide ? d.start - pointer : pointer - d.start
+    const next = Math.min(Math.max(d.startSize + grow, minStep), d.full)
+    const now = performance.now()
+    const dt = now - d.lastT
+    const stepGrow = isSide ? d.last - pointer : pointer - d.last
+    if (dt > 0) d.velocity = stepGrow / dt
+    d.last = pointer
+    d.lastT = now
+    d.size = next
+    setDragSize(next)
+  }
+
+  const onPointerUp = () => {
+    const d = drag.current
+    drag.current = null
+    setDragging(false)
+    setDragSize(null)
+    if (d) setCallSurfaceMode(MODES[nearestStep(d.size, d.velocity, [...stepSizes, d.full])])
+  }
+
+  const speaker = roster.find((p) => p.participantStatus === "joined" && p.userId !== currentUserId) ?? null
+  const speakerName = speaker ? (users.find((u) => u.id === speaker.userId)?.name ?? null) : null
+
+  const dragFull = drag.current?.full ?? stepSizes[stepSizes.length - 1]
+  const contentMode: CallSurfaceMode =
+    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, [...stepSizes, dragFull])] : surfaceMode
+
+  const restingFull = !dragging && contentMode === "full"
+  let positionClass: string
+  let sizeStyle: CSSProperties
+  if (restingFull) {
+    positionClass = "inset-0"
+    sizeStyle = {}
+  } else if (isSide) {
+    positionClass = "inset-y-0 right-0"
+    const w = dragging && dragSize != null ? dragSize : Math.min(SIDE_RESTING[contentMode], ceilW)
+    sizeStyle = { width: `${w}px` }
+  } else {
+    positionClass = "inset-x-0 top-0"
+    const h = dragging && dragSize != null ? dragSize : Math.min(TOP_RESTING[contentMode], ceilH)
+    sizeStyle = { height: `${h}px` }
+  }
+
+  const view: DockViewProps = {
+    workspaceId,
+    connectedAt,
+    currentUserId,
+    roster,
+    users,
+    captureError,
+    title,
+    speakerName,
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className="pointer-events-none fixed inset-y-0 right-0 z-40"
+      style={{ left: "var(--app-content-left, 0px)" }}
+    >
+      <div
+        ref={panelRef}
+        data-testid="desktop-call-dock"
+        data-mode={contentMode}
+        data-position={dockPosition}
+        className={cn(
+          "pointer-events-auto absolute overflow-hidden shadow-xl",
+          positionClass,
+          !dragging && !REDUCED_MOTION && (isSide ? "transition-[width]" : "transition-[height]"),
+          !dragging && !REDUCED_MOTION && "duration-200 ease-out"
+        )}
+        style={sizeStyle}
+      >
+        <DockBody dockPosition={dockPosition} mode={contentMode} view={view} />
+        {/* Keep the handle mounted while dragging even after the content crosses into
+            `full`: it holds the pointer capture + the pointerup/cancel settle, so
+            unmounting it mid-drag would strand `dragging` true and wedge the dock. */}
+        {(dragging || contentMode !== "full") && (
+          <DockResizeHandle
+            orientation={dockPosition}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
 import { cn } from "@/lib/utils"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
-import { useIsMobile } from "@/hooks/use-mobile"
 import { useCallSurfaceMode } from "./call-store-hooks"
 import { useWorkspaceUserPreferences } from "@/stores/workspace-store"
 import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/stores/incoming-call-store"
@@ -52,7 +51,6 @@ function fireLocalRingNotification(call: IncomingCall): void {
 export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   const calls = useIncomingCalls()
   const { launch, callActive } = useCallLaunch()
-  const isMobile = useIsMobile()
   const surfaceMode = useCallSurfaceMode()
   const [searchParams, setSearchParams] = useSearchParams()
   const notifiedRef = useRef<Set<string>>(new Set())
@@ -157,17 +155,20 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
 
   if (calls.length === 0) return null
 
-  // The `callActive` lift clears the desktop bottom dock. On mobile the in-call
-  // surface is the TOP drawer, so the bottom is free — lift only in mobile
-  // fullscreen (where the drawer's bottom control bar would otherwise be covered).
-  const liftAboveDock = callActive && (!isMobile || surfaceMode === "full")
+  // Horizontal: clear a desktop SIDE dock via its inset var (0 with no side dock /
+  // in fullscreen / on mobile, so the ring stays at the edge otherwise). Vertical:
+  // lift above the bottom only when a call surface covers it — mobile or desktop
+  // fullscreen (both put their control bar at the bottom). Non-fullscreen docks leave
+  // the bottom free (mobile drawer is at the top; a side dock is cleared horizontally).
+  const liftAboveDock = callActive && surfaceMode === "full"
 
   return (
     <div
       className={cn(
-        "pointer-events-none fixed right-4 z-50 flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
+        "pointer-events-none fixed z-50 flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
         liftAboveDock ? RING_ABOVE_DOCK_BOTTOM : DOCK_BOTTOM
       )}
+      style={{ right: "calc(1rem + var(--call-dock-inset-right, 0px))" }}
     >
       {calls.map((call) => (
         <div

--- a/apps/frontend/src/components/call/mobile-call-drawer-snap.test.ts
+++ b/apps/frontend/src/components/call/mobile-call-drawer-snap.test.ts
@@ -1,5 +1,47 @@
 import { describe, it, expect } from "vitest"
-import { nearestMode } from "./mobile-call-drawer-snap"
+import { nearestMode, nearestStep } from "./mobile-call-drawer-snap"
+
+describe("nearestStep — generic detent index", () => {
+  // The desktop dock's side widths: rail 56, panel 320, wide 520, full (content) 900.
+  const steps = [56, 320, 520, 900]
+
+  it("returns the index of the detent at each resting size", () => {
+    expect(nearestStep(56, 0, steps)).toBe(0)
+    expect(nearestStep(320, 0, steps)).toBe(1)
+    expect(nearestStep(520, 0, steps)).toBe(2)
+    expect(nearestStep(900, 0, steps)).toBe(3)
+  })
+
+  it("resolves each midpoint to the nearer detent", () => {
+    // Midpoints: 56|320 = 188, 320|520 = 420, 520|900 = 710.
+    expect(nearestStep(187, 0, steps)).toBe(0)
+    expect(nearestStep(189, 0, steps)).toBe(1)
+    expect(nearestStep(419, 0, steps)).toBe(1)
+    expect(nearestStep(421, 0, steps)).toBe(2)
+    expect(nearestStep(709, 0, steps)).toBe(2)
+    expect(nearestStep(711, 0, steps)).toBe(3)
+  })
+
+  it("a fast grow flick advances one detent past nearest", () => {
+    expect(nearestStep(70, 1, steps)).toBe(1)
+    expect(nearestStep(520, 1, steps)).toBe(3)
+  })
+
+  it("a fast shrink flick drops one detent below nearest", () => {
+    expect(nearestStep(500, -1, steps)).toBe(1)
+    expect(nearestStep(320, -1, steps)).toBe(0)
+  })
+
+  it("clamps at the ends (no flick past the last/first detent)", () => {
+    expect(nearestStep(900, 1, steps)).toBe(3)
+    expect(nearestStep(56, -1, steps)).toBe(0)
+  })
+
+  it("sub-threshold velocity falls back to nearest", () => {
+    expect(nearestStep(500, -0.2, steps)).toBe(2)
+    expect(nearestStep(120, 0.2, steps)).toBe(0)
+  })
+})
 
 // Detents (px): min 44, compact 80, standard 248, full-snap 420.
 // Midpoints: min|compact 62, compact|standard 164, standard|full 334.

--- a/apps/frontend/src/components/call/mobile-call-drawer-snap.ts
+++ b/apps/frontend/src/components/call/mobile-call-drawer-snap.ts
@@ -27,44 +27,50 @@ const HEIGHTS: readonly number[] = [
   DRAWER_FULL_SNAP_HEIGHT,
 ]
 
-function nearestIndex(heightPx: number): number {
+/**
+ * The detent index to settle on when a drag ends at `value` with `velocity`
+ * (positive = growing toward a larger step). Nearest detent by distance, then a
+ * fast flick jumps to the next detent in the flick direction (so a quick pull
+ * past a small threshold advances even if the pointer didn't travel the whole
+ * way). Orientation-agnostic: the mobile drawer passes resting heights, the
+ * desktop dock passes its per-orientation widths/heights (INV-35).
+ */
+export function nearestStep(value: number, velocity: number, steps: readonly number[]): number {
   let idx = 0
   let best = Infinity
-  for (let i = 0; i < HEIGHTS.length; i++) {
-    const d = Math.abs(HEIGHTS[i] - heightPx)
+  for (let i = 0; i < steps.length; i++) {
+    const d = Math.abs(steps[i] - value)
     if (d < best) {
       best = d
       idx = i
     }
   }
-  return idx
-}
 
-/**
- * The mode to settle on when a drag ends at `heightPx` with `velocityPxPerMs`
- * (positive = growing/downward). Nearest detent by distance, then a fast flick
- * jumps to the next detent in the flick direction (so a quick pull past a small
- * threshold advances even if the finger didn't travel the whole way).
- */
-export function nearestMode(heightPx: number, velocityPxPerMs: number): CallSurfaceMode {
-  const idx = nearestIndex(heightPx)
-
-  if (velocityPxPerMs > FLICK_VELOCITY) {
-    const nextUp = HEIGHTS.findIndex((h) => h > heightPx)
-    const target = nextUp === -1 ? HEIGHTS.length - 1 : nextUp
-    return MODES[Math.max(idx, target)]
+  if (velocity > FLICK_VELOCITY) {
+    const nextUp = steps.findIndex((s) => s > value)
+    const target = nextUp === -1 ? steps.length - 1 : nextUp
+    return Math.max(idx, target)
   }
 
-  if (velocityPxPerMs < -FLICK_VELOCITY) {
+  if (velocity < -FLICK_VELOCITY) {
     let nextDown = 0
-    for (let i = HEIGHTS.length - 1; i >= 0; i--) {
-      if (HEIGHTS[i] < heightPx) {
+    for (let i = steps.length - 1; i >= 0; i--) {
+      if (steps[i] < value) {
         nextDown = i
         break
       }
     }
-    return MODES[Math.min(idx, nextDown)]
+    return Math.min(idx, nextDown)
   }
 
-  return MODES[idx]
+  return idx
+}
+
+/**
+ * The mode to settle on when a drawer drag ends at `heightPx` with
+ * `velocityPxPerMs` (positive = growing/downward). Delegates the detent physics
+ * to {@link nearestStep} with the drawer's resting heights.
+ */
+export function nearestMode(heightPx: number, velocityPxPerMs: number): CallSurfaceMode {
+  return MODES[nearestStep(heightPx, velocityPxPerMs, HEIGHTS)]
 }

--- a/apps/frontend/src/components/call/mobile-call-drawer.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
 import { ChevronUp } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -15,6 +15,8 @@ import { CallTile } from "./call-tile"
 import { CallStageLayout } from "./call-stage-layout"
 import { CallControls } from "./call-controls"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { CallTimer } from "./call-timer"
+import { CaptureErrorBanner } from "./call-capture-error"
 import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
 import { DRAWER_MIN_HEIGHT, nearestMode } from "./mobile-call-drawer-snap"
@@ -41,49 +43,6 @@ const RESTING_HEIGHT: Record<CallSurfaceMode, string> = {
 function viewportHeight(): number {
   if (typeof window === "undefined") return DRAWER_MIN_HEIGHT
   return window.visualViewport?.height ?? window.innerHeight
-}
-
-/** mm:ss, or h:mm:ss past an hour. */
-function formatElapsed(ms: number): string {
-  const total = Math.max(0, Math.floor(ms / 1000))
-  const h = Math.floor(total / 3600)
-  const m = Math.floor((total % 3600) / 60)
-  const s = total % 60
-  const mm = h > 0 ? String(m).padStart(2, "0") : String(m)
-  const ss = String(s).padStart(2, "0")
-  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
-}
-
-function CallTimer({ connectedAt, className }: { connectedAt: number | null; className?: string }) {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(id)
-  }, [])
-  const elapsed = connectedAt == null ? 0 : now - connectedAt
-  return (
-    <span className={cn("font-mono text-sm tabular-nums", className)} aria-label="Call duration">
-      {formatElapsed(elapsed)}
-    </span>
-  )
-}
-
-function captureErrorText(code: CallCaptureErrorInfo["code"]): string {
-  return code === "capture_rollback_failed"
-    ? "Your microphone stopped working and couldn't be restored. Try leaving and rejoining."
-    : "Couldn't switch your microphone or camera. Your previous device is still active."
-}
-
-function CaptureErrorBanner({ error }: { error: CallCaptureErrorInfo }) {
-  return (
-    <p
-      className="mx-3 mt-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
-      role="alert"
-      data-testid="call-capture-error"
-    >
-      {captureErrorText(error.code)}
-    </p>
-  )
 }
 
 function GrabHandle({
@@ -320,7 +279,7 @@ export function MobileCallDrawer({ workspaceId, streamId }: { workspaceId: strin
         )}
         style={{ height: dragging && dragHeight != null ? `${dragHeight}px` : RESTING_HEIGHT[contentMode] }}
       >
-        {contentMode !== "min" && captureError && <CaptureErrorBanner error={captureError} />}
+        {contentMode !== "min" && captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
         <div className="min-h-0 flex-1 overflow-hidden">
           {contentMode === "min" && <TabView connectedAt={connectedAt} captureError={captureError} />}
           {contentMode === "compact" && <BarView {...viewProps} />}

--- a/apps/frontend/src/components/call/mobile-call-drawer.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.tsx
@@ -261,7 +261,11 @@ export function MobileCallDrawer({ workspaceId, streamId }: { workspaceId: strin
     drag.current = null
     setDragging(false)
     setDragHeight(null)
-    if (d) setCallSurfaceMode(nearestMode(d.height, d.velocity))
+    if (d) {
+      // A pause before release means the drag stopped — don't flick on stale velocity.
+      const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
+      setCallSurfaceMode(nearestMode(d.height, vel))
+    }
   }
 
   const viewProps: ViewProps = { workspaceId, connectedAt, currentUserId, roster, speakerName, title }

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback } from "react"
+import { type ReactNode, useCallback, useEffect } from "react"
 import { RefreshCw } from "lucide-react"
 import { useSidebar, useCoordinatedLoading, type UrgencyBlock } from "@/contexts"
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, useTouchCapable } from "@/hooks"
@@ -207,6 +207,13 @@ export function AppShell({ sidebar, children }: AppShellProps) {
     collapse()
   }, [collapse])
 
+  // Publish the content region's left offset (the sidebar column width) so the
+  // app-mounted desktop call dock can pin itself to the content area — over the
+  // main region, never the sidebar. Mirrors the `--composer-height` var pattern.
+  useEffect(() => {
+    document.documentElement.style.setProperty("--app-content-left", wrapperWidth)
+  }, [wrapperWidth])
+
   // Derive mobile sidebar/backdrop classes outside JSX to avoid nested ternaries (INV-47)
   let backdropVisibility: string | undefined
   if (!isSwiping) {
@@ -400,10 +407,17 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             </aside>
           </div>
 
-          {/* Main content area — safe-area padding for notched devices when keyboard is closed */}
+          {/* Main content area — safe-area padding for notched devices when keyboard is
+               closed; the call dock reserves its resting size here so it pushes the
+               conversation aside instead of overlaying it (0 when no desktop dock /
+               fullscreen). */}
           <main
             className="relative flex flex-1 flex-col overflow-hidden"
-            style={!isKeyboardOpen ? { paddingBottom: "env(safe-area-inset-bottom)" } : undefined}
+            style={{
+              paddingRight: "var(--call-dock-inset-right, 0px)",
+              paddingTop: "var(--call-dock-inset-top, 0px)",
+              ...(!isKeyboardOpen ? { paddingBottom: "env(safe-area-inset-bottom)" } : {}),
+            }}
           >
             <ConnectionStatus />
             {children}


### PR DESCRIPTION
**Chunk 6 (final) of the calls UX overhaul stack** — stacked on #1476. The desktop twin of the mobile drawer, per the approved Seer design.

Replaces the desktop bottom-right floating dock with a **resizable `DesktopCallDock`** that snaps through the shared `surfaceMode` steps and docks **top or side** (user config). Mobile keeps the ch4/ch5 drawer.

## What's here
- **Side dock** (right; best on widescreen — call takes height, work keeps width): **Rail → Panel → Wide → Fullscreen**, drag the **left edge**. **Top dock** (best when narrow): **Tab → Bar → Gallery → Fullscreen**, drag the **bottom edge**. A header **Top/Side** toggle switches orientation (persisted).
- **Pushes the conversation** (doesn't overlay): the dock publishes its resting size as `--call-dock-inset-right`/`-top` and AppShell's `<main>` reserves it; fullscreen covers the content area (never the sidebar) via `--app-content-left`. Both the panel size and the inset are **clamped to the measured content region** so a narrow window / wide sidebar can't push over the sidebar or squash the timeline.
- **Fullscreen** uses `CallStageLayout` (ch5) + `LayoutToggle` + a desktop **bottom/side filmstrip** toggle.
- `nearestStep(value, velocity, steps)` generalized from the drawer's snap (which now delegates); the resize handle stays mounted through a drag into fullscreen and settles on `pointercancel` (the ch4 wedge lesson). Deleted `ActiveCallDock`/`CollapsedDock` (INV-38); extracted shared `CallTimer` + `CaptureErrorBanner` (INV-35).

## Review + testing
- **Adversarial verify** (Opus/xhigh) verdict FIX-THEN-SHIP. The highest-risk items (a phantom `<main>` inset for out-of-call users, a stuck inset after a call ends) verified **clean** — no app-wide regression. The one **MEDIUM** it found (dock resting size not clamped → narrow-window overflow over the sidebar) is **fixed here** by clamping the panel + inset to the measured content region. 3 LOW cosmetic notes left as-is.
- Frontend typecheck + lint clean; dock/snap/call-dock/stage tests green; no orphan references to the deleted dock (INV-38 verified); shared timer/error single-sourced.

## Screenshots
Desktop side + top dock + fullscreen shots land in the batched harness pass (with the drawer + speaker/grid) — added to each PR + posted in the design channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787185179&installation_model_id=20758&pr_number=1477&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1477&signature=ed924a2916a8dc11c29d6b7edf61e9a088cb37d5bb5880ff9f00e097ab486af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->