### PR TITLE
feat(threads): unified thread projections — thread:updated, reply stats on the thread row, anchor-keyed healing

### DIFF
--- a/apps/backend/src/db/migrations/20260721120200_thread_reply_projection_bridge.sql
+++ b/apps/backend/src/db/migrations/20260721120200_thread_reply_projection_bridge.sql
@@ -1,0 +1,57 @@
+-- Keep the canonical thread-row projection correct while predecessor replicas
+-- still update only messages.reply_count during the rolling deploy. Creating the
+-- trigger takes a table lock for this transaction, so the following reconciliation
+-- cannot race a legacy reply-count write.
+CREATE OR REPLACE FUNCTION sync_legacy_message_thread_projection()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE streams AS thread
+  SET reply_count = NEW.reply_count,
+      last_reply_at = (
+        SELECT MAX(created_at)
+        FROM messages
+        WHERE stream_id = thread.id
+          AND deleted_at IS NULL
+      ),
+      updated_at = NOW()
+  WHERE thread.type = 'thread'
+    AND thread.parent_stream_id = NEW.stream_id
+    AND COALESCE(thread.parent_anchor_id, thread.parent_message_id) = NEW.id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_legacy_message_thread_projection ON messages;
+CREATE TRIGGER sync_legacy_message_thread_projection
+AFTER UPDATE OF reply_count ON messages
+FOR EACH ROW
+WHEN (OLD.reply_count IS DISTINCT FROM NEW.reply_count)
+EXECUTE FUNCTION sync_legacy_message_thread_projection();
+
+-- Heal any drift accumulated between the substrate backfill and this projection
+-- deployment before streams.reply_count becomes the live projection.
+UPDATE streams AS thread
+SET reply_count = anchor.reply_count,
+    last_reply_at = (
+      SELECT MAX(created_at)
+      FROM messages
+      WHERE stream_id = thread.id
+        AND deleted_at IS NULL
+    ),
+    updated_at = NOW()
+FROM messages AS anchor
+WHERE thread.type = 'thread'
+  AND thread.parent_stream_id = anchor.stream_id
+  AND COALESCE(thread.parent_anchor_id, thread.parent_message_id) = anchor.id
+  AND (
+    thread.reply_count IS DISTINCT FROM anchor.reply_count
+    OR thread.last_reply_at IS DISTINCT FROM (
+      SELECT MAX(created_at)
+      FROM messages
+      WHERE stream_id = thread.id
+        AND deleted_at IS NULL
+    )
+  );

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -164,7 +164,15 @@ export class BoundaryExtractionService {
         MESSAGES_AFTER
       )
 
-      const threadRootIds = surroundingMessages.filter((m) => m.replyCount > 0).map((m) => m.id)
+      // Which surrounding messages actually anchor a thread with live replies is
+      // read from the thread stream rows (streams.reply_count, the maintained
+      // source of truth), not the message's own shadow count (plan §Projections).
+      const anchorsWithReplies = await StreamRepository.findAnchorsWithReplies(
+        client,
+        stream.id,
+        surroundingMessages.map((m) => m.id)
+      )
+      const threadRootIds = surroundingMessages.filter((m) => anchorsWithReplies.has(m.id)).map((m) => m.id)
       const threadMessagesByParent = await MessageRepository.findThreadMessages(client, threadRootIds)
       const allThreadMessages = Array.from(threadMessagesByParent.values()).flat()
 

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -395,8 +395,8 @@ export const ConversationRepository = {
 
   /**
    * Find conversations in a stream AND in any child threads of that stream.
-   * Child threads are streams where parent_message_id belongs to a message in
-   * the given stream.
+   * Child threads are thread streams whose `parent_stream_id` is this stream —
+   * anchor-agnostic, so threads on cards (event-anchored) are included too.
    */
   async findByStreamIncludingThreads(
     db: Querier,
@@ -412,10 +412,7 @@ export const ConversationRepository = {
           stream_id = ${streamId}
           OR stream_id IN (
             SELECT s.id FROM streams s
-            WHERE s.type = 'thread'
-              AND s.parent_message_id IN (
-                SELECT m.id FROM messages m WHERE m.stream_id = ${streamId}
-              )
+            WHERE s.type = 'thread' AND s.parent_stream_id = ${streamId}
           )
         )
         AND status = ${options.status}
@@ -430,10 +427,7 @@ export const ConversationRepository = {
       WHERE stream_id = ${streamId}
          OR stream_id IN (
            SELECT s.id FROM streams s
-           WHERE s.type = 'thread'
-             AND s.parent_message_id IN (
-               SELECT m.id FROM messages m WHERE m.stream_id = ${streamId}
-             )
+           WHERE s.type = 'thread' AND s.parent_stream_id = ${streamId}
          )
       ORDER BY last_activity_at DESC
       LIMIT ${limit}

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -1281,9 +1281,12 @@ describe("EventService.createMessage parent thread update (reply in thread)", ()
       callback({})) as any)
     spyOn(StreamRepository, "findById").mockResolvedValue({
       id: "stream_thread",
+      workspaceId: "ws_1",
       type: "thread",
       parentStreamId: "stream_root",
+      parentAnchorId: "msg_parent",
       parentMessageId: "msg_parent",
+      replyCount: 5,
     } as any)
     spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
     spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
@@ -1357,14 +1360,15 @@ describe("EventService.createMessage parent thread update (reply in thread)", ()
     )
   })
 
-  it("increments the thread stream's reply_count and dual-emits thread:updated for a msg_ anchor", async () => {
+  it("uses the grace bridge projection and dual-emits thread:updated for a msg_ anchor", async () => {
     const service = new EventService({} as any)
 
     await service.createMessage(baseParams)
 
-    // Reply-count maintenance lives on the thread stream row (INV-20 atomic +1).
-    expect(StreamRepository.bumpThreadReplyCount).toHaveBeenCalledWith(expect.anything(), "stream_thread", 1)
-    // New anchor-agnostic patch, replyCount read off the thread stream row.
+    // The legacy parent write synchronously projects through the rolling-deploy
+    // trigger; a second delta bump would double-count and invert mixed-version lock order.
+    expect(StreamRepository.bumpThreadReplyCount).not.toHaveBeenCalled()
+    // New anchor-agnostic patch reads the post-trigger thread stream row.
     expect(OutboxRepository.insert).toHaveBeenCalledWith(
       expect.anything(),
       "thread:updated",

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -1321,6 +1321,14 @@ describe("EventService.createMessage parent thread update (reply in thread)", ()
     spyOn(MessageRepository, "findById").mockResolvedValue({ id: "msg_parent", replyCount: 4 } as any)
     spyOn(StreamRepository, "findThreadSummaryByParentMessage").mockResolvedValue(null)
     spyOn(StreamRepository, "findByParentMessage").mockResolvedValue({ id: "stream_thread" } as any)
+    spyOn(StreamRepository, "bumpThreadReplyCount").mockResolvedValue({
+      id: "stream_thread",
+      workspaceId: "ws_1",
+      parentStreamId: "stream_root",
+      parentAnchorId: "msg_parent",
+      parentMessageId: "msg_parent",
+      replyCount: 5,
+    } as any)
     spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
     spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
     spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
@@ -1347,5 +1355,67 @@ describe("EventService.createMessage parent thread update (reply in thread)", ()
         threadId: "stream_thread",
       })
     )
+  })
+
+  it("increments the thread stream's reply_count and dual-emits thread:updated for a msg_ anchor", async () => {
+    const service = new EventService({} as any)
+
+    await service.createMessage(baseParams)
+
+    // Reply-count maintenance lives on the thread stream row (INV-20 atomic +1).
+    expect(StreamRepository.bumpThreadReplyCount).toHaveBeenCalledWith(expect.anything(), "stream_thread", 1)
+    // New anchor-agnostic patch, replyCount read off the thread stream row.
+    expect(OutboxRepository.insert).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread:updated",
+      expect.objectContaining({
+        parentStreamId: "stream_root",
+        anchorId: "msg_parent",
+        threadId: "stream_thread",
+        replyCount: 5,
+        threadSummary: null,
+      })
+    )
+    // GRACE: the legacy patch is still dual-emitted for the msg_ anchor.
+    const emitted = (OutboxRepository.insert as any).mock.calls.map((c: unknown[]) => c[1])
+    expect(emitted).toContain("thread:updated")
+    expect(emitted).toContain("message:updated")
+  })
+
+  it("event-anchored thread reply emits thread:updated with the event-id anchor and NO legacy message:updated", async () => {
+    // A thread hung under a card: anchor is an event_ id, no parent message.
+    ;(StreamRepository.findById as any).mockResolvedValue({
+      id: "stream_thread",
+      type: "thread",
+      parentStreamId: "stream_root",
+      parentAnchorId: "event_card1",
+      parentMessageId: null,
+    })
+    ;(StreamRepository.bumpThreadReplyCount as any).mockResolvedValue({
+      id: "stream_thread",
+      workspaceId: "ws_1",
+      parentStreamId: "stream_root",
+      parentAnchorId: "event_card1",
+      parentMessageId: null,
+      replyCount: 1,
+    })
+
+    const service = new EventService({} as any)
+    await service.createMessage(baseParams)
+
+    expect(OutboxRepository.insert).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread:updated",
+      expect.objectContaining({
+        parentStreamId: "stream_root",
+        anchorId: "event_card1",
+        threadId: "stream_thread",
+        replyCount: 1,
+      })
+    )
+    // No message-shadow write and no legacy patch for a card anchor.
+    expect(MessageRepository.incrementReplyCount).not.toHaveBeenCalled()
+    const emitted = (OutboxRepository.insert as any).mock.calls.map((c: unknown[]) => c[1])
+    expect(emitted).not.toContain("message:updated")
   })
 })

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1422,7 +1422,8 @@ export class EventService {
         destinationThread.id,
         uniqueMessageIds.length
       )
-      await this.emitThreadUpdate(client, updatedDestThread ?? destinationThread)
+      const projectedDestinationThread = updatedDestThread ?? destinationThread
+      await this.emitThreadUpdate(client, projectedDestinationThread)
 
       // Snapshot the post-increment reply count + thread summary so we can
       // ship them inside `messages:moved` itself. Without this, source
