### PR TITLE
docs(public-site): tighten marketing copy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Threa contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ Architecture and conventions are documented in [`docs/`](docs/). Start with
 [`docs/architecture.md`](docs/architecture.md), and
 [`docs/core-concepts.md`](docs/core-concepts.md). Code constraints live in
 [`CLAUDE.md`](CLAUDE.md).
+
+## License
+
+Threa is available under the [MIT License](LICENSE).

--- a/apps/public-site/src/components/BaseHead.astro
+++ b/apps/public-site/src/components/BaseHead.astro
@@ -33,7 +33,7 @@ const jsonLd = [
     name: "Threa",
     url: site.href,
     description:
-      "Threa is open-source workplace chat that keeps decisions and their reasoning tied to the conversation through sourced memos, with a public API for connecting your own agents.",
+      "Threa is workplace chat built with memory at its core: decisions and their reasoning stay with the conversation. It's open source and self-hostable, with a public API and bot runtime for your own agents.",
     publisher: { "@id": ORG_ID },
   },
   ...schema,

--- a/apps/public-site/src/components/BaseHead.astro
+++ b/apps/public-site/src/components/BaseHead.astro
@@ -33,7 +33,7 @@ const jsonLd = [
     name: "Threa",
     url: site.href,
     description:
-      "Threa is workplace chat built with memory at its core: decisions and their reasoning stay with the conversation. Open source, self-hostable, with a public API for agents.",
+      "Threa is open-source workplace chat that stores decisions and their reasoning as memos linked to the original conversation. Includes a public API for agents.",
     publisher: { "@id": ORG_ID },
   },
   ...schema,
