### PR TITLE
feat(calls): floating call square surface (component, in isolation)

### DIFF
--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, fireEvent } from "@testing-library/react"
+import { render, screen } from "@/test"
+import * as authModule from "@/auth"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import {
+  clearCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  type CallRosterParticipant,
+} from "@/stores/call-store"
+import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import type { CallController } from "@/calls/call-manager"
+import { FloatingCallSquare, clampSquareToViewport } from "./floating-call-square"
+import { CallManagerProvider } from "./call-manager-context"
+import { CallLaunchProvider } from "./call-launch-context"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_self",
+    participantStatus: "joined",
+    endpointId: "callep_self",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+function renderSquare(manager: CallController = makeManager(), onDockToSide: () => void = vi.fn()) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <CallLaunchProvider>
+        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={onDockToSide} />
+      </CallLaunchProvider>
+    </CallManagerProvider>
+  )
+}
+
+function enterConnected(roster: CallRosterParticipant[]) {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallRoster(roster, 1)
+  })
+}
+
+const TWO_PEERS: CallRosterParticipant[] = [
+  participant({ userId: "usr_self" }),
+  participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+]
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
+  seedUsers()
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("clampSquareToViewport", () => {
+  const size = { width: 200, height: 200 }
+  const viewport = { width: 1000, height: 800 }
+
+  it("passes an in-bounds position through unchanged", () => {
+    expect(clampSquareToViewport({ x: 100, y: 100 }, size, viewport)).toEqual({ x: 100, y: 100 })
+  })
+
+  it("clamps past each edge back to the on-screen bound", () => {
+    expect(clampSquareToViewport({ x: -50, y: -50 }, size, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: 5000, y: 5000 }, size, viewport)).toEqual({ x: 792, y: 592 })
+  })
+
+  it("respects a custom margin", () => {
+    expect(clampSquareToViewport({ x: 0, y: 0 }, size, viewport, 20)).toEqual({ x: 20, y: 20 })
+    expect(clampSquareToViewport({ x: 9999, y: 9999 }, size, viewport, 20)).toEqual({ x: 780, y: 580 })
+  })
+
+  it("clamps to the margin (never negative) when the square is larger than the viewport", () => {
+    const big = { width: 2000, height: 2000 }
+    expect(clampSquareToViewport({ x: 400, y: 400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: -400, y: -400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+  })
+})
+
+describe("FloatingCallSquare — connected", () => {
+  it("renders one tile per joined participant, Leave, and Dock to the side", () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    const square = screen.getByTestId("floating-call-square")
+    expect(square).toHaveAttribute("data-minimized", "false")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Dock to the side")).toBeInTheDocument()
+  })
+
+  it("clicking Dock to the side calls onDockToSide", async () => {
+    const onDockToSide = vi.fn()
+    renderSquare(makeManager(), onDockToSide)
+    enterConnected(TWO_PEERS)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Dock to the side"))
+    })
+    expect(onDockToSide).toHaveBeenCalled()
+  })
+
+  it("clicking Leave dispatches to the manager", async () => {
+    const manager = makeManager()
+    renderSquare(manager)
+    enterConnected([participant({ userId: "usr_self" })])
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Leave call"))
+    })
+    expect(manager.leaveCall).toHaveBeenCalled()
+  })
+})
+
+describe("FloatingCallSquare — minimize / restore", () => {
+  it("minimizes to a bubble (dot + timer) then restores to the tiles", async () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Minimize call"))
+    })
+    const bubble = screen.getByTestId("floating-call-square")
+    expect(bubble).toHaveAttribute("data-minimized", "true")
+    expect(screen.getByLabelText("Restore call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Restore call"))
+    })
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "false")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+  })
+})
+
+describe("FloatingCallSquare — joining", () => {
+  it("renders the joining body (no tiles) when the phase is joining and the launch is idle", () => {
+    renderSquare()
+    act(() => setCallPhase("joining"))
+    expect(screen.getByText("Joining…")).toBeInTheDocument()
+    expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
+    expect(screen.getByLabelText("Cancel joining")).toBeInTheDocument()
+  })
+
+  it("offers no Minimize while joining — a bubble would hide the PreJoinGate", () => {
+    renderSquare()
+    act(() => setCallPhase("joining"))
+    expect(screen.queryByLabelText("Minimize call")).toBeNull()
+  })
+
+  it("force-restores from a bubble if the call leaves the connected phase", async () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    await act(async () => fireEvent.click(screen.getByLabelText("Minimize call")))
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "true")
+    // Dropping out of connected (e.g. back to joining) must expand — never a stale bubble.
+    act(() => setCallPhase("joining"))
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "false")
+    expect(screen.getByText("Joining…")).toBeInTheDocument()
+  })
+})
+
+describe("FloatingCallSquare — drag", () => {
+  it("dragging the header moves the square and settles without wedging", () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    const square = screen.getByTestId("floating-call-square")
+    const header = screen.getByTestId("floating-call-square-header")
+    header.setPointerCapture = vi.fn()
+
+    fireEvent.pointerDown(header, { clientX: 676, clientY: 440, pointerId: 1, isPrimary: true })
+    fireEvent.pointerMove(header, { clientX: 300, clientY: 200, pointerId: 1 })
+    // jsdom viewport is 1024x768; the square measures 0px in jsdom so the clamp
+    // bounds are margin..(viewport-margin). The move delta lands at (300, 200).
+    expect(square.style.left).toBe("300px")
+    expect(square.style.top).toBe("200px")
+
+    fireEvent.pointerUp(header, { clientX: 300, clientY: 200, pointerId: 1 })
+    // Drag released: a lone move must be a no-op (drag ref nulled — no wedge).
+    fireEvent.pointerMove(header, { clientX: 50, clientY: 50, pointerId: 1 })
+    expect(square.style.left).toBe("300px")
+    expect(square.style.top).toBe("200px")
+  })
+})

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
+import { GripHorizontal, Loader2, Minimize2, PanelRight, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useCallLaunch } from "./call-launch-context"
+import { PreJoinGate } from "./pre-join-gate"
+import { CallTile } from "./call-tile"
+import { CallControls } from "./call-controls"
+import { CallTimer } from "./call-timer"
+import { CaptureErrorBanner } from "./call-capture-error"
+import { useCallCaptureError, useCallConnectedAt, useCallPhase, useCallRoster } from "./call-store-hooks"
+
+const REDUCED_MOTION =
+  typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+
+const SQUARE_WIDTH = 340
+const MARGIN = 8
+// Initial-anchor height estimate before the square measures itself; the mount
+// reclamp refines it against the real `offsetHeight`.
+const NOMINAL_HEIGHT = 320
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Size {
+  width: number
+  height: number
+}
+
+/**
+ * Clamp a floating square so it stays fully on-screen with `margin` padding. When
+ * the square is larger than the viewport the upper bound would go negative, so it
+ * floors at `margin` (top-left pinned) rather than clamping to a negative x/y.
+ */
+export function clampSquareToViewport(pos: Point, size: Size, viewport: Size, margin = 8): Point {
+  const maxX = Math.max(margin, viewport.width - size.width - margin)
+  const maxY = Math.max(margin, viewport.height - size.height - margin)
+  return {
+    x: Math.min(Math.max(pos.x, margin), maxX),
+    y: Math.min(Math.max(pos.y, margin), maxY),
+  }
+}
+
+function defaultAnchor(): Point {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1024
+  const vh = typeof window !== "undefined" ? window.innerHeight : 768
+  return clampSquareToViewport(
+    { x: vw - SQUARE_WIDTH - MARGIN, y: vh - NOMINAL_HEIGHT - MARGIN },
+    { width: SQUARE_WIDTH, height: NOMINAL_HEIGHT },
+    { width: vw, height: vh },
+    MARGIN
+  )
+}
+
+interface DragState {
+  pointerId: number
+  startX: number
+  startY: number
+  originX: number
+  originY: number
+}
+
+function SquareHeader({
+  title,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onDockToSide,
+  onMinimize,
+  canMinimize,
+  dragging,
+}: {
+  title: string
+  onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onDockToSide: () => void
+  onMinimize: () => void
+  // Only a connected call may minimize — collapsing the joining/pre-join window would
+  // hide the PreJoinGate permission taxonomy (mirrors call-dock.tsx's force-open guard).
+  canMinimize: boolean
+  dragging: boolean
+}) {
+  return (
+    <div
+      data-testid="floating-call-square-header"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      className={cn(
+        "flex shrink-0 touch-none items-center gap-2 border-b px-3 py-2",
+        dragging ? "cursor-grabbing" : "cursor-grab"
+      )}
+    >
+      <GripHorizontal className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+      <button
+        type="button"
+        aria-label="Dock to the side"
+        onClick={onDockToSide}
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <PanelRight className="h-4 w-4" />
+      </button>
+      {canMinimize && (
+        <button
+          type="button"
+          aria-label="Minimize call"
+          onClick={onMinimize}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Minimize2 className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+function ConnectedBody({
+  workspaceId,
+  currentUserId,
+  roster,
+  captureError,
+}: {
+  workspaceId: string | null
+  currentUserId: string | null
+  roster: ReturnType<typeof useCallRoster>
+  captureError: ReturnType<typeof useCallCaptureError>
+}) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  return (
+    <>
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <div
+        className={cn(
+          "grid min-h-0 flex-1 gap-2 overflow-y-auto p-3",
+          joined.length > 1 ? "grid-cols-2" : "grid-cols-1"
+        )}
+      >
+        {joined.map((p) => (
+          <CallTile
+            key={p.userId}
+            participant={p}
+            workspaceId={workspaceId}
+            isSelf={!!currentUserId && p.userId === currentUserId}
+          />
+        ))}
+      </div>
+      <div className="shrink-0 border-t p-2">
+        <CallControls />
+      </div>
+    </>
+  )
+}
+
+/** Joining/pre-join body — mirrors {@link import("./call-island").MobileCallJoining} inside the square frame. */
+function JoiningBody() {
+  const { state, cancel } = useCallLaunch()
+  const isError = state.status === "permission_error" || state.status === "join_error"
+  if (isError) {
+    return (
+      <div className="p-3">
+        <PreJoinGate />
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center gap-2.5 px-3 py-4" role="status">
+      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" aria-hidden />
+      <span className="flex-1 text-sm font-medium">Joining…</span>
+      <button
+        type="button"
+        aria-label="Cancel joining"
+        onClick={cancel}
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+function MinimizedBubble({
+  pos,
+  connectedAt,
+  onRestore,
+}: {
+  pos: Point
+  connectedAt: number | null
+  onRestore: () => void
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="floating-call-square"
+      data-minimized="true"
+      aria-label="Restore call"
+      onClick={onRestore}
+      style={{ left: `${pos.x}px`, top: `${pos.y}px` }}
+      className="pointer-events-auto fixed z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl"
+    >
+      <span
+        className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
+        aria-hidden
+      />
+      <CallTimer connectedAt={connectedAt} className="text-xs" />
+    </button>
+  )
+}
+
+/**
+ * A draggable, minimizable floating desktop call surface: header (drag / dock-to-
+ * side / minimize) plus the phase body — connected tiles + {@link CallControls}, or
+ * the joining spinner / {@link PreJoinGate}. A LIGHT panel (not the dark mobile
+ * island). Position lives in local state, committed through {@link clampSquareToViewport}
+ * on drag and reclamped on window resize so it never leaves the viewport. Minimize is
+ * connected-only, so a bubble never hides the joining gate.
+ */
+export function FloatingCallSquare({
+  workspaceId,
+  streamId,
+  onDockToSide,
+}: {
+  workspaceId: string | null
+  streamId: string | null
+  onDockToSide: () => void
+}) {
+  const phase = useCallPhase()
+  const roster = useCallRoster()
+  const connectedAt = useCallConnectedAt()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  const title = name ?? "Call"
+
+  const inCall = phase === "connected" || phase === "reconnecting"
+
+  const squareRef = useRef<HTMLDivElement>(null)
+  const drag = useRef<DragState | null>(null)
+  const [pos, setPos] = useState<Point>(() => defaultAnchor())
+  const [dragging, setDragging] = useState(false)
+  const [minimized, setMinimized] = useState(false)
+
+  const reclamp = useCallback(() => {
+    const el = squareRef.current
+    const size = { width: el?.offsetWidth || SQUARE_WIDTH, height: el?.offsetHeight || 0 }
+    const viewport = { width: window.innerWidth, height: window.innerHeight }
+    setPos((prev) => clampSquareToViewport(prev, size, viewport, MARGIN))
+  }, [])
+
+  useEffect(() => {
+    reclamp()
+    window.addEventListener("resize", reclamp)
+    return () => window.removeEventListener("resize", reclamp)
+  }, [reclamp])
+
+  // Never stay minimized outside a connected call — a bubble would hide the joining
+  // PreJoinGate and imply "live" with a 0:00 timer (mirrors call-dock.tsx's force-open).
+  useEffect(() => {
+    if (!inCall) setMinimized(false)
+  }, [inCall])
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // Primary pointer only; the header's action buttons aren't drag handles.
+    if (!e.isPrimary) return
+    if ((e.target as HTMLElement).closest("button")) return
+    drag.current = { pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, originX: pos.x, originY: pos.y }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    setDragging(true)
+  }
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    if (!d || e.pointerId !== d.pointerId) return
+    const el = squareRef.current
+    const size = { width: el?.offsetWidth || SQUARE_WIDTH, height: el?.offsetHeight || 0 }
+    const viewport = { width: window.innerWidth, height: window.innerHeight }
+    const next = { x: d.originX + (e.clientX - d.startX), y: d.originY + (e.clientY - d.startY) }
+    setPos(clampSquareToViewport(next, size, viewport, MARGIN))
+  }
+
+  const onPointerUp = () => {
+    drag.current = null
+    setDragging(false)
+  }
+
+  if (minimized) {
+    return <MinimizedBubble pos={pos} connectedAt={connectedAt} onRestore={() => setMinimized(false)} />
+  }
+
+  return (
+    <div
+      ref={squareRef}
+      data-testid="floating-call-square"
+      data-minimized="false"
+      style={{ left: `${pos.x}px`, top: `${pos.y}px`, width: `${SQUARE_WIDTH}px` }}
+      className="pointer-events-auto fixed z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+    >
+      <SquareHeader
+        title={title}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onDockToSide={onDockToSide}
+        onMinimize={() => setMinimized(true)}
+        canMinimize={inCall}
+        dragging={dragging}
+      />
+      {inCall ? (
+        <ConnectedBody
+          workspaceId={workspaceId}
+          currentUserId={currentUserId}
+          roster={roster}
+          captureError={captureError}
+        />
+      ) : (
+        <JoiningBody />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

Chunk 3 of the desktop calls-dock redesign (`docs/plans/calls-desktop-dock-redesign.md`).
Kris wants a floating square as the eventual desktop default: a small draggable/minimizable
call widget that also hosts the joining state in-place (today desktop joining is a bottom-right
`DockFrame` that then jumps to the side dock). This chunk lands the component in isolation.

## Solution

New `FloatingCallSquare` — a light (not dark-island) fixed panel:

- **Drag**: position in local state, seeded bottom-right, committed through a pure
  `clampSquareToViewport(pos, size, viewport, margin)` on every move and reclamped on window
  resize, so it never leaves the viewport. Reuses the dock's pointer-capture pattern:
  primary-pointer-only, a `closest("button")` guard so the header actions don't start a drag,
  origin captured in a ref (no stale-closure), ref nulled on up/cancel (no wedge).
- **One frame across phases**: connected → `CallTile` grid + shared `CallControls`
  (+ `CaptureErrorBanner`); joining → the `MobileCallJoining` spinner/Cancel, or `PreJoinGate`
  on a permission/join error — reused, not re-implemented (INV-35).
- **Header**: grip, stream title, a "Dock to the side" action (an `onDockToSide` prop — Chunk 4
  wires it to the surface switch), and Minimize.
- **Minimize is connected-only** and force-restores when the call leaves the connected phase.
  This is the fix the adversarial review flagged: an unconditional Minimize could collapse the
  joining window to a bubble, hiding the `PreJoinGate` permission taxonomy and showing a "live"
  0:00 timer — the exact footgun `call-dock.tsx:84-97` guards for its own surface.

Landed in isolation: nothing routes to it yet (only its test renders it); Chunk 4 adds the
`desktopCallSurface` pref + surface switching. No existing file touched.

Built via the build-feature loop: Opus implement → Opus max-effort adversarial verify → its MAJOR
(minimize-hides-gate) folded in; minors (non-scroll gate at 340px, minimized-resize over-margin)
accepted as noted.

## Test plan

- [x] `vitest` floating-call-square: 12 pass (clamp pure ×4, connected, dock-to-side, Leave,
  minimize/restore, joining body, minimize-gated-while-joining, force-restore, drag no-wedge)
- [x] `tsc --noEmit` clean; `eslint` clean on both new files
- [ ] Real-component desktop screenshots — with Chunk 4 wiring, before merge

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787266402&installation_model_id=20758&pr_number=1494&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1494&signature=7b5c0133367db5bda464b2f4f70d7b84abf6d4d49d12b7ff7faac06a21b256d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->