### PR TITLE
feat(calls): responsive controls — per-control async pending

### DIFF
--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -1,9 +1,8 @@
-import { useState } from "react"
-import { toast } from "sonner"
-import { Mic, MicOff, PhoneOff, SwitchCamera, Video, VideoOff } from "lucide-react"
+import { Loader2, Mic, MicOff, PhoneOff, SwitchCamera, Video, VideoOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useAsyncAction } from "@/hooks/use-async-action"
 import { useCallManager } from "./call-manager-context"
 import { useCallCameraOn, useCallDevices, useCallMode, useCallMuted } from "./call-store-hooks"
 
@@ -30,21 +29,39 @@ export function MuteButton({ className }: { className?: string }) {
   )
 }
 
+// Async camera controls disable themselves + swap to an in-place spinner while their
+// OWN recapture runs (via useAsyncAction), so a slow toggle can't register a second
+// state-reversing tap — and a sibling control (flip, a device menu item) is untouched.
+
 export function CameraButton({ className }: { className?: string }) {
   const manager = useCallManager()
   const cameraOn = useCallCameraOn()
   const mode = useCallMode()
+  const { pending, run } = useAsyncAction(() => manager.setCameraOn(!cameraOn), {
+    errorMessage: "Couldn't switch the camera",
+  })
   if (mode === "audio_only") return null
+  let icon = <VideoOff className="h-4 w-4" />
+  let label = "Turn camera on"
+  if (pending) {
+    icon = <Loader2 className="h-4 w-4 animate-spin" />
+    label = "Switching camera…"
+  } else if (cameraOn) {
+    icon = <Video className="h-4 w-4" />
+    label = "Turn camera off"
+  }
   return (
     <Button
       variant="ghost"
       size="icon"
       className={cn("h-9 w-9", className)}
-      aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
+      aria-label={label}
       aria-pressed={cameraOn}
-      onClick={() => void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))}
+      aria-busy={pending}
+      disabled={pending}
+      onClick={run}
     >
-      {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
+      {icon}
     </Button>
   )
 }
@@ -55,39 +72,37 @@ export function FlipButton({ className }: { className?: string }) {
   const mode = useCallMode()
   const devices = useCallDevices()
   const isMobile = useIsMobile()
+  const { pending, run } = useAsyncAction(() => manager.flipCamera(), { errorMessage: "Couldn't flip the camera" })
   if (mode === "audio_only" || !isMobile || devices.cameras.length <= 1) return null
   return (
     <Button
       variant="ghost"
       size="icon"
       className={cn("h-9 w-9", className)}
-      aria-label="Flip camera"
-      onClick={() => void manager.flipCamera().catch(() => toast.error("Couldn't flip the camera"))}
+      aria-label={pending ? "Flipping camera…" : "Flip camera"}
+      aria-busy={pending}
+      disabled={pending}
+      onClick={run}
     >
-      <SwitchCamera className="h-4 w-4" />
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SwitchCamera className="h-4 w-4" />}
     </Button>
   )
 }
 
 export function LeaveButton({ className }: { className?: string }) {
   const manager = useCallManager()
-  const [leaving, setLeaving] = useState(false)
+  const { pending, run } = useAsyncAction(() => manager.leaveCall(), { errorMessage: "Couldn't leave the call" })
   return (
     <Button
       variant="destructive"
       size="icon"
       className={cn("h-9 w-9", className)}
       aria-label="Leave call"
-      disabled={leaving}
-      onClick={() => {
-        setLeaving(true)
-        void manager.leaveCall().catch(() => {
-          setLeaving(false)
-          toast.error("Couldn't leave the call")
-        })
-      }}
+      aria-busy={pending}
+      disabled={pending}
+      onClick={run}
     >
-      <PhoneOff className="h-4 w-4" />
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <PhoneOff className="h-4 w-4" />}
     </Button>
   )
 }

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -155,3 +155,28 @@ describe("CallControls — mobile flip", () => {
     expect(screen.queryByLabelText("Flip camera")).toBeNull()
   })
 })
