### PR TITLE
fix: kick live unmanaged Claude channel sessions

### DIFF
--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -1,6 +1,6 @@
 # harness-daemon
 
-Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). Run `threa-harnessd help` for the full command list.
+Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). If a Claude channel session was launched by the standalone worktree helper and has no inventory row, `kick` can still resolve its exact runtime session ID from a live `server:threa-channel` tmux pane and nudge it without adopting or reviving it. Run `threa-harnessd help` for the full command list.
 
 ## `up` (alias `resume-active`)
 

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -6,7 +6,14 @@ import { installBootResume } from "./boot"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
 import { findLocalClaudeChannelPane, type LocalTmuxPane } from "./discovery"
 import { die } from "./errors"
-import { findAgent, findAgentOrUndefined, inventoryPath, readInventory, upsertAgent } from "./inventory"
+import {
+  findAgent,
+  findAgentOrUndefined,
+  inventoryPath,
+  readInventory,
+  readInventoryReadonly,
+  upsertAgent,
+} from "./inventory"
 import { acquireProcessLock } from "./lock"
 import { commandExists, commandPath, output } from "./shell"
 import {
@@ -552,7 +559,7 @@ export function kickAgent(
   send: typeof sendKeys = sendKeys,
   discover: (runtimeSessionId: string) => LocalTmuxPane | undefined = findLocalClaudeChannelPane
 ): void {
-  const managed = findAgentOrUndefined(ref)
+  const managed = findAgentOrUndefined(ref, readInventoryReadonly())
   if (managed) {
     const target = tmuxKeyTarget(managed)
     send(target, ["Enter"])

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -4,8 +4,9 @@ import { existsSync } from "node:fs"
 import { basename, dirname, join } from "node:path"
 import { installBootResume } from "./boot"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
+import { findLocalClaudeChannelPane, type LocalTmuxPane } from "./discovery"
 import { die } from "./errors"
-import { findAgent, inventoryPath, readInventory, upsertAgent } from "./inventory"
+import { findAgent, findAgentOrUndefined, inventoryPath, readInventory, upsertAgent } from "./inventory"
 import { acquireProcessLock } from "./lock"
 import { commandExists, commandPath, output } from "./shell"
 import {
@@ -545,11 +546,28 @@ function tmuxKeyTarget(agent: ManagedAgent): string {
   return die(`${agent.name} has no unambiguous tmux pane recorded; restart the managed session`)
 }
 
-/** Nudge the managed agent's TUI with Enter (e.g. accept a blocking prompt). */
-export function kickAgent(ref: string, send: typeof sendKeys = sendKeys): void {
-  const target = tmuxKeyTarget(findAgent(ref))
-  send(target, ["Enter"])
-  console.log(`harnessd: kicked ${target}`)
+/** Nudge the linked agent's TUI with Enter (e.g. accept a blocking prompt). */
+export function kickAgent(
+  ref: string,
+  send: typeof sendKeys = sendKeys,
+  discover: (runtimeSessionId: string) => LocalTmuxPane | undefined = findLocalClaudeChannelPane
+): void {
+  const managed = findAgentOrUndefined(ref)
+  if (managed) {
+    const target = tmuxKeyTarget(managed)
+    send(target, ["Enter"])
+    console.log(`harnessd: kicked ${target}`)
+    return
+  }
+
+  const pane = discover(ref)
+  if (!pane) {
+    die(`no managed agent found for ${ref}; no live local Claude channel pane matched that runtime session`)
+  }
+  send(pane.paneId, ["Enter"])
+  console.log(
+    `harnessd: kicked unmanaged Claude channel pane ${pane.paneId} (PID ${pane.panePid}, ${pane.sessionName}:${pane.windowName})`
+  )
 }
 
 /** Send Esc to interrupt the agent's current turn (Claude Code / Pi) without killing the window. */

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -70,6 +70,7 @@ describe("parseClaudeChannelLaunch", () => {
       "bash -c 'claude --dangerously-load-development-channels server:threa-channel'",
       "python claude --dangerously-load-development-channels server:threa-channel",
       "pi --session-id ccs-target --dangerously-load-development-channels server:threa-channel",
+      "claude -- --dangerously-load-development-channels server:threa-channel",
     ]) {
       expect(parseClaudeChannelLaunch(command)).toBeUndefined()
     }

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { deriveClaudeRuntimeIdentity } from "./spawners"
+import {
+  findLocalClaudeChannelPane,
+  listLocalTmuxPanes,
+  parseClaudeChannelLaunch,
+  parseTmuxPanes,
+  type LocalTmuxPane,
+} from "./discovery"
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "1",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 33336,
+    cwd: "/Users/me/dev/threa.feature",
+    startCommand:
+      '"/Users/me/.local/bin/claude --name threa.feature --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions "',
+    ...overrides,
+  }
+}
+
+describe("parseTmuxPanes", () => {
+  test("keeps live panes and their start command", () => {
+    const input = [
+      '0\t1\tfeature\t@7\t%8\t33336\t/Users/me/dev/threa.feature\t"claude --dangerously-load-development-channels server:threa-channel"',
+      "1\t1\tdead\t@9\t%10\t99\t/tmp\tclaude",
+      "",
+    ].join("\n")
+
+    expect(parseTmuxPanes(input)).toEqual([
+      {
+        sessionName: "1",
+        windowName: "feature",
+        windowId: "@7",
+        paneId: "%8",
+        panePid: 33336,
+        cwd: "/Users/me/dev/threa.feature",
+        startCommand: '"claude --dangerously-load-development-channels server:threa-channel"',
+      },
+    ])
+  })
+})
+
+test("tmux inspection failures stay distinguishable from no matching pane", () => {
+  expect(() => listLocalTmuxPanes(() => ({ stdout: "", stderr: "no server running", exitCode: 1 }))).toThrow(
+    "could not inspect local tmux panes: no server running"
+  )
+})
+
+describe("parseClaudeChannelLaunch", () => {
+  test("accepts direct and env-prefixed Claude channel launch forms", () => {
+    expect(
+      parseClaudeChannelLaunch(
+        '"/Users/me/.local/bin/claude --name threa.feature --dangerously-load-development-channels server:threa-channel "'
+      )
+    ).toEqual({ runtimeSessionId: undefined })
+    expect(
+      parseClaudeChannelLaunch(
+        "env 'THREA_RUNTIME_SESSION_ID=ccs.explicit' /opt/bin/claude --dangerously-load-development-channels=server:threa-channel"
+      )
+    ).toEqual({ runtimeSessionId: "ccs-explicit" })
+  })
+
+  test("rejects commands that only contain Claude channel tokens", () => {
+    for (const command of [
+      "echo claude --dangerously-load-development-channels server:threa-channel",
+      "bash -c 'claude --dangerously-load-development-channels server:threa-channel'",
+      "python claude --dangerously-load-development-channels server:threa-channel",
+      "pi --session-id ccs-target --dangerously-load-development-channels server:threa-channel",
+    ]) {
+      expect(parseClaudeChannelLaunch(command)).toBeUndefined()
+    }
+  })
+})
+
+describe("findLocalClaudeChannelPane", () => {
+  test("matches a standalone helper launch by its cwd-derived runtime session id", () => {
+    const candidate = pane()
+
+    expect(deriveClaudeRuntimeIdentity(candidate.cwd, {}, "host-a").runtimeSessionId).toBe("ccs-4dca54f22ee90414")
+    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a")).toEqual(candidate)
+  })
+
+  test("prefers and normalizes the runtime session id explicitly recorded in the launch command", () => {
+    const candidate = pane({
+      startCommand:
+        '"env THREA_INSTANCE_ID=cc-one THREA_RUNTIME_SESSION_ID=ccs.explicit claude --dangerously-load-development-channels server:threa-channel"',
+    })
+
+    expect(findLocalClaudeChannelPane("ccs-explicit", [candidate], {}, "other-host")).toEqual(candidate)
+  })
+
+  test("rejects non-channel, renamed legacy-channel, and non-Claude panes", () => {
+    const candidates = [
+      pane({ startCommand: '"claude --dangerously-skip-permissions"' }),
+      pane({ startCommand: '"claude --dangerously-load-development-channels server:threa"' }),
+      pane({ startCommand: '"echo claude --dangerously-load-development-channels server:threa-channel"' }),
+      pane({
+        startCommand: '"pi --session-id ccs-target --dangerously-load-development-channels server:threa-channel"',
+      }),
+    ]
+
+    expect(
+      findLocalClaudeChannelPane("ccs-target", candidates, { runtimeSessionId: "ccs-target" }, "host-a")
+    ).toBeUndefined()
+  })
+
+  test("refuses an ambiguous runtime identity", () => {
+    expect(() =>
+      findLocalClaudeChannelPane(
+        "ccs-shared",
+        [pane(), pane({ paneId: "%9", panePid: 44444, cwd: "/Users/me/dev/threa.other" })],
+        { runtimeSessionId: "ccs-shared" },
+        "host-a"
+      )
+    ).toThrow("multiple live unmanaged Claude channel panes match ccs-shared: %8, %9")
+  })
+})

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -100,6 +100,7 @@ export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch |
   let channel = false
   for (; index < words.length; index += 1) {
     const word = words[index]!
+    if (word === "--") break
     if (word === "--dangerously-load-development-channels" && words[index + 1] === "server:threa-channel") {
       channel = true
       break

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -1,0 +1,173 @@
+import { basename } from "node:path"
+import { hostname } from "node:os"
+import { output } from "./shell"
+import { deriveClaudeRuntimeIdentity, readThreaChannelConfig, sanitizeId } from "./spawners"
+import type { ThreaChannelConfig } from "./types"
+
+export interface LocalTmuxPane {
+  sessionName: string
+  windowName: string
+  windowId: string
+  paneId: string
+  panePid: number
+  cwd: string
+  startCommand: string
+}
+
+interface ClaudeChannelLaunch {
+  runtimeSessionId?: string
+}
+
+function shellWords(input: string): string[] | undefined {
+  const words: string[] = []
+  let word = ""
+  let quote: "'" | '"' | undefined
+  let escaped = false
+  let started = false
+
+  for (const char of input.trim()) {
+    if (escaped) {
+      word += char
+      escaped = false
+      started = true
+      continue
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true
+      started = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = undefined
+      else word += char
+      started = true
+      continue
+    }
+    if (char === "'" || char === '"') {
+      quote = char
+      started = true
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (started) {
+        words.push(word)
+        word = ""
+        started = false
+      }
+      continue
+    }
+    word += char
+    started = true
+  }
+
+  if (quote || escaped) return undefined
+  if (started) words.push(word)
+  return words
+}
+
+function launchWords(command: string): string[] | undefined {
+  const firstPass = shellWords(command)
+  if (!firstPass) return undefined
+  if (firstPass.length !== 1 || !/\s/.test(firstPass[0]!)) return firstPass
+  return shellWords(firstPass[0]!)
+}
+
+function parseAssignment(word: string): { name: string; value: string } | undefined {
+  const match = word.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/s)
+  return match ? { name: match[1]!, value: match[2]! } : undefined
+}
+
+export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch | undefined {
+  const words = launchWords(command)
+  if (!words || words.length === 0) return undefined
+
+  let index = 0
+  if (basename(words[index]!) === "env") index += 1
+
+  let runtimeSessionId: string | undefined
+  while (index < words.length) {
+    const assignment = parseAssignment(words[index]!)
+    if (!assignment) break
+    if (assignment.name === "THREA_RUNTIME_SESSION_ID") {
+      runtimeSessionId = sanitizeId(assignment.value).slice(0, 64)
+    }
+    index += 1
+  }
+
+  if (index >= words.length || basename(words[index]!) !== "claude") return undefined
+  index += 1
+
+  let channel = false
+  for (; index < words.length; index += 1) {
+    const word = words[index]!
+    if (word === "--dangerously-load-development-channels" && words[index + 1] === "server:threa-channel") {
+      channel = true
+      break
+    }
+    if (word === "--dangerously-load-development-channels=server:threa-channel") {
+      channel = true
+      break
+    }
+  }
+  return channel ? { runtimeSessionId } : undefined
+}
+
+export function parseTmuxPanes(text: string): LocalTmuxPane[] {
+  const panes: LocalTmuxPane[] = []
+  for (const line of text.split("\n")) {
+    if (!line) continue
+    const fields = line.split("\t")
+    const [dead, sessionName, windowName, windowId, paneId, panePid, cwd] = fields
+    if (dead !== "0" || !sessionName || !windowName || !windowId || !paneId || !panePid || !cwd) continue
+    const pid = Number(panePid)
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue
+    panes.push({
+      sessionName,
+      windowName,
+      windowId,
+      paneId,
+      panePid: pid,
+      cwd,
+      startCommand: fields.slice(7).join("\t"),
+    })
+  }
+  return panes
+}
+
+export function listLocalTmuxPanes(run: typeof output = output): LocalTmuxPane[] {
+  const result = run(
+    [
+      "tmux",
+      "list-panes",
+      "-a",
+      "-F",
+      "#{pane_dead}\t#{session_name}\t#{window_name}\t#{window_id}\t#{pane_id}\t#{pane_pid}\t#{pane_current_path}\t#{pane_start_command}",
+    ],
+    { allowFailure: true }
+  )
+  if (result.exitCode !== 0) {
+    throw new Error(`could not inspect local tmux panes: ${result.stderr.trim() || `tmux exited ${result.exitCode}`}`)
+  }
+  return parseTmuxPanes(result.stdout)
+}
+
+function runtimeSessionIdForPane(pane: LocalTmuxPane, config: ThreaChannelConfig, host: string): string | undefined {
+  const launch = parseClaudeChannelLaunch(pane.startCommand)
+  if (!launch) return undefined
+  return launch.runtimeSessionId ?? deriveClaudeRuntimeIdentity(pane.cwd, config, host).runtimeSessionId
+}
+
+export function findLocalClaudeChannelPane(
+  runtimeSessionId: string,
+  panes: LocalTmuxPane[] = listLocalTmuxPanes(),
+  config: ThreaChannelConfig = readThreaChannelConfig(),
+  host = hostname()
+): LocalTmuxPane | undefined {
+  const matches = panes.filter((pane) => runtimeSessionIdForPane(pane, config, host) === runtimeSessionId)
+  if (matches.length > 1) {
+    throw new Error(
+      `multiple live unmanaged Claude channel panes match ${runtimeSessionId}: ${matches.map((pane) => pane.paneId).join(", ")}`
+    )
+  }
+  return matches[0]
+}

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -168,7 +168,7 @@ export function upsertAgent(agent: ManagedAgent): void {
   }
 }
 
-export function findAgent(ref: string): ManagedAgent {
+export function findAgentOrUndefined(ref: string): ManagedAgent | undefined {
   const agents = readInventory()
   const byId = agents.find((agent) => agent.id === ref)
   if (byId) return byId
@@ -179,7 +179,10 @@ export function findAgent(ref: string): ManagedAgent {
   if (byRuntimeSession[0]) return byRuntimeSession[0]
 
   const matches = agents.filter((agent) => agent.name === ref)
-  if (matches.length === 0) die(`no agent found for ${ref}`)
   if (matches.length > 1) die(`multiple agents match ${ref}; use id`)
   return matches[0]
+}
+
+export function findAgent(ref: string): ManagedAgent {
+  return findAgentOrUndefined(ref) ?? die(`no agent found for ${ref}`)
 }

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -113,6 +113,42 @@ export function readInventory(): ManagedAgent[] {
   }
 }
 
+export function readInventoryReadonly(): ManagedAgent[] {
+  const path = inventoryPath()
+  if (!existsSync(path)) return []
+  const db = new Database(path, { readonly: true })
+  try {
+    const table = db.query("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'managed_agents'").get()
+    if (!table) return []
+    const columns = new Set(
+      (db.query("PRAGMA table_info(managed_agents)").all() as Array<{ name: string }>).map(({ name }) => name)
+    )
+    const optional = [
+      "worktree",
+      "branch",
+      "tmux_session",
+      "tmux_window",
+      "tmux_window_id",
+      "tmux_pane_id",
+      "scratchpad_url",
+      "instance_id",
+      "runtime_session_id",
+      "last_output",
+      "probe_failures",
+      "probe_backoff_until",
+    ]
+    const projection = optional.map((name) => (columns.has(name) ? name : `NULL AS ${name}`))
+    const rows = db
+      .query(
+        `SELECT id, name, runtime, status, ${projection.join(", ")}, command_json, created_at, updated_at FROM managed_agents ORDER BY created_at ASC`
+      )
+      .all() as ManagedAgentRow[]
+    return rows.map(rowToAgent)
+  } finally {
+    db.close()
+  }
+}
+
 export function upsertAgent(agent: ManagedAgent): void {
   const db = openInventory()
   try {
@@ -168,8 +204,7 @@ export function upsertAgent(agent: ManagedAgent): void {
   }
 }
 
-export function findAgentOrUndefined(ref: string): ManagedAgent | undefined {
-  const agents = readInventory()
+export function findAgentOrUndefined(ref: string, agents: ManagedAgent[] = readInventory()): ManagedAgent | undefined {
   const byId = agents.find((agent) => agent.id === ref)
   if (byId) return byId
 

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite"
 import { afterEach, expect, mock, spyOn, test } from "bun:test"
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -14,7 +14,7 @@ import {
 import { launchAgentPlist } from "./boot"
 import { parseResume, parseSpawn } from "./cli"
 import { kickAgent, restoredSessionMatches, reviveAgent, type ReviveDeps, type ReviveOutcome } from "./commands"
-import { findAgent, readInventory, upsertAgent } from "./inventory"
+import { findAgent, readInventory, readInventoryReadonly, upsertAgent } from "./inventory"
 import { acquireProcessLock } from "./lock"
 import {
   claudeLaunchArgs,
@@ -161,6 +161,89 @@ test("kick discovers a live unmanaged Claude channel pane by runtime session id"
     )
     expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
     expect(existsSync(inventory)).toBeFalse()
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("kick lookup leaves legacy inventory unchanged for managed and standalone agents", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  const path = join(mkdtempSync(join(tmpdir(), "harnessd-legacy-kick-")), "inventory.sqlite")
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE managed_agents (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, runtime TEXT NOT NULL, status TEXT NOT NULL,
+      tmux_session TEXT, tmux_window TEXT, tmux_pane_id TEXT,
+      command_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    );
+    INSERT INTO managed_agents VALUES (
+      'managed-id', 'managed-name', 'claude', 'online', 'legacy', 'managed', '%9', '["claude"]',
+      '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'
+    )
+  `)
+  const schemaBefore = db.query("PRAGMA table_info(managed_agents)").all()
+  db.close()
+  process.env.THREA_HARNESSD_INVENTORY = path
+  try {
+    const sent: Array<{ target: string; keys: string[] }> = []
+    kickAgent(
+      "managed-id",
+      (target, keys) => sent.push({ target, keys }),
+      () => {
+        throw new Error("exact managed match must take priority")
+      }
+    )
+    kickAgent(
+      "standalone-session",
+      (target, keys) => sent.push({ target, keys }),
+      () => ({
+        sessionName: "1",
+        windowName: "standalone",
+        windowId: "@7",
+        paneId: "%8",
+        panePid: 33336,
+        cwd: "/repo/threa.standalone",
+        startCommand: "claude --dangerously-load-development-channels server:threa-channel",
+      })
+    )
+    expect(sent).toEqual([
+      { target: "%9", keys: ["Enter"] },
+      { target: "%8", keys: ["Enter"] },
+    ])
+    const verify = new Database(path, { readonly: true })
+    expect(verify.query("PRAGMA table_info(managed_agents)").all()).toEqual(schemaBefore)
+    verify.close()
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("kick lookup works with a read-only inventory file", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  const path = join(mkdtempSync(join(tmpdir(), "harnessd-readonly-kick-")), "inventory.sqlite")
+  process.env.THREA_HARNESSD_INVENTORY = path
+  try {
+    upsertAgent(agent({ tmuxWindowId: "@7", tmuxPaneId: "%8" }))
+    chmodSync(path, 0o444)
+    const sent: Array<{ target: string; keys: string[] }> = []
+    kickAgent("claude-1", (target, keys) => sent.push({ target, keys }))
+    expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
+  } finally {
+    chmodSync(path, 0o644)
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("read-only inventory lookup does not create a missing file", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  const path = join(mkdtempSync(join(tmpdir(), "harnessd-readonly-missing-")), "inventory.sqlite")
+  process.env.THREA_HARNESSD_INVENTORY = path
+  try {
+    expect(readInventoryReadonly()).toEqual([])
+    expect(existsSync(path)).toBeFalse()
   } finally {
     if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
     else process.env.THREA_HARNESSD_INVENTORY = previousPath

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -119,15 +119,65 @@ test("resolves slash-command kicks by the latest matching runtime session id", (
   }
 })
 
-test("kick sends Enter to the managed tmux pane", () => {
+test("kick sends Enter to the managed tmux pane without discovery", () => {
   const previousPath = process.env.THREA_HARNESSD_INVENTORY
   const dir = mkdtempSync(join(tmpdir(), "harnessd-kick-"))
   process.env.THREA_HARNESSD_INVENTORY = join(dir, "inventory.sqlite")
   try {
     const sent: Array<{ target: string; keys: string[] }> = []
     upsertAgent(agent({ runtimeSessionId: "ccs-one", tmuxWindowId: "@7", tmuxPaneId: "%8" }))
-    kickAgent("ccs-one", (target, keys) => sent.push({ target, keys }))
+    kickAgent(
+      "ccs-one",
+      (target, keys) => sent.push({ target, keys }),
+      () => {
+        throw new Error("managed kick must not run discovery")
+      }
+    )
     expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("kick discovers a live unmanaged Claude channel pane by runtime session id", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  const inventory = join(mkdtempSync(join(tmpdir(), "harnessd-unmanaged-kick-")), "missing.sqlite")
+  process.env.THREA_HARNESSD_INVENTORY = inventory
+  try {
+    const sent: Array<{ target: string; keys: string[] }> = []
+    kickAgent(
+      "ccs-one",
+      (target, keys) => sent.push({ target, keys }),
+      () => ({
+        sessionName: "1",
+        windowName: "standalone",
+        windowId: "@7",
+        paneId: "%8",
+        panePid: 33336,
+        cwd: "/repo/threa.standalone",
+        startCommand: "claude --dangerously-load-development-channels server:threa-channel",
+      })
+    )
+    expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
+    expect(existsSync(inventory)).toBeFalse()
+  } finally {
+    if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+    else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("kick reports unmanaged lookup separately when no live pane matches", () => {
+  const previousPath = process.env.THREA_HARNESSD_INVENTORY
+  process.env.THREA_HARNESSD_INVENTORY = join(mkdtempSync(join(tmpdir(), "harnessd-missing-kick-")), "missing.sqlite")
+  try {
+    expect(() =>
+      kickAgent(
+        "ccs-missing",
+        () => undefined,
+        () => undefined
+      )
+    ).toThrow("no managed agent found for ccs-missing; no live local Claude channel pane matched that runtime session")
   } finally {
     if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
     else process.env.THREA_HARNESSD_INVENTORY = previousPath

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -492,17 +492,27 @@ export function readThreaChannelConfig(): ThreaChannelConfig {
   }
 }
 
-export function claudeRuntimeIdentity(
+export function deriveClaudeRuntimeIdentity(
   worktree: string,
   config: ThreaChannelConfig = {},
   host = hostname()
 ): { instanceId: string; runtimeSessionId: string } {
   const seed = `${host}:${worktree}`
   return {
-    instanceId: sanitizeId(process.env.THREA_INSTANCE_ID || config.instanceId || stableId("cc", seed)).slice(0, 64),
-    runtimeSessionId: sanitizeId(
-      process.env.THREA_RUNTIME_SESSION_ID || config.runtimeSessionId || stableId("ccs", seed)
-    ).slice(0, 64),
+    instanceId: sanitizeId(config.instanceId || stableId("cc", seed)).slice(0, 64),
+    runtimeSessionId: sanitizeId(config.runtimeSessionId || stableId("ccs", seed)).slice(0, 64),
+  }
+}
+
+export function claudeRuntimeIdentity(
+  worktree: string,
+  config: ThreaChannelConfig = {},
+  host = hostname()
+): { instanceId: string; runtimeSessionId: string } {
+  const derived = deriveClaudeRuntimeIdentity(worktree, config, host)
+  return {
+    instanceId: sanitizeId(process.env.THREA_INSTANCE_ID || derived.instanceId).slice(0, 64),
+    runtimeSessionId: sanitizeId(process.env.THREA_RUNTIME_SESSION_ID || derived.runtimeSessionId).slice(0, 64),
   }
 }
 
@@ -530,7 +540,7 @@ export function claudeLaunchCommand(
     .join(" ")
 }
 
-function sanitizeId(value: string): string {
+export function sanitizeId(value: string): string {
   return value.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "")
 }
 


### PR DESCRIPTION
## Problem

`/kick` resolves only `managed_agents`. Claude channel sessions created by the standalone worktree helper have a valid runtime session ID and live tmux pane but no inventory row, so harnessd reports “no agent found” while the runtime is alive.

## Solution

Allow `kickAgent` to discover an otherwise-unmanaged Claude channel pane by exact runtime identity.

- Enumerate live tmux panes only after inventory lookup misses.
- Accept only a fail-closed launch shape: optional environment assignments, then the `claude` executable, then `--dangerously-load-development-channels server:threa-channel`.
- Prefer an explicit `THREA_RUNTIME_SESSION_ID`; otherwise derive the same stable ID from hostname + exact pane cwd.
- Require one match, send Enter to its stable pane ID, and leave inventory unchanged. This controls an existing process only; it does not adopt, launch, revive, or create a scratchpad.
- Distinguish tmux inspection failure, no matching live pane, and ambiguous matches.

This is the truthful-control slice only. Runtime-state normalization and richer frontend activity remain separate follow-up work.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/discovery.ts` | Parse qualified Claude channel launches and resolve live tmux panes by runtime ID (**new**) |
| `extensions/harness-daemon/src/commands.ts`, `inventory.ts`, `spawners.ts` | Add inventory-miss fallback and shared deterministic identity helpers |
| `extensions/harness-daemon/src/discovery.test.ts`, `resume.test.ts` | Cover exact matching, false-positive rejection, ambiguity, no-match errors, and no inventory adoption |
| `extensions/harness-daemon/README.md` | Document unmanaged `/kick` behavior |

## Test plan

- [x] `cd extensions/harness-daemon && bun test` — 53 pass
- [x] `cd extensions/harness-daemon && bun run typecheck`
- [x] pre-commit repository lint, monorepo typecheck, Dockerfile checks, migration checks, and OpenAPI check
- [x] read-only live fixture: `ccs-940fa3309fada85e` resolved to pane `%140`, PID `33336`, without sending keys

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787301348&installation_model_id=20758&pr_number=1499&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1499&signature=16e0b23f37aac1cea928cb8bd077a7fbed7c5a527a05de1dbc1cec0a0b86087a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->