### PR TITLE
feat(calls): remove the desktop top dock — side-only (dock redesign 1/4)

### DIFF
--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -14,12 +14,7 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import {
-  getCallPrefs,
-  setCallDockPosition,
-  __resetCallPrefsForTests,
-  type CallDockPosition,
-} from "@/stores/call-prefs-store"
+import { getCallPrefs, __resetCallPrefsForTests } from "@/stores/call-prefs-store"
 import type { CallController } from "@/calls/call-manager"
 import { DesktopCallDock } from "./desktop-call-dock"
 import { CallManagerProvider } from "./call-manager-context"
@@ -126,10 +121,6 @@ function setMode(m: CallSurfaceMode) {
   act(() => setCallSurfaceMode(m))
 }
 
-function setPosition(p: CallDockPosition) {
-  act(() => setCallDockPosition(p))
-}
-
 const TWO_PEERS: CallRosterParticipant[] = [
   participant({ userId: "usr_self" }),
   participant({ userId: "usr_peer", endpointId: "callep_peer" }),
@@ -153,7 +144,6 @@ describe("DesktopCallDock — side dock presentations", () => {
   it("min renders the Rail: restore chevron + timer, no controls", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("min")
     const dock = screen.getByTestId("desktop-call-dock")
     expect(dock).toHaveAttribute("data-mode", "min")
@@ -163,84 +153,24 @@ describe("DesktopCallDock — side dock presentations", () => {
     expect(screen.queryByLabelText("Mute")).toBeNull()
   })
 
-  it("compact renders the Panel: tile grid, controls, minimize, and the Top/Side toggle", () => {
+  it("compact renders the Panel: tile grid, controls, minimize", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("compact")
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "compact")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Mute")).toBeInTheDocument()
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
     expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Side" })).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
   })
 
   it("standard renders the Wide gallery: tiles + controls", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("standard")
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-  })
-})
-
-describe("DesktopCallDock — top dock presentations", () => {
-  it("min renders the Tab: timer only, tap to expand", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("min")
-    const dock = screen.getByTestId("desktop-call-dock")
-    expect(dock).toHaveAttribute("data-mode", "min")
-    expect(dock).toHaveAttribute("data-position", "top")
-    expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
-    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Mute")).toBeNull()
-  })
-
-  it("compact renders the Bar: timer + mute/camera/leave + the Top/Side toggle", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("compact")
-    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
-    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
-    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
-  })
-
-  it("standard renders the Gallery: tiles row + controls + minimize", () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setPosition("top")
-    setMode("standard")
-    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
-    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
-    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
-  })
-})
-
-describe("DesktopCallDock — dock-position toggle", () => {
-  it("switches orientation and persists, preserving surfaceMode", async () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setPosition("side")
-    setMode("compact")
-    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-position", "side")
-
-    await userEvent.click(screen.getByRole("radio", { name: "Top" }))
-    expect(getCallPrefs().dockPosition).toBe("top")
-    const dock = screen.getByTestId("desktop-call-dock")
-    expect(dock).toHaveAttribute("data-position", "top")
-    // surfaceMode is preserved across the re-orientation.
-    expect(dock).toHaveAttribute("data-mode", "compact")
-    expect(getCallState().surfaceMode).toBe("compact")
   })
 })
 
@@ -252,7 +182,6 @@ describe("DesktopCallDock — fullscreen", () => {
       participant({ userId: "usr_peer", endpointId: "callep_peer" }),
       participant({ userId: "usr_third", endpointId: "callep_third" }),
     ])
-    setPosition("side")
     setMode("full")
     expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
     expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
