### PR TITLE
feat(calls): self-view mirror + Calls settings tab

### DIFF
--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -3,6 +3,7 @@ import { Settings, Signal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
@@ -10,6 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { resolveSelfMirror, setCallSelfMirror, useCallPrefs } from "@/stores/call-prefs-store"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
@@ -28,13 +30,17 @@ function deviceLabel(device: MediaDeviceInfo, index: number, fallbackPrefix = "D
 export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
   const manager = useCallManager()
   const isMobile = useIsMobile()
+  const { selfMirror } = useCallPrefs()
   // Mobile hides per-camera selection: phones enumerate several back cameras
   // (wide/ultrawide/tele) and picking a specific one by exact deviceId can reject
   // the capture (freezes the feed, then errors). Front/back is the Flip button.
   const hasCameras = !isMobile && devices.cameras.length > 0
+  // The mirror toggle shows on any surface with a camera (front/back on mobile too).
+  const hasVideo = devices.cameras.length > 0
   const hasInputs = devices.inputs.length > 0
   const hasOutputs = OUTPUT_SELECTION_SUPPORTED && devices.outputs.length > 0
-  if (!hasCameras && !hasInputs && !hasOutputs) return null
+  if (!hasCameras && !hasVideo && !hasInputs && !hasOutputs) return null
+  const mirrorOn = resolveSelfMirror(selfMirror, { isMobile, facingMode: devices.facingMode })
 
   return (
     <DropdownMenu>
@@ -44,6 +50,17 @@ export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="center" className="max-w-[280px]">
+        {hasVideo && (
+          <>
+            <DropdownMenuCheckboxItem
+              checked={mirrorOn}
+              onCheckedChange={(checked) => setCallSelfMirror(checked ? "on" : "off")}
+            >
+              Mirror my video
+            </DropdownMenuCheckboxItem>
+            {(hasCameras || hasInputs || hasOutputs) && <DropdownMenuSeparator />}
+          </>
+        )}
         {hasCameras && (
           <>
             <DropdownMenuLabel>Camera</DropdownMenuLabel>

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -3,7 +3,6 @@ import { Settings, Signal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
@@ -11,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { resolveSelfMirror, setCallSelfMirror, useCallPrefs } from "@/stores/call-prefs-store"
+import { setCallSelfMirror, useCallPrefs, type CallSelfMirror } from "@/stores/call-prefs-store"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
@@ -35,12 +34,11 @@ export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
   // (wide/ultrawide/tele) and picking a specific one by exact deviceId can reject
   // the capture (freezes the feed, then errors). Front/back is the Flip button.
   const hasCameras = !isMobile && devices.cameras.length > 0
-  // The mirror toggle shows on any surface with a camera (front/back on mobile too).
+  // The mirror control shows on any surface with a camera (front/back on mobile too).
   const hasVideo = devices.cameras.length > 0
   const hasInputs = devices.inputs.length > 0
   const hasOutputs = OUTPUT_SELECTION_SUPPORTED && devices.outputs.length > 0
-  if (!hasCameras && !hasVideo && !hasInputs && !hasOutputs) return null
-  const mirrorOn = resolveSelfMirror(selfMirror, { isMobile, facingMode: devices.facingMode })
+  if (!hasVideo && !hasInputs && !hasOutputs) return null
 
   return (
     <DropdownMenu>
@@ -52,12 +50,17 @@ export function DevicePickerMenu({ devices }: { devices: CallDeviceState }) {
       <DropdownMenuContent align="center" className="max-w-[280px]">
         {hasVideo && (
           <>
-            <DropdownMenuCheckboxItem
-              checked={mirrorOn}
-              onCheckedChange={(checked) => setCallSelfMirror(checked ? "on" : "off")}
+            {/* Tri-state (matches the Calls settings tab): a boolean toggle would
+                silently drop `auto`, and disagree with the settings radio on a back camera. */}
+            <DropdownMenuLabel>Mirror my video</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={selfMirror}
+              onValueChange={(value) => setCallSelfMirror(value as CallSelfMirror)}
             >
-              Mirror my video
-            </DropdownMenuCheckboxItem>
+              <DropdownMenuRadioItem value="auto">Automatic</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="on">On</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="off">Off</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
             {(hasCameras || hasInputs || hasOutputs) && <DropdownMenuSeparator />}
           </>
         )}

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -8,12 +8,14 @@ import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
 import {
   clearCallState,
+  getCallState,
   setCallSession,
   setCallPhase,
   setCallRoster,
   patchCallLocal,
   setCallActiveElsewhere,
   setCallCaptureError,
+  setCallSurfaceMode,
   bumpCallMediaEpoch,
   type CallRosterParticipant,
 } from "@/stores/call-store"
@@ -220,6 +222,22 @@ describe("CallDock — connected roster", () => {
     // Desktop default (auto → mirror any camera); peers always see the un-mirrored feed.
     expect(container.querySelector('[data-user-id="usr_self"] video')?.className).toContain("-scale-x-100")
     expect(container.querySelector('[data-user-id="usr_peer"] video')?.className).not.toContain("-scale-x-100")
+  })
+
+  it("keeps the self-mirror until the frames re-bind on flip (no premature mirror-flip)", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const { container } = renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    act(() => setCallSurfaceMode("standard")) // tiles render in the gallery, not the compact bar
+    const selfVideo = () => container.querySelector('[data-user-id="usr_self"] video')
+    // Mobile front (facingMode null) → mirrored.
+    expect(selfVideo()?.className).toContain("-scale-x-100")
+    // A flip sets facingMode synchronously, but the still-displayed old frames must NOT
+    // mirror-flip until the recapture re-binds the video (a mediaEpoch bump).
+    act(() => patchCallLocal({ devices: { ...getCallState().local.devices, facingMode: "environment" } }))
+    expect(selfVideo()?.className).toContain("-scale-x-100")
+    act(() => bumpCallMediaEpoch())
+    expect(selfVideo()?.className).not.toContain("-scale-x-100")
   })
 
   it("reflects a local mute toggle in the control label without a toast", () => {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -224,19 +224,27 @@ describe("CallDock — connected roster", () => {
     expect(container.querySelector('[data-user-id="usr_peer"] video')?.className).not.toContain("-scale-x-100")
   })
 
-  it("keeps the self-mirror until the frames re-bind on flip (no premature mirror-flip)", () => {
+  it("flips the self-mirror only when the SELF stream re-binds, not on any mediaEpoch", () => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
-    const { container } = renderDock(makeManager())
+    let selfStream = { id: "s1" } as unknown as MediaStream
+    const manager = makeManager({ getVideoStream: (ep: string) => (ep === "callep_self" ? selfStream : null) })
+    const { container } = renderDock(manager)
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     act(() => setCallSurfaceMode("standard")) // tiles render in the gallery, not the compact bar
     const selfVideo = () => container.querySelector('[data-user-id="usr_self"] video')
     // Mobile front (facingMode null) → mirrored.
     expect(selfVideo()?.className).toContain("-scale-x-100")
-    // A flip sets facingMode synchronously, but the still-displayed old frames must NOT
-    // mirror-flip until the recapture re-binds the video (a mediaEpoch bump).
+    // Flip sets facingMode synchronously — but the still-displayed old frames must NOT flip.
     act(() => patchCallLocal({ devices: { ...getCallState().local.devices, facingMode: "environment" } }))
     expect(selfVideo()?.className).toContain("-scale-x-100")
+    // A REMOTE video change bumps mediaEpoch but the self stream is unchanged → still no flip.
     act(() => bumpCallMediaEpoch())
+    expect(selfVideo()?.className).toContain("-scale-x-100")
+    // The self camera republishes a NEW stream → now the mirror follows the new facing.
+    act(() => {
+      selfStream = { id: "s2" } as unknown as MediaStream
+      bumpCallMediaEpoch()
+    })
     expect(selfVideo()?.className).not.toContain("-scale-x-100")
   })
 

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -211,6 +211,17 @@ describe("CallDock — connected roster", () => {
     expect(video.srcObject).toBe(fakeStream)
   })
 
+  it("mirrors the self tile's video (desktop default) but not a peer's", () => {
+    const { container } = renderDock(makeManager())
+    enterConnectedCall([
+      participant({ userId: "usr_self", endpointId: "callep_self" }),
+      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+    ])
+    // Desktop default (auto → mirror any camera); peers always see the un-mirrored feed.
+    expect(container.querySelector('[data-user-id="usr_self"] video')?.className).toContain("-scale-x-100")
+    expect(container.querySelector('[data-user-id="usr_peer"] video')?.className).not.toContain("-scale-x-100")
+  })
+
   it("reflects a local mute toggle in the control label without a toast", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])

--- a/apps/frontend/src/components/call/call-tile.tsx
+++ b/apps/frontend/src/components/call/call-tile.tsx
@@ -37,10 +37,11 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
   const mediaEpoch = useCallMediaEpoch()
   const manager = useCallManager()
   const videoRef = useRef<HTMLVideoElement>(null)
+  const lastStreamRef = useRef<MediaStream | null>(null)
   const [hasVideo, setHasVideo] = useState(false)
-  // The facing that the currently-DISPLAYED self frames were captured with. Synced on
-  // `mediaEpoch` (when the video re-binds after a flip's recapture), NOT on the immediate
-  // pref change — so the mirror flips exactly when the camera does, never before it.
+  // The facing that the currently-DISPLAYED self frames were captured with. Synced when
+  // the SELF stream re-binds (after a flip's recapture), NOT on the immediate pref change
+  // — so the mirror flips exactly when the camera does, never before it.
   const [displayedFacing, setDisplayedFacing] = useState<"user" | "environment" | null>(
     () => getCallState().local.devices.facingMode
   )
@@ -51,9 +52,11 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
     const stream = endpointId ? manager.getVideoStream(endpointId) : null
     if (el) el.srcObject = stream
     setHasVideo(!!stream)
-    // mediaEpoch bumps whenever the manager's video ref-map changes — the moment the
-    // fresh camera frames re-bind, snapshot their facing for the mirror.
-    if (isSelf) setDisplayedFacing(getCallState().local.devices.facingMode)
+    // Snapshot facing ONLY when the SELF stream itself changes (a flip/toggle republish),
+    // not on every mediaEpoch — which also bumps for remote peers, and a peer's video
+    // change mid-flip would otherwise resnapshot the new facing before the self frames land.
+    if (isSelf && stream !== lastStreamRef.current) setDisplayedFacing(getCallState().local.devices.facingMode)
+    lastStreamRef.current = stream
     return () => {
       // Null the binding on unmount (symmetric with detachRemoteAudio); the manager
       // owns the MediaStream lifecycle, so this only drops the element's reference.

--- a/apps/frontend/src/components/call/call-tile.tsx
+++ b/apps/frontend/src/components/call/call-tile.tsx
@@ -6,10 +6,10 @@ import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
-import type { CallRosterParticipant } from "@/stores/call-store"
+import { getCallState, type CallRosterParticipant } from "@/stores/call-store"
 import { resolveSelfMirror, useCallPrefs } from "@/stores/call-prefs-store"
 import { useCallManager } from "./call-manager-context"
-import { useCallDevices, useCallMediaEpoch, useCallMuted, useSpeakingLevelRef } from "./call-store-hooks"
+import { useCallMediaEpoch, useCallMuted, useSpeakingLevelRef } from "./call-store-hooks"
 
 interface CallTileProps {
   participant: CallRosterParticipant
@@ -38,6 +38,12 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
   const manager = useCallManager()
   const videoRef = useRef<HTMLVideoElement>(null)
   const [hasVideo, setHasVideo] = useState(false)
+  // The facing that the currently-DISPLAYED self frames were captured with. Synced on
+  // `mediaEpoch` (when the video re-binds after a flip's recapture), NOT on the immediate
+  // pref change — so the mirror flips exactly when the camera does, never before it.
+  const [displayedFacing, setDisplayedFacing] = useState<"user" | "environment" | null>(
+    () => getCallState().local.devices.facingMode
+  )
   const endpointId = participant.endpointId
 
   useEffect(() => {
@@ -45,13 +51,15 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
     const stream = endpointId ? manager.getVideoStream(endpointId) : null
     if (el) el.srcObject = stream
     setHasVideo(!!stream)
-    // mediaEpoch bumps whenever the manager's video ref-map changes.
+    // mediaEpoch bumps whenever the manager's video ref-map changes — the moment the
+    // fresh camera frames re-bind, snapshot their facing for the mirror.
+    if (isSelf) setDisplayedFacing(getCallState().local.devices.facingMode)
     return () => {
       // Null the binding on unmount (symmetric with detachRemoteAudio); the manager
       // owns the MediaStream lifecycle, so this only drops the element's reference.
       if (el) el.srcObject = null
     }
-  }, [manager, endpointId, mediaEpoch])
+  }, [manager, endpointId, mediaEpoch, isSelf])
 
   // Only the local participant carries a live speaking level; remote peers have
   // none in v1, so the ring is self-only.
@@ -62,11 +70,10 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
 
   // Mirror ONLY the local self-view (peers always see the un-mirrored feed). A
   // mirrored self-view feels natural like a bathroom mirror; `auto` follows the
-  // camera facing (front/desktop mirror, mobile back normal).
+  // displayed camera's facing (front/desktop mirror, mobile back normal).
   const { selfMirror } = useCallPrefs()
-  const { facingMode } = useCallDevices()
   const isMobile = useIsMobile()
-  const mirror = isSelf && resolveSelfMirror(selfMirror, { isMobile, facingMode })
+  const mirror = isSelf && resolveSelfMirror(selfMirror, { isMobile, facingMode: displayedFacing })
 
   return (
     <div

--- a/apps/frontend/src/components/call/call-tile.tsx
+++ b/apps/frontend/src/components/call/call-tile.tsx
@@ -4,10 +4,12 @@ import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import type { CallRosterParticipant } from "@/stores/call-store"
+import { resolveSelfMirror, useCallPrefs } from "@/stores/call-prefs-store"
 import { useCallManager } from "./call-manager-context"
-import { useCallMediaEpoch, useCallMuted, useSpeakingLevelRef } from "./call-store-hooks"
+import { useCallDevices, useCallMediaEpoch, useCallMuted, useSpeakingLevelRef } from "./call-store-hooks"
 
 interface CallTileProps {
   participant: CallRosterParticipant
@@ -58,6 +60,14 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
   const muted = isSelf ? selfMuted : participant.mediaState.muted === true
   const reconnecting = participant.connectionStatus === "reconnecting"
 
+  // Mirror ONLY the local self-view (peers always see the un-mirrored feed). A
+  // mirrored self-view feels natural like a bathroom mirror; `auto` follows the
+  // camera facing (front/desktop mirror, mobile back normal).
+  const { selfMirror } = useCallPrefs()
+  const { facingMode } = useCallDevices()
+  const isMobile = useIsMobile()
+  const mirror = isSelf && resolveSelfMirror(selfMirror, { isMobile, facingMode })
+
   return (
     <div
       className={cn(
@@ -83,7 +93,7 @@ export function CallTile({ participant, workspaceId, isSelf, stage = false, fill
         autoPlay
         playsInline
         muted
-        className={cn("h-full w-full object-cover", !hasVideo && "hidden")}
+        className={cn("h-full w-full object-cover", mirror && "-scale-x-100", !hasVideo && "hidden")}
         data-testid="call-tile-video"
       />
       {!hasVideo && (

--- a/apps/frontend/src/components/settings/call-settings.test.tsx
+++ b/apps/frontend/src/components/settings/call-settings.test.tsx
@@ -12,15 +12,19 @@ describe("CallSettings", () => {
   it("sets the self-mirror pref from the radio", async () => {
     render(<CallSettings />)
     expect(getCallPrefs().selfMirror).toBe("auto")
+    expect(screen.getByRole("radio", { name: "Automatic" })).toBeChecked()
     await userEvent.click(screen.getByLabelText("Always mirror"))
+    expect(screen.getByRole("radio", { name: "Always mirror" })).toBeChecked()
     expect(getCallPrefs().selfMirror).toBe("on")
     await userEvent.click(screen.getByLabelText("Never mirror"))
+    expect(screen.getByRole("radio", { name: "Never mirror" })).toBeChecked()
     expect(getCallPrefs().selfMirror).toBe("off")
   })
 
   it("sets the default layout from the radio", async () => {
     render(<CallSettings />)
     await userEvent.click(screen.getByLabelText("Grid"))
+    expect(screen.getByRole("radio", { name: "Grid" })).toBeChecked()
     expect(getCallPrefs().layout).toBe("grid")
   })
 })

--- a/apps/frontend/src/components/settings/call-settings.test.tsx
+++ b/apps/frontend/src/components/settings/call-settings.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { render, screen, userEvent } from "@/test"
+import { getCallPrefs, __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import { CallSettings } from "./call-settings"
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetCallPrefsForTests()
+})
+
+describe("CallSettings", () => {
+  it("sets the self-mirror pref from the radio", async () => {
+    render(<CallSettings />)
+    expect(getCallPrefs().selfMirror).toBe("auto")
+    await userEvent.click(screen.getByLabelText("Always mirror"))
+    expect(getCallPrefs().selfMirror).toBe("on")
+    await userEvent.click(screen.getByLabelText("Never mirror"))
+    expect(getCallPrefs().selfMirror).toBe("off")
+  })
+
+  it("sets the default layout from the radio", async () => {
+    render(<CallSettings />)
+    await userEvent.click(screen.getByLabelText("Grid"))
+    expect(getCallPrefs().layout).toBe("grid")
+  })
+})

--- a/apps/frontend/src/components/settings/call-settings.tsx
+++ b/apps/frontend/src/components/settings/call-settings.tsx
@@ -1,0 +1,89 @@
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Separator } from "@/components/ui/separator"
+import {
+  setCallLayout,
+  setCallSelfMirror,
+  useCallPrefs,
+  type CallLayout,
+  type CallSelfMirror,
+} from "@/stores/call-prefs-store"
+
+const MIRROR_OPTIONS: { value: CallSelfMirror; label: string; description: string }[] = [
+  {
+    value: "auto",
+    label: "Automatic",
+    description: "Mirror a front-facing or desktop camera; leave a phone's back camera normal.",
+  },
+  { value: "on", label: "Always mirror", description: "Always show your self-view mirrored." },
+  { value: "off", label: "Never mirror", description: "Always show your self-view the normal way." },
+]
+
+const LAYOUT_OPTIONS: { value: CallLayout; label: string; description: string }[] = [
+  {
+    value: "speaker",
+    label: "Speaker",
+    description: "One large tile for the active speaker, the rest in a filmstrip.",
+  },
+  { value: "grid", label: "Grid", description: "Equal-sized tiles for everyone." },
+]
+
+/**
+ * Call preferences (the persisted {@link import("@/stores/call-prefs-store").CallPrefs}).
+ * The in-call device menu carries a quick mirror toggle; this is the canonical home.
+ */
+export function CallSettings() {
+  const { selfMirror, layout } = useCallPrefs()
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Mirror my video</h3>
+          <p className="text-sm text-muted-foreground">
+            Flips your own self-view like a mirror. Only you see it mirrored — everyone else always sees you the normal
+            way.
+          </p>
+        </div>
+        <RadioGroup
+          value={selfMirror}
+          onValueChange={(value) => setCallSelfMirror(value as CallSelfMirror)}
+          className="space-y-3"
+        >
+          {MIRROR_OPTIONS.map((option) => (
+            <div key={option.value} className="flex items-start space-x-3">
+              <RadioGroupItem value={option.value} id={`mirror-${option.value}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`mirror-${option.value}`} className="cursor-pointer">
+                  {option.label}
+                </Label>
+                <p className="text-sm text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Default layout</h3>
+          <p className="text-sm text-muted-foreground">How a call opens; you can still switch layouts mid-call.</p>
+        </div>
+        <RadioGroup value={layout} onValueChange={(value) => setCallLayout(value as CallLayout)} className="space-y-3">
+          {LAYOUT_OPTIONS.map((option) => (
+            <div key={option.value} className="flex items-start space-x-3">
+              <RadioGroupItem value={option.value} id={`layout-${option.value}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`layout-${option.value}`} className="cursor-pointer">
+                  {option.label}
+                </Label>
+                <p className="text-sm text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -13,6 +13,7 @@ import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
 import { SETTINGS_TAB_CONFIG } from "./tab-config"
 import { AISettings } from "./ai-settings"
 import { DictationSettings } from "./dictation-settings"
+import { CallSettings } from "./call-settings"
 import { ProfileSettings } from "./profile-settings"
 import { AppearanceSettings } from "./appearance-settings"
 import { DateTimeSettings } from "./datetime-settings"
@@ -75,6 +76,9 @@ export function SettingsDialog() {
               </TabsContent>
               <TabsContent value="dictation" className="mt-0">
                 <DictationSettings />
+              </TabsContent>
+              <TabsContent value="calls" className="mt-0">
+                <CallSettings />
               </TabsContent>
               <TabsContent value="appearance" className="mt-0">
                 <AppearanceSettings />

--- a/apps/frontend/src/components/settings/tab-config.ts
+++ b/apps/frontend/src/components/settings/tab-config.ts
@@ -28,6 +28,11 @@ export const SETTINGS_TAB_CONFIG: Record<SettingsTab, SettingsTabConfig> = {
     description: "Voice model, polish, and steering words",
     keywords: ["voice", "dictation", "transcription", "polish", "steering", "speech", "mic"],
   },
+  calls: {
+    label: "Calls",
+    description: "Self-view mirror and default layout",
+    keywords: ["call", "video", "camera", "mirror", "self-view", "layout", "speaker", "grid"],
+  },
   appearance: {
     label: "Appearance",
     description: "Theme and message density",

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -4,11 +4,13 @@ import {
   setCallLayout,
   setCallDockPosition,
   setCallFilmstripSide,
+  setCallSelfMirror,
+  resolveSelfMirror,
   __resetCallPrefsForTests,
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom" }
+const DEFAULTS = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom", selfMirror: "auto" }
 
 beforeEach(() => {
   localStorage.clear()
@@ -25,11 +27,11 @@ describe("call-prefs-store", () => {
     setCallDockPosition("top")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -41,6 +43,32 @@ describe("call-prefs-store", () => {
   it("falls back per-field on an out-of-range persisted value", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "grid", dockPosition: "diagonal" }))
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "side", filmstripSide: "bottom" })
+    expect(getCallPrefs()).toEqual({
+      layout: "grid",
+      dockPosition: "side",
+      filmstripSide: "bottom",
+      selfMirror: "auto",
+    })
+  })
+
+  it("persists an explicit selfMirror override", () => {
+    setCallSelfMirror("off")
+    __resetCallPrefsForTests()
+    expect(getCallPrefs().selfMirror).toBe("off")
+  })
+})
+
+describe("resolveSelfMirror", () => {
+  it("auto mirrors desktop (any camera) and mobile front, not mobile back", () => {
+    expect(resolveSelfMirror("auto", { isMobile: false, facingMode: null })).toBe(true)
+    expect(resolveSelfMirror("auto", { isMobile: false, facingMode: "environment" })).toBe(true)
+    expect(resolveSelfMirror("auto", { isMobile: true, facingMode: "user" })).toBe(true)
+    expect(resolveSelfMirror("auto", { isMobile: true, facingMode: null })).toBe(true)
+    expect(resolveSelfMirror("auto", { isMobile: true, facingMode: "environment" })).toBe(false)
+  })
+
+  it("explicit on/off overrides the facing default", () => {
+    expect(resolveSelfMirror("on", { isMobile: true, facingMode: "environment" })).toBe(true)
+    expect(resolveSelfMirror("off", { isMobile: false, facingMode: null })).toBe(false)
   })
 })

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -15,19 +15,44 @@ import { useSyncExternalStore } from "react"
 export type CallLayout = "speaker" | "grid"
 export type CallDockPosition = "top" | "side"
 export type CallFilmstripSide = "bottom" | "side"
+/** Local self-view mirroring. `auto` = mirror a front/desktop camera, not a mobile back camera. */
+export type CallSelfMirror = "auto" | "on" | "off"
 
 export interface CallPrefs {
   layout: CallLayout
   dockPosition: CallDockPosition
   filmstripSide: CallFilmstripSide
+  selfMirror: CallSelfMirror
 }
 
-const DEFAULT_PREFS: CallPrefs = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom" }
+const DEFAULT_PREFS: CallPrefs = {
+  layout: "speaker",
+  dockPosition: "side",
+  filmstripSide: "bottom",
+  selfMirror: "auto",
+}
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
 const isDockPosition = (v: unknown): v is CallDockPosition => v === "top" || v === "side"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
+const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
+
+/**
+ * Resolve the effective self-view mirror. `auto` mirrors a front-facing view (any
+ * desktop camera, a mobile front/default camera) and leaves a mobile back camera
+ * un-mirrored — matching Messenger. An explicit `on`/`off` overrides. Local preview
+ * only; peers always see the un-mirrored feed.
+ */
+export function resolveSelfMirror(
+  pref: CallSelfMirror,
+  { isMobile, facingMode }: { isMobile: boolean; facingMode: "user" | "environment" | null }
+): boolean {
+  if (pref === "on") return true
+  if (pref === "off") return false
+  if (!isMobile) return true
+  return facingMode !== "environment"
+}
 
 function readPersisted(): CallPrefs {
   if (typeof localStorage === "undefined") return { ...DEFAULT_PREFS }
@@ -41,6 +66,7 @@ function readPersisted(): CallPrefs {
       layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
       dockPosition: isDockPosition(p.dockPosition) ? p.dockPosition : DEFAULT_PREFS.dockPosition,
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
+      selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
     }
   } catch {
     return { ...DEFAULT_PREFS }
@@ -68,7 +94,8 @@ function update(patch: Partial<CallPrefs>): void {
   if (
     next.layout === prefs.layout &&
     next.dockPosition === prefs.dockPosition &&
-    next.filmstripSide === prefs.filmstripSide
+    next.filmstripSide === prefs.filmstripSide &&
+    next.selfMirror === prefs.selfMirror
   ) {
     return
   }
@@ -91,6 +118,10 @@ export function setCallDockPosition(dockPosition: CallDockPosition): void {
 
 export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {
   update({ filmstripSide })
+}
+
+export function setCallSelfMirror(selfMirror: CallSelfMirror): void {
+  update({ selfMirror })
 }
 
 function subscribe(listener: () => void): () => void {

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -221,6 +221,7 @@ export const SETTINGS_TAB_OPTIONS = [
   "profile",
   "ai",
   "dictation",
+  "calls",
   "appearance",
   "datetime",
   "schedule",


### PR DESCRIPTION
From Kris's desktop feedback batch (the self-contained, no-design-decision piece).

## Solution
- The self tile's `<video>` is mirrored **locally only** (peers always see the un-mirrored feed) via `-scale-x-100`.
- `selfMirror` pref (`auto` | `on` | `off`, persisted): `auto` mirrors a front-facing view — **any desktop camera, a mobile front/default camera** — and leaves a **mobile back camera normal**, matching Messenger. `resolveSelfMirror` centralizes the rule.
- A **"Mirror my video"** checkbox in the device menu sets an explicit on/off override.

## Files
| File | Change |
| ---- | ------ |
| `stores/call-prefs-store.ts` | `selfMirror` pref + `resolveSelfMirror` + `setCallSelfMirror` |
| `components/call/call-tile.tsx` | mirror the self video |
| `components/call/call-controls.tsx` | "Mirror my video" checkbox in the device menu |

## Test plan
- [x] `resolveSelfMirror` (desktop/front/back matrix + on/off override), persist round-trip
- [x] self tile mirrored / peer not (call-dock integration)
- [x] typecheck clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252476&installation_model_id=20758&pr_number=1490&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1490&signature=160816bca0341889649f0e632aad297094aeb9ec6c8e05cb4e5cabebd0b2ecc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->