### PR TITLE
fix: smooth sidebar resize dragging

### DIFF
--- a/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
@@ -176,7 +176,7 @@ export function ExplorerShell({ workspaceId, mode, enabled }: ExplorerShellProps
     setPreviewWidth(Math.max(MIN_PREVIEW_WIDTH, Math.min(max, next)))
   }, [])
 
-  const { isResizing, handleResizeStart } = useResizeDrag({
+  const { isResizing, handleResizeStart, handleResizeMove, handleResizeEnd } = useResizeDrag({
     width: previewWidth,
     onWidthChange: handlePreviewWidthChange,
     direction: "left",
@@ -272,7 +272,9 @@ export function ExplorerShell({ workspaceId, mode, enabled }: ExplorerShellProps
             panelWidth={previewWidth}
             minWidth={MIN_PREVIEW_WIDTH}
             maxWidth={maxPreviewWidth}
-            onMouseDown={handleResizeStart}
+            onPointerDown={handleResizeStart}
+            onPointerMove={handleResizeMove}
+            onPointerEnd={handleResizeEnd}
             onKeyDown={handleResizeKeyDown}
             ariaLabel="Resize preview pane"
           />

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,6 +1,13 @@
 import { type CSSProperties, type ReactNode, useCallback, useEffect, useRef } from "react"
 import { RefreshCw } from "lucide-react"
-import { useSidebar, useCoordinatedLoading, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, type UrgencyBlock } from "@/contexts"
+import {
+  useSidebar,
+  useCoordinatedLoading,
+  MIN_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  SIDEBAR_COLLAPSE_THRESHOLD,
+  type UrgencyBlock,
+} from "@/contexts"
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, useTouchCapable } from "@/hooks"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useSyncEngine } from "@/sync/sync-engine"
@@ -132,16 +139,24 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   const inputMode = useInputMode()
 
   const shellRef = useRef<HTMLDivElement>(null)
+  const resizeHandleRef = useRef<HTMLDivElement>(null)
   const handleSidebarWidthChange = useCallback(
     (nextWidth: number) => {
-      const clampedWidth = `clamp(${MIN_SIDEBAR_WIDTH}px, ${nextWidth}px, ${MAX_SIDEBAR_WIDTH}px)`
-      shellRef.current?.style.setProperty("--nav-sidebar-width", clampedWidth)
-      if (state === "pinned") document.documentElement.style.setProperty("--app-content-left", clampedWidth)
+      const willCollapse = nextWidth < SIDEBAR_COLLAPSE_THRESHOLD
+      const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, nextWidth))
+      const liveWidth = willCollapse ? "6px" : `${clampedWidth}px`
+      shellRef.current?.style.setProperty("--nav-sidebar-width", liveWidth)
+      if (state === "pinned") document.documentElement.style.setProperty("--app-content-left", liveWidth)
+
+      resizeHandleRef.current?.setAttribute("aria-valuenow", String(clampedWidth))
+      if (willCollapse) resizeHandleRef.current?.setAttribute("aria-valuetext", "Release to collapse")
+      else resizeHandleRef.current?.removeAttribute("aria-valuetext")
     },
     [state]
   )
   const handleSidebarResizeEnd = useCallback(
     (finalWidth: number) => {
+      resizeHandleRef.current?.removeAttribute("aria-valuetext")
       setWidth(finalWidth)
       stopResizing()
     },
@@ -405,8 +420,10 @@ export function AppShell({ sidebar, children }: AppShellProps) {
 
               {!isCollapsed && !isMobile && (
                 <div
+                  ref={resizeHandleRef}
                   className={cn(
                     "absolute right-0 top-0 h-full w-1 touch-none cursor-col-resize",
+                    "after:absolute after:inset-y-0 after:right-0 [@media(any-pointer:coarse)]:after:w-11",
                     "hover:bg-primary/20 active:bg-primary/30",
                     "transition-colors duration-150",
                     "focus-visible:bg-primary/30 focus-visible:outline-none",

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, useCallback, useEffect, useRef } from "react"
+import { type ReactNode, useCallback, useEffect, useRef } from "react"
 import { RefreshCw } from "lucide-react"
 import {
   useSidebar,
@@ -14,6 +14,7 @@ import { useSyncEngine } from "@/sync/sync-engine"
 import { HistoryBackClose } from "@/components/ui/history-back-close"
 import { TopbarLoadingIndicator } from "./topbar-loading-indicator"
 import { ConnectionStatus } from "./connection-status"
+import { useCommittedSidebarWidth } from "./use-committed-sidebar-width"
 import { cn } from "@/lib/utils"
 
 // Pull indicator styling per mode — INV-47
@@ -140,13 +141,15 @@ export function AppShell({ sidebar, children }: AppShellProps) {
 
   const shellRef = useRef<HTMLDivElement>(null)
   const resizeHandleRef = useRef<HTMLDivElement>(null)
+  useCommittedSidebarWidth(shellRef, width, state)
   const handleSidebarWidthChange = useCallback(
     (nextWidth: number) => {
       const willCollapse = nextWidth < SIDEBAR_COLLAPSE_THRESHOLD
       const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, nextWidth))
-      const liveWidth = willCollapse ? "6px" : `${clampedWidth}px`
-      shellRef.current?.style.setProperty("--nav-sidebar-width", liveWidth)
-      if (state === "pinned") document.documentElement.style.setProperty("--app-content-left", liveWidth)
+      const shellWidth = willCollapse ? "6px" : `${clampedWidth}px`
+      shellRef.current?.style.setProperty("--nav-sidebar-width", `${clampedWidth}px`)
+      shellRef.current?.style.setProperty("--nav-sidebar-shell-width", shellWidth)
+      if (state === "pinned") document.documentElement.style.setProperty("--app-content-left", shellWidth)
 
       resizeHandleRef.current?.setAttribute("aria-valuenow", String(clampedWidth))
       if (willCollapse) resizeHandleRef.current?.setAttribute("aria-valuetext", "Release to collapse")
@@ -197,14 +200,14 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   const isCollapsed = state === "collapsed"
   const isPreview = state === "preview"
   const isOpen = state === "pinned" || isPreview
-  let wrapperWidth = "var(--nav-sidebar-width)"
+  let wrapperWidth = "var(--nav-sidebar-shell-width)"
   if (isMobile) {
     wrapperWidth = "0px"
   } else if (isCollapsed || isPreview) {
     wrapperWidth = "6px"
   }
 
-  let sidebarWidth = "var(--nav-sidebar-width)"
+  let sidebarWidth = "var(--nav-sidebar-shell-width)"
   if (isMobile) {
     sidebarWidth = "min(85vw, 320px)"
   } else if (isCollapsed) {
@@ -271,12 +274,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
     <div
       ref={shellRef}
       className="flex w-screen flex-col overflow-hidden"
-      style={
-        {
-          "--nav-sidebar-width": `${width}px`,
-          height: "var(--viewport-height, 100dvh)",
-        } as CSSProperties
-      }
+      style={{ height: "var(--viewport-height, 100dvh)" }}
     >
       {/* On mobile the sidebar is an overlay, so the OS back gesture should
            dismiss it instead of navigating to the previous stream */}
@@ -377,7 +375,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             {isPreview && !isMobile && (
               <div
                 className="absolute top-0 z-50 h-full w-[30px]"
-                style={{ left: "var(--nav-sidebar-width)" }}
+                style={{ left: "var(--nav-sidebar-shell-width)" }}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
                 aria-hidden="true"
@@ -418,12 +416,11 @@ export function AppShell({ sidebar, children }: AppShellProps) {
                 {sidebar}
               </div>
 
-              {!isCollapsed && !isMobile && (
+              {(!isCollapsed || isResizing) && !isMobile && (
                 <div
                   ref={resizeHandleRef}
                   className={cn(
-                    "absolute right-0 top-0 h-full w-1 touch-none cursor-col-resize",
-                    "after:absolute after:inset-y-0 after:right-0 [@media(any-pointer:coarse)]:after:w-11",
+                    "absolute right-0 top-0 h-full w-1 touch-pan-y cursor-col-resize",
                     "hover:bg-primary/20 active:bg-primary/30",
                     "transition-colors duration-150",
                     "focus-visible:bg-primary/30 focus-visible:outline-none",

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useCallback, useEffect } from "react"
+import { type CSSProperties, type ReactNode, useCallback, useEffect, useRef } from "react"
 import { RefreshCw } from "lucide-react"
-import { useSidebar, useCoordinatedLoading, type UrgencyBlock } from "@/contexts"
+import { useSidebar, useCoordinatedLoading, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, type UrgencyBlock } from "@/contexts"
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, useTouchCapable } from "@/hooks"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useSyncEngine } from "@/sync/sync-engine"
@@ -131,12 +131,28 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   const touchCapable = useTouchCapable()
   const inputMode = useInputMode()
 
-  const { handleResizeStart } = useResizeDrag({
+  const shellRef = useRef<HTMLDivElement>(null)
+  const handleSidebarWidthChange = useCallback(
+    (nextWidth: number) => {
+      const clampedWidth = `clamp(${MIN_SIDEBAR_WIDTH}px, ${nextWidth}px, ${MAX_SIDEBAR_WIDTH}px)`
+      shellRef.current?.style.setProperty("--nav-sidebar-width", clampedWidth)
+      if (state === "pinned") document.documentElement.style.setProperty("--app-content-left", clampedWidth)
+    },
+    [state]
+  )
+  const handleSidebarResizeEnd = useCallback(
+    (finalWidth: number) => {
+      setWidth(finalWidth)
+      stopResizing()
+    },
+    [setWidth, stopResizing]
+  )
+  const { handleResizeStart, handleResizeMove, handleResizeEnd } = useResizeDrag({
     width,
-    onWidthChange: setWidth,
+    onWidthChange: handleSidebarWidthChange,
     direction: "right",
     onResizeStart: startResizing,
-    onResizeEnd: stopResizing,
+    onResizeEnd: handleSidebarResizeEnd,
   })
 
   const isKeyboardOpen = useVisualViewport(isMobile)
@@ -166,14 +182,14 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   const isCollapsed = state === "collapsed"
   const isPreview = state === "preview"
   const isOpen = state === "pinned" || isPreview
-  let wrapperWidth = `${width}px`
+  let wrapperWidth = "var(--nav-sidebar-width)"
   if (isMobile) {
     wrapperWidth = "0px"
   } else if (isCollapsed || isPreview) {
     wrapperWidth = "6px"
   }
 
-  let sidebarWidth = `${width}px`
+  let sidebarWidth = "var(--nav-sidebar-width)"
   if (isMobile) {
     sidebarWidth = "min(85vw, 320px)"
   } else if (isCollapsed) {
@@ -211,8 +227,11 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   // app-mounted desktop call dock can pin itself to the content area — over the
   // main region, never the sidebar. Mirrors the `--composer-height` var pattern.
   useEffect(() => {
-    document.documentElement.style.setProperty("--app-content-left", wrapperWidth)
-  }, [wrapperWidth])
+    let appContentLeft = "6px"
+    if (isMobile) appContentLeft = "0px"
+    else if (state === "pinned") appContentLeft = `${width}px`
+    document.documentElement.style.setProperty("--app-content-left", appContentLeft)
+  }, [isMobile, state, width])
 
   // Derive mobile sidebar/backdrop classes outside JSX to avoid nested ternaries (INV-47)
   let backdropVisibility: string | undefined
@@ -234,7 +253,16 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   // layer forced a full re-raster of the whole app on every keyboard snap,
   // which blacked the screen out for hundreds of ms on mobile GPUs.
   return (
-    <div className="flex w-screen flex-col overflow-hidden" style={{ height: "var(--viewport-height, 100dvh)" }}>
+    <div
+      ref={shellRef}
+      className="flex w-screen flex-col overflow-hidden"
+      style={
+        {
+          "--nav-sidebar-width": `${width}px`,
+          height: "var(--viewport-height, 100dvh)",
+        } as CSSProperties
+      }
+    >
       {/* On mobile the sidebar is an overlay, so the OS back gesture should
            dismiss it instead of navigating to the previous stream */}
       {isMobile && <HistoryBackClose open={isOpen} onClose={collapse} />}
@@ -334,7 +362,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             {isPreview && !isMobile && (
               <div
                 className="absolute top-0 z-50 h-full w-[30px]"
-                style={{ left: `${width}px` }}
+                style={{ left: "var(--nav-sidebar-width)" }}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
                 aria-hidden="true"
@@ -368,8 +396,8 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               <div
                 className="h-full flex-1 flex flex-col overflow-hidden"
                 style={{
-                  width: isMobile ? "min(85vw, 320px)" : `${width}px`,
-                  minWidth: isMobile ? undefined : `${width}px`,
+                  width: isMobile ? "min(85vw, 320px)" : "var(--nav-sidebar-width)",
+                  minWidth: isMobile ? undefined : "var(--nav-sidebar-width)",
                 }}
               >
                 {sidebar}
@@ -378,13 +406,17 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               {!isCollapsed && !isMobile && (
                 <div
                   className={cn(
-                    "absolute right-0 top-0 h-full w-1 cursor-col-resize",
+                    "absolute right-0 top-0 h-full w-1 touch-none cursor-col-resize",
                     "hover:bg-primary/20 active:bg-primary/30",
                     "transition-colors duration-150",
                     "focus-visible:bg-primary/30 focus-visible:outline-none",
                     isResizing && "bg-primary/30"
                   )}
-                  onMouseDown={handleResizeStart}
+                  onPointerDown={handleResizeStart}
+                  onPointerMove={handleResizeMove}
+                  onPointerUp={handleResizeEnd}
+                  onPointerCancel={handleResizeEnd}
+                  onLostPointerCapture={handleResizeEnd}
                   onKeyDown={(e) => {
                     const step = e.shiftKey ? 50 : 10
                     if (e.key === "ArrowLeft") {
@@ -399,8 +431,8 @@ export function AppShell({ sidebar, children }: AppShellProps) {
                   role="separator"
                   aria-orientation="vertical"
                   aria-valuenow={width}
-                  aria-valuemin={200}
-                  aria-valuemax={400}
+                  aria-valuemin={MIN_SIDEBAR_WIDTH}
+                  aria-valuemax={MAX_SIDEBAR_WIDTH}
                   aria-label="Resize sidebar"
                 />
               )}

--- a/apps/frontend/src/components/layout/panel-resize-handle.tsx
+++ b/apps/frontend/src/components/layout/panel-resize-handle.tsx
@@ -6,7 +6,9 @@ interface PanelResizeHandleProps {
   panelWidth: number
   minWidth: number
   maxWidth: number
-  onMouseDown: (e: React.MouseEvent) => void
+  onPointerDown: (e: React.PointerEvent) => void
+  onPointerMove: (e: React.PointerEvent) => void
+  onPointerEnd: (e: React.PointerEvent) => void
   onKeyDown: (e: React.KeyboardEvent) => void
   ariaLabel?: string
 }
@@ -16,20 +18,26 @@ export function PanelResizeHandle({
   panelWidth,
   minWidth,
   maxWidth,
-  onMouseDown,
+  onPointerDown,
+  onPointerMove,
+  onPointerEnd,
   onKeyDown,
   ariaLabel = "Resize thread panel",
 }: PanelResizeHandleProps) {
   return (
     <div
       className={cn(
-        "relative flex w-px flex-shrink-0 items-center justify-center bg-border cursor-col-resize",
+        "relative flex w-px flex-shrink-0 touch-none items-center justify-center bg-border cursor-col-resize",
         "after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2",
         "focus-visible:bg-primary/30 focus-visible:outline-none",
         !isResizing && "transition-colors duration-150",
         isResizing && "bg-primary/30"
       )}
-      onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+      onLostPointerCapture={onPointerEnd}
       onKeyDown={onKeyDown}
       tabIndex={0}
       role="separator"

--- a/apps/frontend/src/components/layout/panel-resize-handle.tsx
+++ b/apps/frontend/src/components/layout/panel-resize-handle.tsx
@@ -29,6 +29,7 @@ export function PanelResizeHandle({
       className={cn(
         "relative flex w-px flex-shrink-0 touch-none items-center justify-center bg-border cursor-col-resize",
         "after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2",
+        "[@media(any-pointer:coarse)]:after:w-11",
         "focus-visible:bg-primary/30 focus-visible:outline-none",
         !isResizing && "transition-colors duration-150",
         isResizing && "bg-primary/30"

--- a/apps/frontend/src/components/layout/panel-resize-handle.tsx
+++ b/apps/frontend/src/components/layout/panel-resize-handle.tsx
@@ -27,9 +27,8 @@ export function PanelResizeHandle({
   return (
     <div
       className={cn(
-        "relative flex w-px flex-shrink-0 touch-none items-center justify-center bg-border cursor-col-resize",
-        "after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2",
-        "[@media(any-pointer:coarse)]:after:w-11",
+        "resize-handle-touch-target relative flex w-px flex-shrink-0 touch-pan-y items-center justify-center bg-border cursor-col-resize",
+        "after:absolute after:left-1/2 after:-translate-x-1/2",
         "focus-visible:bg-primary/30 focus-visible:outline-none",
         !isResizing && "transition-colors duration-150",
         isResizing && "bg-primary/30"

--- a/apps/frontend/src/components/layout/thread-panel-slot.tsx
+++ b/apps/frontend/src/components/layout/thread-panel-slot.tsx
@@ -10,7 +10,9 @@ interface ThreadPanelSlotProps {
   minWidth: number
   maxWidth: number
   onTransitionEnd: (e: React.TransitionEvent) => void
-  onResizeStart: (e: React.MouseEvent) => void
+  onResizeStart: (e: React.PointerEvent) => void
+  onResizeMove: (e: React.PointerEvent) => void
+  onResizeEnd: (e: React.PointerEvent) => void
   onResizeKeyDown: (e: React.KeyboardEvent) => void
   children: React.ReactNode
 }
@@ -25,6 +27,8 @@ export function ThreadPanelSlot({
   maxWidth,
   onTransitionEnd,
   onResizeStart,
+  onResizeMove,
+  onResizeEnd,
   onResizeKeyDown,
   children,
 }: ThreadPanelSlotProps) {
@@ -42,7 +46,9 @@ export function ThreadPanelSlot({
             panelWidth={panelWidth}
             minWidth={minWidth}
             maxWidth={maxWidth}
-            onMouseDown={onResizeStart}
+            onPointerDown={onResizeStart}
+            onPointerMove={onResizeMove}
+            onPointerEnd={onResizeEnd}
             onKeyDown={onResizeKeyDown}
           />
           <div className="flex-1 min-w-0 overflow-hidden">{children}</div>

--- a/apps/frontend/src/components/layout/use-committed-sidebar-width.test.tsx
+++ b/apps/frontend/src/components/layout/use-committed-sidebar-width.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react"
+import { useRef } from "react"
+import { describe, expect, it } from "vitest"
+import { useCommittedSidebarWidth } from "./use-committed-sidebar-width"
+
+function Harness({ width, state }: { width: number; state: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useCommittedSidebarWidth(ref, width, state)
+  return <div ref={ref} data-testid="shell" />
+}
+
+describe("useCommittedSidebarWidth", () => {
+  it("reclaims the live width when sidebar state changes without a persisted width change", () => {
+    const view = render(<Harness width={260} state="pinned" />)
+    const shell = view.getByTestId("shell")
+    expect({
+      content: shell.style.getPropertyValue("--nav-sidebar-width"),
+      shell: shell.style.getPropertyValue("--nav-sidebar-shell-width"),
+    }).toEqual({ content: "260px", shell: "260px" })
+
+    shell.style.setProperty("--nav-sidebar-width", "200px")
+    shell.style.setProperty("--nav-sidebar-shell-width", "6px")
+    view.rerender(<Harness width={260} state="collapsed" />)
+
+    expect({
+      content: shell.style.getPropertyValue("--nav-sidebar-width"),
+      shell: shell.style.getPropertyValue("--nav-sidebar-shell-width"),
+    }).toEqual({ content: "260px", shell: "260px" })
+  })
+})

--- a/apps/frontend/src/components/layout/use-committed-sidebar-width.ts
+++ b/apps/frontend/src/components/layout/use-committed-sidebar-width.ts
@@ -1,0 +1,9 @@
+import { type RefObject, useLayoutEffect } from "react"
+
+export function useCommittedSidebarWidth(shellRef: RefObject<HTMLElement | null>, width: number, sidebarState: string) {
+  useLayoutEffect(() => {
+    // Collapse can leave width unchanged, so the state dependency reclaims this var from the live drag writer.
+    shellRef.current?.style.setProperty("--nav-sidebar-width", `${width}px`)
+    shellRef.current?.style.setProperty("--nav-sidebar-shell-width", `${width}px`)
+  }, [shellRef, sidebarState, width])
+}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -56,7 +56,14 @@ export {
   type CoordinatedPhase,
   type StreamState,
 } from "./coordinated-loading-context"
-export { SidebarProvider, useSidebar, type UrgencyBlock, type CollapseState } from "./sidebar-context"
+export {
+  SidebarProvider,
+  useSidebar,
+  MIN_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  type UrgencyBlock,
+  type CollapseState,
+} from "./sidebar-context"
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
 export {

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -61,6 +61,7 @@ export {
   useSidebar,
   MIN_SIDEBAR_WIDTH,
   MAX_SIDEBAR_WIDTH,
+  SIDEBAR_COLLAPSE_THRESHOLD,
   type UrgencyBlock,
   type CollapseState,
 } from "./sidebar-context"

--- a/apps/frontend/src/contexts/sidebar-context.test.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.test.tsx
@@ -48,6 +48,31 @@ describe("SidebarContext.togglePinned (desktop)", () => {
   })
 })
 
+describe("SidebarContext.setWidth", () => {
+  beforeEach(() => {
+    localStorage.removeItem(SIDEBAR_STATE_KEY)
+  })
+
+  it("clamps a non-collapsing resize to the minimum width", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper })
+
+    act(() => result.current.setWidth(175))
+
+    expect({ state: result.current.state, width: result.current.width }).toEqual({
+      state: "pinned",
+      width: 200,
+    })
+  })
+
+  it("collapses below the resize-to-minimize threshold", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper })
+
+    act(() => result.current.setWidth(149))
+
+    expect(result.current.state).toBe("collapsed")
+  })
+})
+
 describe("SidebarContext.toggleSectionState", () => {
   beforeEach(() => {
     localStorage.removeItem(SIDEBAR_STATE_KEY)

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -42,6 +42,7 @@ interface SidebarPersistedState {
 
 export const MIN_SIDEBAR_WIDTH = 200
 export const MAX_SIDEBAR_WIDTH = 400
+export const SIDEBAR_COLLAPSE_THRESHOLD = MIN_SIDEBAR_WIDTH - 50
 const DEFAULT_SIDEBAR_WIDTH = 260
 const SIDEBAR_STATE_KEY = "threa-sidebar-state"
 
@@ -358,23 +359,20 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 
   const setWidth = useCallback(
     (newWidth: number) => {
-      // Resize-to-minimize: if dragged small enough, collapse instead
-      const collapseThreshold = MIN_SIDEBAR_WIDTH - 50
-
       // If dragging back up from collapsed state, re-expand
       setState((currentState) => {
         if (currentState === "collapsed" && newWidth >= MIN_SIDEBAR_WIDTH) {
           updatePersistedState({ openState: "open" })
           return "pinned"
         }
-        if (currentState !== "collapsed" && newWidth < collapseThreshold) {
+        if (currentState !== "collapsed" && newWidth < SIDEBAR_COLLAPSE_THRESHOLD) {
           updatePersistedState({ openState: "collapsed" })
           return "collapsed"
         }
         return currentState
       })
 
-      if (newWidth >= collapseThreshold) {
+      if (newWidth >= SIDEBAR_COLLAPSE_THRESHOLD) {
         const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, newWidth))
         updatePersistedState({ width: clampedWidth })
       }

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -40,8 +40,8 @@ interface SidebarPersistedState {
   sectionStates: Record<string, CollapseState>
 }
 
-const MIN_SIDEBAR_WIDTH = 200
-const MAX_SIDEBAR_WIDTH = 400
+export const MIN_SIDEBAR_WIDTH = 200
+export const MAX_SIDEBAR_WIDTH = 400
 const DEFAULT_SIDEBAR_WIDTH = 260
 const SIDEBAR_STATE_KEY = "threa-sidebar-state"
 
@@ -374,9 +374,8 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
         return currentState
       })
 
-      // Update width if above minimum
-      if (newWidth >= MIN_SIDEBAR_WIDTH) {
-        const clampedWidth = Math.min(MAX_SIDEBAR_WIDTH, newWidth)
+      if (newWidth >= collapseThreshold) {
+        const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, newWidth))
         updatePersistedState({ width: clampedWidth })
       }
     },

--- a/apps/frontend/src/hooks/use-panel-layout.test.tsx
+++ b/apps/frontend/src/hooks/use-panel-layout.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { usePanelLayout } from "./use-panel-layout"
+
+function pointerEvent(type: "pointerdown" | "pointerup"): React.PointerEvent {
+  return {
+    type,
+    pointerId: 1,
+    clientX: 100,
+    isPrimary: true,
+    button: 0,
+    currentTarget: { setPointerCapture: vi.fn() },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as React.PointerEvent
+}
+
+describe("usePanelLayout", () => {
+  it("keeps captured resize content mounted until a mid-drag close settles", () => {
+    const { result, rerender } = renderHook(({ open }) => usePanelLayout(open), {
+      initialProps: { open: true },
+    })
+
+    act(() => result.current.handleResizeStart(pointerEvent("pointerdown")))
+    rerender({ open: false })
+
+    expect({ isResizing: result.current.isResizing, showContent: result.current.showContent }).toEqual({
+      isResizing: true,
+      showContent: true,
+    })
+
+    act(() => result.current.handleResizeEnd(pointerEvent("pointerup")))
+
+    expect({ isResizing: result.current.isResizing, showContent: result.current.showContent }).toEqual({
+      isResizing: false,
+      showContent: false,
+    })
+  })
+})

--- a/apps/frontend/src/hooks/use-panel-layout.ts
+++ b/apps/frontend/src/hooks/use-panel-layout.ts
@@ -65,7 +65,7 @@ export function usePanelLayout(isPanelOpen: boolean) {
     [containerWidth, maxWidth]
   )
 
-  const { isResizing, handleResizeStart } = useResizeDrag({
+  const { isResizing, handleResizeStart, handleResizeMove, handleResizeEnd } = useResizeDrag({
     width: effectiveWidth,
     onWidthChange: handleWidthChange,
     direction: "left",
@@ -105,6 +105,8 @@ export function usePanelLayout(isPanelOpen: boolean) {
     isResizing,
     showContent,
     handleResizeStart,
+    handleResizeMove,
+    handleResizeEnd,
     handleResizeKeyDown,
     handleTransitionEnd,
   }

--- a/apps/frontend/src/hooks/use-panel-layout.ts
+++ b/apps/frontend/src/hooks/use-panel-layout.ts
@@ -25,6 +25,7 @@ export function usePanelLayout(isPanelOpen: boolean) {
   const [enableTransition, setEnableTransition] = useState(false)
   const [showContent, setShowContent] = useState(isPanelOpen)
   const containerRef = useRef<HTMLDivElement>(null)
+  const closedDuringResizeRef = useRef(false)
 
   // Live-clamped panel width: opening a panel — or a smaller window / sidebar
   // collapse — re-caps the stored width so the default 480 can't crush the main
@@ -74,9 +75,12 @@ export function usePanelLayout(isPanelOpen: boolean) {
   // Content mount/unmount lifecycle — keep content mounted during close animation
   useEffect(() => {
     if (isPanelOpen) {
+      closedDuringResizeRef.current = false
       setShowContent(true)
-    } else if (!enableTransition || isResizing) {
-      // No transition will fire — unmount immediately
+    } else if (isResizing) {
+      closedDuringResizeRef.current = true
+    } else if (!enableTransition || closedDuringResizeRef.current) {
+      closedDuringResizeRef.current = false
       setShowContent(false)
     }
   }, [isPanelOpen, enableTransition, isResizing])

--- a/apps/frontend/src/hooks/use-resize-drag.test.tsx
+++ b/apps/frontend/src/hooks/use-resize-drag.test.tsx
@@ -60,7 +60,7 @@ describe("useResizeDrag", () => {
     render(<ResizeHarness onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
     const handle = screen.getByTestId("handle")
 
-    fireEvent.pointerDown(handle, { pointerId: 7, clientX: 100 })
+    fireEvent.pointerDown(handle, { pointerId: 7, clientX: 100, isPrimary: true, button: 0 })
     expect(setPointerCapture).toHaveBeenCalledWith(7)
     expect(handle).toHaveAttribute("data-resizing", "true")
 
@@ -80,13 +80,41 @@ describe("useResizeDrag", () => {
     expect(handle).toHaveAttribute("data-resizing", "false")
   })
 
+  it("restores the starting width when the pointer is cancelled", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    render(<ResizeHarness onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
+    const handle = screen.getByTestId("handle")
+
+    fireEvent.pointerDown(handle, { pointerId: 5, clientX: 100, isPrimary: true, button: 0 })
+    fireEvent.pointerMove(handle, { pointerId: 5, clientX: 140 })
+    act(() => frames.values().next().value?.(0))
+    fireEvent.pointerCancel(handle, { pointerId: 5, clientX: 140 })
+
+    expect(onWidthChange).toHaveBeenLastCalledWith(250)
+    expect(onResizeEnd).toHaveBeenCalledWith(250)
+  })
+
+  it("ignores secondary pointers and non-primary mouse buttons", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    render(<ResizeHarness onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
+    const handle = screen.getByTestId("handle")
+
+    fireEvent.pointerDown(handle, { pointerId: 8, clientX: 100, isPrimary: false, button: 0 })
+    fireEvent.pointerDown(handle, { pointerId: 9, clientX: 100, isPrimary: true, button: 2 })
+
+    expect(setPointerCapture).not.toHaveBeenCalled()
+    expect(handle).toHaveAttribute("data-resizing", "false")
+  })
+
   it("reverses the drag delta for a right-side panel", () => {
     const onWidthChange = vi.fn()
     const onResizeEnd = vi.fn()
     render(<ResizeHarness direction="left" onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
     const handle = screen.getByTestId("handle")
 
-    fireEvent.pointerDown(handle, { pointerId: 3, clientX: 300 })
+    fireEvent.pointerDown(handle, { pointerId: 3, clientX: 300, isPrimary: true, button: 0 })
     fireEvent.pointerMove(handle, { pointerId: 3, clientX: 260 })
     fireEvent.pointerUp(handle, { pointerId: 3, clientX: 260 })
 

--- a/apps/frontend/src/hooks/use-resize-drag.test.tsx
+++ b/apps/frontend/src/hooks/use-resize-drag.test.tsx
@@ -1,0 +1,95 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useResizeDrag } from "./use-resize-drag"
+
+function ResizeHarness({
+  onWidthChange,
+  onResizeEnd,
+  direction = "right",
+}: {
+  onWidthChange: (width: number) => void
+  onResizeEnd: (width: number) => void
+  direction?: "right" | "left"
+}) {
+  const resize = useResizeDrag({ width: 250, onWidthChange, onResizeEnd, direction })
+  return (
+    <div
+      data-testid="handle"
+      data-resizing={resize.isResizing}
+      onPointerDown={resize.handleResizeStart}
+      onPointerMove={resize.handleResizeMove}
+      onPointerUp={resize.handleResizeEnd}
+      onPointerCancel={resize.handleResizeEnd}
+    />
+  )
+}
+
+describe("useResizeDrag", () => {
+  const frames = new Map<number, FrameRequestCallback>()
+  let nextFrame = 1
+  const setPointerCapture = vi.fn()
+
+  beforeEach(() => {
+    frames.clear()
+    nextFrame = 1
+    setPointerCapture.mockClear()
+    HTMLElement.prototype.setPointerCapture = setPointerCapture
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = nextFrame++
+        frames.set(id, callback)
+        return id
+      })
+    )
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => {
+        frames.delete(id)
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("captures the pointer, coalesces moves, and commits the final width", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    render(<ResizeHarness onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
+    const handle = screen.getByTestId("handle")
+
+    fireEvent.pointerDown(handle, { pointerId: 7, clientX: 100 })
+    expect(setPointerCapture).toHaveBeenCalledWith(7)
+    expect(handle).toHaveAttribute("data-resizing", "true")
+
+    fireEvent.pointerMove(handle, { pointerId: 7, clientX: 120 })
+    fireEvent.pointerMove(handle, { pointerId: 7, clientX: 145 })
+    expect(onWidthChange).not.toHaveBeenCalled()
+
+    act(() => frames.values().next().value?.(0))
+    expect(onWidthChange).toHaveBeenCalledTimes(1)
+    expect(onWidthChange).toHaveBeenLastCalledWith(295)
+
+    fireEvent.pointerMove(handle, { pointerId: 7, clientX: 160 })
+    fireEvent.pointerUp(handle, { pointerId: 7, clientX: 160 })
+
+    expect(onWidthChange).toHaveBeenLastCalledWith(310)
+    expect(onResizeEnd).toHaveBeenCalledWith(310)
+    expect(handle).toHaveAttribute("data-resizing", "false")
+  })
+
+  it("reverses the drag delta for a right-side panel", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    render(<ResizeHarness direction="left" onWidthChange={onWidthChange} onResizeEnd={onResizeEnd} />)
+    const handle = screen.getByTestId("handle")
+
+    fireEvent.pointerDown(handle, { pointerId: 3, clientX: 300 })
+    fireEvent.pointerMove(handle, { pointerId: 3, clientX: 260 })
+    fireEvent.pointerUp(handle, { pointerId: 3, clientX: 260 })
+
+    expect(onResizeEnd).toHaveBeenCalledWith(290)
+  })
+})

--- a/apps/frontend/src/hooks/use-resize-drag.test.tsx
+++ b/apps/frontend/src/hooks/use-resize-drag.test.tsx
@@ -26,6 +26,7 @@ function ResizeHarness({
 
 describe("useResizeDrag", () => {
   const frames = new Map<number, FrameRequestCallback>()
+  const originalSetPointerCapture = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "setPointerCapture")
   let nextFrame = 1
   const setPointerCapture = vi.fn()
 
@@ -33,7 +34,10 @@ describe("useResizeDrag", () => {
     frames.clear()
     nextFrame = 1
     setPointerCapture.mockClear()
-    HTMLElement.prototype.setPointerCapture = setPointerCapture
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+      configurable: true,
+      value: setPointerCapture,
+    })
     vi.stubGlobal(
       "requestAnimationFrame",
       vi.fn((callback: FrameRequestCallback) => {
@@ -51,6 +55,11 @@ describe("useResizeDrag", () => {
   })
 
   afterEach(() => {
+    if (originalSetPointerCapture) {
+      Object.defineProperty(HTMLElement.prototype, "setPointerCapture", originalSetPointerCapture)
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "setPointerCapture")
+    }
     vi.unstubAllGlobals()
   })
 
@@ -69,8 +78,7 @@ describe("useResizeDrag", () => {
     expect(onWidthChange).not.toHaveBeenCalled()
 
     act(() => frames.values().next().value?.(0))
-    expect(onWidthChange).toHaveBeenCalledTimes(1)
-    expect(onWidthChange).toHaveBeenLastCalledWith(295)
+    expect(onWidthChange.mock.calls).toEqual([[295]])
 
     fireEvent.pointerMove(handle, { pointerId: 7, clientX: 160 })
     fireEvent.pointerUp(handle, { pointerId: 7, clientX: 160 })

--- a/apps/frontend/src/hooks/use-resize-drag.ts
+++ b/apps/frontend/src/hooks/use-resize-drag.ts
@@ -3,25 +3,31 @@ import { useState, useEffect, useRef, useCallback } from "react"
 interface UseResizeDragOptions {
   /** Current width of the resizable element */
   width: number
-  /** Called on each mousemove with the computed new width */
+  /** Called at most once per animation frame with the live drag width */
   onWidthChange: (newWidth: number) => void
   /** "right" = dragging right increases width (sidebar), "left" = dragging left increases width (right-side panel) */
   direction?: "right" | "left"
   /** Called when drag starts */
   onResizeStart?: () => void
-  /** Called when drag ends (mouseup or focus loss) */
-  onResizeEnd?: () => void
+  /** Called once with the final width when the pointer is released or cancelled */
+  onResizeEnd?: (finalWidth: number) => void
 }
 
 interface UseResizeDragReturn {
   isResizing: boolean
-  handleResizeStart: (e: React.MouseEvent) => void
+  handleResizeStart: (e: React.PointerEvent) => void
+  handleResizeMove: (e: React.PointerEvent) => void
+  handleResizeEnd: (e: React.PointerEvent) => void
 }
 
-/**
- * Shared drag-resize primitive. Handles mousedown → mousemove → mouseup lifecycle
- * with document-level listeners and blur escape hatch for stuck state prevention.
- */
+interface ResizeState {
+  pointerId: number
+  startX: number
+  startWidth: number
+  latestWidth: number
+  emittedWidth: number
+}
+
 export function useResizeDrag({
   width,
   onWidthChange,
@@ -30,45 +36,77 @@ export function useResizeDrag({
   onResizeEnd,
 }: UseResizeDragOptions): UseResizeDragReturn {
   const [isResizing, setIsResizing] = useState(false)
-  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const resizeRef = useRef<ResizeState | null>(null)
+  const frameRef = useRef<number | null>(null)
+
+  const flushWidthChange = useCallback(() => {
+    frameRef.current = null
+    const resize = resizeRef.current
+    if (resize) {
+      resize.emittedWidth = resize.latestWidth
+      onWidthChange(resize.latestWidth)
+    }
+  }, [onWidthChange])
 
   const handleResizeStart = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.PointerEvent) => {
       e.preventDefault()
       e.stopPropagation()
-      resizeRef.current = { startX: e.clientX, startWidth: width }
+      resizeRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startWidth: width,
+        latestWidth: width,
+        emittedWidth: width,
+      }
+      e.currentTarget.setPointerCapture(e.pointerId)
       setIsResizing(true)
       onResizeStart?.()
     },
     [width, onResizeStart]
   )
 
-  useEffect(() => {
-    if (!isResizing) return
+  const handleResizeMove = useCallback(
+    (e: React.PointerEvent) => {
+      const resize = resizeRef.current
+      if (!resize || resize.pointerId !== e.pointerId) return
 
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!resizeRef.current) return
-      const rawDelta = e.clientX - resizeRef.current.startX
+      const rawDelta = e.clientX - resize.startX
       const delta = direction === "right" ? rawDelta : -rawDelta
-      onWidthChange(resizeRef.current.startWidth + delta)
-    }
+      resize.latestWidth = resize.startWidth + delta
+      if (frameRef.current === null) frameRef.current = requestAnimationFrame(flushWidthChange)
+    },
+    [direction, flushWidthChange]
+  )
 
-    const handleMouseUp = () => {
+  const handleResizeEnd = useCallback(
+    (e: React.PointerEvent) => {
+      const resize = resizeRef.current
+      if (!resize || resize.pointerId !== e.pointerId) return
+
+      if (e.type === "pointerup") {
+        const rawDelta = e.clientX - resize.startX
+        const delta = direction === "right" ? rawDelta : -rawDelta
+        resize.latestWidth = resize.startWidth + delta
+      }
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+      if (resize.latestWidth !== resize.emittedWidth) onWidthChange(resize.latestWidth)
       resizeRef.current = null
       setIsResizing(false)
-      onResizeEnd?.()
-    }
+      onResizeEnd?.(resize.latestWidth)
+    },
+    [direction, onWidthChange, onResizeEnd]
+  )
 
-    document.addEventListener("mousemove", handleMouseMove)
-    document.addEventListener("mouseup", handleMouseUp)
-    window.addEventListener("blur", handleMouseUp)
+  useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+    },
+    []
+  )
 
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove)
-      document.removeEventListener("mouseup", handleMouseUp)
-      window.removeEventListener("blur", handleMouseUp)
-    }
-  }, [isResizing, direction, onWidthChange, onResizeEnd])
-
-  return { isResizing, handleResizeStart }
+  return { isResizing, handleResizeStart, handleResizeMove, handleResizeEnd }
 }

--- a/apps/frontend/src/hooks/use-resize-drag.ts
+++ b/apps/frontend/src/hooks/use-resize-drag.ts
@@ -50,6 +50,7 @@ export function useResizeDrag({
 
   const handleResizeStart = useCallback(
     (e: React.PointerEvent) => {
+      if (!e.isPrimary || e.button !== 0 || resizeRef.current) return
       e.preventDefault()
       e.stopPropagation()
       resizeRef.current = {
@@ -88,6 +89,8 @@ export function useResizeDrag({
         const rawDelta = e.clientX - resize.startX
         const delta = direction === "right" ? rawDelta : -rawDelta
         resize.latestWidth = resize.startWidth + delta
+      } else {
+        resize.latestWidth = resize.startWidth
       }
       if (frameRef.current !== null) {
         cancelAnimationFrame(frameRef.current)

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -119,6 +119,22 @@
     opacity: 1;
     pointer-events: auto;
   }
+
+  .resize-handle-touch-target::after {
+    content: "";
+    top: 0;
+    bottom: 0;
+    width: 4px;
+  }
+  @media (pointer: coarse) {
+    .resize-handle-touch-target::after {
+      top: 50%;
+      bottom: auto;
+      width: 44px;
+      height: 44px;
+      translate: 0 -50%;
+    }
+  }
 }
 
 /* Per-message hover wash (Slack-style row highlight) — GATED to mouse input via

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -309,6 +309,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     isResizing,
     showContent,
     handleResizeStart,
+    handleResizeMove,
+    handleResizeEnd,
     handleResizeKeyDown,
     handleTransitionEnd,
   } = usePanelLayout(isPanelOpen)
@@ -822,6 +824,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         minWidth={minWidth}
         onTransitionEnd={handleTransitionEnd}
         onResizeStart={handleResizeStart}
+        onResizeMove={handleResizeMove}
+        onResizeEnd={handleResizeEnd}
         onResizeKeyDown={handleResizeKeyDown}
       >
         <PanelHost workspaceId={workspaceId} onClose={closePanel} />

--- a/apps/frontend/src/pages/persona-editor.tsx
+++ b/apps/frontend/src/pages/persona-editor.tsx
@@ -67,6 +67,8 @@ export function PersonaEditorPage() {
     isResizing,
     showContent,
     handleResizeStart,
+    handleResizeMove,
+    handleResizeEnd,
     handleResizeKeyDown,
     handleTransitionEnd,
   } = usePanelLayout(showTestPane)
@@ -152,6 +154,8 @@ export function PersonaEditorPage() {
             minWidth={minWidth}
             onTransitionEnd={handleTransitionEnd}
             onResizeStart={handleResizeStart}
+            onResizeMove={handleResizeMove}
+            onResizeEnd={handleResizeEnd}
             onResizeKeyDown={handleResizeKeyDown}
           >
             <PersonaTestChatPane

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -87,6 +87,8 @@ export function StreamPage() {
     isResizing,
     showContent,
     handleResizeStart,
+    handleResizeMove,
+    handleResizeEnd,
     handleResizeKeyDown,
     handleTransitionEnd,
   } = usePanelLayout(isPanelOpen)
@@ -948,6 +950,8 @@ export function StreamPage() {
           minWidth={minWidth}
           onTransitionEnd={handleTransitionEnd}
           onResizeStart={handleResizeStart}
+          onResizeMove={handleResizeMove}
+          onResizeEnd={handleResizeEnd}
           onResizeKeyDown={handleResizeKeyDown}
         >
           <PanelHost key={panelId} workspaceId={workspaceId} onClose={closePanel} />


### PR DESCRIPTION
## Problem

The navigation sidebar called `setWidth` for every mousemove. Each drag frame persisted context state and re-rendered the full sidebar subtree, making channel-heavy sidebars stutter. The shared resize hook also depended on document mouse listeners and a window-blur escape hatch, excluding touch and complicating pointer lifecycle handling.

## Solution

- `AppShell` now writes `--nav-sidebar-width` directly during drag and commits the final width through `SidebarContext.setWidth` only on release. Pinned content inset updates use the same imperative path.
- `useResizeDrag` now uses Pointer Events with pointer capture, cancellation/lost-capture handling, and one live callback per animation frame.
- Shared panel and attachment preview handles use the same pointer path and retain keyboard resizing.
- Sidebar min/max values remain centralized; releases clamp to 200–400px while preserving the existing below-150px resize-to-collapse threshold and local persistence.
- Width transitions remain disabled while resizing.

Pre-PR review found and fixed one boundary case: release between 150px and 199px now settles at the visible 200px minimum instead of snapping to the prior persisted width.

## Files

| Area | Change |
| ---- | ------ |
| Resize hook/handles | Pointer capture, rAF coalescing, touch support, lifecycle tests |
| App shell/sidebar context | Imperative live width, release-only state commit, clamp tests |
| Panel consumers | Pointer handlers wired through existing shared layouts |

## Test plan

- [x] Targeted frontend suites — 61 tests passed
- [x] Frontend TypeScript check
- [x] Pre-commit repository lint, monorepo typechecks, Dockerfile checks, migration checks, and OpenAPI drift check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787255950&installation_model_id=20758&pr_number=1491&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1491&signature=51216297d31110802c2b186f79877feb9dcb18002028218a72731c1675d9e644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->