### PR TITLE
feat: reconnect live Claude sessions

### DIFF
--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -2,9 +2,9 @@
 
 Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). If a Claude channel session was launched by the standalone worktree helper and has no inventory row, `kick` can still resolve its exact runtime session ID from a live `server:threa-channel` tmux pane and nudge it without adopting or reviving it. Run `threa-harnessd help` for the full command list.
 
-## Live Pi reconnect
+## Live reconnect
 
-`threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` replaces a live Pi process in its existing tmux pane and resumes the same native Pi session. It accepts only the exact `pi --session-id <UUID>` launch shape (plus ordinary shell-metacharacter-free harness and Threa identity environment assignments), preflights the exact linked root with create/replace disabled, then revalidates the pane generation before `tmux respawn-pane`. Managed inventory is preferred; a matching standalone pane may be used without writing or adopting it. Missing, ambiguous, stale, unsupported, or mismatched targets fail without launching a fresh session. `--force` is reserved for the shared reconnect interface; it does not weaken Pi validation.
+`threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` replaces a live Pi or Claude process in its existing tmux pane and resumes the same native session. It accepts only the narrow Threa launch shapes, preflights the exact linked root with create/replace disabled, then revalidates the pane generation before `tmux respawn-pane`. Claude reconnect additionally requires an idle, exact live registry entry and transcript, and verifies the replacement kept the same native UUID and cwd; `--force` permits replacing a busy Claude session. Managed inventory is preferred; a matching standalone pane may be used without writing or adopting it. Missing, ambiguous, stale, unsupported, or mismatched targets fail without launching a fresh session.
 
 ## `up` (alias `resume-active`)
 

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test"
+import { output } from "./shell"
+import { parseClaudeLaunch, type LocalTmuxPane } from "./discovery"
+import { defaultClaudeRegistryDeps, resolveClaudeNativeSession, type ClaudeRegistryDeps } from "./claude-registry"
+import { reconnectClaude, type ReconnectDeps } from "./reconnect"
+import { deriveClaudeRuntimeIdentity } from "./spawners"
+import type { ManagedAgent } from "./types"
+
+const RUNTIME = "ccs-runtime"
+const NATIVE = "123e4567-e89b-42d3-a456-426614174000"
+const CWD = "/work/feature"
+const START = "Wed Jul 22 18:13:08 2026"
+const COMMAND = `env THREA_INSTANCE_ID=cc-one THREA_RUNTIME_SESSION_ID=${RUNTIME} THREA_DISPLAY_NAME=Claude THREA_COLD_START_IF_ARCHIVED=create THREA_COLD_START_IF_MISSING=replace THREA_EXPECTED_ROOT_STREAM_ID=stream_one /opt/claude --name threa.feature --mcp-config /tmp/threa.json --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions`
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 1234,
+    cwd: CWD,
+    startCommand: COMMAND,
+    ...overrides,
+  }
+}
+
+function registry(overrides: Record<string, unknown> = {}, exists = true): ClaudeRegistryDeps {
+  const row = {
+    pid: 1234,
+    sessionId: NATIVE,
+    cwd: CWD,
+    procStart: START,
+    name: "threa.feature",
+    status: "idle",
+    ...overrides,
+  }
+  return {
+    home: "/home/test",
+    read: () => JSON.stringify(row),
+    exists: () => exists,
+    canonical: (path) => path,
+    processStart: () => START,
+  }
+}
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "feature",
+    runtime: "claude",
+    status: "online",
+    worktree: CWD,
+    tmuxPaneId: "%8",
+    instanceId: "cc-one",
+    runtimeSessionId: RUNTIME,
+    command: [],
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    ...overrides,
+  }
+}
+
+function deps(overrides: Partial<ReconnectDeps> = {}): ReconnectDeps & { calls: string[][] } {
+  const calls: string[][] = []
+  let paneReads = 0
+  return {
+    calls,
+    inventory: () => [agent()],
+    panes: () => (++paneReads < 3 ? [pane()] : [pane({ panePid: 5678, startCommand: "claude --resume native" })]),
+    piConfig: () => ({}),
+    piLink: () => undefined,
+    claudeConfig: () => ({ workspaceId: "ws", apiKey: "key" }),
+    claudeRegistry: {
+      ...registry(),
+      read: (path) =>
+        JSON.stringify({
+          pid: path.endsWith("5678.json") ? 5678 : 1234,
+          sessionId: NATIVE,
+          cwd: CWD,
+          procStart: START,
+          name: "threa.feature",
+          status: "idle",
+        }),
+    },
+    preflight: async () => ({ status: "linked", rootStreamId: "stream_one" }),
+    mcpFile: () => true,
+    respawn: (target, cwd, command) => calls.push([target, cwd, command]),
+    sleep: async () => undefined,
+    ...overrides,
+  }
+}
+
+describe("parseClaudeLaunch", () => {
+  test("accepts managed, standalone, and named global-channel forms", () => {
+    expect(parseClaudeLaunch(COMMAND)).toMatchObject({
+      executable: "/opt/claude",
+      name: "threa.feature",
+      channel: "threa-channel",
+      mcpConfig: "/tmp/threa.json",
+      skipPermissions: true,
+    })
+    expect(
+      parseClaudeLaunch("claude --name threa.feature --dangerously-load-development-channels server:threa-channel")
+    ).toMatchObject({
+      name: "threa.feature",
+      channel: "threa-channel",
+      mcpConfig: undefined,
+    })
+  })
+
+  test("rejects unsupported policy and shell forms", () => {
+    for (const command of [
+      "claude --dangerously-load-development-channels server:x --unknown",
+      "claude --dangerously-load-development-channels server:x --dangerously-load-development-channels server:x",
+      "env HOME=/tmp claude --dangerously-load-development-channels server:x",
+      "env CLAUDE_CONFIG_DIR=/tmp claude --dangerously-load-development-channels server:x",
+      "claude --mcp-config={} --dangerously-load-development-channels server:x",
+      "claude --mcp-config '[]' --dangerously-load-development-channels server:x",
+      "claude --mcp-config /a --mcp-config /b --dangerously-load-development-channels server:x",
+      "claude prompt --dangerously-load-development-channels server:x",
+      `claude --resume ${NATIVE} --dangerously-load-development-channels server:x`,
+      "claude --dangerously-load-development-channels server:x -- tail",
+    ])
+      expect(parseClaudeLaunch(command.replace("\u0000", ""))).toBeUndefined()
+  })
+})
+
+describe("resolveClaudeNativeSession", () => {
+  test("default process generation uses the registry's UTC ps shape", () => {
+    const expected = output(["env", "TZ=UTC", "ps", "-p", String(process.pid), "-o", "lstart="]).stdout.trim()
+    expect(defaultClaudeRegistryDeps().processStart(process.pid)).toBe(expected)
+  })
+
+  test("validates exact live registry and force policy", () => {
+    expect(resolveClaudeNativeSession(1234, CWD, "threa.feature", false, registry()).sessionId).toBe(NATIVE)
+    expect(() => resolveClaudeNativeSession(1234, CWD, "threa.feature", false, registry({ status: "busy" }))).toThrow(
+      "use --force"
+    )
+    expect(resolveClaudeNativeSession(1234, CWD, "threa.feature", true, registry({ status: "busy" })).status).toBe(
+      "busy"
+    )
+  })
+
+  test("rejects malformed identity, generation, cwd, name, and transcript", () => {
+    const cases: Array<[ClaudeRegistryDeps, string]> = [
+      [{ ...registry(), read: () => "{" }, "invalid Claude live registry"],
+      [registry({ sessionId: "bad" }), "invalid Claude registry shape"],
+      [registry({ pid: 9 }), "invalid Claude registry shape"],
+      [{ ...registry(), processStart: () => "other" }, "generation"],
+      [registry({ cwd: "/other" }), "cwd"],
+      [registry({ name: "threa.other" }), "name"],
+      [registry({}, false), "transcript"],
+    ] as Array<[ClaudeRegistryDeps, string]>
+    for (const [source, message] of cases) {
+      expect(() => resolveClaudeNativeSession(1234, CWD, "threa.feature", false, source)).toThrow(message)
+    }
+  })
+})
+
+describe("reconnectClaude", () => {
+  test("preflights and resumes exact native UUID with supported policy", async () => {
+    const d = deps()
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+    expect(d.calls).toHaveLength(1)
+    expect(d.calls[0]).toEqual([
+      "%8",
+      CWD,
+      `'env' 'THREA_DISPLAY_NAME=Claude' 'THREA_INSTANCE_ID=cc-one' 'THREA_RUNTIME_SESSION_ID=${RUNTIME}' 'THREA_COLD_START_IF_ARCHIVED=wait' 'THREA_COLD_START_IF_MISSING=error' 'THREA_EXPECTED_ROOT_STREAM_ID=stream_one' '/opt/claude' '--resume' '${NATIVE}' '--name' 'threa.feature' '--mcp-config' '/tmp/threa.json' '--dangerously-load-development-channels' 'server:threa-channel' '--dangerously-skip-permissions'`,
+    ])
+  })
+
+  test("validates MCP config type, relative resolution, and pre-respawn existence", async () => {
+    const checked: string[] = []
+    const relative = deps({
+      panes: (() => {
+        let reads = 0
+        return () =>
+          ++reads < 3 ? [pane({ startCommand: COMMAND.replace("/tmp/threa.json", "config/mcp.json") })] : []
+      })(),
+      mcpFile: (path) => (checked.push(path), true),
+    })
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, relative)).rejects.toThrow(
+      "did not verify"
+    )
+    expect(checked).toEqual([`${CWD}/config/mcp.json`, `${CWD}/config/mcp.json`])
+    expect(relative.calls[0]?.[2]).toContain(`'--mcp-config' '${CWD}/config/mcp.json'`)
+
+    for (const value of ["/missing.json", "/config-dir"]) {
+      const invalid = deps({
+        panes: () => [pane({ startCommand: COMMAND.replace("/tmp/threa.json", value) })],
+        mcpFile: () => false,
+      })
+      await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, invalid)).rejects.toThrow(
+        "not an existing regular file"
+      )
+      expect(invalid.calls).toEqual([])
+    }
+
+    let checks = 0
+    const disappeared = deps({ mcpFile: () => ++checks === 1 })
+    await expect(
+      reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, disappeared)
+    ).rejects.toThrow("changed before respawn")
+    expect(disappeared.calls).toEqual([])
+  })
+
+  test("rejects a stale managed row pointing at a valid no-env Claude pane before preflight", async () => {
+    const launch = "claude --name threa.feature --dangerously-load-development-channels server:threa-channel"
+    let preflights = 0
+    const d = deps({
+      panes: () => [pane({ startCommand: launch })],
+      preflight: async () => {
+        preflights += 1
+        return { status: "linked", rootStreamId: "stream_one" }
+      },
+    })
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "Claude runtime identity mismatch"
+    )
+    expect({ preflights, respawns: d.calls.length }).toEqual({ preflights: 0, respawns: 0 })
+  })
+
+  test("normalizes explicit launch identities exactly like channel discovery", async () => {
+    const launch = COMMAND.replace("THREA_INSTANCE_ID=cc-one", "THREA_INSTANCE_ID=cc.one").replace(
+      `THREA_RUNTIME_SESSION_ID=${RUNTIME}`,
+      "THREA_RUNTIME_SESSION_ID=ccs.explicit"
+    )
+    const d = deps({
+      inventory: () => [agent({ instanceId: "cc-one", runtimeSessionId: "ccs-explicit" })],
+      panes: (() => {
+        let reads = 0
+        return () => (++reads < 3 ? [pane({ startCommand: launch })] : [pane({ panePid: 5678 })])
+      })(),
+    })
+    await reconnectClaude({ runtimeSessionId: "ccs-explicit", rootStreamId: "stream_one" }, d)
+    expect(d.calls[0]?.[2]).toContain("'THREA_INSTANCE_ID=cc-one' 'THREA_RUNTIME_SESSION_ID=ccs-explicit'")
+  })
+
+  test("accepts managed no-env launch when config-derived identity exactly matches the row", async () => {
+    const launch = "claude --name threa.feature --dangerously-load-development-channels server:threa-channel"
+    const identity = deriveClaudeRuntimeIdentity(CWD, { instanceId: "cc-derived", runtimeSessionId: "ccs-derived" })
+    const d = deps({
+      inventory: () => [agent({ instanceId: identity.instanceId, runtimeSessionId: identity.runtimeSessionId })],
+      claudeConfig: () => ({
+        workspaceId: "ws",
+        apiKey: "key",
+        instanceId: identity.instanceId,
+        runtimeSessionId: identity.runtimeSessionId,
+      }),
+      panes: (() => {
+        let reads = 0
+        return () => (++reads < 3 ? [pane({ startCommand: launch })] : [pane({ panePid: 5678 })])
+      })(),
+    })
+    await reconnectClaude({ runtimeSessionId: identity.runtimeSessionId, rootStreamId: "stream_one" }, d)
+    expect(d.calls[0]?.[2]).toContain(`'THREA_INSTANCE_ID=${identity.instanceId}'`)
+  })
+
+  test("standalone discovery does not adopt inventory", async () => {
+    let writes = 0
+    const d = deps({
+      inventory: () => [],
+      panes: (() => {
+        let reads = 0
+        return () => (++reads < 4 ? [pane()] : [pane({ panePid: 5678 })])
+      })(),
+    })
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+    expect({ writes, respawns: d.calls.length }).toEqual({ writes: 0, respawns: 1 })
+  })
+
+  test("preflight and generation races leave pane untouched", async () => {
+    const failed = deps({ preflight: async () => ({ status: "archived", reason: "archived" }) })
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, failed)).rejects.toThrow(
+      "preflight failed"
+    )
+    expect(failed.calls).toEqual([])
+
+    let reads = 0
+    const raced = deps({ panes: () => (++reads === 1 ? [pane()] : [pane({ panePid: 9 })]) })
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, raced)).rejects.toThrow(
+      "changed during reconnect"
+    )
+    expect(raced.calls).toEqual([])
+  })
+
+  test("post-respawn verification requires same UUID and never fresh-falls back", async () => {
+    const d = deps({
+      claudeRegistry: {
+        ...registry(),
+        read: (path) =>
+          JSON.stringify({
+            pid: path.endsWith("5678.json") ? 5678 : 1234,
+            sessionId: path.endsWith("5678.json") ? "223e4567-e89b-42d3-a456-426614174000" : NATIVE,
+            cwd: CWD,
+            procStart: START,
+            name: "threa.feature",
+            status: "idle",
+          }),
+      },
+    })
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "did not verify"
+    )
+    expect(d.calls).toHaveLength(1)
+  })
+})

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -107,6 +107,9 @@ describe("parseClaudeLaunch", () => {
       channel: "threa-channel",
       mcpConfig: undefined,
     })
