### PR TITLE
fix: Android spellcheck replacement appended at caret instead of replacing word

### DIFF
--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -956,6 +956,49 @@ describe("handleBeforeInputKeyboardPaste (Gboard suggestion-bar paste)", () => {
     }
   )
 
+  it("ignores insertReplacementText with a non-collapsed target range (Android spellcheck replacement)", () => {
+    const editor = createTestEditor("helo world")
+    editor.commands.setTextSelection(3)
+
+    const event = {
+      inputType: "insertReplacementText",
+      data: "hello",
+      dataTransfer: null,
+      getTargetRanges: () => [{ collapsed: false }],
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    const handled = handleBeforeInputKeyboardPaste(editor, event)
+
+    expect(handled).toBe(false)
+    expect(event.prevented).toBe(false)
+    editor.destroy()
+  })
+
+  it("still intercepts insertReplacementText with collapsed target ranges (IME clipboard commit at caret)", () => {
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = {
+      inputType: "insertReplacementText",
+      data: "pasted text",
+      dataTransfer: null,
+      getTargetRanges: () => [{ collapsed: true }],
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    const handled = handleBeforeInputKeyboardPaste(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("pasted text")
+    editor.destroy()
+  })
+
   it("falls back to a plain-text insert when markdown parsing throws (payload never lost)", () => {
     const editor = createTestEditor("")
     editor.commands.setTextSelection(editor.state.doc.content.size)

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -7,6 +7,7 @@ export interface BeforeInputEventLike {
   inputType: string
   data?: string | null
   dataTransfer?: { getData(format: string): string } | null
+  getTargetRanges?(): readonly { collapsed: boolean }[]
   preventDefault(): void
 }
 
@@ -950,6 +951,13 @@ export function handleBeforeInputKeyboardPaste(
   // heuristic below is skipped for them.
   const isPasteLike = event.inputType === "insertFromPaste" || event.inputType === "insertReplacementText"
   if (event.inputType !== "insertText" && !isPasteLike) return false
+  // Android spellcheck (tap squiggled word → pick suggestion) also arrives as
+  // `insertReplacementText`, distinguished by a non-collapsed target range over
+  // the word being replaced; intercepting would insert at the caret and keep the
+  // misspelled word. Fall through so the native replacement applies.
+  if (event.inputType === "insertReplacementText" && event.getTargetRanges?.().some((r) => !r.collapsed)) {
+    return false
+  }
   if (editor.view.composing) return false
   // Chromium on Android delivers large IME clipboard payloads with `data`
   // null and the text on `dataTransfer` instead.

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -955,7 +955,7 @@ export function handleBeforeInputKeyboardPaste(
   // `insertReplacementText`, distinguished by a non-collapsed target range over
   // the word being replaced; intercepting would insert at the caret and keep the
   // misspelled word. Fall through so the native replacement applies.
-  if (event.inputType === "insertReplacementText" && event.getTargetRanges?.().some((r) => !r.collapsed)) {
+  if (event.inputType === "insertReplacementText" && event.getTargetRanges?.().some((range) => !range.collapsed)) {
     return false
   }
   if (editor.view.composing) return false


### PR DESCRIPTION
## Problem

On Android Chrome, tapping a red-squiggled word and picking a spellcheck suggestion appends the suggestion at the caret instead of replacing the word ("helo" → "helohello"). `handleBeforeInputKeyboardPaste` (`apps/frontend/src/components/editor/multiline-blocks.ts`) treats every `insertReplacementText` beforeinput as an Android IME clipboard-bar paste: it `preventDefault()`s and inserts `event.data` at the current selection, discarding the event's target range. Spellcheck replacements arrive with the same inputType, so the misspelled word survives and the suggestion lands next to it.

## Solution

Discriminate on `getTargetRanges()`: a spellcheck replacement carries a non-collapsed `StaticRange` over the word being replaced, while an IME clipboard commit inserts at a collapsed caret. When `insertReplacementText` has any non-collapsed target range, return `false` so the browser's native replacement goes through and ProseMirror's DOM observer syncs it — the path every other contenteditable app uses. Collapsed/absent ranges keep the existing paste interception (mention/emoji/markdown chipping).

- `BeforeInputEventLike` gains optional `getTargetRanges?(): readonly { collapsed: boolean }[]`, structurally compatible with the real `InputEvent`.
- Trade-off: an IME clipboard commit that replaces a selection (non-collapsed range) now also falls through to native insert, losing markdown chipping for that one path — correctness over chipping.

## Test plan

- [x] `multiline-blocks.test.ts` — 70 pass (2 new: non-collapsed range falls through; collapsed range still intercepted)
- [x] `tsc --noEmit` frontend clean
- [ ] On-device Android Chrome verify — needs Kris's phone; repro is in the report video

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787220280&installation_model_id=20758&pr_number=1484&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1484&signature=534f6bf699c15093bb0b82ed224ddc35cf2721717d7ed02da10e052561b36f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->