### PR TITLE
feat(calls): side dock — freeform width + drop-to-fullscreen + hover-peek + rail controls

### DIFF
--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -141,7 +141,7 @@ afterEach(() => {
 })
 
 describe("DesktopCallDock — side dock presentations", () => {
-  it("min renders the Rail: restore chevron + timer, no controls", () => {
+  it("min renders the Rail: restore chevron + timer + collapsed controls", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("min")
@@ -150,7 +150,8 @@ describe("DesktopCallDock — side dock presentations", () => {
     expect(dock).toHaveAttribute("data-position", "side")
     expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
     expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Mute")).toBeNull()
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
   })
 
   it("compact renders the Panel: tile grid, controls, minimize", () => {
@@ -218,7 +219,7 @@ describe("DesktopCallDock — content push var", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("compact")
-    expect(insetRight()).toBe("320px")
+    expect(insetRight()).toBe("360px")
     setMode("standard")
     expect(insetRight()).toBe("520px")
   })
@@ -234,7 +235,7 @@ describe("DesktopCallDock — content push var", () => {
     const { unmount } = renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("compact")
-    expect(insetRight()).toBe("320px")
+    expect(insetRight()).toBe("360px")
     unmount()
     expect(insetRight()).toBe("0px")
   })
@@ -295,5 +296,70 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
     fireEvent.pointerCancel(handle, { clientX: 100, pointerId: 1 })
     // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
     expect(["standard", "full"]).toContain(getCallState().surfaceMode)
+  })
+
+  it("a mid-range drop persists the freeform width (not a detent) and keeps the open mode", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("standard")
+    const dock = screen.getByTestId("desktop-call-dock")
+    stubRect(dock, { width: 520 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
+    const handle = screen.getByTestId("call-dock-handle")
+    handle.setPointerCapture = vi.fn()
+    // Shrink to 480px: below 0.75*900=675 (no fullscreen) and above MIN_OPEN(280).
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 540, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: 540, pointerId: 1 })
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+    expect(getCallState().surfaceMode).toBe("standard")
+  })
+})
+
+describe("DesktopCallDock — minimized hover overlay", () => {
+  function insetRight() {
+    return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
+  }
+
+  it("hovering the rail overlays the open panel without pushing content", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-hovering", "false")
+    expect(insetRight()).toBe("56px")
+    fireEvent.mouseEnter(dock)
+    expect(dock).toHaveAttribute("data-hovering", "true")
+    // Overlay: the open tiles render but the inset stays at the rail width (no reflow).
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(insetRight()).toBe("56px")
+  })
+
+  it("the peek's pin commits it to a pinned-open dock that pushes content", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    // The un-hovered rail has no pin — it's a peek-only affordance.
+    expect(screen.queryByLabelText("Keep call open")).toBeNull()
+    fireEvent.mouseEnter(dock)
+    act(() => fireEvent.click(screen.getByLabelText("Keep call open")))
+    expect(getCallState().surfaceMode).toBe("standard")
+    // Pinned: the inset reflows to the open width instead of the 56px rail overlay.
+    expect(insetRight()).toBe("520px")
+  })
+
+  it("clicking the collapsed rail's Leave dispatches to the manager", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("min")
+    // fireEvent (no synthetic pointer move) so the click lands on the rail control
+    // itself rather than first arming the hover-overlay; the async flush lets the
+    // control's per-instance action settle.
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Leave call"))
+    })
+    expect(manager.leaveCall).toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
-import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Users } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Pin, Users } from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/initials"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { useInputMode } from "@/hooks/use-input-mode"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import {
@@ -14,39 +15,42 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import { useCallPrefs, setCallFilmstripSide } from "@/stores/call-prefs-store"
+import { useCallPrefs, setCallFilmstripSide, setCallSideDockWidth } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
+import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallStageLayout } from "./call-stage-layout"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
-import { nearestStep } from "./mobile-call-drawer-snap"
 
 const REDUCED_MOTION =
   typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
 
-const MODES: readonly CallSurfaceMode[] = ["min", "compact", "standard", "full"]
-const MODE_INDEX: Record<CallSurfaceMode, number> = { min: 0, compact: 1, standard: 2, full: 3 }
-
-/** The 3 pushing step sizes (px) — min/compact/standard; `full` = the whole content region. */
-const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
-
-// Always leave this much of the conversation beside/below a pushing dock, so a
-// narrow window / wide sidebar can't collapse the timeline to nothing.
+const RAIL_WIDTH = 56
+const MIN_OPEN = 280
+// Always leave this much of the conversation beside a pushing dock, so a narrow
+// window / wide sidebar can't collapse the timeline to nothing.
 const MIN_CONTENT = 320