@@ -284,48 +213,30 @@ describe("DesktopCallDock — content push var", () => {
   function insetRight() {
     return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
   }
-  function insetTop() {
-    return document.documentElement.style.getPropertyValue("--call-dock-inset-top")
-  }
 
-  it("reserves the resting side width and no top inset when docked to the side", () => {
+  it("reserves the resting side width", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     expect(insetRight()).toBe("320px")
-    expect(insetTop()).toBe("0px")
     setMode("standard")
     expect(insetRight()).toBe("520px")
   })
 
-  it("reserves the resting top height and no side inset when docked to the top", () => {
+  it("drops the inset to 0 in fullscreen (the dock overlays, not pushes)", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("standard")
-    expect(insetTop()).toBe("220px")
-    expect(insetRight()).toBe("0px")
-  })
-
-  it("drops both insets to 0 in fullscreen (the dock overlays, not pushes)", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("full")
     expect(insetRight()).toBe("0px")
-    expect(insetTop()).toBe("0px")
   })
 
-  it("resets both insets to 0 when the dock unmounts", () => {
+  it("resets the inset to 0 when the dock unmounts", () => {
     const { unmount } = renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     expect(insetRight()).toBe("320px")
     unmount()
     expect(insetRight()).toBe("0px")
-    expect(insetTop()).toBe("0px")
   })
 })
 
@@ -333,7 +244,6 @@ describe("DesktopCallDock — capture error", () => {
   it("surfaces a mid-call capture error banner in the Panel", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
     expect(screen.getByTestId("call-capture-error")).toHaveTextContent(/couldn't be restored/i)
@@ -351,7 +261,6 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
   it("dragging the side handle past the wide→full threshold caps the preview at standard and settles to full", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("standard")
     const dock = screen.getByTestId("desktop-call-dock")
     stubRect(dock, { width: 520 })
@@ -375,16 +284,15 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
   it("a pointercancel mid-drag settles instead of wedging", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
     setMode("compact")
     const dock = screen.getByTestId("desktop-call-dock")
-    stubRect(dock, { height: 72 })
-    stubRect(dock.parentElement as HTMLElement, { height: 800 })
+    stubRect(dock, { width: 320 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
     const handle = screen.getByTestId("call-dock-handle")
     handle.setPointerCapture = vi.fn()
-    fireEvent.pointerDown(handle, { clientY: 100, pointerId: 1 })
-    fireEvent.pointerMove(handle, { clientY: 500, pointerId: 1 })
-    fireEvent.pointerCancel(handle, { clientY: 500, pointerId: 1 })
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 100, pointerId: 1 })
+    fireEvent.pointerCancel(handle, { clientX: 100, pointerId: 1 })
     // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
     expect(["standard", "full"]).toContain(getCallState().surfaceMode)
   })

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronLeft,
-  Minimize2,
-  PanelBottom,
-  PanelRight,
-  PanelTop,
-  Users,
-} from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Users } from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
@@ -23,16 +14,10 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import {
-  useCallPrefs,
-  setCallDockPosition,
-  setCallFilmstripSide,
-  type CallDockPosition,
-} from "@/stores/call-prefs-store"
+import { useCallPrefs, setCallFilmstripSide } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { CallStageLayout } from "./call-stage-layout"
-import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { LayoutToggle } from "./layout-toggle"
@@ -47,7 +32,6 @@ const MODE_INDEX: Record<CallSurfaceMode, number> = { min: 0, compact: 1, standa
 
 /** The 3 pushing step sizes (px) — min/compact/standard; `full` = the whole content region. */
 const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
-const TOP_STEP_SIZES: readonly number[] = [44, 72, 220]
 
 // Always leave this much of the conversation beside/below a pushing dock, so a
 // narrow window / wide sidebar can't collapse the timeline to nothing.
@@ -73,32 +57,6 @@ interface DockViewProps {
   users: ReturnType<typeof useWorkspaceUsers>
   captureError: CallCaptureErrorInfo | null
   title: string
-  speakerName: string | null
-}
-
-function DockPositionToggle({ dark = false }: { dark?: boolean }) {
-  const { dockPosition } = useCallPrefs()
-  return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      role="radiogroup"
-      value={dockPosition}
-      onValueChange={(next) => {
-        if (next === "top" || next === "side") setCallDockPosition(next)
-      }}
-      aria-label="Dock position"
-      data-testid="call-dock-position-toggle"
-      className={cn("shrink-0 gap-0.5 rounded-md p-0.5", dark ? "bg-white/10" : "bg-muted")}
-    >
-      <ToggleGroupItem value="top" aria-label="Top" title="Dock to the top" className="h-7 px-2 [&_svg]:size-3.5">
-        <PanelTop aria-hidden="true" />
-      </ToggleGroupItem>
-      <ToggleGroupItem value="side" aria-label="Side" title="Dock to the side" className="h-7 px-2 [&_svg]:size-3.5">
-        <PanelRight aria-hidden="true" />
-      </ToggleGroupItem>
-    </ToggleGroup>
-  )
 }
 
 function FilmstripSideToggle() {
@@ -149,12 +107,11 @@ function MinimizeButton() {
   )
 }
 
-/** Title + Top/Side toggle + minimize, shared by the side Panel/Wide and the top Gallery. */
+/** Title + minimize, shared by the side Panel/Wide. */
 function DockHeaderBar({ title }: { title: string }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      <DockPositionToggle />
       <MinimizeButton />
     </div>
   )
@@ -237,90 +194,7 @@ function SideTilesView({ workspaceId, currentUserId, roster, captureError, title
   )
 }
 
-/** Top `min`: a thin bar — live/error dot + timer, tap to expand. */
-function TopTabView({ connectedAt, captureError }: DockViewProps) {
-  return (
-    <button
-      type="button"
-      aria-label="Expand call"
-      onClick={() => setCallSurfaceMode("compact")}
-      className="flex h-full w-full items-center justify-center gap-2 border-b bg-background px-4"
-    >
-      {captureError ? (
-        <span
-          className="h-2 w-2 shrink-0 rounded-full bg-destructive"
-          role="alert"
-          data-testid="call-capture-error"
-          aria-label="Microphone or camera problem — expand the call to see details"
-        />
-      ) : (
-        <span
-          className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
-          aria-hidden
-        />
-      )}
-      <CallTimer connectedAt={connectedAt} />
-    </button>
-  )
-}
-
-/** Top `compact`: timer + speaker + controls, horizontal. */
-function TopBarView({ connectedAt, speakerName, captureError }: DockViewProps) {
-  return (
-    <div className="flex h-full w-full items-center gap-3 border-b bg-background px-4">
-      {captureError && (
-        <span
-          className="flex h-8 w-8 shrink-0 items-center justify-center text-destructive"
-          role="alert"
-          data-testid="call-capture-error"
-          aria-label="Microphone or camera problem"
-        >
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-        </span>
-      )}
-      <div className="flex min-w-0 flex-col">
-        <CallTimer connectedAt={connectedAt} />
-        {speakerName && <span className="truncate text-xs text-muted-foreground">{speakerName}</span>}
-      </div>
-      <div className="ml-auto flex shrink-0 items-center gap-1.5">
-        <MuteButton />
-        <CameraButton />
-        <LeaveButton />
-        <DockPositionToggle />
-        <MinimizeButton />
-      </div>
-    </div>
-  )
-}
-
-/** Top `standard`: header + a tiles row + controls. */
-function TopGalleryView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
-  const joined = roster.filter((p) => p.participantStatus === "joined")
-  return (
-    <div className="flex h-full w-full flex-col border-b bg-background">
-      <DockHeaderBar title={title} />
-      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
-      <div className="flex min-h-0 flex-1 items-stretch gap-2 overflow-x-auto px-3 py-2">
-        {joined.map((p) => (
-          <div key={p.userId} className="aspect-video h-full shrink-0">
-            <CallTile
-              participant={p}
-              workspaceId={workspaceId}
-              isSelf={!!currentUserId && p.userId === currentUserId}
-              stage
-              fill
-            />
-          </div>
-        ))}
-      </div>
-      <div className="shrink-0 border-t p-2">
-        <CallControls />
-      </div>
-    </div>
-  )
-}
-
-/** Fullscreen (both orientations): the ch5 stage with a permanent header of call controls/toggles. */
+/** Fullscreen: the ch5 stage with a permanent header of call controls/toggles. */
 function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title, captureError }: DockViewProps) {
   const { layout, filmstripSide } = useCallPrefs()
   const joined = roster.filter((p) => p.participantStatus === "joined")
@@ -352,7 +226,6 @@ function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, t
           <div data-testid="call-layout-slot">
             <LayoutToggle className="bg-white/10" />
           </div>
-          <DockPositionToggle dark />
         </div>
       </div>
 
@@ -373,53 +246,34 @@ function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, t
   )
 }
 
-function DockBody({
-  dockPosition,
-  mode,
-  view,
-}: {
-  dockPosition: CallDockPosition
-  mode: CallSurfaceMode
-  view: DockViewProps
-}) {
+function DockBody({ mode, view }: { mode: CallSurfaceMode; view: DockViewProps }) {
   if (mode === "full") return <DockFullscreenView {...view} />
-  if (dockPosition === "side") {
-    if (mode === "min") return <SideRailView {...view} />
-    return <SideTilesView {...view} />
-  }
-  if (mode === "min") return <TopTabView {...view} />
-  if (mode === "compact") return <TopBarView {...view} />
-  return <TopGalleryView {...view} />
+  if (mode === "min") return <SideRailView {...view} />
+  return <SideTilesView {...view} />
 }
 
 function DockResizeHandle({
-  orientation,
   onPointerDown,
   onPointerMove,
   onPointerUp,
 }: {
-  orientation: CallDockPosition
   onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
 }) {
-  const side = orientation === "side"
   return (
     <div
       role="separator"
-      aria-orientation={side ? "vertical" : "horizontal"}
+      aria-orientation="vertical"
       aria-label="Resize call"
       data-testid="call-dock-handle"
-      className={cn(
-        "absolute z-10 flex touch-none items-center justify-center",
-        side ? "inset-y-0 left-0 w-2 cursor-col-resize" : "inset-x-0 bottom-0 h-2 cursor-row-resize"
-      )}
+      className="absolute inset-y-0 left-0 z-10 flex w-2 cursor-col-resize touch-none items-center justify-center"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
     >
-      <span className={cn("rounded-full bg-muted-foreground/40", side ? "h-10 w-1" : "h-1 w-10")} aria-hidden />
+      <span className="h-10 w-1 rounded-full bg-muted-foreground/40" aria-hidden />
     </div>
   )
 }
@@ -435,17 +289,15 @@ interface DragState {
 }
 
 /**
- * The desktop in-call surface: a resizable dock, docked to the top or the side
- * (`dockPosition` pref), snapping through the four {@link CallSurfaceMode} steps
- * with the same physics as the mobile drawer ({@link nearestStep}). It pushes the
- * conversation aside via `--call-dock-inset-right`/`--call-dock-inset-top` (the
- * main content region reserves the inset) rather than overlaying it, until
- * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
- * the connected phase; reads the call store, not the route, so it survives stream
- * navigation.
+ * The desktop in-call surface: a resizable dock, docked to the side, snapping
+ * through the four {@link CallSurfaceMode} steps with the same physics as the
+ * mobile drawer ({@link nearestStep}). It pushes the conversation aside via
+ * `--call-dock-inset-right` (the main content region reserves the inset) rather
+ * than overlaying it, until Fullscreen. Rendered by
+ * {@link import("./call-dock").CallDock} on desktop for the connected phase;
+ * reads the call store, not the route, so it survives stream navigation.
  */
 export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
-  const { dockPosition } = useCallPrefs()
   const surfaceMode = useCallSurfaceMode()
   const roster = useCallRoster()
   const connectedAt = useCallConnectedAt()
@@ -455,62 +307,51 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
   const title = name ?? "Call"
 
-  const isSide = dockPosition === "side"
-
   const rootRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const drag = useRef<DragState | null>(null)
   const [dragging, setDragging] = useState(false)
   const [dragSize, setDragSize] = useState<number | null>(null)
   // The dock root spans the content region (left = sidebar width → right:0); its
-  // measured size is the ceiling for the panel + inset so a narrow window / wide
+  // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
-  const [content, setContent] = useState<{ w: number; h: number }>({ w: Infinity, h: Infinity })
+  const [contentW, setContentW] = useState<number>(Infinity)
   useEffect(() => {
     const el = rootRef.current
     if (!el) return
-    const measure = () => setContent({ w: el.clientWidth, h: el.clientHeight })
+    const measure = () => setContentW(el.clientWidth)
     measure()
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
   }, [])
 
-  // Ceilings from the measured content region; 0 means "not laid out yet" (initial
+  // Ceiling from the measured content region; 0 means "not laid out yet" (initial
   // render / jsdom) → treat as unbounded so we never clamp to nothing.
-  const ceilW = content.w || Infinity
-  const ceilH = content.h || Infinity
-
+  const ceilW = contentW || Infinity
   const detentsW = dockDetents(SIDE_STEP_SIZES, ceilW)
-  const detentsH = dockDetents(TOP_STEP_SIZES, ceilH)
 
   // Content push: reserve the pushing mode's detent (which already leaves MIN_CONTENT)
   // on :root so the main content region (AppShell's <main>) reflows. Fullscreen → 0.
-  const insetRight = isSide && surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
-  const insetTop = !isSide && surfaceMode !== "full" ? detentsH[MODE_INDEX[surfaceMode]] : 0
+  const insetRight = surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
   useEffect(() => {
-    const root = document.documentElement
-    root.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
-    root.style.setProperty("--call-dock-inset-top", `${insetTop}px`)
-  }, [insetRight, insetTop])
+    document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
+  }, [insetRight])
   useEffect(
     () => () => {
-      const root = document.documentElement
-      root.style.setProperty("--call-dock-inset-right", "0px")
-      root.style.setProperty("--call-dock-inset-top", "0px")
+      document.documentElement.style.setProperty("--call-dock-inset-right", "0px")
     },
     []
   )
 
