### PR TITLE
feat(calls): call chat as a lazy thread on the call_started card

### DIFF
--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -133,6 +133,7 @@ export function createCallHandlers({ pool, io, callService, featureFlagService, 
         created: result.created,
         participant: result.participant,
         endpoint: result.endpoint,
+        chatAnchorId: result.chatAnchorId,
         rosterVersion: snapshot.rosterVersion,
         roster: snapshot.roster,
       })

--- a/apps/backend/src/features/calls/repository.test.ts
+++ b/apps/backend/src/features/calls/repository.test.ts
@@ -113,6 +113,27 @@ describe("CallRepository — active-call glare + grace re-verification", () => {
     expect(sql).toContain("ORDER BY id")
     expect(sql).toContain("FOR UPDATE")
   })
+
+  it("findCallStartedEventId resolves the chat anchor by stream + call_started + payload callId", async () => {
+    const captured: Captured = { text: "" }
+    const id = await CallRepository.findCallStartedEventId(
+      createQuerier(captured, [{ id: "event_chat_1" }]),
+      "stream_1",
+      "call_1"
+    )
+    expect(id).toBe("event_chat_1")
+    const sql = normalize(captured.text)
+    expect(sql).toContain("FROM stream_events")
+    expect(sql).toContain("stream_id =")
+    expect(sql).toContain("event_type = 'call_started'")
+    expect(sql).toContain("payload->>'callId' =")
+  })
+
+  it("findCallStartedEventId returns null when no matching card exists", async () => {
+    const captured: Captured = { text: "" }
+    const id = await CallRepository.findCallStartedEventId(createQuerier(captured, []), "stream_1", "call_1")
+    expect(id).toBeNull()
+  })
 })
 
 describe("CallParticipantRepository — actor-conditional admission", () => {

--- a/apps/backend/src/features/calls/repository.ts
+++ b/apps/backend/src/features/calls/repository.ts
@@ -150,6 +150,25 @@ export const CallRepository = {
     }))
   },
 