+const FULLSCREEN_FRACTION = 0.75
 
 /**
- * The 4 snap detents [min, compact, standard, full] for a given axis ceiling (the
- * measured content region). The pushing steps are capped to `ceil - MIN_CONTENT`
- * (leaving timeline) and `full` is the whole ceiling — guaranteeing a NON-DECREASING
- * list even on a tiny window (so the snap never sees an unsorted/duplicate-final
- * detent), and the inset a pushing mode reserves never exceeds `ceil - MIN_CONTENT`.
+ * The resting open clamp: ≤75% of the content region, leaving MIN_CONTENT of timeline
+ * where the window allows. On a sub-~600px content region the outer floor wins (MIN_OPEN),
+ * so a very narrow window trades some timeline rather than shrinking the dock below usable.
  */
-function dockDetents(steps: readonly number[], ceil: number): number[] {
-  const cap = Math.max(steps[0], ceil - MIN_CONTENT)
-  return [steps[0], Math.min(steps[1], cap), Math.min(steps[2], cap), ceil]
+function maxOpenWidth(ceil: number): number {
+  return Math.max(MIN_OPEN, Math.min(FULLSCREEN_FRACTION * ceil, ceil - MIN_CONTENT))
+}
+
+function clampOpen(width: number, ceil: number): number {
+  return Math.min(Math.max(width, MIN_OPEN), maxOpenWidth(ceil))
+}
+
+/** First-open width before the user has ever resized: video opens fuller than audio (#1486). */
+function defaultOpen(mode: CallSurfaceMode): number {
+  return mode === "compact" ? 360 : 520
 }
 
 interface DockViewProps {
@@ -57,6 +61,9 @@ interface DockViewProps {
   users: ReturnType<typeof useWorkspaceUsers>
   captureError: CallCaptureErrorInfo | null
   title: string
+  // Rendered from the minimized hover-overlay (a transient peek) rather than a
+  // pinned-open dock — shows the pin affordance to commit the peek.
+  peeking?: boolean
 }
 
 function FilmstripSideToggle() {
@@ -107,12 +114,30 @@ function MinimizeButton() {
   )
 }
 
-/** Title + minimize, shared by the side Panel/Wide. */
-function DockHeaderBar({ title }: { title: string }) {
+/** Keeps a hover-peek open (mouse pre-empts the rail's expand chevron, so the peek needs its own pin). */
+function PinButton() {
+  return (
+    <button
+      type="button"
+      aria-label="Keep call open"
+      onClick={() => setCallSurfaceMode("standard")}
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      <Pin className="h-4 w-4" />
+    </button>
+  )
+}
+
+/**
+ * Title + trailing action. A hover-peek shows Pin (commit to open); an already-open
+ * dock shows Minimize (collapse) — a peek is dismissed by moving the mouse away, so
+ * Minimize there would be a redundant no-op.
+ */
+function DockHeaderBar({ title, peeking }: { title: string; peeking?: boolean }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      <MinimizeButton />
+      {peeking ? <PinButton /> : <MinimizeButton />}
     </div>
   )
 }
@@ -163,19 +188,22 @@ function SideRailView({ roster, users, workspaceId, connectedAt, captureError }:
         />
       )}
       <RailAvatars roster={roster} users={users} workspaceId={workspaceId} />
-      <div className="mt-auto">
-        <CallTimer connectedAt={connectedAt} className="text-xs" />
+      <div className="mt-auto flex flex-col items-center gap-1">
+        <MuteButton />
+        <CameraButton />
+        <LeaveButton />
       </div>
+      <CallTimer connectedAt={connectedAt} className="text-xs" />
     </div>
   )
 }
 
 /** Side `compact`/`standard`: header + tile grid + controls (the panel width does the sizing). */
