### PR TITLE
feat: reconnect live Pi sessions

### DIFF
--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -2,6 +2,10 @@
 
 Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). If a Claude channel session was launched by the standalone worktree helper and has no inventory row, `kick` can still resolve its exact runtime session ID from a live `server:threa-channel` tmux pane and nudge it without adopting or reviving it. Run `threa-harnessd help` for the full command list.
 
+## Live Pi reconnect
+
+`threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` replaces a live Pi process in its existing tmux pane and resumes the same native Pi session. It accepts only the exact `pi --session-id <UUID>` launch shape (plus ordinary shell-metacharacter-free harness and Threa identity environment assignments), preflights the exact linked root with create/replace disabled, then revalidates the pane generation before `tmux respawn-pane`. Managed inventory is preferred; a matching standalone pane may be used without writing or adopting it. Missing, ambiguous, stale, unsupported, or mismatched targets fail without launching a fresh session. `--force` is reserved for the shared reconnect interface; it does not weaken Pi validation.
+
 ## `up` (alias `resume-active`)
 
 Brings every eligible recorded session back up. Safe to rerun: each pass is a no-op for anything already running, and the decision is driven by the **live scratchpad state on Threa**, never by which local directories happen to exist.

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 import { die } from "./errors"
+import type { ReconnectOptions } from "./reconnect"
 import type { ResumeOptions, RuntimeKind, SpawnOptions } from "./types"
 
 export function usage(): never {
@@ -15,6 +16,7 @@ Usage:
   threa-harnessd boot-resume [--tmux <session>] [--dry-run]
   threa-harnessd install-watch [--tmux <session>]
   threa-harnessd install-boot-resume [--tmux <session>]
+  threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]
   threa-harnessd stop <agent-id-or-name>
   threa-harnessd kick <agent-id-or-name-or-runtime-session-id>
   threa-harnessd interrupt <agent-id-or-name>
@@ -104,6 +106,31 @@ export function parseResume(args: string[]): ResumeOptions {
     dryRun: boolFlag(flags, "dry-run"),
     recreateWorktree: boolFlag(flags, "recreate-worktree"),
   }
+}
+
+export function parseReconnect(args: string[]): ReconnectOptions {
+  const runtimeSessionId = args.shift()
+  if (!runtimeSessionId || runtimeSessionId.startsWith("--")) die("reconnect requires a runtime session id")
+  let rootStreamId: string | undefined
+  let force = false
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === "--force") {
+      if (force) die("reconnect accepts --force exactly once")
+      force = true
+      continue
+    }
+    if (arg === "--root-stream-id") {
+      if (rootStreamId) die("reconnect accepts --root-stream-id exactly once")
+      const value = args[++index]
+      if (!value || value.startsWith("--")) die("reconnect requires --root-stream-id <stream-id>")
+      rootStreamId = value
+      continue
+    }
+    die(`unexpected reconnect argument: ${arg}`)
+  }
+  if (!rootStreamId) die("reconnect requires --root-stream-id <stream-id>")
+  return { runtimeSessionId, rootStreamId, force }
 }
 
 export function parseSpawn(args: string[]): SpawnOptions {

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -64,6 +64,14 @@ describe("parseClaudeChannelLaunch", () => {
     ).toEqual({ runtimeSessionId: "ccs-explicit" })
   })
 
