### PR TITLE
feat: add Claude session status command

### DIFF
--- a/apps/backend/src/features/commands/catalog.test.ts
+++ b/apps/backend/src/features/commands/catalog.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "bun:test"
+import { listSessionControlCommandInfos, SESSION_CONTROL_COMMAND_NAMES } from "./catalog"
+
+describe("session-control command catalog", () => {
+  it("defines command info for every canonical runtime command", () => {
+    expect(listSessionControlCommandInfos().map((command) => command.name)).toEqual([...SESSION_CONTROL_COMMAND_NAMES])
+  })
+})

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -16,6 +16,7 @@ export const SESSION_CONTROL_COMMAND_NAMES = [
   "steer",
   "stop",
   "kick",
+  "status",
   "run",
   "carry-on",
 ] as const
@@ -110,6 +111,12 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
     {
       name: "kick",
       description: "Nudge the linked session to continue",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+    },
+    {
+      name: "status",
+      description: "Show the linked session's connection, activity, and current terminal view",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
     },

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -22,7 +22,7 @@ describe("resolveRuntimeInvocationRouting", () => {
   })
 
   it("routes every other command to session-control regardless of runtime kind", () => {
-    for (const name of ["model", "compact", "thinking", "skill", "reload", "shell", "run"]) {
+    for (const name of ["model", "compact", "thinking", "skill", "reload", "shell", "status", "run"]) {
       for (const kind of [BotRuntimeKinds.PI_LOCAL, BotRuntimeKinds.CLAUDE_CODE_CHANNEL]) {
         expect(resolveRuntimeInvocationRouting(name, kind)).toEqual({
           trigger: BotInvocationTriggers.SESSION_CONTROL,

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -2,8 +2,9 @@
 
 Status: **implemented + tmux mechanics live-verified** on `feat/harness-steer`, 2026-06-26.
 Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`, `reload` —
-later joined by `thinking`, `carry-on` (quota carry-on; see `docs/quota-carry-on.md`), and
-`kick` (an Enter nudge routed through harnessd). The
+later joined by `thinking`, `carry-on` (quota carry-on; see `docs/quota-carry-on.md`),
+`kick` (an Enter nudge routed through harnessd), and `status` (Threa connectivity, local session
+metadata, and a bounded capture of the current tmux pane). The
 genuinely-novel tmux paths ($TMUX_PANE inheritance, Esc interrupt, `/model`) are verified against
 Claude Code v2.1.193 (and live testing found + fixed two bugs — see the checklist); the full
 dispatch round-trip through a real scratchpad is still only unit-tested.
@@ -115,6 +116,7 @@ Notes:
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **stop**            | `Escape`                                                                                                                                 | Complete every in-flight invocation (interrupted), ack the stop invocation: "Stopped Claude."                                                                                                                                                                                                                                                           |
 | **kick**            | `harnessd kick <runtime-session-id>` → `Enter`                                                                                           | Nudge a managed pane past a blocking prompt, then acknowledge the command.                                                                                                                                                                                                                                                                              |
+| **status**          | `tmux display-message` + `capture-pane`                                                                                                  | Report channel/link/WebSocket state, active work and blockers, runtime/tmux/git identity, and the current visible pane. Read-only; no key injection.                                                                                                                                                                                                    |
 | **steer `<text>`**  | Turn in flight: `Ctrl-U` + bracketed paste + `Enter` (Claude's native mid-turn steering, **no Escape**). Idle: the interrupt path below. | Turn in flight: record a `steer` step on the RUNNING invocation's trace, fold queued msgs + steer text into the injected block, close swept msgs `noResponse`, complete /steer immediately — the running turn keeps its trace and its `reply` answers the steer. Idle: drain + one combined turn under the /steer invocation (original semantics below) |
 | **model `<alias>`** | `typeLine("/model <alias>")`                                                                                                             | Ack "Model set to `<alias>`." (best-effort)                                                                                                                                                                                                                                                                                                             |
 | **compact**         | `typeLine("/compact")`                                                                                                                   | Ack                                                                                                                                                                                                                                                                                                                                                     |
@@ -194,7 +196,7 @@ The channel advertises in its `bot:hello` / presence `capabilities` **only when 
   "supportsActiveScratchpad": true,
   "supportsPersistentSessions": true,
   "supportsSessionControlCommands": true,
-  "sessionControlCommands": ["stop", "steer", "kick", "model", "thinking", "compact", "run", "reload"],
+  "sessionControlCommands": ["stop", "steer", "kick", "status", "model", "thinking", "compact", "run", "reload"],
   "modelSuggestions": [
     { "value": "opus", "label": "Opus", "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks" },
     // …built-in aliases (default/opus/sonnet/haiku) plus models discovered from the

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -20,6 +20,7 @@ import { z } from "zod"
 import { CarryOnController } from "./carry-on"
 import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
 import { pushBranchAndScheduleRemoval } from "./archive-cleanup"
+import { formatClaudeStatusReport } from "./status"
 import { interrupt, killOwnWindow, steerText, submitLine, tmuxAvailable } from "./tmux-control"
 import { TranscriptTracer } from "./transcript-trace"
 
@@ -33,11 +34,13 @@ export const CHANNEL_SOURCE = "threa-channel"
 // disk this session — `/reload-plugins` is reachable via `run` for the plugin
 // case); Threa's canonical `thinking` maps to Claude Code's `/effort`;
 // `carry-on` queues text for the quota carry-on resume (see carry-on.ts);
-// `kick` asks harnessd to press Enter in this managed session's pane.
+// `kick` asks harnessd to press Enter in this session's pane; `status` reads
+// connection/activity state and captures the visible pane without sending keys.
 const SESSION_CONTROL_COMMANDS = [
   "stop",
   "steer",
   "kick",
+  "status",
   "model",
   "thinking",
   "compact",
@@ -160,7 +163,8 @@ export async function runClaudeCommand(
   name: string,
   args: string,
   carryOn?: CarryOnController,
-  runtimeSessionId?: string
+  runtimeSessionId?: string,
+  statusReport?: () => string
 ): Promise<{ ok: boolean; message: string }> {
   switch (name) {
     case "carry-on": {
@@ -172,6 +176,17 @@ export async function runClaudeCommand(
       const result = runHarnessKick(runtimeSessionId)
       if (!result.ok) throw new Error(`Could not kick the session: ${result.error}`)
       return { ok: true, message: "Kicked the linked Claude Code session." }
+    }
+    case "status": {
+      if (!statusReport) return { ok: false, message: "Session status is unavailable." }
+      try {
+        return { ok: true, message: statusReport() }
+      } catch (error) {
+        return {
+          ok: false,
+          message: `Could not inspect the session: ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
     }
     case "model": {
       const alias = args.trim()
@@ -224,7 +239,8 @@ async function runSlash(slash: string): Promise<{ ok: boolean; message: string }
  */
 export function createClaudeSessionControl(
   carryOn: () => CarryOnController | undefined = () => undefined,
-  runtimeSessionId?: string
+  runtimeSessionId?: string,
+  statusReport?: () => string
 ): SessionControlActuator | undefined {
   if (!tmuxAvailable()) return undefined
   return {
@@ -249,7 +265,7 @@ export function createClaudeSessionControl(
       if (absorbed !== undefined) return true
       return steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`)
     },
-    runCommand: (name, args) => runClaudeCommand(name, args, carryOn(), runtimeSessionId),
+    runCommand: (name, args) => runClaudeCommand(name, args, carryOn(), runtimeSessionId, statusReport),
   }
 }
 
@@ -329,7 +345,20 @@ export class ChannelServer {
       },
       delegate: {
         deliverTurn: (turn) => this.deliverToClaude(turn),
-        sessionControl: createClaudeSessionControl(() => this.carryOn, config.runtimeSessionId),
+        sessionControl: createClaudeSessionControl(
+          () => this.carryOn,
+          config.runtimeSessionId,
+          () =>
+            formatClaudeStatusReport({
+              channelStarted: this.started,
+              instanceId: config.instanceId,
+              runtimeSessionId: config.runtimeSessionId,
+              remote: this.session.statusSnapshot,
+              quotaHolding: this.carryOn?.holding ?? false,
+              pendingPermissionCount: this.openPermissions.size,
+              activeDelegationCount: this.openDelegations.size,
+            })
+        ),
         onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay
           ? { interceptClaimed: (invocation: ClaimedInvocation) => this.interceptVerdict(invocation) }

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -37,6 +37,7 @@ describe("createClaudeSessionControl", () => {
         "stop",
         "steer",
         "kick",
+        "status",
         "model",
         "thinking",
         "compact",
@@ -57,6 +58,7 @@ describe("createClaudeSessionControl", () => {
       expect(createClaudeSessionControl()!.commands).toEqual([
         "stop",
         "steer",
+        "status",
         "model",
         "thinking",
         "compact",
@@ -71,6 +73,18 @@ describe("createClaudeSessionControl", () => {
 describe("runClaudeCommand validation (paths that never touch tmux)", () => {
   it("fails loudly when /kick has no harness-managed runtime identity", async () => {
     expect(runClaudeCommand("kick", "")).rejects.toThrow("Harness kick is unavailable for this session.")
+  })
+
+  it("returns the injected read-only status report", async () => {
+    const outcome = await runClaudeCommand("status", "", undefined, "ccs-one", () => "pane status")
+    expect(outcome).toEqual({ ok: true, message: "pane status" })
+  })
+
+  it("reports status capture failures without throwing out of command handling", async () => {
+    const outcome = await runClaudeCommand("status", "", undefined, "ccs-one", () => {
+      throw new Error("pane disappeared")
+    })
+    expect(outcome).toEqual({ ok: false, message: "Could not inspect the session: pane disappeared" })
   })
 
   it("gives usage help for /model without an argument", async () => {

--- a/extensions/claude-code-remote/src/status.test.ts
+++ b/extensions/claude-code-remote/src/status.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test"
+import type { RemoteSessionStatusSnapshot } from "@threa/remote-session"
+import { formatClaudeStatusReport, type ClaudeChannelStatusContext } from "./status"
+import type { TmuxPaneSnapshot } from "./tmux-control"
+
+const remote: RemoteSessionStatusSnapshot = {
+  stopped: false,
+  linkState: "linked",
+  rootStreamId: "stream_1",
+  activeStreamId: "stream_1",
+  socketConnected: true,
+  inflightCount: 1,
+  activeTurnStreamId: "stream_1",
+}
+
+const context: ClaudeChannelStatusContext = {
+  channelStarted: true,
+  instanceId: "cc-one",
+  runtimeSessionId: "ccs-one",
+  remote,
+  quotaHolding: false,
+  pendingPermissionCount: 0,
+  activeDelegationCount: 0,
+}
+
+const pane: TmuxPaneSnapshot = {
+  sessionName: "1",
+  windowName: "feature",
+  windowId: "@7",
+  paneId: "%8",
+  panePid: 33336,
+  width: 180,
+  height: 48,
+  cwd: "/repo/threa.feature",
+  branch: "feat/status",
+  view: "Waiting for 1 workflow to finish.\n``` nested fence",
+}
+
+describe("formatClaudeStatusReport", () => {
+  it("reports connectivity, work, local identity, and the current pane", () => {
+    const report = formatClaudeStatusReport(context, pane)
+
+    expect(report).toContain("Threa: **Connected via WebSocket**")
+    expect(report).toContain("Work: **Working — 1 active invocation**")
+    expect(report).toContain("Tmux: `1:feature` · pane `%8` · 180×48")
+    expect(report).toContain("Branch: `feat/status`")
+    expect(report).toContain("Waiting for 1 workflow to finish.")
+    expect(report).toContain("    ``` nested fence")
+  })
+
+  it("surfaces degraded connectivity and blockers", () => {
+    const report = formatClaudeStatusReport(
+      {
+        ...context,
+        remote: { ...remote, socketConnected: false },
+        quotaHolding: true,
+        pendingPermissionCount: 1,
+        activeDelegationCount: 2,
+      },
+      pane
+    )
+
+    expect(report).toContain("Threa: **WebSocket disconnected — HTTP fallback enabled**")
+    expect(report).toContain("Work: **Waiting on provider quota**")
+    expect(report).toContain("Pending permissions: 1")
+    expect(report).toContain("Active delegations: 2")
+  })
+})

--- a/extensions/claude-code-remote/src/status.ts
+++ b/extensions/claude-code-remote/src/status.ts
@@ -1,0 +1,77 @@
+import type { RemoteSessionStatusSnapshot } from "@threa/remote-session"
+import { captureTmuxPaneSnapshot, type TmuxPaneSnapshot } from "./tmux-control"
+
+export interface ClaudeChannelStatusContext {
+  channelStarted: boolean
+  instanceId: string
+  runtimeSessionId: string
+  remote: RemoteSessionStatusSnapshot
+  quotaHolding: boolean
+  pendingPermissionCount: number
+  activeDelegationCount: number
+}
+
+function inlineCode(value: string): string {
+  const longest = Math.max(0, ...Array.from(value.matchAll(/`+/g), (match) => match[0].length))
+  const fence = "`".repeat(Math.max(1, longest + 1))
+  return `${fence}${value}${fence}`
+}
+
+function codeBlock(value: string): string {
+  return (value || "(pane is blank)")
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n")
+}
+
+function connectivityLabel(context: ClaudeChannelStatusContext): string {
+  if (!context.channelStarted || context.remote.stopped) return "Stopped"
+  if (context.remote.linkState === "detached") return "Detached — scratchpad archived"
+  if (context.remote.linkState === "unlinked") return "Connecting — scratchpad not linked"
+  if (context.remote.socketConnected) return "Connected via WebSocket"
+  return "WebSocket disconnected — HTTP fallback enabled"
+}
+
+function workLabel(context: ClaudeChannelStatusContext): string {
+  if (context.quotaHolding) return "Waiting on provider quota"
+  if (context.pendingPermissionCount > 0) return "Waiting on user permission"
+  if (context.remote.inflightCount > 0) {
+    return `Working — ${context.remote.inflightCount} active invocation${context.remote.inflightCount === 1 ? "" : "s"}`
+  }
+  if (context.activeDelegationCount > 0) {
+    return `Working — ${context.activeDelegationCount} active delegation${context.activeDelegationCount === 1 ? "" : "s"}`
+  }
+  return "Idle"
+}
+
+export function formatClaudeStatusReport(
+  context: ClaudeChannelStatusContext,
+  pane: TmuxPaneSnapshot = captureTmuxPaneSnapshot()
+): string {
+  const lines = [
+    "**Claude Code session status**",
+    "",
+    `- Threa: **${connectivityLabel(context)}**`,
+    `- Work: **${workLabel(context)}**`,
+  ]
+  if (context.remote.rootStreamId) lines.push(`- Scratchpad: ${inlineCode(context.remote.rootStreamId)}`)
+  if (context.pendingPermissionCount > 0) {
+    lines.push(`- Pending permissions: ${context.pendingPermissionCount}`)
+  }
+  if (context.activeDelegationCount > 0) {
+    lines.push(`- Active delegations: ${context.activeDelegationCount}`)
+  }
+  lines.push(
+    `- Tmux: ${inlineCode(`${pane.sessionName}:${pane.windowName}`)} · pane ${inlineCode(pane.paneId)} · ${pane.width}×${pane.height}`,
+    `- Process: PID ${pane.panePid}`,
+    `- Branch: ${pane.branch ? inlineCode(pane.branch) : "not available"}`,
+    `- Cwd: ${inlineCode(pane.cwd)}`,
+    `- Runtime session: ${inlineCode(context.runtimeSessionId)}`,
+    `- Instance: ${inlineCode(context.instanceId)}`,
+    "",
+    "**Current pane**",
+    "",
+    codeBlock(pane.view)
+  )
+  return lines.join("\n")
+}

--- a/extensions/claude-code-remote/src/tmux-control.test.ts
+++ b/extensions/claude-code-remote/src/tmux-control.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { tmuxAvailable } from "./tmux-control"
+import { captureTmuxPaneSnapshot, tmuxAvailable, type LocalCommandRunner } from "./tmux-control"
 
 describe("tmuxAvailable", () => {
   const saved = {
@@ -41,5 +41,51 @@ describe("tmuxAvailable", () => {
     process.env.TMUX = "/tmp/tmux-501/default,1234,0"
     process.env.THREA_TMUX_TARGET = "work:claude.0"
     expect(tmuxAvailable()).toBe(true)
+  })
+
+  it("captures pane metadata, branch, and the visible terminal", () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    const calls: string[][] = []
+    const run: LocalCommandRunner = (command) => {
+      calls.push(command)
+      if (command[0] === "tmux" && command[1] === "display-message") {
+        return {
+          exitCode: 0,
+          stdout: "1\tfeature\t@7\t%5\t33336\t180\t48\t/repo/threa.feature\t0\n",
+          stderr: "",
+        }
+      }
+      if (command[0] === "tmux" && command[1] === "capture-pane") {
+        return { exitCode: 0, stdout: "Working…   \n\n", stderr: "" }
+      }
+      return { exitCode: 0, stdout: "feat/status\n", stderr: "" }
+    }
+
+    expect(captureTmuxPaneSnapshot(run)).toEqual({
+      sessionName: "1",
+      windowName: "feature",
+      windowId: "@7",
+      paneId: "%5",
+      panePid: 33336,
+      width: 180,
+      height: 48,
+      cwd: "/repo/threa.feature",
+      branch: "feat/status",
+      view: "Working…",
+    })
+    expect(calls.map((command) => command.slice(0, 2))).toEqual([
+      ["tmux", "display-message"],
+      ["tmux", "capture-pane"],
+      ["git", "-C"],
+    ])
+  })
+
+  it("fails loudly when the pane cannot be inspected", () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    expect(() => captureTmuxPaneSnapshot(() => ({ exitCode: 1, stdout: "", stderr: "can't find pane: %5" }))).toThrow(
+      "can't find pane: %5"
+    )
   })
 })

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -18,6 +18,96 @@ function paneTarget(): string | undefined {
   return pane || undefined
 }
 
+export interface TmuxPaneSnapshot {
+  sessionName: string
+  windowName: string
+  windowId: string
+  paneId: string
+  panePid: number
+  width: number
+  height: number
+  cwd: string
+  branch: string | null
+  view: string
+}
+
+export interface LocalCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export type LocalCommandRunner = (command: string[]) => LocalCommandResult
+
+function runLocalCommand(command: string[]): LocalCommandResult {
+  const result = Bun.spawnSync(command, { stdout: "pipe", stderr: "pipe" })
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  }
+}
+
+export function captureTmuxPaneSnapshot(run: LocalCommandRunner = runLocalCommand): TmuxPaneSnapshot {
+  const target = paneTarget()
+  if (!target) throw new Error("tmux pane target is unavailable")
+
+  const details = run([
+    "tmux",
+    "display-message",
+    "-p",
+    "-t",
+    target,
+    "#{session_name}\t#{window_name}\t#{window_id}\t#{pane_id}\t#{pane_pid}\t#{pane_width}\t#{pane_height}\t#{pane_current_path}\t#{pane_dead}",
+  ])
+  if (details.exitCode !== 0) {
+    throw new Error(details.stderr.trim() || `tmux could not inspect ${target}`)
+  }
+  const [sessionName, windowName, windowId, paneId, pidText, widthText, heightText, cwd, dead] = details.stdout
+    .trimEnd()
+    .split("\t")
+  const panePid = Number(pidText)
+  const width = Number(widthText)
+  const height = Number(heightText)
+  if (
+    !sessionName ||
+    !windowName ||
+    !windowId ||
+    !paneId ||
+    !cwd ||
+    dead !== "0" ||
+    !Number.isSafeInteger(panePid) ||
+    panePid <= 0 ||
+    !Number.isSafeInteger(width) ||
+    width <= 0 ||
+    !Number.isSafeInteger(height) ||
+    height <= 0
+  ) {
+    throw new Error(`tmux returned invalid pane details for ${target}`)
+  }
+
+  const captured = run(["tmux", "capture-pane", "-p", "-t", paneId])
+  if (captured.exitCode !== 0) {
+    throw new Error(captured.stderr.trim() || `tmux could not capture ${paneId}`)
+  }
+  const branchResult = run(["git", "-C", cwd, "branch", "--show-current"])
+  return {
+    sessionName,
+    windowName,
+    windowId,
+    paneId,
+    panePid,
+    width,
+    height,
+    cwd,
+    branch: branchResult.exitCode === 0 ? branchResult.stdout.trim() || null : null,
+    view: captured.stdout
+      .replace(/[ \t]+$/gm, "")
+      .trim()
+      .slice(-20_000),
+  }
+}
+
 /** True only when we're inside tmux AND know which pane to drive. Gates whether the channel advertises session control at all (fail-safe: no control → no commands offered). */
 export function tmuxAvailable(): boolean {
   return Boolean(process.env.TMUX && paneTarget())

--- a/extensions/remote-session/src/index.ts
+++ b/extensions/remote-session/src/index.ts
@@ -13,6 +13,7 @@ export {
   type ModelSuggestionInfo,
   type RemoteSessionDelegate,
   type RemoteSessionOptions,
+  type RemoteSessionStatusSnapshot,
   type RuntimeDescriptor,
   type SendResult,
   type SessionControlActuator,

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -367,6 +367,29 @@ describe("RemoteSession.onReplyTimeout", () => {
   })
 })
 
+describe("RemoteSession status snapshot", () => {
+  test("reports link, socket, and active-turn state without mutation", async () => {
+    const { client } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport)
+
+    expect(session.statusSnapshot).toEqual({
+      stopped: false,
+      linkState: "unlinked",
+      rootStreamId: undefined,
+      activeStreamId: undefined,
+      socketConnected: false,
+      inflightCount: 0,
+      activeTurnStreamId: undefined,
+    })
+
+    seedInflight(session, makeInvocation({ id: "binv_status" }))
+    expect(session.statusSnapshot.inflightCount).toBe(1)
+    await session.shutdown()
+    expect(session.statusSnapshot.stopped).toBe(true)
+  })
+})
+
 describe("RemoteSession session-archived handling (grace window)", () => {
   function makeGraceSession(params: {
     client: ThreaClient

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -180,6 +180,16 @@ export interface SendResult {
   retryable?: boolean
 }
 
+export interface RemoteSessionStatusSnapshot {
+  stopped: boolean
+  linkState: "unlinked" | "linked" | "detached"
+  rootStreamId?: string
+  activeStreamId?: string
+  socketConnected: boolean
+  inflightCount: number
+  activeTurnStreamId?: string
+}
+
 type SessionControlCommand = { name: string; args: string }
 
 /**
@@ -402,6 +412,19 @@ export class RemoteSession {
   /** The scratchpad root stream, once linked. */
   get rootStreamId(): string | undefined {
     return this.link?.rootStreamId
+  }
+
+  get statusSnapshot(): RemoteSessionStatusSnapshot {
+    const linkState = this.archivePending ? "detached" : this.link ? "linked" : "unlinked"
+    return {
+      stopped: this.stopped,
+      linkState,
+      rootStreamId: this.link?.rootStreamId ?? this.archivePending?.rootStreamId,
+      activeStreamId: this.link?.activeStreamId,
+      socketConnected: this.transport.socketConnected,
+      inflightCount: this.inflight.size,
+      activeTurnStreamId: this.activeTurnStream,
+    }
   }
 
   // --- Lifecycle ------------------------------------------------------------


### PR DESCRIPTION
## Problem

A linked Claude session can be alive but appear unresponsive because Threa exposes neither its local terminal state nor enough connection/activity detail to distinguish working, waiting, blocked, disconnected, or idle. Diagnosing this currently requires local tmux and process inspection.

## Solution

Add runtime-advertised `/status` for Claude channel scratchpads.

- Report scratchpad link state, `/bot` WebSocket connectivity (including HTTP-fallback mode), active invocation/delegation counts, quota holds, and pending permission prompts.
- Capture the current visible tmux pane plus session/window/pane identity, PID, dimensions, cwd, git branch, runtime session ID, and instance ID.
- Keep execution read-only: `tmux display-message`, `capture-pane`, and `git branch --show-current`; no keys, adoption, revival, or presence mutation.
- Bound terminal output to 20,000 characters and render it as an indented Markdown code block, including in sealed E2E command acknowledgements.
- Advertise the command only through the existing tmux-capable session-control actuator; Pi does not advertise it.

The pane view is intentionally user-requested diagnostic output and may contain terminal content; it is emitted only when the user invokes `/status` in that linked scratchpad.

## Test plan

- [x] `extensions/remote-session`: 121 tests; typecheck
- [x] `extensions/claude-code-remote`: 110 tests; typecheck
- [x] backend command catalog/routing: 4 tests; backend typecheck
- [x] repository pre-commit lint, monorepo typecheck, Dockerfile/migration/OpenAPI checks
- [x] live read-only capture against pane `%140` rendered connection, work, branch, tmux identity, and visible workflow state
- [x] Sol/low pre-PR review: spec/design + correctness/data-flow; no findings

<details>
<summary>📋 Full implementation plan</summary>

1. Add `status` to the canonical runtime command catalog and let runtime capability advertisement gate availability.
2. Expose a read-only `RemoteSessionStatusSnapshot` for link, socket, and active-turn state.
3. Capture bounded tmux metadata/view and format it with Claude-local blocker/delegation state.
4. Cover catalog parity, command dispatch, status formatting, tmux failures, and session lifecycle; document behavior.

</details>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 _PR by [Codex](https://github.com/openai/codex)_