+
+describe("CallControls — async controls disable in-flight", () => {
+  it("camera toggle disables + spins in place while running, ignoring a second tap", async () => {
+    let resolveToggle!: () => void
+    const setCameraOn = vi.fn(() => new Promise<void>((r) => (resolveToggle = r)))
+    const manager = makeManager({ setCameraOn })
+    renderControls(manager)
+    enterVideoCall()
+
+    await userEvent.click(screen.getByLabelText("Turn camera on"))
+    // In flight: label switches to the busy phase and the control is disabled.
+    const busy = screen.getByLabelText("Switching camera…")
+    expect(busy).toBeDisabled()
+    expect(setCameraOn).toHaveBeenCalledTimes(1)
+
+    // A second tap while it's running is a no-op — this is the double-tap guard.
+    await userEvent.click(busy)
+    expect(setCameraOn).toHaveBeenCalledTimes(1)
+
+    // Settles → re-enabled (the fake manager doesn't flip the store, so it returns
+    // to the off label, but crucially it's interactive again).
+    await act(async () => resolveToggle())
+    expect(screen.getByLabelText("Turn camera on")).not.toBeDisabled()
+  })
+})

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react"
 import { toast } from "sonner"
-import { Mic, MicOff, Video, VideoOff, PhoneOff, Settings, Signal, SwitchCamera } from "lucide-react"
+import { Settings, Signal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -12,11 +11,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
 import { useCallManager } from "./call-manager-context"
-import { useCallCameraOn, useCallDevices, useCallDiagnostics, useCallMode, useCallMuted } from "./call-store-hooks"
+import { CameraButton, FlipButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { useCallDevices, useCallDiagnostics } from "./call-store-hooks"
 
 // setSinkId (output device selection) is unsupported on Safari/Firefox; hide the
 // speaker picker where the API is absent rather than showing a dead control.
@@ -156,72 +155,20 @@ export function ConnectionDiagnostics({ diagnostics }: { diagnostics: CallDiagno
 }
 
 export function CallControls() {
-  const manager = useCallManager()
-  const muted = useCallMuted()
-  const cameraOn = useCallCameraOn()
-  const mode = useCallMode()
   const devices = useCallDevices()
   const diagnostics = useCallDiagnostics()
-  const isMobile = useIsMobile()
-  const [leaving, setLeaving] = useState(false)
 
-  const toggleCamera = () => {
-    void manager.setCameraOn(!cameraOn).catch(() => toast.error("Couldn't switch the camera"))
-  }
-
-  const flipCamera = () => {
-    void manager.flipCamera().catch(() => toast.error("Couldn't flip the camera"))
-  }
-
-  const leave = () => {
-    setLeaving(true)
-    void manager.leaveCall().catch(() => {
-      setLeaving(false)
-      toast.error("Couldn't leave the call")
-    })
-  }
-
+  // Mute/Camera/Flip/Leave are the shared, async-aware controls (call-control-buttons):
+  // Camera hides itself on audio_only, Flip on desktop / single-camera — so the row
+  // gates itself without CallControls re-deciding.
   return (
     <div className="flex items-center justify-center gap-1.5">
-      <Button
-        variant="ghost"
-        size="icon"
-        className={cn("h-9 w-9", muted && "text-destructive")}
-        aria-label={muted ? "Unmute" : "Mute"}
-        aria-pressed={muted}
-        onClick={() => manager.setMuted(!muted)}
-      >
-        {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
-      </Button>
-      {mode !== "audio_only" && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-9 w-9"
-          aria-label={cameraOn ? "Turn camera off" : "Turn camera on"}
-          aria-pressed={cameraOn}
-          onClick={toggleCamera}
-        >
-          {cameraOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}
-        </Button>
-      )}
-      {isMobile && mode !== "audio_only" && devices.cameras.length > 1 && (
-        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Flip camera" onClick={flipCamera}>
-          <SwitchCamera className="h-4 w-4" />
-        </Button>
-      )}
+      <MuteButton />
+      <CameraButton />
+      <FlipButton />
       <DevicePickerMenu devices={devices} />
       <ConnectionDiagnostics diagnostics={diagnostics} />
-      <Button
-        variant="destructive"
-        size="icon"
-        className="h-9 w-9"
-        aria-label="Leave call"
-        disabled={leaving}
-        onClick={leave}
-      >
-        <PhoneOff className="h-4 w-4" />
-      </Button>
+      <LeaveButton />
     </div>
   )
 }

--- a/apps/frontend/src/hooks/use-async-action.ts
+++ b/apps/frontend/src/hooks/use-async-action.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef, useState } from "react"
+import { toast } from "sonner"
+
+/**
+ * Wraps an async control action with a PER-INSTANCE pending flag, so a control can
+ * disable itself and show an in-place spinner until its OWN action settles. There is
+ * no shared/global busy state — sibling controls (a flip button, a device menu item,
+ * a screen-share toggle) each track their own, so one in-flight action never disables
+ * or spins the others. General across any async control (camera toggle, flip, device
+ * switch, later screen-share). Re-entrancy is guarded synchronously (a ref) so a
+ * second trigger can't stack while one is running. `errorMessage`, when set, surfaces
+ * a toast on rejection; success stays silent (INV-63). The latest `action` closure is
+ * always invoked (a ref), so callers can pass an inline closure over fresh state.
+ */
+export function useAsyncAction(
+  action: () => Promise<unknown> | unknown,
+  opts?: { errorMessage?: string }
+): { pending: boolean; run: () => void } {
+  const [pending, setPending] = useState(false)
+  const pendingRef = useRef(false)
+  const actionRef = useRef(action)
+  actionRef.current = action
+  const errorMessage = opts?.errorMessage
+
+  const run = useCallback(() => {
+    if (pendingRef.current) return
+    pendingRef.current = true
+    setPending(true)
+    Promise.resolve()
+      .then(() => actionRef.current())
+      .catch(() => {
+        if (errorMessage) toast.error(errorMessage)
+      })
+      .finally(() => {
+        pendingRef.current = false
+        setPending(false)
+      })
+  }, [errorMessage])
+
+  return { pending, run }
+}


### PR DESCRIPTION
## Problem

Async call controls (camera toggle, flip) show no feedback between tap and effect — the recapture takes ~1s, during which the button still reads the old state and accepts taps, so a user re-taps and reverses the action (camera back off). Kris's video shows exactly this on the fullscreen bar.

## Solution

A general **`useAsyncAction(action, { errorMessage })`** hook (`hooks/use-async-action.ts`): PER-INSTANCE pending — the control disables itself and swaps its icon to an in-place spinner until its OWN action settles, then restores (off → spinner → on, the clipboard pattern minus the checkmark). No shared/global busy flag, so a sibling control (flip, a device-menu item, a later screen-share toggle) is never disabled or spun by another's op. Reusable by any async control, not camera-specific — this was the point of the rework after the first `cameraBusy` attempt was too coupled.

- `CameraButton` / `FlipButton` / `LeaveButton` adopt it; re-entrancy guarded so a queued tap can't stack.
- `CallControls` (the fullscreen bar) now **reuses** the shared Mute/Camera/Flip/Leave buttons instead of its own inline copies — one implementation, so the fix lands on every surface at once (INV-35). Success stays silent (INV-63); errors keep their toast.

## Files

| File | Change |
| ---- | ------ |
| `hooks/use-async-action.ts` | **new** — general per-instance async-pending primitive |
| `components/call/call-control-buttons.tsx` | Camera/Flip/Leave use the hook (disable + spinner) |
| `components/call/call-controls.tsx` | reuse the shared buttons (drop the inline duplicates) |

## Test plan

- [x] `call-controls.test.tsx` — camera disables + spins in flight, ignores a second tap
- [x] Full call suite + monorepo lint/typecheck green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787223152&installation_model_id=20758&pr_number=1485&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1485&signature=31702b1f586c2a0fc2b8e3b001affbe5a6c34607fa0a343278d702911b9c7b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->