### PR TITLE
feat: add reachable Claude reconnect command

### DIFF
--- a/apps/backend/src/features/commands/availability.test.ts
+++ b/apps/backend/src/features/commands/availability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test"
+import type { BotRuntimeInstance } from "../bot-runtimes"
+import { resolveAdvertisedSessionControlCommandNames } from "./availability"
+
+function presence(capabilities: Record<string, unknown>): BotRuntimeInstance {
+  return { capabilities } as BotRuntimeInstance
+}
+
+describe("session-control command advertisement", () => {
+  it("makes reconnect available only when the runtime advertises it", () => {
+    expect(
+      resolveAdvertisedSessionControlCommandNames(
+        presence({ supportsSessionControlCommands: true, sessionControlCommands: ["stop", "reconnect"] })
+      )
+    ).toEqual(new Set(["stop", "reconnect"]))
+    expect(
+      resolveAdvertisedSessionControlCommandNames(
+        presence({ supportsSessionControlCommands: true, sessionControlCommands: ["stop"] })
+      )
+    ).toEqual(new Set(["stop"]))
+  })
+
+  it("does not infer reconnect without the session-control capability", () => {
+    expect(resolveAdvertisedSessionControlCommandNames(presence({ sessionControlCommands: ["reconnect"] }))).toEqual(
+      new Set()
+    )
+  })
+})

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -287,7 +287,7 @@ function withArgSuggestions(
  * Returning the intersection (instead of a plain boolean) lets the caller
  * surface exactly the commands the runtime can actually handle.
  */
-function resolveAdvertisedSessionControlCommandNames(presence: BotRuntimeInstance): ReadonlySet<string> {
+export function resolveAdvertisedSessionControlCommandNames(presence: BotRuntimeInstance): ReadonlySet<string> {
   if (presence.capabilities.supportsSessionControlCommands !== true) return new Set()
   const advertised = presence.capabilities.sessionControlCommands
   if (!Array.isArray(advertised)) return new Set()

--- a/apps/backend/src/features/commands/catalog.test.ts
+++ b/apps/backend/src/features/commands/catalog.test.ts
@@ -3,6 +3,14 @@ import { listSessionControlCommandInfos, SESSION_CONTROL_COMMAND_NAMES } from ".
 
 describe("session-control command catalog", () => {
   it("defines command info for every canonical runtime command", () => {
-    expect(listSessionControlCommandInfos().map((command) => command.name)).toEqual([...SESSION_CONTROL_COMMAND_NAMES])
+    const commands = listSessionControlCommandInfos()
+    expect(commands.map((command) => command.name)).toEqual([...SESSION_CONTROL_COMMAND_NAMES])
+    expect(commands.find((command) => command.name === "reconnect")).toEqual({
+      name: "reconnect",
+      description: "Reconnect the linked live session",
+      kind: "bot-runtime",
+      scope: "stream",
+      args: [{ name: "--force", required: false, description: "Reconnect even when the runtime is busy" }],
+    })
   })
 })

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -19,6 +19,7 @@ export const SESSION_CONTROL_COMMAND_NAMES = [
   "status",
   "run",
   "carry-on",
+  "reconnect",
 ] as const
 export type SessionControlCommandName = (typeof SESSION_CONTROL_COMMAND_NAMES)[number]
 
@@ -133,6 +134,13 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "message", required: false, description: "Instruction to deliver when the session resumes" }],
+    },
+    {
+      name: "reconnect",
+      description: "Reconnect the linked live session",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+      args: [{ name: "--force", required: false, description: "Reconnect even when the runtime is busy" }],
     },
   ]
 }

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -32,25 +32,22 @@ export function resolveRuntimeInvocationRouting(
   trigger: (typeof BotInvocationTriggers)[keyof typeof BotInvocationTriggers]
   requiredCapability: (typeof BotInvocationCapabilities)[keyof typeof BotInvocationCapabilities]
 } {
-  if (
-    commandName === "steer" ||
-    commandName === "stop" ||
-    commandName === "kick" ||
-    commandName === "carry-on" ||
-    commandName === "reconnect"
-  ) {
-    // `active-scratchpad` while busy, so it claims them there. The Claude Code
-    // channel instead advertises ONLY `session-control` while busy (so a normal
-    // `active-scratchpad` follow-up stays queued behind the running turn) — route
-    // its interrupts there so a busy channel can still claim them. carry-on's
-    // whole purpose is a session blocked mid-turn on provider quota, so it takes
-    // the same route. See docs/claude-channel-session-control.md.
+  if (commandName === "steer" || commandName === "stop" || commandName === "kick" || commandName === "carry-on") {
+    // Pi advertises `active-scratchpad` while busy. The Claude Code channel
+    // instead advertises only `session-control` while busy, so its interrupts
+    // route there. See docs/claude-channel-session-control.md.
     return {
       trigger: BotInvocationTriggers.SESSION_CONTROL,
       requiredCapability:
         runtimeKind === BotRuntimeKinds.CLAUDE_CODE_CHANNEL
           ? BotInvocationCapabilities.SESSION_CONTROL
           : BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
+    }
+  }
+  if (commandName === "reconnect" && runtimeKind === BotRuntimeKinds.CLAUDE_CODE_CHANNEL) {
+    return {
+      trigger: BotInvocationTriggers.SESSION_CONTROL,
+      requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
     }
   }
   return {

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -32,8 +32,13 @@ export function resolveRuntimeInvocationRouting(
   trigger: (typeof BotInvocationTriggers)[keyof typeof BotInvocationTriggers]
   requiredCapability: (typeof BotInvocationCapabilities)[keyof typeof BotInvocationCapabilities]
 } {
-  if (commandName === "steer" || commandName === "stop" || commandName === "kick" || commandName === "carry-on") {
-    // steer/stop/kick/carry-on must reach the runtime mid-turn. Pi advertises
+  if (
+    commandName === "steer" ||
+    commandName === "stop" ||
+    commandName === "kick" ||
+    commandName === "carry-on" ||
+    commandName === "reconnect"
+  ) {
     // `active-scratchpad` while busy, so it claims them there. The Claude Code
     // channel instead advertises ONLY `session-control` while busy (so a normal
     // `active-scratchpad` follow-up stays queued behind the running turn) — route

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -4,7 +4,7 @@ import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
   it("routes interrupt commands to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -19,6 +19,13 @@ describe("resolveRuntimeInvocationRouting", () => {
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
       })
     }
+  })
+
+  it("keeps reconnect on normal session-control routing for pi-local", () => {
+    expect(resolveRuntimeInvocationRouting("reconnect", BotRuntimeKinds.PI_LOCAL)).toEqual({
+      trigger: BotInvocationTriggers.SESSION_CONTROL,
+      requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
+    })
   })
 
   it("routes every other command to session-control regardless of runtime kind", () => {

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -3,8 +3,8 @@ import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds } fro
 import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
-  it("routes steer/stop/kick/carry-on to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on"]) {
+  it("routes interrupt commands to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -12,8 +12,8 @@ describe("resolveRuntimeInvocationRouting", () => {
     }
   })
 
-  it("routes steer/stop/kick/carry-on to session-control for the Claude Code channel (so a busy channel still claims control)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on"]) {
+  it("routes interrupt commands to session-control for the Claude Code channel (so a busy channel still claims control)", () => {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.CLAUDE_CODE_CHANNEL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,

--- a/extensions/bot-runtime-client/src/harness-reconnect.test.ts
+++ b/extensions/bot-runtime-client/src/harness-reconnect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, mock } from "bun:test"
+import { harnessReconnectAvailable, prepareHarnessReconnect } from "./harness-reconnect"
+
+const filesystem = (events: unknown[]) => ({
+  mkdir: (path: string, options: unknown) => events.push(["mkdir", path, options]),
+  open: (path: string, flags: string, mode: number) => {
+    events.push(["open", path, flags, mode])
+    return 41
+  },
+  chmod: (path: string, mode: number) => events.push(["chmod", path, mode]),
+  close: (fd: number) => events.push(["close", fd]),
+  appendFile: (path: string, data: string, options: unknown) => events.push(["appendFile", path, data, options]),
+})
+
+describe("prepareHarnessReconnect", () => {
+  it("reports availability only for the exact harness entrypoint", () => {
+    expect(
+      harnessReconnectAvailable({ entrypoint: "/exact/harnessd.ts", exists: (path) => path === "/exact/harnessd.ts" })
+    ).toBe(true)
+    expect(harnessReconnectAvailable({ entrypoint: "/missing/harnessd.ts", exists: () => false })).toBe(false)
+  })
+
+  it("starts detached with exact routing and private append-log stdio", () => {
+    const events: unknown[] = []
+    const unref = mock(() => events.push(["unref"]))
+    const spawn = mock((...args: unknown[]) => {
+      events.push(["spawn", ...args])
+      return { on: () => undefined, unref }
+    })
+    const start = prepareHarnessReconnect("runtime_exact", "stream_exact", {
+      force: true,
+      entrypoint: "/repo/harnessd.ts",
+      bunExecutable: "/bun",
+      logPath: "/private/harnessd/reconnect.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: spawn as never,
+    })
+
+    expect(events).toEqual([])
+    start()
+    expect(events).toEqual([
+      ["mkdir", "/private/harnessd", { recursive: true, mode: 0o700 }],
+      ["chmod", "/private/harnessd", 0o700],
+      ["open", "/private/harnessd/reconnect.log", "a", 0o600],
+      ["chmod", "/private/harnessd/reconnect.log", 0o600],
+      [
+        "spawn",
+        "/bun",
+        ["/repo/harnessd.ts", "reconnect", "runtime_exact", "--root-stream-id", "stream_exact", "--force"],
+        { detached: true, stdio: ["ignore", 41, 41] },
+      ],
+      ["unref"],
+      ["close", 41],
+    ])
+    expect(() => start()).toThrow("already started")
+  })
+
+  it("logs a sanitized asynchronous spawn error without crashing after acknowledgement", async () => {
+    const events: unknown[] = []
+    let emitError: ((error: Error & { code?: unknown }) => void) | undefined
+    const start = prepareHarnessReconnect("runtime_secret", "stream_secret", {
+      entrypoint: "/secret/harnessd.ts",
+      bunExecutable: "/secret/bun",
+      logPath: "/logs/reconnect.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: (() => ({
+        on: (_event: "error", listener: typeof emitError) => {
+          emitError = listener
+        },
+        unref: () => undefined,
+      })) as never,
+    })
+
+    start()
+    queueMicrotask(() => emitError?.(Object.assign(new Error("/secret/bun runtime_secret"), { code: "ENOENT" })))
+    await Promise.resolve()
+
+    expect(events.slice(-2)).toEqual([
+      ["close", 41],
+      ["appendFile", "/logs/reconnect.log", "Harness reconnect launch failed (ENOENT)\n", { mode: 0o600 }],
+    ])
+    expect(JSON.stringify(events)).not.toContain("runtime_secret")
+  })
+
+  it("closes the parent log fd when spawn fails", () => {
+    const events: unknown[] = []
+    const start = prepareHarnessReconnect("runtime", "root", {
+      entrypoint: "/harnessd.ts",
+      logPath: "/logs/reconnect.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: (() => {
+        throw new Error("spawn failed")
+      }) as never,
+    })
+    expect(() => start()).toThrow("spawn failed")
+    expect(events.at(-1)).toEqual(["close", 41])
+  })
+
+  it("preparation validates only identity and entrypoint", () => {
+    const spawn = mock(() => ({ on: () => undefined, unref: () => undefined }))
+    expect(() => prepareHarnessReconnect("", "root", { exists: () => true, spawn: spawn as never })).toThrow(
+      "Runtime session"
+    )
+    expect(() => prepareHarnessReconnect("runtime", " ", { exists: () => true, spawn: spawn as never })).toThrow(
+      "Root stream"
+    )
+    expect(() =>
+      prepareHarnessReconnect("runtime", "root", { entrypoint: "/missing", exists: () => false, spawn: spawn as never })
+    ).toThrow("entrypoint not found")
+    expect(spawn).not.toHaveBeenCalled()
+  })
+})

