### PR TITLE
fix(calls): start-call menu copy → "Start voice call" / "Start video call"

### DIFF
--- a/apps/frontend/src/components/call/call-start-menu.test.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.test.tsx
@@ -36,21 +36,21 @@ beforeEach(() => clearCallState())
 afterEach(() => vi.restoreAllMocks())
 
 describe("CallStartMenu", () => {
-  it("starts a mic-only call on 'Start call'", async () => {
+  it("starts a mic-only call on 'Start voice call'", async () => {
     const manager = makeManager()
     renderMenu(manager)
     await userEvent.click(screen.getByRole("button", { name: "Start call" }))
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^Start call$/ }))
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Start voice call" }))
     expect(manager.startCall).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: "ws_1", streamId: "stream_1", mode: "video", cameraOn: false })
     )
   })
 
-  it("starts with the camera on 'Start with camera'", async () => {
+  it("starts with the camera on 'Start video call'", async () => {
     const manager = makeManager()
     renderMenu(manager)
     await userEvent.click(screen.getByRole("button", { name: "Start call" }))
-    await userEvent.click(await screen.findByRole("menuitem", { name: /Start with camera/ }))
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Start video call" }))
     expect(manager.startCall).toHaveBeenCalledWith(expect.objectContaining({ cameraOn: true }))
   })
 

--- a/apps/frontend/src/components/call/call-start-menu.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.tsx
@@ -5,10 +5,10 @@ import { cn } from "@/lib/utils"
 import { useCallLaunch } from "./call-launch-context"
 
 /**
- * The call-start affordance: a small menu offering "Start call" (mic only, opens
- * to the compact bar) and "Start with camera" (camera publishing at join, opens to
- * the gallery). The camera decision is explicit — like the "Copy as markdown" menu
- * — rather than a hidden default. The launch runs inside the item click's user
+ * The call-start affordance: a small menu offering "Start voice call" (mic only,
+ * opens to the compact bar) and "Start video call" (camera publishing at join, opens
+ * to the gallery). The voice/video decision is explicit — like the "Copy as markdown"
+ * menu — rather than a hidden default. The launch runs inside the item click's user
  * gesture so iOS honors the AudioContext (INV via CallLaunch). Disabled (and the
  * menu unopenable) while a call is already active.
  */
@@ -46,11 +46,11 @@ export function CallStartMenu({
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => start(false)}>
           <Phone className="mr-2 h-4 w-4" />
-          {startLabel}
+          Start voice call
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => start(true)}>
           <Video className="mr-2 h-4 w-4" />
-          Start with camera
+          Start video call
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -94,10 +94,10 @@ async function setUpDmPair(browser: Browser): Promise<DmPair> {
 }
 
 async function startCallFromHeader(page: Page): Promise<void> {
-  // The header call button is a menu (Start call / Start with camera); open it and
-  // pick the mic-only start.
+  // The header call button is a menu (Start voice call / Start video call); open it
+  // and pick the mic-only voice start.
   await page.getByRole("button", { name: "Start a call" }).click()
-  await page.getByRole("menuitem", { name: "Start a call" }).click()
+  await page.getByRole("menuitem", { name: "Start voice call" }).click()
   // The dock renders once the connected phase lands — self tile present.
   await expect(page.locator(CALL_TILE)).toHaveCount(1, { timeout: 20000 })
 }


### PR DESCRIPTION
Nit copy change (Kris): the header call menu items now read **Start voice call** / **Start video call** (was "Start call" / "Start with camera"). Also updates the unit + browser-E2E menuitem selectors that key off those labels.

## Test plan
- [x] `call-start-menu.test.tsx` — launches voice (cameraOn false) / video (cameraOn true) via the new labels
- [x] `calls.spec.ts` E2E helper picks "Start voice call"
- [x] typecheck clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787228102&installation_model_id=20758&pr_number=1488&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1488&signature=8246a221ccba7725dbd394b07cd1c78222972b9ae10e0d48078b31988b73cdd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->