-function SideTilesView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
+function SideTilesView({ workspaceId, currentUserId, roster, captureError, title, peeking }: DockViewProps) {
   const joined = roster.filter((p) => p.participantStatus === "joined")
   return (
     <div className="flex h-full w-full flex-col border-l bg-background">
-      <DockHeaderBar title={title} />
+      <DockHeaderBar title={title} peeking={peeking} />
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
         {joined.map((p) => (
@@ -282,23 +310,23 @@ interface DragState {
   start: number
   startSize: number
   size: number
-  velocity: number
-  last: number
-  lastT: number
   full: number
 }
 
 /**
- * The desktop in-call surface: a resizable dock, docked to the side, snapping
- * through the four {@link CallSurfaceMode} steps with the same physics as the
- * mobile drawer ({@link nearestStep}). It pushes the conversation aside via
- * `--call-dock-inset-right` (the main content region reserves the inset) rather
- * than overlaying it, until Fullscreen. Rendered by
- * {@link import("./call-dock").CallDock} on desktop for the connected phase;
- * reads the call store, not the route, so it survives stream navigation.
+ * The desktop in-call surface: a resizable dock, docked to the side, with a
+ * freeform open width (persisted as {@link CallPrefs.sideDockWidth}) capped at
+ * {@link FULLSCREEN_FRACTION} of the content region; dragging past that cap goes
+ * Fullscreen. It pushes the conversation aside via `--call-dock-inset-right` (the
+ * main content region reserves the inset) rather than overlaying it, until
+ * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
+ * the connected phase; reads the call store, not the route, so it survives
+ * stream navigation.
  */
 export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
   const surfaceMode = useCallSurfaceMode()
+  const { sideDockWidth } = useCallPrefs()
+  const inputMode = useInputMode()
   const roster = useCallRoster()
   const connectedAt = useCallConnectedAt()
   const captureError = useCallCaptureError()
@@ -312,6 +340,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const drag = useRef<DragState | null>(null)
   const [dragging, setDragging] = useState(false)
   const [dragSize, setDragSize] = useState<number | null>(null)
+  const [hovering, setHovering] = useState(false)
   // The dock root spans the content region (left = sidebar width → right:0); its
   // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
@@ -329,11 +358,18 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   // Ceiling from the measured content region; 0 means "not laid out yet" (initial
   // render / jsdom) → treat as unbounded so we never clamp to nothing.
   const ceilW = contentW || Infinity
-  const detentsW = dockDetents(SIDE_STEP_SIZES, ceilW)
 
-  // Content push: reserve the pushing mode's detent (which already leaves MIN_CONTENT)
-  // on :root so the main content region (AppShell's <main>) reflows. Fullscreen → 0.
-  const insetRight = surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
+  // The resting open width: the saved freeform width (or the mode's first-open
+  // default), clamped to ≤75% and always leaving MIN_CONTENT.
+  const openWidth = clampOpen(sideDockWidth ?? defaultOpen(surfaceMode), ceilW)
+
+  // Content push: rail → RAIL_WIDTH, open → openWidth (already ≤ ceil−MIN_CONTENT),
+  // fullscreen → 0. Hovering the rail is an overlay, so the inset tracks surfaceMode
+  // (still `min`) and never reflows the timeline.
+  let insetRight: number
+  if (surfaceMode === "full") insetRight = 0
+  else if (surfaceMode === "min") insetRight = RAIL_WIDTH
+  else insetRight = openWidth
   useEffect(() => {
     document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
   }, [insetRight])
@@ -344,23 +380,12 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     []
   )
 
-  const minStep = SIDE_STEP_SIZES[0]
-
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     const panel = panelRef.current?.getBoundingClientRect()
     const root = rootRef.current?.getBoundingClientRect()
-    const full = root?.width ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
-    const startSize = panel?.width ?? SIDE_STEP_SIZES[1]
-    const pointer = e.clientX
-    drag.current = {
-      start: pointer,
-      startSize,
-      size: startSize,
-      velocity: 0,
-      last: pointer,
-      lastT: performance.now(),
-      full,
-    }
+    const full = root?.width ?? ceilW
+    const startSize = panel?.width ?? openWidth
+    drag.current = { start: e.clientX, startSize, size: startSize, full }
     e.currentTarget.setPointerCapture(e.pointerId)
     setDragSize(startSize)
     setDragging(true)
@@ -369,16 +394,9 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     const d = drag.current
     if (!d) return
-    const pointer = e.clientX
-    // Side grows as the pointer moves left.
-    const grow = d.start - pointer
-    const next = Math.min(Math.max(d.startSize + grow, minStep), d.full)
-    const now = performance.now()
-    const dt = now - d.lastT
-    const stepGrow = d.last - pointer
-    if (dt > 0) d.velocity = stepGrow / dt
-    d.last = pointer
-    d.lastT = now
+    // Side grows as the pointer moves left; allow dragging up into the fullscreen zone.
+    const grow = d.start - e.clientX
+    const next = Math.min(Math.max(d.startSize + grow, MIN_OPEN), d.full)
     d.size = next
     setDragSize(next)
   }
@@ -388,20 +406,37 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     drag.current = null
     setDragging(false)
     setDragSize(null)
-    if (d) {
-      // A pause before release means the drag stopped — don't flick on stale velocity.
-      const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
-      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(SIDE_STEP_SIZES, d.full))])
+    if (!d) return
+    if (d.size > FULLSCREEN_FRACTION * d.full) {
+      setCallSurfaceMode("full")
+      return
     }
+    setCallSideDockWidth(clampOpen(d.size, d.full))
+    // Dragging out of the rail (or out of fullscreen) opens it; an already-open mode keeps its mode.
+    if (surfaceMode === "min" || surfaceMode === "full") setCallSurfaceMode("standard")
   }
 