-  const stepSizes = isSide ? SIDE_STEP_SIZES : TOP_STEP_SIZES
-  const minStep = stepSizes[0]
+  const minStep = SIDE_STEP_SIZES[0]
 
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     const panel = panelRef.current?.getBoundingClientRect()
     const root = rootRef.current?.getBoundingClientRect()
-    const full = (isSide ? root?.width : root?.height) ?? stepSizes[stepSizes.length - 1]
-    const startSize = (isSide ? panel?.width : panel?.height) ?? stepSizes[1]
-    const pointer = isSide ? e.clientX : e.clientY
+    const full = root?.width ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
+    const startSize = panel?.width ?? SIDE_STEP_SIZES[1]
+    const pointer = e.clientX
     drag.current = {
       start: pointer,
       startSize,
@@ -528,13 +369,13 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     const d = drag.current
     if (!d) return
-    const pointer = isSide ? e.clientX : e.clientY
-    // Side grows as the pointer moves left; top grows as it moves down.
-    const grow = isSide ? d.start - pointer : pointer - d.start
+    const pointer = e.clientX
+    // Side grows as the pointer moves left.
+    const grow = d.start - pointer
     const next = Math.min(Math.max(d.startSize + grow, minStep), d.full)
     const now = performance.now()
     const dt = now - d.lastT
-    const stepGrow = isSide ? d.last - pointer : pointer - d.last
+    const stepGrow = d.last - pointer
     if (dt > 0) d.velocity = stepGrow / dt
     d.last = pointer
     d.lastT = now
@@ -550,21 +391,17 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     if (d) {
       // A pause before release means the drag stopped — don't flick on stale velocity.
       const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
-      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(stepSizes, d.full))])
+      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(SIDE_STEP_SIZES, d.full))])
     }
   }
 
