### PR TITLE
feat(calls): desktopCallSurface pref + surface switching + Calls settings

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -19,7 +19,7 @@ import {
   bumpCallMediaEpoch,
   type CallRosterParticipant,
 } from "@/stores/call-store"
-import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import { __resetCallPrefsForTests, getCallPrefs, setDesktopCallSurface } from "@/stores/call-prefs-store"
 import { CallCaptureError, type CallController } from "@/calls/call-manager"
 import { CallDock } from "./call-dock"
 import { CallManagerProvider } from "./call-manager-context"
@@ -138,6 +138,9 @@ beforeEach(() => {
   resetWorkspaceStoreCache()
   localStorage.clear()
   __resetCallPrefsForTests()
+  // Default resolves to the floating square now; pin the sidebar dock so the dock-
+  // specific cases below exercise their surface. The routing suite overrides per test.
+  setDesktopCallSurface("sidebar")
   seedUsers()
   vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
 })
@@ -398,5 +401,78 @@ describe("CallDock — mobile drawer vs desktop dock", () => {
     await userEvent.click(screen.getByText("launch"))
     expect(await screen.findByText(/Microphone access denied/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument()
+  })
+})
+
+describe("CallDock — desktop surface routing", () => {
+  it("floating pref renders the square for both joining and connected", () => {
+    setDesktopCallSurface("floating")
+    renderDock(makeManager())
+    act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    // Joining (launch idle): the square owns the joining surface, not the DockFrame.
+    expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Collapse call")).toBeNull()
+    act(() => {
+      setCallPhase("connected")
+      setCallRoster([participant({ userId: "usr_self", endpointId: "callep_self" })], 1)
+    })
+    expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
+    expect(screen.getByTestId("call-tile")).toBeInTheDocument()
+    expect(screen.queryByTestId("desktop-call-dock")).toBeNull()
+  })
+
+  it("sidebar pref renders the DockFrame while joining and the dock in-call", () => {
+    // beforeEach pins sidebar.
+    renderDock(makeManager())
+    act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    // The docked joining panel (not the square); it has no collapse toggle — the gate stays visible.
+    expect(screen.getByText("Connecting…")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Collapse call")).toBeNull()
+    expect(screen.queryByTestId("floating-call-square")).toBeNull()
+    act(() => {
+      setCallPhase("connected")
+      setCallRoster([participant({ userId: "usr_self", endpointId: "callep_self" })], 1)
+    })
+    expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
+    expect(screen.queryByTestId("floating-call-square")).toBeNull()
+  })
+
+  it("floating pref surfaces the pre-join permission gate inside the square during an active launch", async () => {
+    setDesktopCallSurface("floating")
+    const startCall = vi.fn(async () => {
+      throw new CallCaptureError(
+        "capture_failed",
+        Object.assign(new Error("Permission denied"), { name: "NotAllowedError" })
+      )
+    })
+    renderDock(makeManager({ startCall }))
+    await userEvent.click(screen.getByText("launch"))
+    // The gate (not a bare "Joining…" pill) renders on the floating surface — no PreJoinGate = no way to recover permission.
+    expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
+    expect(await screen.findByText(/Microphone access denied/i)).toBeInTheDocument()
+  })
+
+  it("the square's Dock to the side flips to the dock and records the override + last", async () => {
+    setDesktopCallSurface("floating")
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
+    await userEvent.click(screen.getByLabelText("Dock to the side"))
+    expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
+    expect(screen.queryByTestId("floating-call-square")).toBeNull()
+    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
+    expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
+  })
+
+  it("the dock's Float flips to the square and records the override + last", async () => {
+    // beforeEach pins sidebar.
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
+    await userEvent.click(screen.getByLabelText("Pop out to a floating window"))
+    expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
+    expect(screen.queryByTestId("desktop-call-dock")).toBeNull()
+    expect(getCallState().desktopSurfaceOverride).toBe("floating")
+    expect(getCallPrefs().lastDesktopSurface).toBe("floating")
   })
 })

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -139,5 +139,9 @@ export function CallDock() {
 }
 
 function JoiningBody() {
-  return <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Connecting…</div>
+  return (
+    <div role="status" className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+      Connecting…
+    </div>
+  )
 }

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState, type ReactNode } from "react"
-import { ChevronDown, ChevronUp } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { useCallback, useEffect, type ReactNode } from "react"
 import { SidePanel, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
-import { getCallState, setCallSurfaceMode } from "@/stores/call-store"
+import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
+import { resolveDesktopSurface, setLastDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
 import { useCallLaunch } from "./call-launch-context"
-import { useCallActiveElsewhere, useCallPhase, useCallStreamId, useCallWorkspaceId } from "./call-store-hooks"
+import {
+  useCallActiveElsewhere,
+  useCallPhase,
+  useCallStreamId,
+  useCallWorkspaceId,
+  useDesktopSurfaceOverride,
+} from "./call-store-hooks"
 
 // Bottom-anchored call surfaces clear the iOS home indicator on desktop (app
 // convention — see message-composer.tsx) and, on a phone, sit a composer-height
@@ -25,6 +30,7 @@ export const RING_ABOVE_DOCK_BOTTOM =
 import { MobileCallDrawer } from "./mobile-call-drawer"
 import { MobileCallJoining } from "./call-island"
 import { DesktopCallDock } from "./desktop-call-dock"
+import { FloatingCallSquare } from "./floating-call-square"
 import { PreJoinGate } from "./pre-join-gate"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 
@@ -36,20 +42,10 @@ function DockFrame({ children }: { children: ReactNode }) {
   )
 }
 
-function DockHeader({ title, collapsed, onToggle }: { title: string; collapsed: boolean; onToggle: () => void }) {
+function DockHeader({ title }: { title: string }) {
   return (
     <SidePanelHeader className="rounded-t-lg">
       <SidePanelTitle className="text-sm">{title}</SidePanelTitle>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-8 w-8 shrink-0"
-        aria-label={collapsed ? "Expand call" : "Collapse call"}
-        aria-expanded={!collapsed}
-        onClick={onToggle}
-      >
-        {collapsed ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-      </Button>
     </SidePanelHeader>
   )
 }
@@ -71,25 +67,32 @@ export function CallDock() {
   const storeStreamId = useCallStreamId()
   const workspaceId = useCallWorkspaceId()
   const isMobile = useIsMobile()
-  const [collapsed, setCollapsed] = useState(false)
+  const { desktopCallSurface, lastDesktopSurface } = useCallPrefs()
+  const override = useDesktopSurfaceOverride()
 
   const launching = launch.status !== "idle"
   const inCall = phase === "connected" || phase === "reconnecting"
   const joining = phase === "joining"
 
-  // The dock is always mounted, so `collapsed` would otherwise leak across call
-  // lifecycles. The pre-join/joining window must never be collapsed — a collapsed
-  // pill would hide the PreJoinGate and its permission taxonomy — so force it open
-  // whenever a launch is in flight or the call is connecting.
-  useEffect(() => {
-    if (launching || joining) setCollapsed(false)
-  }, [launching, joining])
+  const surface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, override)
+
+  // An in-call switch moves THIS call (the override) and remembers the choice for
+  // `keep_last` next time; the override clears on teardown, so a pinned surface wins
+  // the next call (interaction model A). Silent — the surface change is its own signal.
+  const dockToSide = useCallback(() => {
+    setDesktopSurfaceOverride("sidebar")
+    setLastDesktopSurface("sidebar")
+  }, [])
+  const float = useCallback(() => {
+    setDesktopSurfaceOverride("floating")
+    setLastDesktopSurface("floating")
+  }, [])
 
   // On connect, open to a visible size — `min` (the Tab/Rail) is too minimal a
   // default. Open to the first open state (compact) normally, and the second
   // (standard/gallery) when joining with the camera on, so a video join lands on
   // tiles. Guarded on the initial `min` so it runs once and later drags win;
-  // `surfaceMode` is shared but only one surface renders per session.
+  // `surfaceMode` is read only by the sidebar dock (the square uses its own state).
   useEffect(() => {
     if (inCall && getCallState().surfaceMode === "min") {
       setCallSurfaceMode(getCallState().local.cameraOn ? "standard" : "compact")
@@ -111,21 +114,26 @@ export function CallDock() {
 
   const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
 
-  if (inCall) {
-    // Mobile gets the 4-mode global top drawer; desktop gets the resizable dock.
-    if (isMobile) return <MobileCallDrawer workspaceId={workspaceId} streamId={streamIdForLabel} />
-    return <DesktopCallDock workspaceId={workspaceId} streamId={streamIdForLabel} />
+  // Mobile is unchanged: the 4-mode top drawer in-call, the same top island for
+  // joining/permission (one surface, no bottom→top jump).
+  if (isMobile) {
+    if (inCall) return <MobileCallDrawer workspaceId={workspaceId} streamId={streamIdForLabel} />
+    return <MobileCallJoining />
   }
 
-  // Joining / permission gate. Mobile renders the same top island as the connected
-  // call (one surface, no bottom→top jump); desktop keeps the docked panel.
-  if (isMobile) return <MobileCallJoining />
+  // Desktop floating: the square owns the whole lifecycle (launch / join / in-call).
+  if (surface === "floating") {
+    return <FloatingCallSquare workspaceId={workspaceId} streamId={streamIdForLabel} onDockToSide={dockToSide} />
+  }
+
+  // Desktop sidebar: the resizable dock in-call, the docked pre-join/joining panel
+  // otherwise. The panel is not collapsible — it only ever shows the connecting/
+  // permission gate, which must stay visible (mirrors the floating square).
+  if (inCall) return <DesktopCallDock workspaceId={workspaceId} streamId={streamIdForLabel} onFloat={float} />
   return (
     <DockFrame>
-      <DockHeader title="Call" collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
-      {!collapsed && (
-        <div className="p-4">{joining && launch.status === "idle" ? <JoiningBody /> : <PreJoinGate />}</div>
-      )}
+      <DockHeader title="Call" />
+      <div className="p-4">{joining && launch.status === "idle" ? <JoiningBody /> : <PreJoinGate />}</div>
     </DockFrame>
   )
 }

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -11,6 +11,7 @@ import {
   type CallCaptureErrorInfo,
 } from "@/stores/call-store"
 import type { CallMode } from "@/calls/config"
+import type { DesktopSurface } from "@/stores/call-prefs-store"
 
 /**
  * Slice-scoped reads over the call store. {@link useCallState} re-renders every
@@ -43,6 +44,10 @@ export function useCallPhase(): CallPhase {
 
 export function useCallSurfaceMode(): CallSurfaceMode {
   return useCallSelector((s) => s.surfaceMode)
+}
+
+export function useDesktopSurfaceOverride(): DesktopSurface | null {
+  return useCallSelector((s) => s.desktopSurfaceOverride)
 }
 
 export function useCallStreamId(): string | null {

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -14,12 +14,7 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import {
-  getCallPrefs,
-  setCallDockPosition,
-  __resetCallPrefsForTests,
-  type CallDockPosition,
-} from "@/stores/call-prefs-store"
+import { getCallPrefs, __resetCallPrefsForTests } from "@/stores/call-prefs-store"
 import type { CallController } from "@/calls/call-manager"
 import { DesktopCallDock } from "./desktop-call-dock"
 import { CallManagerProvider } from "./call-manager-context"
@@ -126,10 +121,6 @@ function setMode(m: CallSurfaceMode) {
   act(() => setCallSurfaceMode(m))
 }
 
-function setPosition(p: CallDockPosition) {
-  act(() => setCallDockPosition(p))
-}
-
 const TWO_PEERS: CallRosterParticipant[] = [
   participant({ userId: "usr_self" }),
   participant({ userId: "usr_peer", endpointId: "callep_peer" }),
@@ -153,7 +144,6 @@ describe("DesktopCallDock — side dock presentations", () => {
   it("min renders the Rail: restore chevron + timer, no controls", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("min")
     const dock = screen.getByTestId("desktop-call-dock")
     expect(dock).toHaveAttribute("data-mode", "min")
@@ -163,84 +153,24 @@ describe("DesktopCallDock — side dock presentations", () => {
     expect(screen.queryByLabelText("Mute")).toBeNull()
   })
 
-  it("compact renders the Panel: tile grid, controls, minimize, and the Top/Side toggle", () => {
+  it("compact renders the Panel: tile grid, controls, minimize", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("compact")
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "compact")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Mute")).toBeInTheDocument()
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
     expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Side" })).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
   })
 
   it("standard renders the Wide gallery: tiles + controls", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("standard")
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-  })
-})
-
-describe("DesktopCallDock — top dock presentations", () => {
-  it("min renders the Tab: timer only, tap to expand", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("min")
-    const dock = screen.getByTestId("desktop-call-dock")
-    expect(dock).toHaveAttribute("data-mode", "min")
-    expect(dock).toHaveAttribute("data-position", "top")
-    expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
-    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Mute")).toBeNull()
-  })
-
-  it("compact renders the Bar: timer + mute/camera/leave + the Top/Side toggle", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("compact")
-    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
-    expect(screen.getByLabelText("Turn camera on")).toBeInTheDocument()
-    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByRole("radio", { name: "Top" })).toBeInTheDocument()
-  })
-
-  it("standard renders the Gallery: tiles row + controls + minimize", () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setPosition("top")
-    setMode("standard")
-    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
-    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
-    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
-  })
-})
-
-describe("DesktopCallDock — dock-position toggle", () => {
-  it("switches orientation and persists, preserving surfaceMode", async () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setPosition("side")
-    setMode("compact")
-    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-position", "side")
-
-    await userEvent.click(screen.getByRole("radio", { name: "Top" }))
-    expect(getCallPrefs().dockPosition).toBe("top")
-    const dock = screen.getByTestId("desktop-call-dock")
-    expect(dock).toHaveAttribute("data-position", "top")
-    // surfaceMode is preserved across the re-orientation.
-    expect(dock).toHaveAttribute("data-mode", "compact")
-    expect(getCallState().surfaceMode).toBe("compact")
   })
 })
 
@@ -252,7 +182,6 @@ describe("DesktopCallDock — fullscreen", () => {
       participant({ userId: "usr_peer", endpointId: "callep_peer" }),
       participant({ userId: "usr_third", endpointId: "callep_third" }),
     ])
-    setPosition("side")
     setMode("full")
     expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
     expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
@@ -284,48 +213,30 @@ describe("DesktopCallDock — content push var", () => {
   function insetRight() {
     return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
   }
-  function insetTop() {
-    return document.documentElement.style.getPropertyValue("--call-dock-inset-top")
-  }
 
-  it("reserves the resting side width and no top inset when docked to the side", () => {
+  it("reserves the resting side width", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     expect(insetRight()).toBe("320px")
-    expect(insetTop()).toBe("0px")
     setMode("standard")
     expect(insetRight()).toBe("520px")
   })
 
-  it("reserves the resting top height and no side inset when docked to the top", () => {
+  it("drops the inset to 0 in fullscreen (the dock overlays, not pushes)", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
-    setMode("standard")
-    expect(insetTop()).toBe("220px")
-    expect(insetRight()).toBe("0px")
-  })
-
-  it("drops both insets to 0 in fullscreen (the dock overlays, not pushes)", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("full")
     expect(insetRight()).toBe("0px")
-    expect(insetTop()).toBe("0px")
   })
 
-  it("resets both insets to 0 when the dock unmounts", () => {
+  it("resets the inset to 0 when the dock unmounts", () => {
     const { unmount } = renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     expect(insetRight()).toBe("320px")
     unmount()
     expect(insetRight()).toBe("0px")
-    expect(insetTop()).toBe("0px")
   })
 })
 
@@ -333,7 +244,6 @@ describe("DesktopCallDock — capture error", () => {
   it("surfaces a mid-call capture error banner in the Panel", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("side")
     setMode("compact")
     act(() => setCallCaptureError({ code: "capture_rollback_failed", message: "boom" }))
     expect(screen.getByTestId("call-capture-error")).toHaveTextContent(/couldn't be restored/i)
@@ -351,7 +261,6 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
   it("dragging the side handle past the wide→full threshold caps the preview at standard and settles to full", () => {
     renderDock()
     enterConnected(TWO_PEERS)
-    setPosition("side")
     setMode("standard")
     const dock = screen.getByTestId("desktop-call-dock")
     stubRect(dock, { width: 520 })
@@ -375,16 +284,15 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
   it("a pointercancel mid-drag settles instead of wedging", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
-    setPosition("top")
     setMode("compact")
     const dock = screen.getByTestId("desktop-call-dock")
-    stubRect(dock, { height: 72 })
-    stubRect(dock.parentElement as HTMLElement, { height: 800 })
+    stubRect(dock, { width: 320 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
     const handle = screen.getByTestId("call-dock-handle")
     handle.setPointerCapture = vi.fn()
-    fireEvent.pointerDown(handle, { clientY: 100, pointerId: 1 })
-    fireEvent.pointerMove(handle, { clientY: 500, pointerId: 1 })
-    fireEvent.pointerCancel(handle, { clientY: 500, pointerId: 1 })
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 100, pointerId: 1 })
+    fireEvent.pointerCancel(handle, { clientX: 100, pointerId: 1 })
     // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
     expect(["standard", "full"]).toContain(getCallState().surfaceMode)
   })

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -109,6 +109,14 @@ function renderDock(manager: CallController = makeManager()) {
   )
 }
 
+function renderDockWithFloat(onFloat: () => void, manager: CallController = makeManager()) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <DesktopCallDock workspaceId={WORKSPACE_ID} streamId="stream_1" onFloat={onFloat} />
+    </CallManagerProvider>
+  )
+}
+
 function enterConnected(roster: CallRosterParticipant[]) {
   act(() => {
     setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
@@ -172,6 +180,38 @@ describe("DesktopCallDock — side dock presentations", () => {
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+  })
+})
+
+describe("DesktopCallDock — Float action", () => {
+  it("shows the Float button in the open panel and dispatches onFloat", async () => {
+    const onFloat = vi.fn()
+    renderDockWithFloat(onFloat)
+    enterConnected(TWO_PEERS)
+    setMode("compact")
+    const float = screen.getByLabelText("Pop out to a floating window")
+    expect(float).toBeInTheDocument()
+    await userEvent.click(float)
+    expect(onFloat).toHaveBeenCalled()
+  })
+
+  it("renders no Float button when onFloat is absent", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("compact")
+    expect(screen.queryByLabelText("Pop out to a floating window")).toBeNull()
+    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
+  })
+
+  it("keeps the peek header on Pin, not Float", () => {
+    const onFloat = vi.fn()
+    renderDockWithFloat(onFloat)
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    fireEvent.mouseEnter(dock)
+    expect(screen.getByLabelText("Keep call open")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Pop out to a floating window")).toBeNull()
   })
 })
 

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -141,7 +141,7 @@ afterEach(() => {
 })
 
 describe("DesktopCallDock — side dock presentations", () => {
-  it("min renders the Rail: restore chevron + timer, no controls", () => {
+  it("min renders the Rail: restore chevron + timer + collapsed controls", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("min")
@@ -150,7 +150,8 @@ describe("DesktopCallDock — side dock presentations", () => {
     expect(dock).toHaveAttribute("data-position", "side")
     expect(screen.getByRole("button", { name: "Expand call" })).toBeInTheDocument()
     expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Mute")).toBeNull()
+    expect(screen.getByLabelText("Mute")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
   })
 
   it("compact renders the Panel: tile grid, controls, minimize", () => {
@@ -218,7 +219,7 @@ describe("DesktopCallDock — content push var", () => {
     renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("compact")
-    expect(insetRight()).toBe("320px")
+    expect(insetRight()).toBe("360px")
     setMode("standard")
     expect(insetRight()).toBe("520px")
   })
@@ -234,7 +235,7 @@ describe("DesktopCallDock — content push var", () => {
     const { unmount } = renderDock()
     enterConnected([participant({ userId: "usr_self" })])
     setMode("compact")
-    expect(insetRight()).toBe("320px")
+    expect(insetRight()).toBe("360px")
     unmount()
     expect(insetRight()).toBe("0px")
   })
@@ -295,5 +296,70 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
     fireEvent.pointerCancel(handle, { clientX: 100, pointerId: 1 })
     // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
     expect(["standard", "full"]).toContain(getCallState().surfaceMode)
+  })
+
+  it("a mid-range drop persists the freeform width (not a detent) and keeps the open mode", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("standard")
+    const dock = screen.getByTestId("desktop-call-dock")
+    stubRect(dock, { width: 520 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
+    const handle = screen.getByTestId("call-dock-handle")
+    handle.setPointerCapture = vi.fn()
+    // Shrink to 480px: below 0.75*900=675 (no fullscreen) and above MIN_OPEN(280).
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 540, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: 540, pointerId: 1 })
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+    expect(getCallState().surfaceMode).toBe("standard")
+  })
+})
+
+describe("DesktopCallDock — minimized hover overlay", () => {
+  function insetRight() {
+    return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
+  }
+
+  it("hovering the rail overlays the open panel without pushing content", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-hovering", "false")
+    expect(insetRight()).toBe("56px")
+    fireEvent.mouseEnter(dock)
+    expect(dock).toHaveAttribute("data-hovering", "true")
+    // Overlay: the open tiles render but the inset stays at the rail width (no reflow).
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(insetRight()).toBe("56px")
+  })
+
+  it("the peek's pin commits it to a pinned-open dock that pushes content", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    // The un-hovered rail has no pin — it's a peek-only affordance.
+    expect(screen.queryByLabelText("Keep call open")).toBeNull()
+    fireEvent.mouseEnter(dock)
+    act(() => fireEvent.click(screen.getByLabelText("Keep call open")))
+    expect(getCallState().surfaceMode).toBe("standard")
+    // Pinned: the inset reflows to the open width instead of the 56px rail overlay.
+    expect(insetRight()).toBe("520px")
+  })
+
+  it("clicking the collapsed rail's Leave dispatches to the manager", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("min")
+    // fireEvent (no synthetic pointer move) so the click lands on the rail control
+    // itself rather than first arming the hover-overlay; the async flush lets the
+    // control's per-instance action settle.
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Leave call"))
+    })
+    expect(manager.leaveCall).toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -389,6 +389,20 @@ describe("DesktopCallDock — minimized hover overlay", () => {
     expect(insetRight()).toBe("520px")
   })
 
+  it("pinning a peek then Minimizing (no mouse-leave) actually minimizes — stale hover doesn't re-arm", () => {
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("min")
+    const dock = screen.getByTestId("desktop-call-dock")
+    fireEvent.mouseEnter(dock)
+    act(() => fireEvent.click(screen.getByLabelText("Keep call open")))
+    expect(getCallState().surfaceMode).toBe("standard")
+    // Minimize while the cursor is still inside the panel (no mouseleave fired).
+    act(() => fireEvent.click(screen.getByLabelText("Minimize call")))
+    expect(getCallState().surfaceMode).toBe("min")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "min")
+  })
+
   it("clicking the collapsed rail's Leave dispatches to the manager", async () => {
     const manager = makeManager()
     renderDock(manager)

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
-import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Users } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Pin, Users } from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/initials"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { useInputMode } from "@/hooks/use-input-mode"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import {
@@ -14,39 +15,42 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import { useCallPrefs, setCallFilmstripSide } from "@/stores/call-prefs-store"
+import { useCallPrefs, setCallFilmstripSide, setCallSideDockWidth } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
+import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallStageLayout } from "./call-stage-layout"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
-import { nearestStep } from "./mobile-call-drawer-snap"
 
 const REDUCED_MOTION =
   typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
 
-const MODES: readonly CallSurfaceMode[] = ["min", "compact", "standard", "full"]
-const MODE_INDEX: Record<CallSurfaceMode, number> = { min: 0, compact: 1, standard: 2, full: 3 }
-
-/** The 3 pushing step sizes (px) — min/compact/standard; `full` = the whole content region. */
-const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
-
-// Always leave this much of the conversation beside/below a pushing dock, so a
-// narrow window / wide sidebar can't collapse the timeline to nothing.
+const RAIL_WIDTH = 56
+const MIN_OPEN = 280
+// Always leave this much of the conversation beside a pushing dock, so a narrow
+// window / wide sidebar can't collapse the timeline to nothing.
 const MIN_CONTENT = 320
+const FULLSCREEN_FRACTION = 0.75
 
 /**
- * The 4 snap detents [min, compact, standard, full] for a given axis ceiling (the
- * measured content region). The pushing steps are capped to `ceil - MIN_CONTENT`
- * (leaving timeline) and `full` is the whole ceiling — guaranteeing a NON-DECREASING
- * list even on a tiny window (so the snap never sees an unsorted/duplicate-final
- * detent), and the inset a pushing mode reserves never exceeds `ceil - MIN_CONTENT`.
+ * The resting open clamp: ≤75% of the content region, leaving MIN_CONTENT of timeline
+ * where the window allows. On a sub-~600px content region the outer floor wins (MIN_OPEN),
+ * so a very narrow window trades some timeline rather than shrinking the dock below usable.
  */
-function dockDetents(steps: readonly number[], ceil: number): number[] {
-  const cap = Math.max(steps[0], ceil - MIN_CONTENT)
-  return [steps[0], Math.min(steps[1], cap), Math.min(steps[2], cap), ceil]
+function maxOpenWidth(ceil: number): number {
+  return Math.max(MIN_OPEN, Math.min(FULLSCREEN_FRACTION * ceil, ceil - MIN_CONTENT))
+}
+
+function clampOpen(width: number, ceil: number): number {
+  return Math.min(Math.max(width, MIN_OPEN), maxOpenWidth(ceil))
+}
+
+/** First-open width before the user has ever resized: video opens fuller than audio (#1486). */
+function defaultOpen(mode: CallSurfaceMode): number {
+  return mode === "compact" ? 360 : 520
 }
 
 interface DockViewProps {
@@ -57,6 +61,9 @@ interface DockViewProps {
   users: ReturnType<typeof useWorkspaceUsers>
   captureError: CallCaptureErrorInfo | null
   title: string
+  // Rendered from the minimized hover-overlay (a transient peek) rather than a
+  // pinned-open dock — shows the pin affordance to commit the peek.
+  peeking?: boolean
 }
 
 function FilmstripSideToggle() {
@@ -107,12 +114,30 @@ function MinimizeButton() {
   )
 }
 
-/** Title + minimize, shared by the side Panel/Wide. */
-function DockHeaderBar({ title }: { title: string }) {
+/** Keeps a hover-peek open (mouse pre-empts the rail's expand chevron, so the peek needs its own pin). */
+function PinButton() {
+  return (
+    <button
+      type="button"
+      aria-label="Keep call open"
+      onClick={() => setCallSurfaceMode("standard")}
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      <Pin className="h-4 w-4" />
+    </button>
+  )
+}
+
+/**
+ * Title + trailing action. A hover-peek shows Pin (commit to open); an already-open
+ * dock shows Minimize (collapse) — a peek is dismissed by moving the mouse away, so
+ * Minimize there would be a redundant no-op.
+ */
+function DockHeaderBar({ title, peeking }: { title: string; peeking?: boolean }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      <MinimizeButton />
+      {peeking ? <PinButton /> : <MinimizeButton />}
     </div>
   )
 }
@@ -163,19 +188,22 @@ function SideRailView({ roster, users, workspaceId, connectedAt, captureError }:
         />
       )}
       <RailAvatars roster={roster} users={users} workspaceId={workspaceId} />
-      <div className="mt-auto">
-        <CallTimer connectedAt={connectedAt} className="text-xs" />
+      <div className="mt-auto flex flex-col items-center gap-1">
+        <MuteButton />
+        <CameraButton />
+        <LeaveButton />
       </div>
+      <CallTimer connectedAt={connectedAt} className="text-xs" />
     </div>
   )
 }
 
 /** Side `compact`/`standard`: header + tile grid + controls (the panel width does the sizing). */
-function SideTilesView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
+function SideTilesView({ workspaceId, currentUserId, roster, captureError, title, peeking }: DockViewProps) {
   const joined = roster.filter((p) => p.participantStatus === "joined")
   return (
     <div className="flex h-full w-full flex-col border-l bg-background">
-      <DockHeaderBar title={title} />
+      <DockHeaderBar title={title} peeking={peeking} />
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
         {joined.map((p) => (
@@ -282,23 +310,23 @@ interface DragState {
   start: number
   startSize: number
   size: number
-  velocity: number
-  last: number
-  lastT: number
   full: number
 }
 
 /**
- * The desktop in-call surface: a resizable dock, docked to the side, snapping
- * through the four {@link CallSurfaceMode} steps with the same physics as the
- * mobile drawer ({@link nearestStep}). It pushes the conversation aside via
- * `--call-dock-inset-right` (the main content region reserves the inset) rather
- * than overlaying it, until Fullscreen. Rendered by
- * {@link import("./call-dock").CallDock} on desktop for the connected phase;
- * reads the call store, not the route, so it survives stream navigation.
+ * The desktop in-call surface: a resizable dock, docked to the side, with a
+ * freeform open width (persisted as {@link CallPrefs.sideDockWidth}) capped at
+ * {@link FULLSCREEN_FRACTION} of the content region; dragging past that cap goes
+ * Fullscreen. It pushes the conversation aside via `--call-dock-inset-right` (the
+ * main content region reserves the inset) rather than overlaying it, until
+ * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
+ * the connected phase; reads the call store, not the route, so it survives
+ * stream navigation.
  */
 export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
   const surfaceMode = useCallSurfaceMode()
+  const { sideDockWidth } = useCallPrefs()
+  const inputMode = useInputMode()
   const roster = useCallRoster()
   const connectedAt = useCallConnectedAt()
   const captureError = useCallCaptureError()
@@ -312,6 +340,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const drag = useRef<DragState | null>(null)
   const [dragging, setDragging] = useState(false)
   const [dragSize, setDragSize] = useState<number | null>(null)
+  const [hovering, setHovering] = useState(false)
   // The dock root spans the content region (left = sidebar width → right:0); its
   // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
@@ -329,11 +358,18 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   // Ceiling from the measured content region; 0 means "not laid out yet" (initial
   // render / jsdom) → treat as unbounded so we never clamp to nothing.
   const ceilW = contentW || Infinity
-  const detentsW = dockDetents(SIDE_STEP_SIZES, ceilW)
 
-  // Content push: reserve the pushing mode's detent (which already leaves MIN_CONTENT)
-  // on :root so the main content region (AppShell's <main>) reflows. Fullscreen → 0.
-  const insetRight = surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
+  // The resting open width: the saved freeform width (or the mode's first-open
+  // default), clamped to ≤75% and always leaving MIN_CONTENT.
+  const openWidth = clampOpen(sideDockWidth ?? defaultOpen(surfaceMode), ceilW)
+
+  // Content push: rail → RAIL_WIDTH, open → openWidth (already ≤ ceil−MIN_CONTENT),
+  // fullscreen → 0. Hovering the rail is an overlay, so the inset tracks surfaceMode
+  // (still `min`) and never reflows the timeline.
+  let insetRight: number
+  if (surfaceMode === "full") insetRight = 0
+  else if (surfaceMode === "min") insetRight = RAIL_WIDTH
+  else insetRight = openWidth
   useEffect(() => {
     document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
   }, [insetRight])
@@ -344,23 +380,12 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     []
   )
 
-  const minStep = SIDE_STEP_SIZES[0]
-
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     const panel = panelRef.current?.getBoundingClientRect()
     const root = rootRef.current?.getBoundingClientRect()
-    const full = root?.width ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
-    const startSize = panel?.width ?? SIDE_STEP_SIZES[1]
-    const pointer = e.clientX
-    drag.current = {
-      start: pointer,
-      startSize,
-      size: startSize,
-      velocity: 0,
-      last: pointer,
-      lastT: performance.now(),
-      full,
-    }
+    const full = root?.width ?? ceilW
+    const startSize = panel?.width ?? openWidth
+    drag.current = { start: e.clientX, startSize, size: startSize, full }
     e.currentTarget.setPointerCapture(e.pointerId)
     setDragSize(startSize)
     setDragging(true)
@@ -369,16 +394,9 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     const d = drag.current
     if (!d) return
-    const pointer = e.clientX
-    // Side grows as the pointer moves left.
-    const grow = d.start - pointer
-    const next = Math.min(Math.max(d.startSize + grow, minStep), d.full)
-    const now = performance.now()
-    const dt = now - d.lastT
-    const stepGrow = d.last - pointer
-    if (dt > 0) d.velocity = stepGrow / dt
-    d.last = pointer
-    d.lastT = now
+    // Side grows as the pointer moves left; allow dragging up into the fullscreen zone.
+    const grow = d.start - e.clientX
+    const next = Math.min(Math.max(d.startSize + grow, MIN_OPEN), d.full)
     d.size = next
     setDragSize(next)
   }
@@ -388,20 +406,37 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     drag.current = null
     setDragging(false)
     setDragSize(null)
-    if (d) {
-      // A pause before release means the drag stopped — don't flick on stale velocity.
-      const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
-      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(SIDE_STEP_SIZES, d.full))])
+    if (!d) return
+    if (d.size > FULLSCREEN_FRACTION * d.full) {
+      setCallSurfaceMode("full")
+      return
     }
+    setCallSideDockWidth(clampOpen(d.size, d.full))
+    // Dragging out of the rail (or out of fullscreen) opens it; an already-open mode keeps its mode.
+    if (surfaceMode === "min" || surfaceMode === "full") setCallSurfaceMode("standard")
   }
 
-  const dragFull = drag.current?.full ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
-  const dragMode =
-    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(SIDE_STEP_SIZES, dragFull))] : null
   // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
-  // thrashes the drag) — the preview caps at `standard`; fullscreen mounts on release.
-  const cappedDragMode = dragMode === "full" ? "standard" : dragMode
-  const contentMode: CallSurfaceMode = cappedDragMode ?? surfaceMode
+  // thrashes the drag) — the preview stays on the open tiles; fullscreen mounts on release.
+  // Minimized + mouse hover = a transient peek (overlay, no push); it renders the open
+  // tiles and shows a pin affordance to commit to a pushing, persisted open dock.
+  const peeking = surfaceMode === "min" && hovering
+  let cappedDragMode: CallSurfaceMode | null = null
+  if (dragging) cappedDragMode = surfaceMode === "compact" ? "compact" : "standard"
+  let contentMode: CallSurfaceMode
+  if (cappedDragMode) contentMode = cappedDragMode
+  else if (peeking) contentMode = "standard"
+  else contentMode = surfaceMode
+
+  const dragCeil = drag.current?.full ?? ceilW
+  // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full").
+  const showFullscreenCue =
+    dragging && surfaceMode !== "full" && dragSize != null && dragSize > FULLSCREEN_FRACTION * dragCeil
+
+  let panelWidth: number
+  if (dragging && dragSize != null) panelWidth = dragSize
+  else if (surfaceMode === "min") panelWidth = hovering ? openWidth : RAIL_WIDTH
+  else panelWidth = openWidth
 
   const restingFull = !dragging && surfaceMode === "full"
   let positionClass: string
@@ -411,8 +446,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     sizeStyle = {}
   } else {
     positionClass = "inset-y-0 right-0"
-    const w = dragging && dragSize != null ? dragSize : detentsW[MODE_INDEX[contentMode]]
-    sizeStyle = { width: `${w}px` }
+    sizeStyle = { width: `${panelWidth}px` }
   }
 
   const view: DockViewProps = {
@@ -423,6 +457,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     users,
     captureError,
     title,
+    peeking,
   }
 
   return (
@@ -436,6 +471,14 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         data-testid="desktop-call-dock"
         data-mode={contentMode}
         data-position="side"
+        data-hovering={hovering ? "true" : "false"}
+        onMouseEnter={() => {
+          // Preview only arms from the rail (mirrors the nav-sidebar collapsed→preview);
+          // entering an open panel — including while minimizing with the cursor over it —
+          // must not flip to the overlay.
+          if (inputMode !== "touch" && surfaceMode === "min") setHovering(true)
+        }}
+        onMouseLeave={() => setHovering(false)}
         className={cn(
           "pointer-events-auto absolute overflow-hidden shadow-xl",
           positionClass,
@@ -444,6 +487,16 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         style={sizeStyle}
       >
         <DockBody mode={contentMode} view={view} />
+        {showFullscreenCue && (
+          <div
+            data-testid="call-dock-fullscreen-cue"
+            className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-primary bg-primary/10"
+          >
+            <span className="rounded-md bg-background/80 px-3 py-1.5 text-sm font-medium">
+              Release to go fullscreen
+            </span>
+          </div>
+        )}
         {/* Always mounted — including at rest-fullscreen — so it holds the pointer
             capture/settle through a drag into full AND lets you drag back OUT of
             fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -131,6 +131,7 @@ function FloatButton({ onFloat }: { onFloat: () => void }) {
     <button
       type="button"
       aria-label="Pop out to a floating window"
+      title="Pop out to a floating window"
       onClick={onFloat}
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
     >
@@ -145,6 +146,7 @@ function PinButton() {
     <button
       type="button"
       aria-label="Keep call open"
+      title="Keep call open"
       onClick={() => setCallSurfaceMode("standard")}
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
     >

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
-import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Pin, Users } from "lucide-react"
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronLeft,
+  Minimize2,
+  PanelBottom,
+  PanelRight,
+  PictureInPicture2,
+  Pin,
+  Users,
+} from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
@@ -64,6 +74,8 @@ interface DockViewProps {
   // Rendered from the minimized hover-overlay (a transient peek) rather than a
   // pinned-open dock — shows the pin affordance to commit the peek.
   peeking?: boolean
+  // Pop the call out to the floating square. Absent in tests / when floating is unreachable.
+  onFloat?: () => void
 }
 
 function FilmstripSideToggle() {
@@ -114,6 +126,19 @@ function MinimizeButton() {
   )
 }
 
+function FloatButton({ onFloat }: { onFloat: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label="Pop out to a floating window"
+      onClick={onFloat}
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      <PictureInPicture2 className="h-4 w-4" />
+    </button>
+  )
+}
+
 /** Keeps a hover-peek open (mouse pre-empts the rail's expand chevron, so the peek needs its own pin). */
 function PinButton() {
   return (
@@ -133,11 +158,18 @@ function PinButton() {
  * dock shows Minimize (collapse) — a peek is dismissed by moving the mouse away, so
  * Minimize there would be a redundant no-op.
  */
-function DockHeaderBar({ title, peeking }: { title: string; peeking?: boolean }) {
+function DockHeaderBar({ title, peeking, onFloat }: { title: string; peeking?: boolean; onFloat?: () => void }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      {peeking ? <PinButton /> : <MinimizeButton />}
+      {peeking ? (
+        <PinButton />
+      ) : (
+        <>
+          {onFloat && <FloatButton onFloat={onFloat} />}
+          <MinimizeButton />
+        </>
+      )}
     </div>
   )
 }
@@ -199,11 +231,11 @@ function SideRailView({ roster, users, workspaceId, connectedAt, captureError }:
 }
 
 /** Side `compact`/`standard`: header + tile grid + controls (the panel width does the sizing). */
-function SideTilesView({ workspaceId, currentUserId, roster, captureError, title, peeking }: DockViewProps) {
+function SideTilesView({ workspaceId, currentUserId, roster, captureError, title, peeking, onFloat }: DockViewProps) {
   const joined = roster.filter((p) => p.participantStatus === "joined")
   return (
     <div className="flex h-full w-full flex-col border-l bg-background">
-      <DockHeaderBar title={title} peeking={peeking} />
+      <DockHeaderBar title={title} peeking={peeking} onFloat={onFloat} />
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
         {joined.map((p) => (
@@ -323,7 +355,15 @@ interface DragState {
  * the connected phase; reads the call store, not the route, so it survives
  * stream navigation.
  */
-export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
+export function DesktopCallDock({
+  workspaceId,
+  streamId,
+  onFloat,
+}: {
+  workspaceId: string | null
+  streamId: string | null
+  onFloat?: () => void
+}) {
   const surfaceMode = useCallSurfaceMode()
   const { sideDockWidth } = useCallPrefs()
   const inputMode = useInputMode()
@@ -458,6 +498,7 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     captureError,
     title,
     peeking,
+    onFloat,
   }
 
   return (

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -381,6 +381,12 @@ export function DesktopCallDock({
   const [dragging, setDragging] = useState(false)
   const [dragSize, setDragSize] = useState<number | null>(null)
   const [hovering, setHovering] = useState(false)
+  // Peek hover only means anything at `min`. Pinning (or dragging) out of the rail
+  // with the cursor still inside fires no mouseleave, so clear the flag on the mode
+  // change — else a stale `hovering` keeps re-arming the peek and Minimize looks dead.
+  useEffect(() => {
+    if (surfaceMode !== "min") setHovering(false)
+  }, [surfaceMode])
   // The dock root spans the content region (left = sidebar width → right:0); its
   // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
@@ -447,7 +453,9 @@ export function DesktopCallDock({
     setDragging(false)
     setDragSize(null)
     if (!d) return
-    if (d.size > FULLSCREEN_FRACTION * d.full) {
+    // Only offer fullscreen when there's a real freeform band below it (else a
+    // very narrow content region would send every release to fullscreen).
+    if (FULLSCREEN_FRACTION * d.full > MIN_OPEN && d.size > FULLSCREEN_FRACTION * d.full) {
       setCallSurfaceMode("full")
       return
     }
@@ -469,9 +477,14 @@ export function DesktopCallDock({
   else contentMode = surfaceMode
 
   const dragCeil = drag.current?.full ?? ceilW
-  // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full").
+  // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full"),
+  // and none when the region is too narrow to have a freeform band below the fullscreen line.
   const showFullscreenCue =
-    dragging && surfaceMode !== "full" && dragSize != null && dragSize > FULLSCREEN_FRACTION * dragCeil
+    dragging &&
+    surfaceMode !== "full" &&
+    dragSize != null &&
+    FULLSCREEN_FRACTION * dragCeil > MIN_OPEN &&
+    dragSize > FULLSCREEN_FRACTION * dragCeil
 
   let panelWidth: number
   if (dragging && dragSize != null) panelWidth = dragSize

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronLeft,
-  Minimize2,
-  PanelBottom,
-  PanelRight,
-  PanelTop,
-  Users,
-} from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PanelBottom, PanelRight, Users } from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
@@ -23,16 +14,10 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import {
-  useCallPrefs,
-  setCallDockPosition,
-  setCallFilmstripSide,
-  type CallDockPosition,
-} from "@/stores/call-prefs-store"
+import { useCallPrefs, setCallFilmstripSide } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { CallStageLayout } from "./call-stage-layout"
-import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { LayoutToggle } from "./layout-toggle"
@@ -47,7 +32,6 @@ const MODE_INDEX: Record<CallSurfaceMode, number> = { min: 0, compact: 1, standa
 
 /** The 3 pushing step sizes (px) — min/compact/standard; `full` = the whole content region. */
 const SIDE_STEP_SIZES: readonly number[] = [56, 320, 520]
-const TOP_STEP_SIZES: readonly number[] = [44, 72, 220]
 
 // Always leave this much of the conversation beside/below a pushing dock, so a
 // narrow window / wide sidebar can't collapse the timeline to nothing.
@@ -73,32 +57,6 @@ interface DockViewProps {
   users: ReturnType<typeof useWorkspaceUsers>
   captureError: CallCaptureErrorInfo | null
   title: string
-  speakerName: string | null
-}
-
-function DockPositionToggle({ dark = false }: { dark?: boolean }) {
-  const { dockPosition } = useCallPrefs()
-  return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      role="radiogroup"
-      value={dockPosition}
-      onValueChange={(next) => {
-        if (next === "top" || next === "side") setCallDockPosition(next)
-      }}
-      aria-label="Dock position"
-      data-testid="call-dock-position-toggle"
-      className={cn("shrink-0 gap-0.5 rounded-md p-0.5", dark ? "bg-white/10" : "bg-muted")}
-    >
-      <ToggleGroupItem value="top" aria-label="Top" title="Dock to the top" className="h-7 px-2 [&_svg]:size-3.5">
-        <PanelTop aria-hidden="true" />
-      </ToggleGroupItem>
-      <ToggleGroupItem value="side" aria-label="Side" title="Dock to the side" className="h-7 px-2 [&_svg]:size-3.5">
-        <PanelRight aria-hidden="true" />
-      </ToggleGroupItem>
-    </ToggleGroup>
-  )
 }
 
 function FilmstripSideToggle() {
@@ -149,12 +107,11 @@ function MinimizeButton() {
   )
 }
 
-/** Title + Top/Side toggle + minimize, shared by the side Panel/Wide and the top Gallery. */
+/** Title + minimize, shared by the side Panel/Wide. */
 function DockHeaderBar({ title }: { title: string }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      <DockPositionToggle />
       <MinimizeButton />
     </div>
   )
@@ -237,90 +194,7 @@ function SideTilesView({ workspaceId, currentUserId, roster, captureError, title
   )
 }
 
-/** Top `min`: a thin bar — live/error dot + timer, tap to expand. */
-function TopTabView({ connectedAt, captureError }: DockViewProps) {
-  return (
-    <button
-      type="button"
-      aria-label="Expand call"
-      onClick={() => setCallSurfaceMode("compact")}
-      className="flex h-full w-full items-center justify-center gap-2 border-b bg-background px-4"
-    >
-      {captureError ? (
-        <span
-          className="h-2 w-2 shrink-0 rounded-full bg-destructive"
-          role="alert"
-          data-testid="call-capture-error"
-          aria-label="Microphone or camera problem — expand the call to see details"
-        />
-      ) : (
-        <span
-          className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
-          aria-hidden
-        />
-      )}
-      <CallTimer connectedAt={connectedAt} />
-    </button>
-  )
-}
-
-/** Top `compact`: timer + speaker + controls, horizontal. */
-function TopBarView({ connectedAt, speakerName, captureError }: DockViewProps) {
-  return (
-    <div className="flex h-full w-full items-center gap-3 border-b bg-background px-4">
-      {captureError && (
-        <span
-          className="flex h-8 w-8 shrink-0 items-center justify-center text-destructive"
-          role="alert"
-          data-testid="call-capture-error"
-          aria-label="Microphone or camera problem"
-        >
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-        </span>
-      )}
-      <div className="flex min-w-0 flex-col">
-        <CallTimer connectedAt={connectedAt} />
-        {speakerName && <span className="truncate text-xs text-muted-foreground">{speakerName}</span>}
-      </div>
-      <div className="ml-auto flex shrink-0 items-center gap-1.5">
-        <MuteButton />
-        <CameraButton />
-        <LeaveButton />
-        <DockPositionToggle />
-        <MinimizeButton />
-      </div>
-    </div>
-  )
-}
-
-/** Top `standard`: header + a tiles row + controls. */
-function TopGalleryView({ workspaceId, currentUserId, roster, captureError, title }: DockViewProps) {
-  const joined = roster.filter((p) => p.participantStatus === "joined")
-  return (
-    <div className="flex h-full w-full flex-col border-b bg-background">
-      <DockHeaderBar title={title} />
-      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
-      <div className="flex min-h-0 flex-1 items-stretch gap-2 overflow-x-auto px-3 py-2">
-        {joined.map((p) => (
-          <div key={p.userId} className="aspect-video h-full shrink-0">
-            <CallTile
-              participant={p}
-              workspaceId={workspaceId}
-              isSelf={!!currentUserId && p.userId === currentUserId}
-              stage
-              fill
-            />
-          </div>
-        ))}
-      </div>
-      <div className="shrink-0 border-t p-2">
-        <CallControls />
-      </div>
-    </div>
-  )
-}
-
-/** Fullscreen (both orientations): the ch5 stage with a permanent header of call controls/toggles. */
+/** Fullscreen: the ch5 stage with a permanent header of call controls/toggles. */
 function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title, captureError }: DockViewProps) {
   const { layout, filmstripSide } = useCallPrefs()
   const joined = roster.filter((p) => p.participantStatus === "joined")
@@ -352,7 +226,6 @@ function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, t
           <div data-testid="call-layout-slot">
             <LayoutToggle className="bg-white/10" />
           </div>
-          <DockPositionToggle dark />
         </div>
       </div>
 
@@ -373,53 +246,34 @@ function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, t
   )
 }
 
-function DockBody({
-  dockPosition,
-  mode,
-  view,
-}: {
-  dockPosition: CallDockPosition
-  mode: CallSurfaceMode
-  view: DockViewProps
-}) {
+function DockBody({ mode, view }: { mode: CallSurfaceMode; view: DockViewProps }) {
   if (mode === "full") return <DockFullscreenView {...view} />
-  if (dockPosition === "side") {
-    if (mode === "min") return <SideRailView {...view} />
-    return <SideTilesView {...view} />
-  }
-  if (mode === "min") return <TopTabView {...view} />
-  if (mode === "compact") return <TopBarView {...view} />
-  return <TopGalleryView {...view} />
+  if (mode === "min") return <SideRailView {...view} />
+  return <SideTilesView {...view} />
 }
 
 function DockResizeHandle({
-  orientation,
   onPointerDown,
   onPointerMove,
   onPointerUp,
 }: {
-  orientation: CallDockPosition
   onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
 }) {
-  const side = orientation === "side"
   return (
     <div
       role="separator"
-      aria-orientation={side ? "vertical" : "horizontal"}
+      aria-orientation="vertical"
       aria-label="Resize call"
       data-testid="call-dock-handle"
-      className={cn(
-        "absolute z-10 flex touch-none items-center justify-center",
-        side ? "inset-y-0 left-0 w-2 cursor-col-resize" : "inset-x-0 bottom-0 h-2 cursor-row-resize"
-      )}
+      className="absolute inset-y-0 left-0 z-10 flex w-2 cursor-col-resize touch-none items-center justify-center"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
     >
-      <span className={cn("rounded-full bg-muted-foreground/40", side ? "h-10 w-1" : "h-1 w-10")} aria-hidden />
+      <span className="h-10 w-1 rounded-full bg-muted-foreground/40" aria-hidden />
     </div>
   )
 }
@@ -435,17 +289,15 @@ interface DragState {
 }
 
 /**
- * The desktop in-call surface: a resizable dock, docked to the top or the side
- * (`dockPosition` pref), snapping through the four {@link CallSurfaceMode} steps
- * with the same physics as the mobile drawer ({@link nearestStep}). It pushes the
- * conversation aside via `--call-dock-inset-right`/`--call-dock-inset-top` (the
- * main content region reserves the inset) rather than overlaying it, until
- * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
- * the connected phase; reads the call store, not the route, so it survives stream
- * navigation.
+ * The desktop in-call surface: a resizable dock, docked to the side, snapping
+ * through the four {@link CallSurfaceMode} steps with the same physics as the
+ * mobile drawer ({@link nearestStep}). It pushes the conversation aside via
+ * `--call-dock-inset-right` (the main content region reserves the inset) rather
+ * than overlaying it, until Fullscreen. Rendered by
+ * {@link import("./call-dock").CallDock} on desktop for the connected phase;
+ * reads the call store, not the route, so it survives stream navigation.
  */
 export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string | null; streamId: string | null }) {
-  const { dockPosition } = useCallPrefs()
   const surfaceMode = useCallSurfaceMode()
   const roster = useCallRoster()
   const connectedAt = useCallConnectedAt()
@@ -455,62 +307,51 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
   const title = name ?? "Call"
 
-  const isSide = dockPosition === "side"
-
   const rootRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const drag = useRef<DragState | null>(null)
   const [dragging, setDragging] = useState(false)
   const [dragSize, setDragSize] = useState<number | null>(null)
   // The dock root spans the content region (left = sidebar width → right:0); its
-  // measured size is the ceiling for the panel + inset so a narrow window / wide
+  // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
-  const [content, setContent] = useState<{ w: number; h: number }>({ w: Infinity, h: Infinity })
+  const [contentW, setContentW] = useState<number>(Infinity)
   useEffect(() => {
     const el = rootRef.current
     if (!el) return
-    const measure = () => setContent({ w: el.clientWidth, h: el.clientHeight })
+    const measure = () => setContentW(el.clientWidth)
     measure()
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
   }, [])
 
-  // Ceilings from the measured content region; 0 means "not laid out yet" (initial
+  // Ceiling from the measured content region; 0 means "not laid out yet" (initial
   // render / jsdom) → treat as unbounded so we never clamp to nothing.
-  const ceilW = content.w || Infinity
-  const ceilH = content.h || Infinity
-
+  const ceilW = contentW || Infinity
   const detentsW = dockDetents(SIDE_STEP_SIZES, ceilW)
-  const detentsH = dockDetents(TOP_STEP_SIZES, ceilH)
 
   // Content push: reserve the pushing mode's detent (which already leaves MIN_CONTENT)
   // on :root so the main content region (AppShell's <main>) reflows. Fullscreen → 0.
-  const insetRight = isSide && surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
-  const insetTop = !isSide && surfaceMode !== "full" ? detentsH[MODE_INDEX[surfaceMode]] : 0
+  const insetRight = surfaceMode !== "full" ? detentsW[MODE_INDEX[surfaceMode]] : 0
   useEffect(() => {
-    const root = document.documentElement
-    root.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
-    root.style.setProperty("--call-dock-inset-top", `${insetTop}px`)
-  }, [insetRight, insetTop])
+    document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
+  }, [insetRight])
   useEffect(
     () => () => {
-      const root = document.documentElement
-      root.style.setProperty("--call-dock-inset-right", "0px")
-      root.style.setProperty("--call-dock-inset-top", "0px")
+      document.documentElement.style.setProperty("--call-dock-inset-right", "0px")
     },
     []
   )
 
-  const stepSizes = isSide ? SIDE_STEP_SIZES : TOP_STEP_SIZES
-  const minStep = stepSizes[0]
+  const minStep = SIDE_STEP_SIZES[0]
 
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     const panel = panelRef.current?.getBoundingClientRect()
     const root = rootRef.current?.getBoundingClientRect()
-    const full = (isSide ? root?.width : root?.height) ?? stepSizes[stepSizes.length - 1]
-    const startSize = (isSide ? panel?.width : panel?.height) ?? stepSizes[1]
-    const pointer = isSide ? e.clientX : e.clientY
+    const full = root?.width ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
+    const startSize = panel?.width ?? SIDE_STEP_SIZES[1]
+    const pointer = e.clientX
     drag.current = {
       start: pointer,
       startSize,
@@ -528,13 +369,13 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     const d = drag.current
     if (!d) return
-    const pointer = isSide ? e.clientX : e.clientY
-    // Side grows as the pointer moves left; top grows as it moves down.
-    const grow = isSide ? d.start - pointer : pointer - d.start
+    const pointer = e.clientX
+    // Side grows as the pointer moves left.
+    const grow = d.start - pointer
     const next = Math.min(Math.max(d.startSize + grow, minStep), d.full)
     const now = performance.now()
     const dt = now - d.lastT
-    const stepGrow = isSide ? d.last - pointer : pointer - d.last
+    const stepGrow = d.last - pointer
     if (dt > 0) d.velocity = stepGrow / dt
     d.last = pointer
     d.lastT = now
@@ -550,21 +391,17 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     if (d) {
       // A pause before release means the drag stopped — don't flick on stale velocity.
       const vel = performance.now() - d.lastT > 120 ? 0 : d.velocity
-      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(stepSizes, d.full))])
+      setCallSurfaceMode(MODES[nearestStep(d.size, vel, dockDetents(SIDE_STEP_SIZES, d.full))])
     }
   }
 
-  const speaker = roster.find((p) => p.participantStatus === "joined" && p.userId !== currentUserId) ?? null
-  const speakerName = speaker ? (users.find((u) => u.id === speaker.userId)?.name ?? null) : null
-
-  const dragFull = drag.current?.full ?? stepSizes[stepSizes.length - 1]
+  const dragFull = drag.current?.full ?? SIDE_STEP_SIZES[SIDE_STEP_SIZES.length - 1]
   const dragMode =
-    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(stepSizes, dragFull))] : null
+    dragging && dragSize != null ? MODES[nearestStep(dragSize, 0, dockDetents(SIDE_STEP_SIZES, dragFull))] : null
   // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
   // thrashes the drag) — the preview caps at `standard`; fullscreen mounts on release.
   const cappedDragMode = dragMode === "full" ? "standard" : dragMode
   const contentMode: CallSurfaceMode = cappedDragMode ?? surfaceMode
-  const detents = isSide ? detentsW : detentsH
 
   const restingFull = !dragging && surfaceMode === "full"
   let positionClass: string
@@ -572,14 +409,10 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
   if (restingFull) {
     positionClass = "inset-0"
     sizeStyle = {}
-  } else if (isSide) {
-    positionClass = "inset-y-0 right-0"
-    const w = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
-    sizeStyle = { width: `${w}px` }
   } else {
-    positionClass = "inset-x-0 top-0"
-    const h = dragging && dragSize != null ? dragSize : detents[MODE_INDEX[contentMode]]
-    sizeStyle = { height: `${h}px` }
+    positionClass = "inset-y-0 right-0"
+    const w = dragging && dragSize != null ? dragSize : detentsW[MODE_INDEX[contentMode]]
+    sizeStyle = { width: `${w}px` }
   }
 
   const view: DockViewProps = {
@@ -590,7 +423,6 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
     users,
     captureError,
     title,
-    speakerName,
   }
 
   return (
@@ -603,25 +435,19 @@ export function DesktopCallDock({ workspaceId, streamId }: { workspaceId: string
         ref={panelRef}
         data-testid="desktop-call-dock"
         data-mode={contentMode}
-        data-position={dockPosition}
+        data-position="side"
         className={cn(
           "pointer-events-auto absolute overflow-hidden shadow-xl",
           positionClass,
-          !dragging && !REDUCED_MOTION && (isSide ? "transition-[width]" : "transition-[height]"),
-          !dragging && !REDUCED_MOTION && "duration-200 ease-out"
+          !dragging && !REDUCED_MOTION && "transition-[width] duration-200 ease-out"
         )}
         style={sizeStyle}
       >
-        <DockBody dockPosition={dockPosition} mode={contentMode} view={view} />
+        <DockBody mode={contentMode} view={view} />
         {/* Always mounted — including at rest-fullscreen — so it holds the pointer
             capture/settle through a drag into full AND lets you drag back OUT of
             fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}
-        <DockResizeHandle
-          orientation={dockPosition}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-        />
+        <DockResizeHandle onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
       </div>
     </div>
   )

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, fireEvent } from "@testing-library/react"
+import { render, screen } from "@/test"
+import * as authModule from "@/auth"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import {
+  clearCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  type CallRosterParticipant,
+} from "@/stores/call-store"
+import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import type { CallController } from "@/calls/call-manager"
+import { FloatingCallSquare, clampSquareToViewport } from "./floating-call-square"
+import { CallManagerProvider } from "./call-manager-context"
+import { CallLaunchProvider } from "./call-launch-context"
+
+type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
+
+const WORKSPACE_ID = "workspace_1"
+
+function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
+  return {
+    id: "usr_x",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_x",
+    email: "x@example.com",
+    role: "member",
+    slug: "x",
+    name: "X",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  } as CachedWorkspaceUser
+}
+
+function participant(overrides: Partial<CallRosterParticipant>): CallRosterParticipant {
+  return {
+    userId: "usr_self",
+    participantStatus: "joined",
+    endpointId: "callep_self",
+    connectionStatus: "connected",
+    mediaState: {},
+    publishedTracks: [],
+    ...overrides,
+  }
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function seedUsers() {
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+      user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+    ],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+function renderSquare(manager: CallController = makeManager(), onDockToSide: () => void = vi.fn()) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <CallLaunchProvider>
+        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={onDockToSide} />
+      </CallLaunchProvider>
+    </CallManagerProvider>
+  )
+}
+
+function enterConnected(roster: CallRosterParticipant[]) {
+  act(() => {
+    setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallRoster(roster, 1)
+  })
+}
+
+const TWO_PEERS: CallRosterParticipant[] = [
+  participant({ userId: "usr_self" }),
+  participant({ userId: "usr_peer", endpointId: "callep_peer" }),
+]
+
+beforeEach(() => {
+  clearCallState()
+  resetWorkspaceStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
+  seedUsers()
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("clampSquareToViewport", () => {
+  const size = { width: 200, height: 200 }
+  const viewport = { width: 1000, height: 800 }
+
+  it("passes an in-bounds position through unchanged", () => {
+    expect(clampSquareToViewport({ x: 100, y: 100 }, size, viewport)).toEqual({ x: 100, y: 100 })
+  })
+
+  it("clamps past each edge back to the on-screen bound", () => {
+    expect(clampSquareToViewport({ x: -50, y: -50 }, size, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: 5000, y: 5000 }, size, viewport)).toEqual({ x: 792, y: 592 })
+  })
+
+  it("respects a custom margin", () => {
+    expect(clampSquareToViewport({ x: 0, y: 0 }, size, viewport, 20)).toEqual({ x: 20, y: 20 })
+    expect(clampSquareToViewport({ x: 9999, y: 9999 }, size, viewport, 20)).toEqual({ x: 780, y: 580 })
+  })
+
+  it("clamps to the margin (never negative) when the square is larger than the viewport", () => {
+    const big = { width: 2000, height: 2000 }
+    expect(clampSquareToViewport({ x: 400, y: 400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: -400, y: -400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+  })
+})
+
+describe("FloatingCallSquare — connected", () => {
+  it("renders one tile per joined participant, Leave, and Dock to the side", () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    const square = screen.getByTestId("floating-call-square")
+    expect(square).toHaveAttribute("data-minimized", "false")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Dock to the side")).toBeInTheDocument()
+  })
+
+  it("clicking Dock to the side calls onDockToSide", async () => {
+    const onDockToSide = vi.fn()
+    renderSquare(makeManager(), onDockToSide)
+    enterConnected(TWO_PEERS)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Dock to the side"))
+    })
+    expect(onDockToSide).toHaveBeenCalled()
+  })
+
+  it("clicking Leave dispatches to the manager", async () => {
+    const manager = makeManager()
+    renderSquare(manager)
+    enterConnected([participant({ userId: "usr_self" })])
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Leave call"))
+    })
+    expect(manager.leaveCall).toHaveBeenCalled()
+  })
+})
+
+describe("FloatingCallSquare — minimize / restore", () => {
+  it("minimizes to a bubble (dot + timer) then restores to the tiles", async () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Minimize call"))
+    })
+    const bubble = screen.getByTestId("floating-call-square")
+    expect(bubble).toHaveAttribute("data-minimized", "true")
+    expect(screen.getByLabelText("Restore call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
+    expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Restore call"))
+    })
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "false")
+    expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
+  })
+})
+
+describe("FloatingCallSquare — joining", () => {
+  it("renders the joining body (no tiles) when the phase is joining and the launch is idle", () => {
+    renderSquare()
+    act(() => setCallPhase("joining"))
+    expect(screen.getByText("Joining…")).toBeInTheDocument()
+    expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
+    expect(screen.getByLabelText("Cancel joining")).toBeInTheDocument()
+  })
+
+  it("offers no Minimize while joining — a bubble would hide the PreJoinGate", () => {
+    renderSquare()
+    act(() => setCallPhase("joining"))
+    expect(screen.queryByLabelText("Minimize call")).toBeNull()
+  })
+
+  it("force-restores from a bubble if the call leaves the connected phase", async () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    await act(async () => fireEvent.click(screen.getByLabelText("Minimize call")))
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "true")
+    // Dropping out of connected (e.g. back to joining) must expand — never a stale bubble.
+    act(() => setCallPhase("joining"))
+    expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "false")
+    expect(screen.getByText("Joining…")).toBeInTheDocument()
+  })
+})
+
+describe("FloatingCallSquare — drag", () => {
+  it("dragging the header moves the square and settles without wedging", () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    const square = screen.getByTestId("floating-call-square")
+    const header = screen.getByTestId("floating-call-square-header")
+    header.setPointerCapture = vi.fn()
+
+    fireEvent.pointerDown(header, { clientX: 676, clientY: 440, pointerId: 1, isPrimary: true })
+    fireEvent.pointerMove(header, { clientX: 300, clientY: 200, pointerId: 1 })
+    // jsdom viewport is 1024x768; the square measures 0px in jsdom so the clamp
+    // bounds are margin..(viewport-margin). The move delta lands at (300, 200).
+    expect(square.style.left).toBe("300px")
+    expect(square.style.top).toBe("200px")
+
+    fireEvent.pointerUp(header, { clientX: 300, clientY: 200, pointerId: 1 })
+    // Drag released: a lone move must be a no-op (drag ref nulled — no wedge).
+    fireEvent.pointerMove(header, { clientX: 50, clientY: 50, pointerId: 1 })
+    expect(square.style.left).toBe("300px")
+    expect(square.style.top).toBe("200px")
+  })
+})

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act, fireEvent } from "@testing-library/react"
-import { render, screen } from "@/test"
+import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import {
@@ -11,10 +11,10 @@ import {
   type CallRosterParticipant,
 } from "@/stores/call-store"
 import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
-import type { CallController } from "@/calls/call-manager"
+import { CallCaptureError, type CallController } from "@/calls/call-manager"
 import { FloatingCallSquare, clampSquareToViewport } from "./floating-call-square"
 import { CallManagerProvider } from "./call-manager-context"
-import { CallLaunchProvider } from "./call-launch-context"
+import { CallLaunchProvider, useCallLaunch } from "./call-launch-context"
 
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
 
@@ -103,6 +103,26 @@ function renderSquare(manager: CallController = makeManager(), onDockToSide: () 
     <CallManagerProvider manager={manager}>
       <CallLaunchProvider>
         <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={onDockToSide} />
+      </CallLaunchProvider>
+    </CallManagerProvider>
+  )
+}
+
+function LaunchButton() {
+  const { launch } = useCallLaunch()
+  return (
+    <button type="button" onClick={() => launch({ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })}>
+      launch
+    </button>
+  )
+}
+
+function renderSquareWithLaunch(manager: CallController) {
+  return render(
+    <CallManagerProvider manager={manager}>
+      <CallLaunchProvider>
+        <LaunchButton />
+        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={vi.fn()} />
       </CallLaunchProvider>
     </CallManagerProvider>
   )
@@ -215,12 +235,27 @@ describe("FloatingCallSquare — minimize / restore", () => {
 })
 
 describe("FloatingCallSquare — joining", () => {
-  it("renders the joining body (no tiles) when the phase is joining and the launch is idle", () => {
+  it("renders the Connecting indicator (no tiles) when joining with an idle launch", () => {
     renderSquare()
     act(() => setCallPhase("joining"))
-    expect(screen.getByText("Joining…")).toBeInTheDocument()
+    expect(screen.getByText("Connecting…")).toBeInTheDocument()
     expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
-    expect(screen.getByLabelText("Cancel joining")).toBeInTheDocument()
+    // The old mobile-island pill (icon-only Cancel) must not render on the desktop square.
+    expect(screen.queryByLabelText("Cancel joining")).toBeNull()
+  })
+
+  it("renders the PreJoinGate permission taxonomy during an active launch, not a plain pill", async () => {
+    const startCall = vi.fn(async () => {
+      throw new CallCaptureError(
+        "capture_failed",
+        Object.assign(new Error("Permission denied"), { name: "NotAllowedError" })
+      )
+    })
+    renderSquareWithLaunch(makeManager({ startCall }))
+    await userEvent.click(screen.getByText("launch"))
+    expect(await screen.findByText(/Microphone access denied/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText("Cancel joining")).toBeNull()
   })
 
   it("offers no Minimize while joining — a bubble would hide the PreJoinGate", () => {
@@ -237,7 +272,7 @@ describe("FloatingCallSquare — joining", () => {
     // Dropping out of connected (e.g. back to joining) must expand — never a stale bubble.
     act(() => setCallPhase("joining"))
     expect(screen.getByTestId("floating-call-square")).toHaveAttribute("data-minimized", "false")
-    expect(screen.getByText("Joining…")).toBeInTheDocument()
+    expect(screen.getByText("Connecting…")).toBeInTheDocument()
   })
 })
 

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -255,6 +255,12 @@ export function FloatingCallSquare({
     if (!inCall) setMinimized(false)
   }, [inCall])
 
+  // Restoring measures the full square (the bubble carries no ref, so a resize while
+  // minimized couldn't reclamp it) — pull it back on-screen if the window shrank.
+  useEffect(() => {
+    if (!minimized) reclamp()
+  }, [minimized, reclamp])
+
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     // Primary pointer only; the header's action buttons aren't drag handles.
     if (!e.isPrimary) return

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -101,6 +101,7 @@ function SquareHeader({
       <button
         type="button"
         aria-label="Dock to the side"
+        title="Dock to the side"
         onClick={onDockToSide}
         className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
       >
@@ -172,7 +173,11 @@ function JoiningBody() {
       </div>
     )
   }
-  return <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Connecting…</div>
+  return (
+    <div role="status" className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+      Connecting…
+    </div>
+  )
 }
 
 function MinimizedBubble({

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
-import { GripHorizontal, Loader2, Minimize2, PanelRight, X } from "lucide-react"
+import { GripHorizontal, Minimize2, PanelRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -157,31 +157,22 @@ function ConnectedBody({
   )
 }
 
-/** Joining/pre-join body — mirrors {@link import("./call-island").MobileCallJoining} inside the square frame. */
+/**
+ * Joining/pre-join body — the desktop joining surface, mirroring
+ * {@link import("./call-dock").CallDock}'s DockFrame: an active launch (permission
+ * request / device pick / error) shows the {@link PreJoinGate}; once the launch is
+ * idle and the call is connecting, a plain "Connecting…" indicator.
+ */
 function JoiningBody() {
-  const { state, cancel } = useCallLaunch()
-  const isError = state.status === "permission_error" || state.status === "join_error"
-  if (isError) {
+  const { state } = useCallLaunch()
+  if (state.status !== "idle") {
     return (
       <div className="p-3">
         <PreJoinGate />
       </div>
     )
   }
-  return (
-    <div className="flex items-center gap-2.5 px-3 py-4" role="status">
-      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" aria-hidden />
-      <span className="flex-1 text-sm font-medium">Joining…</span>
-      <button
-        type="button"
-        aria-label="Cancel joining"
-        onClick={cancel}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <X className="h-4 w-4" />
-      </button>
-    </div>
-  )
+  return <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Connecting…</div>
 }
 
 function MinimizedBubble({
@@ -215,7 +206,7 @@ function MinimizedBubble({
 /**
  * A draggable, minimizable floating desktop call surface: header (drag / dock-to-
  * side / minimize) plus the phase body — connected tiles + {@link CallControls}, or
- * the joining spinner / {@link PreJoinGate}. A LIGHT panel (not the dark mobile
+ * the "Connecting…" indicator / {@link PreJoinGate}. A LIGHT panel (not the dark mobile
  * island). Position lives in local state, committed through {@link clampSquareToViewport}
  * on drag and reclamped on window resize so it never leaves the viewport. Minimize is
  * connected-only, so a bubble never hides the joining gate.

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react"
+import { GripHorizontal, Loader2, Minimize2, PanelRight, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useCallLaunch } from "./call-launch-context"
+import { PreJoinGate } from "./pre-join-gate"
+import { CallTile } from "./call-tile"
+import { CallControls } from "./call-controls"
+import { CallTimer } from "./call-timer"
+import { CaptureErrorBanner } from "./call-capture-error"
+import { useCallCaptureError, useCallConnectedAt, useCallPhase, useCallRoster } from "./call-store-hooks"
+
+const REDUCED_MOTION =
+  typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+
+const SQUARE_WIDTH = 340
+const MARGIN = 8
+// Initial-anchor height estimate before the square measures itself; the mount
+// reclamp refines it against the real `offsetHeight`.
+const NOMINAL_HEIGHT = 320
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Size {
+  width: number
+  height: number
+}
+
+/**
+ * Clamp a floating square so it stays fully on-screen with `margin` padding. When
+ * the square is larger than the viewport the upper bound would go negative, so it
+ * floors at `margin` (top-left pinned) rather than clamping to a negative x/y.
+ */
+export function clampSquareToViewport(pos: Point, size: Size, viewport: Size, margin = 8): Point {
+  const maxX = Math.max(margin, viewport.width - size.width - margin)
+  const maxY = Math.max(margin, viewport.height - size.height - margin)
+  return {
+    x: Math.min(Math.max(pos.x, margin), maxX),
+    y: Math.min(Math.max(pos.y, margin), maxY),
+  }
+}
+
+function defaultAnchor(): Point {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1024
+  const vh = typeof window !== "undefined" ? window.innerHeight : 768
+  return clampSquareToViewport(
+    { x: vw - SQUARE_WIDTH - MARGIN, y: vh - NOMINAL_HEIGHT - MARGIN },
+    { width: SQUARE_WIDTH, height: NOMINAL_HEIGHT },
+    { width: vw, height: vh },
+    MARGIN
+  )
+}
+
+interface DragState {
+  pointerId: number
+  startX: number
+  startY: number
+  originX: number
+  originY: number
+}
+
+function SquareHeader({
+  title,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onDockToSide,
+  onMinimize,
+  canMinimize,
+  dragging,
+}: {
+  title: string
+  onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
+  onDockToSide: () => void
+  onMinimize: () => void
+  // Only a connected call may minimize — collapsing the joining/pre-join window would
+  // hide the PreJoinGate permission taxonomy (mirrors call-dock.tsx's force-open guard).
+  canMinimize: boolean
+  dragging: boolean
+}) {
+  return (
+    <div
+      data-testid="floating-call-square-header"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      className={cn(
+        "flex shrink-0 touch-none items-center gap-2 border-b px-3 py-2",
+        dragging ? "cursor-grabbing" : "cursor-grab"
+      )}
+    >
+      <GripHorizontal className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+      <button
+        type="button"
+        aria-label="Dock to the side"
+        onClick={onDockToSide}
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <PanelRight className="h-4 w-4" />
+      </button>
+      {canMinimize && (
+        <button
+          type="button"
+          aria-label="Minimize call"
+          onClick={onMinimize}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Minimize2 className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+function ConnectedBody({
+  workspaceId,
+  currentUserId,
+  roster,
+  captureError,
+}: {
+  workspaceId: string | null
+  currentUserId: string | null
+  roster: ReturnType<typeof useCallRoster>
+  captureError: ReturnType<typeof useCallCaptureError>
+}) {
+  const joined = roster.filter((p) => p.participantStatus === "joined")
+  return (
+    <>
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <div
+        className={cn(
+          "grid min-h-0 flex-1 gap-2 overflow-y-auto p-3",
+          joined.length > 1 ? "grid-cols-2" : "grid-cols-1"
+        )}
+      >
+        {joined.map((p) => (
+          <CallTile
+            key={p.userId}
+            participant={p}
+            workspaceId={workspaceId}
+            isSelf={!!currentUserId && p.userId === currentUserId}
+          />
+        ))}
+      </div>
+      <div className="shrink-0 border-t p-2">
+        <CallControls />
+      </div>
+    </>
+  )
+}
+
+/** Joining/pre-join body — mirrors {@link import("./call-island").MobileCallJoining} inside the square frame. */
+function JoiningBody() {
+  const { state, cancel } = useCallLaunch()
+  const isError = state.status === "permission_error" || state.status === "join_error"
+  if (isError) {
+    return (
+      <div className="p-3">
+        <PreJoinGate />
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center gap-2.5 px-3 py-4" role="status">
+      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" aria-hidden />
+      <span className="flex-1 text-sm font-medium">Joining…</span>
+      <button
+        type="button"
+        aria-label="Cancel joining"
+        onClick={cancel}
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+function MinimizedBubble({
+  pos,
+  connectedAt,
+  onRestore,
+}: {
+  pos: Point
+  connectedAt: number | null
+  onRestore: () => void
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="floating-call-square"
+      data-minimized="true"
+      aria-label="Restore call"
+      onClick={onRestore}
+      style={{ left: `${pos.x}px`, top: `${pos.y}px` }}
+      className="pointer-events-auto fixed z-50 flex items-center gap-2 rounded-full border bg-background px-3 py-2 shadow-xl"
+    >
+      <span
+        className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", !REDUCED_MOTION && "animate-pulse")}
+        aria-hidden
+      />
+      <CallTimer connectedAt={connectedAt} className="text-xs" />
+    </button>
+  )
+}
+
+/**
+ * A draggable, minimizable floating desktop call surface: header (drag / dock-to-
+ * side / minimize) plus the phase body — connected tiles + {@link CallControls}, or
+ * the joining spinner / {@link PreJoinGate}. A LIGHT panel (not the dark mobile
+ * island). Position lives in local state, committed through {@link clampSquareToViewport}
+ * on drag and reclamped on window resize so it never leaves the viewport. Minimize is
+ * connected-only, so a bubble never hides the joining gate.
+ */
+export function FloatingCallSquare({
+  workspaceId,
+  streamId,
+  onDockToSide,
+}: {
+  workspaceId: string | null
+  streamId: string | null
+  onDockToSide: () => void
+}) {
+  const phase = useCallPhase()
+  const roster = useCallRoster()
+  const connectedAt = useCallConnectedAt()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  const title = name ?? "Call"
+
+  const inCall = phase === "connected" || phase === "reconnecting"
+
+  const squareRef = useRef<HTMLDivElement>(null)
+  const drag = useRef<DragState | null>(null)
+  const [pos, setPos] = useState<Point>(() => defaultAnchor())
+  const [dragging, setDragging] = useState(false)
+  const [minimized, setMinimized] = useState(false)
+
+  const reclamp = useCallback(() => {
+    const el = squareRef.current
+    const size = { width: el?.offsetWidth || SQUARE_WIDTH, height: el?.offsetHeight || 0 }
+    const viewport = { width: window.innerWidth, height: window.innerHeight }
+    setPos((prev) => clampSquareToViewport(prev, size, viewport, MARGIN))
+  }, [])
+
+  useEffect(() => {
+    reclamp()
+    window.addEventListener("resize", reclamp)
+    return () => window.removeEventListener("resize", reclamp)
+  }, [reclamp])
+
+  // Never stay minimized outside a connected call — a bubble would hide the joining
+  // PreJoinGate and imply "live" with a 0:00 timer (mirrors call-dock.tsx's force-open).
+  useEffect(() => {
+    if (!inCall) setMinimized(false)
+  }, [inCall])
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // Primary pointer only; the header's action buttons aren't drag handles.
+    if (!e.isPrimary) return
+    if ((e.target as HTMLElement).closest("button")) return
+    drag.current = { pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, originX: pos.x, originY: pos.y }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    setDragging(true)
+  }
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current
+    if (!d || e.pointerId !== d.pointerId) return
+    const el = squareRef.current
+    const size = { width: el?.offsetWidth || SQUARE_WIDTH, height: el?.offsetHeight || 0 }
+    const viewport = { width: window.innerWidth, height: window.innerHeight }
+    const next = { x: d.originX + (e.clientX - d.startX), y: d.originY + (e.clientY - d.startY) }
+    setPos(clampSquareToViewport(next, size, viewport, MARGIN))
+  }
+
+  const onPointerUp = () => {
+    drag.current = null
+    setDragging(false)
+  }
+
+  if (minimized) {
+    return <MinimizedBubble pos={pos} connectedAt={connectedAt} onRestore={() => setMinimized(false)} />
+  }
+
+  return (
+    <div
+      ref={squareRef}
+      data-testid="floating-call-square"
+      data-minimized="false"
+      style={{ left: `${pos.x}px`, top: `${pos.y}px`, width: `${SQUARE_WIDTH}px` }}
+      className="pointer-events-auto fixed z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+    >
+      <SquareHeader
+        title={title}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onDockToSide={onDockToSide}
+        onMinimize={() => setMinimized(true)}
+        canMinimize={inCall}
+        dragging={dragging}
+      />
+      {inCall ? (
+        <ConnectedBody
+          workspaceId={workspaceId}
+          currentUserId={currentUserId}
+          roster={roster}
+          captureError={captureError}
+        />
+      ) : (
+        <JoiningBody />
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -415,7 +415,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             className="relative flex flex-1 flex-col overflow-hidden"
             style={{
               paddingRight: "var(--call-dock-inset-right, 0px)",
-              paddingTop: "var(--call-dock-inset-top, 0px)",
               ...(!isKeyboardOpen ? { paddingBottom: "env(safe-area-inset-bottom)" } : {}),
             }}
           >

--- a/apps/frontend/src/components/settings/call-settings.test.tsx
+++ b/apps/frontend/src/components/settings/call-settings.test.tsx
@@ -28,15 +28,21 @@ describe("CallSettings", () => {
     expect(getCallPrefs().layout).toBe("grid")
   })
 
-  it("sets the desktop call surface from the radio", async () => {
+  it("sets the desktop call surface from the radio, and seeds lastDesktopSurface for an explicit pick", async () => {
     render(<CallSettings />)
     expect(getCallPrefs().desktopCallSurface).toBe("keep_last")
     expect(screen.getByRole("radio", { name: "Keep last" })).toBeChecked()
-    await userEvent.click(screen.getByLabelText("Floating window"))
-    expect(screen.getByRole("radio", { name: "Floating window" })).toBeChecked()
+    await userEvent.click(screen.getByLabelText("Floating square"))
+    expect(screen.getByRole("radio", { name: "Floating square" })).toBeChecked()
     expect(getCallPrefs().desktopCallSurface).toBe("floating")
+    expect(getCallPrefs().lastDesktopSurface).toBe("floating")
     await userEvent.click(screen.getByLabelText("Sidebar"))
-    expect(screen.getByRole("radio", { name: "Sidebar" })).toBeChecked()
     expect(getCallPrefs().desktopCallSurface).toBe("sidebar")
+    // An explicit pick also records "last" so switching to Keep last later resolves to it.
+    expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
+    await userEvent.click(screen.getByLabelText("Keep last"))
+    expect(getCallPrefs().desktopCallSurface).toBe("keep_last")
+    // Keep last must NOT overwrite the remembered surface.
+    expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
   })
 })

--- a/apps/frontend/src/components/settings/call-settings.test.tsx
+++ b/apps/frontend/src/components/settings/call-settings.test.tsx
@@ -27,4 +27,16 @@ describe("CallSettings", () => {
     expect(screen.getByRole("radio", { name: "Grid" })).toBeChecked()
     expect(getCallPrefs().layout).toBe("grid")
   })
+
+  it("sets the desktop call surface from the radio", async () => {
+    render(<CallSettings />)
+    expect(getCallPrefs().desktopCallSurface).toBe("keep_last")
+    expect(screen.getByRole("radio", { name: "Keep last" })).toBeChecked()
+    await userEvent.click(screen.getByLabelText("Floating window"))
+    expect(screen.getByRole("radio", { name: "Floating window" })).toBeChecked()
+    expect(getCallPrefs().desktopCallSurface).toBe("floating")
+    await userEvent.click(screen.getByLabelText("Sidebar"))
+    expect(screen.getByRole("radio", { name: "Sidebar" })).toBeChecked()
+    expect(getCallPrefs().desktopCallSurface).toBe("sidebar")
+  })
 })

--- a/apps/frontend/src/components/settings/call-settings.tsx
+++ b/apps/frontend/src/components/settings/call-settings.tsx
@@ -5,11 +5,19 @@ import {
   setCallLayout,
   setCallSelfMirror,
   setDesktopCallSurface,
+  setLastDesktopSurface,
   useCallPrefs,
   type CallLayout,
   type CallSelfMirror,
   type DesktopCallSurface,
 } from "@/stores/call-prefs-store"
+
+// Picking an explicit surface in settings also seeds `lastDesktopSurface`, so a later
+// switch to "Keep last" resolves to what the user actually chose, not the stale default.
+function chooseDesktopSurface(value: DesktopCallSurface): void {
+  setDesktopCallSurface(value)
+  if (value !== "keep_last") setLastDesktopSurface(value)
+}
 
 const MIRROR_OPTIONS: { value: CallSelfMirror; label: string; description: string }[] = [
   {
@@ -34,7 +42,7 @@ const DESKTOP_SURFACE_OPTIONS: { value: DesktopCallSurface; label: string; descr
   { value: "keep_last", label: "Keep last", description: "Reopen calls wherever you last had them." },
   {
     value: "floating",
-    label: "Floating window",
+    label: "Floating square",
     description: "A movable square you can drag anywhere and minimize.",
   },
   { value: "sidebar", label: "Sidebar", description: "Docked down the right side, resizable." },
@@ -106,7 +114,7 @@ export function CallSettings() {
         </div>
         <RadioGroup
           value={desktopCallSurface}
-          onValueChange={(value) => setDesktopCallSurface(value as DesktopCallSurface)}
+          onValueChange={(value) => chooseDesktopSurface(value as DesktopCallSurface)}
           className="space-y-3"
         >
           {DESKTOP_SURFACE_OPTIONS.map((option) => (

--- a/apps/frontend/src/components/settings/call-settings.tsx
+++ b/apps/frontend/src/components/settings/call-settings.tsx
@@ -4,9 +4,11 @@ import { Separator } from "@/components/ui/separator"
 import {
   setCallLayout,
   setCallSelfMirror,
+  setDesktopCallSurface,
   useCallPrefs,
   type CallLayout,
   type CallSelfMirror,
+  type DesktopCallSurface,
 } from "@/stores/call-prefs-store"
 
 const MIRROR_OPTIONS: { value: CallSelfMirror; label: string; description: string }[] = [
@@ -28,12 +30,22 @@ const LAYOUT_OPTIONS: { value: CallLayout; label: string; description: string }[
   { value: "grid", label: "Grid", description: "Equal-sized tiles for everyone." },
 ]
 
+const DESKTOP_SURFACE_OPTIONS: { value: DesktopCallSurface; label: string; description: string }[] = [
+  { value: "keep_last", label: "Keep last", description: "Reopen calls wherever you last had them." },
+  {
+    value: "floating",
+    label: "Floating window",
+    description: "A movable square you can drag anywhere and minimize.",
+  },
+  { value: "sidebar", label: "Sidebar", description: "Docked down the right side, resizable." },
+]
+
 /**
  * Call preferences (the persisted {@link import("@/stores/call-prefs-store").CallPrefs}).
  * The in-call device menu carries a quick mirror toggle; this is the canonical home.
  */
 export function CallSettings() {
-  const { selfMirror, layout } = useCallPrefs()
+  const { selfMirror, layout, desktopCallSurface } = useCallPrefs()
   return (
     <div className="space-y-6">
       <section className="space-y-3">
@@ -76,6 +88,32 @@ export function CallSettings() {
               <RadioGroupItem value={option.value} id={`layout-${option.value}`} className="mt-1" />
               <div className="grid gap-1">
                 <Label htmlFor={`layout-${option.value}`} className="cursor-pointer">
+                  {option.label}
+                </Label>
+                <p className="text-sm text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Desktop video</h3>
+          <p className="text-sm text-muted-foreground">Where a call opens on desktop; you can still switch mid-call.</p>
+        </div>
+        <RadioGroup
+          value={desktopCallSurface}
+          onValueChange={(value) => setDesktopCallSurface(value as DesktopCallSurface)}
+          className="space-y-3"
+        >
+          {DESKTOP_SURFACE_OPTIONS.map((option) => (
+            <div key={option.value} className="flex items-start space-x-3">
+              <RadioGroupItem value={option.value} id={`desktop-surface-${option.value}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`desktop-surface-${option.value}`} className="cursor-pointer">
                   {option.label}
                 </Label>
                 <p className="text-sm text-muted-foreground">{option.description}</p>

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from "vitest"
 import {
   getCallPrefs,
   setCallLayout,
-  setCallDockPosition,
   setCallFilmstripSide,
   setCallSelfMirror,
   resolveSelfMirror,
@@ -10,7 +9,7 @@ import {
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", dockPosition: "side", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
 
 beforeEach(() => {
   localStorage.clear()
@@ -24,14 +23,13 @@ describe("call-prefs-store", () => {
 
   it("a set persists to localStorage and reads back through the store", () => {
     setCallLayout("grid")
-    setCallDockPosition("top")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", dockPosition: "top", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -41,14 +39,9 @@ describe("call-prefs-store", () => {
   })
 
   it("falls back per-field on an out-of-range persisted value", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "grid", dockPosition: "diagonal" }))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "diagonal", filmstripSide: "side" }))
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({
-      layout: "grid",
-      dockPosition: "side",
-      filmstripSide: "bottom",
-      selfMirror: "auto",
-    })
+    expect(getCallPrefs()).toEqual({ layout: "speaker", filmstripSide: "side", selfMirror: "auto" })
   })
 
   it("persists an explicit selfMirror override", () => {

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -5,12 +5,22 @@ import {
   setCallFilmstripSide,
   setCallSelfMirror,
   setCallSideDockWidth,
+  setDesktopCallSurface,
+  setLastDesktopSurface,
   resolveSelfMirror,
+  resolveDesktopSurface,
   __resetCallPrefsForTests,
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
+const DEFAULTS = {
+  layout: "speaker",
+  filmstripSide: "bottom",
+  selfMirror: "auto",
+  sideDockWidth: null,
+  desktopCallSurface: "keep_last",
+  lastDesktopSurface: "floating",
+}
 
 beforeEach(() => {
   localStorage.clear()
@@ -26,11 +36,11 @@ describe("call-prefs-store", () => {
     setCallLayout("grid")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
+    expect(getCallPrefs()).toEqual({ ...DEFAULTS, layout: "grid", filmstripSide: "side" })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
+    expect(getCallPrefs()).toEqual({ ...DEFAULTS, layout: "grid", filmstripSide: "side" })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -40,14 +50,17 @@ describe("call-prefs-store", () => {
   })
 
   it("falls back per-field on an out-of-range persisted value", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "diagonal", filmstripSide: "side" }))
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        layout: "diagonal",
+        filmstripSide: "side",
+        desktopCallSurface: "corner",
+        lastDesktopSurface: "x",
+      })
+    )
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({
-      layout: "speaker",
-      filmstripSide: "side",
-      selfMirror: "auto",
-      sideDockWidth: null,
-    })
+    expect(getCallPrefs()).toEqual({ ...DEFAULTS, filmstripSide: "side" })
   })
 
   it("persists an explicit selfMirror override", () => {
@@ -69,6 +82,49 @@ describe("call-prefs-store", () => {
       __resetCallPrefsForTests()
       expect(getCallPrefs().sideDockWidth).toBeNull()
     }
+  })
+
+  it("defaults the desktop surface to keep_last with a floating last", () => {
+    expect(getCallPrefs().desktopCallSurface).toBe("keep_last")
+    expect(getCallPrefs().lastDesktopSurface).toBe("floating")
+  })
+
+  it("round-trips desktopCallSurface and lastDesktopSurface through the store", () => {
+    setDesktopCallSurface("sidebar")
+    setLastDesktopSurface("sidebar")
+    expect(getCallPrefs().desktopCallSurface).toBe("sidebar")
+    expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
+    __resetCallPrefsForTests()
+    expect(getCallPrefs().desktopCallSurface).toBe("sidebar")
+    expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
+  })
+
+  it("falls back to defaults on an invalid persisted desktop surface", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ desktopCallSurface: "diagonal", lastDesktopSurface: "keep_last" })
+    )
+    __resetCallPrefsForTests()
+    expect(getCallPrefs().desktopCallSurface).toBe("keep_last")
+    expect(getCallPrefs().lastDesktopSurface).toBe("floating")
+  })
+})
+
+describe("resolveDesktopSurface", () => {
+  it("an override wins over the pref and last", () => {
+    expect(resolveDesktopSurface("sidebar", "sidebar", "floating")).toBe("floating")
+    expect(resolveDesktopSurface("floating", "floating", "sidebar")).toBe("sidebar")
+    expect(resolveDesktopSurface("keep_last", "sidebar", "floating")).toBe("floating")
+  })
+
+  it("keep_last follows the last-used surface when there is no override", () => {
+    expect(resolveDesktopSurface("keep_last", "floating", null)).toBe("floating")
+    expect(resolveDesktopSurface("keep_last", "sidebar", null)).toBe("sidebar")
+  })
+
+  it("an explicit pin returns as-is regardless of last", () => {
+    expect(resolveDesktopSurface("sidebar", "floating", null)).toBe("sidebar")
+    expect(resolveDesktopSurface("floating", "sidebar", null)).toBe("floating")
   })
 })
 

--- a/apps/frontend/src/stores/call-prefs-store.test.ts
+++ b/apps/frontend/src/stores/call-prefs-store.test.ts
@@ -4,12 +4,13 @@ import {
   setCallLayout,
   setCallFilmstripSide,
   setCallSelfMirror,
+  setCallSideDockWidth,
   resolveSelfMirror,
   __resetCallPrefsForTests,
 } from "./call-prefs-store"
 
 const STORAGE_KEY = "threa:callPrefs:v1"
-const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULTS = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
 
 beforeEach(() => {
   localStorage.clear()
@@ -25,11 +26,11 @@ describe("call-prefs-store", () => {
     setCallLayout("grid")
     setCallFilmstripSide("side")
 
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
 
     // Re-read from storage (not a hand-crafted fixture) — proves the write round-trips.
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({ layout: "grid", filmstripSide: "side", selfMirror: "auto", sideDockWidth: null })
   })
 
   it("falls back to defaults on malformed JSON", () => {
@@ -41,13 +42,33 @@ describe("call-prefs-store", () => {
   it("falls back per-field on an out-of-range persisted value", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ layout: "diagonal", filmstripSide: "side" }))
     __resetCallPrefsForTests()
-    expect(getCallPrefs()).toEqual({ layout: "speaker", filmstripSide: "side", selfMirror: "auto" })
+    expect(getCallPrefs()).toEqual({
+      layout: "speaker",
+      filmstripSide: "side",
+      selfMirror: "auto",
+      sideDockWidth: null,
+    })
   })
 
   it("persists an explicit selfMirror override", () => {
     setCallSelfMirror("off")
     __resetCallPrefsForTests()
     expect(getCallPrefs().selfMirror).toBe("off")
+  })
+
+  it("round-trips a sideDockWidth through the store", () => {
+    setCallSideDockWidth(480)
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+    __resetCallPrefsForTests()
+    expect(getCallPrefs().sideDockWidth).toBe(480)
+  })
+
+  it("falls back to null on an invalid persisted sideDockWidth", () => {
+    for (const bad of ["wide", -5, 0]) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ sideDockWidth: bad }))
+      __resetCallPrefsForTests()
+      expect(getCallPrefs().sideDockWidth).toBeNull()
+    }
   })
 })
 

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -16,6 +16,10 @@ export type CallLayout = "speaker" | "grid"
 export type CallFilmstripSide = "bottom" | "side"
 /** Local self-view mirroring. `auto` = mirror a front/desktop camera, not a mobile back camera. */
 export type CallSelfMirror = "auto" | "on" | "off"
+/** A concrete desktop call surface. */
+export type DesktopSurface = "sidebar" | "floating"
+/** The desktop-surface preference: `keep_last` reopens wherever the last call was. */
+export type DesktopCallSurface = "keep_last" | DesktopSurface
 
 export interface CallPrefs {
   layout: CallLayout
@@ -23,16 +27,43 @@ export interface CallPrefs {
   selfMirror: CallSelfMirror
   /** Last resting open width (px) of the desktop side dock; `null` = never resized. */
   sideDockWidth: number | null
+  /** Which desktop surface a call opens on. */
+  desktopCallSurface: DesktopCallSurface
+  /** The surface the last desktop call resolved to — the target of `keep_last`. */
+  lastDesktopSurface: DesktopSurface
 }
 
-const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
+const DEFAULT_PREFS: CallPrefs = {
+  layout: "speaker",
+  filmstripSide: "bottom",
+  selfMirror: "auto",
+  sideDockWidth: null,
+  desktopCallSurface: "keep_last",
+  lastDesktopSurface: "floating",
+}
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
+const isDesktopSurface = (v: unknown): v is DesktopSurface => v === "sidebar" || v === "floating"
+const isDesktopCallSurface = (v: unknown): v is DesktopCallSurface => v === "keep_last" || isDesktopSurface(v)
 const parseSideDockWidth = (v: unknown): number | null =>
   typeof v === "number" && Number.isFinite(v) && v > 0 ? v : null
+
+/**
+ * Resolve the effective desktop surface. An in-call session override wins; else
+ * `keep_last` follows the last-used surface and an explicit pin returns as-is.
+ */
+export function resolveDesktopSurface(
+  pref: DesktopCallSurface,
+  last: DesktopSurface,
+  override: DesktopSurface | null
+): DesktopSurface {
+  if (override) return override
+  if (pref === "keep_last") return last
+  return pref
+}
 
 /**
  * Resolve the effective self-view mirror. `auto` mirrors a front-facing view (any
@@ -63,6 +94,12 @@ function readPersisted(): CallPrefs {
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
       selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
       sideDockWidth: parseSideDockWidth(p.sideDockWidth),
+      desktopCallSurface: isDesktopCallSurface(p.desktopCallSurface)
+        ? p.desktopCallSurface
+        : DEFAULT_PREFS.desktopCallSurface,
+      lastDesktopSurface: isDesktopSurface(p.lastDesktopSurface)
+        ? p.lastDesktopSurface
+        : DEFAULT_PREFS.lastDesktopSurface,
     }
   } catch {
     return { ...DEFAULT_PREFS }
@@ -91,7 +128,9 @@ function update(patch: Partial<CallPrefs>): void {
     next.layout === prefs.layout &&
     next.filmstripSide === prefs.filmstripSide &&
     next.selfMirror === prefs.selfMirror &&
-    next.sideDockWidth === prefs.sideDockWidth
+    next.sideDockWidth === prefs.sideDockWidth &&
+    next.desktopCallSurface === prefs.desktopCallSurface &&
+    next.lastDesktopSurface === prefs.lastDesktopSurface
   ) {
     return
   }
@@ -118,6 +157,14 @@ export function setCallSelfMirror(selfMirror: CallSelfMirror): void {
 
 export function setCallSideDockWidth(px: number): void {
   update({ sideDockWidth: px })
+}
+
+export function setDesktopCallSurface(desktopCallSurface: DesktopCallSurface): void {
+  update({ desktopCallSurface })
+}
+
+export function setLastDesktopSurface(lastDesktopSurface: DesktopSurface): void {
+  update({ lastDesktopSurface })
 }
 
 function subscribe(listener: () => void): () => void {

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -21,14 +21,18 @@ export interface CallPrefs {
   layout: CallLayout
   filmstripSide: CallFilmstripSide
   selfMirror: CallSelfMirror
+  /** Last resting open width (px) of the desktop side dock; `null` = never resized. */
+  sideDockWidth: number | null
 }
 
-const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
+const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto", sideDockWidth: null }
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
+const parseSideDockWidth = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) && v > 0 ? v : null
 
 /**
  * Resolve the effective self-view mirror. `auto` mirrors a front-facing view (any
@@ -58,6 +62,7 @@ function readPersisted(): CallPrefs {
       layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
       selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
+      sideDockWidth: parseSideDockWidth(p.sideDockWidth),
     }
   } catch {
     return { ...DEFAULT_PREFS }
@@ -85,7 +90,8 @@ function update(patch: Partial<CallPrefs>): void {
   if (
     next.layout === prefs.layout &&
     next.filmstripSide === prefs.filmstripSide &&
-    next.selfMirror === prefs.selfMirror
+    next.selfMirror === prefs.selfMirror &&
+    next.sideDockWidth === prefs.sideDockWidth
   ) {
     return
   }
@@ -108,6 +114,10 @@ export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {
 
 export function setCallSelfMirror(selfMirror: CallSelfMirror): void {
   update({ selfMirror })
+}
+
+export function setCallSideDockWidth(px: number): void {
+  update({ sideDockWidth: px })
 }
 
 function subscribe(listener: () => void): () => void {

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -13,28 +13,20 @@ import { useSyncExternalStore } from "react"
  */
 
 export type CallLayout = "speaker" | "grid"
-export type CallDockPosition = "top" | "side"
 export type CallFilmstripSide = "bottom" | "side"
 /** Local self-view mirroring. `auto` = mirror a front/desktop camera, not a mobile back camera. */
 export type CallSelfMirror = "auto" | "on" | "off"
 
 export interface CallPrefs {
   layout: CallLayout
-  dockPosition: CallDockPosition
   filmstripSide: CallFilmstripSide
   selfMirror: CallSelfMirror
 }
 
-const DEFAULT_PREFS: CallPrefs = {
-  layout: "speaker",
-  dockPosition: "side",
-  filmstripSide: "bottom",
-  selfMirror: "auto",
-}
+const DEFAULT_PREFS: CallPrefs = { layout: "speaker", filmstripSide: "bottom", selfMirror: "auto" }
 const STORAGE_KEY = "threa:callPrefs:v1"
 
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
-const isDockPosition = (v: unknown): v is CallDockPosition => v === "top" || v === "side"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
 
@@ -64,7 +56,6 @@ function readPersisted(): CallPrefs {
     const p = parsed as Record<string, unknown>
     return {
       layout: isLayout(p.layout) ? p.layout : DEFAULT_PREFS.layout,
-      dockPosition: isDockPosition(p.dockPosition) ? p.dockPosition : DEFAULT_PREFS.dockPosition,
       filmstripSide: isFilmstripSide(p.filmstripSide) ? p.filmstripSide : DEFAULT_PREFS.filmstripSide,
       selfMirror: isSelfMirror(p.selfMirror) ? p.selfMirror : DEFAULT_PREFS.selfMirror,
     }
@@ -93,7 +84,6 @@ function update(patch: Partial<CallPrefs>): void {
   const next = { ...prefs, ...patch }
   if (
     next.layout === prefs.layout &&
-    next.dockPosition === prefs.dockPosition &&
     next.filmstripSide === prefs.filmstripSide &&
     next.selfMirror === prefs.selfMirror
   ) {
@@ -110,10 +100,6 @@ export function getCallPrefs(): CallPrefs {
 
 export function setCallLayout(layout: CallLayout): void {
   update({ layout })
-}
-
-export function setCallDockPosition(dockPosition: CallDockPosition): void {
-  update({ dockPosition })
 }
 
 export function setCallFilmstripSide(filmstripSide: CallFilmstripSide): void {

--- a/apps/frontend/src/stores/call-store.test.ts
+++ b/apps/frontend/src/stores/call-store.test.ts
@@ -8,6 +8,7 @@ import {
   setCallPhase,
   setCallRoster,
   setCallSurfaceMode,
+  setDesktopSurfaceOverride,
   registerCallHangup,
   resetCallStoreCache,
   clearCallState,
@@ -79,6 +80,20 @@ describe("call-store", () => {
 
     resetCallStoreCache()
     expect(getCallState().surfaceMode).toBe("min")
+  })
+
+  it("desktopSurfaceOverride: defaults null, sets, survives a rejoin, and clears on teardown", () => {
+    expect(getCallState().desktopSurfaceOverride).toBeNull()
+
+    setDesktopSurfaceOverride("sidebar")
+    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
+
+    // A rejoin (new session) keeps "this call"'s override — only teardown clears it.
+    setCallSession({ callId: "call_2", workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
+
+    clearCallState()
+    expect(getCallState().desktopSurfaceOverride).toBeNull()
   })
 
   it("connectedAt: stamped once on connect, preserved across reconnects, cleared on teardown", () => {

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -13,9 +13,9 @@ export type CallPhase = "idle" | "joining" | "connected" | "reconnecting"
 
 /**
  * Unified surface size for the call UI. One enum, four steps; each surface maps a
- * step to its own presentation (mobile Tab/Bar/Tiny-gallery/Fullscreen; desktop-top
- * Tab/Bar/Gallery/Fullscreen; desktop-side Rail/Panel/Wide/Fullscreen). Ephemeral —
- * defaults to "min" ("opens minimal") and resets to "min" on teardown, like the roster.
+ * step to its own presentation (mobile Tab/Bar/Tiny-gallery/Fullscreen; desktop-side
+ * Rail/Panel/Wide/Fullscreen). The floating square ignores it (own local state).
+ * Ephemeral — defaults to "min" and resets to "min" on teardown, like the roster.
  */
 export type CallSurfaceMode = "min" | "compact" | "standard" | "full"
 

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react"
 import type { CallMode, PublishedTrackKind } from "@/calls/config"
+import type { DesktopSurface } from "./call-prefs-store"
 
 // Module store (useSyncExternalStore) for the single active call. The CallManager
 // (non-React, account-scoped) is the sole writer; components read via the hooks.
@@ -87,6 +88,12 @@ export interface CallState {
   /** Unified surface size ({@link CallSurfaceMode}); "min" until a surface steps it up. */
   surfaceMode: CallSurfaceMode
   /**
+   * In-call desktop-surface override — an explicit dock-to-side / float this call
+   * only. Wins over the persisted pref while set; cleared on teardown (so a pinned
+   * Sidebar/Floating governs the next call). Session-scoped like {@link surfaceMode}.
+   */
+  desktopSurfaceOverride: DesktopSurface | null
+  /**
    * `Date.now()` at the first "connected" transition — the in-call timer anchor.
    * Stamped once and preserved across reconnects (a blip must not reset the clock);
    * reset to null on a new session and on teardown.
@@ -131,6 +138,7 @@ function idleState(): CallState {
   return {
     phase: "idle",
     surfaceMode: "min",
+    desktopSurfaceOverride: null,
     connectedAt: null,
     callId: null,
     workspaceId: null,
@@ -185,6 +193,11 @@ export function setCallPhase(phase: CallPhase): void {
 export function setCallSurfaceMode(surfaceMode: CallSurfaceMode): void {
   if (state.surfaceMode === surfaceMode) return
   setState({ ...state, surfaceMode })
+}
+
+export function setDesktopSurfaceOverride(desktopSurfaceOverride: DesktopSurface | null): void {
+  if (state.desktopSurfaceOverride === desktopSurfaceOverride) return
+  setState({ ...state, desktopSurfaceOverride })
 }
 
 export function setCallSession(args: { callId: string; workspaceId: string; streamId: string; mode: CallMode }): void {

--- a/docs/plans/calls-desktop-dock-redesign.md
+++ b/docs/plans/calls-desktop-dock-redesign.md
@@ -1,0 +1,66 @@
+# Calls — Desktop dock redesign
+
+Status: **draft, awaiting ratification**. Approved visual direction: the [desktop dock mock](https://seer.build/ws_vbyzjvdg6g/b/calls-deskdock-1ca712/).
+
+Desktop-only. Mobile surfaces (`mobile-call-drawer.tsx`, `call-island.tsx`) are unchanged. Reference files: `apps/frontend/src/components/call/desktop-call-dock.tsx` (628 lines — top/side dock, `nearestStep` snaps, `--call-dock-inset-*` content push, `ResizeObserver` ceiling), `call-dock.tsx` (phase router), `stores/call-prefs-store.ts`.
+
+## Goals (from Kris's desktop feedback)
+
+1. **Kill the top dock** — it felt awkward; drop the top orientation entirely. Desktop is **side** or **floating** only.
+2. **Floating square = effective default** — a small draggable, minimizable call widget (grip to move anywhere, minimize to a bubble), with a **"dock to side"** action. Joining renders **in the same square** (no bottom-right→dock jump).
+3. **Side dock behaves like the nav sidebar** — **hover-to-overlay** when minimized (opens over the content, doesn't push, like the nav sidebar's closed-hover), plus an open/pinned draggable mode; **freeform width** (remove the width snap detents — snaps control layout/things, not width); **75% max**; a **drop-to-fullscreen indication** past 75% on release; a **"float"** action to switch to the square.
+4. **Collapsed side rail** — put controls (mute / camera / leave) in the wasted vertical space above the timer.
+5. **Surface pref** `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`). `keep_last` remembers the last-used surface; the floating square is the effective default. A control in **Calls settings**.
+
+## Invariants in play
+
+- INV-9 (call-prefs singleton exception), INV-33 (settings-tab config SSOT), INV-15/18 (components UI-only, no inner defs), INV-21 (no layout shift from the hover-overlay/drag), INV-40 (actions = `<button>`), INV-63 (success silent). The content push uses the existing `--call-dock-inset-*` mechanism. Keep the smooth pointer-drag feel (the current dock's pointer loop is the reference — Kris likes it).
+
+## PR-stack breakdown
+
+Each chunk is one PR, based on the previous branch (chunk 1 on `origin/main`).
+
+### Chunk 1 — Remove the top dock (side-only)
+
+- `desktop-call-dock.tsx`: delete the top orientation — `PanelTop`/`PanelBottom` icons, the Top/Side toggle in the dock header, `TOP_STEP_SIZES`/`detentsH`, and the `mode`-vs-`dockPosition` branches for top. Desktop dock renders side-only.
+- `call-prefs-store.ts`: `dockPosition` loses `"top"` — either narrow to `"side"` (vestigial, removed in Chunk 4) or drop the field now if no other reader needs it; `filmstripSide` stays.
+- `layout-toggle.tsx` / dock header: remove the Top/Side control (the Speaker/Grid + filmstrip-side toggles stay).
+- Tests: drop the top-mode cases in `desktop-call-dock.test.tsx`; keep side-mode coverage green.
+- **NOT**: no new surface yet; no pref changes beyond removing `top`.
+
+### Chunk 2 — Side dock: freeform width + 75% cap + drop-to-fullscreen cue + hover-overlay + collapsed controls
+
+- **Freeform width**: replace the width `nearestStep` detents with a continuous clamp `[MIN, 0.75 * ceilW]`; drop the width snap. Keep the smooth pointer drag; commit width to a persisted pref (`sideDockWidth`) on release. (Layout snaps — Speaker/Grid, filmstrip side — are unaffected: those are _content_ toggles, not width.)
+- **75% cap + drop-to-fullscreen**: dragging past the 75% ceiling shows a **drop-to-fullscreen overlay** (dashed, "Release to go fullscreen"); releasing in that zone → fullscreen, releasing below → clamp to ≤75%. A deliberate zone so fullscreen is intentional.
+- **Hover-to-overlay when minimized**: the minimized rail, on hover, expands the dock **over** the content (position: absolute, no `--call-dock-inset` push) — mirroring the nav sidebar's closed-hover (`app-shell.tsx` preview state). Pinned/open still pushes.
+- **Collapsed rail controls**: `SideRailView` gains mute / camera / leave (shared `call-control-buttons`) above the timer.
+- Tests: freeform clamp (no snap; ≤75%), fullscreen-zone release vs clamp release, hover-overlay adds no inset, rail controls dispatch.
+- **NOT**: the floating square; the surface pref.
+
+### Chunk 3 — Floating square surface (component only)
+
+- New `floating-call-square.tsx`: a draggable (grip / whole-header drag via pointer capture, clamped to viewport), **minimizable** (collapse to a small bubble showing dot + timer; click to restore) call widget rendering tiles + the shared controls; a **"dock to side"** action.
+- Joining renders in the same square (a compact "Joining…" state — unify like the mobile `MobileCallJoining`, no separate bottom-right box).
+- Not yet the default — rendered behind the pref in Chunk 4; this chunk lands the component + its tests in isolation (render at a fixed position, drag math via a pure helper, minimize toggle).
+- Tests: drag clamp helper (pure), minimize/restore, controls dispatch, joining state.
+- **NOT**: wiring the pref / switching / keep_last.
+
+### Chunk 4 — `desktopCallSurface` pref + surface switching + Calls settings
+
+- `call-prefs-store.ts`: `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`) + `lastDesktopSurface: sidebar | floating` + `resolveDesktopSurface(pref, last)`; remove the vestigial `dockPosition` if still present.
+- `call-dock.tsx`: on desktop, render the resolved surface — `FloatingCallSquare` or `DesktopCallDock` (side). Joining routes to whichever surface is active (both now render joining in-place).
+- Wire the **"dock to side"** (square → sidebar, updates `lastDesktopSurface`) and **"float"** (sidebar → square) actions.
+- `call-settings.tsx`: a "Desktop video" radio (Keep last / Sidebar / Floating square).
+- Tests: resolver matrix, keep_last persistence, dock-to-side/float switch the surface + update last, settings control.
+- **NOT**: mobile changes.
+
+## Deferred (do NOT build)
+
+- Mobile floating/PiP.
+- Screen-share (two feeds) — its own future stack.
+- Server-persisted (cross-device) layout prefs — localStorage only, as today.
+
+## Verification
+
+- Per chunk: Opus implement → Opus xhigh adversarial verify (typecheck + `bun run test:unit` on the touched suites) → fix loop → `/code-review`.
+- Whole-stack review after Chunk 4. Real-component screenshots of each surface before merge.


### PR DESCRIPTION
## Problem

Chunk 4 (final) of the desktop calls-dock redesign (`docs/plans/calls-desktop-dock-redesign.md`).
Chunks 2–3 landed the side dock (freeform) and the floating square (isolated). This wires them into
a user-selectable desktop surface with in-call switching, so the square can be the effective default
while the sidebar stays opt-in.

## Solution

- **Pref** `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`) +
  `lastDesktopSurface` memory + `resolveDesktopSurface(pref, last, override)`. Default resolved surface
  is the floating square.
- **Interaction model A** (Kris's call): the in-call dock/float toggle sets an **ephemeral
  `desktopSurfaceOverride`** in the call store — moves the surface for THIS call only; it clears on
  teardown, so an explicit Sidebar/Floating pin governs the next call. Each toggle also writes
  `lastDesktopSurface` so `keep_last` remembers. Switches are silent (INV-63).
- **Routing** (`call-dock.tsx`): floating → the square owns the whole desktop lifecycle
  (launch/join/in-call); sidebar → `DesktopCallDock` in-call, the docked panel otherwise. The square's
  "Dock to the side" and the dock's new **Float** button (open-panel header) switch surfaces.
- The floating square's joining body now mirrors the **desktop** DockFrame (`PreJoinGate` during an
  active launch, "Connecting…" once idle), not the mobile island — so the permission/device gate shows
  on the floating surface.
- **"Desktop video"** radio in Calls settings (Keep last / Floating window / Sidebar).

Also fixes a **pre-existing seam** review surfaced: the sidebar joining `DockFrame` was collapsible,
which could hide the `PreJoinGate` mid-join. That panel is joining-only now (connected uses the dock),
so the collapse toggle was a pure footgun — removed it; the gate stays visible, matching the square's
connected-only Minimize.

Built via the build-feature loop: Opus implement → Opus max-effort adversarial verify (SHIPPABLE, no
blockers/majors, routing table confirmed) → its nit + coverage gap + the pre-existing seam folded in.

## Test plan

- [x] `vitest` — the 6 touched suites: 86 pass; broader call/settings/stores sweep: 194 pass
- [x] `tsc --noEmit` clean; `eslint` clean on all touched files
- [ ] Whole-stack review (Fable) across #1492–#1495 + real desktop screenshots — before merge

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787292133&installation_model_id=20758&pr_number=1496&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1496&signature=9935953330c8288bdf66178f62ea8f52765cd379de124fd73d2d7294c8d5d155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->