### PR TITLE
fix(calls): keep connecting state in call surfaces

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -92,11 +92,14 @@ function LaunchButton({ request }: { request: CallLaunchRequest }) {
   )
 }
 
-function renderDock(manager: CallController) {
+function renderDock(
+  manager: CallController,
+  request: CallLaunchRequest = { workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }
+) {
   return render(
     <CallManagerProvider manager={manager}>
       <CallLaunchProvider>
-        <LaunchButton request={{ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }} />
+        <LaunchButton request={request} />
         <CallDock />
       </CallLaunchProvider>
     </CallManagerProvider>
@@ -318,6 +321,7 @@ describe("CallDock — pre-join permission taxonomy", () => {
     act(() => setCallPhase("idle"))
     await userEvent.click(screen.getByText("launch"))
     expect(await screen.findByText("Joining…")).toBeInTheDocument()
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-phase", "joining")
   })
 })
 
@@ -421,19 +425,45 @@ describe("CallDock — desktop surface routing", () => {
     expect(screen.queryByTestId("desktop-call-dock")).toBeNull()
   })
 
-  it("sidebar pref renders the DockFrame while joining and the dock in-call", () => {
+  it("keeps a camera-on joining dock at its final width through async cancel", async () => {
+    const manager = makeManager({ startCall: vi.fn(() => new Promise<void>(() => {})) })
+    renderDock(manager, {
+      workspaceId: WORKSPACE_ID,
+      streamId: "stream_1",
+      mode: "video",
+      cameraOn: true,
+    })
+    await userEvent.click(screen.getByText("launch"))
+
+    expect(getCallState().local.cameraOn).toBe(false)
+    const dock = screen.getByTestId("desktop-call-dock")
+    expect(dock).toHaveAttribute("data-mode", "standard")
+
+    act(() => setCallPhase("joining"))
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    expect(manager.leaveCall).toHaveBeenCalled()
+    expect(dock).toHaveAttribute("data-mode", "standard")
+  })
+
+  it("sidebar pref keeps the actual dock mounted from joining through connected", () => {
     // beforeEach pins sidebar.
     renderDock(makeManager())
     act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
-    // The docked joining panel (not the square); it has no collapse toggle — the gate stays visible.
+
+    const joiningDock = screen.getByTestId("desktop-call-dock")
+    expect(joiningDock).toHaveAttribute("data-phase", "joining")
+    expect(joiningDock).toHaveAttribute("data-mode", "compact")
     expect(screen.getByText("Connecting…")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Collapse call")).toBeNull()
+    expect(screen.queryByLabelText("Minimize call")).toBeNull()
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
+
     act(() => {
       setCallPhase("connected")
       setCallRoster([participant({ userId: "usr_self", endpointId: "callep_self" })], 1)
     })
-    expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
+    expect(screen.getByTestId("desktop-call-dock")).toBe(joiningDock)
+    expect(joiningDock).toHaveAttribute("data-phase", "connected")
+    expect(screen.getByTestId("call-tile")).toBeInTheDocument()
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
   })
 

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, type ReactNode } from "react"
-import { SidePanel, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
+import { useCallback, useLayoutEffect, useRef } from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
@@ -31,24 +30,7 @@ import { MobileCallDrawer } from "./mobile-call-drawer"
 import { MobileCallJoining } from "./call-island"
 import { DesktopCallDock } from "./desktop-call-dock"
 import { FloatingCallSquare } from "./floating-call-square"
-import { PreJoinGate } from "./pre-join-gate"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
-
-function DockFrame({ children }: { children: ReactNode }) {
-  return (
-    <div className={cn("fixed right-4 z-50 w-[340px] max-w-[calc(100vw-2rem)]", DOCK_BOTTOM)}>
-      <SidePanel className="rounded-lg border shadow-xl sm:border">{children}</SidePanel>
-    </div>
-  )
-}
-
-function DockHeader({ title }: { title: string }) {
-  return (
-    <SidePanelHeader className="rounded-t-lg">
-      <SidePanelTitle className="text-sm">{title}</SidePanelTitle>
-    </SidePanelHeader>
-  )
-}
 
 /**
  * The docked call surface. Mounts at the app-layout level and is driven purely by
@@ -73,6 +55,8 @@ export function CallDock() {
   const launching = launch.status !== "idle"
   const inCall = phase === "connected" || phase === "reconnecting"
   const joining = phase === "joining"
+  const joiningModeRef = useRef<"compact" | "standard">("compact")
+  if (launch.status !== "idle") joiningModeRef.current = launch.request.cameraOn ? "standard" : "compact"
 
   const surface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, override)
 
@@ -93,7 +77,7 @@ export function CallDock() {
   // (standard/gallery) when joining with the camera on, so a video join lands on
   // tiles. Guarded on the initial `min` so it runs once and later drags win;
   // `surfaceMode` is read only by the sidebar dock (the square uses its own state).
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (inCall && getCallState().surfaceMode === "min") {
       setCallSurfaceMode(getCallState().local.cameraOn ? "standard" : "compact")
     }
@@ -102,6 +86,7 @@ export function CallDock() {
   // Nothing to show: idle with no launch in flight. Surface the cross-tab chip if
   // another tab holds the call, otherwise render nothing.
   if (!launching && !inCall && !joining) {
+    joiningModeRef.current = "compact"
     if (activeElsewhere) {
       return (
         <div className={cn("fixed right-4 z-50", DOCK_BOTTOM)}>
@@ -126,22 +111,18 @@ export function CallDock() {
     return <FloatingCallSquare workspaceId={workspaceId} streamId={streamIdForLabel} onDockToSide={dockToSide} />
   }
 
-  // Desktop sidebar: the resizable dock in-call, the docked pre-join/joining panel
-  // otherwise. The panel is not collapsible — it only ever shows the connecting/
-  // permission gate, which must stay visible (mirrors the floating square).
-  if (inCall) return <DesktopCallDock workspaceId={workspaceId} streamId={streamIdForLabel} onFloat={float} />
+  // Desktop sidebar owns launch, joining, and connected phases. Keeping one
+  // full-height dock mounted avoids swapping a detached loader for the real dock
+  // after the call connects; the joining gate renders inside its content region.
+  // Cancel clears launch state before the manager's async rollback leaves the
+  // joining phase; retain the request-derived width until this surface unmounts.
   return (
-    <DockFrame>
-      <DockHeader title="Call" />
-      <div className="p-4">{joining && launch.status === "idle" ? <JoiningBody /> : <PreJoinGate />}</div>
-    </DockFrame>
-  )
-}
-
-function JoiningBody() {
-  return (
-    <div role="status" className="flex items-center justify-center py-6 text-sm text-muted-foreground">
-      Connecting…
-    </div>
+    <DesktopCallDock
+      workspaceId={workspaceId}
+      streamId={streamIdForLabel}
+      onFloat={float}
+      joining={!inCall}
+      joiningMode={joiningModeRef.current}
+    />
   )
 }

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react"
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react"
 import {
   AlertTriangle,
   ChevronDown,
@@ -32,6 +39,7 @@ import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallStageLayout } from "./call-stage-layout"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
+import { CallJoiningBody } from "./pre-join-gate"
 import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
 
@@ -160,7 +168,17 @@ function PinButton() {
  * dock shows Minimize (collapse) — a peek is dismissed by moving the mouse away, so
  * Minimize there would be a redundant no-op.
  */
-function DockHeaderBar({ title, peeking, onFloat }: { title: string; peeking?: boolean; onFloat?: () => void }) {
+function DockHeaderBar({
+  title,
+  peeking,
+  onFloat,
+  canMinimize = true,
+}: {
+  title: string
+  peeking?: boolean
+  onFloat?: () => void
+  canMinimize?: boolean
+}) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
@@ -169,7 +187,7 @@ function DockHeaderBar({ title, peeking, onFloat }: { title: string; peeking?: b
       ) : (
         <>
           {onFloat && <FloatButton onFloat={onFloat} />}
-          <MinimizeButton />
+          {canMinimize && <MinimizeButton />}
         </>
       )}
     </div>
@@ -252,6 +270,15 @@ function SideTilesView({ workspaceId, currentUserId, roster, captureError, title
       <div className="shrink-0 border-t p-2">
         <CallControls />
       </div>
+    </div>
+  )
+}
+
+function SideJoiningView({ title, onFloat }: Pick<DockViewProps, "title" | "onFloat">) {
+  return (
+    <div className="flex h-full w-full flex-col border-l bg-background">
+      <DockHeaderBar title={title} onFloat={onFloat} canMinimize={false} />
+      <CallJoiningBody />
     </div>
   )
 }
@@ -353,20 +380,27 @@ interface DragState {
  * {@link FULLSCREEN_FRACTION} of the content region; dragging past that cap goes
  * Fullscreen. It pushes the conversation aside via `--call-dock-inset-right` (the
  * main content region reserves the inset) rather than overlaying it, until
- * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop for
- * the connected phase; reads the call store, not the route, so it survives
- * stream navigation.
+ * Fullscreen. Rendered by {@link import("./call-dock").CallDock} on desktop and
+ * reads the call store, not the route, so it survives stream navigation. During
+ * launch/joining it keeps the same full-height dock mounted and renders the
+ * pre-join gate in the content region, then swaps that body for tiles and
+ * controls when connected.
  */
 export function DesktopCallDock({
   workspaceId,
   streamId,
   onFloat,
+  joining = false,
+  joiningMode = "compact",
 }: {
   workspaceId: string | null
   streamId: string | null
   onFloat?: () => void
+  joining?: boolean
+  joiningMode?: Extract<CallSurfaceMode, "compact" | "standard">
 }) {
   const surfaceMode = useCallSurfaceMode()
+  const displaySurfaceMode = joining ? joiningMode : surfaceMode
   const { sideDockWidth } = useCallPrefs()
   const inputMode = useInputMode()
   const roster = useCallRoster()
@@ -409,16 +443,16 @@ export function DesktopCallDock({
 
   // The resting open width: the saved freeform width (or the mode's first-open
   // default), clamped to ≤75% and always leaving MIN_CONTENT.
-  const openWidth = clampOpen(sideDockWidth ?? defaultOpen(surfaceMode), ceilW)
+  const openWidth = clampOpen(sideDockWidth ?? defaultOpen(displaySurfaceMode), ceilW)
 
   // Content push: rail → RAIL_WIDTH, open → openWidth (already ≤ ceil−MIN_CONTENT),
   // fullscreen → 0. Hovering the rail is an overlay, so the inset tracks surfaceMode
   // (still `min`) and never reflows the timeline.
   let insetRight: number
-  if (surfaceMode === "full") insetRight = 0
-  else if (surfaceMode === "min") insetRight = RAIL_WIDTH
+  if (displaySurfaceMode === "full") insetRight = 0
+  else if (displaySurfaceMode === "min") insetRight = RAIL_WIDTH
   else insetRight = openWidth
-  useEffect(() => {
+  useLayoutEffect(() => {
     document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
   }, [insetRight])
   useEffect(
@@ -470,18 +504,19 @@ export function DesktopCallDock({
   // thrashes the drag) — the preview stays on the open tiles; fullscreen mounts on release.
   // Minimized + mouse hover = a transient peek (overlay, no push); it renders the open
   // tiles and shows a pin affordance to commit to a pushing, persisted open dock.
-  const peeking = surfaceMode === "min" && hovering
+  const peeking = !joining && surfaceMode === "min" && hovering
   let cappedDragMode: CallSurfaceMode | null = null
-  if (dragging) cappedDragMode = surfaceMode === "compact" ? "compact" : "standard"
+  if (dragging) cappedDragMode = displaySurfaceMode === "compact" ? "compact" : "standard"
   let contentMode: CallSurfaceMode
   if (cappedDragMode) contentMode = cappedDragMode
   else if (peeking) contentMode = "standard"
-  else contentMode = surfaceMode
+  else contentMode = displaySurfaceMode
 
   const dragCeil = drag.current?.full ?? ceilW
   // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full"),
   // and none when the region is too narrow to have a freeform band below the fullscreen line.
   const showFullscreenCue =
+    !joining &&
     dragging &&
     surfaceMode !== "full" &&
     dragSize != null &&
@@ -490,10 +525,10 @@ export function DesktopCallDock({
 
   let panelWidth: number
   if (dragging && dragSize != null) panelWidth = dragSize
-  else if (surfaceMode === "min") panelWidth = hovering ? openWidth : RAIL_WIDTH
+  else if (displaySurfaceMode === "min") panelWidth = hovering ? openWidth : RAIL_WIDTH
   else panelWidth = openWidth
 
-  const restingFull = !dragging && surfaceMode === "full"
+  const restingFull = !joining && !dragging && surfaceMode === "full"
   let positionClass: string
   let sizeStyle: CSSProperties
   if (restingFull) {
@@ -527,6 +562,7 @@ export function DesktopCallDock({
         data-testid="desktop-call-dock"
         data-mode={contentMode}
         data-position="side"
+        data-phase={joining ? "joining" : "connected"}
         data-hovering={hovering ? "true" : "false"}
         onMouseEnter={() => {
           // Preview only arms from the rail (mirrors the nav-sidebar collapsed→preview);
@@ -542,7 +578,7 @@ export function DesktopCallDock({
         )}
         style={sizeStyle}
       >
-        <DockBody mode={contentMode} view={view} />
+        {joining ? <SideJoiningView title={title} onFloat={onFloat} /> : <DockBody mode={contentMode} view={view} />}
         {showFullscreenCue && (
           <div
             data-testid="call-dock-fullscreen-cue"
@@ -556,7 +592,9 @@ export function DesktopCallDock({
         {/* Always mounted — including at rest-fullscreen — so it holds the pointer
             capture/settle through a drag into full AND lets you drag back OUT of
             fullscreen (a thin edge strip over the stage); collapse via chevron still works. */}
-        <DockResizeHandle onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+        {!joining && (
+          <DockResizeHandle onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+        )}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -294,13 +294,22 @@ describe("FloatingCallSquare — minimize / restore", () => {
 })
 
 describe("FloatingCallSquare — joining", () => {
-  it("renders the Connecting indicator (no tiles) when joining with an idle launch", () => {
+  it("keeps the full floating surface mounted from connecting through connected", () => {
     renderSquare()
     act(() => setCallPhase("joining"))
+
+    const joiningSquare = screen.getByTestId("floating-call-square")
+    expect(joiningSquare).toHaveClass("min-h-[260px]")
     expect(screen.getByText("Connecting…")).toBeInTheDocument()
-    expect(screen.queryAllByTestId("call-tile")).toHaveLength(0)
+    expect(screen.queryByText("Ada (you)")).toBeNull()
+    expect(screen.queryByText("Grace")).toBeNull()
     // The old mobile-island pill (icon-only Cancel) must not render on the desktop square.
     expect(screen.queryByLabelText("Cancel joining")).toBeNull()
+
+    enterConnected(TWO_PEERS)
+    expect(screen.getByTestId("floating-call-square")).toBe(joiningSquare)
+    expect(screen.getByText("Ada (you)")).toBeVisible()
+    expect(screen.getByText("Grace")).toBeVisible()
   })
 
   it("renders the PreJoinGate permission taxonomy during an active launch, not a plain pill", async () => {

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -14,8 +14,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useCallLaunch } from "./call-launch-context"
-import { PreJoinGate } from "./pre-join-gate"
+import { CallJoiningBody } from "./pre-join-gate"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { CallTimer } from "./call-timer"
@@ -183,28 +182,6 @@ function ConnectedBody({
         <CallControls />
       </div>
     </>
-  )
-}
-
-/**
- * Joining/pre-join body — the desktop joining surface, mirroring
- * {@link import("./call-dock").CallDock}'s DockFrame: an active launch (permission
- * request / device pick / error) shows the {@link PreJoinGate}; once the launch is
- * idle and the call is connecting, a plain "Connecting…" indicator.
- */
-function JoiningBody() {
-  const { state } = useCallLaunch()
-  if (state.status !== "idle") {
-    return (
-      <div className="p-3">
-        <PreJoinGate />
-      </div>
-    )
-  }
-  return (
-    <div role="status" className="flex items-center justify-center py-6 text-sm text-muted-foreground">
-      Connecting…
-    </div>
   )
 }
 
@@ -449,7 +426,7 @@ export function FloatingCallSquare({
       data-testid="floating-call-square"
       data-minimized="false"
       style={{ left: `${pos.x}px`, top: `${pos.y}px`, width: `${SQUARE_WIDTH}px` }}
-      className="pointer-events-auto fixed z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+      className="pointer-events-auto fixed z-50 flex min-h-[260px] max-h-[70vh] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
     >
       <SquareHeader
         title={title}
@@ -470,7 +447,7 @@ export function FloatingCallSquare({
           captureError={captureError}
         />
       ) : (
-        <JoiningBody />
+        <CallJoiningBody />
       )}
     </div>
   )

--- a/apps/frontend/src/components/call/pre-join-gate.tsx
+++ b/apps/frontend/src/components/call/pre-join-gate.tsx
@@ -39,6 +39,22 @@ const PERMISSION_COPY: Record<MediaPermissionErrorKind, { title: string; body: s
   },
 }
 
+/** Shared desktop joining body so floating and sidebar surfaces keep one phase UI. */
+export function CallJoiningBody() {
+  const { state } = useCallLaunch()
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+      {state.status === "idle" ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          Connecting…
+        </p>
+      ) : (
+        <PreJoinGate />
+      )}
+    </div>
+  )
+}
+
 /**
  * The joining phase of the dock: a spinner while the join runs, or the
  * taxonomy-specific permission error with retry/cancel. There is no separate


### PR DESCRIPTION
## Problem

Desktop calls use an interim joining surface before the connected UI appears. Floating mode shrink-wraps the joining gate into a short white panel; sidebar mode mounts a detached bottom-right panel and then replaces it with the full-height dock. Both transitions visibly swap geometry while the call is establishing.

## Solution

Keep the selected desktop call surface mounted from launch through connection:

- `CallDock` routes sidebar launch/joining/error states through `DesktopCallDock` instead of the temporary `DockFrame`.
- `DesktopCallDock` renders the shared joining body inside its full-height content region, keeps the gate non-minimizable, and applies width/content inset before paint.
- `FloatingCallSquare` keeps a stable 260px minimum height while the shared joining body is active, then replaces only the body with tiles and controls.
- Connected opening mode is applied in a layout effect so sidebar mode does not flash through the 56px rail.
- Mobile call surfaces are unchanged.

## Files

| File | Change |
| ---- | ------ |
| `call-dock.tsx` | Keep the real sidebar dock mounted across desktop call phases |
| `desktop-call-dock.tsx` | Add the full-height joining presentation and pre-paint geometry updates |
| `floating-call-square.tsx` | Keep stable floating geometry and use the shared joining body |
| `pre-join-gate.tsx` | Centralize desktop connecting/request/error body selection |
| `call-dock.test.tsx` | Verify sidebar DOM continuity from joining to connected |
| `floating-call-square.test.tsx` | Verify floating DOM continuity and stable joining size |

## Test plan

- [x] Frontend call component tests — 139 passed
- [x] Full monorepo typecheck
- [x] Full monorepo lint, Dockerfile checks, and migration checks
- [x] Local Playwright call sessions — floating and sidebar requesting → connected, 2 passed
- [x] Independent Sol review — no findings at confidence ≥80

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787339958&installation_model_id=20758&pr_number=1509&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1509&signature=6ad4c97be0d21e8e0334125859a123e5bc2155bfc38197272ebba9fe7e5ca0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