-  const dragFull = drag.current?.full ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
-  const dragMode =
-    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(SIDE_STEP_SIZES, dragFull))] : null
   // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
-  // thrashes the drag) — the preview caps at `standard`; fullscreen mounts on release.
-  const cappedDragMode = dragMode === "full" ? "standard" : dragMode
-  const contentMode: CallSurfaceMode = cappedDragMode ?? surfaceMode
+  // thrashes the drag) — the preview stays on the open tiles; fullscreen mounts on release.
+  // Minimized + mouse hover = a transient peek (overlay, no push); it renders the open
+  // tiles and shows a pin affordance to commit to a pushing, persisted open dock.
+  const peeking = surfaceMode === "min" && hovering
+  let cappedDragMode: CallSurfaceMode | null = null
+  if (dragging) cappedDragMode = surfaceMode === "compact" ? "compact" : "standard"
+  let contentMode: CallSurfaceMode
+  if (cappedDragMode) contentMode = cappedDragMode
+  else if (peeking) contentMode = "standard"
+  else contentMode = surfaceMode
+
+  const dragCeil = drag.current?.full ?? ceilW
+  // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full").
+  const showFullscreenCue =
+    dragging && surfaceMode !== "full" && dragSize != null && dragSize > FULLSCREEN_FRACTION * dragCeil
+
+  let panelWidth: number
+  if (dragging && dragSize != null) panelWidth = dragSize
+  else if (surfaceMode === "min") panelWidth = hovering ? openWidth : RAIL_WIDTH
+  else panelWidth = openWidth
 
   const restingFull = !dragging && surfaceMode === "full"
   let positionClass: string