@@ -90,7 +90,7 @@ const jsonLd = [
 
 <!-- Agent entry points: a markdown index of the developer docs and the full
      API contract, discoverable from every page (robots.txt names them too). -->
-<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt — markdown index of the developer docs" />
+<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt: markdown index of the developer docs" />
 <link rel="alternate" type="application/json" href="/openapi.json" title="OpenAPI 3.0 contract for the Threa API" />
 
 <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/apps/public-site/src/components/BaseHead.astro
+++ b/apps/public-site/src/components/BaseHead.astro
@@ -33,7 +33,7 @@ const jsonLd = [
     name: "Threa",
     url: site.href,
     description:
-      "Threa is open-source workplace chat that stores decisions and their reasoning as memos linked to the original conversation. Includes a public API for agents.",
+      "Threa is open-source workplace chat that keeps decisions and their reasoning tied to the conversation through sourced memos, with a public API for connecting your own agents.",
     publisher: { "@id": ORG_ID },
   },
   ...schema,

--- a/apps/public-site/src/layouts/Layout.astro
+++ b/apps/public-site/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const {
   title = "Threa · workplace chat with memory",
-  description = "Threa is open-source workplace chat that stores decisions and their reasoning as memos linked to the original conversation.",
+  description = "Threa is open-source workplace chat that keeps decisions and their reasoning tied to the conversation through sourced memos.",
   schema,
 } = Astro.props
 ---

--- a/apps/public-site/src/layouts/Layout.astro
+++ b/apps/public-site/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const {
   title = "Threa · workplace chat with memory",
-  description = "Threa is workplace chat where the reasoning behind a decision stays with the conversation, so it's there when the question comes up again. Open source and self-hostable.",
+  description = "Threa is open-source workplace chat that stores decisions and their reasoning as memos linked to the original conversation.",
   schema,
 } = Astro.props
 ---

--- a/apps/public-site/src/layouts/Layout.astro
+++ b/apps/public-site/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const {
   title = "Threa · workplace chat with memory",
-  description = "Threa is open-source workplace chat that keeps decisions and their reasoning tied to the conversation through sourced memos.",
+  description = "Threa is workplace chat where the reasoning behind a decision stays with the conversation, so you can find it when the question comes up again. Open source and self-hostable.",
   schema,
 } = Astro.props
 ---

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -86,9 +86,10 @@ const schema = [
             and I rarely find them again. My memory runs on gist: I'll remember
             that we discussed something, sometimes why, rarely the exact wording
             or where we said it, though I'll know it was Kate who said it. I
-            wanted to know whether I could ask Ariadne for a past decision and
-            get the source conversation with it, and whether doing that well was
-            affordable. I assumed it would cost too much. So far it hasn't.
+            started wondering whether a chat app could do something more useful
+            with all that conversational data, keeping decisions and their
+            reasoning tied to the messages they came from. I assumed it would
+            cost too much. So far it hasn't.
           </p>
         </div>
         <div class="about-q">

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -21,7 +21,7 @@ const schema = [
 
 <Layout
   title="About · Threa"
-  description="Why Kristoffer Remback built Threa, an open-source workplace chat app that keeps decisions linked to their source conversations."
+  description="Why Kristoffer Remback built Threa, an open-source workplace chat app with sourced memory and an open API for your own agents."
   schema={schema}
 >
   <SvgDefs />
@@ -55,9 +55,9 @@ const schema = [
           </h1>
           <p class="lede">
             My day job is software engineering, where I spend a lot of time in
-            tools that are <em>fine</em>. Their small frustrations add up.
-            Eventually my curiosity got out of hand, and I started building
-            Threa.
+            tools that are <em>fine</em> but never great. Their little frustrations
+            kept adding up until my curiosity got out of hand and I started
+            building Threa.
           </p>
         </div>
       </div>
@@ -105,8 +105,9 @@ const schema = [
           <h3>Better chat basics</h3>
           <p>
             Nested threads, quoting, replies to a specific message in a busy
-            room, and formatting that behaves. These details add up over a day
-            spent in chat, and I wanted them done well.
+            room, and formatting that behaves all add up over a day spent in
+            chat. After years of putting up with those basics done badly, I
+            wanted to do them well.
           </p>
         </div>
       </div>
@@ -125,7 +126,7 @@ const schema = [
       <p class="lede">
         Hi, I'm Kristoffer. People have paid me to build software for over ten
         years now. During parental leave I started tinkering on Threa to keep
-        myself from going insane, and I'm not sure it worked. Here I am, up late
+        myself from going insane, and I'm not sure it worked: here I am, up late
         after my wife has gone to bed, talking to an agent about who I am and why
         I'm building this.
       </p>
@@ -152,11 +153,11 @@ const schema = [
         change, or replace it.
       </p>
       <p class="lede about-built-lede">
-        Threa has also been my way into building with AI agents. Most of it is
-        written by directing them, but the thinking stays mine. They're useful
-        for chasing a curiosity and still need close review. Learning where they
-        help and where they fall short has been half the fun. The repo is public
-        if you want to see the work in progress.
+        Threa has also been my way into building with AI agents, and most of it is
+        written by directing them. The thinking stays mine, though, and the work
+        still needs close review. They're a good way to chase a curiosity, and
+        learning where they help and where they fall short has been half the fun.
+        The repo is public, so have a look at the work in progress.
       </p>
       <div class="about-cta-row">
         <a class="os-cta" href="https://github.com/threahq/threa">Browse the source <span class="arr">→</span></a>
@@ -170,10 +171,10 @@ const schema = [
        ============================================================ -->
   <div class="frame">
     <div class="memo-shell is-centerpiece about-close">
-      <h2>Threa is <span class="accent">early</span> and open source.</h2>
+      <h2>Threa is an <span class="accent">early, open-source</span> project.</h2>
       <p class="lede">
-        There's plenty left to build. Join the waitlist or follow the work in the
-        public repository.
+        There's plenty left to build, so join the waitlist or follow the work in
+        the public repository.
       </p>
       <div class="actions">
         <a class="cta" href="/#waitlist">Join the waitlist</a>

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -21,7 +21,7 @@ const schema = [
 
 <Layout
   title="About · Threa"
-  description="Threa began as a side project, out of curiosity and frustration with workplace chat: how much more you can do with what a conversation already holds, and whether a tool like this has to lock you in. Built by Kristoffer Remback, in the open."
+  description="Why Kristoffer Remback built Threa, an open-source workplace chat app that keeps decisions linked to their source conversations."
   schema={schema}
 >
   <SvgDefs />
@@ -49,14 +49,15 @@ const schema = [
 
         <div class="about-hero">
           <h1 class="h-display">
-            Threa came out of<br />
-            <span class="accent">curiosity</span>, and a bit<br />
-            of frustration.
+            I built Threa out of<br />
+            <span class="accent">curiosity</span> and<br />
+            frustration.
           </h1>
           <p class="lede">
             My day job is software engineering, where I spend a lot of time in
-            tools that are <em>fine</em> but never great. The little frustrations
-            add up, and eventually my curiosity got out of hand. Meet Threa.
+            tools that are <em>fine</em>. Their small frustrations add up.
+            Eventually my curiosity got out of hand, and I started building
+            Threa.
           </p>
         </div>
       </div>
@@ -70,50 +71,40 @@ const schema = [
   <div class="frame warm">
     <div class="memo-shell">
       <div class="section-meta">
-        <span>Why this exists in the first place</span>
+        <span>Why I built it</span>
       </div>
-      <h2>What I kept running into.</h2>
-      <p class="lede about-why-lede">
-        Three of them stuck around long enough that I did something about them.
-      </p>
+      <h2>Three problems kept coming up.</h2>
 
       <div class="about-duo">
         <div class="about-q">
           <span class="about-qnum">What gets lost</span>
-          <h3>What did we say again?</h3>
+          <h3>Lost context</h3>
           <p>
-            Years of decisions and the reasoning behind them pile up in a
-            workplace chat, and almost none of it resurfaces. My memory runs on
-            gist: I'll remember that we discussed something, sometimes why,
-            rarely the exact wording or where we said it, though I'll know it was
-            Kate who said it. I was curious whether a chat app could surface that
-            context when it helps, instead of just
-            holding it, and whether doing it well was even affordable. I assumed
-            it would be too expensive to bother with. So far it hasn't been.
+            Years of decisions and their reasoning pile up in workplace chat,
+            and I rarely find them again. My memory runs on gist: I'll remember
+            that we discussed something, sometimes why, rarely the exact wording
+            or where we said it, though I'll know it was Kate who said it. I
+            wanted to know whether a chat app could bring that context back when
+            useful and whether doing it well was affordable. I assumed it would
+            cost too much. So far it hasn't.
           </p>
         </div>
         <div class="about-q">
           <span class="about-qnum">On your own terms</span>
-          <h3>Tools are supposed to be yours.</h3>
+          <h3>Use your own agent</h3>
           <p>
-            Most tools want to be the platform you can't afford to leave, and
-            they all insist on shipping their own AI agent. I rarely want it: it
-            runs a cheaper model on thinner context and can't see past its own
-            walls. Yours can. Threa has an assistant too, Ariadne, and I want her
-            to be genuinely great, but she's only ever great inside the room,
-            where the shared context lives. For your own work you'd rather bring
-            your own agent, so Threa connects to it instead of replacing it.
+            I don't want Threa to be hard to leave. It includes Ariadne, where
+            shared room context makes her useful, and exposes workspace data
+            through a public API so you can connect your own agent.
           </p>
         </div>
         <div class="about-q">
           <span class="about-qnum">The chat part too</span>
-          <h3>Chat could be so much nicer.</h3>
+          <h3>Better chat basics</h3>
           <p>
-            Nested threading, quoting, replying to one message in a busy room,
-            formatting that behaves. None of it sells a platform, which is
-            probably why it keeps getting skipped, but it all adds up over a day
-            spent in chat. After years of putting up with the basics done badly,
-            I think we deserve nice things.
+            Nested threads, quoting, replies to a specific message in a busy
+            room, and formatting that behaves. These details add up over a day
+            spent in chat, and I wanted them done well.
           </p>
         </div>
       </div>
@@ -132,7 +123,7 @@ const schema = [
       <p class="lede">
         Hi, I'm Kristoffer. People have paid me to build software for over ten
         years now. During parental leave I started tinkering on Threa to keep
-        myself from going insane, and I'm not sure it worked: here I am, up late
+        myself from going insane, and I'm not sure it worked. Here I am, up late
         after my wife has gone to bed, talking to an agent about who I am and why
         I'm building this.
       </p>
@@ -154,18 +145,16 @@ const schema = [
       </div>
       <h2>Built the way I want tools to work.</h2>
       <p class="lede about-built-lede">
-        Good at its job, composable with everything else, and easy to step away
-        from. Threa is built that way on purpose. The door stays open, so if you
-        stay it's because you want to, not because leaving would cost you.
+        I want Threa to do its job well, work with the rest of your tools, and
+        remain easy to leave. Its source and APIs stay open so you can inspect,
+        change, or replace it.
       </p>
       <p class="lede about-built-lede">
-        It has also been my way into building with AI agents. Most of Threa is
-        written by directing them, but the thinking stays mine, and that matters
-        more than ever. They're a good way to chase a curiosity, and you can get
-        genuinely decent software out of them as long as you do the thinking
-        yourself. Seeing where they shine and where they fall short has been half
-        the fun. It's a work in progress, on what I think is a good trajectory.
-        The repo is public, so have a look.
+        Threa has also been my way into building with AI agents. Most of it is
+        written by directing them, but the thinking stays mine. They're useful
+        for chasing a curiosity and still need close review. Learning where they
+        help and where they fall short has been half the fun. The repo is public
+        if you want to see the work in progress.
       </p>
       <div class="about-cta-row">
         <a class="os-cta" href="https://github.com/threahq/threa">Browse the source <span class="arr">→</span></a>
@@ -179,14 +168,13 @@ const schema = [
        ============================================================ -->
   <div class="frame">
     <div class="memo-shell is-centerpiece about-close">
-      <h2>Early, and <span class="accent">built in the open</span>.</h2>
+      <h2>Threa is <span class="accent">early</span> and open source.</h2>
       <p class="lede">
-        Threa is early, and there's plenty left to build. Join the waitlist, or
-        follow along in the public repo.
+        There's plenty left to build. Join the waitlist or follow the work in the
+        public repository.
       </p>
       <div class="actions">
         <a class="cta" href="/#waitlist">Join the waitlist</a>
-        <span class="quiet">/ early 2026</span>
       </div>
     </div>
   </div>
@@ -213,9 +201,6 @@ const schema = [
       align-items: end;
     }
     .about-hero .lede { max-width: 460px; font-size: 18px; margin: 0 0 6px; }
-
-    /* Constrain the intro line so it doesn't run the full shell width. */
-    .about-why-lede { max-width: 620px; font-size: 17px; margin: 0 0 4px; }
 
     /* The strands: open columns, no card chrome. A hairline rule and a mono
        label give structure without boxing them in. */

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -21,7 +21,7 @@ const schema = [
 
 <Layout
   title="About · Threa"
-  description="Why Kristoffer Remback built Threa, an open-source workplace chat app with sourced memory and an open API for your own agents."
+  description="Threa began as a side project, out of curiosity and frustration with workplace chat: how much more you can do with what a conversation already holds, and whether a tool like this has to lock you in. Built by Kristoffer Remback, in the open."
   schema={schema}
 >
   <SvgDefs />
@@ -49,15 +49,14 @@ const schema = [
 
         <div class="about-hero">
           <h1 class="h-display">
-            I built Threa out of<br />
-            <span class="accent">curiosity</span> and<br />
-            frustration.
+            Threa came out of<br />
+            <span class="accent">curiosity</span>, and a bit<br />
+            of frustration.
           </h1>
           <p class="lede">
             My day job is software engineering, where I spend a lot of time in
-            tools that are <em>fine</em> but never great. Their little frustrations
-            kept adding up until my curiosity got out of hand and I started
-            building Threa.
+            tools that are <em>fine</em> but never great. The little frustrations
+            add up, and eventually my curiosity got out of hand. Meet Threa.
           </p>
         </div>
       </div>
@@ -71,14 +70,17 @@ const schema = [
   <div class="frame warm">
     <div class="memo-shell">
       <div class="section-meta">
-        <span>Why I built it</span>
+        <span>Why this exists in the first place</span>
       </div>
-      <h2>Three problems kept coming up.</h2>
+      <h2>What I kept running into.</h2>
+      <p class="lede about-why-lede">
+        Three of them stuck around long enough that I did something about them.
+      </p>
 
       <div class="about-duo">
         <div class="about-q">
-          <span class="about-qnum">Conversation history</span>
-          <h3>Lost context</h3>
+          <span class="about-qnum">What gets lost</span>
+          <h3>What did we say again?</h3>
           <p>
             Years of decisions and their reasoning pile up in workplace chat,
             and I rarely find them again. My memory runs on gist: I'll remember
@@ -91,23 +93,28 @@ const schema = [
         </div>
         <div class="about-q">
           <span class="about-qnum">On your own terms</span>
-          <h3>Use your own agent</h3>
+          <h3>Tools are supposed to be yours.</h3>
           <p>
-            I don't want Threa to be hard to leave, and I rarely want another
-            built-in agent. Ariadne is useful inside a room because she has its
-            shared context. For my own work, I want the agent I already use to
-            have that context too, so Threa exposes workspace messages and memos
-            through a public API, CLI, and MCP server.
+            Most tools want to become the platform you can't afford to leave, and
+            lately plenty of them insist on shipping their own AI agent. I rarely
+            want it. The agent I already use has my codebase, my tools, and the
+            context I've built around it; another agent inside another app starts
+            without them. Threa has Ariadne too, and I want her to be genuinely
+            great, but she's at her best inside the room, where the shared context
+            lives. For my own work I'd rather bring the agent I already use, so
+            Threa connects to it through the bot runtime, public API, CLI, and MCP
+            server instead of trying to replace it.
           </p>
         </div>
         <div class="about-q">
           <span class="about-qnum">The chat part too</span>
-          <h3>Better chat basics</h3>
+          <h3>Chat could be so much nicer.</h3>
           <p>
-            Nested threads, quoting, replies to a specific message in a busy
-            room, and formatting that behaves all add up over a day spent in
-            chat. After years of putting up with those basics done badly, I
-            wanted to do them well.
+            Nested threading, quoting, replying to one message in a busy room,
+            formatting that behaves. None of it sells a platform, which is
+            probably why it keeps getting skipped, but it all adds up over a day
+            spent in chat. After years of putting up with the basics done badly,
+            I think we deserve nice things.
           </p>
         </div>
       </div>
@@ -148,16 +155,18 @@ const schema = [
       </div>
       <h2>Built the way I want tools to work.</h2>
       <p class="lede about-built-lede">
-        I want Threa to do its job well, work with the rest of your tools, and
-        remain easy to leave. Its source and APIs stay open so you can inspect,
-        change, or replace it.
+        Good at its job, composable with everything else, and easy to step away
+        from. Threa is built that way on purpose. The door stays open, so if you
+        stay it's because you want to, not because leaving would cost you.
       </p>
       <p class="lede about-built-lede">
-        Threa has also been my way into building with AI agents, and most of it is
-        written by directing them. The thinking stays mine, though, and the work
-        still needs close review. They're a good way to chase a curiosity, and
-        learning where they help and where they fall short has been half the fun.
-        The repo is public, so have a look at the work in progress.
+        It has also been my way into building with AI agents. Most of Threa is
+        written by directing them, but the thinking stays mine, and that matters
+        more than ever. They're a good way to chase a curiosity, and you can get
+        genuinely decent software out of them as long as you do the thinking
+        yourself. Seeing where they shine and where they fall short has been half
+        the fun. It's a work in progress, on what I think is a good trajectory.
+        The repo is public, so have a look.
       </p>
       <div class="about-cta-row">
         <a class="os-cta" href="https://github.com/threahq/threa">Browse the source <span class="arr">→</span></a>
@@ -171,10 +180,10 @@ const schema = [
        ============================================================ -->
   <div class="frame">
     <div class="memo-shell is-centerpiece about-close">
-      <h2>Threa is an <span class="accent">early, open-source</span> project.</h2>
+      <h2>Early, and <span class="accent">built in the open</span>.</h2>
       <p class="lede">
-        There's plenty left to build, so join the waitlist or follow the work in
-        the public repository.
+        Threa is early, and there's plenty left to build. Join the waitlist, or
+        follow along in the public repo.
       </p>
       <div class="actions">
         <a class="cta" href="/#waitlist">Join the waitlist</a>
@@ -204,6 +213,7 @@ const schema = [
       align-items: end;
     }
     .about-hero .lede { max-width: 460px; font-size: 18px; margin: 0 0 6px; }
+    .about-why-lede { max-width: 620px; font-size: 17px; margin: 0 0 4px; }
 
     /* The strands: open columns, no card chrome. A hairline rule and a mono
        label give structure without boxing them in. */

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -84,9 +84,9 @@ const schema = [
             and I rarely find them again. My memory runs on gist: I'll remember
             that we discussed something, sometimes why, rarely the exact wording
             or where we said it, though I'll know it was Kate who said it. I
-            wanted to know whether a chat app could bring that context back when
-            useful and whether doing it well was affordable. I assumed it would
-            cost too much. So far it hasn't.
+            wanted to know whether I could ask Ariadne for a past decision and
+            get the source conversation with it, and whether doing that well was
+            affordable. I assumed it would cost too much. So far it hasn't.
           </p>
         </div>
         <div class="about-q">
@@ -94,9 +94,10 @@ const schema = [
           <h3>Use your own agent</h3>
           <p>
             I don't want Threa to be hard to leave, and I rarely want another
-            built-in agent. Ariadne is useful inside a room because she can read
-            its shared context. For my own work, Threa exposes workspace data
-            through a public API so I can connect the agent I already use.
+            built-in agent. Ariadne is useful inside a room because she has its
+            shared context. For my own work, I want the agent I already use to
+            have that context too, so Threa exposes workspace messages and memos
+            through a public API, CLI, and MCP server.
           </p>
         </div>
         <div class="about-q">

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -77,7 +77,7 @@ const schema = [
 
       <div class="about-duo">
         <div class="about-q">
-          <span class="about-qnum">What gets lost</span>
+          <span class="about-qnum">Conversation history</span>
           <h3>Lost context</h3>
           <p>
             Years of decisions and their reasoning pile up in workplace chat,
@@ -93,9 +93,10 @@ const schema = [
           <span class="about-qnum">On your own terms</span>
           <h3>Use your own agent</h3>
           <p>
-            I don't want Threa to be hard to leave. It includes Ariadne, where
-            shared room context makes her useful, and exposes workspace data
-            through a public API so you can connect your own agent.
+            I don't want Threa to be hard to leave, and I rarely want another
+            built-in agent. Ariadne is useful inside a room because she can read
+            its shared context. For my own work, Threa exposes workspace data
+            through a public API so I can connect the agent I already use.
           </p>
         </div>
         <div class="about-q">

--- a/apps/public-site/src/pages/developers/recipes.astro
+++ b/apps/public-site/src/pages/developers/recipes.astro
@@ -220,9 +220,9 @@ async function loop() {
     from a scratchpad.
   </div>
   <p>
-    Those read and search scopes let the bot inspect stream history, search
-    messages and memos, and read attachments while it works, so your local agent
-    can answer with workspace context behind the message that summoned it.
+    With those read and search scopes, the bot can look through stream history,
+    search messages and memos, and read attachments while it works. That gives
+    your local agent the workspace context behind the message that summoned it.
   </p>
 
   <h2 id="delegations">Run a delegation</h2>

--- a/apps/public-site/src/pages/developers/recipes.astro
+++ b/apps/public-site/src/pages/developers/recipes.astro
@@ -121,8 +121,11 @@ import CodeBlock from "../../components/CodeBlock.astro"
   <p>
     In the app, create a bot (give it the <code>mentionable</code> trait so people
     can summon it), then mint a <code>threa_bk_</code> key on it with
-    <code>bot-runtime:write</code>, <code>bot-invocations:write</code>, and
-    <code>messages:write</code>. Use that key as the credential below.
+    <code>bot-runtime:write</code>, <code>bot-invocations:write</code>,
+    <code>messages:write</code>, <code>streams:read</code>,
+    <code>messages:read</code>, <code>messages:search</code>,
+    <code>memos:read</code>, and <code>attachments:read</code>. Use that key as the
+    credential below.
   </p>
 
   <h3>2 · Heartbeat a presence</h3>
@@ -217,10 +220,9 @@ async function loop() {
     from a scratchpad.
   </div>
   <p>
-    A bot key with <code>streams:read</code> and <code>memos:read</code> can also
-    read history and search the same memory Ariadne uses while it works, so your
-    local agent answers with the full workspace context behind the message that
-    summoned it.
+    Those read and search scopes let the bot inspect stream history, search
+    messages and memos, and read attachments while it works, so your local agent
+    can answer with workspace context behind the message that summoned it.
   </p>
 
   <h2 id="delegations">Run a delegation</h2>

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -14,7 +14,7 @@ const schema = [
     name: "Threa",
     url: site.href,
     description:
-      "Team chat with memory at its core: decisions and the reasoning behind them are captured as searchable memos with provenance back to the conversation. Open source and self-hostable, with a public REST API and a bot runtime for connecting your own AI agents.",
+      "Team chat that captures decisions and their reasoning as searchable memos linked to the original conversation. Open source and self-hostable, with a public REST API and bot runtime for connecting AI agents.",
     applicationCategory: "BusinessApplication",
     operatingSystem: "Web",
     softwareHelp: { "@type": "CreativeWork", url: new URL("/developers", site).href },
@@ -44,17 +44,15 @@ const schema = [
         <div>
           <h1 class="h-display">
             Chat that remembers<br/>
-            <span class="accent">the decisions</span>.
+            <span class="accent">decisions</span>.
           </h1>
           <p class="lede">
-            Channels, threads, and DMs, with a memory underneath.
-            The decisions you make and the reasons behind them stay
-            attached to the conversation, so they're still there when
-            the question comes up again.
+            Channels, threads, and DMs with memory underneath. Threa keeps
+            decisions and their reasoning linked to the source conversation,
+            so you can find them when the topic returns.
           </p>
           <div class="actions">
             <a class="cta" href="#waitlist">Join the waitlist</a>
-            <span class="quiet">/ early 2026</span>
           </div>
         </div>
         <div class="hero-right">
@@ -222,14 +220,12 @@ const schema = [
     <div class="section-meta">
       <span>The board</span>
     </div>
-    <h2>Chat you can actually find later.</h2>
+    <h2>Chat you can find later.</h2>
     <p class="lede">
-      A timeline is great for real-time chat. It's linear and immediate,
-      and good for keeping up with what's latest. Where it falls short is
-      discoverability. Once a discussion gets long or complex, it's hard to
-      find again weeks later. The board answers that: the same messages,
-      grouped by topic, so you can go back and find a conversation instead
-      of scrolling for it.
+      Timelines keep current conversation in order. Older discussions become
+      harder to recover as a channel grows. The board groups the same messages
+      by topic, so you can return to a conversation without scrolling through
+      the full timeline.
     </p>
 
     <div class="board-compare">
@@ -406,14 +402,13 @@ const schema = [
   <div class="memo-shell is-centerpiece">
     <div class="section-meta">
       <span>How memory works</span>
-      <span>· capture · hold · return</span>
+      <span>· sourced memos</span>
     </div>
-    <h2>Conversation becomes memory.</h2>
+    <h2>Threa saves decisions as sourced memos.</h2>
     <p class="lede">
-      Threa reads the conversation, finds the part where a
-      decision gets made, and keeps it as a short memo that links
-      back to the messages it came from. When the topic returns,
-      so does the memo.
+      Threa finds decisions in the conversation and stores them as short memos
+      linked to their source messages. When someone asks about the topic
+      later, Ariadne can retrieve the memo and its sources.
     </p>
 
     <div class="memory-flow">
@@ -423,9 +418,8 @@ const schema = [
         <div class="memory-step">01 / Capture</div>
         <h3 class="memory-heading">Finding the decision</h3>
         <p class="memory-why">
-          Most of a channel is noise. The part worth keeping is
-          usually a handful of lines where something actually gets
-          settled.
+          Threa finds the few messages where the team settles something and
+          leaves the rest in the conversation.
         </p>
 
         <div class="capture-list" aria-label="Five-message slice; the three middle messages carry the decision.">
@@ -498,9 +492,8 @@ const schema = [
         <div class="memory-step">02 / Hold</div>
         <h3 class="memory-heading">Keeping it as a memo</h3>
         <p class="memory-why">
-          Nobody rereads a transcript two months later. A short,
-          sourced memo is the part that stays useful once the
-          thread has scrolled away.
+          A short, sourced memo keeps the decision useful after the thread has
+          scrolled away.
         </p>
 
         <div class="memory-card decision-memo">
@@ -528,11 +521,10 @@ const schema = [
       <!-- ============ 03 · RETURN ============ -->
       <div class="memory-col is-return">
         <div class="memory-step">03 / Return</div>
-        <h3 class="memory-heading">When it comes up again</h3>
+        <h3 class="memory-heading">Retrieving it later</h3>
         <p class="memory-why">
-          A reason you can't find isn't worth much. The memo has to
-          show up on its own when the question returns, without
-          anyone remembering to go looking.
+          When you ask Ariadne about a past decision, it searches workspace
+          memory and returns the relevant memo with its source context.
         </p>
 
         <div class="recall-thread">
@@ -609,7 +601,7 @@ const schema = [
           <span class="row"><span class="prompt">$</span><span class="cmd">cd</span> <span class="arg">threa</span> <span class="cmd">&amp;&amp;</span> <span class="cmd">bun install</span></span>
           <span class="row"><span class="prompt">$</span><span class="cmd">bun run dev</span></span>
           <span class="out">→ http://localhost:5173</span>
-          <span class="row"><span class="cmt"># your machine. your data.</span></span>
+          <span class="row"><span class="cmt"># running locally</span></span>
         </div>
 
         <figure class="patch-example" aria-label="Patch Threa by describing the change to your own agent.">
@@ -628,46 +620,36 @@ const schema = [
       <div class="band-copy">
         <div class="section-meta">
           <span>Open source</span>
-          <span>· read · fork · audit</span>
+          <span>· GitHub</span>
         </div>
-        <h2>The whole thing is open source.</h2>
+        <h2>Threa is open source.</h2>
         <p class="lede">
-          Source for the frontend, backend, and control-plane is all
-          public. Read exactly how it works and fork it if you want
-          your own version. The repo you're reading is the one we ship.
+          The frontend, backend, control plane, and infrastructure are public.
+          You can inspect the code, fork it, and run your own version. The public
+          repository contains the code we deploy.
         </p>
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Public source</h4>
+            <h4>Public repository</h4>
             <p>
-              Frontend, backend, control-plane, and infrastructure,
-              all on GitHub. The wrong turns and the design
-              explorations are in there too.
+              The frontend, backend, control plane, and infrastructure live in
+              one repository. It also contains design notes and implementation
+              history.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Yours to fork</h4>
+            <h4>Fork and modify it</h4>
             <p>
-              Fork it and make it yours. Add the feature you want
-              instead of waiting for us to ship it, on the same code
-              we run.
+              Run your own fork or change the product on the same codebase we
+              deploy.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Encrypted where it counts</h4>
+            <h4>Public development</h4>
             <p>
-              Most conversations stay readable to Threa, which is what
-              lets it build memory from them. Turn on end-to-end
-              encryption for the sensitive ones and Threa keeps only
-              ciphertext; those conversations don't become memos.
-            </p>
-          </div>
-          <div class="os-tenet">
-            <h4>Built in the open</h4>
-            <p>
-              Roadmap, design notes, and decisions are public too,
-              not just the finished code.
+              The roadmap, design notes, and decision records are public in the
+              repository.
             </p>
           </div>
         </div>
@@ -692,42 +674,34 @@ const schema = [
       <div class="band-copy">
         <div class="section-meta">
           <span>Bring your own agent</span>
-          <span>· export · open · yours</span>
+          <span>· public API</span>
         </div>
         <h2>Bring the agent you already use.</h2>
         <p class="lede">
-          Threa ships with Ariadne, useful from day one. But you've
-          probably already got an agent set up the way you like it.
-          Threa is built to sit inside the stack you have, so there's
-          an open API with scoped keys over your workspace. Wire up
-          Claude, Cursor, or your own setup and point it at the same
-          memory Ariadne reads.
+          Threa includes Ariadne and exposes workspace messages and memos through
+          a public API with scoped keys. Connect your own agent to the same data,
+          including memo source links.
         </p>
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Readable over the API</h4>
+            <h4>Messages and memos</h4>
             <p>
-              Your memos come back as JSON and your messages as
-              markdown through a public read API. What you put in, you
-              can pull back out programmatically.
+              Read memos as JSON and messages as markdown through the public API.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Agent-agnostic</h4>
+            <h4>Scoped access</h4>
             <p>
-              An open read API over your workspace. Whatever agent you
-              point at it sees the same memory Ariadne does, with the
-              same source links and timestamps.
+              Each API key belongs to one workspace and grants only its configured
+              permissions.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Private to you</h4>
+            <h4>Use any agent</h4>
             <p>
-              We don't train on your data or sell it. AI features send
-              your messages to an inference provider under a
-              no-retention contract; the conversations you encrypt stay
-              opaque even to us.
+              Any agent that can call the API can read memo content, source links,
+              and timestamps.
             </p>
           </div>
         </div>
@@ -736,24 +710,22 @@ const schema = [
       </div>
       <div class="band-media">
         <blockquote class="byo-quote">
-          Ariadne is here to get you started. The agent you rely on should
-          be your own, with your work reachable
-          from it instead of locked inside one more app.
+          Use Ariadne inside Threa, or connect your own agent to the same
+          workspace messages and memos.
         </blockquote>
 
-        <div class="byo-agents" aria-label="Bring the agent you already use: Claude, Claude Code, ChatGPT, Cursor, Copilot, Grok, Gemini, or whatever comes next.">
+        <div class="byo-agents" aria-label="Bring your own agent.">
           <span class="byo-lead">Bring your own</span>
           <span class="byo-clip" aria-hidden="true">
             <span class="byo-track">
-              <span class="byo-word">Claude</span>
-              <span class="byo-word">Claude Code</span>
-              <span class="byo-word">ChatGPT</span>
-              <span class="byo-word">Cursor</span>
-              <span class="byo-word">Copilot</span>
-              <span class="byo-word">Grok</span>
-              <span class="byo-word">Gemini</span>
+              <span class="byo-word">coding agent</span>
+              <span class="byo-word">research agent</span>
+              <span class="byo-word">assistant</span>
+              <span class="byo-word">automation</span>
+              <span class="byo-word">local model</span>
+              <span class="byo-word">custom bot</span>
               <span class="byo-word">whatever's next</span>
-              <span class="byo-word">Claude</span>
+              <span class="byo-word">coding agent</span>
             </span>
           </span>
         </div>
@@ -770,13 +742,13 @@ const schema = [
   <div class="memo-shell">
     <div class="section-meta">
       <span>Why I built this</span>
-      <span>· from one developer</span>
+      <span>· founder notes</span>
     </div>
-    <h2>What I wished other tools had.</h2>
+    <h2>Features I wanted from chat.</h2>
     <p class="lede">
-      Partly I built Threa out of spite. Years of watching decisions
-      disappear into channels, plus a short list of things I wanted
-      from a chat app and never got. So I added them.
+      Partly I built Threa out of spite. Years of watching decisions disappear
+      into channels left me with a list of chat features I wanted, so I started
+      adding them.
     </p>
 
     <ul class="missing-grid">
@@ -819,7 +791,7 @@ const schema = [
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Stash a message</h4>
-          <p>Save a half-written message without sending it and pick it back up later. Not one draft stuck in the input box, but a stash you can pull from.</p>
+          <p>Save half-written messages in a stash and return to them later.</p>
         </div>
       </li>
       <li class="missing-item">
@@ -831,7 +803,6 @@ const schema = [
       </li>
     </ul>
 
-    <p class="missing-sign">Building Threa in the open.</p>
   </div>
 </div>
 
@@ -868,7 +839,7 @@ const schema = [
           aria-hidden="true"
         />
       </form>
-      <span class="quiet" id="wl-status" aria-live="polite">/ early 2026 · no spam</span>
+      <span class="quiet" id="wl-status" aria-live="polite">/ no spam</span>
     </div>
   </div>
 </div>
@@ -1030,7 +1001,7 @@ const schema = [
     const hp = document.getElementById("wl-hp")
     const submit = document.getElementById("wl-submit")
     const status = document.getElementById("wl-status")
-    const idle = "/ early 2026 · no spam"
+    const idle = "/ no spam"
 
     const setStatus = (msg, kind) => {
       status.textContent = msg

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -404,10 +404,10 @@ const schema = [
       <span>How memory works</span>
       <span>· sourced memos</span>
     </div>
-    <h2>Threa saves decisions as sourced memos.</h2>
+    <h2>Threa turns conversations into sourced memory.</h2>
     <p class="lede">
-      Threa turns a settled decision into a short memo linked to its source
-      messages. You can open the original messages from the memo.
+      Threa saves decisions and reusable knowledge as short memos linked to their
+      source messages. You can open the original messages from the memo.
     </p>
 
     <div class="memory-flow">
@@ -415,10 +415,10 @@ const schema = [
       <!-- ============ 01 · CAPTURE ============ -->
       <div class="memory-col">
         <div class="memory-step">01 / Capture</div>
-        <h3 class="memory-heading">Finding the decision</h3>
+        <h3 class="memory-heading">Extracting reusable knowledge</h3>
         <p class="memory-why">
-          Threa finds the few messages where the team settles something and
-          leaves the rest in the conversation.
+          Threa extracts decisions, learnings, procedures, context, and
+          references from the messages that establish them.
         </p>
 
         <div class="capture-list" aria-label="Five-message slice; the three middle messages carry the decision.">
@@ -623,9 +623,9 @@ const schema = [
         </div>
         <h2>Threa is open source.</h2>
         <p class="lede">
-          The frontend, backend, control plane, and infrastructure are public.
-          You can inspect the code, fork it, and run your own version. The public
-          repository contains the code we deploy.
+          The public repository is the code we deploy. It contains the frontend,
+          backend, control plane, and infrastructure. You can inspect it, fork it,
+          and run your own version.
         </p>
 
         <div class="os-tenets">
@@ -672,58 +672,59 @@ const schema = [
       <div class="band-copy">
         <div class="section-meta">
           <span>Bring your own agent</span>
-          <span>· public API</span>
+          <span>· bot runtime · CLI · MCP</span>
         </div>
-        <h2>Bring the agent you already use.</h2>
+        <h2>Your agent can join the workspace.</h2>
         <p class="lede">
-          Threa includes Ariadne and exposes workspace messages and memos through
-          a public API with scoped keys. Connect your own agent to the same data,
-          including memo source links.
+          Connect the agent on your laptop as a Threa bot. It works behind NAT,
+          answers @mentions as a workspace participant, searches messages, memos,
+          and attachments, and posts its work back into the conversation.
         </p>
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Messages and memos</h4>
+            <h4>Answer in the room</h4>
             <p>
-              Read memos as JSON and messages as markdown through the public API.
+              The bot runtime delivers mentions to your local agent and posts its
+              reply under the bot's own identity.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Scoped access</h4>
+            <h4>Use workspace memory</h4>
             <p>
-              Each API key belongs to one workspace and grants only its configured
-              permissions.
+              Search messages by text or meaning, query memos, read attachments,
+              and follow memos back to their source messages.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Use any agent</h4>
+            <h4>Take delegated work</h4>
             <p>
-              Any agent that can call the API can read memo content, source links,
-              and timestamps.
+              Claim a task on your machine, post progress, and return the finished
+              work to the stream.
             </p>
           </div>
         </div>
 
-        <a class="os-cta" href="/developers">Read the data docs <span class="arr">→</span></a>
+        <a class="os-cta" href="/developers/recipes#local-agent">Connect a local agent <span class="arr">→</span></a>
       </div>
       <div class="band-media">
         <blockquote class="byo-quote">
-          Use Ariadne inside Threa, or connect your own agent to the same
-          workspace messages and memos.
+          Your agent keeps its local tools and credentials. Threa gives it the
+          team context and a place to return the result.
         </blockquote>
 
-        <div class="byo-agents" aria-label="Bring your own coding agent, research agent, assistant, automation, local model, custom bot, or whatever comes next.">
+        <div class="byo-agents" aria-label="Bring your own Claude Code, Codex, Cursor, OpenCode, Gemini CLI, custom bot, or whatever comes next.">
           <span class="byo-lead">Bring your own</span>
           <span class="byo-clip" aria-hidden="true">
             <span class="byo-track">
-              <span class="byo-word">coding agent</span>
-              <span class="byo-word">research agent</span>
-              <span class="byo-word">assistant</span>
-              <span class="byo-word">automation</span>
-              <span class="byo-word">local model</span>
+              <span class="byo-word">Claude Code</span>
+              <span class="byo-word">Codex</span>
+              <span class="byo-word">Cursor</span>
+              <span class="byo-word">OpenCode</span>
+              <span class="byo-word">Gemini CLI</span>
               <span class="byo-word">custom bot</span>
               <span class="byo-word">whatever's next</span>
-              <span class="byo-word">coding agent</span>
+              <span class="byo-word">Claude Code</span>
             </span>
           </span>
         </div>

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -14,7 +14,7 @@ const schema = [
     name: "Threa",
     url: site.href,
     description:
-      "Team chat that captures decisions and their reasoning as searchable memos linked to the original conversation. Open source and self-hostable, with a public REST API and bot runtime for connecting AI agents.",
+      "Threa is open-source team chat that turns decisions and their reasoning into searchable memos linked to the conversation, with a public REST API and bot runtime for connecting your own agents.",
     applicationCategory: "BusinessApplication",
     operatingSystem: "Web",
     softwareHelp: { "@type": "CreativeWork", url: new URL("/developers", site).href },
@@ -47,9 +47,9 @@ const schema = [
             <span class="accent">decisions</span>.
           </h1>
           <p class="lede">
-            Channels, threads, and DMs with memory underneath. Threa keeps
-            decisions and their reasoning linked to the source conversation,
-            so you can find them when the topic returns.
+            Channels, threads, and DMs come with memory underneath, keeping
+            decisions and their reasoning linked to the source conversation so
+            you can find them when the topic returns.
           </p>
           <div class="actions">
             <a class="cta" href="#waitlist">Join the waitlist</a>
@@ -222,10 +222,10 @@ const schema = [
     </div>
     <h2>Chat you can find later.</h2>
     <p class="lede">
-      Timelines keep current conversation in order. Older discussions become
-      harder to recover as a channel grows. The board groups the same messages
-      by topic, so you can return to a conversation without scrolling through
-      the full timeline.
+      Timelines keep current conversations in order, but older discussions become
+      harder to recover as a channel grows. The board groups the same messages by
+      topic, so you can return to a conversation without scrolling through the
+      full timeline.
     </p>
 
     <div class="board-compare">
@@ -406,8 +406,8 @@ const schema = [
     </div>
     <h2>Threa turns conversations into sourced memory.</h2>
     <p class="lede">
-      Threa saves decisions and reusable knowledge as short memos linked to their
-      source messages. You can open the original messages from the memo.
+      Each short memo captures a decision or piece of reusable knowledge and
+      links back to the original messages.
     </p>
 
     <div class="memory-flow">
@@ -415,10 +415,11 @@ const schema = [
       <!-- ============ 01 · CAPTURE ============ -->
       <div class="memory-col">
         <div class="memory-step">01 / Capture</div>
-        <h3 class="memory-heading">Extracting reusable knowledge</h3>
+        <h3 class="memory-heading">Finding reusable knowledge</h3>
         <p class="memory-why">
-          Threa extracts decisions, learnings, procedures, context, and
-          references from the messages that establish them.
+          Threa identifies the messages where the team made a decision, learned
+          something, worked out a procedure, or shared useful context or reference
+          information.
         </p>
 
         <div class="capture-list" aria-label="Five-message slice; the three middle messages carry the decision.">
@@ -623,9 +624,9 @@ const schema = [
         </div>
         <h2>Threa is open source.</h2>
         <p class="lede">
-          The public repository is the code we deploy. It contains the frontend,
-          backend, control plane, and infrastructure. You can inspect it, fork it,
-          and run your own version.
+          The code we deploy is public, from the frontend and backend to the
+          control plane and infrastructure, so you can inspect it, fork it, or run
+          your own version.
         </p>
 
         <div class="os-tenets">
@@ -639,14 +640,14 @@ const schema = [
           <div class="os-tenet">
             <h4>Fork and modify it</h4>
             <p>
-              Run your own fork or change the product on the same codebase we
-              deploy.
+              You can fork the same codebase we deploy to run your own version or
+              modify the product.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Public development</h4>
+            <h4>Follow development</h4>
             <p>
-              The roadmap, design notes, and decision records are public in the
+              We publish the roadmap, design notes, and decision records in the
               repository.
             </p>
           </div>
@@ -697,7 +698,7 @@ const schema = [
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Take delegated work</h4>
+            <h4>Take on delegated work</h4>
             <p>
               Claim a task on your machine, post progress, and return the finished
               work to the stream.
@@ -709,8 +710,8 @@ const schema = [
       </div>
       <div class="band-media">
         <blockquote class="byo-quote">
-          Your agent keeps its local tools and credentials. Threa gives it the
-          team context and a place to return the result.
+          Your agent keeps its local tools and credentials, uses Threa for team
+          context, and returns the result to the conversation.
         </blockquote>
 
         <div class="byo-agents" aria-label="Bring your own Claude Code, Codex, Cursor, OpenCode, Gemini CLI, custom bot, or whatever comes next.">
@@ -745,9 +746,8 @@ const schema = [
     </div>
     <h2>Features I wanted from chat.</h2>
     <p class="lede">
-      Partly I built Threa out of spite. Years of watching decisions disappear
-      into channels left me with a list of chat features I wanted, so I started
-      adding them.
+      Partly I built Threa out of spite. After years of watching decisions
+      disappear into channels, I started building the chat app I wanted to use.
     </p>
 
     <ul class="missing-grid">
@@ -797,7 +797,7 @@ const schema = [
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Decisions you can find later</h4>
-          <p>The reasoning behind a call is kept as a memo that Ariadne can retrieve later.</p>
+          <p>The reasoning behind a call stays in a memo for Ariadne to retrieve when you ask about it again.</p>
         </div>
       </li>
     </ul>

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -14,7 +14,7 @@ const schema = [
     name: "Threa",
     url: site.href,
     description:
-      "Threa is open-source team chat that turns decisions and their reasoning into searchable memos linked to the conversation, with a public REST API and bot runtime for connecting your own agents.",
+      "Team chat with memory at its core: decisions and their reasoning become searchable memos linked to the conversation. Open source and self-hostable, with a public REST API and bot runtime for connecting your own agents.",
     applicationCategory: "BusinessApplication",
     operatingSystem: "Web",
     softwareHelp: { "@type": "CreativeWork", url: new URL("/developers", site).href },
@@ -44,12 +44,13 @@ const schema = [
         <div>
           <h1 class="h-display">
             Chat that remembers<br/>
-            <span class="accent">decisions</span>.
+            <span class="accent">the decisions</span>.
           </h1>
           <p class="lede">
-            Channels, threads, and DMs come with memory underneath, keeping
-            decisions and their reasoning linked to the source conversation so
-            you can find them when the topic returns.
+            Channels, threads, and DMs, with a memory underneath. The decisions
+            you make and the reasons behind them stay attached to the
+            conversation, so they're still there when the question comes up
+            again.
           </p>
           <div class="actions">
             <a class="cta" href="#waitlist">Join the waitlist</a>
@@ -220,12 +221,13 @@ const schema = [
     <div class="section-meta">
       <span>The board</span>
     </div>
-    <h2>Chat you can find later.</h2>
+    <h2>Chat you can actually find later.</h2>
     <p class="lede">
-      Timelines keep current conversations in order, but older discussions become
-      harder to recover as a channel grows. The board groups the same messages by
-      topic, so you can return to a conversation without scrolling through the
-      full timeline.
+      A timeline is great for real-time chat. It's linear and immediate, and good
+      for keeping up with what's latest. Where it falls short is discoverability.
+      Once a discussion gets long or complex, it's hard to find again weeks later.
+      The board answers that: the same messages, grouped by topic, so you can go
+      back and find a conversation instead of scrolling for it.
     </p>
 
     <div class="board-compare">
@@ -402,12 +404,14 @@ const schema = [
   <div class="memo-shell is-centerpiece">
     <div class="section-meta">
       <span>How memory works</span>
-      <span>· sourced memos</span>
+      <span>· capture · hold · return</span>
     </div>
-    <h2>Threa turns conversations into sourced memory.</h2>
+    <h2>Conversation becomes memory.</h2>
     <p class="lede">
-      Each short memo captures a decision or piece of reusable knowledge and
-      links back to the original messages.
+      Threa reads the conversation, finds the decisions and context worth
+      keeping, and saves them as short memos linked to the messages they came
+      from. When the question comes up again, ask Ariadne to search workspace
+      memory for the relevant memo and its source conversation.
     </p>
 
     <div class="memory-flow">
@@ -415,11 +419,11 @@ const schema = [
       <!-- ============ 01 · CAPTURE ============ -->
       <div class="memory-col">
         <div class="memory-step">01 / Capture</div>
-        <h3 class="memory-heading">Finding reusable knowledge</h3>
+        <h3 class="memory-heading">Finding what matters</h3>
         <p class="memory-why">
-          Threa identifies the messages where the team made a decision, learned
-          something, worked out a procedure, or shared useful context or reference
-          information.
+          Most of a channel is noise. The parts worth keeping are usually a
+          handful of lines where the team settles something, works out a process,
+          or shares context they'll need again.
         </p>
 
         <div class="capture-list" aria-label="Five-message slice; the three middle messages carry the decision.">
@@ -492,8 +496,8 @@ const schema = [
         <div class="memory-step">02 / Hold</div>
         <h3 class="memory-heading">Keeping it as a memo</h3>
         <p class="memory-why">
-          A short, sourced memo keeps the decision useful after the thread has
-          scrolled away.
+          Nobody rereads a transcript two months later. A short, sourced memo is
+          the part that stays useful once the thread has scrolled away.
         </p>
 
         <div class="memory-card decision-memo">
@@ -521,10 +525,11 @@ const schema = [
       <!-- ============ 03 · RETURN ============ -->
       <div class="memory-col is-return">
         <div class="memory-step">03 / Return</div>
-        <h3 class="memory-heading">Retrieving it later</h3>
+        <h3 class="memory-heading">When it comes up again</h3>
         <p class="memory-why">
-          When you ask Ariadne about a past decision, it searches workspace
-          memory and returns the relevant memo with its source context.
+          A reason you can't find isn't worth much. When the question returns,
+          ask Ariadne to search for the relevant memo and follow its links back to
+          the source conversation.
         </p>
 
         <div class="recall-thread">
@@ -601,7 +606,7 @@ const schema = [
           <span class="row"><span class="prompt">$</span><span class="cmd">cd</span> <span class="arg">threa</span> <span class="cmd">&amp;&amp;</span> <span class="cmd">bun install</span></span>
           <span class="row"><span class="prompt">$</span><span class="cmd">bun run dev</span></span>
           <span class="out">→ http://localhost:5173</span>
-          <span class="row"><span class="cmt"># running locally</span></span>
+          <span class="row"><span class="cmt"># your machine. your fork.</span></span>
         </div>
 
         <figure class="patch-example" aria-label="Patch Threa by describing the change to your own agent.">
@@ -620,35 +625,35 @@ const schema = [
       <div class="band-copy">
         <div class="section-meta">
           <span>Open source</span>
-          <span>· GitHub</span>
+          <span>· read · fork · audit</span>
         </div>
-        <h2>Threa is open source.</h2>
+        <h2>The whole thing is open source.</h2>
         <p class="lede">
-          The code we deploy is public, from the frontend and backend to the
-          control plane and infrastructure, so you can inspect it, fork it, or run
-          your own version.
+          The frontend, backend, control plane, and infrastructure are all public.
+          Read exactly how Threa works, fork it if you want your own version, or
+          run it yourself. The public repo is the one we ship.
         </p>
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Inspect the implementation</h4>
+            <h4>Public source</h4>
             <p>
-              The repository shows how Threa stores data, checks access, calls
-              models, and deploys each service.
+              The code, data model, access checks, model calls, and deployment
+              setup are all there on GitHub.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Fork and modify it</h4>
+            <h4>Yours to fork</h4>
             <p>
-              You can fork the same codebase we deploy to run your own version or
-              modify the product.
+              It's MIT-licensed. Fork it, change the product, or run your own
+              version on the same codebase we deploy.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Follow development</h4>
+            <h4>Built in the open</h4>
             <p>
-              We publish the roadmap, design notes, and decision records in the
-              repository.
+              Design docs, implementation plans, and the feature inventory are
+              public too, not just the finished code.
             </p>
           </div>
         </div>
@@ -675,33 +680,35 @@ const schema = [
           <span>Bring your own agent</span>
           <span>· bot runtime · CLI · MCP</span>
         </div>
-        <h2>Your agent can join the workspace.</h2>
+        <h2>Bring the agent you already use.</h2>
         <p class="lede">
-          Connect the agent on your laptop as a Threa bot. It works behind NAT,
-          answers @mentions as a workspace participant, searches messages, memos,
-          and attachments, and posts its work back into the conversation.
+          Threa ships with Ariadne, useful from day one. But you've probably
+          already got an agent set up the way you like it. Connect that agent as a
+          Threa bot and it can stay on your laptop behind NAT, answer @mentions,
+          search messages, memos, and attachments, and post its work back into the
+          conversation.
         </p>
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Answer in the room</h4>
+            <h4>Ask it in the room</h4>
             <p>
-              The bot runtime delivers mentions to your local agent and posts its
-              reply under the bot's own identity.
+              Mention the bot in a channel and the runtime sends the invocation
+              to your local agent, then posts its reply under the bot's identity.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Use workspace memory</h4>
+            <h4>Let it look things up</h4>
             <p>
-              Search messages by text or meaning, query memos, read attachments,
-              and follow memos back to their source messages.
+              Your agent can search messages by text or meaning, read memos and
+              attachments, and follow every memo back to its source messages.
             </p>
           </div>
           <div class="os-tenet">
-            <h4>Take on delegated work</h4>
+            <h4>Hand it the work</h4>
             <p>
-              Claim a task on your machine, post progress, and return the finished
-              work to the stream.
+              Delegate a task, follow its progress in the stream, and get the
+              finished work back where the team can see it.
             </p>
           </div>
         </div>
@@ -710,8 +717,9 @@ const schema = [
       </div>
       <div class="band-media">
         <blockquote class="byo-quote">
-          Your agent keeps its local tools and credentials, uses Threa for team
-          context, and returns the result to the conversation.
+          Ariadne is here to get you started. The agent you rely on can stay on
+          your machine, with your work reachable from it instead of locked inside
+          one more app.
         </blockquote>
 
         <div class="byo-agents" aria-label="Bring your own Claude Code, Codex, Cursor, OpenCode, Gemini CLI, custom bot, or whatever comes next.">
@@ -742,12 +750,13 @@ const schema = [
   <div class="memo-shell">
     <div class="section-meta">
       <span>Why I built this</span>
-      <span>· founder notes</span>
+      <span>· from one developer</span>
     </div>
-    <h2>Features I wanted from chat.</h2>
+    <h2>What I wished other tools had.</h2>
     <p class="lede">
-      Partly I built Threa out of spite. After years of watching decisions
-      disappear into channels, I started building the chat app I wanted to use.
+      Partly I built Threa out of spite. Years of watching decisions disappear
+      into channels, plus a short list of things I wanted from a chat app and
+      never got. So I added them.
     </p>
 
     <ul class="missing-grid">
@@ -790,18 +799,19 @@ const schema = [
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Stash a message</h4>
-          <p>Save half-written messages in a stash and return to them later.</p>
+          <p>Save a half-written message without sending it and pick it back up later. Not one draft stuck in the input box, but a stash you can pull from.</p>
         </div>
       </li>
       <li class="missing-item">
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Decisions you can find later</h4>
-          <p>The reasoning behind a call stays in a memo for Ariadne to retrieve when you ask about it again.</p>
+          <p>The reasoning behind a call stays in a memo, ready for Ariadne to retrieve when you ask about it again.</p>
         </div>
       </li>
     </ul>
 
+    <p class="missing-sign">Building Threa in the open.</p>
   </div>
 </div>
 

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -631,11 +631,10 @@ const schema = [
 
         <div class="os-tenets">
           <div class="os-tenet">
-            <h4>Public repository</h4>
+            <h4>Inspect the implementation</h4>
             <p>
-              The frontend, backend, control plane, and infrastructure live in
-              one repository. It also contains design notes and implementation
-              history.
+              The repository shows how Threa stores data, checks access, calls
+              models, and deploys each service.
             </p>
           </div>
           <div class="os-tenet">
@@ -714,7 +713,7 @@ const schema = [
           workspace messages and memos.
         </blockquote>
 
-        <div class="byo-agents" aria-label="Bring your own agent.">
+        <div class="byo-agents" aria-label="Bring your own coding agent, research agent, assistant, automation, local model, custom bot, or whatever comes next.">
           <span class="byo-lead">Bring your own</span>
           <span class="byo-clip" aria-hidden="true">
             <span class="byo-track">

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -406,9 +406,8 @@ const schema = [
     </div>
     <h2>Threa saves decisions as sourced memos.</h2>
     <p class="lede">
-      Threa finds decisions in the conversation and stores them as short memos
-      linked to their source messages. When someone asks about the topic
-      later, Ariadne can retrieve the memo and its sources.
+      Threa turns a settled decision into a short memo linked to its source
+      messages. You can open the original messages from the memo.
     </p>
 
     <div class="memory-flow">

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -395,8 +395,8 @@ const schema = [
 <!-- ============================================================
      MEMORY FLOW — capture · hold · return
      Mirrors the real mechanic: extract a decision from the
-     conversation, hold it as a memo, return it when the topic
-     comes back. No invented graph relations.
+     conversation, hold it as a memo, retrieve it when someone asks
+     about the topic again. No invented graph relations.
      ============================================================ -->
 <div class="frame warm">
   <div class="memo-shell is-centerpiece">
@@ -796,7 +796,7 @@ const schema = [
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Decisions you can find later</h4>
-          <p>The reasoning behind a call is kept as a memo and comes back when the topic does.</p>
+          <p>The reasoning behind a call is kept as a memo that Ariadne can retrieve later.</p>
         </div>
       </li>
     </ul>

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -2280,13 +2280,6 @@ body::after {
   line-height: 1.5;
   color: hsl(var(--ink-soft));
 }
-.missing-sign {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  color: hsl(var(--muted));
-  margin: 0;
-}
 @media (max-width: 880px) {
   .missing-grid {
     grid-template-columns: 1fr;

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -2280,6 +2280,13 @@ body::after {
   line-height: 1.5;
   color: hsl(var(--ink-soft));
 }
+.missing-sign {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: hsl(var(--muted));
+  margin: 0;
+}
 @media (max-width: 880px) {
   .missing-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Problem

The homepage and About page contain filler, rhetorical contrasts, repeated claims, and compressed copy that smooths over the founder voice or hides concrete product mechanics. They also advertise an expired “early 2026” date, imply that memory resurfaces automatically, mention an E2E feature marked `public_site: false`, and make privacy-contract claims without a current public source. The repository calls itself open source but has no license granting reuse or modification rights.

## Solution

- Rewrite homepage and About headings, section copy, cards, accessibility text, and shared metadata using the `deslopify` skill without sanding away the founder voice.
- Keep the blunt first-person details, dry jokes, and opinions: spite, parental leave, “I'm the team,” and “we deserve nice things” remain.
- Describe memory as sourced memos that Ariadne retrieves on request; cover decisions, learnings, procedures, context, and references.
- Lead the bring-your-own-agent section with the shipped bot runtime: local agents work behind NAT, answer mentions, search workspace memory, and complete delegated tasks.
- Use current agent hosts as concrete compatibility examples; link directly to the local-agent recipe and grant every scope that recipe needs.
- Remove the stale launch date, unshipped E2E marketing, and unsupported retention/training claims.
- License the full repository under MIT and link the license from the README.
- Keep accent color to the hero and closing CTA on each marketing page.

## Files

| File | Change |
| ---- | ------ |
| `LICENSE` | Adds the MIT license for the repository |
| `README.md` | Links the repository license |
| `apps/public-site/src/pages/index.astro` | Rewrites homepage copy and corrects product claims |
| `apps/public-site/src/pages/about.astro` | Tightens founder copy without removing its voice |
| `apps/public-site/src/pages/developers/recipes.astro` | Aligns local-agent setup scopes with advertised search capabilities |
| `apps/public-site/src/layouts/Layout.astro` | Rewrites default metadata |
| `apps/public-site/src/components/BaseHead.astro` | Rewrites structured metadata and visible link title |

## Test plan

- [x] `bun run --cwd apps/public-site typecheck`
- [x] `bun run --cwd apps/public-site build`
- [x] Desktop and 390px screenshots for `/` and `/about`
- [x] Full pre-commit lint, typecheck, Dockerfile, migration, and API-doc checks
- [x] Multi-perspective and Kimi voice reviews; accepted findings fixed, while unshipped or unsourced claims stayed out
- [x] Final Kimi factual rereview against the code; replaced two deterministic recall claims with request-driven search wording

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787350357&installation_model_id=20758&pr_number=1514&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1514&signature=af7d92a884a15fa4c2b267a1a4f5d23f5e99b4760b48130786d40696a7b89307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