-  const speaker = roster.find((p) => p.participantStatus === "joined" && p.userId !== currentUserId) ?? null
-  const speakerName = speaker ? (users.find((u) => u.id === speaker.userId)?.name ?? null) : null
-
-  const dragFull = drag.current?.full ?? stepSizes[stepSizes.length - 1]
+  const dragFull = drag.current?.full ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
   const dragMode =
-    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(stepSizes, dragFull))] : null
+    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(SIDE_STEP_SIZES, dragFull))] : null
   // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
   // thrashes the drag) — the preview caps at `standard`; fullscreen mounts on release.
   const cappedDragMode = dragMode === "full" ? "standard" : dragMode
   const contentMode: CallSurfaceMode = cappedDragMode ?? surfaceMode
-  const detents = isSide ? detentsW : detentsH
 
   const restingFull = !dragging && surfaceMode === "full"
   let positionClass: string
@@ -572,14 +409,10 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   if (restingFull) {
     positionClass = "inset-0"
     sizeStyle = {}
-  } else if (isSide) {
-    positionClass = "inset-y-0 right-0"
-    const w = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
-    sizeStyle = { width: `${w}px` }
   } else {
-    positionClass = "inset-x-0 top-0"
-    const h = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
-    sizeStyle = { height: `${h}px` }
+    positionClass = "inset-y-0 right-0"
+    const w = dragging && dragSize != null ? dragSize : detentsW[MODE_INDEX[contentMode]]
+    sizeStyle = { width: `${w}px` }
   }
 
   const view: DockViewProps = {
@@ -590,7 +423,6 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     users,
     captureError,
     title,
-    speakerName,
   }
 
   return (
@@ -603,25 +435,19 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         ref={panelRef}
         data-testid="desktop-call-dock"
         data-mode={contentMode}
-        data-position={dockPosition}
+        data-position="side"
         className={cn(
           "pointer-events-auto absolute overflow-hidden shadow-xl",
           positionClass,
-          !dragging && !REDUCED_MOTION && (isSide ? "transition-[width]" : "transition-[height]"),
-          !dragging && !REDUCED_MOTION && "duration-200 ease-out"
+          !dragging && !REDUCED_MOTION && "transition-[width] duration-200 ease-out"
         )}
         style={sizeStyle}
       >
-        <DockBody dockPosition={dockPosition} mode={contentMode} view={view} />
+        <DockBody mode={contentMode} view={view} />
         {/* Always mounted — including at rest-fullscreen — so it holds the pointer
             capture/settle through a drag into full AND lets you drag back OUT of
             fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}
-        <DockResizeHandle
-          orientation={dockPosition}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-        />
+        <DockResizeHandle onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
       </div>
     </div>
   )

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -415,7 +415,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             className="relative flex flex-1 flex-col overflow-hidden"
             style={{
               paddingRight: "var(--call-dock-inset-right, 0px)",
-              paddingTop: "var(--call-dock-inset-top, 0px)",
               ...(!isKeyboardOpen ? { paddingBottom: "env(safe-area-inset-bottom)" } : {}),
             }}
           >

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from "vitest"
 import {
   getCallPrefs,
   setCallLayout,
-  setCallDockPosition,
   setCallFilmstripSide,
   setCallSelfMirror,
   resolveSelfMirror,
@@ -10,7 +9,7 @@ import {
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
 
 beforeEach(() => {
   localStorage.clear()
@@ -24,14 +23,13 @@ describe("call-prefs-store", () => {
 
   it("a set persists to localStorage and reads back through the store", () => {
     setCallLayout("grid")
-    setCallDockPosition("top")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -41,14 +39,9 @@ describe("call-prefs-store", () => {
   })
 
   it("falls back per-field on an out-of-range persisted value", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "grid", dockPosition: "diagonal" }))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "diagonal", filmstripSide: "side" }))
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({
-      layout: "grid",
-      dockPosition: "side",
-      filmstripSide: "bottom",
-      selfMirror: "auto",
-    })
+    expect(getCallPrefs()).toEqual({ layout: "speaker", filmstripSide: "side", selfMirror: "auto" })
   })
 
   it("persists an explicit selfMirror override", () => {

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -13,28 +13,20 @@ import { useSyncExternalStore } from "react"
  */
 
 export type CallLayout = "speaker" | "grid"
-export type CallDockPosition = "top" | "side"
 export type CallFilmstripSide = "bottom" | "side"
 /** Local self-view mirroring. `auto` = mirror a front/desktop camera, not a mobile back camera. */
 export type CallSelfMirror = "auto" | "on" | "off"
 
 export interface CallPrefs {
   layout: CallLayout
-  dockPosition: CallDockPosition
   filmstripSide: CallFilmstripSide
   selfMirror: CallSelfMirror
 }
 
-const DEFAULT_PREFS: CallPrefs = {
-  layout: "speaker",
-  dockPosition: "side",
-  filmstripSide: "bottom",
-  selfMirror: "auto",
-}
+const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
-const isDockPosition = (v: unknown): v is CallDockPosition => v === "top" || v === "side"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
 
@@ -64,7 +56,6 @@ function readPersisted(): CallPrefs {
     const p = parsed as Record<string, unknown>
     return {
       layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
-      dockPosition: isDockPosition(p.dockPosition) ? p.dockPosition : DEFAULT_PREFS.dockPosition,
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
       selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
     }
@@ -93,7 +84,6 @@ function update(patch: Partial<CallPrefs>): void {
   const next = { ...prefs, ...patch }
   if (
     next.layout === prefs.layout &&
-    next.dockPosition === prefs.dockPosition &&
     next.filmstripSide === prefs.filmstripSide &&
     next.selfMirror === prefs.selfMirror
   ) {
@@ -110,10 +100,6 @@ export function getCallPrefs(): CallPrefs {
 
 export function setCallLayout(layout: CallLayout): void {
   update({ layout })
-}
-
-export function setCallDockPosition(dockPosition: CallDockPosition): void {
-  update({ dockPosition })
 }
 
 export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {

--- a/docs/plans/calls-desktop-dock-redesign.md
+++ b/docs/plans/calls-desktop-dock-redesign.md
@@ -1,0 +1,66 @@
+# Calls — Desktop dock redesign
+
+Status: **draft, awaiting ratification**. Approved visual direction: the [desktop dock mock](https://seer.build/ws_vbyzjvdg6g/b/calls-deskdock-1ca712/).
+
+Desktop-only. Mobile surfaces (`mobile-call-drawer.tsx`, `call-island.tsx`) are unchanged. Reference files: `apps/frontend/src/components/call/desktop-call-dock.tsx` (628 lines — top/side dock, `nearestStep` snaps, `--call-dock-inset-*` content push, `ResizeObserver` ceiling), `call-dock.tsx` (phase router), `stores/call-prefs-store.ts`.
+
+## Goals (from Kris's desktop feedback)
+
+1. **Kill the top dock** — it felt awkward; drop the top orientation entirely. Desktop is **side** or **floating** only.
+2. **Floating square = effective default** — a small draggable, minimizable call widget (grip to move anywhere, minimize to a bubble), with a **"dock to side"** action. Joining renders **in the same square** (no bottom-right→dock jump).
+3. **Side dock behaves like the nav sidebar** — **hover-to-overlay** when minimized (opens over the content, doesn't push, like the nav sidebar's closed-hover), plus an open/pinned draggable mode; **freeform width** (remove the width snap detents — snaps control layout/things, not width); **75% max**; a **drop-to-fullscreen indication** past 75% on release; a **"float"** action to switch to the square.
+4. **Collapsed side rail** — put controls (mute / camera / leave) in the wasted vertical space above the timer.
+5. **Surface pref** `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`). `keep_last` remembers the last-used surface; the floating square is the effective default. A control in **Calls settings**.
+
+## Invariants in play
+
+- INV-9 (call-prefs singleton exception), INV-33 (settings-tab config SSOT), INV-15/18 (components UI-only, no inner defs), INV-21 (no layout shift from the hover-overlay/drag), INV-40 (actions = `<button>`), INV-63 (success silent). The content push uses the existing `--call-dock-inset-*` mechanism. Keep the smooth pointer-drag feel (the current dock's pointer loop is the reference — Kris likes it).
+
+## PR-stack breakdown
+
+Each chunk is one PR, based on the previous branch (chunk 1 on `origin/main`).
+
+### Chunk 1 — Remove the top dock (side-only)
+
+- `desktop-call-dock.tsx`: delete the top orientation — `PanelTop`/`PanelBottom` icons, the Top/Side toggle in the dock header, `TOP_STEP_SIZES`/`detentsH`, and the `mode`-vs-`dockPosition` branches for top. Desktop dock renders side-only.
+- `call-prefs-store.ts`: `dockPosition` loses `"top"` — either narrow to `"side"` (vestigial, removed in Chunk 4) or drop the field now if no other reader needs it; `filmstripSide` stays.
+- `layout-toggle.tsx` / dock header: remove the Top/Side control (the Speaker/Grid + filmstrip-side toggles stay).
+- Tests: drop the top-mode cases in `desktop-call-dock.test.tsx`; keep side-mode coverage green.
+- **NOT**: no new surface yet; no pref changes beyond removing `top`.
+
+### Chunk 2 — Side dock: freeform width + 75% cap + drop-to-fullscreen cue + hover-overlay + collapsed controls
+
+- **Freeform width**: replace the width `nearestStep` detents with a continuous clamp `[MIN, 0.75 * ceilW]`; drop the width snap. Keep the smooth pointer drag; commit width to a persisted pref (`sideDockWidth`) on release. (Layout snaps — Speaker/Grid, filmstrip side — are unaffected: those are _content_ toggles, not width.)
+- **75% cap + drop-to-fullscreen**: dragging past the 75% ceiling shows a **drop-to-fullscreen overlay** (dashed, "Release to go fullscreen"); releasing in that zone → fullscreen, releasing below → clamp to ≤75%. A deliberate zone so fullscreen is intentional.
+- **Hover-to-overlay when minimized**: the minimized rail, on hover, expands the dock **over** the content (position: absolute, no `--call-dock-inset` push) — mirroring the nav sidebar's closed-hover (`app-shell.tsx` preview state). Pinned/open still pushes.
+- **Collapsed rail controls**: `SideRailView` gains mute / camera / leave (shared `call-control-buttons`) above the timer.
+- Tests: freeform clamp (no snap; ≤75%), fullscreen-zone release vs clamp release, hover-overlay adds no inset, rail controls dispatch.
+- **NOT**: the floating square; the surface pref.
+
+### Chunk 3 — Floating square surface (component only)
+
+- New `floating-call-square.tsx`: a draggable (grip / whole-header drag via pointer capture, clamped to viewport), **minimizable** (collapse to a small bubble showing dot + timer; click to restore) call widget rendering tiles + the shared controls; a **"dock to side"** action.
+- Joining renders in the same square (a compact "Joining…" state — unify like the mobile `MobileCallJoining`, no separate bottom-right box).
+- Not yet the default — rendered behind the pref in Chunk 4; this chunk lands the component + its tests in isolation (render at a fixed position, drag math via a pure helper, minimize toggle).
+- Tests: drag clamp helper (pure), minimize/restore, controls dispatch, joining state.
+- **NOT**: wiring the pref / switching / keep_last.
+
+### Chunk 4 — `desktopCallSurface` pref + surface switching + Calls settings
+
+- `call-prefs-store.ts`: `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`) + `lastDesktopSurface: sidebar | floating` + `resolveDesktopSurface(pref, last)`; remove the vestigial `dockPosition` if still present.
+- `call-dock.tsx`: on desktop, render the resolved surface — `FloatingCallSquare` or `DesktopCallDock` (side). Joining routes to whichever surface is active (both now render joining in-place).
+- Wire the **"dock to side"** (square → sidebar, updates `lastDesktopSurface`) and **"float"** (sidebar → square) actions.
+- `call-settings.tsx`: a "Desktop video" radio (Keep last / Sidebar / Floating square).
+- Tests: resolver matrix, keep_last persistence, dock-to-side/float switch the surface + update last, settings control.
+- **NOT**: mobile changes.
+
+## Deferred (do NOT build)
+
+- Mobile floating/PiP.
+- Screen-share (two feeds) — its own future stack.
+- Server-persisted (cross-device) layout prefs — localStorage only, as today.
+
+## Verification
+
+- Per chunk: Opus implement → Opus xhigh adversarial verify (typecheck + `bun run test:unit` on the touched suites) → fix loop → `/code-review`.
+- Whole-stack review after Chunk 4. Real-component screenshots of each surface before merge.


### PR DESCRIPTION
**Chunk 1 of the desktop calls-dock redesign** (ratified plan: `docs/plans/calls-desktop-dock-redesign.md`). Stack base.

## Problem
The desktop top dock felt awkward (Kris) — dropping it entirely rather than leaving a half-baked orientation.

## Solution
Desktop call dock is now **side-only**. Removed the top orientation end-to-end and the `dockPosition` pref (its only two readers were the prefs store and the dock):
- `desktop-call-dock.tsx`: deleted `TopTabView`/`TopBarView`/`TopGalleryView`, `TOP_STEP_SIZES`, `detentsH`/`ceilH`/`insetTop` + the `--call-dock-inset-top` write, the Top/Side toggle, the `PanelTop` import, and all `isSide`/`orientation` branching. The resize handle, width detents, `--call-dock-inset-right` push, SideRail/Panel/Wide/Fullscreen views, minimize, and the Speaker/Grid + filmstrip-side toggles are untouched.
- `call-prefs-store.ts`: removed `CallDockPosition`, the `dockPosition` field/default/validator/read-map/update-clause/setter. Old persisted blobs ignore the stray key.
- `app-shell.tsx`: dropped the now-dead `paddingTop: var(--call-dock-inset-top)` on `<main>` (nothing writes that var anymore — INV-38). `--call-dock-inset-right` untouched.

Verified by an Opus xhigh adversarial pass (re-derived diff, grep-clean, side-dock intact, persistence safe, no scope creep).

## Files
| File | Change |
| ---- | ------ |
| `components/call/desktop-call-dock.tsx` | remove top orientation → side-only |
| `stores/call-prefs-store.ts` | remove `dockPosition` pref end-to-end |
| `components/layout/app-shell.tsx` | drop dead `--call-dock-inset-top` reservation |
| `desktop-call-dock.test.tsx`, `call-prefs-store.test.ts` | drop top-dock + dock-position tests |

## Test plan
- [x] typecheck clean; `desktop-call-dock` + `call-dock` + `call-prefs-store` suites — 37 pass; broader call/app-shell — 111 pass; eslint clean
- [x] Opus xhigh adversarial verify — CLEAN, no findings

## Next in stack
Chunk 2 (side-dock freeform width + 75% cap + drop-to-fullscreen + hover-overlay + collapsed controls) → Chunk 3 (floating square) → Chunk 4 (`desktopCallSurface` pref).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787262708&installation_model_id=20758&pr_number=1492&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1492&signature=2b60cf1710f8a67d652ecd0416ba842ceaaa76be77cf65533001000ba7de9ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->