### PR TITLE
fix(calls): apply CF's tracks/close answer so camera on→off→on works

### DIFF
--- a/apps/backend/src/features/calls/cloudflare.test.ts
+++ b/apps/backend/src/features/calls/cloudflare.test.ts
@@ -118,6 +118,18 @@ describe("CloudflareRealtimeApi tracks", () => {
     expect(body).toEqual({ tracks: [{ mid: "0" }, { mid: "1" }], force: true })
   })
 
+  it("closeTracks forwards the offer and returns CF's answer (unpublish reneg)", async () => {
+    const answer = { type: "answer", sdp: "a" } as const
+    const f = stubFetch(async () => jsonResponse({ tracks: [], sessionDescription: answer }))
+    const api = new CloudflareRealtimeApi(CONFIG)
+
+    const result = await api.closeTracks("sess_1", { mids: ["0"], sdp: { type: "offer", sdp: "o" } })
+
+    const { body } = lastCall(f)
+    expect(body).toEqual({ tracks: [{ mid: "0" }], force: false, sessionDescription: { type: "offer", sdp: "o" } })
+    expect(result).toEqual({ tracks: [], sessionDescription: answer })
+  })
+
   it("closeSession enumerates the session's tracks via state GET, then force-closes them by mid", async () => {
     const f = stubFetch(async (url, init) => {
       if (init.method === "GET") {

--- a/apps/backend/src/features/calls/cloudflare.ts
+++ b/apps/backend/src/features/calls/cloudflare.ts
@@ -66,6 +66,8 @@ export interface RenegotiateResult {
 
 export interface CloseTracksResult {
   tracks: TrackResult[]
+  /** CF's answer when the close carried an offer (unpublishing a local track); the caller must apply it. */
+  sessionDescription?: SessionDescription
 }
 
 /**
@@ -196,7 +198,7 @@ export class CloudflareRealtimeApi implements RealtimeMediaApi {
     sessionId: string,
     params: { mids: string[]; force?: boolean; sdp?: SessionDescription }
   ): Promise<CloseTracksResult> {
-    const body = await this.request<{ tracks?: TrackResult[] }>(
+    const body = await this.request<{ tracks?: TrackResult[]; sessionDescription?: SessionDescription }>(
       "PUT",
       `/${this.appId}/sessions/${encodeURIComponent(sessionId)}/tracks/close`,
       {
@@ -205,7 +207,7 @@ export class CloudflareRealtimeApi implements RealtimeMediaApi {
         ...(params.sdp ? { sessionDescription: params.sdp } : {}),
       }
     )
-    return { tracks: body.tracks ?? [] }
+    return { tracks: body.tracks ?? [], sessionDescription: body.sessionDescription }
   }
 
   async closeSession(sessionId: string): Promise<void> {

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -168,6 +168,31 @@ describe("CloudflareSfuTransport", () => {
     expect(closeCall?.body.mids).toEqual(["remote-0"])
   })
 
+  it("unpublish applies CF's close answer so the PC leaves have-local-offer and re-publish works", async () => {
+    const closeAnswer = { type: "answer", sdp: "close-answer-sdp" }
+    const pc = makeFakePc()
+    const { transport } = makeTransport({
+      pc,
+      post: async (path: string, body: unknown) => {
+        void body
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish")) return { requiresImmediateRenegotiation: false, tracks: [] }
+        if (path.endsWith("/tracks/close")) return { tracks: [], sessionDescription: closeAnswer }
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("camera", makeTrack("video"))
+    await transport.unpublish("camera")
+
+    // The close carried an offer → CF answers it; without applying the answer the PC
+    // stays in have-local-offer and the re-publish below fails (the camera on→off→on bug).
+    expect(pc.setRemoteDescription).toHaveBeenCalledWith(closeAnswer)
+
+    await expect(transport.publish("camera", makeTrack("video"))).resolves.toBeUndefined()
+    expect(pc.addTransceiver).toHaveBeenCalledTimes(2)
+  })
+
   it("keeps the queue alive after a failed job", async () => {
     let call = 0
     const { transport } = makeTransport({

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -94,6 +94,12 @@ interface CfRenegotiateResult {
   sessionDescription?: CfSessionDescription
 }
 
+interface CfCloseTracksResult {
+  tracks?: CfTrackResult[]
+  /** CF's answer when the close carried an offer (unpublishing a local track); apply it to finish the reneg. */
+  sessionDescription?: CfSessionDescription
+}
+
 type PostJson = <T>(path: string, body: unknown) => Promise<T>
 
 /**
@@ -113,7 +119,7 @@ export interface CallProxyClient {
     mids: string[]
     unpublishKinds?: PublishedTrackKind[]
     sdp?: CfSessionDescription
-  }): Promise<unknown>
+  }): Promise<CfCloseTracksResult>
 }
 
 export function createCallProxyClient(args: {
@@ -323,11 +329,17 @@ export class CloudflareSfuTransport implements MediaTransport {
       const pc = this.requirePc()
       const offer = await pc.createOffer()
       await pc.setLocalDescription(offer)
-      await this.proxy!.closeTracks({
+      const result = await this.proxy!.closeTracks({
         mids: [mid],
         unpublishKinds: [kind],
         sdp: { type: "offer", sdp: offer.sdp ?? "" },
       })
+      // The close carried an offer (removing our m-line), so CF answers it. Apply
+      // it — leaving the PC in `have-local-offer` corrupts the next negotiation and
+      // the following publish (re-enabling the camera) fails.
+      if (result.sessionDescription?.type === "answer") {
+        await pc.setRemoteDescription(result.sessionDescription)
+      }
     })
   }
 


### PR DESCRIPTION
## Problem

Toggling the camera **off then on** in a call failed with the toast "Couldn't switch the camera" (repro'd on mobile: on → off → on rejects). Root cause is a dropped renegotiation answer, not the camera picker itself.

`CloudflareSfuTransport.unpublish` (`media-transport.ts`) turns the camera off by `transceiver.stop()` + `createOffer` + `setLocalDescription(offer)`, then POSTs that offer to CF via `tracks/close`. CF answers it — but the answer was thrown away on **both** sides: the backend adapter `CloudflareRealtimeApi.closeTracks` (`cloudflare.ts`) destructured only `{ tracks }` off CF's response, and the transport ignored `closeTracks`' return entirely. With no `setRemoteDescription(answer)`, the `RTCPeerConnection` is left stuck in `have-local-offer`. The next `publish` (camera back on) then renegotiates against that corrupt signaling state and rejects → `CallCaptureError` → the toast.

Camera-**off** looked fine (it never applies an answer, so it doesn't throw); only the following **on** surfaced the break.

## Solution

Plumb CF's `tracks/close` answer through and apply it — completing the renegotiation the off-toggle started.

- `cloudflare.ts`: `CloseTracksResult` gains `sessionDescription?`; `closeTracks` reads it off CF's response body and returns it. Flows unchanged through `service.closeTracks` (`result.cf`) and the handler (`res.json(result.cf)`).
- `media-transport.ts`: `CallProxyClient.closeTracks` returns a typed `CfCloseTracksResult` (was `Promise<unknown>`); `unpublish` applies `result.sessionDescription` via `setRemoteDescription` when it's an answer, so the PC returns to `stable` before the next publish.
- Defensive: applied only `if (result.sessionDescription?.type === "answer")`, so it's a strict no-op if CF returns no answer — no regression. `stopPull` (remote-track close, no offer sent) is untouched and never sees an answer to mis-apply.

Scope note: the CF `tracks/close`-with-offer answer is the same symmetric reneg as publish/pull (CLOUDFLARE_API.md Q2, live-confirmed for `tracks/new`) but wasn't itself a live-probed question — worth a confirm on the live stack. No behavioral change to camera-off's roster/registry teardown (peers stop pulling off the roster, not the SDP).

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/calls/cloudflare.ts` | `CloseTracksResult.sessionDescription?`; `closeTracks` reads + returns CF's answer |
| `apps/backend/src/features/calls/cloudflare.test.ts` | close forwards the offer and returns the answer |
| `apps/frontend/src/calls/media-transport.ts` | typed `CfCloseTracksResult`; `unpublish` applies the close answer |
| `apps/frontend/src/calls/media-transport.test.ts` | publish→unpublish→re-publish applies the answer, re-publish succeeds |

## Test plan

- [x] `apps/frontend` vitest `src/calls/` — 39 pass (incl. new re-publish regression)
- [x] `apps/backend` bun:test `src/features/calls/` — 140 pass (incl. new close-answer case)
- [x] Pre-commit: full monorepo lint + typecheck (all workspaces) — 0 errors
- [ ] Live-stack manual on→off→on toggle — not run here (needs the CF dev stack); the fix is defensive so it can't regress if CF's close-answer shape differs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787205691&installation_model_id=20758&pr_number=1478&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1478&signature=a36f7a48cd3038204ca7bef2b67728e98e7239654189dfa69517b312896bfb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->