### PR TITLE
fix(calls): mobile camera picker is flip-only, no per-camera selection

### DIFF
--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -107,6 +107,21 @@ describe("DevicePickerMenu — camera group", () => {
     expect(await screen.findByText("Microphone")).toBeInTheDocument()
     expect(screen.queryByText("Camera")).toBeNull()
   })
+
+  it("hides the camera group on mobile even with cameras (flip is the only camera control there)", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    renderPicker(
+      makeManager(),
+      makeDevices({
+        cameras: [device("cam-front", "Front camera", "videoinput"), device("cam-back", "Back camera", "videoinput")],
+        inputs: [device("m1", "Mic 1", "audioinput")],
+      })
+    )
+
+    await userEvent.click(screen.getByLabelText("Devices"))
+    expect(await screen.findByText("Microphone")).toBeInTheDocument()
+    expect(screen.queryByText("Camera")).toBeNull()
+  })
 })
 
 describe("CallControls — mobile flip", () => {

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -28,7 +28,11 @@ function deviceLabel(device: MediaDeviceInfo, index: number, fallbackPrefix = "D
 
 export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
   const manager = useCallManager()
-  const hasCameras = devices.cameras.length > 0
+  const isMobile = useIsMobile()
+  // Mobile hides per-camera selection: phones enumerate several back cameras
+  // (wide/ultrawide/tele) and picking a specific one by exact deviceId can reject
+  // the capture (freezes the feed, then errors). Front/back is the Flip button.
+  const hasCameras = !isMobile && devices.cameras.length > 0
   const hasInputs = devices.inputs.length > 0
   const hasOutputs = OUTPUT_SELECTION_SUPPORTED && devices.outputs.length > 0
   if (!hasCameras && !hasInputs && !hasOutputs) return null

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -82,8 +82,8 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
   }
 }
 
-function device(deviceId: string, label: string): MediaDeviceInfo {
-  return { deviceId, label, kind: "videoinput", groupId: "grp", toJSON: () => ({}) } as MediaDeviceInfo
+function device(deviceId: string, label: string, kind: MediaDeviceKind = "videoinput"): MediaDeviceInfo {
+  return { deviceId, label, kind, groupId: "grp", toJSON: () => ({}) } as MediaDeviceInfo
 }
 
 function makeDevices(overrides: Partial<CallDeviceState> = {}): CallDeviceState {
@@ -184,7 +184,16 @@ describe("MobileCallDrawer — mode rendering", () => {
       participant({ userId: "usr_self" }),
       participant({ userId: "usr_peer", endpointId: "callep_peer" }),
     ])
-    act(() => setCallDevices(makeDevices({ cameras: [device("c1", "Front"), device("c2", "Back")] })))
+    // A live call always has a mic; the device menu keeps mic/speaker on mobile
+    // (per-camera selection is hidden there — flip is the only camera control).
+    act(() =>
+      setCallDevices(
+        makeDevices({
+          cameras: [device("c1", "Front"), device("c2", "Back")],
+          inputs: [device("m1", "Mic", "audioinput")],
+        })
+      )
+    )
     setMode("standard")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Flip camera")).toBeInTheDocument()


### PR DESCRIPTION
## Problem

On mobile the in-call device menu (`DevicePickerMenu`, `call-controls.tsx`) listed **every** enumerated camera. Modern phones expose several back cameras (wide / ultrawide / telephoto) as distinct `videoinput` devices, so the menu offered a confusing per-lens list users never expect. Worse, selecting one drives `switchCameraDevice(exact deviceId)` — iOS frequently rejects an `exact` capture on those virtual/composite lenses, which **freezes the feed then errors** (the late-video failure in Kris's repro).

## Solution

Hide the per-camera radio group on mobile; front/back stays as the existing **Flip** button (`flipCamera`, facingMode toggle — never `exact` deviceId). Desktop keeps the full picker.

- `call-controls.tsx`: `hasCameras = !isMobile && devices.cameras.length > 0` (`useIsMobile`, already imported). Mic + speaker groups unchanged.

Screen-share as a mobile camera-menu option was raised but is a separate capability (`getDisplayMedia`) — not in scope here.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/call/call-controls.tsx` | gate the camera group behind `!isMobile` |
| `apps/frontend/src/components/call/call-controls.test.tsx` | mobile hides the camera group (mic still shown) |

## Test plan

- [x] `call-controls.test.tsx` — 7 pass (added the mobile-hides-camera case)
- [x] Pre-commit: full monorepo lint + typecheck — 0 errors

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787209928&installation_model_id=20758&pr_number=1480&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1480&signature=80abdcb5ea2de86d53168ab140fcf0c34a8d68c60546285a0531e6f60b5a83ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->