### PR TITLE
fix: legacy flat featureFlags value crashes first render after flags redesign

### DIFF
--- a/apps/frontend/src/hooks/use-feature-flags.test.tsx
+++ b/apps/frontend/src/hooks/use-feature-flags.test.tsx
@@ -121,6 +121,33 @@ describe("feature flags — first render off persisted layers", () => {
     await waitFor(() => expect(result.current).toBe("on"))
   })
 
+  it("survives a legacy flat featureFlags map persisted before the layered shape", async () => {
+    // Pre-#1455 clients persisted the flat resolved map (empty registry → `{}`).
+    // Reading it as layers crashed the first render (Object.entries(undefined))
+    // before any bootstrap could rewrite the row — the app must instead render
+    // registry defaults.
+    const queryClient = new QueryClient()
+    await persistMetadataLayers("ws_1", {} as FeatureFlagLayers)
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("on"))
+  })
+
+  it("survives a legacy flat featureFlags map in the cached bootstrap", async () => {
+    const queryClient = new QueryClient()
+    cacheBootstrapLayers(queryClient, "ws_1", { warmStart: "off" } as unknown as FeatureFlagLayers)
+
+    const { result } = renderHook(() => useOverriddenFeatureFlags("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    // The flat keys are unlayerable and dropped — no overrides, no crash.
+    expect(result.current).toEqual([])
+  })
+
   it("treats a cached bootstrap with no layers as authoritative, not a fall-through to stale IDB", async () => {
     // A bootstrap is cached but carries no featureFlags (older server / no
     // overrides = all defaults). IDB still holds a stale "off". The present

--- a/apps/frontend/src/hooks/use-feature-flags.test.tsx
+++ b/apps/frontend/src/hooks/use-feature-flags.test.tsx
@@ -148,6 +148,37 @@ describe("feature flags — first render off persisted layers", () => {
     expect(result.current).toEqual([])
   })
 
+  it("coerces malformed layer records per key, keeping the valid sibling layer", async () => {
+    // Corrupted persistence: an array where a layer record should be, next to a
+    // valid user layer. The malformed layer coerces to {}; the valid override
+    // still applies.
+    const queryClient = new QueryClient()
+    await persistMetadataLayers("ws_1", {
+      workspace: ["not", "a", "record"],
+      user: { warmStart: "off" },
+    } as unknown as FeatureFlagLayers)
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("off"))
+  })
+
+  it("discards a layer record carrying non-string values", async () => {
+    const queryClient = new QueryClient()
+    await persistMetadataLayers("ws_1", {
+      workspace: { warmStart: 123 },
+      user: {},
+    } as unknown as FeatureFlagLayers)
+
+    const { result } = renderHook(() => useFeatureFlag("ws_1", "warmStart" as FeatureFlagKey), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current).toBe("on"))
+  })
+
   it("treats a cached bootstrap with no layers as authoritative, not a fall-through to stale IDB", async () => {
     // A bootstrap is cached but carries no featureFlags (older server / no
     // overrides = all defaults). IDB still holds a stale "off". The present

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -60,7 +60,8 @@ function coerceLayers(layers: FeatureFlagLayers | null): FeatureFlagLayers | nul
 }
 
 function isLayerRecord(value: unknown): value is Record<string, string> {
-  return typeof value === "object" && value !== null
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false
+  return Object.values(value).every((entry) => typeof entry === "string")
 }
 
 /**

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -40,7 +40,27 @@ function useFeatureFlagLayers(workspaceId: string): FeatureFlagLayers | null {
   // A cached bootstrap wins even when its layers are null — an authoritative
   // server snapshot with no overrides must not be shadowed by a stale IDB row.
   // Fall back to the persisted row only when no bootstrap is cached at all.
-  return cached ? cached.layers : persistedLayers
+  const layers = cached ? cached.layers : persistedLayers
+  return useMemo(() => coerceLayers(layers), [layers])
+}
+
+// Pre-#1455 clients stored `featureFlags` as the flat resolved map (typically
+// `{}`); read as layers, `layers.workspace`/`layers.user` are undefined and the
+// resolver throws on Object.entries — killing the first render until the row is
+// rewritten. Coerce any value missing a layer record to well-formed layers
+// (dropping the unlayerable flat keys — the next bootstrap re-persists the real
+// shape); a well-formed value passes through by reference so downstream memos hold.
+function coerceLayers(layers: FeatureFlagLayers | null): FeatureFlagLayers | null {
+  if (!layers) return null
+  if (isLayerRecord(layers.workspace) && isLayerRecord(layers.user)) return layers
+  return {
+    workspace: isLayerRecord(layers.workspace) ? layers.workspace : {},
+    user: isLayerRecord(layers.user) ? layers.user : {},
+  }
+}
+
+function isLayerRecord(value: unknown): value is Record<string, string> {
+  return typeof value === "object" && value !== null
 }
 
 /**


### PR DESCRIPTION
## Problem

Prod white-screen (Firefox + installed PWA) after the feature-flags redesign (#1455/#1459/#1461). Clients that fetched a bootstrap during the deploy window — Cloudflare Pages ships the new frontend minutes before the Railway backend finishes building — got the pre-redesign flat `featureFlags` map (`{}`, empty registry) from the old backend and persisted it to `workspaceMetadata.featureFlags` (IDB, #1459's warm-start path). The new layered resolver reads `layers.workspace` / `layers.user` off that value: `Object.entries(undefined)` throws inside `useResolvedFeatureFlags`'s `useMemo`, killing the first render of the workspace layout — before the network bootstrap can rewrite the row, so the client crash-loops on every start. Verified against the deployed bundle: the reported minified stack (`JP`/`lre`/`fz` in `index-CM75qQyN.js`) is `applyLayer`/`resolveAgainstRegistry`.

The server side is clean: `FeatureFlagOverrideRepository.findLayers` always returns both records, and prod has zero `feature_flag_overrides` rows.

## Solution

Coerce at the single read boundary, `useFeatureFlagLayers`:

- `coerceLayers` accepts the cache/IDB value; anything missing a layer record becomes `{ workspace: {}, user: {} }` (per-key: a valid record is kept). Flat legacy keys are unlayerable and dropped — the flag renders its registry default, and the next successful bootstrap re-persists the real shape, so no IDB migration is needed.
- Well-formed values pass through **by reference**, keeping the downstream `useMemo`/`listOverriddenFlags` memoization intact; the coercion itself is memoized on the raw value reference.
- Boundary-normalize over hardening `resolveAgainstRegistry` — the shared resolver stays strict for backend callers (whose repo guarantees the shape), and `winningScope` reads `layers.user` directly so a resolver-only guard would still crash `useOverriddenFeatureFlags`.

## Test plan

- [x] `use-feature-flags.test.tsx` — 9 pass, incl. two new legacy-flat-shape cases (persisted row + cached bootstrap); the cached-bootstrap case reproduces the crash on the unfixed hook
- [x] Frontend `tsc --noEmit` + pre-commit lint/typecheck gates green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787250078&installation_model_id=20758&pr_number=1489&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1489&signature=8d58807a4310719d6e83f281ac37cb94390722361319e719421d24ca72f624ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->