@@ -1453,7 +1454,7 @@ export class EventService {
         await OutboxRepository.insert(client, "stream:created", {
           workspaceId: params.workspaceId,
           streamId: params.sourceStreamId,
-          stream: destinationThread,
+          stream: projectedDestinationThread,
         })
       }
 
@@ -1548,7 +1549,7 @@ export class EventService {
         destinationStreamId: destinationThread.id,
         targetMessageId: params.targetMessageId,
         movedMessageIds: uniqueMessageIds,
-        thread: destinationThread,
+        thread: projectedDestinationThread,
         events: serializedDestinationEvents,
         removedEventIds,
         sourceTombstoneEvent: serializedSourceTombstone,
@@ -1562,7 +1563,7 @@ export class EventService {
         destinationStreamId: destinationThread.id,
         targetMessageId: params.targetMessageId,
         movedMessageIds: uniqueMessageIds,
-        thread: destinationThread,
+        thread: projectedDestinationThread,
         events: serializedDestinationEvents,
         removedEventIds,
         sourceTombstoneEvent: serializedSourceTombstone,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1,7 +1,7 @@
 import type { Pool, PoolClient } from "pg"
 import { withTransaction, withClient, sql } from "../../db"
 import { StreamEventRepository, type StreamEvent, type MoveEventIdSequenceUpdate } from "../streams"
-import { StreamRepository } from "../streams"
+import { StreamRepository, type Stream } from "../streams"
 import { StreamMemberRepository, SparseReadRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
@@ -845,10 +845,17 @@ export class EventService {
     if (stream?.parentStreamId && (stream.parentAnchorId || stream.parentMessageId)) {
       // Legacy shadow: keep messages.reply_count dual-written for msg_ anchors
       // (grace). Authoritative count lives on the thread stream row.
+      let updatedThread: Stream | null
       if (stream.parentMessageId) {
+        // The rolling-deploy trigger mirrors this legacy write into the canonical
+        // stream projection. Do not also delta-bump the stream row: predecessor
+        // replicas may have changed the shadow, and taking both locks in opposite
+        // order can deadlock mixed-version transactions.
         await MessageRepository.incrementReplyCount(client, stream.parentMessageId)
+        updatedThread = await StreamRepository.findById(client, stream.id)
+      } else {
+        updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, 1)
       }
-      const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, 1)
       await this.emitThreadUpdate(client, updatedThread ?? stream)
     }
 
@@ -1132,10 +1139,13 @@ export class EventService {
 
         const stream = await StreamRepository.findById(client, params.streamId)
         if (stream?.parentStreamId && (stream.parentAnchorId || stream.parentMessageId)) {
+          let updatedThread: Stream | null
           if (stream.parentMessageId) {
             await MessageRepository.decrementReplyCount(client, stream.parentMessageId)
+            updatedThread = await StreamRepository.findById(client, stream.id)
+          } else {
+            updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
           }
-          const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
           await this.emitThreadUpdate(client, updatedThread ?? stream)
         }
       }
@@ -1417,12 +1427,8 @@ export class EventService {
       })
 
       await MessageRepository.incrementReplyCountBy(client, params.targetMessageId, uniqueMessageIds.length)
-      const updatedDestThread = await StreamRepository.bumpThreadReplyCount(
-        client,
-        destinationThread.id,
-        uniqueMessageIds.length
-      )
-      const projectedDestinationThread = updatedDestThread ?? destinationThread
+      const projectedDestinationThread =
+        (await StreamRepository.findById(client, destinationThread.id)) ?? destinationThread
       await this.emitThreadUpdate(client, projectedDestinationThread)
 
       // Snapshot the post-increment reply count + thread summary so we can
@@ -1439,14 +1445,17 @@ export class EventService {
       )
 
       if (sourceStream.parentStreamId && (sourceStream.parentAnchorId || sourceStream.parentMessageId)) {
+        let updatedSourceThread: Stream | null
         if (sourceStream.parentMessageId) {
           await MessageRepository.decrementReplyCountBy(client, sourceStream.parentMessageId, uniqueMessageIds.length)
+          updatedSourceThread = await StreamRepository.findById(client, sourceStream.id)
+        } else {
+          updatedSourceThread = await StreamRepository.bumpThreadReplyCount(
+            client,
+            sourceStream.id,
+            -uniqueMessageIds.length
+          )
         }
-        const updatedSourceThread = await StreamRepository.bumpThreadReplyCount(
-          client,
-          sourceStream.id,
-          -uniqueMessageIds.length
-        )
         await this.emitThreadUpdate(client, updatedSourceThread ?? sourceStream)
       }
 

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -35,6 +35,7 @@ import {
   ConversationIntents,
   StreamTypes,
   Visibilities,
+  THREAD_ANCHORABLE_EVENT_TYPES,
   draftStreamScope,
   draftThreadScope,
   type AttachmentSummary,
@@ -394,38 +395,67 @@ export interface ConversationAssigner {
   ): Promise<string>
 }
 
+/**
+ * Minimal thread stream shape `emitThreadUpdate` needs — accepts both the
+ * repository's row-mapped `Stream` (dates) and the wire `Stream` (strings),
+ * since only these anchor/identity/count fields are read.
+ */
+interface ThreadStreamStats {
+  id: string
+  workspaceId: string
+  parentStreamId: string | null
+  parentAnchorId?: string | null
+  parentMessageId: string | null
+  replyCount?: number
+}
+
 export class EventService {
   constructor(
     private pool: Pool,
     private conversationAssigner?: ConversationAssigner
   ) {}
 
-  private async publishParentThreadUpdate(
-    client: PoolClient,
-    params: {
-      workspaceId: string
-      parentStreamId: string | null
-      parentMessageId: string | null
-    }
-  ): Promise<void> {
-    if (!params.parentStreamId || !params.parentMessageId) return
+  /**
+   * Emit the projection patch(es) for a thread whose reply stats just changed.
+   * The thread IS the stream its replies land in, so `threadStream` carries the
+   * post-mutation `replyCount` (read off `streams.reply_count` via the caller's
+   * `bumpThreadReplyCount`) and the anchor it hangs under.
+   *
+   * Emits `thread:updated` for EVERY anchor kind (message- or event-anchored),
+   * routed to the parent stream room. GRACE: for `msg_` anchors it also dual-emits
+   * the legacy `message:updated {updateType:"reply_count"}` patch so a client that
+   * hasn't upgraded still heals the anchor message; removed in the cleanup chunk.
+   */
+  private async emitThreadUpdate(client: PoolClient, threadStream: ThreadStreamStats | null): Promise<void> {
+    if (!threadStream?.parentStreamId) return
+    const anchorId = threadStream.parentAnchorId ?? threadStream.parentMessageId
+    if (!anchorId) return
 
-    const parentMessage = await MessageRepository.findById(client, params.parentMessageId)
-    if (!parentMessage) return
-
-    const [threadSummary, thread] = await Promise.all([
-      StreamRepository.findThreadSummaryByParentMessage(client, params.parentMessageId),
-      StreamRepository.findByParentMessage(client, params.parentStreamId, params.parentMessageId),
-    ])
-    await OutboxRepository.insert(client, "message:updated", {
-      workspaceId: params.workspaceId,
-      streamId: params.parentStreamId,
-      messageId: params.parentMessageId,
-      updateType: "reply_count",
-      replyCount: parentMessage.replyCount,
+    const threadSummary = await StreamRepository.findThreadSummaryByParentMessage(client, anchorId)
+    await OutboxRepository.insert(client, "thread:updated", {
+      workspaceId: threadStream.workspaceId,
+      streamId: threadStream.parentStreamId,
+      parentStreamId: threadStream.parentStreamId,
+      anchorId,
+      threadId: threadStream.id,
+      replyCount: threadStream.replyCount ?? 0,
       threadSummary,
-      threadId: thread?.id ?? null,
     })
+
+    if (anchorId.startsWith("msg_")) {
+      const parentMessage = await MessageRepository.findById(client, anchorId)
+      if (parentMessage) {
+        await OutboxRepository.insert(client, "message:updated", {
+          workspaceId: threadStream.workspaceId,
+          streamId: threadStream.parentStreamId,
+          messageId: anchorId,
+          updateType: "reply_count",
+          replyCount: parentMessage.replyCount,
+          threadSummary,
+          threadId: threadStream.id,
+        })
+      }
+    }
   }
 
   private async resolveActorType(
@@ -812,13 +842,14 @@ export class EventService {
       },
     })
 
-    if (stream?.parentMessageId && stream?.parentStreamId) {
-      await MessageRepository.incrementReplyCount(client, stream.parentMessageId)
-      await this.publishParentThreadUpdate(client, {
-        workspaceId: params.workspaceId,
-        parentStreamId: stream.parentStreamId,
-        parentMessageId: stream.parentMessageId,
-      })
+    if (stream?.parentStreamId && (stream.parentAnchorId || stream.parentMessageId)) {
+      // Legacy shadow: keep messages.reply_count dual-written for msg_ anchors
+      // (grace). Authoritative count lives on the thread stream row.
+      if (stream.parentMessageId) {
+        await MessageRepository.incrementReplyCount(client, stream.parentMessageId)
+      }
+      const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, 1)
+      await this.emitThreadUpdate(client, updatedThread ?? stream)
     }
 
     // A declared message assigns its conversation synchronously, in this same
@@ -972,12 +1003,10 @@ export class EventService {
         })
 
         const stream = await StreamRepository.findById(client, params.streamId)
-        if (stream?.parentMessageId && stream.parentStreamId) {
-          await this.publishParentThreadUpdate(client, {
-            workspaceId: params.workspaceId,
-            parentStreamId: stream.parentStreamId,
-            parentMessageId: stream.parentMessageId,
-          })
+        if (stream?.parentStreamId && (stream.parentAnchorId || stream.parentMessageId)) {
+          // No count change on edit — refresh the thread summary (latest-reply
+          // preview may have changed). `stream.replyCount` is already current.
+          await this.emitThreadUpdate(client, stream)
         }
       }
 
@@ -1102,13 +1131,12 @@ export class EventService {
         })
 
         const stream = await StreamRepository.findById(client, params.streamId)
-        if (stream?.parentMessageId && stream?.parentStreamId) {
-          await MessageRepository.decrementReplyCount(client, stream.parentMessageId)
-          await this.publishParentThreadUpdate(client, {
-            workspaceId: params.workspaceId,
-            parentStreamId: stream.parentStreamId,
-            parentMessageId: stream.parentMessageId,
-          })
+        if (stream?.parentStreamId && (stream.parentAnchorId || stream.parentMessageId)) {
+          if (stream.parentMessageId) {
+            await MessageRepository.decrementReplyCount(client, stream.parentMessageId)
+          }
+          const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
+          await this.emitThreadUpdate(client, updatedThread ?? stream)
         }
       }
 
@@ -1389,11 +1417,12 @@ export class EventService {
       })
 
       await MessageRepository.incrementReplyCountBy(client, params.targetMessageId, uniqueMessageIds.length)
-      await this.publishParentThreadUpdate(client, {
-        workspaceId: params.workspaceId,
-        parentStreamId: params.sourceStreamId,
-        parentMessageId: params.targetMessageId,
-      })
+      const updatedDestThread = await StreamRepository.bumpThreadReplyCount(
+        client,
+        destinationThread.id,
+        uniqueMessageIds.length
+      )
+      await this.emitThreadUpdate(client, updatedDestThread ?? destinationThread)
 
       // Snapshot the post-increment reply count + thread summary so we can
       // ship them inside `messages:moved` itself. Without this, source
@@ -1408,13 +1437,16 @@ export class EventService {
         params.targetMessageId
       )
 
-      if (sourceStream.parentStreamId && sourceStream.parentMessageId) {
-        await MessageRepository.decrementReplyCountBy(client, sourceStream.parentMessageId, uniqueMessageIds.length)
-        await this.publishParentThreadUpdate(client, {
-          workspaceId: params.workspaceId,
-          parentStreamId: sourceStream.parentStreamId,
-          parentMessageId: sourceStream.parentMessageId,
-        })
+      if (sourceStream.parentStreamId && (sourceStream.parentAnchorId || sourceStream.parentMessageId)) {
+        if (sourceStream.parentMessageId) {
+          await MessageRepository.decrementReplyCountBy(client, sourceStream.parentMessageId, uniqueMessageIds.length)
+        }
+        const updatedSourceThread = await StreamRepository.bumpThreadReplyCount(
+          client,
+          sourceStream.id,
+          -uniqueMessageIds.length
+        )
+        await this.emitThreadUpdate(client, updatedSourceThread ?? sourceStream)
       }
 
       if (created) {
@@ -1886,6 +1918,23 @@ export class EventService {
                 },
               }
             : event
+        }
+        // Threadable card events (delegation:created, call_started) anchor by
+        // their event id — inject the same thread projection so a fresh-load
+        // card renders its thread affordance without a second fetch.
+        if (event.eventType !== "message_created" && THREAD_ANCHORABLE_EVENT_TYPES.includes(event.eventType)) {
+          const threadData = threadDataMap.get(event.id)
+          if (!threadData) return event
+          const threadSummary = threadSummaryMap.get(event.id)
+          return {
+            ...event,
+            payload: {
+              ...(event.payload as Record<string, unknown>),
+              threadId: threadData.threadId,
+              replyCount: threadData.replyCount,
+              ...(threadSummary ? { threadSummary } : {}),
+            },
+          }
         }
         if (event.eventType !== "message_created") return event
         const payload = event.payload as MessageCreatedPayload

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import type { LinkPreviewSummary } from "@threa/types"
 import type { Request, Response } from "express"
 import type { StreamEvent } from "./event-repository"
-import { applyLinkPreviewStateToEvents, createStreamHandlers } from "./handlers"
+import { applyLinkPreviewStateToEvents, collectThreadAnchorIds, createStreamHandlers } from "./handlers"
 import type { StreamService } from "./service"
 import * as agentsBarrel from "../agents"
 
@@ -23,6 +23,16 @@ function createMessageEvent(messageId: string): StreamEvent {
     },
   }
 }