+    expect(
+      parseClaudeLaunch(`claude --resume ${NATIVE} --dangerously-load-development-channels server:threa-channel`)
+    ).toMatchObject({ resumeSessionId: NATIVE, channel: "threa-channel" })
   })
 
   test("rejects unsupported policy and shell forms", () => {
@@ -119,7 +122,9 @@ describe("parseClaudeLaunch", () => {
       "claude --mcp-config '[]' --dangerously-load-development-channels server:x",
       "claude --mcp-config /a --mcp-config /b --dangerously-load-development-channels server:x",
       "claude prompt --dangerously-load-development-channels server:x",
-      `claude --resume ${NATIVE} --dangerously-load-development-channels server:x`,
+      "claude --resume invalid --dangerously-load-development-channels server:x",
+      `claude --resume ${NATIVE} --resume ${NATIVE} --dangerously-load-development-channels server:x`,
+      `claude ${NATIVE} --dangerously-load-development-channels server:x`,
       "claude --dangerously-load-development-channels server:x -- tail",
     ])
       expect(parseClaudeLaunch(command.replace("\u0000", ""))).toBeUndefined()
@@ -168,6 +173,58 @@ describe("reconnectClaude", () => {
       CWD,
       `'env' 'THREA_DISPLAY_NAME=Claude' 'THREA_INSTANCE_ID=cc-one' 'THREA_RUNTIME_SESSION_ID=${RUNTIME}' 'THREA_COLD_START_IF_ARCHIVED=wait' 'THREA_COLD_START_IF_MISSING=error' 'THREA_EXPECTED_ROOT_STREAM_ID=stream_one' '/opt/claude' '--resume' '${NATIVE}' '--name' 'threa.feature' '--mcp-config' '/tmp/threa.json' '--dangerously-load-development-channels' 'server:threa-channel' '--dangerously-skip-permissions'`,
     ])
+  })
+
+  test("reconnects a generated launch again with exactly the same native UUID", async () => {
+    let current = pane()
+    let nextPid = current.panePid
+    const calls: string[][] = []
+    const d = deps({
+      panes: () => [current],
+      claudeRegistry: {
+        ...registry(),
+        read: (path) =>
+          JSON.stringify({
+            pid: Number(path.match(/(\d+)\.json$/)?.[1]),
+            sessionId: NATIVE,
+            cwd: CWD,
+            procStart: START,
+            name: "threa.feature",
+            status: "idle",
+          }),
+      },
+      respawn: (target, cwd, command) => {
+        calls.push([target, cwd, command])
+        current = pane({ panePid: ++nextPid, startCommand: command })
+      },
+    })
+
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+    expect(parseClaudeLaunch(calls[0]![2])).toMatchObject({ resumeSessionId: NATIVE })
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+
+    expect(calls).toHaveLength(2)
+    for (const [, , command] of calls) {
+      expect(command.match(/'--resume'/g)).toHaveLength(1)
+      expect(parseClaudeLaunch(command)?.resumeSessionId).toBe(NATIVE)
+    }
+  })
+
+  test("rejects generated resume UUID mismatch before preflight and leaves pane untouched", async () => {
+    let preflights = 0
+    const other = "223e4567-e89b-42d3-a456-426614174000"
+    const d = deps({
+      panes: () => [pane({ startCommand: COMMAND.replace("/opt/claude", `/opt/claude --resume ${other}`) })],
+      preflight: async () => {
+        preflights += 1
+        return { status: "linked", rootStreamId: "stream_one" }
+      },
+    })
+
+    await expect(reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "resume UUID does not match"
+    )
+    expect({ preflights, respawns: d.calls.length }).toEqual({ preflights: 0, respawns: 0 })
   })
 
   test("validates MCP config type, relative resolution, and pre-respawn existence", async () => {

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { output } from "./shell"
 import { parseClaudeLaunch, type LocalTmuxPane } from "./discovery"
 import { defaultClaudeRegistryDeps, resolveClaudeNativeSession, type ClaudeRegistryDeps } from "./claude-registry"
-import { reconnectClaude, type ReconnectDeps } from "./reconnect"
+import { reconnectClaude, reconnectRuntime, type ReconnectDeps } from "./reconnect"
 import { deriveClaudeRuntimeIdentity } from "./spawners"
 import type { ManagedAgent } from "./types"
 
@@ -255,6 +255,22 @@ describe("reconnectClaude", () => {
     })
     await reconnectClaude({ runtimeSessionId: identity.runtimeSessionId, rootStreamId: "stream_one" }, d)
     expect(d.calls[0]?.[2]).toContain(`'THREA_INSTANCE_ID=${identity.instanceId}'`)
+  })
+
+  test("standalone dispatch rejects cross-runtime identity collisions", async () => {
+    const claude = pane({
+      startCommand: COMMAND.replaceAll(RUNTIME, NATIVE),
+    })
+    const pi = pane({
+      paneId: "%9",
+      panePid: 9999,
+      startCommand: `/opt/pi --session-id ${NATIVE}`,
+    })
+    const d = deps({ inventory: () => [], panes: () => [claude, pi] })
+    await expect(reconnectRuntime({ runtimeSessionId: NATIVE, rootStreamId: "stream_one" }, d)).rejects.toThrow(
+      "multiple live runtimes match"
+    )
+    expect(d.calls).toEqual([])
   })
 
   test("standalone discovery does not adopt inventory", async () => {

--- a/extensions/harness-daemon/src/claude-registry.ts
+++ b/extensions/harness-daemon/src/claude-registry.ts
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { output } from "./shell"
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export interface ClaudeNativeSession {
+  pid: number
+  sessionId: string
+  cwd: string
+  procStart: string
+  name?: string
+  status: string
+}
+
+export interface ClaudeRegistryDeps {
+  read(path: string): string
+  exists(path: string): boolean
+  canonical(path: string): string
+  processStart(pid: number): string | undefined
+  home: string
+}
+
+export function defaultClaudeRegistryDeps(run: typeof output = output): ClaudeRegistryDeps {
+  return {
+    read: (path) => readFileSync(path, "utf8"),
+    exists: existsSync,
+    canonical: realpathSync,
+    processStart: (pid) => {
+      const result = run(["env", "TZ=UTC", "ps", "-p", String(pid), "-o", "lstart="], { allowFailure: true })
+      return result.exitCode === 0 ? result.stdout.trim() || undefined : undefined
+    },
+    home: homedir(),
+  }
+}
+
+function projectDirectory(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-")
+}
+
+export function resolveClaudeNativeSession(
+  panePid: number,
+  cwd: string,
+  launchName: string | undefined,
+  force: boolean,
+  deps: ClaudeRegistryDeps = defaultClaudeRegistryDeps()
+): ClaudeNativeSession {
+  const path = join(deps.home, ".claude", "sessions", `${panePid}.json`)
+  let value: unknown
+  try {
+    value = JSON.parse(deps.read(path))
+  } catch {
+    throw new Error(`invalid Claude live registry: ${path}`)
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid Claude registry shape")
+  const row = value as Record<string, unknown>
+  if (
+    row.pid !== panePid ||
+    typeof row.sessionId !== "string" ||
+    !UUID_RE.test(row.sessionId) ||
+    typeof row.cwd !== "string" ||
+    typeof row.procStart !== "string" ||
+    typeof row.status !== "string"
+  )
+    throw new Error("invalid Claude registry shape")
+  if (deps.processStart(panePid) !== row.procStart) throw new Error("Claude process generation does not match registry")
+  let registryCwd: string
+  let paneCwd: string
+  try {
+    registryCwd = deps.canonical(row.cwd)
+    paneCwd = deps.canonical(cwd)
+  } catch {
+    throw new Error("Claude registry cwd is not canonicalizable")
+  }
+  if (registryCwd !== paneCwd || row.cwd !== registryCwd) throw new Error("Claude registry cwd does not match pane")
+  if ((row.name === undefined ? undefined : row.name) !== launchName)
+    throw new Error("Claude registry name does not match launch")
+  if (!force && row.status !== "idle") throw new Error(`Claude session is ${row.status}; use --force to reconnect`)
+  const transcript = join(deps.home, ".claude", "projects", projectDirectory(registryCwd), `${row.sessionId}.jsonl`)
+  if (!deps.exists(transcript)) throw new Error(`Claude transcript is missing: ${transcript}`)
+  return {
+    pid: panePid,
+    sessionId: row.sessionId,
+    cwd: registryCwd,
+    procStart: row.procStart,
+    name: typeof row.name === "string" ? row.name : undefined,
+    status: row.status,
+  }
+}

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -21,6 +21,7 @@ interface ClaudeChannelLaunch {
 export interface ClaudeLaunch {
   executable: string
   name?: string
+  resumeSessionId?: string
   channel: string
   mcpConfig?: string
   skipPermissions: boolean
@@ -241,13 +242,18 @@ export function parseClaudeLaunch(command: string): ClaudeLaunch | undefined {
   const executable = words[index++]
   if (!executable || basename(executable) !== "claude") return undefined
   let name: string | undefined
+  let resumeSessionId: string | undefined
   let channel: string | undefined
   let mcpConfig: string | undefined
   let skipPermissions = false
   while (index < words.length) {
     const option = words[index++]!
-    if (option === "--" || option === "--resume" || option.includes("=")) return undefined
-    if (option === "--name") {
+    if (option === "--" || option.includes("=")) return undefined
+    if (option === "--resume") {
+      const value = words[index++]
+      if (resumeSessionId || !value || !UUID_RE.test(value)) return undefined
+      resumeSessionId = value
+    } else if (option === "--name") {
       const value = words[index++]
       if (name || !value?.match(/^threa\.[A-Za-z0-9_-]+$/)) return undefined
       name = value
@@ -264,7 +270,7 @@ export function parseClaudeLaunch(command: string): ClaudeLaunch | undefined {
       mcpConfig = value
     } else return undefined
   }
-  return channel ? { executable, name, channel, mcpConfig, skipPermissions, environment } : undefined
+  return channel ? { executable, name, resumeSessionId, channel, mcpConfig, skipPermissions, environment } : undefined
 }
 
 export function findLocalPiPane(

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -18,12 +18,32 @@ interface ClaudeChannelLaunch {
   runtimeSessionId?: string
 }
 
+export interface ClaudeLaunch {
+  executable: string
+  name?: string
+  channel: string
+  mcpConfig?: string
+  skipPermissions: boolean
+  environment: Array<{ name: string; value: string }>
+}
+
 export interface PiLaunch {
   executable: string
   sessionId: string
   environment: Array<{ name: string; value: string }>
 }
 
+const CLAUDE_ENVIRONMENT = new Set([
+  "THREA_INSTANCE_ID",
+  "THREA_RUNTIME_SESSION_ID",
+  "THREA_DISPLAY_NAME",
+  "THREA_DEFAULT_LABEL",
+  "THREA_HARNESSD_ENTRYPOINT",
+  "THREA_HARNESSD_BUN_BIN",
+  "THREA_COLD_START_IF_ARCHIVED",
+  "THREA_COLD_START_IF_MISSING",
+  "THREA_EXPECTED_ROOT_STREAM_ID",
+])
 const PI_ENVIRONMENT = new Set([
   "THREA_HARNESSD_ENTRYPOINT",
   "THREA_HARNESSD_BUN_BIN",
@@ -192,6 +212,59 @@ export function parsePiLaunch(command: string): PiLaunch | undefined {
   const runtimeIdentity = environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value
   if (runtimeIdentity && runtimeIdentity !== sessionId) return undefined
   return { executable, sessionId, environment }
+}
+
+export function parseClaudeLaunch(command: string): ClaudeLaunch | undefined {
+  const words = strictLaunchWords(command)
+  if (!words?.length) return undefined
+  let index = 0
+  const environment: ClaudeLaunch["environment"] = []
+  const environmentNames = new Set<string>()
+  if (basename(words[index]!) === "env") {
+    index += 1
+    while (index < words.length) {
+      const assignment = parseAssignment(words[index]!)
+      if (!assignment) break
+      if (
+        !CLAUDE_ENVIRONMENT.has(assignment.name) ||
+        environmentNames.has(assignment.name) ||
+        !assignment.value ||
+        /[$`*?[\]{};|&<>]/.test(assignment.value)
+      )
+        return undefined
+      environmentNames.add(assignment.name)
+      environment.push(assignment)
+      index += 1
+    }
+  } else if (parseAssignment(words[index]!)) return undefined
+
+  const executable = words[index++]
+  if (!executable || basename(executable) !== "claude") return undefined
+  let name: string | undefined
+  let channel: string | undefined
+  let mcpConfig: string | undefined
+  let skipPermissions = false
+  while (index < words.length) {
+    const option = words[index++]!
+    if (option === "--" || option === "--resume" || option.includes("=")) return undefined
+    if (option === "--name") {
+      const value = words[index++]
+      if (name || !value?.match(/^threa\.[A-Za-z0-9_-]+$/)) return undefined
+      name = value
+    } else if (option === "--dangerously-load-development-channels") {
+      const value = words[index++]
+      if (channel || !value?.match(/^server:[A-Za-z0-9_-]+$/)) return undefined
+      channel = value.slice("server:".length)
+    } else if (option === "--dangerously-skip-permissions") {
+      if (skipPermissions) return undefined
+      skipPermissions = true
+    } else if (option === "--mcp-config") {
+      const value = words[index++]
+      if (mcpConfig || !value || value.startsWith("-") || /^[{[]/.test(value.trim())) return undefined
+      mcpConfig = value
+    } else return undefined
+  }
+  return channel ? { executable, name, channel, mcpConfig, skipPermissions, environment } : undefined
 }
 
 export function findLocalPiPane(

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -18,14 +18,14 @@ import {
   watchUnarchived,
 } from "./commands"
 import { die } from "./errors"
-import { reconnectPi } from "./reconnect"
+import { reconnectRuntime } from "./reconnect"
 
 async function main(): Promise<void> {
   const [, , command, ...args] = process.argv
   if (!command || command === "help" || command === "--help" || command === "-h") usage()
   if (command === "spawn") return spawnAgent(parseSpawn(args))
   if (command === "list") return listAgents()
-  if (command === "reconnect") return reconnectPi(parseReconnect(args))
+  if (command === "reconnect") return reconnectRuntime(parseReconnect(args))
   if (
     command === "up" ||
     command === "revive-unarchived" ||

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -245,6 +245,9 @@ function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): Cl
     }
   }
   const native = resolveClaudeNativeSession(pane.panePid, pane.cwd, launch.name, options.force ?? false, registryDeps)
+  if (launch.resumeSessionId && launch.resumeSessionId !== native.sessionId) {
+    throw new Error("Claude launch resume UUID does not match live registry session")
+  }
   return { pane, launch, native, instanceId }
 }
 
@@ -319,6 +322,9 @@ export async function reconnectClaude(
   )
   if (native.sessionId !== target.native.sessionId)
     throw new Error("Claude native session changed during reconnect preflight")
+  if (launch.resumeSessionId && launch.resumeSessionId !== native.sessionId) {
+    throw new Error("Claude launch resume UUID changed during reconnect preflight")
+  }
 
   if (target.launch.mcpConfig && !(deps.mcpFile ?? ((path) => statSync(path).isFile()))(target.launch.mcpConfig)) {
     throw new Error(`Claude MCP config changed before respawn: ${target.launch.mcpConfig}`)

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -359,6 +359,14 @@ export async function reconnectRuntime(
   if (exact[0]?.runtime === "pi") return reconnectPi(options, deps)
   if (exact[0]?.runtime === "claude") return reconnectClaude(options, deps)
   const panes = deps.panes()
-  if (findLocalPiPane(options.runtimeSessionId, panes)) return reconnectPi(options, deps)
-  return reconnectClaude(options, deps)
+  const piPane = findLocalPiPane(options.runtimeSessionId, panes)
+  const claudePane = findLocalClaudeChannelPane(
+    options.runtimeSessionId,
+    panes,
+    (deps.claudeConfig ?? readThreaChannelConfig)()
+  )
+  if (piPane && claudePane) throw new Error(`multiple live runtimes match ${options.runtimeSessionId}`)
+  if (piPane) return reconnectPi(options, deps)
+  if (claudePane) return reconnectClaude(options, deps)
+  throw new Error(`no live runtime matched ${options.runtimeSessionId}`)
 }

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -1,15 +1,35 @@
-import { basename } from "node:path"
-import { findLocalPiPane, listLocalTmuxPanes, parsePiLaunch, type LocalTmuxPane, type PiLaunch } from "./discovery"
+import { statSync } from "node:fs"
+import { basename, resolve } from "node:path"
+import {
+  defaultClaudeRegistryDeps,
+  resolveClaudeNativeSession,
+  type ClaudeNativeSession,
+  type ClaudeRegistryDeps,
+} from "./claude-registry"
+import {
+  findLocalClaudeChannelPane,
+  findLocalPiPane,
+  listLocalTmuxPanes,
+  parseClaudeLaunch,
+  parsePiLaunch,
+  type ClaudeLaunch,
+  type LocalTmuxPane,
+  type PiLaunch,
+} from "./discovery"
 import { readInventoryReadonly } from "./inventory"
 import { preflightRuntimeSession, type RuntimePreflightResult } from "./resume"
 import { shellQuote } from "./shell"
 import {
   configuredThreaBaseUrl,
+  deriveClaudeRuntimeIdentity,
   readPiRemoteConfig,
   readPiRemoteSession,
   type PiRemoteConfig,
+  readThreaChannelConfig,
+  sanitizeId,
   type PiRemoteSession,
 } from "./spawners"
+import type { ThreaChannelConfig } from "./types"
 import { respawnPane } from "./tmux"
 import type { ManagedAgent } from "./types"
 
@@ -25,6 +45,13 @@ interface ReconnectTarget {
   instanceId: string
 }
 
+interface ClaudeReconnectTarget {
+  pane: LocalTmuxPane
+  launch: ClaudeLaunch
+  native: ClaudeNativeSession
+  instanceId: string
+}
+
 export interface ReconnectDeps {
   inventory: () => ManagedAgent[]
   panes: () => LocalTmuxPane[]
@@ -32,6 +59,10 @@ export interface ReconnectDeps {
   piLink: (runtimeSessionId: string) => PiRemoteSession | undefined
   preflight: (params: Parameters<typeof preflightRuntimeSession>[0]) => Promise<RuntimePreflightResult>
   respawn: (target: string, cwd: string, command: string) => void
+  claudeConfig?: () => ThreaChannelConfig
+  claudeRegistry?: ClaudeRegistryDeps
+  mcpFile?: (path: string) => boolean
+  sleep?: (ms: number) => Promise<void>
 }
 
 export function defaultReconnectDeps(): ReconnectDeps {
@@ -162,4 +193,172 @@ export async function reconnectPi(
     reconstructPiCommand(target, options.runtimeSessionId, options.rootStreamId)
   )
   console.log(`harnessd: reconnected Pi session ${options.runtimeSessionId} in ${target.pane.paneId}`)
+}
+
+function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): ClaudeReconnectTarget {
+  const config = (deps.claudeConfig ?? readThreaChannelConfig)()
+  const managed = deps.inventory().filter((agent) => agent.runtimeSessionId === options.runtimeSessionId)
+  let pane: LocalTmuxPane | undefined
+  let agent: ManagedAgent | undefined
+  if (managed.length) {
+    if (managed.length !== 1) throw new Error(`multiple managed agents match ${options.runtimeSessionId}`)
+    agent = managed[0]
+    if (agent.runtime !== "claude") throw new Error(`${options.runtimeSessionId} is not a Claude runtime session`)
+    if (!agent.tmuxPaneId) throw new Error(`managed Claude session ${options.runtimeSessionId} has no recorded pane`)
+    const matches = deps.panes().filter((candidate) => candidate.paneId === agent!.tmuxPaneId)
+    if (matches.length !== 1) throw new Error(`managed Claude pane ${agent.tmuxPaneId} is missing or ambiguous`)
+    pane = matches[0]
+  } else {
+    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config)
+    if (!pane) throw new Error(`no live Claude pane matched ${options.runtimeSessionId}`)
+  }
+  const launch = parseClaudeLaunch(pane.startCommand)
+  if (!launch) throw new Error(`pane ${pane.paneId} has an unsupported Claude launch`)
+  const registryDeps = deps.claudeRegistry ?? defaultClaudeRegistryDeps()
+  if (agent?.worktree) {
+    let paneCwd: string
+    let managedCwd: string
+    try {
+      paneCwd = registryDeps.canonical(pane.cwd)
+      managedCwd = registryDeps.canonical(agent.worktree)
+    } catch {
+      throw new Error("managed Claude cwd is not canonicalizable")
+    }
+    if (paneCwd !== managedCwd) throw new Error("managed Claude cwd does not match pane")
+  }
+  const derived = deriveClaudeRuntimeIdentity(pane.cwd, config)
+  const explicitInstanceId = launch.environment.find(({ name }) => name === "THREA_INSTANCE_ID")?.value
+  const explicitRuntimeSessionId = launch.environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value
+  const instanceId = explicitInstanceId ? sanitizeId(explicitInstanceId).slice(0, 64) : derived.instanceId
+  const runtimeSessionId = explicitRuntimeSessionId
+    ? sanitizeId(explicitRuntimeSessionId).slice(0, 64)
+    : derived.runtimeSessionId
+  if (!instanceId || !runtimeSessionId) throw new Error("Claude launch identity is empty after normalization")
+  if (runtimeSessionId !== options.runtimeSessionId) throw new Error("Claude runtime identity mismatch")
+  if (agent && (agent.runtimeSessionId !== runtimeSessionId || agent.instanceId !== instanceId)) {
+    throw new Error("managed Claude identity does not match pane launch")
+  }
+  if (launch.mcpConfig) {
+    launch.mcpConfig = resolve(pane.cwd, launch.mcpConfig)
+    if (!(deps.mcpFile ?? ((path) => statSync(path).isFile()))(launch.mcpConfig)) {
+      throw new Error(`Claude MCP config is not an existing regular file: ${launch.mcpConfig}`)
+    }
+  }
+  const native = resolveClaudeNativeSession(pane.panePid, pane.cwd, launch.name, options.force ?? false, registryDeps)
+  return { pane, launch, native, instanceId }
+}
+
+export function reconstructClaudeCommand(
+  target: ClaudeReconnectTarget,
+  runtimeSessionId: string,
+  rootStreamId: string
+): string {
+  const pinned = new Set([
+    "THREA_INSTANCE_ID",
+    "THREA_RUNTIME_SESSION_ID",
+    "THREA_COLD_START_IF_ARCHIVED",
+    "THREA_COLD_START_IF_MISSING",
+    "THREA_EXPECTED_ROOT_STREAM_ID",
+  ])
+  const words = [
+    "env",
+    ...target.launch.environment.filter(({ name }) => !pinned.has(name)).map(({ name, value }) => `${name}=${value}`),
+    `THREA_INSTANCE_ID=${target.instanceId}`,
+    `THREA_RUNTIME_SESSION_ID=${runtimeSessionId}`,
+    "THREA_COLD_START_IF_ARCHIVED=wait",
+    "THREA_COLD_START_IF_MISSING=error",
+    `THREA_EXPECTED_ROOT_STREAM_ID=${rootStreamId}`,
+    target.launch.executable,
+    "--resume",
+    target.native.sessionId,
+  ]
+  if (target.launch.name) words.push("--name", target.launch.name)
+  if (target.launch.mcpConfig) words.push("--mcp-config", target.launch.mcpConfig)
+  words.push("--dangerously-load-development-channels", `server:${target.launch.channel}`)
+  if (target.launch.skipPermissions) words.push("--dangerously-skip-permissions")
+  return words.map(shellQuote).join(" ")
+}
+
+export async function reconnectClaude(
+  options: ReconnectOptions,
+  deps: ReconnectDeps = defaultReconnectDeps()
+): Promise<void> {
+  const target = resolveClaudeTarget(options, deps)
+  const config = (deps.claudeConfig ?? readThreaChannelConfig)()
+  const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+  const apiKey = process.env.THREA_API_KEY || config.apiKey
+  if (!workspaceId || !apiKey) throw new Error("no Claude channel Threa credentials found")
+  const result = await deps.preflight({
+    baseUrl: configuredThreaBaseUrl(config),
+    workspaceId,
+    apiKey,
+    runtimeKind: "claude-code-channel",
+    instanceId: target.instanceId,
+    runtimeSessionId: options.runtimeSessionId,
+    displayName: process.env.THREA_DISPLAY_NAME || config.displayName || `Claude Code - ${basename(target.pane.cwd)}`,
+    localCwd: target.pane.cwd,
+    expectedRootStreamId: options.rootStreamId,
+    labelName: process.env.THREA_DEFAULT_LABEL || config.defaultLabel || "coding",
+  })
+  if (result.status !== "linked") {
+    const detail = result.status === "mismatch" ? `root mismatch: ${result.rootStreamId}` : result.reason
+    throw new Error(`Claude reconnect preflight failed: ${detail}`)
+  }
+  const current = deps.panes().filter((pane) => pane.paneId === target.pane.paneId)
+  if (current.length !== 1 || !samePaneGeneration(target.pane, current[0]!)) {
+    throw new Error(`Claude pane ${target.pane.paneId} changed during reconnect preflight`)
+  }
+  const launch = parseClaudeLaunch(current[0]!.startCommand)
+  if (!launch) throw new Error("Claude launch changed during reconnect preflight")
+  const native = resolveClaudeNativeSession(
+    current[0]!.panePid,
+    current[0]!.cwd,
+    launch.name,
+    options.force ?? false,
+    deps.claudeRegistry ?? defaultClaudeRegistryDeps()
+  )
+  if (native.sessionId !== target.native.sessionId)
+    throw new Error("Claude native session changed during reconnect preflight")
+
+  if (target.launch.mcpConfig && !(deps.mcpFile ?? ((path) => statSync(path).isFile()))(target.launch.mcpConfig)) {
+    throw new Error(`Claude MCP config changed before respawn: ${target.launch.mcpConfig}`)
+  }
+  deps.respawn(
+    target.pane.paneId,
+    target.pane.cwd,
+    reconstructClaudeCommand(target, options.runtimeSessionId, result.rootStreamId)
+  )
+  const sleep = deps.sleep ?? Bun.sleep
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await sleep(250)
+    const replacement = deps.panes().find((pane) => pane.paneId === target.pane.paneId)
+    if (!replacement || replacement.panePid === target.pane.panePid || replacement.cwd !== target.pane.cwd) continue
+    try {
+      const replacementNative = resolveClaudeNativeSession(
+        replacement.panePid,
+        replacement.cwd,
+        target.launch.name,
+        true,
+        deps.claudeRegistry ?? defaultClaudeRegistryDeps()
+      )
+      if (replacementNative.sessionId === target.native.sessionId) {
+        console.log(`harnessd: reconnected Claude session ${options.runtimeSessionId} in ${target.pane.paneId}`)
+        return
+      }
+    } catch {}
+  }
+  throw new Error("Claude replacement did not verify the same native session and cwd")
+}
+
+export async function reconnectRuntime(
+  options: ReconnectOptions,
+  deps: ReconnectDeps = defaultReconnectDeps()
+): Promise<void> {
+  const exact = deps.inventory().filter((agent) => agent.runtimeSessionId === options.runtimeSessionId)
+  if (exact.length > 1) throw new Error(`multiple managed agents match ${options.runtimeSessionId}`)
+  if (exact[0]?.runtime === "pi") return reconnectPi(options, deps)
+  if (exact[0]?.runtime === "claude") return reconnectClaude(options, deps)
+  const panes = deps.panes()
+  if (findLocalPiPane(options.runtimeSessionId, panes)) return reconnectPi(options, deps)
+  return reconnectClaude(options, deps)
 }


### PR DESCRIPTION
## Problem

PR #1508 can reconnect Pi because its native session ID is explicit in the launch command. Claude requires a different identity boundary: the Threa runtime ID is not the native conversation UUID, and resuming the wrong or newest transcript would fork or replace the wrong session.

## Solution

Add live-only Claude reconnect on top of the shared Pi replacement path:

- `resolveClaudeNativeSession` reads only `~/.claude/sessions/<pane-pid>.json` and validates UUID, PID generation in UTC, cwd, optional name, idle/force state, and exact transcript existence.
- `parseClaudeLaunch` accepts only the ordinary Threa development-channel form, one file-backed MCP config, supported identity variables, and no prompt, prior resume, custom config, or inline policy.
- Managed targets prove pane cwd and effective normalized runtime/instance identity before preflight; exact standalone discovery remains read-only and non-adopting.
- Respawn adds `claude --resume <same-uuid>` and pins `wait`/`error`/expected-root variables so a race after preflight cannot create or replace a scratchpad.
- Pane, registry generation, and MCP file are revalidated immediately before replacement; bounded verification requires the replacement registry to report the same UUID and cwd.

Dead sessions, transcript recency fallback, descriptors, arbitrary launch policy, config-directory support, and remote command routing remain excluded.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/claude-registry.ts` | Strict default-location live native-session resolution (**new**) |
| `extensions/harness-daemon/src/claude-reconnect.test.ts` | Native identity, parser, ownership, policy, race, and verification regressions (**new**) |
| `extensions/harness-daemon/src/discovery.ts` | Narrow reconnect-specific Claude launch parsing |
| `extensions/harness-daemon/src/reconnect.ts` | Claude target ownership, safe reconstruction, respawn, and verification |
| `extensions/harness-daemon/src/index.ts` | Runtime-aware reconnect dispatch |
| `extensions/harness-daemon/README.md` | Live Claude reconnect contract |

## Test plan

- [x] Harness daemon tests — 83 passed
- [x] Root unit tests — 3,460 passed
- [x] Parent Claude remote — 110 passed
- [x] Parent remote-session — 121 passed
- [x] Parent bot-runtime client — 57 passed
- [x] Harness and monorepo TypeScript checks
- [x] Repository lint, Prettier, Dockerfile checks, and 230 migration checks
- [x] `git diff --check`
- [x] Sol/high adversarial verification, human checkpoint, and targeted final recheck — clean at 7/7
- [x] Sol/high PR review — cross-runtime ambiguity fixed and independently rechecked clean at 7/7

<details>
<summary>📋 Full implementation plan</summary>

# Live runtime reconnect and safe keys

Status: ratified 2026-07-22.

This replaces the abandoned broad reconnect prototype preserved under `.tmp/oversized-reconnect-*`.

## Goal

Add small, truthful controls for live Threa-linked Pi and Claude sessions:

- `/reconnect [--force]` replaces a live runtime process in the same tmux pane and resumes the same native session.
- `/key <name>` sends one allowlisted tmux key to the exact live pane.

This feature is intentionally limited to channels that remain connected long enough to claim and acknowledge the command. It is not an offline supervisor.

## Shared invariants

- Target the exact routed `instanceId`, `runtimeSessionId`, and root stream.
- Inventory remains authoritative when an exact managed row exists; exact live-pane discovery may supplement it without adoption.
- Missing, ambiguous, stale, or unsupported identity fails closed.
- Never pick the newest session, transcript, pane, or inventory row.
- Preserve cwd, tmux pane/window/session, native runtime session, Threa runtime identity, channel, and the narrow supported launch policy.
- Perform same-root preflight with `ifArchived: wait` and `ifMissing: error` before replacement.
- Never create, replace, revive, or unarchive a scratchpad.
- Never launch a fresh native session as fallback.
- Complete the Threa command acknowledgement before a detached reconnect starts.
- Reconnect acknowledgement says it was accepted, not that the replacement already connected.
- Standalone discovery never writes harness inventory.

## Narrow launch contracts

### Pi

Support only exact Threa Pi forms:

```text
pi --session-id <uuid>
```

The executable may be an absolute path. A leading `env` is allowed only for explicit Threa runtime/instance identity and the existing harness entrypoint/Bun variables, using ordinary values without shell metacharacters. Unknown options, positional prompts, duplicate session IDs, arguments after `--`, exotic shell-dependent values, and unrelated environment assignments fail before tmux is touched.

The native Pi session ID is the validated `--session-id` UUID. No title or recency fallback exists.

### Claude

Support only the ordinary Threa/channel helper form:

- executable basename `claude`;
- optional exact `--name threa.<name>`;
- exactly one `--dangerously-load-development-channels server:<channel>`;
- optional `--dangerously-skip-permissions`;
- optional one file-backed `--mcp-config <path>`;
- optional explicit `THREA_INSTANCE_ID` and `THREA_RUNTIME_SESSION_ID` assignments;
- no positional prompt or arguments after `--`.

Unknown options, inline/variadic MCP JSON, multiple MCP configs, custom config directories, and unrelated environment assignments fail before tmux is touched. Named global channel registration is reused as named; reconnect does not copy or materialize MCP configuration.

Claude native identity comes only from the live `~/.claude/sessions/<pane_pid>.json` registry. Require matching PID, process start, canonical cwd, optional parsed name, valid UUID, idle status unless forced, and existing exact transcript. No dead-process or newest-transcript fallback exists.

## Shared process replacement

The complete replacement command is built and all identity/pane facts are pinned before mutation. Immediately before mutation, revalidate pane ID, PID, cwd, start command, and native identity.

Use exactly:

```text
tmux respawn-pane -k -t <pane-id> -c <cwd> <shell-quoted-command>
```

This keeps pane/window/session identity and avoids kill/wait/recreate, anchor windows, durable descriptors, and retry machinery.

After successful respawn, bounded local verification may confirm a live process with the same native session and cwd. Failure is logged and never falls back to a fresh session.

## PR stack

This is an actual GitHub stack above PR #1501, managed with non-interactive `gh stack` commands.

### PR 1 — Live Pi reconnect primitive

Deliverables:

- Exact Pi launch parser and native session extraction.
- Exact managed-first/live-standalone pane resolution without inventory adoption.
- Small shared `tmux respawn-pane` helper.
- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` for Pi targets.
- Same-root preflight and generation revalidation.
- CLI/README documentation.

Required tests:

- exact managed and standalone Pi forms;
- malformed UUID, duplicate ID, unknown option/env/positional/`--` rejection;
- missing or ambiguous pane rejection;
- preflight failure and generation change leave pane untouched;
- exact respawn arguments preserve cwd/pane/session ID/Threa identity;
- failure never launches fresh or writes inventory.

Implementation budget: 250–500 lines excluding focused tests. Inventory schema changes, persistent descriptors, runtime extension lifecycle changes, or generic supervisor infrastructure require a plan checkpoint.

### PR 2 — Live Claude reconnect primitive

Deliverables:

- Reuse PR 1's replacement/preflight path.
- Strict live Claude registry resolver with injectable tests.
- Narrow Claude launch parser/reconstructor.
- Managed-first/live-standalone Claude targeting without inventory adoption.
- Same native UUID resume and bounded replacement verification.

Required tests:

- current managed and standalone helper launch forms;
- malformed/stale registry, PID reuse, cwd/name/transcript/status mismatch;
- `--force` behavior;
- unsupported option/env/MCP/`--` rejection;
- preflight and generation races leave pane untouched;
- exact `claude --resume <same-uuid>` respawn;
- no fresh launch or inventory writes on failure.

Implementation budget: 250–500 lines excluding focused tests. Do not add dead-session recovery, descriptor persistence, config-dir abstraction, policy snapshots, or extension-side reconnect evidence.

### PR 3 — Reachable `/reconnect`

Deliverables:

- Canonical command catalog and capability advertisement for supported Pi and Claude tmux sessions.
- Empty args or exact `--force` validation.
- Minimal optional post-ack action in remote-session command handling.
- Seal acknowledgement first, then spawn detached harnessd with exact runtime/root IDs.
- Truthful copy and docs explaining the reachable-channel limitation.

Required tests:

- command advertised only where locally supported;
- routed runtime/root IDs and force flag reach harnessd exactly;
- acknowledgement completion precedes helper spawn;
- failed acknowledgement never spawns;
- preparation failure is returned before acknowledgement;
- existing sealed command completion remains intact.

Implementation budget: 200–400 lines excluding tests. No backend outbox, supervisor delivery, or offline recovery.

### PR 4 — Allowlisted `/key`

Deliverables:

- `/key <name>` for reachable supported Pi and Claude tmux sessions.
- Initial allowlist only: `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, `ctrl-u`.
- Exact pane re-resolution immediately before one `tmux send-keys` call.
- No raw text, key sequences, repeat counts, arbitrary tmux syntax, or shell interpolation.
- Canonical catalog/capability/docs updates.

Required tests:

- every allowed name maps to one exact tmux token;
- casing/aliases/extra args/unknown values fail;
- ambiguity/stale generation leaves pane untouched;
- command sends exactly once to the routed runtime pane;
- acknowledgement is truthful and sealed through the normal command path.

Implementation budget: 150–300 lines excluding tests.

## Binding exclusions

- Fully disconnected/offline command recovery.
- Supervisor outbox/control jobs.
- Dead-process or transcript-only reconnect.
- Durable standalone reconnect descriptors or retry after failed replacement.
- Arbitrary Claude/Pi launch-policy reconstruction.
- Inline or multiple MCP configs.
- `CLAUDE_CONFIG_DIR` support.
- Inventory schema changes or legacy inventory migration.
- New frontend runtime state or overview UI.
- `/type`, raw text entry, arbitrary keys, repeats, or key sequences.
- Starting a fresh native session.
- Creating, replacing, reviving, or unarchiving scratchpads.

## Build protocol

Use `build-feature` with these binding overrides:

- implementer: GPT-5.6 Sol, effort `minimal`, Pi harness only;
- adversarial verifier: GPT-5.6 Sol, effort `high`, Pi harness only;
- per-PR reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- whole-stack reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- do not use Fable, Claude Code, Claude Agent SDK, or any Claude-backed harness;
- use actual `gh stack` branches/PRs and `gh stack submit --auto`/`gh stack view --json`;
- per PR: brief -> implement -> adversarial verify -> fix/reverify -> commit -> stacked PR -> review.

Scope controls:

- Copy binding exclusions and the current PR's implementation budget into every agent brief.
- Classify every review finding as `in-scope` or `follow-up` before fixing it.
- A fix that adds a deferred subsystem, exceeds the budget, or broadens supported launch policy requires a human plan checkpoint.
- After two fix/reverify rounds without a clean result, stop and report concrete remaining findings instead of continuing automatically.
- Agents receive only the current chunk brief plus paths to relevant source/plan files, not an invitation to redesign the whole stack.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787340378&installation_model_id=20758&pr_number=1510&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1510&signature=e43f621380701f3774d7011755368ff8465ab2ba1cafc73b00c62916f458a516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