+  test("retains parent-compatible tmux parsing for single-quoted literal expansions", () => {
+    expect(
+      parseClaudeChannelLaunch(
+        "\"env 'THREA_DISPLAY_NAME=price $5 `literal`' THREA_RUNTIME_SESSION_ID=ccs.parent claude --dangerously-load-development-channels server:threa-channel\""
+      )
+    ).toEqual({ runtimeSessionId: "ccs-parent" })
+  })
+
   test("rejects commands that only contain Claude channel tokens", () => {
     for (const command of [
       "echo claude --dangerously-load-development-channels server:threa-channel",

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -18,28 +18,51 @@ interface ClaudeChannelLaunch {
   runtimeSessionId?: string
 }
 
+export interface PiLaunch {
+  executable: string
+  sessionId: string
+  environment: Array<{ name: string; value: string }>
+}
+
+const PI_ENVIRONMENT = new Set([
+  "THREA_HARNESSD_ENTRYPOINT",
+  "THREA_HARNESSD_BUN_BIN",
+  "THREA_INSTANCE_ID",
+  "THREA_RUNTIME_SESSION_ID",
+])
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
 function shellWords(input: string): string[] | undefined {
   const words: string[] = []
   let word = ""
   let quote: "'" | '"' | undefined
-  let escaped = false
   let started = false
 
-  for (const char of input.trim()) {
-    if (escaped) {
-      word += char
-      escaped = false
-      started = true
-      continue
-    }
-    if (char === "\\" && quote !== "'") {
-      escaped = true
-      started = true
-      continue
-    }
-    if (quote) {
+  for (let index = 0; index < input.trim().length; index += 1) {
+    const char = input.trim()[index]!
+    if (quote === "'") {
       if (char === quote) quote = undefined
       else word += char
+      started = true
+      continue
+    }
+    if (quote === '"') {
+      if (char === quote) quote = undefined
+      else if (char === "\\") {
+        const next = input.trim()[index + 1]
+        if (next && '$`"\\'.includes(next)) word += input.trim()[++index]!
+        else word += char
+      } else {
+        if (char === "$" || char === "`") return undefined
+        word += char
+      }
+      started = true
+      continue
+    }
+    if (char === "\\") {
+      const next = input.trim()[++index]
+      if (!next || next === "\n") return undefined
+      word += next
       started = true
       continue
     }
@@ -56,11 +79,12 @@ function shellWords(input: string): string[] | undefined {
       }
       continue
     }
+    if ("$`*?[]{};|&<>".includes(char) || (char === "~" && !started)) return undefined
     word += char
     started = true
   }
 
-  if (quote || escaped) return undefined
+  if (quote) return undefined
   if (started) words.push(word)
   return words
 }
@@ -75,6 +99,57 @@ function launchWords(command: string): string[] | undefined {
 function parseAssignment(word: string): { name: string; value: string } | undefined {
   const match = word.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/s)
   return match ? { name: match[1]!, value: match[2]! } : undefined
+}
+
+export function parsePiLaunch(command: string): PiLaunch | undefined {
+  const words = launchWords(command)
+  if (!words?.length) return undefined
+
+  let index = 0
+  const environment: PiLaunch["environment"] = []
+  const names = new Set<string>()
+  if (basename(words[index]!) === "env") {
+    index += 1
+    while (index < words.length) {
+      const assignment = parseAssignment(words[index]!)
+      if (!assignment) break
+      if (
+        !PI_ENVIRONMENT.has(assignment.name) ||
+        names.has(assignment.name) ||
+        !assignment.value ||
+        /[$`*?[\]{};|&<>]/.test(assignment.value)
+      )
+        return undefined
+      names.add(assignment.name)
+      environment.push(assignment)
+      index += 1
+    }
+  } else if (parseAssignment(words[index]!)) {
+    return undefined
+  }
+
+  const executable = words[index]
+  if (!executable || basename(executable) !== "pi") return undefined
+  index += 1
+  if (words.length - index !== 2 || words[index] !== "--session-id") return undefined
+  const sessionId = words[index + 1]!
+  if (!UUID_RE.test(sessionId)) return undefined
+  const runtimeIdentity = environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value
+  if (runtimeIdentity && runtimeIdentity !== sessionId) return undefined
+  return { executable, sessionId, environment }
+}
+
+export function findLocalPiPane(
+  runtimeSessionId: string,
+  panes: LocalTmuxPane[] = listLocalTmuxPanes()
+): LocalTmuxPane | undefined {
+  const matches = panes.filter((pane) => parsePiLaunch(pane.startCommand)?.sessionId === runtimeSessionId)
+  if (matches.length > 1) {
+    throw new Error(
+      `multiple live standalone Pi panes match ${runtimeSessionId}: ${matches.map((pane) => pane.paneId).join(", ")}`
+    )
+  }
+  return matches[0]
 }
 
 export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch | undefined {

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -29,10 +29,11 @@ const PI_ENVIRONMENT = new Set([
   "THREA_HARNESSD_BUN_BIN",
   "THREA_INSTANCE_ID",
   "THREA_RUNTIME_SESSION_ID",
+  "THREA_EXPECTED_ROOT_STREAM_ID",
 ])
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-function shellWords(input: string): string[] | undefined {
+function strictShellWords(input: string): string[] | undefined {
   const words: string[] = []
   let word = ""
   let quote: "'" | '"' | undefined
@@ -89,11 +90,65 @@ function shellWords(input: string): string[] | undefined {
   return words
 }
 
-function launchWords(command: string): string[] | undefined {
-  const firstPass = shellWords(command)
+function strictLaunchWords(command: string): string[] | undefined {
+  const firstPass = strictShellWords(command)
   if (!firstPass) return undefined
   if (firstPass.length !== 1 || !/\s/.test(firstPass[0]!)) return firstPass
-  return shellWords(firstPass[0]!)
+  return strictShellWords(firstPass[0]!)
+}
+
+function permissiveShellWords(input: string): string[] | undefined {
+  const words: string[] = []
+  let word = ""
+  let quote: "'" | '"' | undefined
+  let escaped = false
+  let started = false
+
+  for (const char of input.trim()) {
+    if (escaped) {
+      word += char
+      escaped = false
+      started = true
+      continue
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true
+      started = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = undefined
+      else word += char
+      started = true
+      continue
+    }
+    if (char === "'" || char === '"') {
+      quote = char
+      started = true
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (started) {
+        words.push(word)
+        word = ""
+        started = false
+      }
+      continue
+    }
+    word += char
+    started = true
+  }
+
+  if (quote || escaped) return undefined
+  if (started) words.push(word)
+  return words
+}
+
+function permissiveLaunchWords(command: string): string[] | undefined {
+  const firstPass = permissiveShellWords(command)
+  if (!firstPass) return undefined
+  if (firstPass.length !== 1 || !/\s/.test(firstPass[0]!)) return firstPass
+  return permissiveShellWords(firstPass[0]!)
 }
 
 function parseAssignment(word: string): { name: string; value: string } | undefined {
@@ -102,7 +157,7 @@ function parseAssignment(word: string): { name: string; value: string } | undefi
 }
 
 export function parsePiLaunch(command: string): PiLaunch | undefined {
-  const words = launchWords(command)
+  const words = strictLaunchWords(command)
   if (!words?.length) return undefined
 
   let index = 0
@@ -153,7 +208,7 @@ export function findLocalPiPane(
 }
 
 export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch | undefined {
-  const words = launchWords(command)
+  const words = permissiveLaunchWords(command)
   if (!words || words.length === 0) return undefined
 
   let index = 0

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { parseResume, parseSpawn, usage } from "./cli"
+import { parseReconnect, parseResume, parseSpawn, usage } from "./cli"
 import {
   attachAgent,
   bootResume,
@@ -18,12 +18,14 @@ import {
   watchUnarchived,
 } from "./commands"
 import { die } from "./errors"
+import { reconnectPi } from "./reconnect"
 
 async function main(): Promise<void> {
   const [, , command, ...args] = process.argv
   if (!command || command === "help" || command === "--help" || command === "-h") usage()
   if (command === "spawn") return spawnAgent(parseSpawn(args))
   if (command === "list") return listAgents()
+  if (command === "reconnect") return reconnectPi(parseReconnect(args))
   if (
     command === "up" ||
     command === "revive-unarchived" ||

--- a/extensions/harness-daemon/src/reconnect.test.ts
+++ b/extensions/harness-daemon/src/reconnect.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { existsSync, mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { parseReconnect } from "./cli"
+import { findLocalPiPane, parsePiLaunch, type LocalTmuxPane } from "./discovery"
+import { reconnectPi, type ReconnectDeps } from "./reconnect"
+import { readInventoryReadonly } from "./inventory"
+import type { ManagedAgent } from "./types"
+
+const SESSION = "123e4567-e89b-42d3-a456-426614174000"
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 1234,
+    cwd: "/work/feature",
+    startCommand: `env THREA_HARNESSD_ENTRYPOINT=/h/index.ts THREA_HARNESSD_BUN_BIN=/bin/bun THREA_INSTANCE_ID=pi-one THREA_RUNTIME_SESSION_ID=${SESSION} /opt/bin/pi --session-id ${SESSION}`,
+    ...overrides,
+  }
+}
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "pi-1",
+    name: "feature",
+    runtime: "pi",
+    status: "online",
+    tmuxPaneId: "%8",
+    instanceId: "pi-one",
+    runtimeSessionId: SESSION,
+    command: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function deps(overrides: Partial<ReconnectDeps> = {}): ReconnectDeps & { calls: string[][] } {
+  const calls: string[][] = []
+  return {
+    calls,
+    inventory: () => [agent()],
+    panes: () => [pane()],
+    piConfig: () => ({ baseUrl: "https://app.threa.io", workspaceId: "ws_one", apiKey: "key" }),
+    piLink: () => ({ instanceId: "pi-one", rootStreamId: "stream_one", scratchpadUrl: "unused" }),
+    preflight: async () => ({ status: "linked", rootStreamId: "stream_one" }),
+    respawn: (target, cwd, command) => calls.push([target, cwd, command]),
+    ...overrides,
+  }
+}
+
+describe("parsePiLaunch", () => {
+  test("accepts exact standalone and managed launch forms", () => {
+    expect(parsePiLaunch(`/usr/local/bin/pi --session-id ${SESSION}`)).toEqual({
+      executable: "/usr/local/bin/pi",
+      sessionId: SESSION,
+      environment: [],
+    })
+    expect(parsePiLaunch(pane().startCommand)?.environment).toEqual([
+      { name: "THREA_HARNESSD_ENTRYPOINT", value: "/h/index.ts" },
+      { name: "THREA_HARNESSD_BUN_BIN", value: "/bin/bun" },
+      { name: "THREA_INSTANCE_ID", value: "pi-one" },
+      { name: "THREA_RUNTIME_SESSION_ID", value: SESSION },
+    ])
+  })
+
+  test("preserves safely quoted words and double-quoted literal backslashes", () => {
+    expect(parsePiLaunch(`env THREA_INSTANCE_ID="pi\\one" '/opt/my pi/pi' --session-id ${SESSION}`)).toMatchObject({
+      executable: "/opt/my pi/pi",
+      environment: [{ name: "THREA_INSTANCE_ID", value: "pi\\one" }],
+    })
+  })
+
+  test("rejects malformed, duplicate, expansion-dependent, and empty identity forms", () => {
+    for (const command of [
+      "pi --session-id nope",
+      `pi --session-id ${SESSION} --session-id ${SESSION}`,
+      `pi --unknown --session-id ${SESSION}`,
+      `pi hello --session-id ${SESSION}`,
+      `pi --session-id ${SESSION} -- tail`,
+      `env HOME=/tmp pi --session-id ${SESSION}`,
+      `env THREA_INSTANCE_ID=one THREA_INSTANCE_ID=two pi --session-id ${SESSION}`,
+      `env THREA_INSTANCE_ID= pi --session-id ${SESSION}`,
+      `env THREA_RUNTIME_SESSION_ID='' pi --session-id ${SESSION}`,
+      `env THREA_RUNTIME_SESSION_ID=other pi --session-id ${SESSION}`,
+      `~/bin/pi --session-id ${SESSION}`,
+      `/opt/*/pi --session-id ${SESSION}`,
+      `env THREA_INSTANCE_ID=$USER pi --session-id ${SESSION}`,
+      `env THREA_INSTANCE_ID="$(whoami)" pi --session-id ${SESSION}`,
+      `env THREA_HARNESSD_ENTRYPOINT='a\`b' pi --session-id ${SESSION}`,
+    ])
+      expect(parsePiLaunch(command)).toBeUndefined()
+  })
+})
+
+test("standalone pane resolution rejects missing and ambiguous matches", () => {
+  expect(findLocalPiPane(SESSION, [])).toBeUndefined()
+  expect(() => findLocalPiPane(SESSION, [pane(), pane({ paneId: "%9" })])).toThrow("multiple live standalone")
+})
+
+describe("reconnectPi", () => {
+  test("uses managed pane first and respawns with exact preserved identity", async () => {
+    let preflight: unknown
+    const d = deps({
+      panes: () => [pane(), pane({ paneId: "%standalone" })],
+      preflight: async (params) => {
+        preflight = params
+        return { status: "linked", rootStreamId: "stream_one" }
+      },
+    })
+    await reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)
+    expect(preflight).toMatchObject({
+      runtimeKind: "pi-local",
+      instanceId: "pi-one",
+      runtimeSessionId: SESSION,
+      expectedRootStreamId: "stream_one",
+    })
+    expect(d.calls).toEqual([
+      [
+        "%8",
+        "/work/feature",
+        `'env' 'THREA_HARNESSD_ENTRYPOINT=/h/index.ts' 'THREA_HARNESSD_BUN_BIN=/bin/bun' 'THREA_INSTANCE_ID=pi-one' 'THREA_RUNTIME_SESSION_ID=${SESSION}' '/opt/bin/pi' '--session-id' '${SESSION}'`,
+      ],
+    ])
+  })
+
+  test("supports standalone without adopting inventory", async () => {
+    let inventoryReads = 0
+    const d = deps({ inventory: () => (inventoryReads++, []), panes: () => [pane()] })
+    await reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)
+    expect({ inventoryReads, respawns: d.calls.length }).toEqual({ inventoryReads: 1, respawns: 1 })
+  })
+
+  test("fails closed on duplicate exact managed inventory matches", async () => {
+    const d = deps({ inventory: () => [agent(), agent({ id: "pi-2", updatedAt: "2027-01-01T00:00:00Z" })] })
+    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "multiple managed agents match"
+    )
+    expect(d.calls).toEqual([])
+  })
+
+  test("preflight failure leaves pane untouched", async () => {
+    const d = deps({ preflight: async () => ({ status: "archived", reason: "archived" }) })
+    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "preflight failed"
+    )
+    expect(d.calls).toEqual([])
+  })
+
+  test("pane generation changes leave pane untouched", async () => {
+    for (const changed of [
+      { panePid: 9999 },
+      { cwd: "/work/other" },
+      { startCommand: `/opt/bin/pi --session-id ${SESSION}` },
+    ]) {
+      let reads = 0
+      const d = deps({ panes: () => (++reads === 1 ? [pane()] : [pane(changed)]) })
+      await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+        "changed during reconnect preflight"
+      )
+      expect(d.calls).toEqual([])
+    }
+  })
+
+  test("missing managed pane and tmux/preflight failures never launch fresh", async () => {
+    const missing = deps({ panes: () => [] })
+    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, missing)).rejects.toThrow(
+      "missing or ambiguous"
+    )
+    const failed = deps({
+      respawn: () => {
+        throw new Error("tmux failed")
+      },
+    })
+    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, failed)).rejects.toThrow(
+      "tmux failed"
+    )
+    expect(missing.calls).toEqual([])
+  })
+})
+
+describe("readInventoryReadonly", () => {
+  test("does not create a missing inventory", () => {
+    const previous = process.env.THREA_HARNESSD_INVENTORY
+    const path = join(mkdtempSync(join(tmpdir(), "harnessd-reconnect-missing-")), "inventory.sqlite")
+    process.env.THREA_HARNESSD_INVENTORY = path
+    try {
+      expect(readInventoryReadonly()).toEqual([])
+      expect(existsSync(path)).toBeFalse()
+    } finally {
+      if (previous === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+      else process.env.THREA_HARNESSD_INVENTORY = previous
+    }
+  })
+
+  test("reads a legacy schema without migrating it", () => {
+    const previous = process.env.THREA_HARNESSD_INVENTORY
+    const path = join(mkdtempSync(join(tmpdir(), "harnessd-reconnect-legacy-")), "inventory.sqlite")
+    const db = new Database(path)
+    db.exec(`CREATE TABLE managed_agents (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, runtime TEXT NOT NULL, status TEXT NOT NULL,
+      worktree TEXT, branch TEXT, tmux_session TEXT, tmux_window TEXT, scratchpad_url TEXT,
+      command_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_output TEXT
+    )`)
+    db.query("INSERT INTO managed_agents VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+      "old",
+      "legacy",
+      "pi",
+      "online",
+      null,
+      null,
+      null,
+      null,
+      null,
+      "[]",
+      "2026-01-01",
+      "2026-01-01",
+      null
+    )
+    const before = db.query("PRAGMA table_info(managed_agents)").all()
+    db.close()
+    process.env.THREA_HARNESSD_INVENTORY = path
+    try {
+      expect(readInventoryReadonly()).toEqual([
+        expect.objectContaining({ id: "old", runtimeSessionId: undefined, tmuxPaneId: undefined }),
+      ])
+      const check = new Database(path, { readonly: true })
+      expect(check.query("PRAGMA table_info(managed_agents)").all()).toEqual(before)
+      check.close()
+    } finally {
+      if (previous === undefined) delete process.env.THREA_HARNESSD_INVENTORY
+      else process.env.THREA_HARNESSD_INVENTORY = previous
+    }
+  })
+})
+
+describe("parseReconnect", () => {
+  test("requires exact root and accepts force once", () => {
+    expect(parseReconnect([SESSION, "--root-stream-id", "stream_one", "--force"])).toEqual({
+      runtimeSessionId: SESSION,
+      rootStreamId: "stream_one",
+      force: true,
+    })
+    expect(() => parseReconnect([SESSION])).toThrow("requires --root-stream-id")
+    expect(() => parseReconnect([SESSION, "--root-stream-id", "stream_one", "--force", "--force"])).toThrow(
+      "exactly once"
+    )
+    expect(() => parseReconnect([SESSION, "--root-stream-id", "stream_one", "--extra"])).toThrow("unexpected")
+  })
+})

--- a/extensions/harness-daemon/src/reconnect.test.ts
+++ b/extensions/harness-daemon/src/reconnect.test.ts
@@ -7,6 +7,7 @@ import { parseReconnect } from "./cli"
 import { findLocalPiPane, parsePiLaunch, type LocalTmuxPane } from "./discovery"
 import { reconnectPi, type ReconnectDeps } from "./reconnect"
 import { readInventoryReadonly } from "./inventory"
+import { piResumeCommand } from "./spawners"
 import type { ManagedAgent } from "./types"
 
 const SESSION = "123e4567-e89b-42d3-a456-426614174000"
@@ -127,6 +128,35 @@ describe("reconnectPi", () => {
         `'env' 'THREA_HARNESSD_ENTRYPOINT=/h/index.ts' 'THREA_HARNESSD_BUN_BIN=/bin/bun' 'THREA_INSTANCE_ID=pi-one' 'THREA_RUNTIME_SESSION_ID=${SESSION}' '/opt/bin/pi' '--session-id' '${SESSION}'`,
       ],
     ])
+  })
+
+  test("preserves the production resume command root binding", async () => {
+    const startCommand = piResumeCommand("/opt/bin/pi", SESSION, "stream_one")
+    const d = deps({ panes: () => [pane({ startCommand })] })
+
+    await reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)
+
+    expect(parsePiLaunch(d.calls[0]![2]!)?.environment).toContainEqual({
+      name: "THREA_EXPECTED_ROOT_STREAM_ID",
+      value: "stream_one",
+    })
+  })
+
+  test("production resume command root mismatch leaves pane untouched before preflight", async () => {
+    let preflights = 0
+    const startCommand = piResumeCommand("/opt/bin/pi", SESSION, "stream_other")
+    const d = deps({
+      panes: () => [pane({ startCommand })],
+      preflight: async () => {
+        preflights += 1
+        return { status: "linked", rootStreamId: "stream_one" }
+      },
+    })
+
+    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "expects root stream_other, not stream_one"
+    )
+    expect({ preflights, respawns: d.calls.length }).toEqual({ preflights: 0, respawns: 0 })
   })
 
   test("supports standalone without adopting inventory", async () => {

--- a/extensions/harness-daemon/src/reconnect.test.ts
+++ b/extensions/harness-daemon/src/reconnect.test.ts
@@ -125,7 +125,7 @@ describe("reconnectPi", () => {
       [
         "%8",
         "/work/feature",
-        `'env' 'THREA_HARNESSD_ENTRYPOINT=/h/index.ts' 'THREA_HARNESSD_BUN_BIN=/bin/bun' 'THREA_INSTANCE_ID=pi-one' 'THREA_RUNTIME_SESSION_ID=${SESSION}' '/opt/bin/pi' '--session-id' '${SESSION}'`,
+        `'env' 'THREA_HARNESSD_ENTRYPOINT=/h/index.ts' 'THREA_HARNESSD_BUN_BIN=/bin/bun' 'THREA_INSTANCE_ID=pi-one' 'THREA_RUNTIME_SESSION_ID=${SESSION}' 'THREA_EXPECTED_ROOT_STREAM_ID=stream_one' '/opt/bin/pi' '--session-id' '${SESSION}'`,
       ],
     ])
   })
@@ -142,28 +142,34 @@ describe("reconnectPi", () => {
     })
   })
 
-  test("production resume command root mismatch leaves pane untouched before preflight", async () => {
-    let preflights = 0
+  test("replaces the production resume command root binding with the routed root", async () => {
     const startCommand = piResumeCommand("/opt/bin/pi", SESSION, "stream_other")
-    const d = deps({
-      panes: () => [pane({ startCommand })],
-      preflight: async () => {
-        preflights += 1
-        return { status: "linked", rootStreamId: "stream_one" }
-      },
-    })
+    const d = deps({ panes: () => [pane({ startCommand })] })
 
-    await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
-      "expects root stream_other, not stream_one"
-    )
-    expect({ preflights, respawns: d.calls.length }).toEqual({ preflights: 0, respawns: 0 })
+    await reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)
+
+    expect(parsePiLaunch(d.calls[0]![2]!)?.environment).toContainEqual({
+      name: "THREA_EXPECTED_ROOT_STREAM_ID",
+      value: "stream_one",
+    })
   })
 
-  test("supports standalone without adopting inventory", async () => {
+  test("standalone launch without environment gains the routed expected root without adopting inventory", async () => {
     let inventoryReads = 0
-    const d = deps({ inventory: () => (inventoryReads++, []), panes: () => [pane()] })
+    const startCommand = `/usr/local/bin/pi --session-id ${SESSION}`
+    const d = deps({ inventory: () => (inventoryReads++, []), panes: () => [pane({ startCommand })] })
+
     await reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)
+
     expect({ inventoryReads, respawns: d.calls.length }).toEqual({ inventoryReads: 1, respawns: 1 })
+    expect(parsePiLaunch(d.calls[0]![2]!)).toMatchObject({
+      sessionId: SESSION,
+      environment: expect.arrayContaining([
+        { name: "THREA_INSTANCE_ID", value: "pi-one" },
+        { name: "THREA_RUNTIME_SESSION_ID", value: SESSION },
+        { name: "THREA_EXPECTED_ROOT_STREAM_ID", value: "stream_one" },
+      ]),
+    })
   })
 
   test("fails closed on duplicate exact managed inventory matches", async () => {
@@ -180,6 +186,25 @@ describe("reconnectPi", () => {
       "preflight failed"
     )
     expect(d.calls).toEqual([])
+  })
+
+  test("post-preflight link mutations leave pane untouched", async () => {
+    for (const changedLink of [
+      undefined,
+      { instanceId: "pi-relinked", rootStreamId: "stream_one", scratchpadUrl: "unused" },
+      { instanceId: "pi-one", rootStreamId: "stream_other", scratchpadUrl: "unused" },
+    ]) {
+      let reads = 0
+      const d = deps({
+        piLink: () =>
+          ++reads === 1 ? { instanceId: "pi-one", rootStreamId: "stream_one", scratchpadUrl: "unused" } : changedLink,
+      })
+
+      await expect(reconnectPi({ runtimeSessionId: SESSION, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+        "link changed during reconnect preflight"
+      )
+      expect(d.calls).toEqual([])
+    }
   })
 
   test("pane generation changes leave pane untouched", async () => {

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -88,6 +88,10 @@ function resolveTarget(options: ReconnectOptions, deps: ReconnectDeps): Reconnec
   if (commandInstance && commandInstance !== link.instanceId) {
     throw new Error(`pane ${pane.paneId} has a different Threa instance identity`)
   }
+  const commandRoot = launch.environment.find(({ name }) => name === "THREA_EXPECTED_ROOT_STREAM_ID")?.value
+  if (commandRoot && commandRoot !== options.rootStreamId) {
+    throw new Error(`pane ${pane.paneId} expects root ${commandRoot}, not ${options.rootStreamId}`)
+  }
   return { pane, launch, instanceId: link.instanceId }
 }
 

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -88,20 +88,18 @@ function resolveTarget(options: ReconnectOptions, deps: ReconnectDeps): Reconnec
   if (commandInstance && commandInstance !== link.instanceId) {
     throw new Error(`pane ${pane.paneId} has a different Threa instance identity`)
   }
-  const commandRoot = launch.environment.find(({ name }) => name === "THREA_EXPECTED_ROOT_STREAM_ID")?.value
-  if (commandRoot && commandRoot !== options.rootStreamId) {
-    throw new Error(`pane ${pane.paneId} expects root ${commandRoot}, not ${options.rootStreamId}`)
-  }
   return { pane, launch, instanceId: link.instanceId }
 }
 
-export function reconstructPiCommand(target: ReconnectTarget, runtimeSessionId: string): string {
+export function reconstructPiCommand(target: ReconnectTarget, runtimeSessionId: string, rootStreamId: string): string {
   const environment = target.launch.environment.filter(
-    ({ name }) => name !== "THREA_INSTANCE_ID" && name !== "THREA_RUNTIME_SESSION_ID"
+    ({ name }) =>
+      name !== "THREA_INSTANCE_ID" && name !== "THREA_RUNTIME_SESSION_ID" && name !== "THREA_EXPECTED_ROOT_STREAM_ID"
   )
   environment.push(
     { name: "THREA_INSTANCE_ID", value: target.instanceId },
-    { name: "THREA_RUNTIME_SESSION_ID", value: runtimeSessionId }
+    { name: "THREA_RUNTIME_SESSION_ID", value: runtimeSessionId },
+    { name: "THREA_EXPECTED_ROOT_STREAM_ID", value: rootStreamId }
   )
   return [
     "env",
@@ -149,7 +147,19 @@ export async function reconnectPi(
   if (!currentLaunch || currentLaunch.sessionId !== target.launch.sessionId) {
     throw new Error(`Pi session identity changed during reconnect preflight`)
   }
+  const currentLink = deps.piLink(options.runtimeSessionId)
+  if (
+    !currentLink ||
+    currentLink.instanceId !== target.instanceId ||
+    currentLink.rootStreamId !== options.rootStreamId
+  ) {
+    throw new Error(`Pi remote link changed during reconnect preflight`)
+  }
 
-  deps.respawn(target.pane.paneId, target.pane.cwd, reconstructPiCommand(target, options.runtimeSessionId))
+  deps.respawn(
+    target.pane.paneId,
+    target.pane.cwd,
+    reconstructPiCommand(target, options.runtimeSessionId, options.rootStreamId)
+  )
   console.log(`harnessd: reconnected Pi session ${options.runtimeSessionId} in ${target.pane.paneId}`)
 }

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -1,0 +1,151 @@
+import { basename } from "node:path"
+import { findLocalPiPane, listLocalTmuxPanes, parsePiLaunch, type LocalTmuxPane, type PiLaunch } from "./discovery"
+import { readInventoryReadonly } from "./inventory"
+import { preflightRuntimeSession, type RuntimePreflightResult } from "./resume"
+import { shellQuote } from "./shell"
+import {
+  configuredThreaBaseUrl,
+  readPiRemoteConfig,
+  readPiRemoteSession,
+  type PiRemoteConfig,
+  type PiRemoteSession,
+} from "./spawners"
+import { respawnPane } from "./tmux"
+import type { ManagedAgent } from "./types"
+
+export interface ReconnectOptions {
+  runtimeSessionId: string
+  rootStreamId: string
+  force?: boolean
+}
+
+interface ReconnectTarget {
+  pane: LocalTmuxPane
+  launch: PiLaunch
+  instanceId: string
+}
+
+export interface ReconnectDeps {
+  inventory: () => ManagedAgent[]
+  panes: () => LocalTmuxPane[]
+  piConfig: () => PiRemoteConfig
+  piLink: (runtimeSessionId: string) => PiRemoteSession | undefined
+  preflight: (params: Parameters<typeof preflightRuntimeSession>[0]) => Promise<RuntimePreflightResult>
+  respawn: (target: string, cwd: string, command: string) => void
+}
+
+export function defaultReconnectDeps(): ReconnectDeps {
+  return {
+    inventory: readInventoryReadonly,
+    panes: listLocalTmuxPanes,
+    piConfig: readPiRemoteConfig,
+    piLink: readPiRemoteSession,
+    preflight: preflightRuntimeSession,
+    respawn: respawnPane,
+  }
+}
+
+function samePaneGeneration(left: LocalTmuxPane, right: LocalTmuxPane): boolean {
+  return (
+    left.paneId === right.paneId &&
+    left.panePid === right.panePid &&
+    left.cwd === right.cwd &&
+    left.startCommand === right.startCommand
+  )
+}
+
+function resolveTarget(options: ReconnectOptions, deps: ReconnectDeps): ReconnectTarget {
+  const managed = deps.inventory().filter((agent) => agent.runtimeSessionId === options.runtimeSessionId)
+  let pane: LocalTmuxPane | undefined
+  let agent: ManagedAgent | undefined
+  if (managed.length > 0) {
+    if (managed.length !== 1) throw new Error(`multiple managed agents match ${options.runtimeSessionId}`)
+    const piAgents = managed.filter((candidate) => candidate.runtime === "pi")
+    if (piAgents.length !== managed.length) throw new Error(`${options.runtimeSessionId} is not a Pi runtime session`)
+    agent = piAgents[0]
+    if (!agent?.tmuxPaneId) throw new Error(`managed Pi session ${options.runtimeSessionId} has no recorded pane`)
+    const matches = deps.panes().filter((candidate) => candidate.paneId === agent!.tmuxPaneId)
+    if (matches.length !== 1) throw new Error(`managed Pi pane ${agent.tmuxPaneId} is missing or ambiguous`)
+    pane = matches[0]
+  } else {
+    pane = findLocalPiPane(options.runtimeSessionId, deps.panes())
+    if (!pane) throw new Error(`no live Pi pane matched ${options.runtimeSessionId}`)
+  }
+
+  const launch = parsePiLaunch(pane.startCommand)
+  if (!launch || launch.sessionId !== options.runtimeSessionId) {
+    throw new Error(`pane ${pane.paneId} is not the exact Pi session ${options.runtimeSessionId}`)
+  }
+  const link = deps.piLink(options.runtimeSessionId)
+  if (!link) throw new Error(`Pi remote link is missing or disabled for ${options.runtimeSessionId}`)
+  if (link.rootStreamId !== options.rootStreamId) {
+    throw new Error(`Pi remote root mismatch: expected ${options.rootStreamId}, got ${link.rootStreamId}`)
+  }
+  if (agent?.instanceId && agent.instanceId !== link.instanceId) {
+    throw new Error(`managed Pi instance mismatch: expected ${agent.instanceId}, got ${link.instanceId}`)
+  }
+  const commandInstance = launch.environment.find(({ name }) => name === "THREA_INSTANCE_ID")?.value
+  if (commandInstance && commandInstance !== link.instanceId) {
+    throw new Error(`pane ${pane.paneId} has a different Threa instance identity`)
+  }
+  return { pane, launch, instanceId: link.instanceId }
+}
+
+export function reconstructPiCommand(target: ReconnectTarget, runtimeSessionId: string): string {
+  const environment = target.launch.environment.filter(
+    ({ name }) => name !== "THREA_INSTANCE_ID" && name !== "THREA_RUNTIME_SESSION_ID"
+  )
+  environment.push(
+    { name: "THREA_INSTANCE_ID", value: target.instanceId },
+    { name: "THREA_RUNTIME_SESSION_ID", value: runtimeSessionId }
+  )
+  return [
+    "env",
+    ...environment.map(({ name, value }) => `${name}=${value}`),
+    target.launch.executable,
+    "--session-id",
+    runtimeSessionId,
+  ]
+    .map(shellQuote)
+    .join(" ")
+}
+
+export async function reconnectPi(
+  options: ReconnectOptions,
+  deps: ReconnectDeps = defaultReconnectDeps()
+): Promise<void> {
+  const target = resolveTarget(options, deps)
+  const config = deps.piConfig()
+  const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+  const apiKey = process.env.THREA_API_KEY || config.apiKey
+  if (!workspaceId || !apiKey) throw new Error("no Pi remote Threa credentials found")
+
+  const result = await deps.preflight({
+    baseUrl: configuredThreaBaseUrl(config),
+    workspaceId,
+    apiKey,
+    runtimeKind: "pi-local",
+    instanceId: target.instanceId,
+    runtimeSessionId: options.runtimeSessionId,
+    displayName: process.env.THREA_DISPLAY_NAME || config.defaultDisplayName || `Pi - ${basename(target.pane.cwd)}`,
+    localCwd: target.pane.cwd,
+    expectedRootStreamId: options.rootStreamId,
+    labelName: process.env.THREA_DEFAULT_LABEL || config.defaultLabel || "coding",
+  })
+  if (result.status !== "linked") {
+    const detail = result.status === "mismatch" ? `root mismatch: ${result.rootStreamId}` : result.reason
+    throw new Error(`Pi reconnect preflight failed: ${detail}`)
+  }
+
+  const current = deps.panes().filter((pane) => pane.paneId === target.pane.paneId)
+  if (current.length !== 1 || !samePaneGeneration(target.pane, current[0]!)) {
+    throw new Error(`Pi pane ${target.pane.paneId} changed during reconnect preflight`)
+  }
+  const currentLaunch = parsePiLaunch(current[0]!.startCommand)
+  if (!currentLaunch || currentLaunch.sessionId !== target.launch.sessionId) {
+    throw new Error(`Pi session identity changed during reconnect preflight`)
+  }
+
+  deps.respawn(target.pane.paneId, target.pane.cwd, reconstructPiCommand(target, options.runtimeSessionId))
+  console.log(`harnessd: reconnected Pi session ${options.runtimeSessionId} in ${target.pane.paneId}`)
+}

--- a/extensions/harness-daemon/src/tmux.ts
+++ b/extensions/harness-daemon/src/tmux.ts
@@ -95,6 +95,10 @@ export function createWindow(
   return { windowId, paneId }
 }
 
+export function respawnPane(target: string, cwd: string, command: string): void {
+  run(["tmux", "respawn-pane", "-k", "-t", target, "-c", cwd, command])
+}
+
 export function capturePane(target: string, lines = 30): string {
   return output(["tmux", "capture-pane", "-t", target, "-p", "-S", `-${lines}`], {
     allowFailure: true,


### PR DESCRIPTION
## Problem

A live Pi session can remain linked to Threa while its local TUI/runtime is wedged. Existing `kick` and `status` controls cannot replace that process, and starting a new Pi process would lose the native conversation or target the wrong scratchpad.

## Solution

Add a fail-closed local reconnect primitive for exact live Pi sessions:

- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` accepts only the narrow `pi --session-id <UUID>` launch contract.
- Managed inventory wins when exactly one row matches; otherwise live tmux discovery may resolve one standalone pane without adopting it.
- `reconnectPi` preflights the exact existing root with `ifArchived: wait` and `ifMissing: error`, then revalidates pane PID, cwd, command, and native session immediately before mutation.
- `tmux respawn-pane -k` replaces Pi in the same pane and cwd with the same session and allowed identity environment.
- Unsupported shell-dependent policy, ambiguity, stale generations, missing roots, and failures stop without inventory writes or fresh-session fallback.

This PR is the bottom reconnect layer. Claude native resume, reachable `/reconnect`, `/key`, and offline recovery are intentionally deferred to higher layers or later work.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/reconnect.ts` | Exact Pi target resolution, root preflight, generation pinning, and respawn orchestration (**new**) |
| `extensions/harness-daemon/src/reconnect.test.ts` | Parser, ambiguity, read-only inventory, preflight, race, and CLI regressions (**new**) |
| `extensions/harness-daemon/src/discovery.ts` | Narrow Pi launch parser and exact standalone pane lookup |
| `extensions/harness-daemon/src/inventory.ts` | Read-only legacy-compatible inventory lookup that never creates or migrates |
| `extensions/harness-daemon/src/tmux.ts` | Exact `respawn-pane` wrapper |
| `extensions/harness-daemon/src/cli.ts` | Strict reconnect CLI argument parser |
| `extensions/harness-daemon/src/index.ts` | Reconnect command dispatch |
| `extensions/harness-daemon/README.md` | Live Pi reconnect contract and exclusions |

## Test plan

- [x] Harness daemon tests — 69 passed
- [x] Root unit tests — 3,460 passed
- [x] Harness and root TypeScript checks
- [x] Repository lint, Prettier, Dockerfile checks, and 230 migration checks
- [x] `git diff --check`
- [x] Two Sol/high adversarial rounds: three findings fixed; shell-metacharacter-bearing env values explicitly rejected by approved narrow-policy disposition
- [x] Sol/high PR review — two compatibility findings fixed and rechecked clean at 7/7

<details>
<summary>📋 Full implementation plan</summary>

# Live runtime reconnect and safe keys

Status: ratified 2026-07-22.

This replaces the abandoned broad reconnect prototype preserved under `.tmp/oversized-reconnect-*`.

## Goal

Add small, truthful controls for live Threa-linked Pi and Claude sessions:

- `/reconnect [--force]` replaces a live runtime process in the same tmux pane and resumes the same native session.
- `/key <name>` sends one allowlisted tmux key to the exact live pane.

This feature is intentionally limited to channels that remain connected long enough to claim and acknowledge the command. It is not an offline supervisor.

## Shared invariants

- Target the exact routed `instanceId`, `runtimeSessionId`, and root stream.
- Inventory remains authoritative when an exact managed row exists; exact live-pane discovery may supplement it without adoption.
- Missing, ambiguous, stale, or unsupported identity fails closed.
- Never pick the newest session, transcript, pane, or inventory row.
- Preserve cwd, tmux pane/window/session, native runtime session, Threa runtime identity, channel, and the narrow supported launch policy.
- Perform same-root preflight with `ifArchived: wait` and `ifMissing: error` before replacement.
- Never create, replace, revive, or unarchive a scratchpad.
- Never launch a fresh native session as fallback.
- Complete the Threa command acknowledgement before a detached reconnect starts.
- Reconnect acknowledgement says it was accepted, not that the replacement already connected.
- Standalone discovery never writes harness inventory.

## Narrow launch contracts

### Pi

Support only exact Threa Pi forms:

```text
pi --session-id <uuid>
```

The executable may be an absolute path. A leading `env` is allowed only for explicit Threa runtime/instance identity and the existing harness entrypoint/Bun variables, using ordinary values without shell metacharacters. Unknown options, positional prompts, duplicate session IDs, arguments after `--`, exotic shell-dependent values, and unrelated environment assignments fail before tmux is touched.

The native Pi session ID is the validated `--session-id` UUID. No title or recency fallback exists.

### Claude

Support only the ordinary Threa/channel helper form:

- executable basename `claude`;
- optional exact `--name threa.<name>`;
- exactly one `--dangerously-load-development-channels server:<channel>`;
- optional `--dangerously-skip-permissions`;
- optional one file-backed `--mcp-config <path>`;
- optional explicit `THREA_INSTANCE_ID` and `THREA_RUNTIME_SESSION_ID` assignments;
- no positional prompt or arguments after `--`.

Unknown options, inline/variadic MCP JSON, multiple MCP configs, custom config directories, and unrelated environment assignments fail before tmux is touched. Named global channel registration is reused as named; reconnect does not copy or materialize MCP configuration.

Claude native identity comes only from the live `~/.claude/sessions/<pane_pid>.json` registry. Require matching PID, process start, canonical cwd, optional parsed name, valid UUID, idle status unless forced, and existing exact transcript. No dead-process or newest-transcript fallback exists.

## Shared process replacement

The complete replacement command is built and all identity/pane facts are pinned before mutation. Immediately before mutation, revalidate pane ID, PID, cwd, start command, and native identity.

Use exactly:

```text
tmux respawn-pane -k -t <pane-id> -c <cwd> <shell-quoted-command>
```

This keeps pane/window/session identity and avoids kill/wait/recreate, anchor windows, durable descriptors, and retry machinery.

After successful respawn, bounded local verification may confirm a live process with the same native session and cwd. Failure is logged and never falls back to a fresh session.

## PR stack

This is an actual GitHub stack above PR #1501, managed with non-interactive `gh stack` commands.

### PR 1 — Live Pi reconnect primitive

Deliverables:

- Exact Pi launch parser and native session extraction.
- Exact managed-first/live-standalone pane resolution without inventory adoption.
- Small shared `tmux respawn-pane` helper.
- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` for Pi targets.
- Same-root preflight and generation revalidation.
- CLI/README documentation.

Required tests:

- exact managed and standalone Pi forms;
- malformed UUID, duplicate ID, unknown option/env/positional/`--` rejection;
- missing or ambiguous pane rejection;
- preflight failure and generation change leave pane untouched;
- exact respawn arguments preserve cwd/pane/session ID/Threa identity;
- failure never launches fresh or writes inventory.

Implementation budget: 250–500 lines excluding focused tests. Inventory schema changes, persistent descriptors, runtime extension lifecycle changes, or generic supervisor infrastructure require a plan checkpoint.

### PR 2 — Live Claude reconnect primitive

Deliverables:

- Reuse PR 1's replacement/preflight path.
- Strict live Claude registry resolver with injectable tests.
- Narrow Claude launch parser/reconstructor.
- Managed-first/live-standalone Claude targeting without inventory adoption.
- Same native UUID resume and bounded replacement verification.

Required tests:

- current managed and standalone helper launch forms;
- malformed/stale registry, PID reuse, cwd/name/transcript/status mismatch;
- `--force` behavior;
- unsupported option/env/MCP/`--` rejection;
- preflight and generation races leave pane untouched;
- exact `claude --resume <same-uuid>` respawn;
- no fresh launch or inventory writes on failure.

Implementation budget: 250–500 lines excluding focused tests. Do not add dead-session recovery, descriptor persistence, config-dir abstraction, policy snapshots, or extension-side reconnect evidence.

### PR 3 — Reachable `/reconnect`

Deliverables:

- Canonical command catalog and capability advertisement for supported Pi and Claude tmux sessions.
- Empty args or exact `--force` validation.
- Minimal optional post-ack action in remote-session command handling.
- Seal acknowledgement first, then spawn detached harnessd with exact runtime/root IDs.
- Truthful copy and docs explaining the reachable-channel limitation.

Required tests:

- command advertised only where locally supported;
- routed runtime/root IDs and force flag reach harnessd exactly;
- acknowledgement completion precedes helper spawn;
- failed acknowledgement never spawns;
- preparation failure is returned before acknowledgement;
- existing sealed command completion remains intact.

Implementation budget: 200–400 lines excluding tests. No backend outbox, supervisor delivery, or offline recovery.

### PR 4 — Allowlisted `/key`

Deliverables:

- `/key <name>` for reachable supported Pi and Claude tmux sessions.
- Initial allowlist only: `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, `ctrl-u`.
- Exact pane re-resolution immediately before one `tmux send-keys` call.
- No raw text, key sequences, repeat counts, arbitrary tmux syntax, or shell interpolation.
- Canonical catalog/capability/docs updates.

Required tests:

- every allowed name maps to one exact tmux token;
- casing/aliases/extra args/unknown values fail;
- ambiguity/stale generation leaves pane untouched;
- command sends exactly once to the routed runtime pane;
- acknowledgement is truthful and sealed through the normal command path.

Implementation budget: 150–300 lines excluding tests.

## Binding exclusions

- Fully disconnected/offline command recovery.
- Supervisor outbox/control jobs.
- Dead-process or transcript-only reconnect.
- Durable standalone reconnect descriptors or retry after failed replacement.
- Arbitrary Claude/Pi launch-policy reconstruction.
- Inline or multiple MCP configs.
- `CLAUDE_CONFIG_DIR` support.
- Inventory schema changes or legacy inventory migration.
- New frontend runtime state or overview UI.
- `/type`, raw text entry, arbitrary keys, repeats, or key sequences.
- Starting a fresh native session.
- Creating, replacing, reviving, or unarchiving scratchpads.

## Build protocol

Use `build-feature` with these binding overrides:

- implementer: GPT-5.6 Sol, effort `minimal`, Pi harness only;
- adversarial verifier: GPT-5.6 Sol, effort `high`, Pi harness only;
- per-PR reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- whole-stack reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- do not use Fable, Claude Code, Claude Agent SDK, or any Claude-backed harness;
- use actual `gh stack` branches/PRs and `gh stack submit --auto`/`gh stack view --json`;
- per PR: brief -> implement -> adversarial verify -> fix/reverify -> commit -> stacked PR -> review.

Scope controls:

- Copy binding exclusions and the current PR's implementation budget into every agent brief.
- Classify every review finding as `in-scope` or `follow-up` before fixing it.
- A fix that adds a deferred subsystem, exceeds the budget, or broadens supported launch policy requires a human plan checkpoint.
- After two fix/reverify rounds without a clean result, stop and report concrete remaining findings instead of continuing automatically.
- Agents receive only the current chunk brief plus paths to relevant source/plan files, not an invitation to redesign the whole stack.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336082&installation_model_id=20758&pr_number=1508&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1508&signature=2834aa0c697dc2700395302bffd94e8d0ac647969867d6596b8c53f88928a99c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