+
+describe("collectThreadAnchorIds", () => {
+  it("collects canonical message and threadable card anchors", () => {
+    const message = createMessageEvent("msg_1")
+    const delegation = { ...message, id: "event_delegation", eventType: "delegation:created" as const, payload: {} }
+    const membership = { ...message, id: "event_member", eventType: "member_joined" as const, payload: {} }
+
+    expect(collectThreadAnchorIds([message, delegation, membership])).toEqual(["msg_1", "event_delegation"])
+  })
+})
 
 describe("applyLinkPreviewStateToEvents", () => {
   it("attaches preview summaries to matching message events", () => {

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -288,6 +288,16 @@ const actorRewrapSchema = z.object({
 /** Default number of events returned in bootstrap and event list queries. */
 const EVENTS_DEFAULT_LIMIT = 50
 
+export function collectThreadAnchorIds(events: readonly StreamEvent[]): string[] {
+  return events
+    .map((event) => {
+      if (event.eventType === "message_created") return (event.payload as { messageId?: string }).messageId
+      if (THREAD_ANCHORABLE_EVENT_TYPES.includes(event.eventType)) return event.id
+      return undefined
+    })
+    .filter((id): id is string => !!id)
+}
+
 /** Audit ref for a range read: the stream plus the min/max sequence loaded. */
 function streamSequenceRangeRef(streamId: string, events: readonly StreamEvent[]): AuditSubjectRef {
   const ref: AuditSubjectRef = { type: "stream", id: streamId }
@@ -797,7 +807,12 @@ export function createStreamHandlers({
         })
       }
 
-      const enrichedEvents = await eventService.enrichBootstrapEvents(result.events, new Map())
+      const candidateAnchorIds = collectThreadAnchorIds(result.events)
+      const [threadDataMap, threadSummaryMap] = await Promise.all([
+        streamService.getThreadsWithReplyCounts(streamId, candidateAnchorIds),
+        streamService.getThreadSummaries(streamId, candidateAnchorIds),
+      ])
+      const enrichedEvents = await eventService.enrichBootstrapEvents(result.events, threadDataMap, threadSummaryMap)
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(
         linkPreviewService,
         workspaceId,
@@ -1066,13 +1081,7 @@ export function createStreamHandlers({
       // Candidate anchors = message ids of message_created events + event ids of
       // threadable card events (delegation:created, call_started). One anchor
       // track: a message anchors by its `msg_` id, a card by its `event_` id.
-      const candidateAnchorIds = events
-        .map((e) => {
-          if (e.eventType === "message_created") return (e.payload as { messageId?: string }).messageId
-          if (THREAD_ANCHORABLE_EVENT_TYPES.includes(e.eventType)) return e.id
-          return undefined
-        })
-        .filter((id): id is string => !!id)
+      const candidateAnchorIds = collectThreadAnchorIds(events)
       const threadScope = syncMode === "append" ? undefined : candidateAnchorIds
       const [threadDataMap, threadSummaryMap] = await Promise.all([
         streamService.getThreadsWithReplyCounts(streamId, threadScope),

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -24,6 +24,7 @@ import {
   StreamTypes,
   SLUG_PATTERN,
   CompanionModes,
+  THREAD_ANCHORABLE_EVENT_TYPES,
   E2E_ACTOR_KINDS,
   E2E_KEY_WRAP_RECIPIENT_KINDS,
   TOOL_PRIVACY_CATEGORIES,
@@ -1062,22 +1063,31 @@ export function createStreamHandlers({
       // otherwise stay stale until a hard refresh. The full map rides the
       // response as `threadStates` so the client can heal already-persisted
       // parent rows.
-      const parentMessageIds = events
-        .filter((e) => e.eventType === "message_created")
-        .map((e) => (e.payload as { messageId?: string }).messageId)
+      // Candidate anchors = message ids of message_created events + event ids of
+      // threadable card events (delegation:created, call_started). One anchor
+      // track: a message anchors by its `msg_` id, a card by its `event_` id.
+      const candidateAnchorIds = events
+        .map((e) => {
+          if (e.eventType === "message_created") return (e.payload as { messageId?: string }).messageId
+          if (THREAD_ANCHORABLE_EVENT_TYPES.includes(e.eventType)) return e.id
+          return undefined
+        })
         .filter((id): id is string => !!id)
-      const threadScope = syncMode === "append" ? undefined : parentMessageIds
+      const threadScope = syncMode === "append" ? undefined : candidateAnchorIds
       const [threadDataMap, threadSummaryMap] = await Promise.all([
         streamService.getThreadsWithReplyCounts(streamId, threadScope),
         streamService.getThreadSummaries(streamId, threadScope),
       ])
       const threadStates =
         syncMode === "append"
-          ? [...threadDataMap.entries()].map(([parentMessageId, thread]) => ({
-              parentMessageId,
+          ? [...threadDataMap.entries()].map(([anchorId, thread]) => ({
+              anchorId,
+              // Grace: msg_ anchors carry the legacy field (== anchorId) so an
+              // un-upgraded client keying on it stays correct; null for cards.
+              parentMessageId: anchorId.startsWith("msg_") ? anchorId : null,
               threadId: thread.threadId,
               replyCount: thread.replyCount,
-              threadSummary: threadSummaryMap.get(parentMessageId) ?? null,
+              threadSummary: threadSummaryMap.get(anchorId) ?? null,
             }))
           : undefined
 

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -1191,9 +1191,10 @@ export const StreamRepository = {
   },
 
   /**
-   * Find all threads anchored in a given parent stream, with reply counts read
-   * from the maintained `streams.reply_count` (the thread IS the stream its
-   * replies land in). Returns a map of anchorId -> { threadId, replyCount },
+   * Find all threads anchored in a given parent stream. During grace, message
+   * anchors read the legacy parent-message shadow because predecessor replicas
+   * update only that column; event anchors read `streams.reply_count`. Returns a
+   * map of anchorId -> { threadId, replyCount },
    * keyed by `COALESCE(parent_anchor_id, parent_message_id)` so message- and
    * event-anchored threads surface uniformly (and grace-window rows written by
    * an old-deploy replica with only the legacy column still resolve).
@@ -1214,8 +1215,15 @@ export const StreamRepository = {
       SELECT
         COALESCE(s.parent_anchor_id, s.parent_message_id) AS anchor_id,
         s.id,
-        s.reply_count
+        CASE
+          WHEN COALESCE(s.parent_anchor_id, s.parent_message_id) LIKE 'msg_%'
+            THEN COALESCE(anchor_message.reply_count, s.reply_count)
+          ELSE s.reply_count
+        END AS reply_count
       FROM streams s
+      LEFT JOIN messages anchor_message
+        ON anchor_message.id = COALESCE(s.parent_anchor_id, s.parent_message_id)
+       AND anchor_message.stream_id = s.parent_stream_id
       WHERE s.parent_stream_id = ${parentStreamId}
         AND s.type = 'thread'
         AND COALESCE(s.parent_anchor_id, s.parent_message_id) IS NOT NULL
@@ -1255,19 +1263,27 @@ export const StreamRepository = {
 
   /**
    * Anchor ids (of the given candidate set) whose thread in this parent stream
-   * has at least one live reply — read from the maintained `streams.reply_count`
-   * (plan §Projections). Used by boundary extraction to decide which anchors to
+   * has at least one live reply. Message anchors use the grace-period parent
+   * shadow; event anchors use `streams.reply_count`. Used by boundary extraction
+   * to decide which anchors to
    * pull thread content for.
    */
   async findAnchorsWithReplies(db: Querier, parentStreamId: string, anchorIds: string[]): Promise<Set<string>> {
     if (anchorIds.length === 0) return new Set<string>()
     const result = await db.query<{ anchor_id: string }>(sql`
-      SELECT COALESCE(parent_anchor_id, parent_message_id) AS anchor_id
-      FROM streams
-      WHERE parent_stream_id = ${parentStreamId}
-        AND type = 'thread'
-        AND reply_count > 0
-        AND COALESCE(parent_anchor_id, parent_message_id) = ANY(${anchorIds})
+      SELECT COALESCE(s.parent_anchor_id, s.parent_message_id) AS anchor_id
+      FROM streams s
+      LEFT JOIN messages anchor_message
+        ON anchor_message.id = COALESCE(s.parent_anchor_id, s.parent_message_id)
+       AND anchor_message.stream_id = s.parent_stream_id
+      WHERE s.parent_stream_id = ${parentStreamId}
+        AND s.type = 'thread'
+        AND CASE
+          WHEN COALESCE(s.parent_anchor_id, s.parent_message_id) LIKE 'msg_%'
+            THEN COALESCE(anchor_message.reply_count, s.reply_count)
+          ELSE s.reply_count
+        END > 0
+        AND COALESCE(s.parent_anchor_id, s.parent_message_id) = ANY(${anchorIds})
     `)
     return new Set(result.rows.map((r) => r.anchor_id))
   },

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -66,7 +66,7 @@ interface StreamRow {
  * the two aligned arrays and zip them in `threadSummaryFromRow`.
  */
 interface ThreadSummaryRow {
-  parent_message_id: string
+  anchor_id: string
   latest_message_id: string
   latest_author_id: string
   latest_author_type: string
@@ -1186,49 +1186,90 @@ export const StreamRepository = {
       SET parent_stream_id = ${params.destinationParentStreamId}, updated_at = NOW()
       WHERE workspace_id = ${params.workspaceId}
         AND parent_stream_id = ${params.sourceParentStreamId}
-        AND parent_message_id = ANY(${params.parentMessageIds})
+        AND COALESCE(parent_anchor_id, parent_message_id) = ANY(${params.parentMessageIds})
     `)
   },
 
   /**
-   * Find all threads for messages in a given parent stream, including reply counts.
-   * Returns a map of parentMessageId -> { threadId, replyCount }
-   * Counts only non-deleted replies so bootstrap matches the live thread-summary
-   * semantics and doesn't resurrect deleted-only threads after refresh.
+   * Find all threads anchored in a given parent stream, with reply counts read
+   * from the maintained `streams.reply_count` (the thread IS the stream its
+   * replies land in). Returns a map of anchorId -> { threadId, replyCount },
+   * keyed by `COALESCE(parent_anchor_id, parent_message_id)` so message- and
+   * event-anchored threads surface uniformly (and grace-window rows written by
+   * an old-deploy replica with only the legacy column still resolve).
    */
   async findThreadsWithReplyCounts(
     db: Querier,
     parentStreamId: string,
-    parentMessageIds?: string[]
+    anchorIds?: string[]
   ): Promise<Map<string, { threadId: string; replyCount: number }>> {
     // An empty scope matches nothing — skip the round-trip entirely.
-    if (parentMessageIds !== undefined && parentMessageIds.length === 0) {
+    if (anchorIds !== undefined && anchorIds.length === 0) {
       return new Map<string, { threadId: string; replyCount: number }>()
     }
-    // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
-    // list scopes the scan to those parents (bootstrap only needs summaries for
-    // the messages in its window, not every thread in the stream). An empty list
-    // matches nothing, returning an empty map without scanning.
-    const result = await db.query<{ parent_message_id: string; id: string; reply_count: string }>(sql`
+    // `anchorIds === undefined` keeps the whole-stream behavior; passing a list
+    // scopes the scan to those anchors (bootstrap only needs state for the items
+    // in its window, not every thread in the stream).
+    const result = await db.query<{ anchor_id: string; id: string; reply_count: number }>(sql`
       SELECT
-        s.parent_message_id,
+        COALESCE(s.parent_anchor_id, s.parent_message_id) AS anchor_id,
         s.id,
-        COUNT(m.id)::text AS reply_count
+        s.reply_count
       FROM streams s
-      LEFT JOIN messages m ON m.stream_id = s.id AND m.deleted_at IS NULL
       WHERE s.parent_stream_id = ${parentStreamId}
-        AND s.parent_message_id IS NOT NULL
-        AND (${parentMessageIds === undefined} OR s.parent_message_id = ANY(${parentMessageIds ?? []}))
-      GROUP BY s.id, s.parent_message_id
+        AND s.type = 'thread'
+        AND COALESCE(s.parent_anchor_id, s.parent_message_id) IS NOT NULL
+        AND (${anchorIds === undefined} OR COALESCE(s.parent_anchor_id, s.parent_message_id) = ANY(${anchorIds ?? []}))
     `)
     const map = new Map<string, { threadId: string; replyCount: number }>()
     for (const row of result.rows) {
-      map.set(row.parent_message_id, {
+      map.set(row.anchor_id, {
         threadId: row.id,
-        replyCount: parseInt(row.reply_count, 10),
+        replyCount: row.reply_count,
       })
     }
     return map
+  },
+
+  /**
+   * Atomically apply a reply-count delta to a thread stream row and refresh its
+   * `last_reply_at` from its own live messages (the source of truth, so a delete
+   * settles the timestamp back correctly). Increment is a race-safe in-place
+   * UPDATE (INV-20); `GREATEST(0, …)` guards underflow. Returns the updated row
+   * (with the post-mutation `replyCount`) for the caller's `thread:updated` emit.
+   */
+  async bumpThreadReplyCount(db: Querier, threadId: string, delta: number): Promise<Stream | null> {
+    const result = await db.query<StreamRow>(sql`
+      UPDATE streams
+      SET reply_count = GREATEST(0, reply_count + ${delta}),
+          last_reply_at = (
+            SELECT MAX(created_at) FROM messages
+            WHERE stream_id = ${threadId} AND deleted_at IS NULL
+          ),
+          updated_at = NOW()
+      WHERE id = ${threadId} AND type = 'thread'
+      RETURNING ${sql.raw(SELECT_FIELDS)}
+    `)
+    return result.rows[0] ? mapRowToStream(result.rows[0]) : null
+  },
+
+  /**
+   * Anchor ids (of the given candidate set) whose thread in this parent stream
+   * has at least one live reply — read from the maintained `streams.reply_count`
+   * (plan §Projections). Used by boundary extraction to decide which anchors to
+   * pull thread content for.
+   */
+  async findAnchorsWithReplies(db: Querier, parentStreamId: string, anchorIds: string[]): Promise<Set<string>> {
+    if (anchorIds.length === 0) return new Set<string>()
+    const result = await db.query<{ anchor_id: string }>(sql`
+      SELECT COALESCE(parent_anchor_id, parent_message_id) AS anchor_id
+      FROM streams
+      WHERE parent_stream_id = ${parentStreamId}
+        AND type = 'thread'
+        AND reply_count > 0
+        AND COALESCE(parent_anchor_id, parent_message_id) = ANY(${anchorIds})
+    `)
+    return new Set(result.rows.map((r) => r.anchor_id))
   },
 
   /**
@@ -1251,19 +1292,21 @@ export const StreamRepository = {
   async findThreadSummaries(
     db: Querier,
     parentStreamId: string,
-    parentMessageIds?: string[]
+    anchorIds?: string[]
   ): Promise<Map<string, ThreadSummary>> {
     // An empty scope matches nothing — skip the round-trip entirely.
-    if (parentMessageIds !== undefined && parentMessageIds.length === 0) {
+    if (anchorIds !== undefined && anchorIds.length === 0) {
       return new Map<string, ThreadSummary>()
     }
-    // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
-    // list scopes the (potentially large) reply scan to just those parents so a
+    // `anchorIds === undefined` keeps the whole-stream behavior; passing a list
+    // scopes the (potentially large) reply scan to just those anchors so a
     // bootstrap of a deep stream doesn't summarize every thread it has ever had.
+    // Keyed by `COALESCE(parent_anchor_id, parent_message_id)` so event-anchored
+    // threads surface and grace-window legacy-only rows still resolve.
     const result = await db.query<ThreadSummaryRow>(sql`
       WITH thread_messages AS (
         SELECT
-          s.parent_message_id,
+          COALESCE(s.parent_anchor_id, s.parent_message_id) AS anchor_id,
           m.id,
           m.author_id,
           m.author_type,
@@ -1272,40 +1315,41 @@ export const StreamRepository = {
         FROM streams s
         JOIN messages m ON m.stream_id = s.id
         WHERE s.parent_stream_id = ${parentStreamId}
-          AND s.parent_message_id IS NOT NULL
+          AND s.type = 'thread'
+          AND COALESCE(s.parent_anchor_id, s.parent_message_id) IS NOT NULL
           AND m.deleted_at IS NULL
-          AND (${parentMessageIds === undefined} OR s.parent_message_id = ANY(${parentMessageIds ?? []}))
+          AND (${anchorIds === undefined} OR COALESCE(s.parent_anchor_id, s.parent_message_id) = ANY(${anchorIds ?? []}))
       ),
       latest AS (
-        SELECT DISTINCT ON (parent_message_id)
-          parent_message_id, id, author_id, author_type, content_markdown, created_at
+        SELECT DISTINCT ON (anchor_id)
+          anchor_id, id, author_id, author_type, content_markdown, created_at
         FROM thread_messages
-        ORDER BY parent_message_id, created_at DESC, id DESC
+        ORDER BY anchor_id, created_at DESC, id DESC
       ),
       participants_distinct AS (
-        -- Pick the earliest reply row per (parent, author) so first_reply_at
+        -- Pick the earliest reply row per (anchor, author) so first_reply_at
         -- and first_reply_id come from the same row. Independent MIN()s could
         -- pair an early timestamp with a later id from the same author and
         -- destabilize the (first_reply_at, first_reply_id) tie-break.
-        SELECT DISTINCT ON (parent_message_id, author_id, author_type)
-          parent_message_id,
+        SELECT DISTINCT ON (anchor_id, author_id, author_type)
+          anchor_id,
           author_id,
           author_type,
           created_at AS first_reply_at,
           id AS first_reply_id
         FROM thread_messages
-        ORDER BY parent_message_id, author_id, author_type, created_at ASC, id ASC
+        ORDER BY anchor_id, author_id, author_type, created_at ASC, id ASC
       ),
       participants AS (
         SELECT
-          parent_message_id,
+          anchor_id,
           (ARRAY_AGG(author_id ORDER BY first_reply_at, first_reply_id))[1:3] AS author_ids,
           (ARRAY_AGG(author_type ORDER BY first_reply_at, first_reply_id))[1:3] AS author_types
         FROM participants_distinct
-        GROUP BY parent_message_id
+        GROUP BY anchor_id
       )
       SELECT
-        l.parent_message_id,
+        l.anchor_id,
         l.id AS latest_message_id,
         l.author_id AS latest_author_id,
         l.author_type AS latest_author_type,
@@ -1314,12 +1358,12 @@ export const StreamRepository = {
         COALESCE(p.author_ids, ARRAY[]::TEXT[]) AS participant_ids,
         COALESCE(p.author_types, ARRAY[]::TEXT[]) AS participant_types
       FROM latest l
-      LEFT JOIN participants p USING (parent_message_id)
+      LEFT JOIN participants p USING (anchor_id)
     `)
 
     const map = new Map<string, ThreadSummary>()
     for (const row of result.rows) {
-      map.set(row.parent_message_id, threadSummaryFromRow(row))
+      map.set(row.anchor_id, threadSummaryFromRow(row))
     }
     return map
   },
@@ -1337,11 +1381,11 @@ export const StreamRepository = {
    * is covered by a test that asserts both entry points return the same
    * `ThreadSummary` for a given parent.
    */
-  async findThreadSummaryByParentMessage(db: Querier, parentMessageId: string): Promise<ThreadSummary | null> {
+  async findThreadSummaryByParentMessage(db: Querier, anchorId: string): Promise<ThreadSummary | null> {
     const result = await db.query<ThreadSummaryRow>(sql`
       WITH thread_messages AS (
         SELECT
-          s.parent_message_id,
+          COALESCE(s.parent_anchor_id, s.parent_message_id) AS anchor_id,
           m.id,
           m.author_id,
           m.author_type,
@@ -1349,7 +1393,8 @@ export const StreamRepository = {
           m.created_at
         FROM streams s
         JOIN messages m ON m.stream_id = s.id
-        WHERE s.parent_message_id = ${parentMessageId}
+        WHERE COALESCE(s.parent_anchor_id, s.parent_message_id) = ${anchorId}
+          AND s.type = 'thread'
           AND m.deleted_at IS NULL
       ),
       participants_distinct AS (
@@ -1370,7 +1415,7 @@ export const StreamRepository = {
         FROM participants_distinct
       )
       SELECT
-        l.parent_message_id,
+        l.anchor_id,
         l.id AS latest_message_id,
         l.author_id AS latest_author_id,
         l.author_type AS latest_author_type,

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -2075,19 +2075,20 @@ export class StreamService {
   }
 
   /**
-   * Fetches threads and reply counts in a single query.
-   * Pass `parentMessageIds` to scope the scan to a specific bootstrap window.
+   * Fetches threads and reply counts in a single query, keyed by anchor id
+   * (`msg_…` / `event_…`). Pass `anchorIds` to scope the scan to a bootstrap
+   * window.
    */
   async getThreadsWithReplyCounts(
     streamId: string,
-    parentMessageIds?: string[]
+    anchorIds?: string[]
   ): Promise<Map<string, { threadId: string; replyCount: number }>> {
-    return StreamRepository.findThreadsWithReplyCounts(this.pool, streamId, parentMessageIds)
+    return StreamRepository.findThreadsWithReplyCounts(this.pool, streamId, anchorIds)
   }
 
   /**
-   * Get a map of parent messageId -> ThreadSummary for all messages in a stream
-   * whose thread has at least one non-deleted reply. See
+   * Get a map of anchorId -> ThreadSummary for every thread in a stream whose
+   * anchor has at least one non-deleted reply. See
    * {@link StreamRepository.findThreadSummaries}.
    *
    * The single-parent counterpart (`findThreadSummaryByParentMessage`) is
@@ -2096,9 +2097,9 @@ export class StreamService {
    * either break out of its existing `client` transaction or duplicate the
    * pool accessor, so it stays as a repository call.
    *
-   * Pass `parentMessageIds` to scope the scan to a specific bootstrap window.
+   * Pass `anchorIds` to scope the scan to a specific bootstrap window.
    */
-  async getThreadSummaries(streamId: string, parentMessageIds?: string[]): Promise<Map<string, ThreadSummary>> {
-    return StreamRepository.findThreadSummaries(this.pool, streamId, parentMessageIds)
+  async getThreadSummaries(streamId: string, anchorIds?: string[]): Promise<Map<string, ThreadSummary>> {
+    return StreamRepository.findThreadSummaries(this.pool, streamId, anchorIds)
   }
 }

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -34,6 +34,7 @@ export type OutboxEventType =
   | "message:deleted"
   | "messages:moved"
   | "message:updated"
+  | "thread:updated"
   | "reaction:added"
   | "reaction:removed"
   | "stream:created"
@@ -136,6 +137,7 @@ export type StreamScopedEventType =
   | "message:deleted"
   | "messages:moved"
   | "message:updated"
+  | "thread:updated"
   | "reaction:added"
   | "reaction:removed"
   | "stream:display_name_updated"
@@ -271,6 +273,24 @@ export interface MessageUpdatedOutboxPayload extends StreamScopedPayload {
    * each patch self-sufficient.
    */
   threadId?: string | null
+}
+
+/**
+ * A thread's reply stats changed. Stream-scoped ONLY (no timeline row, no
+ * EVENT_TYPES entry — same delivery class as `call:participants_changed`):
+ * `streamId` is the PARENT stream, so the generic stream-scoped router fans it
+ * to the parent room. Replaces `message:updated {updateType:"reply_count"}` for
+ * every anchor kind; the legacy patch is dual-emitted for `msg_` anchors through
+ * the grace period. `anchorId` is the canonical id of the anchored timeline item
+ * (`msg_…` / `event_…`); `replyCount` is the post-mutation value read off the
+ * thread stream row; `threadSummary` is `null` when the thread has no live reply.
+ */
+export interface ThreadUpdatedOutboxPayload extends StreamScopedPayload {
+  parentStreamId: string
+  anchorId: string
+  threadId: string
+  replyCount: number
+  threadSummary: import("@threa/types").ThreadSummary | null
 }
 
 export interface ReactionOutboxPayload extends StreamScopedPayload {
@@ -1110,6 +1130,7 @@ export interface OutboxEventPayloadMap {
   "message:deleted": MessageDeletedOutboxPayload
   "messages:moved": MessagesMovedOutboxPayload
   "message:updated": MessageUpdatedOutboxPayload
+  "thread:updated": ThreadUpdatedOutboxPayload
   "reaction:added": ReactionOutboxPayload
   "reaction:removed": ReactionOutboxPayload
   "stream:created": StreamCreatedOutboxPayload
@@ -1241,6 +1262,7 @@ const STREAM_SCOPED_EVENTS: StreamScopedEventType[] = [
   "message:deleted",
   "messages:moved",
   "message:updated",
+  "thread:updated",
   "reaction:added",
   "reaction:removed",
   "stream:display_name_updated",

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -159,6 +159,7 @@ describe("message move integration", () => {
     expect(result.thread.parentMessageId).toBe(target.id)
     expect(result.thread.rootStreamId).toBe(sourceStreamId)
     expect(result.thread.companionMode).toBe("on")
+    expect(result.thread.replyCount).toBe(2)
 
     // Move-in bumps the destination thread's streams.reply_count set-based by the
     // number of moved messages (chunk 2 projections; INV-56 single UPDATE).

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -160,6 +160,11 @@ describe("message move integration", () => {
     expect(result.thread.rootStreamId).toBe(sourceStreamId)
     expect(result.thread.companionMode).toBe("on")
 
+    // Move-in bumps the destination thread's streams.reply_count set-based by the
+    // number of moved messages (chunk 2 projections; INV-56 single UPDATE).
+    const destThreadRow = await StreamRepository.findById(pool, result.thread.id)
+    expect(destThreadRow?.replyCount).toBe(2)
+
     const sourceEvents = await StreamEventRepository.list(pool, sourceStreamId, { types: ["message_created"] })
     const sourceMessageIds = sourceEvents.map((event) => (event.payload as { messageId: string }).messageId)
     expect(sourceMessageIds).toEqual([target.id, keep.id])

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -412,7 +412,18 @@ describe("SyncLogRepository catch-up reads", () => {
   const HOUR = 60 * 60 * 1000
   const DAY = 24 * HOUR
 
+  // The prune window is global (its LIMIT spans all workspaces), so expired rows
+  // accumulated in a long-lived local threa_test DB crowd a fresh workspace out
+  // of the batch and the exact-assertion tests below see an empty prune result.
+  async function drainExpired(cutoff: Date) {
+    for (;;) {
+      const { deletedCount } = await SyncLogRepository.pruneExpiredEntries(pool, { cutoff, minKeep: 0, limit: 1000 })
+      if (deletedCount < 1000) break
+    }
+  }
+
   test("prune deletes expired entries beyond the count floor and advances retained_from atomically", async () => {
+    await drainExpired(new Date(Date.now() - 30 * DAY))
     const workspaceId = uniqueId("ws")
     const userId = uniqueId("usr")
     const ids: bigint[] = []
@@ -462,6 +473,7 @@ describe("SyncLogRepository catch-up reads", () => {
   })
 
   test("the time horizon spares entries newer than the cutoff", async () => {
+    await drainExpired(new Date(Date.now() - 30 * DAY))
     const workspaceId = uniqueId("ws")
     const userId = uniqueId("usr")
     const ids: bigint[] = []

--- a/apps/backend/tests/integration/thread-graph.test.ts
+++ b/apps/backend/tests/integration/thread-graph.test.ts
@@ -761,4 +761,181 @@ describe("Thread Graph", () => {
       expect(second.createdBy).toBe(first.createdBy)
     })
   })
+
+  describe("Projections: streams.reply_count maintenance + thread:updated", () => {
+    async function seedChannel(name: string) {
+      const ownerId = userId()
+      const actorId = userId()
+      const wsId = workspaceId()
+      await withTestTransaction(pool, async (client) => {
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: `${name} Workspace`,
+          slug: `${name}-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+        await addTestMember(client, wsId, ownerId)
+        await addTestMember(client, wsId, actorId)
+      })
+      const channel = await streamService.createChannel({
+        workspaceId: wsId,
+        slug: `${name}-channel-${Date.now()}`,
+        createdBy: ownerId,
+        visibility: Visibilities.PUBLIC,
+      })
+      return { wsId, ownerId, actorId, channelId: channel.id }
+    }
+
+    async function outboxByAnchor(anchorId: string) {
+      const rows = await pool.query<{ event_type: string; payload: Record<string, unknown> }>(
+        `SELECT event_type, payload FROM outbox
+         WHERE (event_type = 'thread:updated' AND payload->>'anchorId' = $1)
+            OR (event_type = 'message:updated' AND payload->>'messageId' = $1 AND payload->>'updateType' = 'reply_count')
+         ORDER BY id ASC`,
+        [anchorId]
+      )
+      return rows.rows
+    }
+
+    test("message-anchored reply bumps streams.reply_count and dual-emits thread:updated + legacy message:updated", async () => {
+      const { wsId, ownerId, channelId } = await seedChannel("proj-msg")
+      const parent = await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: channelId,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("parent"),
+      })
+      const thread = await streamService.createThread({
+        workspaceId: wsId,
+        parentStreamId: channelId,
+        parentAnchorId: parent.id,
+        createdBy: ownerId,
+      })
+
+      const reply = await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: thread.id,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("reply one"),
+      })
+
+      const afterReply = await StreamRepository.findById(pool, thread.id)
+      expect(afterReply?.replyCount).toBe(1)
+      expect(afterReply?.lastReplyAt).not.toBeNull()
+
+      const emitted = await outboxByAnchor(parent.id)
+      const threadUpdated = emitted.find((r) => r.event_type === "thread:updated")
+      expect(threadUpdated?.payload).toMatchObject({
+        parentStreamId: channelId,
+        anchorId: parent.id,
+        threadId: thread.id,
+        replyCount: 1,
+      })
+      // GRACE: legacy patch dual-emitted for the msg_ anchor.
+      expect(emitted.some((r) => r.event_type === "message:updated")).toBe(true)
+
+      // Deleting the reply settles the count back to 0.
+      await eventService.deleteMessage({
+        workspaceId: wsId,
+        streamId: thread.id,
+        messageId: reply.id,
+        actorId: ownerId,
+      })
+      const afterDelete = await StreamRepository.findById(pool, thread.id)
+      expect(afterDelete?.replyCount).toBe(0)
+    })
+
+    test("event-anchored reply bumps reply_count and emits thread:updated with the event anchor and NO legacy message:updated", async () => {
+      const { wsId, ownerId, actorId, channelId } = await seedChannel("proj-event")
+      const cardEvent = await StreamEventRepository.insert(pool, {
+        id: eventId(),
+        streamId: channelId,
+        eventType: "delegation:created",
+        payload: {},
+        actorId,
+        actorType: "user",
+      })
+      const thread = await streamService.createThread({
+        workspaceId: wsId,
+        parentStreamId: channelId,
+        parentAnchorId: cardEvent.id,
+        createdBy: ownerId,
+      })
+
+      await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: thread.id,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("reply on the card"),
+      })
+
+      const afterReply = await StreamRepository.findById(pool, thread.id)
+      expect(afterReply?.replyCount).toBe(1)
+
+      const emitted = await outboxByAnchor(cardEvent.id)
+      expect(emitted.map((r) => r.event_type)).toContain("thread:updated")
+      expect(emitted.map((r) => r.event_type)).not.toContain("message:updated")
+      const threadUpdated = emitted.find((r) => r.event_type === "thread:updated")
+      expect(threadUpdated?.payload).toMatchObject({
+        parentStreamId: channelId,
+        anchorId: cardEvent.id,
+        threadId: thread.id,
+        replyCount: 1,
+      })
+    })
+
+    test("bootstrap threadStates carries anchorId for both message and card anchors, counts from streams columns", async () => {
+      const { wsId, ownerId, actorId, channelId } = await seedChannel("proj-bootstrap")
+      // Message-anchored thread with one reply.
+      const parent = await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: channelId,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("parent msg"),
+      })
+      const msgThread = await streamService.createThread({
+        workspaceId: wsId,
+        parentStreamId: channelId,
+        parentAnchorId: parent.id,
+        createdBy: ownerId,
+      })
+      await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: msgThread.id,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("reply"),
+      })
+      // Event-anchored thread with one reply.
+      const cardEvent = await StreamEventRepository.insert(pool, {
+        id: eventId(),
+        streamId: channelId,
+        eventType: "delegation:created",
+        payload: {},
+        actorId,
+        actorType: "user",
+      })
+      const cardThread = await streamService.createThread({
+        workspaceId: wsId,
+        parentStreamId: channelId,
+        parentAnchorId: cardEvent.id,
+        createdBy: ownerId,
+      })
+      await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: cardThread.id,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("reply on card"),
+      })
+
+      const dataMap = await streamService.getThreadsWithReplyCounts(channelId, [parent.id, cardEvent.id])
+      expect(dataMap.get(parent.id)).toEqual({ threadId: msgThread.id, replyCount: 1 })
+      expect(dataMap.get(cardEvent.id)).toEqual({ threadId: cardThread.id, replyCount: 1 })
+    })
+  })
 })

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -311,34 +311,31 @@ describe("Thread Summary", () => {
       })
     })
 
-    test("message anchors honor predecessor-replica reply-count writes during grace", async () => {
+    test("predecessor-replica writes keep the thread projection synchronized during grace", async () => {
       const fixture = await seedThread(1, 1)
 
       await pool.query("UPDATE streams SET reply_count = 0 WHERE id = $1", [fixture.threadId])
-      await pool.query("UPDATE messages SET reply_count = 1 WHERE id = $1", [fixture.parentMessageId])
+      await pool.query("UPDATE messages SET reply_count = 2 WHERE id = $1", [fixture.parentMessageId])
 
       let counts = await StreamRepository.findThreadsWithReplyCounts(pool, fixture.channelId, [fixture.parentMessageId])
       let anchors = await StreamRepository.findAnchorsWithReplies(pool, fixture.channelId, [fixture.parentMessageId])
+      const projectedAfterIncrement = await StreamRepository.findById(pool, fixture.threadId)
       expect({
         count: counts.get(fixture.parentMessageId)?.replyCount,
+        projectedCount: projectedAfterIncrement?.replyCount,
         included: anchors.has(fixture.parentMessageId),
-      }).toEqual({
-        count: 1,
-        included: true,
-      })
+      }).toEqual({ count: 2, projectedCount: 2, included: true })
 
-      await pool.query("UPDATE streams SET reply_count = 1 WHERE id = $1", [fixture.threadId])
       await pool.query("UPDATE messages SET reply_count = 0 WHERE id = $1", [fixture.parentMessageId])
 
       counts = await StreamRepository.findThreadsWithReplyCounts(pool, fixture.channelId, [fixture.parentMessageId])
       anchors = await StreamRepository.findAnchorsWithReplies(pool, fixture.channelId, [fixture.parentMessageId])
+      const projectedAfterDecrement = await StreamRepository.findById(pool, fixture.threadId)
       expect({
         count: counts.get(fixture.parentMessageId)?.replyCount,
+        projectedCount: projectedAfterDecrement?.replyCount,
         included: anchors.has(fixture.parentMessageId),
-      }).toEqual({
-        count: 0,
-        included: false,
-      })
+      }).toEqual({ count: 0, projectedCount: 0, included: false })
     })
   })
 

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -310,6 +310,36 @@ describe("Thread Summary", () => {
         counts: [],
       })
     })
