### PR TITLE
fix(calls): keep incoming rings clear of floating controls

### DIFF
--- a/apps/frontend/src/auth/account-scope.test.tsx
+++ b/apps/frontend/src/auth/account-scope.test.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "@/auth"
 import { AccountScopeProvider, useAccountScope, type AccountScopeValue } from "@/auth/account-scope"
 import { hasSeededWorkspaceCache, seedWorkspaceCache } from "@/stores/workspace-store"
 import { addIncomingCall, getIncomingCalls } from "@/stores/incoming-call-store"
+import { getFloatingSurfaceGeometry, publishFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
 import type { CachedWorkspace } from "@/db"
 
 // PR-4a headline test. Mounts the real AuthProvider + AccountScopeProvider
@@ -175,6 +176,14 @@ describe("AccountScope", () => {
     })
     expect(getIncomingCalls()).toHaveLength(1)
 
+    // Same for the floating call surface's published geometry: it outlives the
+    // remount, so a stale square would keep displacing B's rings.
+    publishFloatingSurfaceGeometry({
+      rect: { x: 676, y: 440, width: 340, height: 320 },
+      protectedRects: [{ x: 684, y: 700, width: 324, height: 44 }],
+    })
+    expect(getFloatingSurfaceGeometry()).not.toBeNull()
+
     await act(async () => {
       await scope.switchAccount("workos_B")
     })
@@ -201,6 +210,7 @@ describe("AccountScope", () => {
     // Layer 3 — module store cache: flushed on switch.
     expect(hasSeededWorkspaceCache("workspace_A")).toBe(false)
     expect(getIncomingCalls()).toHaveLength(0)
+    expect(getFloatingSurfaceGeometry()).toBeNull()
   })
 
   it("flips a second tab over BroadcastChannel and serves no cross-account data", async () => {

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -18,6 +18,7 @@ import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-repl
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
 import { resetCallStoreCache } from "@/stores/call-store"
 import { resetIncomingCallStoreCache } from "@/stores/incoming-call-store"
+import { resetFloatingSurfaceGeometryStoreCache } from "@/stores/floating-surface-geometry-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
 import { useAuth } from "./hooks"
 
@@ -84,6 +85,7 @@ function flushModuleStoreCaches(): void {
   // account switch with a live call never leaves the prior account's mic hot.
   resetCallStoreCache()
   resetIncomingCallStoreCache()
+  resetFloatingSurfaceGeometryStoreCache()
   resetRevealGate()
 }
 

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -14,6 +14,7 @@ import { setCallSelfMirror, useCallPrefs, type CallSelfMirror } from "@/stores/c
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { CallDeviceState, CallDiagnostics } from "@/stores/call-store"
+import { CALL_SURFACE_PROTECTED_ATTR } from "./call-surface-geometry"
 import { useCallManager } from "./call-manager-context"
 import { CameraButton, ChatButton, FlipButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { useCallDevices, useCallDiagnostics } from "./call-store-hooks"
@@ -182,7 +183,7 @@ export function CallControls() {
   // Camera hides itself on audio_only, Flip on desktop / single-camera — so the row
   // gates itself without CallControls re-deciding.
   return (
-    <div className="flex items-center justify-center gap-1.5">
+    <div {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }} className="flex items-center justify-center gap-1.5">
       <MuteButton />
       <CameraButton />
       <FlipButton />

--- a/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
+++ b/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
@@ -1,0 +1,483 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, cleanup, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { render, screen } from "@/test"
+import * as authModule from "@/auth"
+import * as ringTone from "@/calls/ring-tone"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import {
+  clearCallState,
+  setCallSession,
+  setCallPhase,
+  setCallRoster,
+  type CallRosterParticipant,
+} from "@/stores/call-store"
+import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import { addIncomingCall, resetIncomingCallStoreCache, type IncomingCall } from "@/stores/incoming-call-store"
+import type { CallController } from "@/calls/call-manager"
+import { getFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
+import { FloatingCallSquare } from "./floating-call-square"
+import { IncomingCallOverlay } from "./incoming-call-overlay"
+import { CallManagerProvider } from "./call-manager-context"
+import { CallLaunchProvider, useCallLaunch } from "./call-launch-context"
+
+const WORKSPACE_ID = "workspace_1"
+
+// jsdom lays nothing out, so the ring stack's rect is emulated the way the browser
+// resolves its CSS anchor: 320px wide, 16px from the bottom-right corner, one 72px
+// card per ring with an 8px gap — plus whatever translation the component applied,
+// exactly as a real getBoundingClientRect would report it.
+const CARD_HEIGHT = 72
+const CARD_GAP = 8
+const RING_WIDTH = 320
+const RING_INSET = 16
+
+const EMPTY_RECT = { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, toJSON: () => ({}) }
+
+const EXPANDED_SIZE = { width: 340, height: 320 }
+const MINIMIZED_SIZE = { width: 260, height: 50 }
+
+function domRect(x: number, y: number, width: number, height: number): DOMRect {
+  return { x, y, left: x, top: y, right: x + width, bottom: y + height, width, height, toJSON: () => ({}) } as DOMRect
+}
+
+function appliedTranslate(el: HTMLElement): { x: number; y: number } {
+  const match = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(el.style.transform)
+  return match ? { x: Number(match[1]), y: Number(match[2]) } : { x: 0, y: 0 }
+}
+
+// jsdom lays nothing out, so both surfaces are emulated where the browser would
+// resolve their CSS — the square from its committed left/top, its marked groups
+// where its flex layout puts them (the header band across the top, the controls
+// row centred along the bottom, PreJoinGate actions centred in the body). Without
+// this the measured rects are all-zero and the avoidance policy is never exercised
+// on anything but the fallback. Each group is identified by what it *is* — the
+// header's test id, the presence of the Leave control — never by a utility class
+// or a button count, so restyling the surface can't silently re-map the emulation
+// onto the wrong region.
+const HEADER_HEIGHT = 45
+
+function squareBox(square: HTMLElement) {
+  const size = square.dataset.minimized === "true" ? MINIMIZED_SIZE : EXPANDED_SIZE
+  return { x: Number.parseFloat(square.style.left), y: Number.parseFloat(square.style.top), ...size }
+}
+
+function protectedGroupRect(el: HTMLElement, square: HTMLElement): DOMRect {
+  const box = squareBox(square)
+  // The minimized bar is its own protected root.
+  if (el === square) return domRect(box.x, box.y, box.width, box.height)
+  if (el.dataset.testid === "floating-call-square-header") {
+    return domRect(box.x, box.y, box.width, HEADER_HEIGHT)
+  }
+  if (el.querySelector('[aria-label="Leave call"]')) {
+    return domRect(box.x + 47, box.y + box.height - 44, 246, 36)
+  }
+  return domRect(box.x + 54, box.y + 40 + (box.height - 40) / 2 - 52, 232, 104)
+}
+
+function installSurfaceLayout() {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+    if (this.dataset.testid === "incoming-call-overlay") {
+      const cards = this.querySelectorAll('[role="alert"]').length
+      const height = cards * CARD_HEIGHT + Math.max(0, cards - 1) * CARD_GAP
+      const applied = appliedTranslate(this)
+      return domRect(
+        window.innerWidth - RING_INSET - RING_WIDTH + applied.x,
+        window.innerHeight - RING_INSET - height + applied.y,
+        RING_WIDTH,
+        height
+      )
+    }
+    const square = this.closest('[data-testid="floating-call-square"]') as HTMLElement | null
+    if (!square) return EMPTY_RECT as DOMRect
+    if (this === square && !this.hasAttribute("data-call-surface-protected")) {
+      const box = squareBox(square)
+      return domRect(box.x, box.y, box.width, box.height)
+    }
+    if (!this.hasAttribute("data-call-surface-protected")) return EMPTY_RECT as DOMRect
+    return protectedGroupRect(this, square)
+  })
+}
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width })
+  Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: height })
+}
+
+function makeManager(overrides: Partial<CallController> = {}): CallController {
+  return {
+    startCall: vi.fn(async () => {}),
+    leaveCall: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setCameraOn: vi.fn(async () => {}),
+    switchInputDevice: vi.fn(async () => {}),
+    switchCameraDevice: vi.fn(async () => {}),
+    flipCamera: vi.fn(async () => {}),
+    setOutputDevice: vi.fn(async () => {}),
+    getVideoStream: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+function makeRing(overrides: Partial<IncomingCall> = {}): IncomingCall {
+  return {
+    attemptId: "callinv_1",
+    callId: "call_1",
+    workspaceId: WORKSPACE_ID,
+    streamId: "stream_dm",
+    inviterId: "usr_peer",
+    inviterName: "Grace",
+    mode: "video",
+    expiresAtMs: Date.now() + 45_000,
+    ...overrides,
+  }
+}
+
+const SELF: CallRosterParticipant = {
+  userId: "usr_self",
+  participantStatus: "joined",
+  endpointId: "callep_self",
+  connectionStatus: "connected",
+  mediaState: {},
+  publishedTracks: [],
+}
+
+function LaunchButton() {
+  const { launch } = useCallLaunch()
+  return (
+    <button type="button" onClick={() => launch({ workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })}>
+      launch
+    </button>
+  )
+}
+
+function renderBothSurfaces(manager: CallController = makeManager()) {
+  return render(
+    <MemoryRouter>
+      <CallManagerProvider manager={manager}>
+        <CallLaunchProvider>
+          <LaunchButton />
+          <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={vi.fn()} />
+          <IncomingCallOverlay workspaceId={WORKSPACE_ID} />
+        </CallLaunchProvider>
+      </CallManagerProvider>
+    </MemoryRouter>
+  )
+}
+
+function enterConnected() {
+  act(() => {
+    setCallSession({ callId: "call_live", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" })
+    setCallPhase("connected")
+    setCallRoster([SELF], 1)
+  })
+}
+
+function squareRect() {
+  const square = screen.getByTestId("floating-call-square")
+  const minimized = square.getAttribute("data-minimized") === "true"
+  return {
+    x: Number.parseFloat(square.style.left),
+    y: Number.parseFloat(square.style.top),
+    width: minimized ? 260 : 340,
+    height: minimized ? 50 : 320,
+  }
+}
+
+function ringRect() {
+  const overlay = screen.getByTestId("incoming-call-overlay")
+  const box = overlay.getBoundingClientRect()
+  return { x: box.left, y: box.top, width: box.width, height: box.height }
+}
+
+function overlapsRect(a: { x: number; y: number; width: number; height: number }) {
+  const r = ringRect()
+  return r.x < a.x + a.width && a.x < r.x + r.width && r.y < a.y + a.height && a.y < r.y + r.height
+}
+
+function overlapsSquare() {
+  return overlapsRect(squareRect())
+}
+
+function protectedRects() {
+  return getFloatingSurfaceGeometry()?.protectedRects ?? []
+}
+
+function fullyOnScreen(margin = 8) {
+  const r = ringRect()
+  return (
+    r.x >= margin &&
+    r.y >= margin &&
+    r.x + r.width <= window.innerWidth - margin &&
+    r.y + r.height <= window.innerHeight - margin
+  )
+}
+
+function dragSquareTo(x: number, y: number) {
+  const header = screen.getByTestId("floating-call-square-header")
+  header.setPointerCapture = vi.fn()
+  const start = squareRect()
+  act(() => {
+    fireEvent.pointerDown(header, { clientX: start.x, clientY: start.y, pointerId: 1, isPrimary: true })
+    fireEvent.pointerMove(header, { clientX: x, clientY: y, pointerId: 1 })
+    fireEvent.pointerUp(header, { clientX: x, clientY: y, pointerId: 1 })
+  })
+}
+
+beforeEach(() => {
+  setViewport(1024, 768)
+  clearCallState()
+  resetWorkspaceStoreCache()
+  resetIncomingCallStoreCache()
+  localStorage.clear()
+  __resetCallPrefsForTests()
+  seedWorkspaceCache(WORKSPACE_ID, {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+  vi.spyOn(ringTone, "installRingAudioWarmup").mockReturnValue(() => {})
+  vi.spyOn(ringTone, "startRing").mockReturnValue(true)
+  vi.spyOn(ringTone, "stopRing").mockReturnValue(undefined)
+  installSurfaceLayout()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  resetIncomingCallStoreCache()
+  clearCallState()
+  setViewport(1024, 768)
+})
+
+describe("incoming ring ↔ floating call square", () => {
+  it("leaves the ring in its corner when no floating surface is mounted", () => {
+    render(
+      <MemoryRouter>
+        <CallLaunchProvider>
+          <IncomingCallOverlay workspaceId={WORKSPACE_ID} />
+        </CallLaunchProvider>
+      </MemoryRouter>
+    )
+    act(() => addIncomingCall(makeRing()))
+    expect(screen.getByTestId("incoming-call-overlay").style.transform).toBe("")
+  })
+
+  it("lifts a ring that arrives over the square, and keeps both surfaces usable", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+
+    expect(screen.getByTestId("incoming-call-overlay").style.transform).not.toBe("")
+    expect(overlapsSquare()).toBe(false)
+    expect(fullyOnScreen()).toBe(true)
+    expect(screen.getByLabelText("Accept call")).toBeInTheDocument()
+    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
+  })
+
+  it("re-resolves live while the square is dragged under and away from the ring", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+    expect(overlapsSquare()).toBe(false)
+
+    dragSquareTo(40, 40)
+    expect(screen.getByTestId("incoming-call-overlay").style.transform).toBe("")
+    expect(overlapsSquare()).toBe(false)
+
+    dragSquareTo(700, 500)
+    expect(overlapsSquare()).toBe(false)
+    expect(fullyOnScreen()).toBe(true)
+  })
+
+  it("tracks the minimized bar — a smaller obstacle needs a smaller lift", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+    const expandedLift = appliedTranslate(screen.getByTestId("incoming-call-overlay")).y
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Minimize call"), { clientX: 1000, clientY: 750, detail: 1 })
+    })
+
+    const minimizedLift = appliedTranslate(screen.getByTestId("incoming-call-overlay")).y
+    expect(minimizedLift).toBeGreaterThan(expandedLift)
+    expect(overlapsSquare()).toBe(false)
+    expect(screen.getByLabelText("Restore call")).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Restore call"))
+    })
+    expect(overlapsSquare()).toBe(false)
+  })
+
+  it("clears the square with several stacked ring cards", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => {
+      addIncomingCall(makeRing())
+      addIncomingCall(makeRing({ attemptId: "callinv_2", callId: "call_2", inviterName: "Bo" }))
+      addIncomingCall(makeRing({ attemptId: "callinv_3", callId: "call_3", inviterName: "Cy" }))
+    })
+
+    expect(screen.getAllByRole("alert")).toHaveLength(3)
+    expect(overlapsSquare()).toBe(false)
+    expect(fullyOnScreen()).toBe(true)
+  })
+
+  it("re-resolves on viewport resize and keeps the ring on-screen", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+
+    act(() => {
+      setViewport(500, 400)
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(fullyOnScreen()).toBe(true)
+
+    act(() => {
+      setViewport(1440, 900)
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(overlapsSquare()).toBe(false)
+    expect(fullyOnScreen()).toBe(true)
+  })
+
+  it("returns the ring to its anchor when the floating square unmounts", () => {
+    const view = renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+    expect(screen.getByTestId("incoming-call-overlay").style.transform).not.toBe("")
+
+    act(() => {
+      view.rerender(
+        <MemoryRouter>
+          <CallManagerProvider manager={makeManager()}>
+            <CallLaunchProvider>
+              <IncomingCallOverlay workspaceId={WORKSPACE_ID} />
+            </CallLaunchProvider>
+          </CallManagerProvider>
+        </MemoryRouter>
+      )
+    })
+
+    expect(screen.getByTestId("incoming-call-overlay").style.transform).toBe("")
+  })
+  it("publishes the connected surface's measured control groups, and clears them", () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+
+    // Two groups, measured — not a guessed band: the whole header (its grip and
+    // title drag the square, so the marked region spans the surface's full width,
+    // not just the action pair) and the controls row.
+    const [header, controls] = protectedRects()
+    expect(header).toMatchObject({ x: squareRect().x, y: squareRect().y, width: squareRect().width })
+    expect(controls!.width).toBeLessThan(squareRect().width)
+    for (const region of protectedRects()) expect(overlapsRect(region)).toBe(false)
+  })
+
+  it("re-avoids when only the phase body changes — the joining gate's controls sit mid-surface", async () => {
+    setViewport(800, 700)
+    // Never settles: the launch parks in `requesting`, so the PreJoinGate swap is
+    // purely a child's state change — FloatingCallSquare itself does not rerender,
+    // and only the observed republish can move the ring.
+    renderBothSurfaces(makeManager({ startCall: vi.fn(() => new Promise<void>(() => {})) }))
+    dragSquareTo(206, 224)
+    act(() => {
+      for (let i = 0; i < 3; i++) {
+        addIncomingCall(makeRing({ attemptId: `callinv_${i}`, callId: `call_${i}` }))
+      }
+    })
+
+    // Launch idle: the body is a "Connecting…" label with nothing to hit, so only
+    // the header is protected — and the ring settles across where the gate is
+    // about to appear.
+    expect(screen.getByText("Connecting…")).toBeInTheDocument()
+    expect(protectedRects()).toHaveLength(1)
+    const settled = ringRect()
+
+    act(() => {
+      fireEvent.click(screen.getByText("launch"))
+    })
+    expect(screen.getByText("Joining…")).toBeInTheDocument()
+
+    // One microtask turn — the observer's own scheduling, not an incidental rerender.
+    await act(async () => {})
+    expect(protectedRects()).toHaveLength(2)
+    // The gate's arrival alone moved the ring; nothing rerendered the square.
+    expect(ringRect()).not.toEqual(settled)
+    // Every measured group, the header included — not just the gate that
+    // triggered the republish.
+    for (const region of protectedRects()) expect(overlapsRect(region)).toBe(false)
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+    expect(fullyOnScreen()).toBe(true)
+  })
+
+  it("republishes when the surface's subtree changes without a rerender of its own", async () => {
+    renderBothSurfaces()
+    enterConnected()
+    act(() => addIncomingCall(makeRing()))
+    expect(protectedRects()).toHaveLength(2)
+
+    // The phase body owns its own state, so a swap there can land without
+    // rerendering the square: mutate the subtree directly and require the
+    // observer, not a render, to republish.
+    act(() => {
+      screen.getByLabelText("Leave call").closest("[data-call-surface-protected]")?.remove()
+    })
+
+    // One microtask turn — the observer's own scheduling. A later incidental
+    // rerender would republish too, so the assertion is deliberately prompt.
+    await act(async () => {})
+    expect(protectedRects()).toHaveLength(1)
+  })
+
+  it("yields stacking to the floating surface when no placement can clear its controls", () => {
+    // 400x400 with the expanded square in its clamped home and four stacked ring
+    // cards: every on-screen placement lies across the header's drag surface, so
+    // geometry has run out. The ring drops below the z-50 surface rather than
+    // taking its clicks.
+    setViewport(400, 400)
+    renderBothSurfaces()
+    enterConnected()
+    act(() => {
+      for (let i = 0; i < 4; i++) addIncomingCall(makeRing({ attemptId: `callinv_${i}`, callId: `call_${i}` }))
+    })
+
+    const overlay = screen.getByTestId("incoming-call-overlay")
+    expect(protectedRects().some((region) => overlapsRect(region))).toBe(true)
+    expect(overlay.className).toContain("z-[49]")
+    expect(overlay.className).not.toContain("z-50")
+    expect(screen.getByTestId("floating-call-square").className).toContain("z-50")
+    expect(fullyOnScreen()).toBe(true)
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+    expect(screen.getByTestId("floating-call-square-header")).toBeInTheDocument()
+    const acceptButtons = screen.getAllByLabelText("Accept call")
+    expect(acceptButtons).toHaveLength(4)
+    for (const button of acceptButtons) expect(button.parentElement).toHaveAttribute("inert")
+
+    act(() => {
+      setViewport(1440, 900)
+      window.dispatchEvent(new Event("resize"))
+    })
+    expect(protectedRects().some((region) => overlapsRect(region))).toBe(false)
+    expect(screen.getByTestId("incoming-call-overlay").className).toContain("z-50")
+    for (const button of acceptButtons) expect(button.parentElement).not.toHaveAttribute("inert")
+  })
+})