--- a/extensions/bot-runtime-client/src/harness-reconnect.ts
+++ b/extensions/bot-runtime-client/src/harness-reconnect.ts
@@ -1,0 +1,86 @@
+import { spawn as nodeSpawn } from "node:child_process"
+import { appendFileSync, chmodSync, closeSync, existsSync, mkdirSync, openSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { harnessDaemonEntrypoint } from "./harness-kick"
+
+type DetachedChild = { on(event: "error", listener: (error: Error & { code?: unknown }) => void): void; unref(): void }
+
+type HarnessSpawn = (
+  executable: string,
+  args: string[],
+  options: { detached: true; stdio: ["ignore", number, number] }
+) => DetachedChild
+
+interface HarnessReconnectFs {
+  mkdir(path: string, options: { recursive: true; mode: number }): void
+  open(path: string, flags: string, mode: number): number
+  chmod(path: string, mode: number): void
+  close(fd: number): void
+  appendFile(path: string, data: string, options: { mode: number }): void
+}
+
+export interface PrepareHarnessReconnectOptions {
+  force?: boolean
+  entrypoint?: string
+  bunExecutable?: string
+  exists?: (path: string) => boolean
+  spawn?: HarnessSpawn
+  logPath?: string
+  fs?: HarnessReconnectFs
+}
+
+export function harnessReconnectAvailable(
+  options: Pick<PrepareHarnessReconnectOptions, "entrypoint" | "exists"> = {}
+): boolean {
+  return (options.exists ?? existsSync)(options.entrypoint ?? harnessDaemonEntrypoint())
+}
+
+export function prepareHarnessReconnect(
+  runtimeSessionId: string,
+  rootStreamId: string,
+  options: PrepareHarnessReconnectOptions = {}
+): () => void {
+  if (!runtimeSessionId.trim()) throw new Error("Runtime session id is missing.")
+  if (!rootStreamId.trim()) throw new Error("Root stream id is missing.")
+  const entrypoint = options.entrypoint ?? harnessDaemonEntrypoint()
+  if (!harnessReconnectAvailable(options)) throw new Error(`Harness daemon entrypoint not found: ${entrypoint}`)
+
+  let started = false
+  return () => {
+    if (started) throw new Error("Harness reconnect was already started.")
+    started = true
+    const args = [entrypoint, "reconnect", runtimeSessionId, "--root-stream-id", rootStreamId]
+    if (options.force) args.push("--force")
+    const bunExecutable = (options.bunExecutable ?? process.env.THREA_HARNESSD_BUN_BIN?.trim()) || "bun"
+    const logPath = options.logPath ?? join(homedir(), ".threa", "harnessd", "reconnect.log")
+    const fs = options.fs ?? {
+      mkdir: mkdirSync,
+      open: openSync,
+      chmod: chmodSync,
+      close: closeSync,
+      appendFile: appendFileSync,
+    }
+    const logDir = dirname(logPath)
+    fs.mkdir(logDir, { recursive: true, mode: 0o700 })
+    fs.chmod(logDir, 0o700)
+    const logFd = fs.open(logPath, "a", 0o600)
+    try {
+      fs.chmod(logPath, 0o600)
+      const spawn = options.spawn ?? (nodeSpawn as HarnessSpawn)
+      const child = spawn(bunExecutable, args, {
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+      })
+      child.on("error", (error) => {
+        const code = typeof error.code === "string" && /^E[A-Z0-9_]{1,31}$/.test(error.code) ? ` (${error.code})` : ""
+        try {
+          fs.appendFile(logPath, `Harness reconnect launch failed${code}\n`, { mode: 0o600 })
+        } catch {}
+      })
+      child.unref()
+    } finally {
+      fs.close(logFd)
+    }
+  }
+}

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -1,6 +1,11 @@
 export { BotRuntimeTransport } from "./transport"
 export { harnessDaemonEntrypoint, runHarnessKick, type HarnessKickResult } from "./harness-kick"
 export {
+  harnessReconnectAvailable,
+  prepareHarnessReconnect,
+  type PrepareHarnessReconnectOptions,
+} from "./harness-reconnect"
+export {
   BotSupervisorTransport,
   type BotSessionRestoredPayload,
   type BotSupervisorTransportOptions,

--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import * as socketIoClient from "socket.io-client"
 import { BotRuntimeTransport } from "./transport"
+import type { BotRuntimeHello } from "./types"
 import { buildBotSocketUrl, parseWsHint } from "./ws-hint"
 
 const HELLO = {
@@ -10,6 +11,20 @@ const HELLO = {
   acceptingInvocations: true,
   supportedCapabilities: ["active-scratchpad"],
 }
+
+const LEGACY_PI_HELLO: BotRuntimeHello = {
+  instanceId: "inst_legacy",
+  runtimeKind: "pi-local",
+  supportedCapabilities: ["active-scratchpad"],
+}
+
+it("keeps status fields optional for legacy Pi hello payloads", () => {
+  expect(LEGACY_PI_HELLO).toEqual({
+    instanceId: "inst_legacy",
+    runtimeKind: "pi-local",
+    supportedCapabilities: ["active-scratchpad"],
+  })
+})
 
 function makeTransport(): BotRuntimeTransport {
   return new BotRuntimeTransport({

--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -6,6 +6,8 @@ import { buildBotSocketUrl, parseWsHint } from "./ws-hint"
 const HELLO = {
   instanceId: "inst_42",
   runtimeKind: "pi-local",
+  status: "available" as const,
+  acceptingInvocations: true,
   supportedCapabilities: ["active-scratchpad"],
 }
 
@@ -228,6 +230,50 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
       staleSocketRedialMs,
     })
   }
+
+  it("refreshes the initial and reconnect hello payloads immediately before emission", async () => {
+    const fake = makeFakeSocket()
+    const hellos: unknown[] = []
+    fake.emit = (event, payload) => {
+      if (event === "bot:hello") hellos.push(structuredClone(payload))
+    }
+    const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      let commands = ["stop"]
+      let busy = true
+      const transport = new BotRuntimeTransport({
+        baseUrl: "https://app.example.test",
+        workspaceId: "ws_1",
+        apiKey: "threa_bk_test",
+        hello: { ...HELLO, capabilities: {} },
+        beforeHello: (hello) => {
+          Object.assign(hello, {
+            status: busy ? "busy" : "available",
+            acceptingInvocations: !busy,
+            capabilities: { sessionControlCommands: commands },
+          })
+        },
+      })
+      await transport.connect()
+      fake.handlers.connect!()
+      commands = ["stop", "reconnect"]
+      busy = false
+      fake.handlers.connect!()
+
+      expect(hellos).toEqual([
+        {
+          ...HELLO,
+          status: "busy",
+          acceptingInvocations: false,
+          capabilities: { sessionControlCommands: ["stop"] },
+        },
+        { ...HELLO, capabilities: { sessionControlCommands: ["stop", "reconnect"] } },
+      ])
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
 
   it("redials after a server-initiated disconnect (Socket.IO won't reconnect on its own)", async () => {
     const fake = makeFakeSocket()

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -42,6 +42,7 @@ export class BotRuntimeTransport {
   private readonly workspaceId: string
   private readonly apiKey: string
   private readonly hello: BotRuntimeTransportOptions["hello"]
+  private readonly beforeHello: BotRuntimeTransportOptions["beforeHello"]
   private readonly callbacks: BotRuntimeTransportCallbacks
   private readonly wsAckTimeoutMs: number
   private readonly reconnectionDelayMaxMs: number
@@ -63,6 +64,7 @@ export class BotRuntimeTransport {
     this.workspaceId = opts.workspaceId
     this.apiKey = opts.apiKey
     this.hello = opts.hello
+    this.beforeHello = opts.beforeHello
     this.callbacks = opts.callbacks ?? {}
     this.wsAckTimeoutMs = opts.wsAckTimeoutMs ?? DEFAULT_WS_ACK_TIMEOUT_MS
     this.reconnectionDelayMaxMs = opts.reconnectionDelayMaxMs ?? DEFAULT_RECONNECTION_DELAY_MAX_MS
@@ -168,6 +170,7 @@ export class BotRuntimeTransport {
   sendHello(): void {
     const socket = this.socket
     if (!socket) return
+    this.beforeHello?.(this.hello)
     socket.emit(
       "bot:hello",
       { ...this.hello, ...(this.cursor ? { sinceCursor: this.cursor } : {}) },

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -29,6 +29,8 @@ export interface BotRuntimeHello {
   runtimeKind: string
   runtimeSessionId?: string
   displayName?: string | null
+  status: "available" | "busy" | "offline" | "error"
+  acceptingInvocations: boolean
   supportedCapabilities: string[]
   capabilities?: Record<string, unknown>
   manifest?: { output: { reply?: boolean; trace?: boolean; sources?: boolean } }
@@ -84,6 +86,7 @@ export interface BotRuntimeTransportOptions {
   workspaceId: string
   apiKey: string
   hello: BotRuntimeHello
+  beforeHello?: (hello: BotRuntimeHello) => void
   callbacks?: BotRuntimeTransportCallbacks
   /** How long to wait for a write-event ack before falling back to HTTP. Default 5s. */
   wsAckTimeoutMs?: number

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -29,8 +29,8 @@ export interface BotRuntimeHello {
   runtimeKind: string
   runtimeSessionId?: string
   displayName?: string | null
-  status: "available" | "busy" | "offline" | "error"
-  acceptingInvocations: boolean
+  status?: "available" | "busy" | "offline" | "error"
+  acceptingInvocations?: boolean
   supportedCapabilities: string[]
   capabilities?: Record<string, unknown>
   manifest?: { output: { reply?: boolean; trace?: boolean; sources?: boolean } }

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -109,7 +109,7 @@ The flag is required for the scratchpad to link at all: the server checks its pa
 
 Open the scratchpad in Threa and type a message. No `@`-mention needed: the bot is the scratchpad's active actor, so every message you post is forwarded to your Claude Code session. The presence pill shows **Available** / **Working**. Claude's answer posts back as a `BOT` message.
 
-For harness-managed sessions, `/kick` asks harnessd to send Enter to the session's recorded tmux pane. Use it to accept or move past a blocking Claude Code prompt without opening the terminal.
+For harness-managed sessions, `/kick` asks harnessd to send Enter to the session's recorded tmux pane. Use it to accept or move past a blocking Claude Code prompt without opening the terminal. `/reconnect [--force]` is offered only while the exact linked Claude runtime is live in tmux; after acknowledging, it asks harnessd to replace the pane process and resume the same native session. It is not offline recovery and is unavailable after the channel disconnects.
 
 ## Permission relay
 

--- a/extensions/claude-code-remote/install-local.ts
+++ b/extensions/claude-code-remote/install-local.ts
@@ -35,6 +35,7 @@ const VENDORED = [
       "sealed.ts",
       "supervisor.ts",
       "harness-kick.ts",
+      "harness-reconnect.ts",
     ],
     dir: "bot-runtime-client",
   },

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -12,6 +12,7 @@ import {
   buildInstructions,
   formatDelegationContent,
   parsePermissionVerdict,
+  runClaudeCommand,
   verdictCandidateText,
 } from "./channel-server"
 
@@ -193,6 +194,98 @@ describe("ChannelServer delegations", () => {
     expect(internals.reconnectBusy()).toBe(false)
     internals.openDelegations.set("dlg_1", {})
     expect(internals.reconnectBusy()).toBe(true)
+  })
+
+  test("reconnect stops delegation intake and rechecks active work before non-force handoff", async () => {
+    const server = new ChannelServer(makeConfig(), new ThreaClient(makeConfig()), makeFakeTransport())
+    const internals = server as any
+    let stopped = false
+    internals.delegations = {
+      stop: () => {
+        stopped = true
+        internals.openDelegations.set("dlg_race", { reject: () => {}, clear: () => {} })
+        return Promise.resolve()
+      },
+    }
+
+    await expect(internals.stopDelegationsForReconnect(false)).rejects.toThrow("Claude became busy")
+    expect(stopped).toBe(true)
+  })
+
+  test("handoff reset restarts delegation intake while archive-detached, but not during shutdown", () => {
+    const server = new ChannelServer(makeConfig(), new ThreaClient(makeConfig()), makeFakeTransport())
+    const internals = server as any
+    let starts = 0
+    internals.delegations = { start: () => starts++ }
+    internals.started = true
+    internals.session.archivePending = { rootStreamId: "stream_root" }
+
+    internals.restartDelegationsAfterReset()
+    internals.shuttingDown = true
+    internals.restartDelegationsAfterReset()
+
+    expect(starts).toBe(1)
+  })
+
+  test("shared runner stop lets shutdown prevent reconnect spawn and delegation restart", async () => {
+    const server = new ChannelServer(makeConfig(), new ThreaClient(makeConfig()), makeFakeTransport())
+    const internals = server as any
+    let releaseStop!: () => void
+    const sharedStop = new Promise<void>((resolve) => (releaseStop = resolve))
+    let starts = 0
+    internals.started = true
+    internals.delegations = { stop: () => sharedStop, start: () => starts++ }
+    spyOn(server.session, "shutdown").mockResolvedValue()
+
+    const outcome = await runClaudeCommand(
+      "reconnect",
+      "--force",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      undefined,
+      () => internals.stopDelegationsForReconnect(true),
+      () => internals.restartDelegationsAfterReset(),
+      () => ({ stopped: false, linkGeneration: 1, linkState: "linked", rootStreamId: "root" }),
+      () => !internals.shuttingDown
+    )
+    const reconnect = outcome.afterAck?.()
+    await Promise.resolve()
+    const shutdown = server.shutdown()
+    releaseStop()
+
+    await expect(reconnect).rejects.toThrow(
+      "Remote session changed while delegation intake was quiescing; reconnect was not started."
+    )
+    outcome.onHandoffReset?.()
+    await shutdown
+    expect(starts).toBe(0)
+  })
+
+  test("force reconnect interrupts active delegation and waits for its fail report", async () => {
+    const server = new ChannelServer(makeConfig(), new ThreaClient(makeConfig()), makeFakeTransport())
+    const internals = server as any
+    let releaseStop!: () => void
+    let rejectedWith = ""
+    internals.delegations = { stop: () => new Promise<void>((resolve) => (releaseStop = resolve)) }
+    internals.openDelegations.set("dlg_active", {
+      reject: (error: Error) => {
+        rejectedWith = error.message
+      },
+      clear: () => {},
+    })
+
+    let finished = false
+    const stopping = internals.stopDelegationsForReconnect(true).then(() => (finished = true))
+    await Promise.resolve()
+    expect({ rejectedWith, finished }).toEqual({
+      rejectedWith: "Claude Code channel reconnected mid-delegation",
+      finished: false,
+    })
+    releaseStop()
+    await stopping
+    expect(finished).toBe(true)
   })
 
   test("shutdown fails an in-flight delegation instead of stranding its claim", async () => {

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -186,6 +186,15 @@ describe("ChannelServer delegations", () => {
     await server.shutdown()
   })
 
+  test("active delegations make reconnect busy", () => {
+    const config = makeConfig()
+    const server = new ChannelServer(config, new ThreaClient(config), makeFakeTransport())
+    const internals = server as any
+    expect(internals.reconnectBusy()).toBe(false)
+    internals.openDelegations.set("dlg_1", {})
+    expect(internals.reconnectBusy()).toBe(true)
+  })
+
   test("shutdown fails an in-flight delegation instead of stranding its claim", async () => {
     const { server, calls } = await startDelegatingServer("dlg_1")
     await server.shutdown()

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -1,7 +1,12 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
-import { runHarnessKick, type BotRuntimeTransport } from "@threa/bot-runtime-client"
+import {
+  harnessReconnectAvailable,
+  prepareHarnessReconnect,
+  runHarnessKick,
+  type BotRuntimeTransport,
+} from "@threa/bot-runtime-client"
 import {
   DelegationClient,
   DelegationRunner,
@@ -47,6 +52,7 @@ const SESSION_CONTROL_COMMANDS = [
   "run",
   "reload",
   "carry-on",
+  "reconnect",
 ] as const
 // Model options for the composer's arg picker: built-in /model aliases plus
 // whatever the local client's own picker cache discovers (see model-catalog).
@@ -164,9 +170,27 @@ export async function runClaudeCommand(
   args: string,
   carryOn?: CarryOnController,
   runtimeSessionId?: string,
-  statusReport?: () => string
-): Promise<{ ok: boolean; message: string }> {
+  statusReport?: () => string,
+  rootStreamId?: () => string | undefined,
+  reconnectBusy?: () => boolean
+): Promise<{ ok: boolean; message: string; afterAck?: () => void }> {
   switch (name) {
+    case "reconnect": {
+      if (args !== "" && args !== "--force") {
+        return { ok: false, message: "Usage: `/reconnect [--force]`." }
+      }
+      if (args !== "--force" && reconnectBusy?.()) {
+        return { ok: false, message: "Claude is busy; retry when idle or use `/reconnect --force`." }
+      }
+      const root = rootStreamId?.()
+      if (!runtimeSessionId || !root) throw new Error("Harness reconnect is unavailable for this session.")
+      const afterAck = prepareHarnessReconnect(runtimeSessionId, root, { force: args === "--force" })
+      return {
+        ok: true,
+        message: "Reconnect request accepted; attempting to resume the linked Claude session.",
+        afterAck,
+      }
+    }
     case "carry-on": {
       if (!carryOn) return { ok: false, message: "Quota carry-on is unavailable for this session." }
       return carryOn.enqueue(args)
@@ -240,13 +264,19 @@ async function runSlash(slash: string): Promise<{ ok: boolean; message: string }
 export function createClaudeSessionControl(
   carryOn: () => CarryOnController | undefined = () => undefined,
   runtimeSessionId?: string,
-  statusReport?: () => string
+  statusReport?: () => string,
+  rootStreamId?: () => string | undefined,
+  reconnectBusy?: () => boolean
 ): SessionControlActuator | undefined {
   if (!tmuxAvailable()) return undefined
   return {
-    commands: runtimeSessionId
-      ? [...SESSION_CONTROL_COMMANDS]
-      : SESSION_CONTROL_COMMANDS.filter((command) => command !== "kick"),
+    get commands() {
+      return runtimeSessionId
+        ? SESSION_CONTROL_COMMANDS.filter(
+            (command) => command !== "reconnect" || Boolean(rootStreamId?.() && harnessReconnectAvailable())
+          )
+        : SESSION_CONTROL_COMMANDS.filter((command) => command !== "kick" && command !== "reconnect")
+    },
     modelSuggestions: MODEL_SUGGESTIONS,
     thinkingLevels: [...THINKING_LEVELS],
     interrupt: () => {
@@ -265,7 +295,8 @@ export function createClaudeSessionControl(
       if (absorbed !== undefined) return true
       return steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`)
     },
-    runCommand: (name, args) => runClaudeCommand(name, args, carryOn(), runtimeSessionId, statusReport),
+    runCommand: (name, args) =>
+      runClaudeCommand(name, args, carryOn(), runtimeSessionId, statusReport, rootStreamId, reconnectBusy),
   }
 }
 
@@ -357,7 +388,9 @@ export class ChannelServer {
               quotaHolding: this.carryOn?.holding ?? false,
               pendingPermissionCount: this.openPermissions.size,
               activeDelegationCount: this.openDelegations.size,
-            })
+            }),
+          () => this.session?.rootStreamId,
+          () => (this.session?.statusSnapshot.inflightCount ?? 0) > 0 || (this.carryOn?.holding ?? false)
         ),
         onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -18,6 +18,7 @@ import {
   type DelegationExecutorContext,
   type DeliveredTurn,
   type RemoteSessionConfig,
+  type RemoteSessionStatusSnapshot,
   type SendResult,
   type SessionControlActuator,
 } from "@threa/remote-session"
@@ -165,6 +166,8 @@ export function buildInstructions(permissionRelay: boolean, channelActive = true
  * slash-command equivalent into the tmux pane. `stop`/`steer` never reach this
  * — the SDK actuates those itself via `interrupt`/`steer`.
  */
+type ReconnectTarget = Pick<RemoteSessionStatusSnapshot, "stopped" | "linkGeneration" | "linkState" | "rootStreamId">
+
 export async function runClaudeCommand(
   name: string,
   args: string,
@@ -172,8 +175,17 @@ export async function runClaudeCommand(
   runtimeSessionId?: string,
   statusReport?: () => string,
   rootStreamId?: () => string | undefined,
-  reconnectBusy?: () => boolean
-): Promise<{ ok: boolean; message: string; afterAck?: () => void }> {
+  reconnectBusy?: () => boolean,
+  stopDelegationsForReconnect?: (force: boolean) => Promise<void>,
+  restartDelegationsAfterReset?: () => void,
+  reconnectTarget?: () => ReconnectTarget,
+  reconnectReady?: () => boolean
+): Promise<{
+  ok: boolean
+  message: string
+  afterAck?: () => void | Promise<void>
+  onHandoffReset?: () => void
+}> {
   switch (name) {
     case "reconnect": {
       if (args !== "" && args !== "--force") {
@@ -182,21 +194,35 @@ export async function runClaudeCommand(
       if (args !== "--force" && reconnectBusy?.()) {
         return { ok: false, message: "Claude is busy; retry when idle or use `/reconnect --force`." }
       }
-      const root = rootStreamId?.()
+      const target = reconnectTarget?.()
+      const root = target?.rootStreamId ?? rootStreamId?.()
       if (!runtimeSessionId || !root) throw new Error("Harness reconnect is unavailable for this session.")
       const force = args === "--force"
       const startReconnect = prepareHarnessReconnect(runtimeSessionId, root, { force })
       return {
         ok: true,
         message: "Reconnect request accepted; attempting to resume the linked Claude session.",
-        afterAck: () => {
+        afterAck: async () => {
           if (!force && reconnectBusy?.()) {
             throw new Error(
               "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
             )
           }
+          await stopDelegationsForReconnect?.(force)
+          const current = reconnectTarget?.()
+          if (
+            reconnectReady?.() === false ||
+            (current &&
+              (current.stopped ||
+                current.linkState !== "linked" ||
+                current.rootStreamId !== root ||
+                current.linkGeneration !== target?.linkGeneration))
+          ) {
+            throw new Error("Remote session changed while delegation intake was quiescing; reconnect was not started.")
+          }
           startReconnect()
         },
+        onHandoffReset: restartDelegationsAfterReset,
       }
     }
     case "carry-on": {
@@ -274,7 +300,11 @@ export function createClaudeSessionControl(
   runtimeSessionId?: string,
   statusReport?: () => string,
   rootStreamId?: () => string | undefined,
-  reconnectBusy?: () => boolean
+  reconnectBusy?: () => boolean,
+  stopDelegationsForReconnect?: (force: boolean) => Promise<void>,
+  restartDelegationsAfterReset?: () => void,
+  reconnectTarget?: () => ReconnectTarget,
+  reconnectReady?: () => boolean
 ): SessionControlActuator | undefined {
   if (!tmuxAvailable()) return undefined
   return {
@@ -304,7 +334,19 @@ export function createClaudeSessionControl(
       return steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`)
     },
     runCommand: (name, args) =>
-      runClaudeCommand(name, args, carryOn(), runtimeSessionId, statusReport, rootStreamId, reconnectBusy),
+      runClaudeCommand(
+        name,
+        args,
+        carryOn(),
+        runtimeSessionId,
+        statusReport,
+        rootStreamId,
+        reconnectBusy,
+        stopDelegationsForReconnect,
+        restartDelegationsAfterReset,
+        reconnectTarget,
+        reconnectReady
+      ),
   }
 }
 
@@ -339,6 +381,7 @@ export class ChannelServer {
     }
   >()
   private started = false
+  private shuttingDown = false
 
   constructor(
     private readonly config: RemoteSessionConfig,
@@ -398,7 +441,14 @@ export class ChannelServer {
               activeDelegationCount: this.openDelegations.size,
             }),
           () => this.session?.rootStreamId,
-          () => this.reconnectBusy()
+          () => this.reconnectBusy(),
+          (force) => this.stopDelegationsForReconnect(force),
+          () => this.restartDelegationsAfterReset(),
+          () => {
+            const remote = this.session.statusSnapshot
+            return { ...remote, rootStreamId: this.session.rootStreamId }
+          },
+          () => !this.shuttingDown
         ),
         onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay
@@ -439,6 +489,37 @@ export class ChannelServer {
     )
   }
 
+  private async stopDelegationsForReconnect(force: boolean): Promise<void> {
+    const reason = "Claude Code channel reconnected mid-delegation"
+    const stopping = this.delegations?.stop(reason, { strict: true }) ?? Promise.resolve()
+
+    if (force) {
+      this.failOpenDelegations(reason)
+      await stopping
+      return
+    }
+
+    if (this.openDelegations.size > 0) {
+      void stopping.catch((error) =>
+        log(`delegation stop failed: ${error instanceof Error ? error.message : String(error)}`)
+      )
+      throw new Error(
+        "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
+      )
+    }
+
+    await stopping
+    if (this.openDelegations.size > 0) {
+      throw new Error(
+        "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
+      )
+    }
+  }
+
+  private restartDelegationsAfterReset(): void {
+    if (this.started && !this.shuttingDown) this.delegations?.start()
+  }
+
   /** Connect the stdio transport so Claude Code can talk to the server and discover tools. */
   async connectStdio(): Promise<void> {
     await this.mcp.connect(new StdioServerTransport())
@@ -451,6 +532,7 @@ export class ChannelServer {
   }
 
   async shutdown(): Promise<void> {
+    this.shuttingDown = true
     this.tracer.stop()
     this.carryOn?.stop()
     // Fail an in-flight delegation loudly (its executor promise rejects →

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -184,11 +184,19 @@ export async function runClaudeCommand(
       }
       const root = rootStreamId?.()
       if (!runtimeSessionId || !root) throw new Error("Harness reconnect is unavailable for this session.")
-      const afterAck = prepareHarnessReconnect(runtimeSessionId, root, { force: args === "--force" })
+      const force = args === "--force"
+      const startReconnect = prepareHarnessReconnect(runtimeSessionId, root, { force })
       return {
         ok: true,
         message: "Reconnect request accepted; attempting to resume the linked Claude session.",
-        afterAck,
+        afterAck: () => {
+          if (!force && reconnectBusy?.()) {
+            throw new Error(
+              "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
+            )
+          }
+          startReconnect()
+        },
       }
     }
     case "carry-on": {
@@ -390,7 +398,7 @@ export class ChannelServer {
               activeDelegationCount: this.openDelegations.size,
             }),
           () => this.session?.rootStreamId,
-          () => (this.session?.statusSnapshot.inflightCount ?? 0) > 0 || (this.carryOn?.holding ?? false)
+          () => this.reconnectBusy()
         ),
         onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay
@@ -421,6 +429,14 @@ export class ChannelServer {
       log,
     })
     this.registerHandlers()
+  }
+
+  private reconnectBusy(): boolean {
+    return (
+      (this.session.statusSnapshot.inflightCount ?? 0) > 0 ||
+      (this.carryOn?.holding ?? false) ||
+      this.openDelegations.size > 0
+    )
   }
 
   /** Connect the stdio transport so Claude Code can talk to the server and discover tools. */

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -6,6 +6,7 @@ function withTmuxEnv<T>(env: { TMUX?: string; TMUX_PANE?: string }, fn: () => T)
     TMUX: process.env.TMUX,
     TMUX_PANE: process.env.TMUX_PANE,
     THREA_TMUX_TARGET: process.env.THREA_TMUX_TARGET,
+    THREA_HARNESSD_ENTRYPOINT: process.env.THREA_HARNESSD_ENTRYPOINT,
   }
   delete process.env.THREA_TMUX_TARGET
   if (env.TMUX === undefined) delete process.env.TMUX
@@ -53,6 +54,19 @@ describe("createClaudeSessionControl", () => {
     })
   })
 
+  it("advertises reconnect only with exact runtime, root, and harness entrypoint", () => {
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).toContain("reconnect")
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => undefined)!.commands).not.toContain(
+        "reconnect"
+      )
+      process.env.THREA_HARNESSD_ENTRYPOINT = "/definitely/missing/harnessd.ts"
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).not.toContain(
+        "reconnect"
+      )
+    })
+  })
+
   it("does not advertise /kick without a harness runtime identity", () => {
     withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
       expect(createClaudeSessionControl()!.commands).toEqual([
@@ -71,6 +85,47 @@ describe("createClaudeSessionControl", () => {
 })
 
 describe("runClaudeCommand validation (paths that never touch tmux)", () => {
+  it("accepts only empty or exact --force reconnect args", async () => {
+    for (const args of ["--FORCE", "force", "--force=true", "--force --force", "extra"]) {
+      expect(await runClaudeCommand("reconnect", args, undefined, "runtime", undefined, () => "root")).toEqual({
+        ok: false,
+        message: "Usage: `/reconnect [--force]`.",
+      })
+    }
+    for (const args of ["", "--force"]) {
+      const outcome = await runClaudeCommand("reconnect", args, undefined, "runtime", undefined, () => "root")
+      expect(outcome.ok).toBe(true)
+      expect(outcome.message).toBe("Reconnect request accepted; attempting to resume the linked Claude session.")
+      expect(typeof outcome.afterAck).toBe("function")
+    }
+  })
+
+  it("refuses non-force reconnect during in-flight or quota-held work", async () => {
+    const busy = await runClaudeCommand(
+      "reconnect",
+      "",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      () => true
+    )
+    expect(busy).toEqual({ ok: false, message: "Claude is busy; retry when idle or use `/reconnect --force`." })
+    expect(
+      (
+        await runClaudeCommand(
+          "reconnect",
+          "--force",
+          undefined,
+          "runtime",
+          undefined,
+          () => "root",
+          () => true
+        )
+      ).ok
+    ).toBe(true)
+  })
+
   it("fails loudly when /kick has no harness-managed runtime identity", async () => {
     expect(runClaudeCommand("kick", "")).rejects.toThrow("Harness kick is unavailable for this session.")
   })

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -126,6 +126,25 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     ).toBe(true)
   })
 
+  it("refuses non-force reconnect when work begins after the outcome but before afterAck", async () => {
+    let busy = false
+    const outcome = await runClaudeCommand(
+      "reconnect",
+      "",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      () => busy
+    )
+
+    expect(outcome.ok).toBe(true)
+    busy = true
+    expect(() => outcome.afterAck?.()).toThrow(
+      "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
+    )
+  })
+
   it("fails loudly when /kick has no harness-managed runtime identity", async () => {
     expect(runClaudeCommand("kick", "")).rejects.toThrow("Harness kick is unavailable for this session.")
   })

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -140,9 +140,69 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
 
     expect(outcome.ok).toBe(true)
     busy = true
-    expect(() => outcome.afterAck?.()).toThrow(
+    await expect(outcome.afterAck?.()).rejects.toThrow(
       "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
     )
+  })
+
+  for (const lifecycle of ["shutdown", "archive→same-root restore"] as const) {
+    it(`does not launch reconnect when ${lifecycle} wins during deferred delegation quiesce`, async () => {
+      let releaseQuiesce!: () => void
+      const quiesce = new Promise<void>((resolve) => (releaseQuiesce = resolve))
+      let target: {
+        stopped: boolean
+        linkGeneration: number
+        linkState: "unlinked" | "linked" | "detached"
+        rootStreamId: string | undefined
+      } = { stopped: false, linkGeneration: 1, linkState: "linked", rootStreamId: "root" }
+      const outcome = await runClaudeCommand(
+        "reconnect",
+        "--force",
+        undefined,
+        "runtime",
+        undefined,
+        () => "root",
+        undefined,
+        () => quiesce,
+        undefined,
+        () => target
+      )
+
+      const postAck = outcome.afterAck?.()
+      target =
+        lifecycle === "shutdown"
+          ? { stopped: true, linkGeneration: 1, linkState: "unlinked", rootStreamId: undefined }
+          : { stopped: false, linkGeneration: 3, linkState: "linked", rootStreamId: "root" }
+      releaseQuiesce()
+
+      await expect(postAck).rejects.toThrow(
+        "Remote session changed while delegation intake was quiescing; reconnect was not started."
+      )
+    })
+  }
+
+  it("does not launch reconnect when delegation quiesce fails and exposes intake restoration", async () => {
+    const releaseError = new Error("delegation release failed: 500")
+    let resets = 0
+    const outcome = await runClaudeCommand(
+      "reconnect",
+      "--force",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      undefined,
+      async () => {
+        throw releaseError
+      },
+      () => {
+        resets += 1
+      }
+    )
+
+    await expect(outcome.afterAck?.()).rejects.toBe(releaseError)
+    outcome.onHandoffReset?.()
+    expect(resets).toBe(1)
   })
 
   it("fails loudly when /kick has no harness-managed runtime identity", async () => {

--- a/extensions/claude-code-remote/src/status.test.ts
+++ b/extensions/claude-code-remote/src/status.test.ts
@@ -5,6 +5,7 @@ import type { TmuxPaneSnapshot } from "./tmux-control"
 
 const remote: RemoteSessionStatusSnapshot = {
   stopped: false,
+  linkGeneration: 1,
   linkState: "linked",
   rootStreamId: "stream_1",
   activeStreamId: "stream_1",

--- a/extensions/remote-session/src/delegation-runner.test.ts
+++ b/extensions/remote-session/src/delegation-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { ThreaApiError } from "./client"
 import type { ClaimedDelegation, DelegationClient, DelegationSummary } from "./delegation-client"
-import { DelegationRunner, type DelegationExecutor } from "./delegation-runner"
+import { DELEGATION_STOP_REASON, DelegationRunner, type DelegationExecutor } from "./delegation-runner"
 
 function summary(id: string): DelegationSummary {
   return {
@@ -35,7 +35,11 @@ interface StubCalls {
   accessRequests: string[]
 }
 
-function stubClient(overrides: { queue?: DelegationSummary[][]; claimError?: (id: string) => Error | null }): {
+function stubClient(overrides: {
+  queue?: DelegationSummary[][]
+  claimError?: (id: string) => Error | null
+  failError?: Error
+}): {
   client: DelegationClient
   calls: StubCalls
 } {
@@ -79,6 +83,7 @@ function stubClient(overrides: { queue?: DelegationSummary[][]; claimError?: (id
     },
     fail: async (id: string, token: string, errorMessage: string) => {
       calls.fails.push({ id, token, errorMessage })
+      if (overrides.failError) throw overrides.failError
       return { ...summary(id), status: "failed" }
     },
     requestAccess: async (id: string) => {
@@ -302,6 +307,127 @@ describe("DelegationRunner", () => {
 
     expect(calls.claims.map((c) => c.id)).toEqual(["dlg_listed"])
     expect(calls.accessRequests).toEqual([])
+  })
+
+  for (const trigger of ["nudge", "poll"] as const) {
+    it(`stop wins while a ${trigger} claim is in flight`, async () => {
+      let releaseClaim!: (task: ClaimedDelegation) => void
+      let claimStarted!: () => void
+      const started = new Promise<void>((resolve) => (claimStarted = resolve))
+      const calls: StubCalls["fails"] = []
+      const client = {
+        listOpen: async () => (trigger === "poll" ? [summary("dlg_race")] : []),
+        claim: () =>
+          new Promise<ClaimedDelegation>((resolve) => {
+            releaseClaim = resolve
+            claimStarted()
+          }),
+        fail: async (id: string, token: string, errorMessage: string) => {
+          calls.push({ id, token, errorMessage })
+        },
+      } as unknown as DelegationClient
+      let executions = 0
+      const runner = makeRunner(client, async () => {
+        executions += 1
+      })
+
+      runner.start()
+      if (trigger === "nudge") runner.notifyAvailable({ delegationId: "dlg_race" })
+      await started
+      const stopped = runner.stop()
+      releaseClaim(claimed("dlg_race"))
+      await stopped
+
+      expect({ executions, calls }).toEqual({
+        executions: 0,
+        calls: [{ id: "dlg_race", token: "token-dlg_race", errorMessage: DELEGATION_STOP_REASON }],
+      })
+    })
+  }
+
+  for (const trigger of ["list", "nudge"] as const) {
+    it(`strict stop propagates a failed ${trigger} claim release`, async () => {
+      let releaseClaim!: (task: ClaimedDelegation) => void
+      let claimStarted!: () => void
+      const started = new Promise<void>((resolve) => (claimStarted = resolve))
+      const logs: string[] = []
+      const releaseError = new Error(trigger === "list" ? "release 500" : "release timed out")
+      const client = {
+        listOpen: async () => (trigger === "list" ? [summary("dlg_race")] : []),
+        claim: () =>
+          new Promise<ClaimedDelegation>((resolve) => {
+            releaseClaim = resolve
+            claimStarted()
+          }),
+        fail: async () => {
+          throw releaseError
+        },
+      } as unknown as DelegationClient
+      const runner = makeRunner(client, async () => {}, { log: (message) => logs.push(message) })
+
+      runner.start()
+      if (trigger === "nudge") runner.notifyAvailable({ delegationId: "dlg_race" })
+      await started
+      const stopped = runner.stop(DELEGATION_STOP_REASON, { strict: true })
+      releaseClaim(claimed("dlg_race"))
+
+      await expect(stopped).rejects.toBe(releaseError)
+      expect(logs).toEqual([
+        `delegation dlg_race stop fail report failed: ${releaseError.message}`,
+        `delegation drain failed: ${releaseError.message}`,
+      ])
+    })
+  }
+
+  it("normal shutdown stop clears an overlapping reconnect strict stop", async () => {
+    let releaseClaim!: (task: ClaimedDelegation) => void
+    let claimStarted!: () => void
+    const started = new Promise<void>((resolve) => (claimStarted = resolve))
+    const releaseError = new Error("release 500")
+    const client = {
+      listOpen: async () => [summary("dlg_race")],
+      claim: () =>
+        new Promise<ClaimedDelegation>((resolve) => {
+          releaseClaim = resolve
+          claimStarted()
+        }),
+      fail: async () => {
+        throw releaseError
+      },
+    } as unknown as DelegationClient
+    const runner = makeRunner(client, async () => {})
+
+    runner.start()
+    await started
+    const reconnectStop = runner.stop(DELEGATION_STOP_REASON, { strict: true })
+    const shutdownStop = runner.stop()
+    releaseClaim(claimed("dlg_race"))
+
+    await expect(reconnectStop).resolves.toBeUndefined()
+    await expect(shutdownStop).resolves.toBeUndefined()
+  })
+
+  it("strict stop propagates a failed terminal fail for active work", async () => {
+    let rejectExecution!: (error: Error) => void
+    let executionStarted!: () => void
+    const started = new Promise<void>((resolve) => (executionStarted = resolve))
+    const releaseError = new Error("terminal fail 500")
+    const { client } = stubClient({ queue: [[summary("dlg_active")]], failError: releaseError })
+    const runner = makeRunner(
+      client,
+      () =>
+        new Promise((_, reject) => {
+          rejectExecution = reject
+          executionStarted()
+        })
+    )
+
+    runner.start()
+    await started
+    const stopped = runner.stop(DELEGATION_STOP_REASON, { strict: true })
+    rejectExecution(new Error("reconnect"))
+
+    await expect(stopped).rejects.toBe(releaseError)
   })
 
   it("does nothing after stop()", async () => {

--- a/extensions/remote-session/src/delegation-runner.ts
+++ b/extensions/remote-session/src/delegation-runner.ts
@@ -8,6 +8,7 @@ const DEFAULT_HEARTBEAT_MS = 5 * 60 * 1000
 const FAIL_MESSAGE_MAX = 1_000
 /** The server's `statusNote` validator cap. */
 const STATUS_NOTE_MAX = 2_000
+export const DELEGATION_STOP_REASON = "Delegation runner stopped for reconnect or shutdown"
 
 export interface DelegationExecutorContext {
   /** Put a progress note on the card (also renews the lease). Best-effort. */
@@ -65,6 +66,8 @@ export class DelegationRunner {
   private readonly log: (message: string) => void
 
   private stopped = true
+  private stopReason = DELEGATION_STOP_REASON
+  private strictStop = false
   /** The in-flight drain, when one is running — the single-flight latch. */
   private current: Promise<void> | undefined
   private pollTimer: ReturnType<typeof setInterval> | undefined
@@ -92,6 +95,8 @@ export class DelegationRunner {
   start(): void {
     if (!this.stopped) return
     this.stopped = false
+    this.stopReason = DELEGATION_STOP_REASON
+    this.strictStop = false
     this.pollTimer = setInterval(() => this.drain(), this.pollMs)
     this.drain()
   }
@@ -100,8 +105,10 @@ export class DelegationRunner {
    * Resolves once the in-flight drain (if any) has finished, so a graceful
    * shutdown can reject its executor and still see the fail report posted.
    */
-  stop(): Promise<void> {
+  stop(reason = DELEGATION_STOP_REASON, options?: { strict?: boolean }): Promise<void> {
     this.stopped = true
+    this.stopReason = reason
+    this.strictStop = options?.strict ?? false
     if (this.pollTimer) clearInterval(this.pollTimer)
     this.pollTimer = undefined
     return this.current ?? Promise.resolve()
@@ -143,6 +150,10 @@ export class DelegationRunner {
           if (this.stopped) return
           const claimed = await this.tryClaim(summary)
           if (!claimed) continue
+          if (this.stopped) {
+            await this.releaseStoppedClaim(claimed)
+            return
+          }
           await this.execute(claimed)
           // One at a time: after finishing, re-list rather than working a
           // possibly-stale snapshot of the queue.
@@ -156,6 +167,10 @@ export class DelegationRunner {
           if (this.stopped) return
           const claimed = await this.tryClaimNudged(id)
           if (!claimed) continue
+          if (this.stopped) {
+            await this.releaseStoppedClaim(claimed)
+            return
+          }
           await this.execute(claimed)
           executed = true
           break
@@ -163,6 +178,7 @@ export class DelegationRunner {
       }
     } catch (error) {
       this.log(`delegation drain failed: ${error instanceof Error ? error.message : String(error)}`)
+      if (this.stopped && this.strictStop) throw error
     }
   }
 
@@ -227,6 +243,17 @@ export class DelegationRunner {
     }
   }
 
+  private async releaseStoppedClaim(task: ClaimedDelegation): Promise<void> {
+    try {
+      await this.client.fail(task.id, task.claimToken, this.stopReason)
+    } catch (error) {
+      this.log(
+        `delegation ${task.id} stop fail report failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+      if (this.strictStop) throw error
+    }
+  }
+
   private async execute(task: ClaimedDelegation): Promise<void> {
     const { id, claimToken } = task
     const heartbeat = setInterval(() => {
@@ -265,6 +292,7 @@ export class DelegationRunner {
             failError instanceof Error ? failError.message : String(failError)
           }`
         )
+        if (this.stopped && this.strictStop) throw failError
       }
     } finally {
       clearInterval(heartbeat)

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -15,7 +15,7 @@ import {
   type SessionControlActuator,
 } from "./session"
 import type { RemoteSessionConfig } from "./identity"
-import type { ClaimedInvocation, ThreaClient } from "./client"
+import { ThreaApiError, type ClaimedInvocation, type ThreaClient } from "./client"
 
 function makeConfig(overrides?: Partial<RemoteSessionConfig>): RemoteSessionConfig {
   return {
@@ -376,6 +376,7 @@ describe("RemoteSession status snapshot", () => {
 
     expect(session.statusSnapshot).toEqual({
       stopped: false,
+      linkGeneration: 0,
       linkState: "unlinked",
       rootStreamId: undefined,
       activeStreamId: undefined,
@@ -635,6 +636,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     expect(created).toHaveLength(1)
     expect(asInternal(session).archivePending).toBeUndefined()
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
+    expect(session.statusSnapshot.linkGeneration).toBe(2)
     expect(presence.at(-1)?.status).toBe("available")
     expect(archived).toEqual([])
     await session.shutdown()
@@ -914,6 +916,41 @@ describe("session control via the actuator", () => {
     })
   }
 
+  test("runs the handoff reset once before restoring intake after a post-ack failure", async () => {
+    const { client } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const order: string[] = []
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["reconnect"],
+        interrupt: () => true,
+        runCommand: async () => ({
+          ok: true,
+          message: "accepted",
+          afterAck: () => {
+            order.push("post-ack")
+            throw new Error("launch failed")
+          },
+          onHandoffReset: () => order.push("reset"),
+        }),
+      },
+    })
+    ;(session as any).link = { rootStreamId: "stream_root" }
+    ;(session as any).syncPresence = async () => order.push("presence")
+    ;(session as any).claimDrain = async () => order.push("drain")
+
+    await (session as any).handleSessionControl(
+      makeInvocation({
+        trigger: "session-control",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+      })
+    )
+    ;(session as any).resetReconnectHandoff()
+    await Bun.sleep(0)
+
+    expect(order).toEqual(["presence", "post-ack", "reset", "presence", "drain"])
+  })
+
   test("logs a post-ack action error after preserving the successful acknowledgement", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()
@@ -950,6 +987,41 @@ describe("session control via the actuator", () => {
     expect({ completed: calls.complete.length, logs }).toEqual({
       completed: 1,
       logs: ["session-control post-ack action failed: detached launch failed"],
+    })
+  })
+
+  test("does not run a post-ack action when sealed key-race fallback only closes silently", async () => {
+    const { client, calls } = makeFakeClient()
+    ;(client as unknown as { complete: (id: string, body: Record<string, unknown>) => Promise<void> }).complete =
+      async (id, body) => {
+        if (body.finalMessageMarkdown) {
+          throw new ThreaApiError("plaintext rejected", 400, "E2E_STREAM_PLAINTEXT_UNSUPPORTED")
+        }
+        calls.complete.push({ id, body })
+      }
+    const { transport } = makeFakeTransport()
+    let started = false
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["reconnect"],
+        interrupt: () => true,
+        runCommand: async () => ({ ok: true, message: "accepted", afterAck: () => (started = true) }),
+      },
+    })
+    ;(session as any).link = { rootStreamId: "stream_root" }
+    ;(session as any).sealSessionControlAck = async () => undefined
+
+    await (session as any).handleSessionControl(
+      makeInvocation({
+        trigger: "session-control",
+        sealedAck: { keyWraps: [] },
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+      })
+    )
+
+    expect({ started, silentCloses: calls.complete.filter((call) => call.body.noResponse).length }).toEqual({
+      started: false,
+      silentCloses: 1,
     })
   })
 

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -664,6 +664,35 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     await session.shutdown()
   })
 
+  test("writes offline after an already-fired reconnect fallback", async () => {
+    const client = { fail: async () => {} } as unknown as ThreaClient
+    const { transport, presence } = makeFakeTransport()
+    let releasePresence!: () => void
+    const blocked = new Promise<void>((resolve) => (releasePresence = resolve))
+    ;(transport as unknown as { updatePresence: (body: Record<string, unknown>) => Promise<void> }).updatePresence =
+      async (body) => {
+        presence.push(body)
+        if (body.status === "available") await blocked
+      }
+    const session = makeGraceSession({ client, transport, archiveGraceMs: 60_000 })
+    ;(session as any).link = { rootStreamId: "stream_root" }
+    ;(session as any).reconnectHandoff = true
+    ;(session as any).resetReconnectHandoff()
+    await Bun.sleep(0)
+
+    const archived = asInternal(session).handleSessionArchived({
+      runtimeSessionId: "rts-test",
+      rootStreamId: "stream_root",
+    })
+    await Bun.sleep(0)
+    expect(presence.map((body) => body.status)).toEqual(["available"])
+    releasePresence()
+    await archived
+
+    expect(presence.map((body) => body.status)).toEqual(["available", "offline"])
+    await session.shutdown()
+  })
+
   test("winds down (onArchived) when the grace expires without a restore", async () => {
     const client = { fail: async () => {} } as unknown as ThreaClient
     const { transport, presence } = makeFakeTransport()
@@ -704,6 +733,31 @@ describe("RemoteSession session-archived handling (grace window)", () => {
 })
 
 describe("RemoteSession.shutdown", () => {
+  test("writes offline after an already-fired reconnect fallback", async () => {
+    const { client } = makeFakeClient()
+    const { transport, presence } = makeFakeTransport()
+    let releasePresence!: () => void
+    const blocked = new Promise<void>((resolve) => (releasePresence = resolve))
+    ;(transport as unknown as { updatePresence: (body: Record<string, unknown>) => Promise<void> }).updatePresence =
+      async (body) => {
+        presence.push(body)
+        if (body.status === "available") await blocked
+      }
+    const session = makeSession(client, transport)
+    ;(session as any).link = { rootStreamId: "stream_root" }
+    ;(session as any).reconnectHandoff = true
+    ;(session as any).resetReconnectHandoff()
+    await Bun.sleep(0)
+
+    const shutdown = session.shutdown()
+    await Bun.sleep(0)
+    expect(presence.map((body) => body.status)).toEqual(["available"])
+    releasePresence()
+    await shutdown
+
+    expect(presence.map((body) => body.status)).toEqual(["available", "offline"])
+  })
+
   test("marks presence offline and fails every in-flight claim", async () => {
     const failed: Array<{ id: string; body: Record<string, unknown> }> = []
     const client = {
@@ -755,6 +809,132 @@ describe("session control via the actuator", () => {
 
     expect(ran).toEqual([{ name: "model", args: "opus" }])
     expect(calls.complete[0]?.body.finalMessageMarkdown).toBe("Set model to `opus`.")
+  })
+
+  test("refreshes hello with the current nonaccepting handoff state", () => {
+    const { client } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport)
+    ;(session as any).reconnectHandoff = true
+    ;(session as any).refreshHelloCapabilities()
+    expect((session as any).hello).toMatchObject({ status: "busy", acceptingInvocations: false })
+  })
+
+  test("handoff fallback restores presence and drains only while linked and running", async () => {
+    const { client } = makeFakeClient()
+    const { transport, presence } = makeFakeTransport()
+    const session = makeSession(client, transport)
+    let drains = 0
+    ;(session as any).link = { rootStreamId: "stream_root" }
+    ;(session as any).reconnectHandoff = true
+    ;(session as any).claimDrain = async () => {
+      drains++
+    }
+    ;(session as any).resetReconnectHandoff()
+    await Bun.sleep(0)
+    expect({ presence: presence.at(-1), drains }).toMatchObject({
+      presence: { status: "available", acceptingInvocations: true },
+      drains: 1,
+    })
+    ;(session as any).stopped = true
+    ;(session as any).reconnectHandoff = true
+    ;(session as any).resetReconnectHandoff()
+    await Bun.sleep(0)
+    expect({ writes: presence.length, drains }).toEqual({ writes: 1, drains: 1 })
+  })
+
+  test("runs a post-ack action only after acknowledgement completes", async () => {
+    const { client } = makeFakeClient()
+    const { transport, presence } = makeFakeTransport()
+    const order: string[] = []
+    const complete = (client as unknown as { complete: (...args: unknown[]) => Promise<void> }).complete
+    ;(client as unknown as { complete: (...args: unknown[]) => Promise<void> }).complete = async (...args) => {
+      await complete(...args)
+      order.push("ack")
+    }
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["reconnect"],
+        interrupt: () => true,
+        runCommand: async () => ({ ok: true, message: "accepted", afterAck: () => order.push("start") }),
+      },
+    })
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(
+      makeInvocation({
+        trigger: "session-control",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+      })
+    )
+    expect(order).toEqual(["ack", "start"])
+    expect(presence.at(-1)).toMatchObject({ status: "busy", acceptingInvocations: false })
+  })
+
+  test("logs a post-ack action error after preserving the successful acknowledgement", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const logs: string[] = []
+    const session = new RemoteSession({
+      config: makeConfig(),
+      client,
+      delegate: {
+        deliverTurn: async () => {},
+        sessionControl: {
+          commands: ["reconnect"],
+          interrupt: () => true,
+          runCommand: async () => ({
+            ok: true,
+            message: "accepted",
+            afterAck: () => {
+              throw new Error("detached launch failed")
+            },
+          }),
+        },
+      },
+      runtime: RUNTIME,
+      transport,
+      log: (message) => logs.push(message),
+    })
+
+    await (session as any).handleSessionControl(
+      makeInvocation({
+        trigger: "session-control",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+      })
+    )
+    expect({ completed: calls.complete.length, logs }).toEqual({
+      completed: 1,
+      logs: ["session-control post-ack action failed: detached launch failed"],
+    })
+  })
+
+  test("does not run a post-ack action when acknowledgement fails", async () => {
+    const { client } = makeFakeClient()
+    ;(client as unknown as { complete: () => Promise<void> }).complete = async () => {
+      throw new Error("ack failed")
+    }
+    const { transport, presence } = makeFakeTransport()
+    let started = false
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["reconnect"],
+        interrupt: () => true,
+        runCommand: async () => ({ ok: true, message: "accepted", afterAck: () => (started = true) }),
+      },
+    })
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(
+      makeInvocation({
+        trigger: "session-control",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+      })
+    )
+    expect(started).toBe(false)
+    expect(presence.at(-1)).toMatchObject({ status: "busy", acceptingInvocations: false })
   })
 
   test("a failed actuator command fails the invocation instead of completing it", async () => {

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { BotRuntimeTransport } from "@threa/bot-runtime-client"
 import {
+  RECONNECT_HANDOFF_FALLBACK_MS,
   RemoteSession,
   buildSteerContent,
   claimCapabilitiesFor,
@@ -782,6 +783,10 @@ describe("RemoteSession.shutdown", () => {
 })
 
 describe("session control via the actuator", () => {
+  test("keeps reconnect handoff through the complete local replacement bound", () => {
+    expect(RECONNECT_HANDOFF_FALLBACK_MS).toBe(30_000)
+  })
+
   test("routes an advertised command to runCommand and acks with its message", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()
@@ -859,6 +864,7 @@ describe("session control via the actuator", () => {
         runCommand: async () => ({ ok: true, message: "accepted", afterAck: () => order.push("start") }),
       },
     })
+    ;(session as any).link = { rootStreamId: "stream_root" }
 
     await (
       session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
@@ -871,6 +877,42 @@ describe("session control via the actuator", () => {
     expect(order).toEqual(["ack", "start"])
     expect(presence.at(-1)).toMatchObject({ status: "busy", acceptingInvocations: false })
   })
+
+  for (const lifecycle of ["shutdown", "archive"] as const) {
+    test(`does not run a post-ack action when ack resolves after ${lifecycle}`, async () => {
+      const { client } = makeFakeClient()
+      let releaseAck!: () => void
+      const ackBlocked = new Promise<void>((resolve) => (releaseAck = resolve))
+      ;(client as unknown as { complete: () => Promise<void> }).complete = () => ackBlocked
+      const { transport } = makeFakeTransport()
+      let started = false
+      const session = makeSession(client, transport, {
+        sessionControl: {
+          commands: ["reconnect"],
+          interrupt: () => true,
+          runCommand: async () => ({ ok: true, message: "accepted", afterAck: () => (started = true) }),
+        },
+      })
+      ;(session as any).link = { rootStreamId: "stream_root" }
+      const handling = (session as any).handleSessionControl(
+        makeInvocation({
+          trigger: "session-control",
+          metadata: { command: { executionKind: "bot-runtime", id: "cmd", name: "reconnect", args: "" } },
+        })
+      )
+      await Bun.sleep(0)
+
+      if (lifecycle === "shutdown") await session.shutdown()
+      else {
+        await (session as any).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+      }
+      releaseAck()
+      await handling
+
+      expect(started).toBe(false)
+      if (lifecycle === "archive") await session.shutdown()
+    })
+  }
 
   test("logs a post-ack action error after preserving the successful acknowledgement", async () => {
     const { client, calls } = makeFakeClient()
@@ -897,6 +939,7 @@ describe("session control via the actuator", () => {
       transport,
       log: (message) => logs.push(message),
     })
+    ;(session as any).link = { rootStreamId: "stream_root" }
 
     await (session as any).handleSessionControl(
       makeInvocation({

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -123,8 +123,7 @@ export interface SessionControlActuator {
    * interrupt + redeliver. False = control lost.
    */
   steer?(text: string): Promise<boolean> | boolean
-  /** Execute an advertised non-steer/stop command. Returns the ack posted to the scratchpad. */
-  runCommand(name: string, args: string): Promise<{ ok: boolean; message: string }>
+  runCommand(name: string, args: string): Promise<{ ok: boolean; message: string; afterAck?: () => void }>
 }
 
 /**
@@ -335,6 +334,9 @@ export class RemoteSession {
   private readonly hello: BotRuntimeHello
   private link: RuntimeSessionLink | undefined
   private claiming = false
+  private reconnectHandoff = false
+  private reconnectResetTimer: ReturnType<typeof setTimeout> | undefined
+  private reconnectFallbackTask: Promise<unknown> | undefined
   private stopped = false
   private readonly archiveGraceMs: number
   /**
@@ -370,12 +372,8 @@ export class RemoteSession {
     // The transport re-sends this exact object on every reconnect hello, so the
     // BIK fields assigned into it at start() (after ensure()) ride every one.
     this.hello = {
-      instanceId: this.config.instanceId,
-      runtimeKind: this.runtime.kind,
-      runtimeSessionId: this.config.runtimeSessionId,
-      displayName: this.config.displayName,
+      ...this.presenceBody("available"),
       supportedCapabilities: supportedCapabilitiesFor(this.sessionControlEnabled),
-      capabilities: runtimeCapabilitiesFor(this.config.runtimeSessionId, this.delegate.sessionControl),
       ...(this.runtime.manifest ? { manifest: this.runtime.manifest } : {}),
     }
     this.transport =
@@ -385,6 +383,7 @@ export class RemoteSession {
         workspaceId: this.config.workspaceId,
         apiKey: this.config.apiKey,
         hello: this.hello,
+        beforeHello: () => this.refreshHelloCapabilities(),
         callbacks: {
           onInvocationAvailable: () => void this.claimDrain(),
           ...(options.onDelegationAvailable
@@ -402,6 +401,11 @@ export class RemoteSession {
 
   private get sessionControlEnabled(): boolean {
     return Boolean(this.delegate.sessionControl)
+  }
+
+  private refreshHelloCapabilities(): void {
+    Object.assign(this.hello, this.presenceBody(this.reconnectHandoff || this.inflight.size > 0 ? "busy" : "available"))
+    this.hello.supportedCapabilities = supportedCapabilitiesFor(this.sessionControlEnabled)
   }
 
   /** The stream of the turn the runtime is executing right now, if any. */
@@ -495,6 +499,8 @@ export class RemoteSession {
       clearTimeout(this.archivePending.deadline)
       this.archivePending = undefined
     }
+    this.resetReconnectHandoff()
+    await this.reconnectFallbackTask
     // Fast, idempotent teardown first so SIGTERM cleanup isn't held hostage by
     // slow writes when Threa is the thing that's unreachable. Dropping the socket
     // before the offline push means updatePresence falls straight to HTTP rather
@@ -630,7 +636,7 @@ export class RemoteSession {
     // No claims while detached-pending-restore: the scratchpad is archived, so
     // any claimable work predates the archive and would reply into a closed
     // stream. Restore re-runs the drain.
-    if (this.stopped || this.claiming || this.archivePending) return false
+    if (this.stopped || this.claiming || this.archivePending || this.reconnectHandoff) return false
     let claimedAny = false
     this.claiming = true
     try {
@@ -642,6 +648,7 @@ export class RemoteSession {
         // tool approval whose verdict arrives as an ordinary message) keeps
         // draining with full caps via `interceptHoldsClaims`. Without runtime
         // control there's nothing to claim while busy: strict one-at-a-time.
+        if (this.reconnectHandoff) break
         const busy = this.inflight.size > 0 && !this.interceptHoldsClaims
         if (busy && !this.sessionControlEnabled) break
         const invocation = await this.claimNext(busy)
@@ -849,7 +856,21 @@ export class RemoteSession {
             return
           }
           const outcome = await actuator.runCommand(command.name, command.args)
-          await this.completeAck(invocation, outcome.message)
+          if (!outcome.afterAck) {
+            await this.completeAck(invocation, outcome.message)
+            return
+          }
+          this.reconnectHandoff = true
+          await this.syncPresence()
+          const completed = await this.completeAck(invocation, outcome.message)
+          if (!completed) return this.resetReconnectHandoff()
+          try {
+            outcome.afterAck()
+            this.reconnectResetTimer = setTimeout(() => this.resetReconnectHandoff(), 5_000)
+          } catch (error) {
+            this.log(`session-control post-ack action failed: ${this.summarize(error)}`)
+            this.resetReconnectHandoff()
+          }
         }
       }
     } catch (error) {
@@ -1053,21 +1074,24 @@ export class RemoteSession {
     }
   }
 
-  private async completeAck(invocation: ClaimedInvocation, markdown: string): Promise<void> {
+  private async completeAck(invocation: ClaimedInvocation, markdown: string): Promise<boolean> {
     // Sealed session-control ack on E2E: seal the confirmation under the stream
     // key and post it as `sealedReply`. Falls through to the plaintext path when
     // the bot can't seal (no wrap / key race), which silently closes on E2E.
     const sealedReply = await this.sealSessionControlAck(invocation, markdown)
     if (sealedReply) {
-      await this.client
-        .complete(invocation.id, {
+      try {
+        await this.client.complete(invocation.id, {
           instanceId: this.config.instanceId,
           claimToken: invocation.claimToken,
           sealedReply,
           metadata: { "remote.invocationId": invocation.id, "remote.sessionControl": "true" },
         })
-        .catch((error) => this.log(`sealed session-control ack failed: ${this.summarize(error)}`))
-      return
+        return true
+      } catch (error) {
+        this.log(`sealed session-control ack failed: ${this.summarize(error)}`)
+        return false
+      }
     }
     try {
       await this.client.complete(invocation.id, {
@@ -1084,13 +1108,18 @@ export class RemoteSession {
       // feedback. Narrow to that exact code so a capability/validation 400 isn't
       // masked as a successful close (INV-11, fail loud).
       if (error instanceof ThreaApiError && error.code === "E2E_STREAM_PLAINTEXT_UNSUPPORTED") {
-        await this.completeTurn(invocation, { noResponse: true }).catch((inner) =>
+        try {
+          await this.completeTurn(invocation, { noResponse: true })
+          return true
+        } catch (inner) {
           this.log(`session-control silent ack failed: ${this.summarize(inner)}`)
-        )
-        return
+          return false
+        }
       }
       this.log(`session-control ack failed: ${this.summarize(error)}`)
+      return false
     }
+    return true
   }
 
   private async completeNoResponse(invocation: ClaimedInvocation): Promise<void> {
@@ -1462,6 +1491,8 @@ export class RemoteSession {
       deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
     }
     this.archivePending = pending
+    this.resetReconnectHandoff()
+    await this.reconnectFallbackTask
     // Pull the next poll tick onto the probe cadence NOW — the pending tick was
     // scheduled with the slow socket-backstop delay (15 min), which could land
     // zero probes inside the grace window if the restore push is then missed.
@@ -1604,15 +1635,28 @@ export class RemoteSession {
 
   // --- Helpers --------------------------------------------------------------
 
+  private resetReconnectHandoff(): void {
+    if (this.reconnectResetTimer) clearTimeout(this.reconnectResetTimer)
+    this.reconnectHandoff = false
+    if (this.stopped || !this.link || this.archivePending) return
+    let task: Promise<unknown>
+    task = this.syncPresence()
+      .then(() => this.claimDrain())
+      .finally(() => {
+        if (this.reconnectFallbackTask === task) this.reconnectFallbackTask = undefined
+      })
+    this.reconnectFallbackTask = task
+  }
+
   /** Push presence derived from the current in-flight count, so rapid transitions converge on the truth. */
   private async syncPresence(): Promise<void> {
-    const busy = this.inflight.size > 0
+    const busy = this.reconnectHandoff || this.inflight.size > 0
     await this.transport
       .updatePresence(this.presenceBody(busy ? "busy" : "available", busy ? this.runtime.busyStatusText : undefined))
       .catch(() => undefined)
   }
 
-  private presenceBody(status: "available" | "busy" | "offline", statusText?: string): Record<string, unknown> {
+  private presenceBody(status: "available" | "busy" | "offline", statusText?: string) {
     return {
       runtimeKind: this.runtime.kind,
       instanceId: this.config.instanceId,

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -70,6 +70,8 @@ const ARCHIVE_RESTORE_GRACE_MS = 5 * 60 * 1000
 // (≤ ~7 requests), so it cannot become a quota burn; each probe is a
 // session-create that either reattaches (scratchpad unarchived) or 409s.
 const ARCHIVE_RESTORE_PROBE_MS = 45_000
+// Harness preflight can take 10s and replacement verification up to 15s.
+export const RECONNECT_HANDOFF_FALLBACK_MS = 30_000
 const MAX_CLAIMS_PER_DRAIN = 20
 // Server-side cap on frames per bot:invocation:steps call (`stepsFrameSchema`
 // in apps/backend/src/features/bot-runtimes/socket-handler.ts).
@@ -863,10 +865,13 @@ export class RemoteSession {
           this.reconnectHandoff = true
           await this.syncPresence()
           const completed = await this.completeAck(invocation, outcome.message)
-          if (!completed) return this.resetReconnectHandoff()
+          if (!completed || this.stopped || !this.link || this.archivePending) {
+            this.resetReconnectHandoff()
+            return
+          }
           try {
             outcome.afterAck()
-            this.reconnectResetTimer = setTimeout(() => this.resetReconnectHandoff(), 5_000)
+            this.reconnectResetTimer = setTimeout(() => this.resetReconnectHandoff(), RECONNECT_HANDOFF_FALLBACK_MS)
           } catch (error) {
             this.log(`session-control post-ack action failed: ${this.summarize(error)}`)
             this.resetReconnectHandoff()

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -125,7 +125,15 @@ export interface SessionControlActuator {
    * interrupt + redeliver. False = control lost.
    */
   steer?(text: string): Promise<boolean> | boolean
-  runCommand(name: string, args: string): Promise<{ ok: boolean; message: string; afterAck?: () => void }>
+  runCommand(
+    name: string,
+    args: string
+  ): Promise<{
+    ok: boolean
+    message: string
+    afterAck?: () => unknown | Promise<unknown>
+    onHandoffReset?: () => unknown | Promise<unknown>
+  }>
 }
 
 /**
@@ -183,6 +191,7 @@ export interface SendResult {
 
 export interface RemoteSessionStatusSnapshot {
   stopped: boolean
+  linkGeneration: number
   linkState: "unlinked" | "linked" | "detached"
   rootStreamId?: string
   activeStreamId?: string
@@ -335,8 +344,10 @@ export class RemoteSession {
   private readonly bik: BikKeystore
   private readonly hello: BotRuntimeHello
   private link: RuntimeSessionLink | undefined
+  private linkGeneration = 0
   private claiming = false
   private reconnectHandoff = false
+  private onHandoffReset: (() => unknown | Promise<unknown>) | undefined
   private reconnectResetTimer: ReturnType<typeof setTimeout> | undefined
   private reconnectFallbackTask: Promise<unknown> | undefined
   private stopped = false
@@ -424,6 +435,7 @@ export class RemoteSession {
     const linkState = this.archivePending ? "detached" : this.link ? "linked" : "unlinked"
     return {
       stopped: this.stopped,
+      linkGeneration: this.linkGeneration,
       linkState,
       rootStreamId: this.link?.rootStreamId ?? this.archivePending?.rootStreamId,
       activeStreamId: this.link?.activeStreamId,
@@ -465,6 +477,7 @@ export class RemoteSession {
         return
       }
       this.link = link
+      this.linkGeneration += 1
       // A successful link while detached-pending-restore is the reattach (the
       // server revived the archived link for this runtime session) — the probe
       // beat the bot:session_restored push. Cancel the wind-down.
@@ -863,6 +876,7 @@ export class RemoteSession {
             return
           }
           this.reconnectHandoff = true
+          this.onHandoffReset = outcome.onHandoffReset
           await this.syncPresence()
           const completed = await this.completeAck(invocation, outcome.message)
           if (!completed || this.stopped || !this.link || this.archivePending) {
@@ -870,7 +884,7 @@ export class RemoteSession {
             return
           }
           try {
-            outcome.afterAck()
+            await outcome.afterAck()
             this.reconnectResetTimer = setTimeout(() => this.resetReconnectHandoff(), RECONNECT_HANDOFF_FALLBACK_MS)
           } catch (error) {
             this.log(`session-control post-ack action failed: ${this.summarize(error)}`)
@@ -1115,7 +1129,7 @@ export class RemoteSession {
       if (error instanceof ThreaApiError && error.code === "E2E_STREAM_PLAINTEXT_UNSUPPORTED") {
         try {
           await this.completeTurn(invocation, { noResponse: true })
-          return true
+          return false
         } catch (inner) {
           this.log(`session-control silent ack failed: ${this.summarize(inner)}`)
           return false
@@ -1491,6 +1505,7 @@ export class RemoteSession {
     this.inflight.clear()
     this.activeTurnStream = undefined
     this.link = undefined
+    this.linkGeneration += 1
     const pending = {
       rootStreamId,
       deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
@@ -1642,14 +1657,31 @@ export class RemoteSession {
 
   private resetReconnectHandoff(): void {
     if (this.reconnectResetTimer) clearTimeout(this.reconnectResetTimer)
+    this.reconnectResetTimer = undefined
+    const wasHandoff = this.reconnectHandoff
     this.reconnectHandoff = false
-    if (this.stopped || !this.link || this.archivePending) return
+    const onHandoffReset = this.onHandoffReset
+    this.onHandoffReset = undefined
+    if (!wasHandoff && !onHandoffReset) return
+    let callbackTask: Promise<unknown> | undefined
+    if (onHandoffReset) {
+      try {
+        callbackTask = Promise.resolve(onHandoffReset()).catch((error) =>
+          this.log(`session-control handoff reset failed: ${this.summarize(error)}`)
+        )
+      } catch (error) {
+        this.log(`session-control handoff reset failed: ${this.summarize(error)}`)
+      }
+    }
+    if (this.stopped || !this.link || this.archivePending) {
+      if (callbackTask) this.reconnectFallbackTask = callbackTask
+      return
+    }
     let task: Promise<unknown>
-    task = this.syncPresence()
-      .then(() => this.claimDrain())
-      .finally(() => {
-        if (this.reconnectFallbackTask === task) this.reconnectFallbackTask = undefined
-      })
+    const restoreIntake = () => this.syncPresence().then(() => this.claimDrain())
+    task = (callbackTask ? callbackTask.then(restoreIntake) : restoreIntake()).finally(() => {
+      if (this.reconnectFallbackTask === task) this.reconnectFallbackTask = undefined
+    })
     this.reconnectFallbackTask = task
   }
 


### PR DESCRIPTION
## Problem

PR #1510 provides exact local Claude reconnect, but users cannot invoke it through Threa. The channel must acknowledge the command before replacing the process that owns that acknowledgement, without claiming another turn during handoff or moving execution into the backend.

## Solution

Add reachable `/reconnect [--force]` for linked Claude tmux sessions:

- Backend availability intersects canonical `reconnect` metadata with the live runtime’s advertised commands.
- `prepareHarnessReconnect` validates local routing before acknowledgement and returns a one-shot detached no-shell helper using exact argv.
- Remote-session actuator outcomes may include `afterAck`; the SDK runs it only after a real plaintext, sealed, or silent E2E completion succeeds.
- A reconnect handoff state publishes busy/nonaccepting hello and presence, suspends claim drains, and is lifecycle-ordered through archive/shutdown. A bounded fallback restores presence and immediately drains if the old process survives.
- Claude refuses known-busy non-force requests; `--force` opts in.
- Capability advertisement requires tmux, exact runtime/root linkage, and an installed harness entrypoint.
- Detached harness output and sanitized asynchronous launch failures use private `~/.threa/harnessd/reconnect.log` permissions.

The acknowledgement says the request was accepted and is attempting resume; `/status` reports the resulting process. Pi command lifecycle is intentionally split into the next stacked PR.

## Files

| Area | Change |
| ---- | ------ |
| Backend commands | Canonical metadata and advertised/non-advertised availability coverage |
| `extensions/bot-runtime-client` | One-shot detached reconnect preparation, private logging, hello refresh support, install exports |
| `extensions/remote-session` | Ack-success-aware post-ack action, handoff claim/presence lifecycle, linked hello capabilities |
| `extensions/claude-code-remote` | Advertised command, busy/force behavior, exact root/runtime preparation, vendored helper |

## Test plan

- [x] Bot-runtime client — 64 passed
- [x] Remote-session — 131 passed
- [x] Claude remote — 115 passed
- [x] Backend command tests — 21 passed
- [x] Fresh Claude install/import smoke probe
- [x] Relevant package and monorepo TypeScript checks
- [x] Repository lint, Prettier, Dockerfile checks, 230 migrations, and `git diff --check`
- [x] Sol/high lifecycle review; combined PR split at the runtime lifecycle boundary; Claude-only re-review clean at 7/7

<details>
<summary>📋 Full implementation plan</summary>

# Live runtime reconnect and safe keys

Status: ratified 2026-07-22.

This replaces the abandoned broad reconnect prototype preserved under `.tmp/oversized-reconnect-*`.

## Goal

Add small, truthful controls for live Threa-linked Pi and Claude sessions:

- `/reconnect [--force]` replaces a live runtime process in the same tmux pane and resumes the same native session.
- `/key <name>` sends one allowlisted tmux key to the exact live pane.

This feature is intentionally limited to channels that remain connected long enough to claim and acknowledge the command. It is not an offline supervisor.

## Shared invariants

- Target the exact routed `instanceId`, `runtimeSessionId`, and root stream.
- Inventory remains authoritative when an exact managed row exists; exact live-pane discovery may supplement it without adoption.
- Missing, ambiguous, stale, or unsupported identity fails closed.
- Never pick the newest session, transcript, pane, or inventory row.
- Preserve cwd, tmux pane/window/session, native runtime session, Threa runtime identity, channel, and the narrow supported launch policy.
- Perform same-root preflight with `ifArchived: wait` and `ifMissing: error` before replacement.
- Never create, replace, revive, or unarchive a scratchpad.
- Never launch a fresh native session as fallback.
- Complete the Threa command acknowledgement before a detached reconnect starts.
- Reconnect acknowledgement says it was accepted, not that the replacement already connected.
- Standalone discovery never writes harness inventory.

## Narrow launch contracts

### Pi

Support only exact Threa Pi forms:

```text
pi --session-id <uuid>
```

The executable may be an absolute path. A leading `env` is allowed only for explicit Threa runtime/instance identity and the existing harness entrypoint/Bun variables, using ordinary values without shell metacharacters. Unknown options, positional prompts, duplicate session IDs, arguments after `--`, exotic shell-dependent values, and unrelated environment assignments fail before tmux is touched.

The native Pi session ID is the validated `--session-id` UUID. No title or recency fallback exists.

### Claude

Support only the ordinary Threa/channel helper form:

- executable basename `claude`;
- optional exact `--name threa.<name>`;
- exactly one `--dangerously-load-development-channels server:<channel>`;
- optional `--dangerously-skip-permissions`;
- optional one file-backed `--mcp-config <path>`;
- optional explicit `THREA_INSTANCE_ID` and `THREA_RUNTIME_SESSION_ID` assignments;
- no positional prompt or arguments after `--`.

Unknown options, inline/variadic MCP JSON, multiple MCP configs, custom config directories, and unrelated environment assignments fail before tmux is touched. Named global channel registration is reused as named; reconnect does not copy or materialize MCP configuration.

Claude native identity comes only from the live `~/.claude/sessions/<pane_pid>.json` registry. Require matching PID, process start, canonical cwd, optional parsed name, valid UUID, idle status unless forced, and existing exact transcript. No dead-process or newest-transcript fallback exists.

## Shared process replacement

The complete replacement command is built and all identity/pane facts are pinned before mutation. Immediately before mutation, revalidate pane ID, PID, cwd, start command, and native identity.

Use exactly:

```text
tmux respawn-pane -k -t <pane-id> -c <cwd> <shell-quoted-command>
```

This keeps pane/window/session identity and avoids kill/wait/recreate, anchor windows, durable descriptors, and retry machinery.

After successful respawn, bounded local verification may confirm a live process with the same native session and cwd. Failure is logged and never falls back to a fresh session.

## PR stack

This is an actual GitHub stack above PR #1501, managed with non-interactive `gh stack` commands.

### PR 1 — Live Pi reconnect primitive

Deliverables:

- Exact Pi launch parser and native session extraction.
- Exact managed-first/live-standalone pane resolution without inventory adoption.
- Small shared `tmux respawn-pane` helper.
- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` for Pi targets.
- Same-root preflight and generation revalidation.
- CLI/README documentation.

Required tests:

- exact managed and standalone Pi forms;
- malformed UUID, duplicate ID, unknown option/env/positional/`--` rejection;
- missing or ambiguous pane rejection;
- preflight failure and generation change leave pane untouched;
- exact respawn arguments preserve cwd/pane/session ID/Threa identity;
- failure never launches fresh or writes inventory.

Implementation budget: 250–500 lines excluding focused tests. Inventory schema changes, persistent descriptors, runtime extension lifecycle changes, or generic supervisor infrastructure require a plan checkpoint.

### PR 2 — Live Claude reconnect primitive

Deliverables:

- Reuse PR 1's replacement/preflight path.
- Strict live Claude registry resolver with injectable tests.
- Narrow Claude launch parser/reconstructor.
- Managed-first/live-standalone Claude targeting without inventory adoption.
- Same native UUID resume and bounded replacement verification.

Required tests:

- current managed and standalone helper launch forms;
- malformed/stale registry, PID reuse, cwd/name/transcript/status mismatch;
- `--force` behavior;
- unsupported option/env/MCP/`--` rejection;
- preflight and generation races leave pane untouched;
- exact `claude --resume <same-uuid>` respawn;
- no fresh launch or inventory writes on failure.

Implementation budget: 250–500 lines excluding focused tests. Do not add dead-session recovery, descriptor persistence, config-dir abstraction, policy snapshots, or extension-side reconnect evidence.

### PR 3 — Reachable `/reconnect`

Deliverables:

- Canonical command catalog and capability advertisement for supported Pi and Claude tmux sessions.
- Empty args or exact `--force` validation.
- Minimal optional post-ack action in remote-session command handling.
- Seal acknowledgement first, then spawn detached harnessd with exact runtime/root IDs.
- Truthful copy and docs explaining the reachable-channel limitation.

Required tests:

- command advertised only where locally supported;
- routed runtime/root IDs and force flag reach harnessd exactly;
- acknowledgement completion precedes helper spawn;
- failed acknowledgement never spawns;
- preparation failure is returned before acknowledgement;
- existing sealed command completion remains intact.

Implementation budget: 200–400 lines excluding tests. No backend outbox, supervisor delivery, or offline recovery.

### PR 4 — Allowlisted `/key`

Deliverables:

- `/key <name>` for reachable supported Pi and Claude tmux sessions.
- Initial allowlist only: `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, `ctrl-u`.
- Exact pane re-resolution immediately before one `tmux send-keys` call.
- No raw text, key sequences, repeat counts, arbitrary tmux syntax, or shell interpolation.
- Canonical catalog/capability/docs updates.

Required tests:

- every allowed name maps to one exact tmux token;
- casing/aliases/extra args/unknown values fail;
- ambiguity/stale generation leaves pane untouched;
- command sends exactly once to the routed runtime pane;
- acknowledgement is truthful and sealed through the normal command path.

Implementation budget: 150–300 lines excluding tests.

## Binding exclusions

- Fully disconnected/offline command recovery.
- Supervisor outbox/control jobs.
- Dead-process or transcript-only reconnect.
- Durable standalone reconnect descriptors or retry after failed replacement.
- Arbitrary Claude/Pi launch-policy reconstruction.
- Inline or multiple MCP configs.
- `CLAUDE_CONFIG_DIR` support.
- Inventory schema changes or legacy inventory migration.
- New frontend runtime state or overview UI.
- `/type`, raw text entry, arbitrary keys, repeats, or key sequences.
- Starting a fresh native session.
- Creating, replacing, reviving, or unarchiving scratchpads.

## Build protocol

Use `build-feature` with these binding overrides:

- implementer: GPT-5.6 Sol, effort `minimal`, Pi harness only;
- adversarial verifier: GPT-5.6 Sol, effort `high`, Pi harness only;
- per-PR reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- whole-stack reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- do not use Fable, Claude Code, Claude Agent SDK, or any Claude-backed harness;
- use actual `gh stack` branches/PRs and `gh stack submit --auto`/`gh stack view --json`;
- per PR: brief -> implement -> adversarial verify -> fix/reverify -> commit -> stacked PR -> review.

Scope controls:

- Copy binding exclusions and the current PR's implementation budget into every agent brief.
- Classify every review finding as `in-scope` or `follow-up` before fixing it.
- A fix that adds a deferred subsystem, exceeds the budget, or broadens supported launch policy requires a human plan checkpoint.
- After two fix/reverify rounds without a clean result, stop and report concrete remaining findings instead of continuing automatically.
- Agents receive only the current chunk brief plus paths to relevant source/plan files, not an invitation to redesign the whole stack.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