+
+    test("message anchors honor predecessor-replica reply-count writes during grace", async () => {
+      const fixture = await seedThread(1, 1)
+
+      await pool.query("UPDATE streams SET reply_count = 0 WHERE id = $1", [fixture.threadId])
+      await pool.query("UPDATE messages SET reply_count = 1 WHERE id = $1", [fixture.parentMessageId])
+
+      let counts = await StreamRepository.findThreadsWithReplyCounts(pool, fixture.channelId, [fixture.parentMessageId])
+      let anchors = await StreamRepository.findAnchorsWithReplies(pool, fixture.channelId, [fixture.parentMessageId])
+      expect({
+        count: counts.get(fixture.parentMessageId)?.replyCount,
+        included: anchors.has(fixture.parentMessageId),
+      }).toEqual({
+        count: 1,
+        included: true,
+      })
+
+      await pool.query("UPDATE streams SET reply_count = 1 WHERE id = $1", [fixture.threadId])
+      await pool.query("UPDATE messages SET reply_count = 0 WHERE id = $1", [fixture.parentMessageId])
+
+      counts = await StreamRepository.findThreadsWithReplyCounts(pool, fixture.channelId, [fixture.parentMessageId])
+      anchors = await StreamRepository.findAnchorsWithReplies(pool, fixture.channelId, [fixture.parentMessageId])
+      expect({
+        count: counts.get(fixture.parentMessageId)?.replyCount,
+        included: anchors.has(fixture.parentMessageId),
+      }).toEqual({
+        count: 0,
+        included: false,
+      })
+    })
   })
 
   describe("thread-summary reactivity", () => {

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -2287,6 +2287,145 @@ describe("registerStreamSocketHandlers — message:updated reply_count patch", (
   })
 })
 