--- a/apps/frontend/src/components/call/call-surface-geometry.test.ts
+++ b/apps/frontend/src/components/call/call-surface-geometry.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest"
+import {
+  anchorSurfaceAtPointer,
+  clampSquareToViewport,
+  placementOverlapsProtected,
+  resolveAvoidanceOffset,
+  type FloatingSurfaceGeometry,
+  type Rect,
+} from "./call-surface-geometry"
+
+const VIEWPORT = { width: 1024, height: 768 }
+
+// The ring stack as the browser lays it out: 320px wide, anchored 16px from the
+// bottom-right corner. One card is 72px tall, each extra card adds 80px.
+function ringStack(cards = 1, viewport = VIEWPORT): Rect {
+  const height = cards * 72 + (cards - 1) * 8
+  return { x: viewport.width - 16 - 320, y: viewport.height - 16 - height, width: 320, height }
+}
+
+// The floating square's interactive groups where its CSS puts them, so the unit
+// tests score the same shapes FloatingCallSquare measures at runtime: the whole
+// header band (grip, title and action pair are one drag surface), and (connected)
+// the centred controls row at the bottom or (joining) the PreJoinGate action block
+// centred in the body.
+const HEADER_HEIGHT = 45
+
+function headerBand(rect: Rect): Rect {
+  return { x: rect.x, y: rect.y, width: rect.width, height: HEADER_HEIGHT }
+}
+
+function connectedSquare(rect: Rect): FloatingSurfaceGeometry {
+  return {
+    rect,
+    protectedRects: [headerBand(rect), { x: rect.x + 47, y: rect.y + rect.height - 44, width: 246, height: 36 }],
+  }
+}
+
+function joiningSquare(rect: Rect): FloatingSurfaceGeometry {
+  return {
+    rect,
+    protectedRects: [
+      headerBand(rect),
+      { x: rect.x + 54, y: rect.y + 40 + (rect.height - 40) / 2 - 52, width: 232, height: 104 },
+    ],
+  }
+}
+
+function bare(rect: Rect): FloatingSurfaceGeometry {
+  return { rect, protectedRects: [] }
+}
+
+function shifted(rect: Rect, offset: { x: number; y: number }): Rect {
+  return { ...rect, x: rect.x + offset.x, y: rect.y + offset.y }
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
+}
+
+function onScreen(rect: Rect, viewport = VIEWPORT, margin = 8): boolean {
+  return (
+    rect.x >= margin &&
+    rect.y >= margin &&
+    rect.x + rect.width <= viewport.width - margin &&
+    rect.y + rect.height <= viewport.height - margin
+  )
+}
+
+describe("clampSquareToViewport", () => {
+  const size = { width: 200, height: 200 }
+  const viewport = { width: 1000, height: 800 }
+
+  it("passes an in-bounds position through unchanged", () => {
+    expect(clampSquareToViewport({ x: 100, y: 100 }, size, viewport)).toEqual({ x: 100, y: 100 })
+  })
+
+  it("clamps past each edge back to the on-screen bound", () => {
+    expect(clampSquareToViewport({ x: -50, y: -50 }, size, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: 5000, y: 5000 }, size, viewport)).toEqual({ x: 792, y: 592 })
+  })
+
+  it("respects a custom margin", () => {
+    expect(clampSquareToViewport({ x: 0, y: 0 }, size, viewport, 20)).toEqual({ x: 20, y: 20 })
+    expect(clampSquareToViewport({ x: 9999, y: 9999 }, size, viewport, 20)).toEqual({ x: 780, y: 580 })
+  })
+
+  it("clamps to the margin (never negative) when the square is larger than the viewport", () => {
+    const big = { width: 2000, height: 2000 }
+    expect(clampSquareToViewport({ x: 400, y: 400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+    expect(clampSquareToViewport({ x: -400, y: -400 }, big, viewport)).toEqual({ x: 8, y: 8 })
+  })
+})
+
+describe("anchorSurfaceAtPointer", () => {
+  it("centers and clamps a surface at the pointer", () => {
+    const size = { width: 200, height: 48 }
+    const viewport = { width: 1000, height: 800 }
+    expect(anchorSurfaceAtPointer({ x: 500, y: 400 }, size, viewport)).toEqual({ x: 400, y: 376 })
+    expect(anchorSurfaceAtPointer({ x: 500, y: 400 }, size, viewport, { x: 180, y: 24 })).toEqual({
+      x: 320,
+      y: 376,
+    })
+    expect(anchorSurfaceAtPointer({ x: 10, y: 10 }, size, viewport)).toEqual({ x: 8, y: 8 })
+  })
+})
+
+describe("resolveAvoidanceOffset", () => {
+  it("stays put with no obstacle, no overlap, or a degenerate rect", () => {
+    const ring = ringStack()
+    expect(resolveAvoidanceOffset(ring, null, VIEWPORT)).toEqual({ x: 0, y: 0 })
+    // Clear of the ring by more than the gap.
+    expect(resolveAvoidanceOffset(ring, connectedSquare({ x: 40, y: 40, width: 340, height: 320 }), VIEWPORT)).toEqual({
+      x: 0,
+      y: 0,
+    })
+    expect(
+      resolveAvoidanceOffset(
+        { ...ring, width: 0, height: 0 },
+        connectedSquare({ x: 676, y: 440, width: 340, height: 320 }),
+        VIEWPORT
+      )
+    ).toEqual({ x: 0, y: 0 })
+    expect(resolveAvoidanceOffset(ring, bare({ x: 676, y: 440, width: 0, height: 0 }), VIEWPORT)).toEqual({
+      x: 0,
+      y: 0,
+    })
+  })
+
+  it("lifts the ring above a bottom-right expanded square", () => {
+    const square = connectedSquare({ x: 676, y: 440, width: 340, height: 320 })
+    const ring = ringStack()
+    const offset = resolveAvoidanceOffset(ring, square, VIEWPORT)
+    expect(offset).toEqual({ x: 0, y: -324 })
+    expect(overlaps(shifted(ring, offset), square.rect)).toBe(false)
+    expect(onScreen(shifted(ring, offset))).toBe(true)
+  })
+
+  it("keeps the gap — a merely adjacent obstacle still displaces the ring", () => {
+    const square = connectedSquare({ x: 676, y: 440, width: 340, height: 320 })
+    const ring = { x: 688, y: 400, width: 320, height: 32 }
+    expect(resolveAvoidanceOffset(ring, square, VIEWPORT)).toEqual({ x: 0, y: -4 })
+  })
+
+  it("escapes sideways when a tall square leaves no headroom", () => {
+    const tall = connectedSquare({ x: 676, y: 8, width: 340, height: 740 })
+    const ring = ringStack()
+    const offset = resolveAvoidanceOffset(ring, tall, VIEWPORT)
+    expect(offset).toEqual({ x: -344, y: 0 })
+    expect(overlaps(shifted(ring, offset), tall.rect)).toBe(false)
+    expect(onScreen(shifted(ring, offset))).toBe(true)
+  })
+
+  it("drops below, then moves right, when those are the only clear directions", () => {
+    const ring = { x: 688, y: 660, width: 320, height: 40 }
+    const capping = bare({ x: 8, y: 8, width: 1008, height: 672 })
+    expect(resolveAvoidanceOffset(ring, capping, VIEWPORT)).toEqual({ x: 0, y: 32 })
+
+    const leftHalf = bare({ x: 8, y: 8, width: 600, height: 752 })
+    const narrowRing = { x: 500, y: 660, width: 160, height: 40 }
+    expect(resolveAvoidanceOffset(narrowRing, leftHalf, VIEWPORT)).toEqual({ x: 120, y: 0 })
+  })
+
+  it("clears a multi-card stack as one block", () => {
+    const square = connectedSquare({ x: 676, y: 440, width: 340, height: 320 })
+    const stack = ringStack(3)
+    const offset = resolveAvoidanceOffset(stack, square, VIEWPORT)
+    expect(overlaps(shifted(stack, offset), square.rect)).toBe(false)
+    expect(onScreen(shifted(stack, offset))).toBe(true)
+  })
+
+  it("keeps every measured control group clear when nothing fits, over minimizing total overlap", () => {
+    // Reachable desktop layout: 640x500 viewport, expanded square parked in its
+    // clamped bottom-right home, three stacked ring cards. Every escape direction
+    // runs off-screen, so the fallback ranks clamped placements.
+    const viewport = { width: 640, height: 500 }
+    const square = connectedSquare({ x: 292, y: 172, width: 340, height: 320 })
+    const stack = ringStack(3, viewport)
+    expect(stack).toEqual({ x: 304, y: 252, width: 320, height: 232 })
+
+    // Clamped "left" (-296, 0) is the only placement that clears both groups:
+    // clamped "above" carries less total overlap but rides onto the header band,
+    // and staying put lies across the controls row.
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    expect(offset).toEqual({ x: -296, y: 0 })
+
+    const placed = shifted(stack, offset)
+    for (const region of square.protectedRects) expect(overlaps(placed, region)).toBe(false)
+    expect(onScreen(placed, viewport)).toBe(true)
+  })
+
+  it("keeps the header band clear rather than taking the least-overlap placement", () => {
+    // 800x700, a tall connected square dragged near the top-left, two ring cards.
+    // Nothing fits, and the clamped "above" placement rides up onto the header —
+    // grip, title and action pair — a region a fixed bottom-strip guess never
+    // protected.
+    const viewport = { width: 800, height: 700 }
+    const square = connectedSquare({ x: 176, y: 56, width: 340, height: 490 })
+    const stack = ringStack(2, viewport)
+
+    const above = { x: 0, y: -524 }
+    expect(overlaps(shifted(stack, above), square.protectedRects[0]!)).toBe(true)
+
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    expect(offset).toEqual({ x: 0, y: 8 })
+    const placed = shifted(stack, offset)
+    for (const region of square.protectedRects) expect(overlaps(placed, region)).toBe(false)
+    expect(onScreen(placed, viewport)).toBe(true)
+  })
+
+  it("keeps the joining gate's actions clear — its controls are mid-surface, not at the bottom", () => {
+    // Same 800x700 desktop, square still joining (or showing a permission error):
+    // the Cancel / Try again block sits centred in the body and the bottom band is
+    // empty padding, so protecting a bottom strip protects nothing that exists.
+    const viewport = { width: 800, height: 700 }
+    const square = joiningSquare({ x: 302, y: 8, width: 340, height: 490 })
+    const stack = ringStack(3, viewport)
+
+    const above = { x: 0, y: -444 }
+    expect(overlaps(shifted(stack, above), square.protectedRects[1]!)).toBe(true)
+
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    expect(offset).toEqual({ x: -456, y: 0 })
+    const placed = shifted(stack, offset)
+    for (const region of square.protectedRects) expect(overlaps(placed, region)).toBe(false)
+    expect(onScreen(placed, viewport)).toBe(true)
+  })
+
+  it("finds a placement between two groups that box the ring in on different axes", () => {
+    // 640x500, the joining square dragged to mid-screen, three stacked ring cards.
+    // The header band only clears by moving down, the gate block only by moving
+    // left — every single-axis retreat leaves one of them covered, so the fallback
+    // has to combine them.
+    const viewport = { width: 640, height: 500 }
+    const square = joiningSquare({ x: 276, y: 208, width: 340, height: 240 })
+    const stack = ringStack(3, viewport)
+    expect(stack).toEqual({ x: 304, y: 252, width: 320, height: 232 })
+
+    // Exhaustive, not a sample: no on-screen placement that moves one axis alone
+    // clears both groups.
+    for (let y = 8; y <= viewport.height - 8 - stack.height; y++) {
+      expect(square.protectedRects.some((region) => overlaps({ ...stack, y }, region))).toBe(true)
+    }
+    for (let x = 8; x <= viewport.width - 8 - stack.width; x++) {
+      expect(square.protectedRects.some((region) => overlaps({ ...stack, x }, region))).toBe(true)
+    }
+
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    expect(offset).toEqual({ x: -296, y: 8 })
+    const placed = shifted(stack, offset)
+    for (const region of square.protectedRects) expect(overlaps(placed, region)).toBe(false)
+    expect(onScreen(placed, viewport)).toBe(true)
+  })
+
+  it("threads the ring between groups when no whole-obstacle retreat clears them", () => {
+    // Three marked groups (the count is whatever the surface's DOM reports): a
+    // tall right-hand group, a small top group, and a band across the body. Every
+    // whole-obstacle retreat clamps to a screen edge and lands on one of them, so
+    // only a placement derived from the groups' own edges clears all three.
+    const viewport = { width: 800, height: 700 }
+    const square: FloatingSurfaceGeometry = {
+      rect: { x: 290, y: 8, width: 260, height: 500 },
+      protectedRects: [
+        { x: 300, y: 378, width: 200, height: 120 },
+        { x: 300, y: 8, width: 40, height: 32 },
+        { x: 502, y: 8, width: 40, height: 120 },
+      ],
+    }
+    const stack = ringStack(4, viewport)
+
+    for (const corner of [
+      { x: 8, y: 8 },
+      { x: 8, y: 380 },
+      { x: 472, y: 8 },
+      { x: 472, y: 380 },
+    ]) {
+      const at = { ...stack, ...corner }
+      expect(square.protectedRects.some((region) => overlaps(at, region))).toBe(true)
+    }
+
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    const placed = shifted(stack, offset)
+    expect(placed).toEqual({ x: 8, y: 54, width: 320, height: 312 })
+    for (const region of square.protectedRects) expect(overlaps(placed, region)).toBe(false)
+    expect(onScreen(placed, viewport)).toBe(true)
+  })
+
+  it("stays put on a tie rather than translating the ring for nothing", () => {
+    // Obstacle fills the whole safe area: every clamped candidate lands on the
+    // identical fully-overlapped rect, so the stay-put seed must hold.
+    const viewport = { width: 400, height: 400 }
+    const square = connectedSquare({ x: 8, y: 8, width: 384, height: 384 })
+    const ring = { x: 8, y: 8, width: 384, height: 384 }
+    expect(resolveAvoidanceOffset(ring, square, viewport)).toEqual({ x: 0, y: 0 })
+  })
+
+  it("stays on-screen with the least residual overlap when nothing fits", () => {
+    const viewport = { width: 400, height: 400 }
+    // No protected groups, so the second-tier total-overlap ranking decides.
+    const square = bare({ x: 40, y: 40, width: 320, height: 320 })
+    const ring = { x: 60, y: 300, width: 320, height: 72 }
+    const offset = resolveAvoidanceOffset(ring, square, viewport)
+    expect(offset).toEqual({ x: 0, y: -292 })
+    expect(onScreen(shifted(ring, offset), viewport)).toBe(true)
+  })
+})
+
+describe("placementOverlapsProtected", () => {
+  it("reports clear with no obstacle and for a placement that cleared every group", () => {
+    const ring = ringStack()
+    expect(placementOverlapsProtected(ring, { x: 0, y: 0 }, null)).toBe(false)
+
+    const square = connectedSquare({ x: 676, y: 440, width: 340, height: 320 })
+    const offset = resolveAvoidanceOffset(ring, square, VIEWPORT)
+    expect(placementOverlapsProtected(ring, offset, square)).toBe(false)
+  })
+
+  it("judges the offset it is handed, not the one geometry would prefer", () => {
+    const ring = ringStack()
+    const square = connectedSquare({ x: 676, y: 440, width: 340, height: 320 })
+    // Staying put is what the ring renders if the caller never applies the policy.
+    expect(placementOverlapsProtected(ring, { x: 0, y: 0 }, square)).toBe(true)
+  })
+
+  it("reports the crowded viewport where no placement clears the controls", () => {
+    // 400x400 with an expanded square in its clamped home and four stacked cards:
+    // the ring is wider than the gap on either side of the square and taller than
+    // the band above it, so every on-screen placement lies across the header.
+    const viewport = { width: 400, height: 400 }
+    const square = connectedSquare({ x: 52, y: 72, width: 340, height: 320 })
+    const stack = ringStack(4, viewport)
+
+    for (let x = 8; x <= viewport.width - 8 - stack.width; x++) {
+      for (let y = 8; y <= viewport.height - 8 - stack.height; y++) {
+        expect(square.protectedRects.some((region) => overlaps({ ...stack, x, y }, region))).toBe(true)
+      }
+    }
+
+    const offset = resolveAvoidanceOffset(stack, square, viewport)
+    expect(placementOverlapsProtected(stack, offset, square)).toBe(true)
+    expect(onScreen(shifted(stack, offset), viewport)).toBe(true)
+  })
+})

--- a/apps/frontend/src/components/call/call-surface-geometry.ts
+++ b/apps/frontend/src/components/call/call-surface-geometry.ts
@@ -1,0 +1,180 @@
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface Size {
+  width: number
+  height: number
+}
+
+export interface Rect extends Point, Size {}
+
+/**
+ * Marks an interactive group on a floating call surface — the whole header (grip,
+ * title and action pair are one drag surface), the controls row, the pre-join
+ * actions, the minimized bar. Anything overlapping
+ * one of these both hides a control and eats its clicks, so avoidance scores these
+ * regions ahead of the surface as a whole. Semantic, not a test id: the surfaces
+ * that own these groups (`call-controls`, `pre-join-gate`) carry the attribute, and
+ * whichever floating surface hosts them measures its own subtree.
+ */
+export const CALL_SURFACE_PROTECTED_ATTR = "data-call-surface-protected"
+
+/** A floating call surface's published viewport geometry. */
+export interface FloatingSurfaceGeometry {
+  rect: Rect
+  /** Viewport rects of the surface's marked interactive groups, measured, not guessed. */
+  protectedRects: Rect[]
+}
+
+const NO_OFFSET: Point = { x: 0, y: 0 }
+
+/**
+ * Clamp a floating square so it stays fully on-screen with `margin` padding. When
+ * the square is larger than the viewport the upper bound would go negative, so it
+ * floors at `margin` (top-left pinned) rather than clamping to a negative x/y.
+ */
+export function clampSquareToViewport(pos: Point, size: Size, viewport: Size, margin = 8): Point {
+  const maxX = Math.max(margin, viewport.width - size.width - margin)
+  const maxY = Math.max(margin, viewport.height - size.height - margin)
+  return {
+    x: Math.min(Math.max(pos.x, margin), maxX),
+    y: Math.min(Math.max(pos.y, margin), maxY),
+  }
+}
+
+export function anchorSurfaceAtPointer(
+  pointer: Point,
+  size: Size,
+  viewport: Size,
+  anchor: Point = { x: size.width / 2, y: size.height / 2 },
+  margin = 8
+): Point {
+  return clampSquareToViewport({ x: pointer.x - anchor.x, y: pointer.y - anchor.y }, size, viewport, margin)
+}
+
+function inflate(rect: Rect, by: number): Rect {
+  return { x: rect.x - by, y: rect.y - by, width: rect.width + by * 2, height: rect.height + by * 2 }
+}
+
+function shift(rect: Rect, offset: Point): Rect {
+  return { ...rect, x: rect.x + offset.x, y: rect.y + offset.y }
+}
+
+function overlapArea(a: Rect, b: Rect): number {
+  const w = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x)
+  const h = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y)
+  return w > 0 && h > 0 ? w * h : 0
+}
+
+function fitsViewport(rect: Rect, viewport: Size, margin: number): boolean {
+  return (
+    rect.x >= margin &&
+    rect.y >= margin &&
+    rect.x + rect.width <= viewport.width - margin &&
+    rect.y + rect.height <= viewport.height - margin
+  )
+}
+
+/**
+ * Displacement that moves `surface` (the incoming-ring stack) clear of `obstacle`
+ * (the draggable floating call surface), as a translation from the surface's own
+ * CSS anchor.
+ *
+ * Order is load-bearing. Clearing the whole obstacle by `gap` wins outright, first
+ * fit of above → left → below → right. Only when none of those fits the viewport
+ * do the per-protected-region escapes join the pool, and then every candidate is
+ * clamped on-screen and ranked lexicographically: least overlap with the measured
+ * `protectedRects`, then least total overlap. Protected-first, not total-first,
+ * because the smallest-area placement is often a nudge that still lies across a
+ * control group — covering it and eating its clicks — while a larger overlap
+ * elsewhere leaves every control reachable. Corner placements are the last tier
+ * (see below).
+ *
+ * Ranking is seeded with staying put and candidates win only on strict
+ * improvement, so a tie never translates the ring for nothing. The result depends
+ * only on the obstacle's current geometry, never on how it got there.
+ */
+export function resolveAvoidanceOffset(
+  surface: Rect,
+  obstacle: FloatingSurfaceGeometry | null,
+  viewport: Size,
+  gap = 12,
+  margin = 8
+): Point {
+  if (!obstacle) return NO_OFFSET
+  const { rect, protectedRects } = obstacle
+  if (surface.width <= 0 || surface.height <= 0 || rect.width <= 0 || rect.height <= 0) return NO_OFFSET
+
+  const blocked = inflate(rect, gap)
+  if (overlapArea(surface, blocked) === 0) return NO_OFFSET
+
+  const escapes = (box: Rect): Point[] => [
+    { x: 0, y: box.y - (surface.y + surface.height) },
+    { x: box.x - (surface.x + surface.width), y: 0 },
+    { x: 0, y: box.y + box.height - surface.y },
+    { x: box.x + box.width - surface.x, y: 0 },
+  ]
+
+  const wholeEscapes = escapes(blocked)
+  for (const candidate of wholeEscapes) {
+    if (fitsViewport(shift(surface, candidate), viewport, margin)) return candidate
+  }
+
+  const axisEscapes: Point[] = [...wholeEscapes, ...protectedRects.flatMap((region) => escapes(inflate(region, gap)))]
+
+  const score = (candidate: Point) => {
+    const pos = clampSquareToViewport(shift(surface, candidate), surface, viewport, margin)
+    const placed = { ...surface, ...pos }
+    return {
+      offset: { x: pos.x - surface.x, y: pos.y - surface.y },
+      protectedArea: protectedRects.reduce((sum, region) => sum + overlapArea(placed, region), 0),
+      totalArea: overlapArea(placed, blocked),
+    }
+  }
+
+  let best = score(NO_OFFSET)
+  const rank = (candidates: Point[]) => {
+    for (const candidate of candidates) {
+      const next = score(candidate)
+      if (
+        next.protectedArea < best.protectedArea ||
+        (next.protectedArea === best.protectedArea && next.totalArea < best.totalArea)
+      ) {
+        best = next
+      }
+    }
+  }
+
+  rank(axisEscapes)
+  // Every escape moves one axis, so regions that box the surface in on different
+  // axes are cleared only by a pair. Corner placements are consulted last and
+  // only when no single-axis candidate got protected overlap to zero, so they
+  // never perturb a placement the axis candidates already settled.
+  if (best.protectedArea > 0) {
+    rank(axisEscapes.flatMap((horizontal) => axisEscapes.map((vertical) => ({ x: horizontal.x, y: vertical.y }))))
+  }
+  return best.offset
+}
+
+/**
+ * Whether the placement actually applied — the offset from
+ * {@link resolveAvoidanceOffset} after the caller rounds it to whole pixels —
+ * still lies across a measured interactive group.
+ *
+ * In a viewport too crowded for any clear placement this is the signal that
+ * geometry has run out, and the caller drops the ring one stacking level so the
+ * floating surface paints above it and keeps its clicks. Takes the rounded offset
+ * rather than recomputing, because the rendered transform is what the user's
+ * pointer actually hits.
+ */
+export function placementOverlapsProtected(
+  surface: Rect,
+  offset: Point,
+  obstacle: FloatingSurfaceGeometry | null
+): boolean {
+  if (!obstacle) return false
+  const placed = shift(surface, offset)
+  return obstacle.protectedRects.some((region) => overlapArea(placed, region) > 0)
+}

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/stores/call-store"
 import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
 import { CallCaptureError, type CallController } from "@/calls/call-manager"