+  /**
+   * The `call_started` event id for a call — the anchor for its chat thread. Read
+   * from the host stream's timeline (there is exactly one per call, appended in the
+   * start transaction). Scoped by `stream_id` (stream_events carries no
+   * workspace_id; the stream is the scoping key). Null when the row is missing
+   * (e.g. a pre-timeline legacy call). Kept in the calls feature so the chat-anchor
+   * association resolves without a streams→calls dependency.
+   */
+  async findCallStartedEventId(db: Querier, streamId: string, callId: string): Promise<string | null> {
+    const result = await db.query<{ id: string }>(sql`
+      SELECT id FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type = 'call_started'
+        AND payload->>'callId' = ${callId}
+      LIMIT 1
+    `)
+    return result.rows[0]?.id ?? null
+  },
+
   /** Read a call, workspace-scoped (INV-8). */
   async findById(db: Querier, workspaceId: string, id: string): Promise<Call | null> {
     const result = await db.query<CallRow>(sql`

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -132,6 +132,9 @@ describe("CallService.startCall — product glare", () => {
     })
 
     expect(result).toMatchObject({ created: true, call: { id: "call_1" }, endpoint: { id: "callep_1" } })
+    // The freshly-appended `call_started` event is the chat-thread anchor handed
+    // back to the client (stubbed StreamEventRepository.insert → { id: "evt_1" }).
+    expect(result.chatAnchorId).toBe("evt_1")
     expect(admit).toHaveBeenCalledTimes(1)
     expect(insert).toHaveBeenCalledTimes(1)
   })
@@ -148,6 +151,9 @@ describe("CallService.startCall — product glare", () => {
     )
     stubCleanEndpointAdmission()
     spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+    // A join onto an existing call appends no new card — the chat anchor is the
+    // pre-existing `call_started` event, resolved by id from the host stream.
+    const findAnchor = spyOn(CallRepository, "findCallStartedEventId").mockResolvedValue("event_existing")
 
     const result = await makeService().startCall({
       workspaceId: "ws_1",
@@ -157,6 +163,8 @@ describe("CallService.startCall — product glare", () => {
     })
 
     expect(result).toMatchObject({ created: false, call: { id: "call_winner" } })
+    expect(result.chatAnchorId).toBe("event_existing")
+    expect(findAnchor).toHaveBeenCalledWith(expect.anything(), "stream_1", "call_winner")
     expect(findOpen).toHaveBeenCalledTimes(1)
     expect(admit).toHaveBeenCalledTimes(1)
   })

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -70,6 +70,13 @@ export interface StartCallResult {
   created: boolean
   participant: CallParticipant
   endpoint: CallEndpoint
+  /**
+   * The `call_started` event id — the anchor for the call's chat thread (a thread
+   * on this event, created lazily on first chat open). Handed to the client so the
+   * dock can open the thread panel without loading the host-stream timeline. Null
+   * only if the started card row is somehow missing (never for a fresh create).
+   */
+  chatAnchorId: string | null
 }
 
 export interface JoinCallResult {
@@ -187,14 +194,18 @@ export class CallService {
       // A newly created call is a slotted broadcast row on the host stream
       // (INV-4/7): append it in the SAME transaction as the call insert so every
       // member sees the live card and it survives reload. A join onto an existing
-      // call adds no row (the card already exists) — only the roster changes.
+      // call adds no row (the card already exists) — only the roster changes, so
+      // resolve the pre-existing card's event id to hand back as the chat anchor.
+      let chatAnchorId: string | null
       if (created) {
-        await this.appendCallStarted(client, {
+        chatAnchorId = await this.appendCallStarted(client, {
           call: admitted.call,
           streamId: params.streamId,
           streamVisibility: stream.visibility,
           startedBy: params.userId,
         })
+      } else {
+        chatAnchorId = await CallRepository.findCallStartedEventId(client, params.streamId, targetCallId)
       }
 
       if (created && stream.type === StreamTypes.DM) {
@@ -225,7 +236,13 @@ export class CallService {
       }
 
       return {
-        result: { call: admitted.call, created, participant: admitted.participant, endpoint: admitted.endpoint },
+        result: {
+          call: admitted.call,
+          created,
+          participant: admitted.participant,
+          endpoint: admitted.endpoint,
+          chatAnchorId,
+        },
         closedSessionIds: admitted.closedSessionIds,
       }
     })
@@ -1453,7 +1470,7 @@ export class CallService {
   private async appendCallStarted(
     client: PoolClient,
     args: { call: Call; streamId: string; streamVisibility: Visibility; startedBy: string }
-  ): Promise<void> {
+  ): Promise<string> {
     const payload: CallStartedEventPayload = {
       callId: args.call.id,
       mode: args.call.mode,
@@ -1477,6 +1494,7 @@ export class CallService {
       streamVisibility: args.streamVisibility,
       memberUserIds,
     })
+    return event.id
   }
 
   /**

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -130,6 +130,7 @@ function makeDeps(socket: FakeSocket, transport: MediaTransport) {
       created: true,
       participant: { id: "p_1" },
       endpoint: { id: "ep_rest" },
+      chatAnchorId: "event_chat_1",
       rosterVersion: 0,
       roster: [],
     })),
@@ -228,6 +229,7 @@ describe("CallManager", () => {
       created: false,
       participant: { id: "p_1" },
       endpoint: { id: "ep_rest" },
+      chatAnchorId: "event_chat_1",
       rosterVersion: 0,
       roster: [],
     })

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -45,6 +45,8 @@ interface StartCallResponse {
   created: boolean
   participant: { id: string }
   endpoint: { id: string }
+  /** The `call_started` event id — anchor for the call's chat thread (dock Chat control). */
+  chatAnchorId: string | null
   rosterVersion: number
   roster: CallRosterParticipant[]
 }
@@ -330,7 +332,13 @@ export class CallManager implements CallController {
       // even when the launch surface hardcoded "video") — the camera control hides
       // instead of tripping the server's camera-not-allowed gate.
       const mode = started.call.mode
-      setCallSession({ callId, workspaceId: params.workspaceId, streamId: params.streamId, mode })
+      setCallSession({
+        callId,
+        workspaceId: params.workspaceId,
+        streamId: params.streamId,
+        mode,
+        chatAnchorId: started.chatAnchorId,
+      })
       // One tab owns the call (Web Locks). A second tab sees the lock held →
       // activeElsewhere; on this tab's crash the lock releases and the other tab
       // may offer rejoin (surfaced via the store; UI is M1.2).

--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -1,10 +1,20 @@
-import { Loader2, Mic, MicOff, PhoneOff, SwitchCamera, Video, VideoOff } from "lucide-react"
+import { Link } from "react-router-dom"
+import { Loader2, MessageSquare, Mic, MicOff, PhoneOff, SwitchCamera, Video, VideoOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { createDraftPanelId } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useAsyncAction } from "@/hooks/use-async-action"
 import { useCallManager } from "./call-manager-context"
-import { useCallCameraOn, useCallDevices, useCallMode, useCallMuted } from "./call-store-hooks"
+import {
+  useCallCameraOn,
+  useCallChatAnchor,
+  useCallDevices,
+  useCallMode,
+  useCallMuted,
+  useCallStreamId,
+  useCallWorkspaceId,
+} from "./call-store-hooks"
 
 // The mute / camera / flip / leave controls, one component each so the compact
 // island and the (later) desktop pill share one implementation instead of
@@ -85,6 +95,37 @@ export function FlipButton({ className }: { className?: string }) {
       onClick={run}
     >
       {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SwitchCamera className="h-4 w-4" />}
+    </Button>
+  )
+}
+
+/**
+ * Opens the call's chat thread — a thread anchored on the `call_started` event
+ * (`chatAnchorId` from the start/join response). Opening the draft panel resolves
+ * to the real thread once one exists (chunk-3 auto-redirect) and otherwise starts
+ * one on first send, so a single target covers both. Navigation, so a <Link>
+ * (INV-40); hidden until the anchor is known.
+ *
+ * The dock mounts ABOVE `PanelProvider` (it survives navigation and takes no URL
+ * state), so it can't call `getPanelUrl`. It builds the absolute host-stream URL
+ * with the `panel` query itself — navigating to the call's stream and opening the
+ * thread panel there in one hop, which also lands the user on the right page.
+ */
+export function ChatButton({ className }: { className?: string }) {
+  const workspaceId = useCallWorkspaceId()
+  const streamId = useCallStreamId()
+  const chatAnchorId = useCallChatAnchor()
+  if (!workspaceId || !streamId || !chatAnchorId) return null
+  const search = new URLSearchParams({ panel: createDraftPanelId(streamId, chatAnchorId) }).toString()
+  return (
+    <Button asChild variant="ghost" size="icon" className={cn("h-9 w-9", className)}>
+      <Link
+        to={{ pathname: `/w/${workspaceId}/s/${streamId}`, search }}
+        aria-label="Open call chat"
+        title="Open call chat"
+      >
+        <MessageSquare className="h-4 w-4" />
+      </Link>
     </Button>
   )
 }

--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -15,6 +15,7 @@ import {
   useCallStreamId,
   useCallWorkspaceId,
 } from "./call-store-hooks"
+import { getCallState, setCallSurfaceMode } from "@/stores/call-store"
 
 // The mute / camera / flip / leave controls, one component each so the compact
 // island and the (later) desktop pill share one implementation instead of
@@ -123,6 +124,11 @@ export function ChatButton({ className }: { className?: string }) {
         to={{ pathname: `/w/${workspaceId}/s/${streamId}`, search }}
         aria-label="Open call chat"
         title="Open call chat"
+        onClick={() => {
+          // The fullscreen mobile surface is an opaque route-independent overlay —
+          // without collapsing it the thread panel opens invisibly underneath.
+          if (getCallState().surfaceMode === "full") setCallSurfaceMode("standard")
+        }}
       >
         <MessageSquare className="h-4 w-4" />
       </Link>

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -1,9 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
-import { render, screen, userEvent } from "@/test"
+import { fireEvent, render, screen, userEvent } from "@/test"
 import * as useMobileModule from "@/hooks/use-mobile"
-import { clearCallState, setCallSession, setCallPhase, setCallDevices, type CallDeviceState } from "@/stores/call-store"
+import {
+  clearCallState,
+  getCallState,
+  setCallSession,
+  setCallPhase,
+  setCallDevices,
+  setCallSurfaceMode,
+  type CallDeviceState,
+} from "@/stores/call-store"
 import type { CallController } from "@/calls/call-manager"
 import { CallControls, DevicePickerMenu } from "./call-controls"
 import { CallManagerProvider } from "./call-manager-context"
@@ -154,6 +162,23 @@ describe("CallControls — call chat", () => {
     // on the call_started event id.
     expect(href).toContain("/w/ws_1/s/stream_1")
     expect(href).toContain("draft%3Astream_1%3Aevent_chat_1")
+  })
+
+  it("collapses the fullscreen surface when chat opens (panel would render under the overlay)", () => {
+    act(() => {
+      setCallSession({
+        callId: "call_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: "video",
+        chatAnchorId: "event_chat_1",
+      })
+      setCallPhase("connected")
+      setCallSurfaceMode("full")
+    })
+    renderRouted(makeManager())
+    fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
+    expect(getCallState().surfaceMode).toBe("standard")
   })
 
   it("hides the chat control until the anchor is known", () => {

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { render, screen, userEvent } from "@/test"
 import * as useMobileModule from "@/hooks/use-mobile"
 import { clearCallState, setCallSession, setCallPhase, setCallDevices, type CallDeviceState } from "@/stores/call-store"
@@ -121,6 +122,47 @@ describe("DevicePickerMenu — camera group", () => {
     await userEvent.click(screen.getByLabelText("Devices"))
     expect(await screen.findByText("Microphone")).toBeInTheDocument()
     expect(screen.queryByText("Camera")).toBeNull()
+  })
+})
+
+describe("CallControls — call chat", () => {
+  function renderRouted(manager: CallController) {
+    return render(
+      <MemoryRouter initialEntries={["/w/ws_1/s/other"]}>
+        <CallManagerProvider manager={manager}>
+          <CallControls />
+        </CallManagerProvider>
+      </MemoryRouter>
+    )
+  }
+
+  it("opens the call chat thread on the call_started anchor of the call's stream", () => {
+    act(() => {
+      setCallSession({
+        callId: "call_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: "video",
+        chatAnchorId: "event_chat_1",
+      })
+      setCallPhase("connected")
+    })
+    renderRouted(makeManager())
+    const chat = screen.getByRole("link", { name: "Open call chat" })
+    const href = chat.getAttribute("href") ?? ""
+    // Absolute host-stream URL (dock is above PanelProvider) + draft panel keyed
+    // on the call_started event id.
+    expect(href).toContain("/w/ws_1/s/stream_1")
+    expect(href).toContain("draft%3Astream_1%3Aevent_chat_1")
+  })
+
+  it("hides the chat control until the anchor is known", () => {
+    act(() => {
+      setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+      setCallPhase("connected")
+    })
+    renderRouted(makeManager())
+    expect(screen.queryByRole("link", { name: "Open call chat" })).toBeNull()
   })
 })
 

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -15,7 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
 import { useCallManager } from "./call-manager-context"
-import { CameraButton, FlipButton, LeaveButton, MuteButton } from "./call-control-buttons"
+import { CameraButton, ChatButton, FlipButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { useCallDevices, useCallDiagnostics } from "./call-store-hooks"
 
 // setSinkId (output device selection) is unsupported on Safari/Firefox; hide the
@@ -188,6 +188,7 @@ export function CallControls() {
       <FlipButton />
       <DevicePickerMenu devices={devices} />
       <ConnectionDiagnostics diagnostics={diagnostics} />
+      <ChatButton />
       <LeaveButton />
     </div>
   )

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -58,6 +58,11 @@ export function useCallConnectedAt(): number | null {
   return useCallSelector((s) => s.connectedAt)
 }
 
+/** The `call_started` event id anchoring the live call's chat thread, or null. */
+export function useCallChatAnchor(): string | null {
+  return useCallSelector((s) => s.chatAnchorId)
+}
+
 export function useCallMode(): CallMode | null {
   return useCallSelector((s) => s.mode)
 }

--- a/apps/frontend/src/components/timeline/call-card.test.tsx
+++ b/apps/frontend/src/components/timeline/call-card.test.tsx
@@ -86,6 +86,7 @@ describe("CallCard", () => {
     renderCard()
     expect(screen.getByText("Call in progress")).toBeTruthy()
     const join = screen.getByRole("button", { name: "Join" })
+    expect(join).toHaveClass("min-h-9")
     await userEvent.click(join)
     expect(launch).toHaveBeenCalledWith({
       workspaceId: "ws_1",
@@ -138,6 +139,7 @@ describe("CallCard", () => {
     const chat = screen.getByRole("link", { name: /Discuss this call/i })
     // Draft panel keyed on the card's event id — the call chat anchor.
     expect(chat.getAttribute("href")).toContain("draft%3Astream_1%3Aevt_call")
+    expect(chat).toHaveClass("min-h-9", "min-w-9")
   })
 
   it("renders the thread chip and hides Chat once the call has replies (live and ended)", () => {

--- a/apps/frontend/src/components/timeline/call-card.test.tsx
+++ b/apps/frontend/src/components/timeline/call-card.test.tsx
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
 import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent } from "@threa/types"
 import * as hooksModule from "@/hooks"
+import { PanelProvider } from "@/contexts"
 import * as launchModule from "@/components/call/call-launch-context"
 import * as callHooksModule from "@/components/call/call-store-hooks"
 import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls-store"
@@ -33,7 +35,9 @@ const STARTED: CallStartedEventPayload = {
   startedAt: new Date().toISOString(),
 }
 
-function startedEvent(): StreamEvent {
+function startedEvent(
+  payloadExtra?: Partial<CallStartedEventPayload> & { threadId?: string; replyCount?: number }
+): StreamEvent {
   return {
     id: "evt_call",
     streamId: "stream_1",
@@ -43,12 +47,18 @@ function startedEvent(): StreamEvent {
     actorId: "usr_a",
     actorType: "user",
     createdAt: new Date().toISOString(),
-    payload: STARTED,
+    payload: { ...STARTED, ...payloadExtra },
   }
 }
 
-function renderCard(endedPatch?: CallEndedEventPayload) {
-  return render(<CallCard event={startedEvent()} workspaceId="ws_1" streamId="stream_1" endedPatch={endedPatch} />)
+function renderCard(endedPatch?: CallEndedEventPayload, event: StreamEvent = startedEvent()) {
+  return render(
+    <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
+      <PanelProvider>
+        <CallCard event={event} workspaceId="ws_1" streamId="stream_1" endedPatch={endedPatch} />
+      </PanelProvider>
+    </MemoryRouter>
+  )
 }
 
 describe("CallCard", () => {
@@ -118,5 +128,26 @@ describe("CallCard", () => {
     renderCard()
     expect(screen.getByText("In this call")).toBeTruthy()
     expect(screen.queryByRole("button", { name: "Join" })).toBeNull()
+  })
+
+  it("shows a Chat affordance opening the draft thread on the call_started event when no replies exist", () => {
+    renderCard(
+      { callId: "call_1", durationMs: 1000, participantUserIds: ["usr_a"], endedReason: "completed" },
+      startedEvent()
+    )
+    const chat = screen.getByRole("link", { name: /Discuss this call/i })
+    // Draft panel keyed on the card's event id — the call chat anchor.
+    expect(chat.getAttribute("href")).toContain("draft%3Astream_1%3Aevt_call")
+  })
+
+  it("renders the thread chip and hides Chat once the call has replies (live and ended)", () => {
+    // Ended card with a healed thread on its event: chip shows, Chat is the
+    // duplicate entry point so it's hidden.
+    renderCard(
+      { callId: "call_1", durationMs: 1000, participantUserIds: ["usr_a"], endedReason: "completed" },
+      startedEvent({ threadId: "stream_thread", replyCount: 2 })
+    )
+    expect(screen.getByText("2 replies")).toBeTruthy()
+    expect(screen.queryByRole("link", { name: /Discuss this call/i })).toBeNull()
   })
 })

--- a/apps/frontend/src/components/timeline/call-card.tsx
+++ b/apps/frontend/src/components/timeline/call-card.tsx
@@ -175,7 +175,7 @@ export function CallCard({ event, workspaceId, streamId, endedPatch }: CallCardP
               to={replyUrl}
               aria-label="Discuss this call"
               title="Discuss this call in a thread"
-              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:min-h-0 sm:min-w-0 sm:justify-start"
             >
               <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
               <span className="hidden sm:inline">Chat</span>
@@ -191,7 +191,7 @@ export function CallCard({ event, workspaceId, streamId, endedPatch }: CallCardP
                 disabled={callActive}
                 title={callActive ? "You're already in another call" : undefined}
                 className={cn(
-                  "rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors",
+                  "min-h-9 rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors sm:min-h-0",
                   callActive ? "opacity-50" : "hover:bg-primary/90"
                 )}
               >

--- a/apps/frontend/src/components/timeline/call-card.tsx
+++ b/apps/frontend/src/components/timeline/call-card.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react"
-import { Phone, Video } from "lucide-react"
-import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent } from "@threa/types"
+import { Link } from "react-router-dom"
+import { MessageSquareReply, Phone, Video } from "lucide-react"
+import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent, ThreadSummary } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { useActors } from "@/hooks"
 import { useActiveCall } from "@/stores/active-calls-store"
 import { useCallLaunch } from "@/components/call/call-launch-context"
 import { useCallPhase, useCallStreamId } from "@/components/call/call-store-hooks"
 import { cn } from "@/lib/utils"
+import { ThreadSlot } from "./thread-slot"
+import { useThreadAnchor } from "./use-thread-anchor"
 
 interface CallCardProps {
   event: StreamEvent
@@ -91,11 +94,18 @@ function ParticipantAvatars({ userIds, workspaceId }: { userIds: string[]; works
  * (INV-63): joining just brings up the dock.
  */
 export function CallCard({ event, workspaceId, streamId, endedPatch }: CallCardProps) {
-  const payload = event.payload as CallStartedEventPayload | undefined
+  // Chunk-2 healing lands thread stats on this event's payload once a thread
+  // exists, keyed on the event id — the anchor the call chat threads on.
+  const payload = event.payload as
+    | (CallStartedEventPayload & { threadId?: string; replyCount?: number; threadSummary?: ThreadSummary })
+    | undefined
   const live = useActiveCall(workspaceId, payload?.callId)
   const { launch, callActive } = useCallLaunch()
   const callPhase = useCallPhase()
   const inCallStreamId = useCallStreamId()
+  // Shared thread affordance keyed on the card's event id: `replyUrl` opens the
+  // real thread when one exists, else the draft panel to start the call chat.
+  const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
 
   if (!payload) return null
 
@@ -104,6 +114,14 @@ export function CallCard({ event, workspaceId, streamId, endedPatch }: CallCardP
   // The viewer is already in THIS call (one active call per stream) when a call
   // is up and their local session is on this stream.
   const selfInThisCall = callPhase !== "idle" && inCallStreamId === streamId
+
+  // Chat opens (or starts) the call's discussion thread. Live and ended cards
+  // both carry it — the discussion is the call's persistent home. Hidden only
+  // when the footer chip already links the thread (a duplicate entry point),
+  // mirroring the delegation card.
+  const replyCount = payload.replyCount ?? 0
+  const threadChipShowing = replyCount > 0 && !!threadHref
+  const showChat = !threadChipShowing
 
   return (
     <div className="px-3 sm:px-6 py-1.5">
@@ -151,26 +169,47 @@ export function CallCard({ event, workspaceId, streamId, endedPatch }: CallCardP
           )}
         </div>
 
-        {isLive &&
-          (selfInThisCall ? (
-            <span className="shrink-0 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground">
-              In this call
-            </span>
-          ) : (
-            <button
-              type="button"
-              onClick={() => launch({ workspaceId, streamId, mode: payload.mode, expectedCallId: payload.callId })}
-              disabled={callActive}
-              title={callActive ? "You're already in another call" : undefined}
-              className={cn(
-                "shrink-0 rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors",
-                callActive ? "opacity-50" : "hover:bg-primary/90"
-              )}
+        <div className="flex shrink-0 items-center gap-1">
+          {showChat && (
+            <Link
+              to={replyUrl}
+              aria-label="Discuss this call"
+              title="Discuss this call in a thread"
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
-              Join
-            </button>
-          ))}
+              <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
+              <span className="hidden sm:inline">Chat</span>
+            </Link>
+          )}
+          {isLive &&
+            (selfInThisCall ? (
+              <span className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground">In this call</span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => launch({ workspaceId, streamId, mode: payload.mode, expectedCallId: payload.callId })}
+                disabled={callActive}
+                title={callActive ? "You're already in another call" : undefined}
+                className={cn(
+                  "rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors",
+                  callActive ? "opacity-50" : "hover:bg-primary/90"
+                )}
+              >
+                Join
+              </button>
+            ))}
+        </div>
       </div>
+
+      {/* Thread anchored on this card — the call's discussion (and future call
+          summary) surfaces as a footer chip once replies land. Keyed on the
+          event id via `useThreadAnchor`; healed payload drives the count. */}
+      <ThreadSlot
+        replyCount={replyCount}
+        threadHref={threadHref}
+        summary={payload.threadSummary}
+        workspaceId={workspaceId}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -102,6 +102,13 @@ export interface CallState {
   callId: string | null
   workspaceId: string | null
   streamId: string | null
+  /**
+   * The `call_started` event id — the anchor for this call's chat thread. Handed
+   * back by the start/join REST response so the dock's Chat control can open the
+   * thread panel (draft on the anchor, or the real thread once it exists) without
+   * loading the host-stream timeline. Null when the started card row is missing.
+   */
+  chatAnchorId: string | null
   mode: CallMode | null
   roster: CallRosterParticipant[]
   rosterVersion: number
@@ -143,6 +150,7 @@ function idleState(): CallState {
     callId: null,
     workspaceId: null,
     streamId: null,
+    chatAnchorId: null,
     mode: null,
     roster: [],
     rosterVersion: 0,
@@ -200,8 +208,16 @@ export function setDesktopSurfaceOverride(desktopSurfaceOverride: DesktopSurface
   setState({ ...state, desktopSurfaceOverride })
 }
 
-export function setCallSession(args: { callId: string; workspaceId: string; streamId: string; mode: CallMode }): void {
-  setState({ ...state, ...args, phase: "joining", connectedAt: null })
+export function setCallSession(args: {
+  callId: string
+  workspaceId: string
+  streamId: string
+  mode: CallMode
+  /** The `call_started` event id anchoring this call's chat thread; null if unknown. */
+  chatAnchorId?: string | null
+}): void {
+  const { chatAnchorId = null, ...session } = args
+  setState({ ...state, ...session, chatAnchorId, phase: "joining", connectedAt: null })
 }
 
 export function setCallRoster(roster: CallRosterParticipant[], rosterVersion: number): void {

--- a/docs/plans/event-anchored-threads.md
+++ b/docs/plans/event-anchored-threads.md
@@ -87,7 +87,9 @@ Board cards are conversations (`message_ids[]`); branches key off `forkMessageId
 
 ### Consumer 2: calls (the chat becomes the thread)
 
-The call chat = a thread anchored on the `call_started` event. Created lazily on first chat open/message via `insertThreadOrFind` (race-safe on the anchor index); v1 resolves the association through anchor propagation and lookup without writing `calls.chat_stream_id`.
+The call chat = a thread anchored on the `call_started` event. Created lazily on first chat open/message via `insertThreadOrFind` (race-safe on the anchor index).
+
+Build decision (PR 5): `calls.chat_stream_id` stays **unwritten** in v1 — stamping it from `createThreadOn` would couple the streams service to the calls table, and no v1 reader needs it (the card heals `threadId` via `thread:updated`; the dock carries the `call_started` event id from `startCall`). The association is derivable by anchor query (`findByAnchor(streamId, callStartedEventId)`); the transcription follow-up decides whether to stamp the column when it needs to post summaries into the thread.
 
 - Access: plain `root_stream_id` inheritance — v1 calls require host-stream access (calls plan v5/v7 ruling: zero `access.ts` changes), so thread inheritance is exactly right. The deferred guest primitive composes later.
 - During-call: dock/expanded call UI opens the thread panel (existing panel machinery); members discuss live.


### PR DESCRIPTION
## Problem

The call card has no discussion surface: nowhere to chat during a call, nowhere for the future call summary to live. The calls plan reserved `calls.chat_stream_id` for a bespoke linked stream — the second workaround shape event-anchored threads exist to replace. PR 5 of 7, plan `docs/plans/event-anchored-threads.md` §Consumer 2; ships dark behind `callsEnabled` (default off).

## Solution

The call chat is an ordinary thread anchored on the `call_started` event — lazy, like every other thread (Kris's call).

- CallCard opts into the chunk-3 affordance: footer thread chip when replies exist (healed `threadId/replyCount/threadSummary`, same path as DelegationEvent) + a "Chat" link opening/starting the thread; live and ended cards both (the ended card keeps the discussion and is where the transcription follow-up will post summaries). Chat hides once the chip serves as the entry.
- Dock/drawer `ChatButton` in `CallControls`: the dock mounts above `PanelProvider`, so it links absolutely to `/w/:ws/s/:stream?panel=draft:<stream>:<anchor>` (INV-40) — host stream + panel in one hop; hidden until the anchor is known.
- Anchor plumbing: `startCall` returns `chatAnchorId` (the `call_started` event id) — from `appendCallStarted` on create, else new `CallRepository.findCallStartedEventId(streamId, callId)` on join — through the session into `call-store`.
- **`calls.chat_stream_id` stays unwritten in v1** (decision recorded in the plan): stamping from `createThreadOn` would couple the streams service to the calls table, and no v1 reader needs the column — the association is derivable by anchor query. The transcription follow-up decides whether to stamp it.
- Zero `access.ts` changes: the thread inherits via `root_stream_id` (v1 calls require host-stream access — calls-plan ruling holds).
- Lazy creation, draft→real promotion, healing: all existing chunk-1–3 machinery, no new paths.

Not included (honest): a Playwright start-call→chat→thread flow — the fake-CF harness covers media/dock convergence, not thread-panel composer interaction; new harness machinery wasn't worth this chunk. Covered by unit/vitest suites.

## Test plan

- [x] backend `bun run test:unit` — 3477 pass (startCall chatAnchorId create/join, findCallStartedEventId); typecheck clean
- [x] frontend FULL vitest — 4822 pass (CallCard chip/Chat routing/hide-on-chip, dock ChatButton link + hidden-without-anchor; 3 known billing-timezone flakes pass in isolation); typecheck clean
- [x] packages/types 136 pass; check:migrations clean
- Adversarial verify (Opus xhigh): verdict clean, zero fix rounds

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787313440&installation_model_id=20758&pr_number=1504&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1504&signature=ce89e903052a64047b815f4a10e85aaaa94134e541cc5a8b79f37279b35e6589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->