+describe("registerStreamSocketHandlers — thread:updated patch (anchor-agnostic)", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  const summary = {
+    lastReplyAt: new Date().toISOString(),
+    participants: [{ id: "user_2", type: "user" as const }],
+    latestReply: { messageId: "msg_r1", actorId: "user_2", actorType: "user" as const, contentMarkdown: "a reply" },
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("heals a message anchor (msg_) live by canonical id", async () => {
+    const streamId = "stream_tu_msg"
+    await db.events.put({
+      ...makeEvent({ id: "evt_msg_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_anchor", contentMarkdown: "parent" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    await emit("thread:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      parentStreamId: streamId,
+      anchorId: "msg_anchor",
+      threadId: "stream_thread_m",
+      replyCount: 3,
+      threadSummary: summary,
+    })
+
+    const row = await db.events.get("evt_msg_parent")
+    expect(row?.payload).toMatchObject({
+      messageId: "msg_anchor",
+      threadId: "stream_thread_m",
+      replyCount: 3,
+      threadSummary: summary,
+    })
+    cleanup()
+  })
+
+  it("heals a card anchor (event_) live, located by event id", async () => {
+    const streamId = "stream_tu_card"
+    // A threadable card row (e.g. delegation:created) — anchored by its own id.
+    await db.events.put({
+      ...makeEvent({ id: "event_card1", streamId, sequence: "12", eventType: "delegation:created" }),
+      payload: { delegationId: "dlg_1", title: "Do the thing" },
+      workspaceId: "ws_1",
+      _sequenceNum: 12,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    await emit("thread:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      parentStreamId: streamId,
+      anchorId: "event_card1",
+      threadId: "stream_thread_c",
+      replyCount: 2,
+      threadSummary: summary,
+    })
+
+    const row = await db.events.get("event_card1")
+    expect(row?.payload).toMatchObject({
+      delegationId: "dlg_1",
+      threadId: "stream_thread_c",
+      replyCount: 2,
+      threadSummary: summary,
+    })
+    cleanup()
+  })
+
+  it("double delivery (both thread:updated and legacy message:updated) converges — no double count", async () => {
+    const streamId = "stream_tu_double"
+    await db.events.put({
+      ...makeEvent({ id: "evt_double_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_double", contentMarkdown: "parent" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    // Both patches carry the same ABSOLUTE count — last-write-wins is idempotent.
+    await emit("thread:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      parentStreamId: streamId,
+      anchorId: "msg_double",
+      threadId: "stream_thread_d",
+      replyCount: 4,
+      threadSummary: summary,
+    })
+    await emit("message:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      messageId: "msg_double",
+      updateType: "reply_count",
+      replyCount: 4,
+      threadSummary: summary,
+      threadId: "stream_thread_d",
+    })
+
+    const row = await db.events.get("evt_double_parent")
+    expect(row?.payload).toMatchObject({ replyCount: 4, threadId: "stream_thread_d", threadSummary: summary })
+    cleanup()
+  })
+})
+
 describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
   beforeEach(async () => {
     await db.events.clear()
@@ -2318,7 +2457,13 @@ describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
       syncMode: "append",
       snapshotAt: new Date().toISOString(),
       threadStates: [
-        { parentMessageId: "msg_stale_parent", threadId: "stream_thread_1", replyCount: 6, threadSummary: healSummary },
+        {
+          anchorId: "msg_stale_parent",
+          parentMessageId: "msg_stale_parent",
+          threadId: "stream_thread_1",
+          replyCount: 6,
+          threadSummary: healSummary,
+        },
       ],
     }
 
@@ -2354,7 +2499,13 @@ describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
       syncMode: "append",
       snapshotAt,
       threadStates: [
-        { parentMessageId: "msg_fresh_parent", threadId: "stream_thread_2", replyCount: 6, threadSummary: null },
+        {
+          anchorId: "msg_fresh_parent",
+          parentMessageId: "msg_fresh_parent",
+          threadId: "stream_thread_2",
+          replyCount: 6,
+          threadSummary: null,
+        },
       ],
     }
 
@@ -2387,7 +2538,13 @@ describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
       syncMode: "append",
       snapshotAt: new Date().toISOString(),
       threadStates: [
-        { parentMessageId: "msg_noop_parent", threadId: "stream_thread_3", replyCount: 2, threadSummary: null },
+        {
+          anchorId: "msg_noop_parent",
+          parentMessageId: "msg_noop_parent",
+          threadId: "stream_thread_3",
+          replyCount: 2,
+          threadSummary: null,
+        },
       ],
     }
 
@@ -2395,5 +2552,82 @@ describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
 
     const row = await db.events.get("evt_noop_parent")
     expect(row?._cachedAt).toBe(cachedAt)
+  })
+
+  it("heals a card event's payload by anchorId (event_ anchor)", async () => {
+    const streamId = "stream_heal_card"
+
+    // A threadable card row persisted before its thread got replies.
+    await db.events.put({
+      ...makeEvent({ id: "event_card_stale", streamId, sequence: "10", eventType: "delegation:created" }),
+      payload: { delegationId: "dlg_9", title: "task" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now() - 60_000,
+    })
+
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([makeEvent({ id: "evt_new", streamId, sequence: "20" })], streamId),
+      syncMode: "append",
+      snapshotAt: new Date().toISOString(),
+      threadStates: [
+        {
+          anchorId: "event_card_stale",
+          parentMessageId: null,
+          threadId: "stream_thread_card",
+          replyCount: 4,
+          threadSummary: healSummary,
+        },
+      ],
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const row = await db.events.get("event_card_stale")
+    expect(row?.payload).toMatchObject({
+      delegationId: "dlg_9",
+      threadId: "stream_thread_card",
+      replyCount: 4,
+      threadSummary: healSummary,
+    })
+    expect(row?._patchedAt).toBeUndefined()
+  })
+
+  it("heals from a legacy threadState with no anchorId (old-backend deploy skew)", async () => {
+    const streamId = "stream_heal_legacy"
+
+    await db.events.put({
+      ...makeEvent({ id: "evt_legacy_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_legacy_parent", contentMarkdown: "parent" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now() - 60_000,
+    })
+
+    // Old-backend append response: legacy shape, keyed on parentMessageId only,
+    // anchorId absent at runtime (required in the type, unfilled on the wire).
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([makeEvent({ id: "evt_new", streamId, sequence: "20" })], streamId),
+      syncMode: "append",
+      snapshotAt: new Date().toISOString(),
+      threadStates: [
+        {
+          parentMessageId: "msg_legacy_parent",
+          threadId: "stream_thread_legacy",
+          replyCount: 6,
+          threadSummary: healSummary,
+        } as unknown as NonNullable<StreamBootstrap["threadStates"]>[number],
+      ],
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const row = await db.events.get("evt_legacy_parent")
+    expect(row?.payload).toMatchObject({
+      messageId: "msg_legacy_parent",
+      threadId: "stream_thread_legacy",
+      replyCount: 6,
+      threadSummary: healSummary,
+    })
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -481,37 +481,69 @@ async function writeBootstrapEventsAndStream(
  * `_cachedAt` is bumped — this is bootstrap data, not a socket patch, so
  * `_patchedAt` must stay untouched for later bootstraps to reason against.
  */
+type BootstrapThreadState = NonNullable<StreamBootstrap["threadStates"]>[number]
+
 async function applyBootstrapThreadStates(streamId: string, bootstrap: StreamBootstrap, now: number): Promise<void> {
   if (!bootstrap.threadStates || bootstrap.threadStates.length === 0) return
 
   const snapshotMs = bootstrap.snapshotAt ? Date.parse(bootstrap.snapshotAt) : null
-  const stateByMessageId = new Map(bootstrap.threadStates.map((state) => [state.parentMessageId, state]))
 
-  await db.events
-    .where("[streamId+eventType]")
-    .equals([streamId, "message_created"])
-    .filter((event) => {
-      const state = stateByMessageId.get((event.payload as { messageId?: string })?.messageId ?? "")
-      if (!state) return false
-      if (snapshotMs !== null && event._patchedAt !== undefined && event._patchedAt > snapshotMs) return false
-      const payload = event.payload as { threadId?: string; replyCount?: number; threadSummary?: unknown }
-      return (
-        payload.threadId !== state.threadId ||
-        (payload.replyCount ?? 0) !== state.replyCount ||
-        JSON.stringify(payload.threadSummary ?? null) !== JSON.stringify(state.threadSummary)
-      )
-    })
-    .modify((event) => {
-      const state = stateByMessageId.get((event.payload as { messageId?: string })?.messageId ?? "")
-      if (!state) return
-      event.payload = {
-        ...(event.payload as Record<string, unknown>),
-        threadId: state.threadId,
-        replyCount: state.replyCount,
-        threadSummary: state.threadSummary,
-      }
-      event._cachedAt = now
-    })
+  // A row patched by a socket handler AFTER the bootstrap snapshot keeps its
+  // (newer) values — the snapshot may have read stale data. Only `_cachedAt` is
+  // bumped: this is bootstrap data, not a socket patch.
+  const isStale = (event: CachedEvent): boolean =>
+    snapshotMs !== null && event._patchedAt !== undefined && event._patchedAt > snapshotMs
+  const differs = (payload: Record<string, unknown>, state: BootstrapThreadState): boolean =>
+    payload.threadId !== state.threadId ||
+    ((payload.replyCount as number | undefined) ?? 0) !== state.replyCount ||
+    JSON.stringify(payload.threadSummary ?? null) !== JSON.stringify(state.threadSummary)
+  const heal = (event: CachedEvent, state: BootstrapThreadState): void => {
+    event.payload = {
+      ...(event.payload as Record<string, unknown>),
+      threadId: state.threadId,
+      replyCount: state.replyCount,
+      threadSummary: state.threadSummary,
+    }
+    event._cachedAt = now
+  }
+
+  // Message anchors: located by payload.messageId over the indexed
+  // message_created rows. Event anchors (card threads): located by event id
+  // (the anchor id IS the event's primary key).
+  const anchorIdOf = (s: BootstrapThreadState): string | null => s.anchorId ?? s.parentMessageId
+  const messageStateByAnchor = new Map<string, BootstrapThreadState>()
+  const eventAnchorStates: BootstrapThreadState[] = []
+  for (const s of bootstrap.threadStates) {
+    const id = anchorIdOf(s)
+    if (id === null || id === undefined) continue
+    if (id.startsWith("msg_")) messageStateByAnchor.set(id, s)
+    else eventAnchorStates.push(s)
+  }
+
+  if (messageStateByAnchor.size > 0) {
+    await db.events
+      .where("[streamId+eventType]")
+      .equals([streamId, "message_created"])
+      .filter((event) => {
+        const state = messageStateByAnchor.get((event.payload as { messageId?: string })?.messageId ?? "")
+        if (!state || isStale(event)) return false
+        return differs(event.payload as Record<string, unknown>, state)
+      })
+      .modify((event) => {
+        const state = messageStateByAnchor.get((event.payload as { messageId?: string })?.messageId ?? "")
+        if (state) heal(event, state)
+      })
+  }
+
+  for (const state of eventAnchorStates) {
+    await db.events
+      .where("id")
+      .equals(anchorIdOf(state) as string)
+      .modify((event) => {
+        if (event.streamId !== streamId || isStale(event)) return
+        if (differs(event.payload as Record<string, unknown>, state)) heal(event, state)
+      })
+  }
 }
 
 /**
@@ -653,6 +685,18 @@ interface MessageUpdatedPayload {
   threadId?: string | null
 }
 
+interface ThreadUpdatedPayload {
+  workspaceId: string
+  /** The PARENT stream (routing scope) — where the anchored timeline item lives. */
+  streamId: string
+  parentStreamId: string
+  /** Canonical id of the anchored item: `msg_…` (message) or `event_…` (card). */
+  anchorId: string
+  threadId: string
+  replyCount: number
+  threadSummary: ThreadSummary | null
+}
+
 interface CommandEventPayload {
   workspaceId: string
   streamId: string
@@ -746,6 +790,34 @@ export async function updateMessageEvent(
       // bumped by socket-handler patches (and the optimistic helpers below
       // that mirror them); bootstrap apply leaves it alone so a later
       // bootstrap response can decide whether its enrichment is stale.
+      event._patchedAt = now
+    })
+}
+
+/**
+ * Patch the timeline row a thread anchors on, by its canonical anchor id. A
+ * `msg_` anchor routes to the message_created row via {@link updateMessageEvent};
+ * an `event_` anchor (card thread) is located by the event's own primary key.
+ * One lookup for both kinds (mirrors `matchesDeepLinkTarget`: payload.messageId
+ * for messages, event id for cards).
+ */
+export async function updateEventByAnchor(
+  streamId: string,
+  anchorId: string,
+  updater: (payload: Record<string, unknown>) => Record<string, unknown>
+): Promise<void> {
+  if (anchorId.startsWith("msg_")) {
+    await updateMessageEvent(streamId, anchorId, updater)
+    return
+  }
+  await db.events
+    .where("id")
+    .equals(anchorId)
+    .modify((event) => {
+      if (event.streamId !== streamId) return
+      const now = Date.now()
+      event.payload = updater(event.payload as Record<string, unknown>)
+      event._cachedAt = now
       event._patchedAt = now
     })
 }
@@ -1166,9 +1238,10 @@ export function registerStreamSocketHandlers(
   const handleStreamCreated = async (payload: StreamCreatedPayload) => {
     if (payload.streamId !== streamId) return
     const stream = payload.stream
-    if (!stream.parentMessageId) return
+    const anchorId = stream.parentAnchorId ?? stream.parentMessageId
+    if (!anchorId) return
 
-    await updateMessageEvent(streamId, stream.parentMessageId, (p) => ({
+    await updateEventByAnchor(streamId, anchorId, (p) => ({
       ...p,
       threadId: stream.id,
     }))
@@ -1216,6 +1289,21 @@ export function registerStreamSocketHandlers(
       }
       return p
     })
+  }
+
+  // Live thread reply-stat patch for EVERY anchor kind. Heals the anchored row
+  // (message or card) by canonical id. Payloads carry ABSOLUTE counts, so this
+  // is idempotent last-write-wins — for `msg_` anchors the legacy
+  // `message:updated` patch (below) also arrives during the grace period and
+  // converges on the identical values (no double-increment, no flicker).
+  const handleThreadUpdated = async (payload: ThreadUpdatedPayload) => {
+    if (payload.streamId !== streamId) return
+    await updateEventByAnchor(streamId, payload.anchorId, (p) => ({
+      ...p,
+      replyCount: payload.replyCount,
+      threadSummary: payload.threadSummary,
+      threadId: payload.threadId,
+    }))
   }
 
   const handleAppendEvent = async (
@@ -1402,6 +1490,7 @@ export function registerStreamSocketHandlers(
   socket.on("reaction:removed", handleReactionRemoved)
   socket.on("stream:created", handleStreamCreated)
   socket.on("message:updated", handleMessageUpdated)
+  socket.on("thread:updated", handleThreadUpdated)
   socket.on("stream:member_joined", handleAppendEvent)
   socket.on("stream:member_added", handleAppendEvent)
   socket.on("stream:member_removed", handleAppendEvent)
@@ -1444,6 +1533,7 @@ export function registerStreamSocketHandlers(
     socket.off("reaction:removed", handleReactionRemoved)
     socket.off("stream:created", handleStreamCreated)
     socket.off("message:updated", handleMessageUpdated)
+    socket.off("thread:updated", handleThreadUpdated)
     socket.off("stream:member_joined", handleAppendEvent)
     socket.off("stream:member_added", handleAppendEvent)
     socket.off("stream:member_removed", handleAppendEvent)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -226,7 +226,18 @@ export interface StreamBootstrap {
    * replies.
    */
   threadStates?: Array<{
-    parentMessageId: string
+    /**
+     * Canonical id of the timeline item the thread anchors on: `msg_…` for a
+     * message, `event_…` for a card. The one anchor track — healing locates the
+     * row to patch by this id (INV-2 prefix is the discriminator).
+     */
+    anchorId: string
+    /**
+     * Legacy message anchor. Populated (== `anchorId`) for `msg_` anchors during
+     * the grace period so old-deploy clients keying on it stay correct; `null`
+     * for event-anchored threads.
+     */
+    parentMessageId: string | null
     threadId: string
     replyCount: number
     threadSummary: ThreadSummary | null


### PR DESCRIPTION
## Problem

PR 1 (#1495) made threads creatable on card events, but every "thread exists" projection is still message-shaped: reply counts live on `messages.reply_count`, live updates ride `message:updated {updateType:"reply_count"}`, bootstrap `threadStates` keys on `parentMessageId`, and frontend healing stamps only message rows. An event-anchored thread would be invisible everywhere. PR 2 of 7, plan `docs/plans/event-anchored-threads.md` §Projections.

## Solution

One projection track for all anchors, legacy dual-emitted through the deploy-skew window (Kris: unify now, grace then remove).

- New outbox event `thread:updated { parentStreamId, anchorId, threadId, replyCount, threadSummary }` (`lib/outbox/repository.ts`) — stream-scoped fan-out like `message:updated`, no timeline row, no broadcast slot (INV-61 untouched). `emitThreadUpdate` replaces `publishParentThreadUpdate` in `event-service.ts`; legacy `message:updated` reply_count patch still dual-emitted for `msg_` anchors only.
- Reply stats maintained on the thread stream row: `StreamRepository.bumpThreadReplyCount` (atomic, `GREATEST(0, …)` underflow guard, INV-20) at all four mutation sites (create/delete/move-in/move-out); `messages.reply_count` stays dual-written (grace). `last_reply_at` recomputed absolute from live messages, not decremented.
- Anchor-blind reads converted to `COALESCE(parent_anchor_id, parent_message_id)`: `findThreadsWithReplyCounts`, `findThreadSummaries`, `findThreadSummaryByParentMessage`, `moveChildThreadsToParent`; counts now read `streams.reply_count`. Conversations child-thread query simplified to `parent_stream_id = streamId` (a thread's parent stream IS its anchor's stream — correct for both kinds). Boundary extraction's `threadRootIds` reads threads-with-replies from `streams` (`findAnchorsWithReplies`) instead of `messages.reply_count`.
- Bootstrap `threadStates` entries become `{ anchorId, parentMessageId, threadId, replyCount, threadSummary }` — `anchorId` authoritative, `parentMessageId` grace-populated for msg_ anchors; the builder gathers candidate anchors from `message_created` AND `THREAD_ANCHORABLE_EVENT_TYPES` card events, so card rows arrive pre-enriched.
- Frontend `stream-sync.ts`: `updateEventByAnchor` heals by canonical id (message path via `payload.messageId`, card path via event-row id); new `thread:updated` handler; `handleStreamCreated` stamps `threadId` for both kinds; legacy reply_count handler untouched. Deploy-skew regression test: a legacy `{parentMessageId}`-only threadState (old backend) heals without throwing.
- Ride-along test fix (surfaced by this run): `sync-catch-up.test.ts` prune tests assumed a clean table, but the prune window is global (`LIMIT` spans workspaces) — 14k expired rows accumulated in a long-lived local `threa_test` crowd the test workspace out. Tests now drain the backlog first; failing locally since before this stack, green in CI's fresh DB.

## Test plan

- [x] backend `bun run test:unit` — 3473 pass; typecheck clean
- [x] backend integration (live DB) — 650 pass incl. new thread-graph reply-flow/emit for both anchor kinds, message-move reply_count, fixed sync-catch-up 16/16
- [x] frontend `src/sync` vitest — 394 pass (incl. deploy-skew healing + double-delivery convergence); typecheck clean
- [x] packages/types — 136 pass
- Adversarial verify (Opus xhigh): 2 fix rounds (deploy-skew healing crash on legacy threadStates; reply-count underflow); final verdict clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