-import { FloatingCallSquare, anchorSurfaceAtPointer, clampSquareToViewport } from "./floating-call-square"
+import { FloatingCallSquare } from "./floating-call-square"
 import { CallManagerProvider } from "./call-manager-context"
 import { CallLaunchProvider, useCallLaunch } from "./call-launch-context"
 
@@ -152,44 +152,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
-})
-
-describe("clampSquareToViewport", () => {
-  const size = { width: 200, height: 200 }
-  const viewport = { width: 1000, height: 800 }
-
-  it("passes an in-bounds position through unchanged", () => {
-    expect(clampSquareToViewport({ x: 100, y: 100 }, size, viewport)).toEqual({ x: 100, y: 100 })
-  })
-
-  it("clamps past each edge back to the on-screen bound", () => {
-    expect(clampSquareToViewport({ x: -50, y: -50 }, size, viewport)).toEqual({ x: 8, y: 8 })
-    expect(clampSquareToViewport({ x: 5000, y: 5000 }, size, viewport)).toEqual({ x: 792, y: 592 })
-  })
-
-  it("respects a custom margin", () => {
-    expect(clampSquareToViewport({ x: 0, y: 0 }, size, viewport, 20)).toEqual({ x: 20, y: 20 })
-    expect(clampSquareToViewport({ x: 9999, y: 9999 }, size, viewport, 20)).toEqual({ x: 780, y: 580 })
-  })
-
-  it("clamps to the margin (never negative) when the square is larger than the viewport", () => {
-    const big = { width: 2000, height: 2000 }
-    expect(clampSquareToViewport({ x: 400, y: 400 }, big, viewport)).toEqual({ x: 8, y: 8 })
-    expect(clampSquareToViewport({ x: -400, y: -400 }, big, viewport)).toEqual({ x: 8, y: 8 })
-  })
-})
-
-describe("anchorSurfaceAtPointer", () => {
-  it("centers and clamps a surface at the pointer", () => {
-    const size = { width: 200, height: 48 }
-    const viewport = { width: 1000, height: 800 }
-    expect(anchorSurfaceAtPointer({ x: 500, y: 400 }, size, viewport)).toEqual({ x: 400, y: 376 })
-    expect(anchorSurfaceAtPointer({ x: 500, y: 400 }, size, viewport, { x: 180, y: 24 })).toEqual({
-      x: 320,
-      y: 376,
-    })
-    expect(anchorSurfaceAtPointer({ x: 10, y: 10 }, size, viewport)).toEqual({ x: 8, y: 8 })
-  })
 })
 
 describe("FloatingCallSquare — connected", () => {

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -21,6 +21,16 @@ import { CallTimer } from "./call-timer"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { useCallCaptureError, useCallConnectedAt, useCallPhase, useCallRoster } from "./call-store-hooks"
+import {
+  anchorSurfaceAtPointer,
+  clampSquareToViewport,
+  CALL_SURFACE_PROTECTED_ATTR,
+  type FloatingSurfaceGeometry,
+  type Point,
+  type Rect,
+  type Size,
+} from "./call-surface-geometry"
+import { publishFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
 
 const REDUCED_MOTION =
   typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
@@ -34,40 +44,6 @@ const MINIMIZED_SIZE = { width: 260, height: 50 }
 const MINIMIZED_POINTER_ANCHOR = { x: MINIMIZED_SIZE.width - 24, y: MINIMIZED_SIZE.height / 2 }
 const KEYBOARD_MOVE_STEP = 16
 
-interface Point {
-  x: number
-  y: number
-}
-
-interface Size {
-  width: number
-  height: number
-}
-
-/**
- * Clamp a floating square so it stays fully on-screen with `margin` padding. When
- * the square is larger than the viewport the upper bound would go negative, so it
- * floors at `margin` (top-left pinned) rather than clamping to a negative x/y.
- */
-export function clampSquareToViewport(pos: Point, size: Size, viewport: Size, margin = 8): Point {
-  const maxX = Math.max(margin, viewport.width - size.width - margin)
-  const maxY = Math.max(margin, viewport.height - size.height - margin)
-  return {
-    x: Math.min(Math.max(pos.x, margin), maxX),
-    y: Math.min(Math.max(pos.y, margin), maxY),
-  }
-}
-
-export function anchorSurfaceAtPointer(
-  pointer: Point,
-  size: Size,
-  viewport: Size,
-  anchor: Point = { x: size.width / 2, y: size.height / 2 },
-  margin = 8
-): Point {
-  return clampSquareToViewport({ x: pointer.x - anchor.x, y: pointer.y - anchor.y }, size, viewport, margin)
-}
-
 function defaultAnchor(): Point {
   const vw = typeof window !== "undefined" ? window.innerWidth : 1024
   const vh = typeof window !== "undefined" ? window.innerHeight : 768
@@ -77,6 +53,31 @@ function defaultAnchor(): Point {
     { width: vw, height: vh },
     MARGIN
   )
+}
+
+function toRect(box: DOMRect): Rect {
+  return { x: box.left, y: box.top, width: box.width, height: box.height }
+}
+
+/**
+ * Measure the surface and every interactive group inside it, in viewport
+ * coordinates. Measured boxes are authoritative: they already carry any
+ * transform/zoom the ring's own `getBoundingClientRect` sees, so both sides
+ * compare like with like. jsdom lays nothing out and reports an all-zero box,
+ * hence the caller-supplied fallback for the root; zero-sized groups drop out
+ * rather than scoring as a point obstacle.
+ */
+function measureSurfaceGeometry(root: HTMLElement, fallbackRect: Rect): FloatingSurfaceGeometry {
+  const box = root.getBoundingClientRect()
+  const groups: Element[] = [...root.querySelectorAll(`[${CALL_SURFACE_PROTECTED_ATTR}]`)]
+  if (root.hasAttribute(CALL_SURFACE_PROTECTED_ATTR)) groups.unshift(root)
+  return {
+    rect: box.width > 0 && box.height > 0 ? toRect(box) : fallbackRect,
+    protectedRects: groups
+      .map((group) => group.getBoundingClientRect())
+      .filter((groupBox) => groupBox.width > 0 && groupBox.height > 0)
+      .map(toRect),
+  }
 }
 
 interface DragState {
@@ -113,6 +114,10 @@ function SquareHeader({
   return (
     <div
       data-testid="floating-call-square-header"
+      // The whole header is protected, not just the action pair: the grip, the
+      // title and the empty space between them are the drag surface, so a ring
+      // lying across them is as unusable as one lying across the buttons.
+      {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
@@ -197,7 +202,7 @@ function MinimizedBar({
   onRestore,
   restoreRef,
 }: {
-  surfaceRef: RefObject<HTMLDivElement | null>
+  surfaceRef: (node: HTMLDivElement | null) => void
   pos: Point
   connectedAt: number | null
   dragging: boolean
@@ -213,6 +218,7 @@ function MinimizedBar({
       ref={surfaceRef}
       data-testid="floating-call-square"
       data-minimized="true"
+      {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }}
       style={{ left: `${pos.x}px`, top: `${pos.y}px`, width: `${MINIMIZED_SIZE.width}px` }}
       className="pointer-events-auto fixed z-50 flex items-center gap-1 rounded-xl border bg-background p-1.5 shadow-xl"
     >
@@ -286,7 +292,14 @@ export function FloatingCallSquare({
 
   const inCall = phase === "connected" || phase === "reconnecting"
 
-  const surfaceRef = useRef<HTMLDivElement>(null)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  // Node in state, not just a ref: the observers below must re-attach when
+  // minimize/restore swaps the root element out for a different one.
+  const [surfaceNode, setSurfaceNode] = useState<HTMLDivElement | null>(null)
+  const attachSurface = useCallback((node: HTMLDivElement | null) => {
+    surfaceRef.current = node
+    setSurfaceNode(node)
+  }, [])
   const minimizeButtonRef = useRef<HTMLButtonElement>(null)
   const restoreButtonRef = useRef<HTMLButtonElement>(null)
   const pendingFocus = useRef<"minimize" | "restore" | null>(null)
@@ -311,6 +324,43 @@ export function FloatingCallSquare({
   useLayoutEffect(() => {
     reclamp()
   }, [reclamp])
+
+  const posRef = useRef(pos)
+  posRef.current = pos
+
+  const publishGeometry = useCallback(() => {
+    const root = surfaceRef.current
+    if (!root) return
+    const fallback = { x: posRef.current.x, y: posRef.current.y, ...getSurfaceSize() }
+    publishFloatingSurfaceGeometry(measureSurfaceGeometry(root, fallback))
+  }, [getSurfaceSize])
+
+  // Publish on every render — position, minimize and content-driven size changes
+  // all land here — so the incoming-ring overlay can avoid the surface.
+  useLayoutEffect(publishGeometry)
+
+  // ...but the phase body is a child that owns its own state: a PreJoinGate going
+  // requesting → permission_error changes which controls exist, and where, without
+  // rerendering this component. Observe the subtree so those republish too.
+  // Attributes are filtered to `class`: a control group can move or disappear by
+  // class alone (hidden/size utilities) with no childList change, while a drag
+  // rewrites the root's inline style every frame and already republishes through
+  // the render above — observing all attributes would republish per drag frame.
+  useEffect(() => {
+    if (!surfaceNode) return
+    const mutations = new MutationObserver(publishGeometry)
+    mutations.observe(surfaceNode, { childList: true, subtree: true, attributes: true, attributeFilter: ["class"] })
+    const resizes = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(publishGeometry)
+    resizes?.observe(surfaceNode)
+    return () => {
+      mutations.disconnect()
+      resizes?.disconnect()
+    }
+  }, [surfaceNode, publishGeometry])
+
+  // Layout-effect cleanup, not an effect: the ring must lose the obstacle in the
+  // same commit the square unmounts, or it paints one frame still translated.
+  useLayoutEffect(() => () => publishFloatingSurfaceGeometry(null), [])
 
   useEffect(() => {
     const handleResize = () => {
@@ -406,7 +456,7 @@ export function FloatingCallSquare({
   if (minimized) {
     return (
       <MinimizedBar
-        surfaceRef={surfaceRef}
+        surfaceRef={attachSurface}
         pos={pos}
         connectedAt={connectedAt}
         dragging={dragging}
@@ -422,7 +472,7 @@ export function FloatingCallSquare({
 
   return (
     <div
-      ref={surfaceRef}
+      ref={attachSurface}
       data-testid="floating-call-square"
       data-minimized="false"
       style={{ left: `${pos.x}px`, top: `${pos.y}px`, width: `${SQUARE_WIDTH}px` }}

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { Phone, PhoneOff, BellOff, Video } from "lucide-react"
@@ -13,6 +13,72 @@ import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/store
 import { installRingAudioWarmup, startRing, stopRing } from "@/calls/ring-tone"
 import { useCallLaunch } from "./call-launch-context"
 import { DOCK_BOTTOM, RING_ABOVE_DOCK_BOTTOM } from "./call-dock"
+import { placementOverlapsProtected, resolveAvoidanceOffset, type Point } from "./call-surface-geometry"
+import { useFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
+
+interface RingPlacement {
+  offset: Point
+  /** No placement clears the surface's controls, so the ring must yield stacking. */
+  yieldStacking: boolean
+}
+
+const NO_PLACEMENT: RingPlacement = { offset: { x: 0, y: 0 }, yieldStacking: false }
+
+/**
+ * Keep the CSS-anchored ring stack clear of the draggable floating call surface.
+ * The stack is measured where the browser laid it out and the applied translation
+ * subtracted back out, so the input to {@link resolveAvoidanceOffset} is always the
+ * un-translated anchor rect — the policy therefore converges in one extra render
+ * and never drifts as the square is dragged.
+ *
+ * Placement is applied instantly, with no transition or hysteresis: an animated
+ * or damped move would spend its duration on top of the controls it exists to
+ * clear, which is the exact failure this avoids.
+ */
+function useRingPlacement(containerRef: { current: HTMLElement | null }): RingPlacement {
+  const obstacle = useFloatingSurfaceGeometry()
+  const appliedRef = useRef<RingPlacement>(NO_PLACEMENT)
+  const [placement, setPlacement] = useState<RingPlacement>(NO_PLACEMENT)
+
+  const measure = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const applied = appliedRef.current
+    const box = el.getBoundingClientRect()
+    const anchored = {
+      x: box.left - applied.offset.x,
+      y: box.top - applied.offset.y,
+      width: box.width,
+      height: box.height,
+    }
+    const raw = resolveAvoidanceOffset(anchored, obstacle, {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    })
+    // Round before comparing: measured rects are subpixel, so an unrounded offset
+    // can differ from the applied one by a fraction that the rendered transform
+    // rounds away — the comparison never settles and the effect re-renders forever.
+    const offset = { x: Math.round(raw.x), y: Math.round(raw.y) }
+    const yieldStacking = placementOverlapsProtected(anchored, offset, obstacle)
+    // Compare both: a drag can leave the offset identical while flipping whether
+    // that placement is still clear, and only re-rendering restores the stacking.
+    if (offset.x === applied.offset.x && offset.y === applied.offset.y && yieldStacking === applied.yieldStacking) {
+      return
+    }
+    const next = { offset, yieldStacking }
+    appliedRef.current = next
+    setPlacement(next)
+  }, [containerRef, obstacle])
+
+  useLayoutEffect(measure)
+
+  useEffect(() => {
+    window.addEventListener("resize", measure)
+    return () => window.removeEventListener("resize", measure)
+  }, [measure])
+
+  return placement
+}
 
 /**
  * Fire a local service-worker notification for a ring when the page can't sound
@@ -54,6 +120,8 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   const surfaceMode = useCallSurfaceMode()
   const [searchParams, setSearchParams] = useSearchParams()
   const notifiedRef = useRef<Set<string>>(new Set())
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { offset: avoidanceOffset, yieldStacking } = useRingPlacement(containerRef)
   // Per-attempt mute (INV-... scoped so a fresh ring rings again). State, not a
   // ref, so muting one ring re-evaluates whether any other ring should still sound.
   const [mutedAttempts, setMutedAttempts] = useState<Set<string>>(() => new Set())
@@ -164,11 +232,25 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
 
   return (
     <div
+      ref={containerRef}
+      data-testid="incoming-call-overlay"
       className={cn(
-        "pointer-events-none fixed z-50 flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
+        "pointer-events-none fixed flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2",
+        // Normally the ring shares the floating surface's level and simply moves
+        // out of its way. When the viewport is too crowded for any clear
+        // placement, geometry can't help — so the ring drops one level and the
+        // z-50 call surface paints above it and keeps its pointer input. Losing a
+        // corner of a ring card beats losing Leave.
+        yieldStacking ? "z-[49]" : "z-50",
         liftAboveDock ? RING_ABOVE_DOCK_BOTTOM : DOCK_BOTTOM
       )}
-      style={{ right: "calc(1rem + var(--call-dock-inset-right, 0px))" }}
+      style={{
+        right: "calc(1rem + var(--call-dock-inset-right, 0px))",
+        transform:
+          avoidanceOffset.x || avoidanceOffset.y
+            ? `translate(${avoidanceOffset.x}px, ${avoidanceOffset.y}px)`
+            : undefined,
+      }}
     >
       {calls.map((call) => (
         <div
@@ -183,7 +265,7 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
             <p className="truncate text-sm font-medium">{call.inviterName ?? "Someone"} is calling…</p>
             <p className="text-xs text-muted-foreground">{call.mode === "video" ? "Video call" : "Voice call"}</p>
           </div>
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1" inert={yieldStacking}>
             <Button size="icon" variant="ghost" aria-label="Silence ring" onClick={() => muteRing(call.attemptId)}>
               <BellOff className="size-4" />
             </Button>

--- a/apps/frontend/src/components/call/pre-join-gate.tsx
+++ b/apps/frontend/src/components/call/pre-join-gate.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useCallLaunch } from "./call-launch-context"
+import { CALL_SURFACE_PROTECTED_ATTR } from "./call-surface-geometry"
 import type { MediaPermissionErrorKind } from "./media-permissions"
 
 // Distinct copy per permission-taxonomy class (plan §Permission UX). Each states
@@ -71,7 +72,7 @@ export function PreJoinGate({ onDark = false }: { onDark?: boolean } = {}) {
 
   if (state.status === "requesting") {
     return (
-      <div className="flex flex-col items-center gap-3 py-6 text-center">
+      <div {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }} className="flex flex-col items-center gap-3 py-6 text-center">
         <Loader2 className={cn("h-6 w-6 animate-spin", subtle)} aria-hidden />
         <p className={cn("text-sm", subtle)}>Joining…</p>
         <Button variant="ghost" size="sm" className={cancelClass} onClick={cancel}>
@@ -83,7 +84,7 @@ export function PreJoinGate({ onDark = false }: { onDark?: boolean } = {}) {
 
   if (state.status === "join_error") {
     return (
-      <div className="flex flex-col items-center gap-3 py-6 text-center">
+      <div {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }} className="flex flex-col items-center gap-3 py-6 text-center">
         <p className="text-sm font-medium">Couldn't start the call</p>
         <p className={cn("text-xs", subtle)}>The call service didn't respond. Try again in a moment.</p>
         <div className="flex gap-2">
@@ -101,7 +102,11 @@ export function PreJoinGate({ onDark = false }: { onDark?: boolean } = {}) {
   if (state.status === "permission_error") {
     const copy = PERMISSION_COPY[state.error.kind]
     return (
-      <div className="flex flex-col items-center gap-3 py-6 text-center" data-error-kind={state.error.kind}>
+      <div
+        {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }}
+        className="flex flex-col items-center gap-3 py-6 text-center"
+        data-error-kind={state.error.kind}
+      >
         <p className="text-sm font-medium">{copy.title}</p>
         <p className={cn("text-xs", subtle)}>{copy.body}</p>
         <div className="flex gap-2">

--- a/apps/frontend/src/stores/floating-surface-geometry-store.ts
+++ b/apps/frontend/src/stores/floating-surface-geometry-store.ts
@@ -1,0 +1,53 @@
+import { useSyncExternalStore } from "react"
+import type { FloatingSurfaceGeometry, Rect } from "@/components/call/call-surface-geometry"
+
+// Layout channel: the desktop floating call surface publishes its viewport
+// geometry — its own rect plus the measured rects of its interactive groups —
+// here so the sibling incoming-ring overlay (mounted elsewhere in the tree) can
+// step out of its way. Module-level state survives the account-switch remount, so
+// AccountScope clears it explicitly (INV-9) rather than relying on the surface's
+// own unmount cleanup landing first — otherwise the next account's ring avoids a
+// square that is no longer on screen.
+
+let geometry: FloatingSurfaceGeometry | null = null
+const listeners = new Set<() => void>()
+
+function sameRect(a: Rect, b: Rect): boolean {
+  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+}
+
+function sameGeometry(a: FloatingSurfaceGeometry | null, b: FloatingSurfaceGeometry | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (!sameRect(a.rect, b.rect)) return false
+  if (a.protectedRects.length !== b.protectedRects.length) return false
+  return a.protectedRects.every((region, i) => {
+    const other = b.protectedRects[i]
+    return !!other && sameRect(region, other)
+  })
+}
+
+export function publishFloatingSurfaceGeometry(next: FloatingSurfaceGeometry | null): void {
+  if (sameGeometry(geometry, next)) return
+  geometry = next
+  for (const listener of listeners) listener()
+}
+
+export function getFloatingSurfaceGeometry(): FloatingSurfaceGeometry | null {
+  return geometry
+}
+
+export function resetFloatingSurfaceGeometryStoreCache(): void {
+  publishFloatingSurfaceGeometry(null)
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function useFloatingSurfaceGeometry(): FloatingSurfaceGeometry | null {
+  return useSyncExternalStore(subscribe, getFloatingSurfaceGeometry, getFloatingSurfaceGeometry)
+}


### PR DESCRIPTION
## Problem

A second incoming-call ring and the desktop floating call square both default to the bottom-right viewport corner. The ring mounts later at the same z-index, so it can cover and intercept the square’s mute, camera, leave, minimize, dock, or joining/error controls. Fixed offsets do not solve this because the square is draggable, minimizable, and content-sized.

## Solution

Publish the floating surface’s measured viewport geometry and reposition the ring stack around its current interactive regions:

- `FloatingCallSquare` measures its root plus semantically marked control groups (header actions, connected controls, joining/error actions, or the minimized bar) and republishes on drag, minimize/restore, subtree changes, resize, and unmount.
- `IncomingCallOverlay` measures its untranslated CSS anchor and applies a transform selected by the pure `resolveAvoidanceOffset` policy.
- The policy first prefers a fully clear on-screen placement. In crowded viewports it ranks whole-surface and per-control edge/corner candidates by control overlap first, then total surface overlap, so controls remain reachable even when some non-interactive chrome must overlap. If no on-screen placement can clear every measured control, the ring yields stacking to the active call surface.
- The geometry channel is reset during account switching (INV-9); sidebar and mobile call surfaces never publish floating geometry and retain their existing behavior.

Deliberately unchanged: incoming-ring copy/icons, ring acceptance/decline/audio/push behavior, mobile floating/PiP, screen share, and call preferences.

## Files

| File | Change |
| ---- | ------ |
| `call-surface-geometry.ts` | Pure viewport clamping and protected-region avoidance policy |
| `floating-surface-geometry-store.ts` | Floating geometry publication/subscription with account reset |
| `floating-call-square.tsx` | Measure and publish live root/control geometry |
| `incoming-call-overlay.tsx` | Reposition the ring stack without focus or layout changes |
| `call-controls.tsx`, `pre-join-gate.tsx` | Mark interactive groups for measured protection |
| `*.test.ts(x)`, `account-scope.test.tsx` | Geometry, real-component coordination, lifecycle, and reset coverage |

## Test plan

- [x] Focused call/account/store suites — 168 passed
- [x] Full frontend suite — 4,865 passed
- [x] Full monorepo lint and typecheck (pre-commit)
- [x] Opus medium implementation → Opus xhigh adversarial verify/fix loops; known reachable small-viewport and joining/header-control failures folded before commit

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787347981&installation_model_id=20758&pr_number=1513&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1513&signature=cbc41b3367c4c06f26c79c48680b2390898053bc35ccdb1554ebf393479f17a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