@@ -411,8 +446,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     sizeStyle = {}
   } else {
     positionClass = "inset-y-0 right-0"
-    const w = dragging && dragSize != null ? dragSize : detentsW[MODE_INDEX[contentMode]]
-    sizeStyle = { width: `${w}px` }
+    sizeStyle = { width: `${panelWidth}px` }
   }
 
   const view: DockViewProps = {
@@ -423,6 +457,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     users,
     captureError,
     title,
+    peeking,
   }
 
   return (
@@ -436,6 +471,14 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         data-testid="desktop-call-dock"
         data-mode={contentMode}
         data-position="side"
+        data-hovering={hovering ? "true" : "false"}
+        onMouseEnter={() => {
+          // Preview only arms from the rail (mirrors the nav-sidebar collapsed→preview);
+          // entering an open panel — including while minimizing with the cursor over it —
+          // must not flip to the overlay.
+          if (inputMode !== "touch" && surfaceMode === "min") setHovering(true)
+        }}
+        onMouseLeave={() => setHovering(false)}
         className={cn(
           "pointer-events-auto absolute overflow-hidden shadow-xl",
           positionClass,
@@ -444,6 +487,16 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         style={sizeStyle}
       >
         <DockBody mode={contentMode} view={view} />
+        {showFullscreenCue && (
+          <div
+            data-testid="call-dock-fullscreen-cue"
+            className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-primary bg-primary/10"
+          >
+            <span className="rounded-md bg-background/80 px-3 py-1.5 text-sm font-medium">
+              Release to go fullscreen
+            </span>
+          </div>
+        )}
         {/* Always mounted — including at rest-fullscreen — so it holds the pointer
             capture/settle through a drag into full AND lets you drag back OUT of
             fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -4,12 +4,13 @@ import {
   setCallLayout,
   setCallFilmstripSide,
   setCallSelfMirror,
+  setCallSideDockWidth,
   resolveSelfMirror,
   __resetCallPrefsForTests,
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
 
 beforeEach(() => {
   localStorage.clear()
@@ -25,11 +26,11 @@ describe("call-prefs-store", () => {
     setCallLayout("grid")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -41,13 +42,33 @@ describe("call-prefs-store", () => {
   it("falls back per-field on an out-of-range persisted value", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "diagonal", filmstripSide: "side" }))
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "speaker", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({
+      layout: "speaker",
+      filmstripSide: "side",
+      selfMirror: "auto",
+      sideDockWidth: null,
+    })
   })
 
   it("persists an explicit selfMirror override", () => {
     setCallSelfMirror("off")
     __resetCallPrefsForTests()
     expect(getCallPrefs().selfMirror).toBe("off")
+  })
+
+  it("round-trips a sideDockWidth through the store", () => {
+    setCallSideDockWidth(480)
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+    __resetCallPrefsForTests()
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+  })
+
+  it("falls back to null on an invalid persisted sideDockWidth", () => {
+    for (const bad of ["wide", -5, 0]) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ sideDockWidth: bad }))
+      __resetCallPrefsForTests()
+      expect(getCallPrefs().sideDockWidth).toBeNull()
+    }
   })
 })
 

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -21,14 +21,18 @@ export interface CallPrefs {
   layout: CallLayout
   filmstripSide: CallFilmstripSide
   selfMirror: CallSelfMirror
+  /** Last resting open width (px) of the desktop side dock; `null` = never resized. */
+  sideDockWidth: number | null
 }
 
-const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
+const parseSideDockWidth = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) && v > 0 ? v : null
 
 /**
  * Resolve the effective self-view mirror. `auto` mirrors a front-facing view (any
@@ -58,6 +62,7 @@ function readPersisted(): CallPrefs {
       layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
       selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
+      sideDockWidth: parseSideDockWidth(p.sideDockWidth),
     }
   } catch {
     return { ...DEFAULT_PREFS }
@@ -85,7 +90,8 @@ function update(patch: Partial<CallPrefs>): void {
   if (
     next.layout === prefs.layout &&
     next.filmstripSide === prefs.filmstripSide &&
-    next.selfMirror === prefs.selfMirror
+    next.selfMirror === prefs.selfMirror &&
+    next.sideDockWidth === prefs.sideDockWidth
   ) {
     return
   }
@@ -108,6 +114,10 @@ export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {
 
 export function setCallSelfMirror(selfMirror: CallSelfMirror): void {
   update({ selfMirror })
+}
+
+export function setCallSideDockWidth(px: number): void {
+  update({ sideDockWidth: px })
 }
 
 function subscribe(listener: () => void): () => void {


### PR DESCRIPTION
## Problem

Chunk 2 of the desktop calls-dock redesign (`docs/plans/calls-desktop-dock-redesign.md`).
After Chunk 1 made the dock side-only, its width still snapped through fixed
compact/standard detents — Kris wanted freeform resize (snaps control layout, not
width), a 75%-cap with a deliberate drop-to-fullscreen gesture, a nav-sidebar-style
hover-peek when minimized, and controls in the collapsed rail's wasted vertical space.

## Solution

Open width is now freeform, persisted as `callPrefs.sideDockWidth`:

- Drag resizes continuously, clamped to `[280, min(0.75·ceil, ceil−320)]` — the timeline
  keeps `MIN_CONTENT` where the window allows; `--call-dock-inset-right` reserves the live
  width. Removed the snap machinery (`nearestStep`/`dockDetents`/`SIDE_STEP_SIZES`/`MODE_INDEX`)
  from the dock; `nearestStep` stays for the mobile drawer. `CallSurfaceMode` enum unchanged.
- Release past `0.75·ceil` → fullscreen; a dashed "Release to go fullscreen" cue shows while
  dragging into that zone and is suppressed when dragging back OUT of fullscreen (that drag is
  an exit). First-open width still honors #1486 (video/`standard` 520 > audio/`compact` 360)
  until the first resize, then `sideDockWidth` governs both.
- Minimized rail: mouse-hover (guarded by `useInputMode` — touch still taps the chevron) overlays
  the open tiles **without** pushing content, mirroring `app-shell`'s collapsed→preview. A **Pin**
  affordance in the peek header commits it to a pinned, pushing dock (the hover pre-empts the rail
  chevron, so the peek needs its own pin; Pin/Minimize are mutually exclusive by state).
- Collapsed rail gains mute/camera/leave (shared `call-control-buttons`) above the timer.

Built via the build-feature loop: Opus implement → Opus max-effort adversarial verify (all green,
no wedge, invariants clean) → its MAJOR (pin discoverability) + two MINORs folded in here.

## Test plan

- [x] `vitest` — call-prefs-store, desktop-call-dock, call-dock: 48 pass
- [x] `tsc --noEmit` clean; `eslint` clean on touched files
- [ ] Real-component desktop screenshots — before merge (per plan)

Residual (accepted): a sub-~600px content region trades some timeline; a very short viewport can
clip the bottom rail control. Chunk 3 (floating square) + Chunk 4 (`desktopCallSurface` pref) follow.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787265267&installation_model_id=20758&pr_number=1493&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1493&signature=2dbd3d7cea096067c7ecfb8d0b47b9d0cea4afacafec7b9a72d26a848d08ca65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->