### PR TITLE
feat(delegations): result threads anchor on the delegation card — retire the #1334 anchor-message workaround

### DIFF
--- a/apps/backend/src/features/delegations/repository.test.ts
+++ b/apps/backend/src/features/delegations/repository.test.ts
@@ -370,6 +370,27 @@ describe("DelegatedTaskRepository.findByIdWithEvent", () => {
   })
 })
 
+describe("DelegatedTaskRepository.findCreatedEventId", () => {
+  afterEach(() => mock.restore())
+
+  it("returns the delegation:created event id, scoped to id + workspace", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [{ id: "event_1" }])
+
+    const eventId = await DelegatedTaskRepository.findCreatedEventId(db, "ws_1", "dlg_1")
+
+    expect(captured.text).toContain("event_type = 'delegation:created'")
+    expect(captured.text).toContain("payload->>'delegationId'")
+    expect(captured.values).toEqual(["dlg_1", "ws_1", "dlg_1"])
+    expect(eventId).toBe("event_1")
+  })
+
+  it("returns null when the card event is absent", async () => {
+    const db = createQuerier({ text: null, values: null }, [])
+    expect(await DelegatedTaskRepository.findCreatedEventId(db, "ws_1", "dlg_missing")).toBeNull()
+  })
+})
+
 describe("DelegatedTaskRepository.expireLapsedClaims", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/delegations/repository.ts
+++ b/apps/backend/src/features/delegations/repository.ts
@@ -154,6 +154,23 @@ export const DelegatedTaskRepository = {
   },
 
   /**
+   * The delegation's `delegation:created` event id — the timeline card its
+   * result thread anchors on (INV-27: the targeted read the completion flow
+   * needs inside its claim-locked transaction, without re-fetching the whole
+   * row it already holds). Mirrors the join in `findByIdWithEvent`.
+   */
+  async findCreatedEventId(db: Querier, workspaceId: string, id: string): Promise<string | null> {
+    const result = await db.query<{ id: string }>(sql`
+      SELECT id FROM stream_events
+      WHERE stream_id = (SELECT stream_id FROM delegated_tasks WHERE id = ${id} AND workspace_id = ${workspaceId})
+        AND event_type = 'delegation:created'
+        AND payload->>'delegationId' = ${id}
+      LIMIT 1
+    `)
+    return result.rows[0]?.id ?? null
+  },
+
+  /**
    * A workspace's open (claimable) delegations, oldest first — the 5.3 list
    * surface. `since` narrows to rows created after the instant, so a polling
    * runner that remembers its last sweep doesn't re-download the whole queue.

--- a/apps/backend/src/features/delegations/service.test.ts
+++ b/apps/backend/src/features/delegations/service.test.ts
@@ -303,7 +303,7 @@ describe("DelegationService.heartbeat", () => {
 describe("DelegationService.complete / fail / markRunning", () => {
   afterEach(() => mock.restore())
 
-  it("complete appends the completed patch carrying the result message id", async () => {
+  it("complete appends the completed patch carrying the result message id and thread stream id", async () => {
     stubTransaction()
     spyOn(DelegatedTaskRepository, "complete").mockResolvedValue(
       fakeDelegation({ status: DelegationStatuses.COMPLETED, resultMessageId: "msg_result" })
@@ -315,12 +315,17 @@ describe("DelegationService.complete / fail / markRunning", () => {
       id: "dlg_1",
       claimToken: "tok_1",
       resultMessageId: "msg_result",
+      threadStreamId: "stream_thread",
     })
 
     expect(insertEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        payload: expect.objectContaining({ status: DelegationStatuses.COMPLETED, resultMessageId: "msg_result" }),
+        payload: expect.objectContaining({
+          status: DelegationStatuses.COMPLETED,
+          resultMessageId: "msg_result",
+          threadStreamId: "stream_thread",
+        }),
       })
     )
   })

--- a/apps/backend/src/features/delegations/service.ts
+++ b/apps/backend/src/features/delegations/service.ts
@@ -271,8 +271,19 @@ export class DelegationService {
     id: string
     claimToken: string
     resultMessageId?: string
+    threadStreamId?: string
   }): Promise<DelegatedTask | null> {
     return withTransaction(this.pool, (client) => this.completeInTransaction(client, params))
+  }
+
+  /**
+   * The delegation's `delegation:created` event id — the card its result thread
+   * anchors on. Callable on a transaction client so the completion flow resolves
+   * the anchor inside its claim-locked envelope (INV-30 single query → the
+   * caller's querier).
+   */
+  async findCreatedEventId(client: PoolClient, params: { workspaceId: string; id: string }): Promise<string | null> {
+    return DelegatedTaskRepository.findCreatedEventId(client, params.workspaceId, params.id)
   }
 
   /**
@@ -301,7 +312,7 @@ export class DelegationService {
    */
   async completeInTransaction(
     client: PoolClient,
-    params: { workspaceId: string; id: string; claimToken: string; resultMessageId?: string }
+    params: { workspaceId: string; id: string; claimToken: string; resultMessageId?: string; threadStreamId?: string }
   ): Promise<DelegatedTask | null> {
     const completed = await DelegatedTaskRepository.complete(client, {
       workspaceId: params.workspaceId,
@@ -310,7 +321,7 @@ export class DelegationService {
       resultMessageId: params.resultMessageId ?? null,
     })
     if (!completed) return null
-    await this.appendStatusEvent(client, completed, SYSTEM_ACTOR)
+    await this.appendStatusEvent(client, completed, SYSTEM_ACTOR, { threadStreamId: params.threadStreamId })
     return completed
   }
 
@@ -363,13 +374,15 @@ export class DelegationService {
   private async appendStatusEvent(
     client: PoolClient,
     delegation: DelegatedTask,
-    actor: { actorId?: string; actorType: AuthorType }
+    actor: { actorId?: string; actorType: AuthorType },
+    extra: { threadStreamId?: string } = {}
   ): Promise<void> {
     const payload: DelegationStatusChangedEventPayload = {
       delegationId: delegation.id,
       status: delegation.status,
       claimedByLabel: delegation.claimedByLabel,
       resultMessageId: delegation.resultMessageId,
+      threadStreamId: extra.threadStreamId,
       statusNote: delegation.statusNote,
     }
     await this.appendDelegationEvent(client, {

--- a/apps/backend/src/features/public-api/delegation-endpoints.test.ts
+++ b/apps/backend/src/features/public-api/delegation-endpoints.test.ts
@@ -293,15 +293,14 @@ describe("completeDelegation", () => {
     completeInTransaction?: DelegationService["completeInTransaction"]
     createMessageInTransaction?: EventService["createMessageInTransaction"]
     findClaimedForUpdate?: DelegationService["findClaimedForUpdate"]
+    findCreatedEventId?: DelegationService["findCreatedEventId"]
     isE2e?: boolean
   }) {
     spyOn(db, "withTransaction").mockImplementation(async (_pool, fn) => fn({} as PoolClient))
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(overrides.isE2e ?? false)
     const createMessageInTransaction =
       overrides.createMessageInTransaction ??
-      (mock(async (_client: unknown, params: { clientMessageId?: string }) => ({
-        message: { id: params.clientMessageId?.endsWith(":result") ? "msg_result" : "msg_anchor" },
-      })) as unknown as EventService["createMessageInTransaction"])
+      (mock(async () => ({ message: { id: "msg_result" } })) as unknown as EventService["createMessageInTransaction"])
     const completeInTransaction =
       overrides.completeInTransaction ??
       (mock(async () =>
@@ -312,12 +311,23 @@ describe("completeDelegation", () => {
       (mock(async () =>
         makeDelegation({ status: DelegationStatuses.CLAIMED })
       ) as DelegationService["findClaimedForUpdate"])
+    // The `delegation:created` card event the result thread anchors on. Legacy
+    // delegations (predating the anchor substrate) return their existing event
+    // id here just the same — the completion path never depends on when it was
+    // created, only that the card exists to hang the thread under.
+    const findCreatedEventId =
+      overrides.findCreatedEventId ?? (mock(async () => "event_created") as DelegationService["findCreatedEventId"])
     const createThreadOn = mock(
       async () => ({ id: "stream_thread" }) as never
     ) as unknown as StreamService["createThreadOn"]
     return {
       handlers: makeHandlers({
-        delegationService: { getById: mock(async () => makeDelegation()), completeInTransaction, findClaimedForUpdate },
+        delegationService: {
+          getById: mock(async () => makeDelegation()),
+          completeInTransaction,
+          findClaimedForUpdate,
+          findCreatedEventId,
+        },
         streamService: { tryAccess: mock(async () => ({ id: "stream_1" }) as never), createThreadOn },
         botChannelService: { isStreamAccessibleForBot: mock(async () => true) },
         eventService: { createMessageInTransaction },
@@ -325,11 +335,12 @@ describe("completeDelegation", () => {
       createMessageInTransaction,
       completeInTransaction,
       findClaimedForUpdate,
+      findCreatedEventId,
       createThreadOn,
     }
   }
 
-  it("posts a compact anchor + the result as a thread reply, and completes in the same transaction", async () => {
+  it("anchors the result thread on the delegation card and posts the result inside it — no synthetic anchor message", async () => {
     const { handlers, createMessageInTransaction, completeInTransaction, createThreadOn } = transactionalHandlers({})
     const { res, payloads } = createResponse()
 
@@ -338,37 +349,35 @@ describe("completeDelegation", () => {
       res
     )
 
-    // First message: the anchor in the delegation's stream — compact, no metadata.
-    const anchorParams = (createMessageInTransaction as ReturnType<typeof mock>).mock.calls[0][1]
-    expect(anchorParams).toMatchObject({
-      streamId: "stream_1",
-      authorId: "usr_1",
-      authorType: AuthorTypes.USER,
-      clientMessageId: "delegation:dlg_1",
-      sentVia: "api_key:uak_1",
-    })
-    expect(anchorParams.contentMarkdown).toContain("Result in thread")
-    // The thread hangs under the anchor, created by the same identity.
+    // The thread hangs under the delegation's own card event, created by the
+    // completing identity.
     expect((createThreadOn as ReturnType<typeof mock>).mock.calls[0][1]).toMatchObject({
       parentStreamId: "stream_1",
-      parentAnchorId: "msg_anchor",
+      parentAnchorId: "event_created",
       createdBy: "usr_1",
       createdByType: "user",
     })
-    // Second message: the full result inside the thread, carrying the metadata.
-    const resultParams = (createMessageInTransaction as ReturnType<typeof mock>).mock.calls[1][1]
-    expect(resultParams).toMatchObject({
+    // Exactly one message is posted — the result, inside the thread — carrying
+    // the metadata. No synthetic anchor message lands in the host stream (INV-23).
+    const messageCalls = (createMessageInTransaction as ReturnType<typeof mock>).mock.calls
+    expect(messageCalls.length).toBe(1)
+    expect(messageCalls[0][1]).toMatchObject({
       streamId: "stream_thread",
+      authorId: "usr_1",
+      authorType: AuthorTypes.USER,
       contentMarkdown: "All done.",
       clientMessageId: "delegation:dlg_1:result",
+      sentVia: "api_key:uak_1",
       metadata: { "github.pr": "https://x/1" },
     })
-    // The card points at the anchor — the row a viewer can see in the stream.
+    expect(messageCalls.some((call) => (call[1] as { streamId: string }).streamId === "stream_1")).toBe(false)
+    // The card points at the result message and its thread (zero-fetch card).
     expect((completeInTransaction as ReturnType<typeof mock>).mock.calls[0][1]).toMatchObject({
       claimToken: "tok",
-      resultMessageId: "msg_anchor",
+      resultMessageId: "msg_result",
+      threadStreamId: "stream_thread",
     })
-    expect((payloads[0] as { data: { resultMessageId?: string } }).data.resultMessageId).toBe("msg_anchor")
+    expect((payloads[0] as { data: { resultMessageId?: string } }).data.resultMessageId).toBe("msg_result")
   })
 
   it("404s (rolling the message back with the transaction) when the claim CAS matches nothing", async () => {
@@ -381,15 +390,17 @@ describe("completeDelegation", () => {
     ).rejects.toMatchObject({ status: 404 })
   })
 
-  it("completes without posting a message when no result is given", async () => {
-    const { handlers, createMessageInTransaction, completeInTransaction } = transactionalHandlers({})
+  it("completes without posting a message or thread when no result is given", async () => {
+    const { handlers, createMessageInTransaction, completeInTransaction, createThreadOn } = transactionalHandlers({})
     const { res } = createResponse()
 
     await handlers.completeDelegation(makeRequest({ token: "tok", body: {} }), res)
 
     expect((createMessageInTransaction as ReturnType<typeof mock>).mock.calls.length).toBe(0)
+    expect((createThreadOn as ReturnType<typeof mock>).mock.calls.length).toBe(0)
     expect((completeInTransaction as ReturnType<typeof mock>).mock.calls[0][1]).toMatchObject({
       resultMessageId: undefined,
+      threadStreamId: undefined,
     })
   })
 

--- a/apps/backend/src/features/public-api/delegation-handlers.ts
+++ b/apps/backend/src/features/public-api/delegation-handlers.ts
@@ -283,15 +283,6 @@ export function createDelegationPublicApiHandlers({
       const contentJson = contentMarkdown ? parseMarkdown(contentMarkdown, undefined, toEmoji) : null
       const attachmentIds = contentJson ? collectAttachmentReferenceIds(contentJson) : []
 
-      // The result is delivered as a compact anchor in the stream with the
-      // full payload as a thread reply under it (Kris's F1 ruling: no more
-      // wall-of-text in the timeline). The card's result_message_id points at
-      // the anchor — the row a viewer can see and deep-link to.
-      const anchorMarkdown = contentMarkdown
-        ? normalizeMessage(`✓ Completed: **${delegation.title}**. Result in thread.`)
-        : null
-      const anchorJson = anchorMarkdown ? parseMarkdown(anchorMarkdown, undefined, toEmoji) : null
-
       const { completed, resultMessageId } = await withTransaction(pool, async (client: PoolClient) => {
         // Validate the claim BEFORE any write (FOR UPDATE, token-guarded): an
         // invalid or lapsed token does no work, and the row lock serializes
@@ -301,25 +292,24 @@ export function createDelegationPublicApiHandlers({
           throw new HttpError("Delegation claim not found", { status: 404, code: "NOT_FOUND" })
         }
         let resultMessageId: string | undefined
-        if (contentMarkdown && contentJson && anchorMarkdown && anchorJson && author) {
-          const { message: anchor } = await eventService.createMessageInTransaction(client, {
-            workspaceId,
-            streamId: delegation.streamId,
-            authorId: author.authorId,
-            authorType: author.authorType,
-            contentJson: anchorJson,
-            contentMarkdown: anchorMarkdown,
-            clientMessageId: `delegation:${delegation.id}`,
-            sentVia: author.sentVia,
-          })
+        let threadStreamId: string | undefined
+        if (contentMarkdown && contentJson && author) {
+          // The result thread anchors on the delegation's own card (its
+          // `delegation:created` event) — no synthetic anchor message. The card
+          // IS the timeline row; the full result lives one level down in the
+          // thread, and `result_message_id` points at that result message.
+          const createdEventId = await delegationService.findCreatedEventId(client, { workspaceId, id })
+          if (!createdEventId) {
+            throw new HttpError("Delegation card event not found", { status: 500, code: "DELEGATION_EVENT_MISSING" })
+          }
           const thread = await streamService.createThreadOn(client, {
             workspaceId,
             parentStreamId: delegation.streamId,
-            parentAnchorId: anchor.id,
+            parentAnchorId: createdEventId,
             createdBy: author.authorId,
             createdByType: author.authorType === AuthorTypes.BOT ? "bot" : "user",
           })
-          await eventService.createMessageInTransaction(client, {
+          const { message: result } = await eventService.createMessageInTransaction(client, {
             workspaceId,
             streamId: thread.id,
             authorId: author.authorId,
@@ -331,13 +321,15 @@ export function createDelegationPublicApiHandlers({
             sentVia: author.sentVia,
             metadata,
           })
-          resultMessageId = anchor.id
+          resultMessageId = result.id
+          threadStreamId = thread.id
         }
         const completed = await delegationService.completeInTransaction(client, {
           workspaceId,
           id,
           claimToken,
           resultMessageId,
+          threadStreamId,
         })
         if (!completed) {
           throw new HttpError("Delegation claim not found", { status: 404, code: "NOT_FOUND" })

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import type { DelegationCreatedEventPayload, DelegationStatusChangedEventPayload, StreamEvent } from "@threa/types"
 import { toast } from "sonner"
 import * as hooksModule from "@/hooks"
+import { PanelProvider } from "@/contexts"
 import { delegationsApi } from "@/api"
 import { buildDelegationPrompt, DelegationEvent } from "./delegation-event"
 
@@ -15,7 +16,13 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof hooksModule.useActors>)
 })
 
-function createdEvent(payload: DelegationCreatedEventPayload): StreamEvent {
+/** Healed thread stats (chunk-2) ride alongside the created payload on the card event. */
+type CardPayload = DelegationCreatedEventPayload & {
+  threadId?: string
+  replyCount?: number
+}
+
+function createdEvent(payload: CardPayload): StreamEvent {
   return {
     id: "evt_dlg",
     streamId: "stream_1",
@@ -37,15 +44,17 @@ const CREATED_PAYLOAD: DelegationCreatedEventPayload = {
   sourceConversationId: null,
 }
 
-function renderCard(statusPatch?: DelegationStatusChangedEventPayload) {
+function renderCard(statusPatch?: DelegationStatusChangedEventPayload, payloadOverride?: Partial<CardPayload>) {
   return render(
-    <MemoryRouter>
-      <DelegationEvent
-        event={createdEvent(CREATED_PAYLOAD)}
-        workspaceId="ws_1"
-        streamId="stream_1"
-        statusPatch={statusPatch}
-      />
+    <MemoryRouter initialEntries={["/w/ws_1"]}>
+      <PanelProvider>
+        <DelegationEvent
+          event={createdEvent({ ...CREATED_PAYLOAD, ...payloadOverride })}
+          workspaceId="ws_1"
+          streamId="stream_1"
+          statusPatch={statusPatch}
+        />
+      </PanelProvider>
     </MemoryRouter>
   )
 }
@@ -95,12 +104,41 @@ describe("DelegationEvent", () => {
     expect(screen.getByText("tests are compiling")).toBeInTheDocument()
   })
 
-  it("completed: links the result message, hides Cancel", () => {
+  it("completed (new shape): View result opens the result thread panel, hides Cancel and Discuss", () => {
+    renderCard({
+      delegationId: "dlg_1",
+      status: "completed",
+      resultMessageId: "msg_result",
+      threadStreamId: "stream_thread",
+    })
+
+    const link = screen.getByRole("link", { name: "View result" })
+    expect(link).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
+  })
+
+  it("completed (legacy shape): no threadStreamId falls back to the ?m= result deep-link", () => {
     renderCard({ delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" })
 
     const link = screen.getByRole("link", { name: "View result" })
     expect(link).toHaveAttribute("href", "/w/ws_1/s/stream_1?m=msg_result")
     expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+  })
+
+  it("open card: Discuss opens a draft thread panel keyed on the card's event id", () => {
+    renderCard()
+
+    const discuss = screen.getByRole("link", { name: "Discuss this delegation" })
+    expect(discuss).toHaveAttribute("href", "/w/ws_1?panel=draft%3Astream_1%3Aevt_dlg")
+  })
+
+  it("renders the thread chip from the healed payload (replies land on the card's own event)", () => {
+    renderCard(undefined, { threadId: "stream_thread", replyCount: 2 })
+
+    const chip = screen.getByRole("link", { name: /replies/ })
+    expect(chip).toHaveTextContent("2 replies")
+    expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
   })
 
   it.each(["failed", "expired"] as const)("%s is terminal: no Cancel, status in meta", (status) => {
@@ -212,12 +250,14 @@ describe("DelegationEvent", () => {
 
   it("renders nothing without a payload", () => {
     const { container } = render(
-      <MemoryRouter>
-        <DelegationEvent
-          event={{ ...createdEvent(CREATED_PAYLOAD), payload: undefined }}
-          workspaceId="ws_1"
-          streamId="stream_1"
-        />
+      <MemoryRouter initialEntries={["/w/ws_1"]}>
+        <PanelProvider>
+          <DelegationEvent
+            event={{ ...createdEvent(CREATED_PAYLOAD), payload: undefined }}
+            workspaceId="ws_1"
+            streamId="stream_1"
+          />
+        </PanelProvider>
       </MemoryRouter>
     )
     expect(container).toBeEmptyDOMElement()

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -104,16 +104,22 @@ describe("DelegationEvent", () => {
     expect(screen.getByText("tests are compiling")).toBeInTheDocument()
   })
 
-  it("completed (new shape): View result opens the result thread panel, hides Cancel and Discuss", () => {
-    renderCard({
-      delegationId: "dlg_1",
-      status: "completed",
-      resultMessageId: "msg_result",
-      threadStreamId: "stream_thread",
-    })
+  it("completed with threadStreamId: chip + View result reach the thread, no Discuss duplicate", () => {
+    renderCard(
+      {
+        delegationId: "dlg_1",
+        status: "completed",
+        resultMessageId: "msg_result",
+        threadStreamId: "stream_thread",
+      },
+      { threadId: "stream_thread", replyCount: 3 }
+    )
 
     const link = screen.getByRole("link", { name: "View result" })
     expect(link).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
+    const chip = screen.getByRole("link", { name: /replies/ })
+    expect(chip).toHaveTextContent("3 replies")
+    expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
     expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
     expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
   })
@@ -147,6 +153,16 @@ describe("DelegationEvent", () => {
     expect(screen.getByText(new RegExp(`Ariadne · ${status}`, "i"))).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /Cancel/ })).not.toBeInTheDocument()
   })
+
+  it.each(["failed", "cancelled", "expired"] as const)(
+    "%s card is discussion-worthy: Discuss stays available when there's no thread yet",
+    (status) => {
+      renderCard({ delegationId: "dlg_1", status })
+
+      const discuss = screen.getByRole("link", { name: "Discuss this delegation" })
+      expect(discuss).toHaveAttribute("href", "/w/ws_1?panel=draft%3Astream_1%3Aevt_dlg")
+    }
+  )
 
   it("cancelled keeps the relabeled button in place (follow-up card pattern: focus retained, announced)", () => {
     renderCard({ delegationId: "dlg_1", status: "cancelled" })

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -44,7 +44,11 @@ const CREATED_PAYLOAD: DelegationCreatedEventPayload = {
   sourceConversationId: null,
 }
 
-function renderCard(statusPatch?: DelegationStatusChangedEventPayload, payloadOverride?: Partial<CardPayload>) {
+function renderCard(
+  statusPatch?: DelegationStatusChangedEventPayload,
+  payloadOverride?: Partial<CardPayload>,
+  isThreadParent = false
+) {
   return render(
     <MemoryRouter initialEntries={["/w/ws_1"]}>
       <PanelProvider>
@@ -53,6 +57,7 @@ function renderCard(statusPatch?: DelegationStatusChangedEventPayload, payloadOv
           workspaceId="ws_1"
           streamId="stream_1"
           statusPatch={statusPatch}
+          isThreadParent={isThreadParent}
         />
       </PanelProvider>
     </MemoryRouter>
@@ -121,6 +126,23 @@ describe("DelegationEvent", () => {
     expect(chip).toHaveTextContent("3 replies")
     expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
     expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
+  })
+
+  it("completed thread parent suppresses self-links and nested thread affordances", () => {
+    renderCard(
+      {
+        delegationId: "dlg_1",
+        status: "completed",
+        resultMessageId: "msg_result",
+        threadStreamId: "stream_thread",
+      },
+      { threadId: "stream_thread", replyCount: 3 },
+      true
+    )
+
+    expect(screen.queryByRole("link", { name: "View result" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /replies/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
   })
 

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -147,6 +147,21 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
 
   const replyCount = payload.replyCount ?? 0
 
+  // Discuss starts (or opens) a thread on this card. Failure cards are
+  // discussion-worthy too ("why did this fail"), so it shows on every state
+  // EXCEPT when the card already exposes its thread another way: a completed
+  // card's thread opens via "View result" (threadStreamId), and any card with
+  // replies shows the footer thread chip. Either would make Discuss a duplicate
+  // entry point.
+  const threadChipShowing = replyCount > 0 && !!threadHref
+  const showDiscuss = !threadStreamId && !threadChipShowing
+
+  // Icon-only below `sm` (labels appear at `sm`). Force a ~36px square hit area
+  // on narrow viewports so three adjacent targets aren't sub-30px mis-taps;
+  // desktop footprint is unchanged (min sizing reset at `sm`).
+  const iconActionClass =
+    "inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:min-h-0 sm:min-w-0 sm:justify-start"
+
   const promptText = () => buildDelegationPrompt(payload, { workspaceId, origin: window.location.origin })
 
   async function handleCopy() {
@@ -273,15 +288,15 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
               </Link>
             )}
             {/* Discuss the card: start (or open) a thread anchored on this
-                event. Shown while the delegation is live — a completed card's
-                thread is reached via "View result". Navigation, so a <Link>
-                to the draft/thread panel (INV-40). */}
-            {!terminal && (
+                event. Hidden only when the card already has a thread entry
+                (View result / footer chip) — see `showDiscuss`. Navigation, so
+                a <Link> to the draft/thread panel (INV-40). */}
+            {showDiscuss && (
               <Link
                 to={replyUrl}
                 aria-label="Discuss this delegation"
                 title="Discuss this delegation in a thread"
-                className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                className={iconActionClass}
               >
                 <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
                 <span className="hidden sm:inline">Discuss</span>
@@ -293,7 +308,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
               aria-label={copyDone ? "Prompt copied" : "Copy prompt"}
               aria-live="polite"
               title="Copy the hand-off prompt for a local agent"
-              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className={iconActionClass}
             >
               {copyDone ? (
                 <Check className="h-3 w-3" aria-hidden="true" />
@@ -309,7 +324,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
               aria-label={copyLinkDone ? "Link copied" : "Copy link"}
               aria-live="polite"
               title="Copy a shareable link to this delegation"
-              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className={iconActionClass}
             >
               {copyLinkDone ? (
                 <Check className="h-3 w-3" aria-hidden="true" />

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -1,19 +1,32 @@
 import { useRef, useState, type ReactNode } from "react"
 import { Link } from "react-router-dom"
 import { toast } from "sonner"
-import { Check, ChevronDown, ChevronRight, Copy, Link2, Loader2, TerminalSquare } from "lucide-react"
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Link2,
+  Loader2,
+  MessageSquareReply,
+  TerminalSquare,
+} from "lucide-react"
 import {
   DelegationStatuses,
   type DelegationCreatedEventPayload,
   type DelegationStatus,
   type DelegationStatusChangedEventPayload,
   type StreamEvent,
+  type ThreadSummary,
 } from "@threa/types"
 import { delegationsApi } from "@/api"
+import { usePanel } from "@/contexts"
 import { useActors } from "@/hooks"
 import { DELEGATION_STATUS_LABEL, DELEGATION_TERMINAL } from "@/lib/delegation-display"
 import { buildDelegationLink } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
+import { ThreadSlot } from "./thread-slot"
+import { useThreadAnchor } from "./use-thread-anchor"
 
 interface DelegationEventProps {
   event: StreamEvent
@@ -88,7 +101,16 @@ export function buildDelegationPrompt(
  */
 export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: DelegationEventProps) {
   const { getActorName } = useActors(workspaceId)
-  const payload = event.payload as DelegationCreatedEventPayload | undefined
+  const { getPanelUrl } = usePanel()
+  // Healing (chunk-2) lands thread stats on the card's own payload once a thread
+  // exists, keyed on this event's id — the same anchor the thread was created on.
+  const payload = event.payload as
+    | (DelegationCreatedEventPayload & { threadId?: string; replyCount?: number; threadSummary?: ThreadSummary })
+    | undefined
+  // Shared thread affordance, keyed on the card's canonical id (its event id) —
+  // the anchor delegation completion threads on. `replyUrl` points at the real
+  // thread when one exists, else the draft panel for starting one.
+  const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
   const [optimisticallyCancelled, setOptimisticallyCancelled] = useState(false)
   const [optimisticallyDone, setOptimisticallyDone] = useState(false)
   const [cancelling, setCancelling] = useState(false)
@@ -111,8 +133,19 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
   const metaParts = [`${actorName} · ${DELEGATION_STATUS_LABEL[status]}`]
   if (statusPatch?.claimedByLabel && !optimisticFlip) metaParts.push(statusPatch.claimedByLabel)
   const statusNote = !optimisticFlip ? statusPatch?.statusNote : null
-  const resultMessageId =
-    status === DelegationStatuses.COMPLETED ? (statusPatch?.resultMessageId ?? undefined) : undefined
+
+  // "View result" target. New completions carry `threadStreamId` — the result
+  // lives in a thread anchored on this card, so open that thread panel. Legacy
+  // completions have only `resultMessageId` (a synthetic anchor message), which
+  // still deep-links via `?m=`. Both are navigation (INV-40).
+  const completed = status === DelegationStatuses.COMPLETED
+  const threadStreamId = completed ? (statusPatch?.threadStreamId ?? undefined) : undefined
+  const legacyResultMessageId = completed && !threadStreamId ? (statusPatch?.resultMessageId ?? undefined) : undefined
+  let viewResultHref: string | null = null
+  if (threadStreamId) viewResultHref = getPanelUrl(threadStreamId)
+  else if (legacyResultMessageId) viewResultHref = `/w/${workspaceId}/s/${streamId}?m=${legacyResultMessageId}`
+
+  const replyCount = payload.replyCount ?? 0
 
   const promptText = () => buildDelegationPrompt(payload, { workspaceId, origin: window.location.origin })
 
@@ -231,12 +264,27 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
           </div>
 
           <div className="flex shrink-0 items-center gap-1">
-            {resultMessageId && (
+            {viewResultHref && (
               <Link
-                to={`/w/${workspaceId}/s/${streamId}?m=${resultMessageId}`}
+                to={viewResultHref}
                 className="inline-flex items-center rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
                 View result
+              </Link>
+            )}
+            {/* Discuss the card: start (or open) a thread anchored on this
+                event. Shown while the delegation is live — a completed card's
+                thread is reached via "View result". Navigation, so a <Link>
+                to the draft/thread panel (INV-40). */}
+            {!terminal && (
+              <Link
+                to={replyUrl}
+                aria-label="Discuss this delegation"
+                title="Discuss this delegation in a thread"
+                className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
+                <span className="hidden sm:inline">Discuss</span>
               </Link>
             )}
             <button
@@ -335,6 +383,16 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
           </div>
         )}
       </div>
+
+      {/* Thread anchored on this card — surfaces the discussion (and a completed
+          delegation's result) as a footer chip once replies land. Keyed on the
+          card's event id via `useThreadAnchor`; healed payload drives the count. */}
+      <ThreadSlot
+        replyCount={replyCount}
+        threadHref={threadHref}
+        summary={payload.threadSummary}
+        workspaceId={workspaceId}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -32,6 +32,7 @@ interface DelegationEventProps {
   event: StreamEvent
   workspaceId: string
   streamId: string
+  isThreadParent?: boolean
   /**
    * The latest `delegation:status_changed` patch for this delegation within
    * the loaded window — the authoritative live status, so every viewer (not
@@ -99,7 +100,7 @@ export function buildDelegationPrompt(
  * The status from `statusPatch` is authoritative; the local optimistic flips
  * only fast-path the clicking member's own action.
  */
-export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: DelegationEventProps) {
+export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isThreadParent }: DelegationEventProps) {
   const { getActorName } = useActors(workspaceId)
   const { getPanelUrl } = usePanel()
   // Healing (chunk-2) lands thread stats on the card's own payload once a thread
@@ -142,8 +143,9 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
   const threadStreamId = completed ? (statusPatch?.threadStreamId ?? undefined) : undefined
   const legacyResultMessageId = completed && !threadStreamId ? (statusPatch?.resultMessageId ?? undefined) : undefined
   let viewResultHref: string | null = null
-  if (threadStreamId) viewResultHref = getPanelUrl(threadStreamId)
-  else if (legacyResultMessageId) viewResultHref = `/w/${workspaceId}/s/${streamId}?m=${legacyResultMessageId}`
+  if (!isThreadParent && threadStreamId) viewResultHref = getPanelUrl(threadStreamId)
+  else if (!isThreadParent && legacyResultMessageId)
+    viewResultHref = `/w/${workspaceId}/s/${streamId}?m=${legacyResultMessageId}`
 
   const replyCount = payload.replyCount ?? 0
 
@@ -153,8 +155,8 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
   // card's thread opens via "View result" (threadStreamId), and any card with
   // replies shows the footer thread chip. Either would make Discuss a duplicate
   // entry point.
-  const threadChipShowing = replyCount > 0 && !!threadHref
-  const showDiscuss = !threadStreamId && !threadChipShowing
+  const threadChipShowing = replyCount > 0 && !!threadHref && !isThreadParent
+  const showDiscuss = !threadStreamId && !threadChipShowing && !isThreadParent
 
   // Icon-only below `sm` (labels appear at `sm`). Force a ~36px square hit area
   // on narrow viewports so three adjacent targets aren't sub-30px mis-taps;
@@ -402,12 +404,14 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
       {/* Thread anchored on this card — surfaces the discussion (and a completed
           delegation's result) as a footer chip once replies land. Keyed on the
           card's event id via `useThreadAnchor`; healed payload drives the count. */}
-      <ThreadSlot
-        replyCount={replyCount}
-        threadHref={threadHref}
-        summary={payload.threadSummary}
-        workspaceId={workspaceId}
-      />
+      {!isThreadParent && (
+        <ThreadSlot
+          replyCount={replyCount}
+          threadHref={threadHref}
+          summary={payload.threadSummary}
+          workspaceId={workspaceId}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -194,7 +194,13 @@ export function EventItem({
       const statusPatch = delegationId ? delegationStatusPatches?.get(delegationId) : undefined
       return (
         <div data-event-id={event.id}>
-          <DelegationEvent event={event} workspaceId={workspaceId} streamId={streamId} statusPatch={statusPatch} />
+          <DelegationEvent
+            event={event}
+            workspaceId={workspaceId}
+            streamId={streamId}
+            statusPatch={statusPatch}
+            isThreadParent={isThreadParent}
+          />
         </div>
       )
     }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1297,6 +1297,14 @@ export interface DelegationStatusChangedEventPayload {
   claimedByLabel?: string | null
   /** The stream message the completing agent posted its result as. */
   resultMessageId?: string | null
+  /**
+   * The thread stream the completing agent's result was posted into, anchored
+   * on the delegation card itself. Present on completions that carried a result
+   * (the card opens this thread for "View result", zero-fetch). Absent on
+   * legacy completions, whose `resultMessageId` points at a synthetic anchor
+   * message the card deep-links via `?m=` instead.
+   */
+  threadStreamId?: string | null
   /** Free-text progress/error note from the executing agent. */
   statusNote?: string | null
 }


### PR DESCRIPTION
## Problem

Delegation completion still ships the F1 workaround (#1334): a synthetic anchor message (`✓ Completed: …`) posted into the host stream purely so a thread had something to root on — the card and the anchor message are two timeline rows saying the same thing. PR 4 of 7, plan `docs/plans/event-anchored-threads.md` §Consumer 1; first real consumer of the event-anchored substrate (PRs 1–3).

## Solution

- `completeDelegation` (public-api/delegation-handlers.ts), same claim-locked transaction: thread = `createThreadOn(parentAnchorId: <delegation:created event id>)` via new targeted `DelegationRepository.findCreatedEventId`; result message posted INTO the thread; `result_message_id` = the result message (was: anchor message). No host-stream message — asserted absent in tests (INV-23).
- Missing card event at completion → `500 DELEGATION_EVENT_MISSING` (fail-loud INV-11; every delegation emits the card at creation, so this is an impossible-state guard, not a fallback).
- `delegation:status_changed` completed-payload gains `threadStreamId` — the card renders its thread chip zero-fetch. Idempotent re-completion unchanged (early-return before the txn; card reads `threadStreamId` from the persisted payload, not the HTTP response).
- Grandfathering: old completed delegations keep their anchor-message threads (ordinary message-anchored threads); completing an OLD open delegation works with no branch — `delegation:created` is threadable regardless of event age (test-pinned).
- Frontend `DelegationEvent`: opts into the chunk-3 `useThreadAnchor` + `ThreadSlot` (first card to do so); "View result" opens the thread panel when `threadStreamId` present, legacy `?m=` deep-link otherwise (both tested); open cards get a "Discuss" `<Link>` to the event-anchored draft panel (INV-40).
- `markDone` and the fail path stay thread-less (plan-pinned).

## Test plan

- [x] backend `bun run test:unit` — green incl. new delegation-endpoints thread-on-card / no-anchor-message / threadStreamId / old-event tests; typecheck clean
- [x] frontend FULL vitest — 4818 pass (delegation-event 21/21; an earlier 43-failure run was CPU starvation from concurrent suites — A/B'd clean alone on both HEAD and diff); typecheck clean
- [x] packages/types — 136 pass; `check:migrations` clean
- Adversarial verify (Opus xhigh): verdict clean, zero findings, zero fix rounds

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787310854&installation_model_id=20758&pr_number=1503&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1503&signature=455e9518253ce8827d62efc174c0654ad3d6f5d4f1854162c938e4804c4a25d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->