### PR TITLE
ci: parallelize test workloads

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -15,8 +15,39 @@ on:
       - "bun.lock"
       - ".github/workflows/browser-tests.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build frontend once
+        run: bun run --cwd apps/frontend build:e2e
+        env:
+          VITE_BACKEND_PORT: "1"
+          VITE_DRAFT_DEBOUNCE_MS: "5"
+
+      - name: Upload frontend build
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-test-frontend
+          path: apps/frontend/dist/
+          retention-days: 1
+
   browser-tests:
+    needs: build-frontend
     runs-on: ubuntu-latest
     timeout-minutes: 25
     continue-on-error: true
@@ -147,6 +178,12 @@ jobs:
             echo "Database already exists: ${cp_db}"
           fi
 
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: browser-test-frontend
+          path: apps/frontend/dist/
+
       - name: Run browser tests
         id: initial-run
         continue-on-error: true
@@ -154,6 +191,7 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_TEST_DB_NAME: ${{ env.PLAYWRIGHT_TEST_DB_NAME }}
+          PLAYWRIGHT_FRONTEND_PREBUILT: "true"
 
       - name: Archive initial blob report before retry
         if: steps.initial-run.outcome == 'failure'
@@ -175,6 +213,7 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_TEST_DB_NAME: ${{ env.PLAYWRIGHT_TEST_DB_NAME }}
+          PLAYWRIGHT_FRONTEND_PREBUILT: "true"
 
       - name: Write shard result marker
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint
@@ -142,14 +146,35 @@ jobs:
       - name: Run workspace-router tests
         run: bun run --cwd apps/workspace-router test
 
-      - name: Run frontend tests
-        run: bun run --cwd apps/frontend test
-
       - name: Run enclave tests
         run: bun run --cwd apps/enclave test
 
       - name: Run cli tests
         run: bun run --cwd packages/cli test
+
+  frontend-tests:
+    name: Frontend Tests (${{ matrix.shard_index }}/${{ strategy.job-total }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run frontend tests
+        run: bun run --cwd apps/frontend test -- --shard=${{ matrix.shard_index }}/${{ strategy.job-total }}
 
   extension-tests:
     name: Extension Tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -93,8 +93,9 @@ const webServerTimeout = isCI ? 120000 : 60000
 // failures — e.g. virtualized-list scroll position differing from the dev server
 // — are otherwise impossible to reproduce on a dev machine.
 const useProdFrontend = isCI || !!process.env.PLAYWRIGHT_PROD_FRONTEND
+const usePrebuiltFrontend = !!process.env.PLAYWRIGHT_FRONTEND_PREBUILT
 const frontendCommand = useProdFrontend
-  ? "bun run --cwd apps/frontend build:e2e && bun run --cwd apps/frontend preview"
+  ? `${usePrebuiltFrontend ? "" : "bun run --cwd apps/frontend build:e2e && "}bun run --cwd apps/frontend preview`
   : "bun run test:browser:frontend"
 // The prod build needs more headroom than a dev-server boot.
 const frontendServerTimeout = useProdFrontend ? 180000 : webServerTimeout


### PR DESCRIPTION
## Problem

The `Tests` job is the CI critical path: recent runs take ~11 minutes, with the frontend Vitest step alone taking ~9 minutes while every other test step waits serially. Browser E2E also rebuilds the same production frontend independently in all four shards. Superseded PR runs continue consuming runners and increase queue time.

## Solution

- Move frontend tests into a four-shard matrix; keep the existing `Tests` check for backend, control-plane, router, enclave, CLI, and script coverage.
- Build the E2E frontend once with the existing E2E-only build inputs, upload `apps/frontend/dist`, and serve that artifact from every browser shard and isolation retry.
- Cancel superseded pull-request runs in both workflows. Main pushes remain uncancelled so push-only WorkOS synchronization cannot be interrupted.
- Bound frontend shard and shared-build jobs with explicit timeouts.

The PR run completed the CI critical path in 2m43s, down from the recent ~11m16s median (~76% faster). Browser E2E stayed green while building the frontend once instead of four times. Dependency caching was deliberately omitted: current `bun install` steps take only ~6–7 seconds, so caching adds complexity without material wall-time benefit.

## Files

| File | Change |
| ---- | ------ |
| `.github/workflows/ci.yml` | Four-way frontend test matrix and PR concurrency |
| `.github/workflows/browser-tests.yml` | Shared frontend build artifact and PR concurrency |
| `playwright.config.ts` | Serve a prebuilt frontend when the workflow supplies one |

## Test plan

- [x] Frontend Vitest shards — 441 files, 4,759 tests passed across 4/4 shards
- [x] Frontend E2E production build
- [x] Playwright discovery — 227 tests in 41 files
- [x] Frontend typecheck
- [x] Repository pre-commit lint, full monorepo typecheck, migration/Dockerfile/API-doc checks
- [x] PR CI — slowest shard 2m43s; all checks passed
- [x] Browser E2E — 4/4 shards and result evaluation passed
- [x] `actionlint`, Prettier, and `git diff --check`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787217838&installation_model_id=20758&pr_number=1483&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1483&signature=926a43dbaeff73a953b2e04b9042a39e04d46bf1a555298422e17756fff0cce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
