### PR TITLE
feat: add reachable Pi reconnect command

### DIFF
--- a/apps/backend/src/features/commands/catalog.test.ts
+++ b/apps/backend/src/features/commands/catalog.test.ts
@@ -10,7 +10,7 @@ describe("session-control command catalog", () => {
       description: "Reconnect the linked live session",
       kind: "bot-runtime",
       scope: "stream",
-      args: [{ name: "--force", required: false, description: "Reconnect even when the runtime is busy" }],
+      args: [{ name: "--force", required: false, description: "Reconnect despite local runtime activity" }],
     })
   })
 })

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -140,7 +140,7 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
       description: "Reconnect the linked live session",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
-      args: [{ name: "--force", required: false, description: "Reconnect even when the runtime is busy" }],
+      args: [{ name: "--force", required: false, description: "Reconnect despite local runtime activity" }],
     },
   ]
 }

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -32,7 +32,13 @@ export function resolveRuntimeInvocationRouting(
   trigger: (typeof BotInvocationTriggers)[keyof typeof BotInvocationTriggers]
   requiredCapability: (typeof BotInvocationCapabilities)[keyof typeof BotInvocationCapabilities]
 } {
-  if (commandName === "steer" || commandName === "stop" || commandName === "kick" || commandName === "carry-on") {
+  if (
+    commandName === "steer" ||
+    commandName === "stop" ||
+    commandName === "kick" ||
+    commandName === "carry-on" ||
+    (commandName === "reconnect" && runtimeKind === BotRuntimeKinds.PI_LOCAL)
+  ) {
     // Pi advertises `active-scratchpad` while busy. The Claude Code channel
     // instead advertises only `session-control` while busy, so its interrupts
     // route there. See docs/claude-channel-session-control.md.

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -4,7 +4,7 @@ import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
   it("routes interrupt commands to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -19,13 +19,6 @@ describe("resolveRuntimeInvocationRouting", () => {
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
       })
     }
-  })
-
-  it("keeps reconnect on normal session-control routing for pi-local", () => {
-    expect(resolveRuntimeInvocationRouting("reconnect", BotRuntimeKinds.PI_LOCAL)).toEqual({
-      trigger: BotInvocationTriggers.SESSION_CONTROL,
-      requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
-    })
   })
 
   it("routes every other command to session-control regardless of runtime kind", () => {

--- a/extensions/pi-remote/README.md
+++ b/extensions/pi-remote/README.md
@@ -35,7 +35,7 @@ bun run extensions/pi-remote/install-local.ts
 
 Then run `/reload` in Pi. Pass a different target dir as the first argument if needed.
 
-For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt. `/reconnect [--force]` is offered only to a live, linked Pi running in tmux; it acknowledges first, then asks harnessd to replace the pane process and resume the same Pi session. Without `--force`, Pi must be idle. The command cannot recover a disconnected runtime. Direct `harnessd reconnect` for Pi has no activity signal, so `--force` is currently inert there; this intentionally does not add IPC, status reporting, or another supervisor.
+For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt. `/reconnect [--force]` is offered only to a live, linked Pi running in tmux; it acknowledges first, then asks harnessd to replace the pane process and resume the same Pi session. `--force` may bypass only local Pi activity; an owned pending Threa invocation always fails closed and must be cleared with `/stop` first. The command cannot recover a disconnected runtime. Direct `harnessd reconnect` for Pi has no activity signal, so `--force` is currently inert there; this intentionally does not add IPC, status reporting, or another supervisor.
 
 The script rebuilds `~/.pi/agent/extensions/threa-remote` from scratch each time, so re-running it is the supported way to update.
 

--- a/extensions/pi-remote/README.md
+++ b/extensions/pi-remote/README.md
@@ -35,7 +35,7 @@ bun run extensions/pi-remote/install-local.ts
 
 Then run `/reload` in Pi. Pass a different target dir as the first argument if needed.
 
-For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt.
+For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt. `/reconnect [--force]` is offered only to a live, linked Pi running in tmux; it acknowledges first, then asks harnessd to replace the pane process and resume the same Pi session. Without `--force`, Pi must be idle. The command cannot recover a disconnected runtime. Direct `harnessd reconnect` for Pi has no activity signal, so `--force` is currently inert there; this intentionally does not add IPC, status reporting, or another supervisor.
 
 The script rebuilds `~/.pi/agent/extensions/threa-remote` from scratch each time, so re-running it is the supported way to update.
 

--- a/extensions/pi-remote/install-local.ts
+++ b/extensions/pi-remote/install-local.ts
@@ -30,6 +30,7 @@ const VENDOR_FILES = [
   "sealed.ts",
   "supervisor.ts",
   "harness-kick.ts",
+  "harness-reconnect.ts",
 ]
 
 // 1. Clean any prior install — both the legacy single-file form and the dir form.

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -888,7 +888,12 @@ describe("buildPersistedConfig", () => {
 })
 
 describe("Pi reconnect session control", () => {
-  const invocation = { id: "binv_reconnect", claimToken: "claim", claimedInstanceId: "pi-instance" } as never
+  const invocation = {
+    id: "binv_reconnect",
+    claimToken: "claim",
+    claimedInstanceId: "pi-instance",
+    rootStreamId: "stream-root-exact",
+  } as never
   const context = (idle: boolean) =>
     ({
       sessionManager: { getSessionId: () => "runtime-exact" },
@@ -946,19 +951,72 @@ describe("Pi reconnect session control", () => {
     }
   })
 
-  test("advertises reconnect only with tmux, an exact root link, and the helper", () => {
+  test("advertises reconnect only for the exact current reconnect link", () => {
     const ctx = context(true)
-    expect(__testing.buildRuntimeCapabilities(ctx, () => true)).toMatchObject({
-      sessionControlCommands: expect.arrayContaining(["reconnect"]),
+    const validLink = {
+      enabled: true,
+      instanceId: "pi-instance",
+      runtimeSessionId: "runtime-exact",
+      rootStreamId: "stream-root-exact",
+      activeStreamId: "stream-root-exact",
+      streamUrlPath: "/streams/stream-root-exact",
+    }
+    const advertised = () =>
+      (__testing.buildRuntimeCapabilities(ctx, () => true).sessionControlCommands as string[]).includes("reconnect")
+
+    expect(advertised()).toBe(true)
+    for (const invalidLink of [
+      { ...validLink, enabled: false },
+      { ...validLink, rootStreamId: "" },
+      { ...validLink, rootStreamId: "   " },
+      { ...validLink, runtimeSessionId: "runtime-other" },
+      { ...validLink, instanceId: undefined },
+    ]) {
+      __testing.setConfigForTesting({
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        linkedSessions: { "runtime-exact": invalidLink },
+      })
+      expect(advertised()).toBe(false)
+    }
+
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { "runtime-exact": validLink },
     })
     delete process.env.TMUX_PANE
-    expect(__testing.buildRuntimeCapabilities(ctx, () => true)).toMatchObject({
-      sessionControlCommands: expect.not.arrayContaining(["reconnect"]),
-    })
+    expect(advertised()).toBe(false)
     process.env.TMUX_PANE = "%9"
-    expect(__testing.buildRuntimeCapabilities(ctx, () => false)).toMatchObject({
-      sessionControlCommands: expect.not.arrayContaining(["reconnect"]),
-    })
+    expect(
+      (__testing.buildRuntimeCapabilities(ctx, () => false).sessionControlCommands as string[]).includes("reconnect")
+    ).toBe(false)
+  })
+
+  test("a claim from link A cannot prepare or ack after relinking to B", async () => {
+    let prepared = 0
+    let acknowledged = 0
+    for (const staleInvocation of [
+      { ...invocation, rootStreamId: "stream-root-a" },
+      { ...invocation, claimedInstanceId: "pi-instance-a" },
+    ]) {
+      await expect(
+        __testing.runReconnectCommand(staleInvocation as never, "", context(true), {
+          available: () => true,
+          prepare: () => {
+            prepared++
+            return () => undefined
+          },
+          complete: async () => {
+            acknowledged++
+            return true
+          },
+        } as never)
+      ).rejects.toThrow("Harness reconnect is unavailable")
+    }
+    expect({ prepared, acknowledged }).toEqual({ prepared: 0, acknowledged: 0 })
   })
 
   test("accepts only empty args or exact --force", async () => {
@@ -1032,6 +1090,83 @@ describe("Pi reconnect session control", () => {
     }
   })
 
+  test("E2E key failure that only closes noResponse does not start reconnect", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      if (String(input).endsWith("/complete")) bodies.push(body)
+      if (body.finalMessageMarkdown) {
+        return new Response(JSON.stringify({ error: { code: "E2E_STREAM_PLAINTEXT_UNSUPPORTED" } }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    let started = false
+    await __testing.runReconnectCommand({ ...invocation, sealedAck: { invalid: true } } as never, "", context(true), {
+      available: () => true,
+      prepare: () => () => {
+        started = true
+      },
+      complete: __testing.completeInvocationWithMarkdown,
+      heartbeat: async () => undefined,
+    } as never)
+    expect({ bodies, started }).toEqual({
+      bodies: [
+        expect.objectContaining({ finalMessageMarkdown: expect.any(String) }),
+        expect.objectContaining({ noResponse: true }),
+      ],
+      started: false,
+    })
+    fetchSpy.mockRestore()
+  })
+
+  test("revalidates pinned link facts after ack and restores actual presence", async () => {
+    for (const mutate of [
+      (link: Record<string, unknown>) => (link.enabled = false),
+      (link: Record<string, unknown>) => (link.rootStreamId = "stream-other"),
+      (link: Record<string, unknown>) => (link.runtimeSessionId = "runtime-other"),
+      (link: Record<string, unknown>) => (link.instanceId = "pi-other"),
+    ]) {
+      const link = {
+        enabled: true,
+        instanceId: "pi-instance",
+        runtimeSessionId: "runtime-exact",
+        rootStreamId: "stream-root-exact",
+      }
+      __testing.setConfigForTesting({
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        linkedSessions: { "runtime-exact": link },
+      })
+      let started = false
+      const presence: string[] = []
+      await __testing.runReconnectCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => () => {
+          started = true
+        },
+        complete: async () => {
+          mutate(link)
+          return true
+        },
+        heartbeat: async (status: string) => {
+          presence.push(status)
+        },
+      } as never)
+      expect({ started, presence: presence.at(-1) }).toEqual({
+        started: false,
+        presence: link.enabled ? "available" : "offline",
+      })
+      __testing.clearPendingForTesting()
+    }
+  })
+
   test("synchronous start failure restores the handoff state", async () => {
     await expect(
       __testing.runReconnectCommand(invocation, "", context(true), {
@@ -1046,7 +1181,7 @@ describe("Pi reconnect session control", () => {
     expect(__testing.reconnectPending()).toBe(false)
   })
 
-  test("refuses idle-only reconnect while busy but force bypasses the refusal", async () => {
+  test("force bypasses only local busy state and never an owned Threa invocation", async () => {
     const messages: string[] = []
     let prepared = 0
     const deps = {
@@ -1063,10 +1198,14 @@ describe("Pi reconnect session control", () => {
     } as never
     await __testing.runReconnectCommand(invocation, "", context(false), deps)
     await __testing.runReconnectCommand(invocation, "--force", context(false), deps)
+    __testing.clearPendingForTesting()
+    __testing.beginPendingInvocation({ id: "binv_owned", claimToken: "owned" } as never)
+    await __testing.runReconnectCommand(invocation, "--force", context(false), deps)
     expect({ messages, prepared }).toEqual({
       messages: [
         "Pi is busy; retry when idle or use `/reconnect --force`.",
         "Reconnect request accepted; attempting to resume the linked Pi session.",
+        "A Threa invocation is still running; use `/stop` before reconnecting.",
       ],
       prepared: 1,
     })

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -887,10 +887,303 @@ describe("buildPersistedConfig", () => {
   })
 })
 
-describe("session-scoped lifecycle isolation", () => {
+describe("Pi reconnect session control", () => {
+  const invocation = { id: "binv_reconnect", claimToken: "claim", claimedInstanceId: "pi-instance" } as never
+  const context = (idle: boolean) =>
+    ({
+      sessionManager: { getSessionId: () => "runtime-exact" },
+      modelRegistry: { getAvailable: () => [] },
+      isIdle: () => idle,
+    }) as never
+
+  beforeEach(() => {
+    process.env.TMUX_PANE = "%9"
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        "runtime-exact": {
+          enabled: true,
+          instanceId: "pi-instance",
+          runtimeSessionId: "runtime-exact",
+          rootStreamId: "stream-root-exact",
+          activeStreamId: "stream-root-exact",
+          streamUrlPath: "/streams/stream-root-exact",
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.TMUX_PANE
+    __testing.clearPendingForTesting()
+    __testing.setConfigForTesting(undefined)
+  })
+
+  test("uses exact routing, gates start on ack, preserves force, and stays nonaccepting", async () => {
+    for (const force of [false, true]) {
+      const prepared: unknown[][] = []
+      let started = false
+      await __testing.runReconnectCommand(invocation, force ? "--force" : "", context(true), {
+        available: () => true,
+        prepare: (...args: unknown[]) => {
+          prepared.push(args)
+          return () => {
+            started = true
+          }
+        },
+        complete: async () => true,
+        heartbeat: async () => undefined,
+      } as never)
+      expect({ prepared, started, guarded: __testing.reconnectPending() }).toEqual({
+        prepared: [["runtime-exact", "stream-root-exact", { force }]],
+        started: true,
+        guarded: true,
+      })
+      expect(await __testing.claimNextInvocation(context(true))).toBeNull()
+      __testing.clearPendingForTesting()
+    }
+  })
+
+  test("advertises reconnect only with tmux, an exact root link, and the helper", () => {
+    const ctx = context(true)
+    expect(__testing.buildRuntimeCapabilities(ctx, () => true)).toMatchObject({
+      sessionControlCommands: expect.arrayContaining(["reconnect"]),
+    })
+    delete process.env.TMUX_PANE
+    expect(__testing.buildRuntimeCapabilities(ctx, () => true)).toMatchObject({
+      sessionControlCommands: expect.not.arrayContaining(["reconnect"]),
+    })
+    process.env.TMUX_PANE = "%9"
+    expect(__testing.buildRuntimeCapabilities(ctx, () => false)).toMatchObject({
+      sessionControlCommands: expect.not.arrayContaining(["reconnect"]),
+    })
+  })
+
+  test("accepts only empty args or exact --force", async () => {
+    const messages: string[] = []
+    let prepared = 0
+    for (const args of ["--force ", " --force", "--force=yes", "extra"]) {
+      await __testing.runReconnectCommand(invocation, args, context(true), {
+        available: () => true,
+        prepare: () => {
+          prepared++
+          return () => undefined
+        },
+        complete: async (_invocation: unknown, message: string) => {
+          messages.push(message)
+          return true
+        },
+      } as never)
+    }
+    expect({ messages, prepared }).toEqual({
+      messages: Array(4).fill("Usage: `/reconnect [--force]`."),
+      prepared: 0,
+    })
+  })
+
+  test("preparation failure and failed ack never start reconnect", async () => {
+    expect(
+      __testing.runReconnectCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => {
+          throw new Error("preflight failed")
+        },
+        complete: async () => true,
+      } as never)
+    ).rejects.toThrow("preflight failed")
+
+    let started = false
+    await __testing.runReconnectCommand(invocation, "", context(true), {
+      available: () => true,
+      prepare: () => () => {
+        started = true
+      },
+      complete: async () => false,
+      heartbeat: async () => undefined,
+    } as never)
+    expect(started).toBe(false)
+    expect(__testing.reconnectPending()).toBe(false)
+  })
+
+  test("real plaintext completion finishes before start and completion failure prevents start", async () => {
+    for (const completeOk of [true, false]) {
+      const order: string[] = []
+      const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = String(input)
+        order.push(url.includes("/complete") ? "complete" : "trace")
+        return new Response(JSON.stringify({ data: {} }), {
+          status: url.includes("/complete") && !completeOk ? 500 : 200,
+          headers: { "content-type": "application/json" },
+        })
+      })
+      const reconnect = __testing.runReconnectCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => () => order.push("start"),
+        complete: __testing.completeInvocationWithMarkdown,
+        heartbeat: async () => undefined,
+      } as never)
+      if (completeOk) await expect(reconnect).resolves.toBeUndefined()
+      else await expect(reconnect).rejects.toThrow("500")
+      expect(order.filter((step) => step !== "trace")).toEqual(completeOk ? ["complete", "start"] : ["complete"])
+      fetchSpy.mockRestore()
+      __testing.clearPendingForTesting()
+    }
+  })
+
+  test("synchronous start failure restores the handoff state", async () => {
+    await expect(
+      __testing.runReconnectCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => () => {
+          throw new Error("start failed")
+        },
+        complete: async () => true,
+        heartbeat: async () => undefined,
+      } as never)
+    ).rejects.toThrow("start failed")
+    expect(__testing.reconnectPending()).toBe(false)
+  })
+
+  test("refuses idle-only reconnect while busy but force bypasses the refusal", async () => {
+    const messages: string[] = []
+    let prepared = 0
+    const deps = {
+      available: () => true,
+      prepare: () => {
+        prepared++
+        return () => {}
+      },
+      complete: async (_invocation: unknown, message: string) => {
+        messages.push(message)
+        return true
+      },
+      heartbeat: async () => undefined,
+    } as never
+    await __testing.runReconnectCommand(invocation, "", context(false), deps)
+    await __testing.runReconnectCommand(invocation, "--force", context(false), deps)
+    expect({ messages, prepared }).toEqual({
+      messages: [
+        "Pi is busy; retry when idle or use `/reconnect --force`.",
+        "Reconnect request accepted; attempting to resume the linked Pi session.",
+      ],
+      prepared: 1,
+    })
+  })
+})
+
+describe("claim drain serialization", () => {
   afterEach(() => {
     __testing.clearPendingForTesting()
     __testing.setConfigForTesting(undefined)
+  })
+
+  test("shares one claim pass between concurrent callers", async () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { runtime: { enabled: true, instanceId: "pi-instance", runtimeSessionId: "runtime" } },
+    })
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    let requests = 0
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      requests++
+      await gate
+      return new Response(JSON.stringify({ data: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => "runtime" },
+      isIdle: () => true,
+      cwd: "/tmp",
+    } as never
+    const pi = {} as never
+
+    const first = __testing.claimIfIdle(pi, ctx)
+    const second = __testing.claimIfIdle(pi, ctx)
+    expect(first).toBe(second)
+    release()
+    expect(await Promise.all([first, second])).toEqual([true, true])
+    expect(requests).toBe(1)
+    fetchSpy.mockRestore()
+  })
+})
+
+describe("session-scoped lifecycle isolation", () => {
+  afterEach(() => {
+    delete process.env.TMUX_PANE
+    __testing.teardownTransport()
+    __testing.setSupervisedRevivalBlockedForTesting(false)
+    __testing.clearPendingForTesting()
+    __testing.setConfigForTesting(undefined)
+  })
+
+  test("closes a claim returned after shutdown before teardown completes", async () => {
+    const shutdownHandlers: Array<(event: unknown, ctx: unknown) => Promise<void>> = []
+    threaRemote({
+      registerCommand: () => {},
+      on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<void>) => {
+        if (event === "session_shutdown") shutdownHandlers.push(handler)
+      },
+    } as never)
+    __testing.teardownTransport()
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { parent: { enabled: true, instanceId: "pi-parent", runtimeSessionId: "parent" } },
+    })
+    let releaseClaim!: () => void
+    const claimGate = new Promise<void>((resolve) => (releaseClaim = resolve))
+    const writes: string[] = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/claim")) {
+        await claimGate
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: "binv_late",
+              activeStreamId: "stream_1",
+              sourceMessageId: "msg_1",
+              promptMarkdown: "late work",
+              claimToken: "claim_late",
+              claimExpiresAt: null,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      if (url.endsWith("/bot-invocations/binv_late/fail")) writes.push("fail")
+      if (url.endsWith("/bot-runtime/presence")) writes.push("offline")
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => "parent" },
+      isIdle: () => true,
+      cwd: "/tmp",
+      ui: { setStatus: () => {}, notify: () => {} },
+    } as never
+
+    try {
+      const claim = __testing.claimIfIdle({} as never, ctx)
+      await Bun.sleep(0)
+      const shutdown = shutdownHandlers[0]!({ reason: "quit" }, ctx)
+      releaseClaim()
+      expect(await claim).toBe(false)
+      await shutdown
+      expect(writes.at(0)).toBe("fail")
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 
   test("child shutdown preserves the parent claim while parent shutdown clears it", async () => {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -696,6 +696,25 @@ function buildModelSuggestions(ctx: ExtensionContext): Array<{ value: string; la
   return ordered.slice(0, 30)
 }
 
+function currentReconnectLink(
+  ctx: ExtensionContext,
+  reconnectAvailable: () => boolean = harnessReconnectAvailable
+): RuntimeSessionLink | undefined {
+  const link = getCurrentSessionLink(ctx)
+  if (
+    link?.enabled !== true ||
+    typeof link.rootStreamId !== "string" ||
+    link.rootStreamId.trim().length === 0 ||
+    link.runtimeSessionId !== getRuntimeSessionId(ctx) ||
+    link.instanceId !== getSessionInstanceId(ctx) ||
+    !process.env.TMUX_PANE ||
+    !reconnectAvailable()
+  ) {
+    return undefined
+  }
+  return link
+}
+
 function buildRuntimeCapabilities(
   ctx?: ExtensionContext,
   reconnectAvailable: () => boolean = harnessReconnectAvailable
@@ -706,9 +725,7 @@ function buildRuntimeCapabilities(
     supportsMentionInvocations: true,
     supportsSessionControlCommands: true,
     sessionControlCommands: SESSION_CONTROL_COMMANDS.filter(
-      (command) =>
-        command !== "reconnect" ||
-        Boolean(ctx && process.env.TMUX_PANE && getCurrentSessionLink(ctx)?.rootStreamId && reconnectAvailable())
+      (command) => command !== "reconnect" || Boolean(ctx && currentReconnectLink(ctx, reconnectAvailable))
     ),
     thinkingLevels: [...THINKING_LEVELS],
     preferredModels: [...(config?.preferredModels ?? [])],
@@ -2080,6 +2097,7 @@ async function completeInvocationWithMarkdown(
       } catch {
         return false
       }
+      return false
     }
     return true
   } finally {
@@ -2574,16 +2592,36 @@ async function runReconnectCommand(
     await deps.complete(invocation, "Usage: `/reconnect [--force]`.", ctx)
     return
   }
-  if (args !== "--force" && (!ctx.isIdle() || pending)) {
+  if (pending) {
+    await deps.complete(invocation, "A Threa invocation is still running; use `/stop` before reconnecting.", ctx)
+    return
+  }
+  if (args !== "--force" && !ctx.isIdle()) {
     await deps.complete(invocation, "Pi is busy; retry when idle or use `/reconnect --force`.", ctx)
     return
   }
-  const link = getCurrentSessionLink(ctx)
+  const link = currentReconnectLink(ctx, deps.available)
   const lifecycleGeneration = sessionLifecycleGeneration
-  if (!process.env.TMUX_PANE || !link?.rootStreamId || !deps.available() || sessionTearingDown) {
+  const runtimeSessionId = getRuntimeSessionId(ctx)
+  const instanceId = getSessionInstanceId(ctx)
+  const invocationFacts = {
+    rootStreamId: invocation.rootStreamId,
+    claimedInstanceId: invocation.claimedInstanceId,
+  }
+  if (
+    !link ||
+    invocationFacts.rootStreamId !== link.rootStreamId ||
+    invocationFacts.claimedInstanceId !== instanceId ||
+    sessionTearingDown
+  ) {
     throw new Error("Harness reconnect is unavailable for this session.")
   }
-  const start = deps.prepare(getRuntimeSessionId(ctx), link.rootStreamId, { force: args === "--force" })
+  const linkFacts = {
+    instanceId: link.instanceId,
+    runtimeSessionId: link.runtimeSessionId,
+    rootStreamId: link.rootStreamId,
+  }
+  const start = deps.prepare(runtimeSessionId, linkFacts.rootStreamId, { force: args === "--force" })
   reconnectPending = true
   await sendHeartbeat("busy", "Reconnect handoff…", ctx).catch(() => undefined)
   try {
@@ -2592,21 +2630,35 @@ async function runReconnectCommand(
       "Reconnect request accepted; attempting to resume the linked Pi session.",
       ctx
     )
+    const currentLink = currentReconnectLink(ctx, deps.available)
     const lifecycleChanged =
-      sessionTearingDown || sessionLifecycleGeneration !== lifecycleGeneration || getCurrentSessionLink(ctx) !== link
+      sessionTearingDown ||
+      sessionLifecycleGeneration !== lifecycleGeneration ||
+      !currentLink ||
+      currentLink.instanceId !== linkFacts.instanceId ||
+      currentLink.runtimeSessionId !== linkFacts.runtimeSessionId ||
+      currentLink.rootStreamId !== linkFacts.rootStreamId ||
+      getRuntimeSessionId(ctx) !== runtimeSessionId ||
+      getSessionInstanceId(ctx) !== instanceId ||
+      invocation.rootStreamId !== invocationFacts.rootStreamId ||
+      invocation.claimedInstanceId !== invocationFacts.claimedInstanceId
     if (!acknowledged || lifecycleChanged) {
       reconnectPending = false
-      if (!lifecycleChanged) {
-        await sendHeartbeat(ctx.isIdle() && !pending ? "available" : "busy", undefined, ctx).catch(() => undefined)
-      }
+      const enabled = isEnabled(ctx)
+      await sendHeartbeat(
+        enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline",
+        undefined,
+        ctx
+      ).catch(() => undefined)
       return
     }
     start()
   } catch (error) {
     reconnectPending = false
-    if (!sessionTearingDown && sessionLifecycleGeneration === lifecycleGeneration) {
-      await sendHeartbeat(ctx.isIdle() && !pending ? "available" : "busy", undefined, ctx).catch(() => undefined)
-    }
+    const enabled = isEnabled(ctx)
+    await sendHeartbeat(enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline", undefined, ctx).catch(
+      () => undefined
+    )
     throw error
   }
 }

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -22,8 +22,10 @@ import {
   mintStreamKeyWraps,
   openSealedAck,
   openSealedTurnContext,
+  harnessReconnectAvailable,
   parseSealedAckContext,
   parseSealedTurnContext,
+  prepareHarnessReconnect,
   runHarnessKick,
   scrubSealedError,
   sealReply,
@@ -99,6 +101,7 @@ const SESSION_CONTROL_COMMANDS = [
   "stop",
   "kick",
   "carry-on",
+  "reconnect",
 ] as const
 type PiSessionControlCommandName = (typeof SESSION_CONTROL_COMMANDS)[number]
 const STEER_DRAIN_LIMIT = 10
@@ -278,6 +281,10 @@ let lastPollDebugSummary: string | undefined
 let pollingRunId = 0
 let fallbackRuntimeSessionId: string | undefined
 let supervisedRevivalBlocked = false
+let reconnectPending = false
+let claimIfIdleInFlight: Promise<boolean> | undefined
+let sessionLifecycleGeneration = 0
+let sessionTearingDown = false
 // Owns the /bot socket + routes presence/renew/steps over it (HTTP fallback
 // when the socket is down). Built lazily once the session ctx is known; torn
 // down + rebuilt on a workspace/auth change so it never reuses a stale target.
@@ -689,17 +696,39 @@ function buildModelSuggestions(ctx: ExtensionContext): Array<{ value: string; la
   return ordered.slice(0, 30)
 }
 
-function buildRuntimeCapabilities(ctx?: ExtensionContext): Record<string, unknown> {
+function buildRuntimeCapabilities(
+  ctx?: ExtensionContext,
+  reconnectAvailable: () => boolean = harnessReconnectAvailable
+): Record<string, unknown> {
   return {
     supportsActiveScratchpad: true,
     supportsPersistentSessions: true,
     supportsMentionInvocations: true,
     supportsSessionControlCommands: true,
-    sessionControlCommands: [...SESSION_CONTROL_COMMANDS],
+    sessionControlCommands: SESSION_CONTROL_COMMANDS.filter(
+      (command) =>
+        command !== "reconnect" ||
+        Boolean(ctx && process.env.TMUX_PANE && getCurrentSessionLink(ctx)?.rootStreamId && reconnectAvailable())
+    ),
     thinkingLevels: [...THINKING_LEVELS],
     preferredModels: [...(config?.preferredModels ?? [])],
     ...(ctx?.model && { currentModel: `${ctx.model.provider}/${ctx.model.id}` }),
     ...(ctx && { modelSuggestions: buildModelSuggestions(ctx) }),
+  }
+}
+
+function presenceBody(status: "available" | "busy" | "offline" | "error", statusText?: string, ctx?: ExtensionContext) {
+  const effectiveStatus = status === "available" && reconnectPending ? "busy" : status
+  return {
+    runtimeKind: "pi-local",
+    instanceId: ctx ? getSessionInstanceId(ctx) : ensureInstanceId(),
+    runtimeSessionId: ctx ? getRuntimeSessionId(ctx) : undefined,
+    displayName: presenceDisplayNameFromCwd(ctx?.cwd) ?? config?.defaultDisplayName,
+    status: effectiveStatus,
+    acceptingInvocations: effectiveStatus === "available",
+    capabilities: buildRuntimeCapabilities(ctx),
+    statusText,
+    ...bikKeystore.presenceFields(),
   }
 }
 
@@ -708,22 +737,11 @@ async function heartbeat(
   statusText?: string,
   ctx?: ExtensionContext
 ): Promise<void> {
-  if (!config) return
+  if (!config || (sessionTearingDown && status !== "offline")) return
   // Cached after the first call; awaiting here guarantees no presence write
   // ever omits the BIK (the upsert would clear the registered key).
   await bikKeystore.ensure()
-  const runtimeSessionId = ctx ? getRuntimeSessionId(ctx) : undefined
-  const body = {
-    runtimeKind: "pi-local",
-    instanceId: ctx ? getSessionInstanceId(ctx) : ensureInstanceId(),
-    runtimeSessionId,
-    displayName: presenceDisplayNameFromCwd(ctx?.cwd) ?? config.defaultDisplayName,
-    status,
-    acceptingInvocations: status === "available",
-    capabilities: buildRuntimeCapabilities(ctx),
-    statusText,
-    ...bikKeystore.presenceFields(),
-  }
+  const body = presenceBody(status, statusText, ctx)
   // Prefer the socket once the transport exists (it falls back to HTTP itself
   // when the socket is down); before the transport is built (a heartbeat that
   // fires pre-enable) go straight to HTTP.
@@ -756,25 +774,21 @@ async function heartbeatBusyIfStale(statusText = "Working…", ctx?: ExtensionCo
 function ensureTransport(pi: ExtensionAPI, ctx: ExtensionContext): BotRuntimeTransport | undefined {
   if (!config) return undefined
   if (transport) return transport
-  const link = getCurrentSessionLink(ctx)
   const hello: BotRuntimeHello = {
-    instanceId: getSessionInstanceId(ctx),
-    runtimeKind: "pi-local",
-    runtimeSessionId: getRuntimeSessionId(ctx),
-    displayName: presenceDisplayNameFromCwd(ctx.cwd) ?? config.defaultDisplayName,
+    ...presenceBody(reconnectPending || pending || !ctx.isIdle() ? "busy" : "available", undefined, ctx),
     supportedCapabilities: ["active-scratchpad", "mentionable", SESSION_CONTROL_CAPABILITY],
-    capabilities: buildRuntimeCapabilities(ctx),
-    ...(link?.wsCursor ? { sinceCursor: link.wsCursor } : {}),
-    // The hello is a snapshot the transport re-sends on every reconnect, so the
-    // BIK must be loaded BEFORE the transport is built (see session_start /
-    // enableRemote, which ensure it ahead of this call).
-    ...bikKeystore.presenceFields(),
+    ...(getCurrentSessionLink(ctx)?.wsCursor ? { sinceCursor: getCurrentSessionLink(ctx)?.wsCursor } : {}),
   }
   transport = new BotRuntimeTransport({
     baseUrl: config.baseUrl,
     workspaceId: config.workspaceId,
     apiKey: config.apiKey,
     hello,
+    beforeHello: () =>
+      Object.assign(
+        hello,
+        presenceBody(reconnectPending || pending || !ctx.isIdle() ? "busy" : "available", undefined, ctx)
+      ),
     reconnectionDelayMaxMs: WS_RECONNECTION_DELAY_MAX_MS,
     fetchTimeoutMs: FETCH_TIMEOUT_MS,
     callbacks: {
@@ -1820,7 +1834,7 @@ function buildClaimInvocationBody(ctx: ExtensionContext): Record<string, unknown
 }
 
 async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvocation | null> {
-  if (!config) return null
+  if (!config || reconnectPending || sessionTearingDown) return null
   const startedAt = Date.now()
   try {
     const body = await request<{ data: (ClaimedInvocation & { sealedContext?: unknown }) | null }>(
@@ -2005,74 +2019,74 @@ async function completeInvocationWithMarkdown(
   invocation: ClaimedInvocation,
   finalMessageMarkdown: string,
   ctx?: ExtensionContext
-): Promise<void> {
-  if (!config) return
+): Promise<boolean> {
+  if (!config) return false
   const instanceId = getInvocationInstanceId(invocation)
-
-  // Sealed session-control ack: on an E2E scratchpad the claim carries the SSK
-  // wraps, so seal the "Model changed …" confirmation under the stream key and
-  // post it as `sealedReply`. No plaintext trace step (the server would reject
-  // it, and it'd leak the ack text). Falls through to the plaintext path when
-  // the bot can't seal (no wrap / key race) — which silently closes on E2E.
-  const sealedReply = await sealSessionControlAck(invocation, finalMessageMarkdown)
-  if (sealedReply) {
-    await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
-      method: "POST",
-      body: JSON.stringify({
-        instanceId,
-        claimToken: invocation.claimToken,
-        sealedReply,
-        metadata: {
-          "pi.remote.invocationId": invocation.id,
-          "pi.remote.instanceId": instanceId,
-          "pi.remote.sessionControl": "true",
-        },
-      }),
-    }).catch(() => undefined)
-    lastBusyHeartbeatAt = 0
-    await heartbeat("available", undefined, ctx).catch(() => undefined)
-    return
-  }
-
-  await recordInvocationTraceStep(invocation, "response", finalMessageMarkdown, "Composing response…")
   try {
-    await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
-      method: "POST",
-      body: JSON.stringify({
-        instanceId,
-        claimToken: invocation.claimToken,
-        finalMessageMarkdown,
-        metadata: {
-          "pi.remote.invocationId": invocation.id,
-          "pi.remote.instanceId": instanceId,
-          "pi.remote.sessionControl": "true",
-        },
-      }),
-    })
-  } catch (error) {
-    // Reached only when the ack couldn't be sealed (no BIK / wrap race, so
-    // `sealSessionControlAck` returned undefined). On an E2E scratchpad the
-    // plaintext ack is rejected; close with noResponse so the command doesn't
-    // show as failed — it already ran locally and command:completed still lands.
-    // Any other error is a real failure, so rethrow.
-    if (!String(error).includes("E2E_STREAM_PLAINTEXT_UNSUPPORTED")) throw error
-    await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
-      method: "POST",
-      body: JSON.stringify({
-        instanceId,
-        claimToken: invocation.claimToken,
-        noResponse: true,
-        metadata: {
-          "pi.remote.invocationId": invocation.id,
-          "pi.remote.instanceId": instanceId,
-          "pi.remote.sessionControl": "true",
-          "pi.remote.noResponse": "true",
-        },
-      }),
-    }).catch(() => undefined)
+    const sealedReply = await sealSessionControlAck(invocation, finalMessageMarkdown)
+    if (sealedReply) {
+      try {
+        await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+          method: "POST",
+          body: JSON.stringify({
+            instanceId,
+            claimToken: invocation.claimToken,
+            sealedReply,
+            metadata: {
+              "pi.remote.invocationId": invocation.id,
+              "pi.remote.instanceId": instanceId,
+              "pi.remote.sessionControl": "true",
+            },
+          }),
+        })
+      } catch {
+        return false
+      }
+      return true
+    }
+
+    await recordInvocationTraceStep(invocation, "response", finalMessageMarkdown, "Composing response…")
+    try {
+      await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+        method: "POST",
+        body: JSON.stringify({
+          instanceId,
+          claimToken: invocation.claimToken,
+          finalMessageMarkdown,
+          metadata: {
+            "pi.remote.invocationId": invocation.id,
+            "pi.remote.instanceId": instanceId,
+            "pi.remote.sessionControl": "true",
+          },
+        }),
+      })
+    } catch (error) {
+      if (!String(error).includes("E2E_STREAM_PLAINTEXT_UNSUPPORTED")) throw error
+      try {
+        await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+          method: "POST",
+          body: JSON.stringify({
+            instanceId,
+            claimToken: invocation.claimToken,
+            noResponse: true,
+            metadata: {
+              "pi.remote.invocationId": invocation.id,
+              "pi.remote.instanceId": instanceId,
+              "pi.remote.sessionControl": "true",
+              "pi.remote.noResponse": "true",
+            },
+          }),
+        })
+      } catch {
+        return false
+      }
+    }
+    return true
+  } finally {
+    lastBusyHeartbeatAt = 0
+    const busy = reconnectPending || pending !== undefined || (ctx !== undefined && !ctx.isIdle())
+    await heartbeat(busy ? "busy" : "available", busy ? "Busy in Pi…" : undefined, ctx).catch(() => undefined)
   }
-  lastBusyHeartbeatAt = 0
-  await heartbeat("available", undefined, ctx).catch(() => undefined)
 }
 
 async function buildInvocationPrompt(
@@ -2537,6 +2551,66 @@ async function runKickCommand(invocation: ClaimedInvocation, ctx: ExtensionConte
   await completeInvocationWithMarkdown(invocation, "Kicked the linked Pi session.", ctx)
 }
 
+interface ReconnectCommandDeps {
+  available: () => boolean
+  prepare: typeof prepareHarnessReconnect
+  complete: typeof completeInvocationWithMarkdown
+  heartbeat?: typeof heartbeat
+}
+
+async function runReconnectCommand(
+  invocation: ClaimedInvocation,
+  args: string,
+  ctx: ExtensionContext,
+  deps: ReconnectCommandDeps = {
+    available: harnessReconnectAvailable,
+    prepare: prepareHarnessReconnect,
+    complete: completeInvocationWithMarkdown,
+    heartbeat,
+  }
+): Promise<void> {
+  const sendHeartbeat = deps.heartbeat ?? heartbeat
+  if (args !== "" && args !== "--force") {
+    await deps.complete(invocation, "Usage: `/reconnect [--force]`.", ctx)
+    return
+  }
+  if (args !== "--force" && (!ctx.isIdle() || pending)) {
+    await deps.complete(invocation, "Pi is busy; retry when idle or use `/reconnect --force`.", ctx)
+    return
+  }
+  const link = getCurrentSessionLink(ctx)
+  const lifecycleGeneration = sessionLifecycleGeneration
+  if (!process.env.TMUX_PANE || !link?.rootStreamId || !deps.available() || sessionTearingDown) {
+    throw new Error("Harness reconnect is unavailable for this session.")
+  }
+  const start = deps.prepare(getRuntimeSessionId(ctx), link.rootStreamId, { force: args === "--force" })
+  reconnectPending = true
+  await sendHeartbeat("busy", "Reconnect handoff…", ctx).catch(() => undefined)
+  try {
+    const acknowledged = await deps.complete(
+      invocation,
+      "Reconnect request accepted; attempting to resume the linked Pi session.",
+      ctx
+    )
+    const lifecycleChanged =
+      sessionTearingDown || sessionLifecycleGeneration !== lifecycleGeneration || getCurrentSessionLink(ctx) !== link
+    if (!acknowledged || lifecycleChanged) {
+      reconnectPending = false
+      if (!lifecycleChanged) {
+        await sendHeartbeat(ctx.isIdle() && !pending ? "available" : "busy", undefined, ctx).catch(() => undefined)
+      }
+      return
+    }
+    start()
+  } catch (error) {
+    reconnectPending = false
+    if (!sessionTearingDown && sessionLifecycleGeneration === lifecycleGeneration) {
+      await sendHeartbeat(ctx.isIdle() && !pending ? "available" : "busy", undefined, ctx).catch(() => undefined)
+    }
+    throw error
+  }
+}
+
 async function runStopCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
   const hadPendingRemoteInvocation = pending !== undefined
   const wasBusy = !ctx.isIdle()
@@ -2665,13 +2739,17 @@ async function handleSessionControlInvocation(
       case "carry-on":
         await runCarryOnCommand(invocation, command.args, ctx)
         return
+      case "reconnect":
+        await runReconnectCommand(invocation, command.args, ctx)
+        return
       default:
         await failInvocation(invocation, `Unsupported session-control command: ${command.name}`)
     }
   } catch (error) {
     await failInvocation(invocation, error)
     lastBusyHeartbeatAt = 0
-    await heartbeat("available", undefined, ctx).catch(() => undefined)
+    const busy = reconnectPending || pending !== undefined || !ctx.isIdle()
+    await heartbeat(busy ? "busy" : "available", busy ? "Busy in Pi…" : undefined, ctx).catch(() => undefined)
   } finally {
     clearInterval(renewTimer)
   }
@@ -2731,8 +2809,17 @@ async function executeProviderRetry(pi: ExtensionAPI, ctx: ExtensionContext, att
   pi.sendUserMessage(buildRetryPrompt(prompt, queued))
 }
 
-async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boolean> {
-  if (!config || !isEnabled(ctx)) return false
+function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boolean> {
+  if (sessionTearingDown) return Promise.resolve(false)
+  claimIfIdleInFlight ??= claimIfIdlePass(pi, ctx, sessionLifecycleGeneration).finally(() => {
+    claimIfIdleInFlight = undefined
+  })
+  return claimIfIdleInFlight
+}
+
+async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycleGeneration: number): Promise<boolean> {
+  if (!config || !isEnabled(ctx) || sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration)
+    return false
   if (pending) await renewActiveClaims()
 
   if (isWaitingForRetry) {
@@ -2742,13 +2829,21 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boo
     // /carry-on and /steer queue text for it, and plain messages fold in like
     // a steer sweep (N messages → the one retried response). Without this the
     // session is deaf until the retry fires.
-    for (let claimedCount = 0; claimedCount < STEER_DRAIN_LIMIT; claimedCount++) {
+    for (
+      let claimedCount = 0;
+      claimedCount < STEER_DRAIN_LIMIT && !sessionTearingDown && lifecycleGeneration === sessionLifecycleGeneration;
+      claimedCount++
+    ) {
       const invocation = await claimNextInvocation(ctx)
+      if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) {
+        if (invocation) await failInvocation(invocation, "Pi session lifecycle changed while claiming")
+        return false
+      }
       if (!invocation) break
       if (isSessionControlInvocation(invocation)) {
         await handleSessionControlInvocation(pi, ctx, invocation)
         // A /stop cancelled the wait (and possibly the turn) — stop sweeping.
-        if (!isWaitingForRetry) break
+        if (!isWaitingForRetry || reconnectPending) break
       } else {
         const text = invocation.promptMarkdown.trim() || "(empty message)"
         await recordTraceStep("steer", `Queued while rate-limited:\n\n${text}`, "Queued for retry…").catch(
@@ -2771,16 +2866,24 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boo
     return true
   }
 
-  for (let claimedCount = 0; claimedCount < STEER_DRAIN_LIMIT; claimedCount++) {
+  for (
+    let claimedCount = 0;
+    claimedCount < STEER_DRAIN_LIMIT && !sessionTearingDown && lifecycleGeneration === sessionLifecycleGeneration;
+    claimedCount++
+  ) {
     const steer = pending !== undefined || !ctx.isIdle()
     if (steer) await heartbeatBusyIfStale(pending ? "Working on Threa invocation…" : "Busy in Pi…", ctx)
 
     const invocation = await claimNextInvocation(ctx)
+    if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) {
+      if (invocation) await failInvocation(invocation, "Pi session lifecycle changed while claiming")
+      return false
+    }
     if (!invocation) return true
     if (isSessionControlInvocation(invocation)) {
       const command = resolveSessionControlCommand(invocation)
       await handleSessionControlInvocation(pi, ctx, invocation)
-      if (command?.name === "stop") return true
+      if (command?.name === "stop" || reconnectPending) return true
     } else {
       await injectInvocation(pi, ctx, invocation, steer)
     }
@@ -3354,6 +3457,9 @@ export const __testing = {
   setConfigForTesting: (value: unknown) => {
     config = value as Config | undefined
   },
+  setSupervisedRevivalBlockedForTesting: (value: boolean) => {
+    supervisedRevivalBlocked = value
+  },
   buildClaimInvocationPayload,
   buildPersistedConfig,
   buildRuntimeCapabilities,
@@ -3400,9 +3506,21 @@ export const __testing = {
     stopClaimRenewTimer()
     pending = undefined
     steeredInvocations = []
+    reconnectPending = false
+    claimIfIdleInFlight = undefined
+    sessionLifecycleGeneration++
+    sessionTearingDown = false
   },
   NO_SOCKET_POLL_CAP_MS,
   nextQuietPollMs,
+  completeInvocationWithMarkdown,
+  claimNextInvocation,
+  claimIfIdle,
+  runReconnectCommand,
+  reconnectPending: () => reconnectPending,
+  sessionLifecycleGeneration: () => sessionLifecycleGeneration,
+  sessionTearingDown: () => sessionTearingDown,
+  teardownTransport,
   resetQuietPollsForTesting: () => {
     consecutiveQuietPolls = 0
   },
@@ -3536,8 +3654,11 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("session_start", async (event, ctx) => {
-    config = readConfig()
-    if (!config) return
+    if (!config) config = readConfig()
+    if (!config || !shouldHandleSessionEvents(ctx)) return
+    sessionLifecycleGeneration++
+    reconnectPending = false
+    sessionTearingDown = false
     if (!isCurrentSessionEnabled(ctx)) {
       setRemoteStatus(ctx, getCurrentSessionLink(ctx) ? "Threa remote: off" : "Threa remote: not linked")
       return
@@ -3678,11 +3799,16 @@ export default function (pi: ExtensionAPI): void {
     // In-process Pi child sessions can discover this global extension. Never
     // let an unlinked child tear down or complete the linked parent's claim.
     if (!shouldHandleSessionEvents(ctx)) return
+    sessionTearingDown = true
+    sessionLifecycleGeneration++
+    reconnectPending = false
     stopPolling()
     stopClaimRenewTimer()
+    await claimIfIdleInFlight?.catch(() => undefined)
     teardownTransport()
     if (event.reason === "reload" && config && isEnabled(ctx)) {
       setRemoteStatus(ctx, "Threa remote: reloading…")
+      await heartbeat("offline", undefined, ctx).catch(() => undefined)
       return
     }
     await failPending("Pi session shut down", ctx)


### PR DESCRIPTION
## Problem

PR #1512 adds reachable reconnect for Claude through RemoteSession, but Pi owns a separate polling, sealed-ack, presence, and lifecycle loop. Combining both runtimes in one PR exceeded the review budget and obscured Pi-specific shutdown races.

## Solution

Add reachable `/reconnect [--force]` to Pi as its own stack layer:

- Advertise only when the Pi session is linked in tmux with an exact root/runtime and installed harness helper.
- Validate only empty args or exact `--force`; default refuses busy Pi.
- Prepare exact runtime/root routing before acknowledgement and start the shared detached helper only after real plaintext or sealed completion succeeds.
- Serialize poll/socket claim drains and hold `reconnectPending` so an accepted handoff remains busy/nonaccepting and claims no more work.
- Recheck lifecycle/link ownership after acknowledgement; shutdown or reload races never start replacement.
- Explicitly close a claim returned after teardown rather than leaving its 120-second lease outstanding.
- Successful detached start has no automatic fallback: the old process remains nonaccepting until replacement. Async failure is fail-closed in the private reconnect log, and the orchestrator/operator restarts Pi.
- Route Pi reconnect through its busy-claimable capability; Claude and other routing remain unchanged.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/commands/handlers.ts` | Pi-only busy-claimable reconnect routing |
| `apps/backend/src/features/commands/routing.test.ts` | Pi reconnect and unchanged Claude/other routing regressions |
| `extensions/pi-remote/src/threa-remote.ts` | Capability, exact command handling, ack ordering, claim serialization, and teardown guard |
| `extensions/pi-remote/src/threa-remote.test.ts` | Plain/sealed ack, busy/force, claim and lifecycle regressions with no real network |
| `extensions/pi-remote/install-local.ts` | Vendor shared reconnect helper |
| `extensions/pi-remote/README.md` | Reachable Pi reconnect contract and no-fallback tradeoff |

## Test plan

- [x] Pi remote — 115 passed with unmocked network detector at zero
- [x] Bot-runtime client — 64 passed
- [x] Harness daemon — 83 passed
- [x] Backend unit — 3,462 passed
- [x] Isolated backend E2E — 367 passed
- [x] Backend focused commands — 6 passed
- [x] Fresh Pi install/import smoke
- [x] Monorepo and relevant package typechecks, lint, Prettier, Dockerfile/migration checks, and `git diff --check`
- [x] Two Sol/high adversarial rounds, approved no-fallback simplification, and post-PR review clean at 7/7

<details>
<summary>📋 Full implementation plan</summary>

# Live runtime reconnect and safe keys

Status: ratified 2026-07-22.

This replaces the abandoned broad reconnect prototype preserved under `.tmp/oversized-reconnect-*`.

## Goal

Add small, truthful controls for live Threa-linked Pi and Claude sessions:

- `/reconnect [--force]` replaces a live runtime process in the same tmux pane and resumes the same native session.
- `/key <name>` sends one allowlisted tmux key to the exact live pane.

This feature is intentionally limited to channels that remain connected long enough to claim and acknowledge the command. It is not an offline supervisor.

## Shared invariants

- Target the exact routed `instanceId`, `runtimeSessionId`, and root stream.
- Inventory remains authoritative when an exact managed row exists; exact live-pane discovery may supplement it without adoption.
- Missing, ambiguous, stale, or unsupported identity fails closed.
- Never pick the newest session, transcript, pane, or inventory row.
- Preserve cwd, tmux pane/window/session, native runtime session, Threa runtime identity, channel, and the narrow supported launch policy.
- Perform same-root preflight with `ifArchived: wait` and `ifMissing: error` before replacement.
- Never create, replace, revive, or unarchive a scratchpad.
- Never launch a fresh native session as fallback.
- Complete the Threa command acknowledgement before a detached reconnect starts.
- Reconnect acknowledgement says it was accepted, not that the replacement already connected.
- Standalone discovery never writes harness inventory.

## Narrow launch contracts

### Pi

Support only exact Threa Pi forms:

```text
pi --session-id <uuid>
```

The executable may be an absolute path. A leading `env` is allowed only for explicit Threa runtime/instance identity and the existing harness entrypoint/Bun variables, using ordinary values without shell metacharacters. Unknown options, positional prompts, duplicate session IDs, arguments after `--`, exotic shell-dependent values, and unrelated environment assignments fail before tmux is touched.

The native Pi session ID is the validated `--session-id` UUID. No title or recency fallback exists.

### Claude

Support only the ordinary Threa/channel helper form:

- executable basename `claude`;
- optional exact `--name threa.<name>`;
- exactly one `--dangerously-load-development-channels server:<channel>`;
- optional `--dangerously-skip-permissions`;
- optional one file-backed `--mcp-config <path>`;
- optional explicit `THREA_INSTANCE_ID` and `THREA_RUNTIME_SESSION_ID` assignments;
- no positional prompt or arguments after `--`.

Unknown options, inline/variadic MCP JSON, multiple MCP configs, custom config directories, and unrelated environment assignments fail before tmux is touched. Named global channel registration is reused as named; reconnect does not copy or materialize MCP configuration.

Claude native identity comes only from the live `~/.claude/sessions/<pane_pid>.json` registry. Require matching PID, process start, canonical cwd, optional parsed name, valid UUID, idle status unless forced, and existing exact transcript. No dead-process or newest-transcript fallback exists.

## Shared process replacement

The complete replacement command is built and all identity/pane facts are pinned before mutation. Immediately before mutation, revalidate pane ID, PID, cwd, start command, and native identity.

Use exactly:

```text
tmux respawn-pane -k -t <pane-id> -c <cwd> <shell-quoted-command>
```

This keeps pane/window/session identity and avoids kill/wait/recreate, anchor windows, durable descriptors, and retry machinery.

After successful respawn, bounded local verification may confirm a live process with the same native session and cwd. Failure is logged and never falls back to a fresh session.

## PR stack

This is an actual GitHub stack above PR #1501, managed with non-interactive `gh stack` commands.

### PR 1 — Live Pi reconnect primitive

Deliverables:

- Exact Pi launch parser and native session extraction.
- Exact managed-first/live-standalone pane resolution without inventory adoption.
- Small shared `tmux respawn-pane` helper.
- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` for Pi targets.
- Same-root preflight and generation revalidation.
- CLI/README documentation.

Required tests:

- exact managed and standalone Pi forms;
- malformed UUID, duplicate ID, unknown option/env/positional/`--` rejection;
- missing or ambiguous pane rejection;
- preflight failure and generation change leave pane untouched;
- exact respawn arguments preserve cwd/pane/session ID/Threa identity;
- failure never launches fresh or writes inventory.

Implementation budget: 250–500 lines excluding focused tests. Inventory schema changes, persistent descriptors, runtime extension lifecycle changes, or generic supervisor infrastructure require a plan checkpoint.

### PR 2 — Live Claude reconnect primitive

Deliverables:

- Reuse PR 1's replacement/preflight path.
- Strict live Claude registry resolver with injectable tests.
- Narrow Claude launch parser/reconstructor.
- Managed-first/live-standalone Claude targeting without inventory adoption.
- Same native UUID resume and bounded replacement verification.

Required tests:

- current managed and standalone helper launch forms;
- malformed/stale registry, PID reuse, cwd/name/transcript/status mismatch;
- `--force` behavior;
- unsupported option/env/MCP/`--` rejection;
- preflight and generation races leave pane untouched;
- exact `claude --resume <same-uuid>` respawn;
- no fresh launch or inventory writes on failure.

Implementation budget: 250–500 lines excluding focused tests. Do not add dead-session recovery, descriptor persistence, config-dir abstraction, policy snapshots, or extension-side reconnect evidence.

### PR 3 — Reachable Claude `/reconnect`

Deliverables:

- Canonical command catalog and Claude capability advertisement.
- Empty args or exact `--force` validation.
- Minimal optional post-ack action in remote-session command handling.
- Seal acknowledgement first, suspend claims through handoff, then spawn detached harnessd with exact runtime/root IDs.
- Truthful copy and docs explaining the reachable-channel limitation.

Required tests:

- command advertised only where locally supported;
- routed runtime/root IDs and force flag reach harnessd exactly;
- acknowledgement completion precedes helper spawn;
- failed acknowledgement never spawns;
- preparation failure is returned before acknowledgement;
- existing sealed command completion remains intact;
- shutdown/archive/new-work races never launch or claim across handoff.

Implementation budget: 200–400 lines excluding tests. No Pi polling lifecycle, backend outbox, supervisor delivery, or offline recovery.

### PR 4 — Reachable Pi `/reconnect`

Deliverables:

- Pi capability advertisement and empty/exact `--force` validation.
- Prepare before acknowledgement; spawn the shared detached harness helper only after real sealed/plain completion.
- Serialize Pi claim drains and hold busy/nonaccepting presence through acknowledgement and replacement handoff.
- Default refuses when Pi is busy; `--force` permits replacement while retaining the same handoff guard.
- After successful detached start, the old Pi process stays nonaccepting until replacement; there is no automatic fallback. If the helper later fails, the private log records it and the orchestrator/manual operator restarts Pi.
- Route reconnect through Pi's busy-claimable capability without changing other runtimes.

Required tests:

- exact runtime/root/force arguments and install packaging;
- idle refusal/force behavior;
- sealed/plain ack ordering and failed ack/start paths;
- concurrent poll/socket claims serialize;
- accepted handoff never advertises available or claims more work;
- shutdown/reload races never start reconnect or claim after teardown; a claim returned during teardown is closed explicitly;
- successful handoff has no timer that can restore old-process presence or claims.

Implementation budget: 200–400 lines excluding tests. No RemoteSession/Claude changes, offline supervisor, or outbox.

### PR 5 — Allowlisted `/key`

Deliverables:

- `/key <name>` for reachable supported Pi and Claude tmux sessions.
- Initial allowlist only: `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, `ctrl-u`.
- Exact pane re-resolution immediately before one `tmux send-keys` call.
- No raw text, key sequences, repeat counts, arbitrary tmux syntax, or shell interpolation.
- Canonical catalog/capability/docs updates.

Required tests:

- every allowed name maps to one exact tmux token;
- casing/aliases/extra args/unknown values fail;
- ambiguity/stale generation leaves pane untouched;
- command sends exactly once to the routed runtime pane;
- acknowledgement is truthful and sealed through the normal command path.

Implementation budget: 150–300 lines excluding tests.

## Binding exclusions

- Fully disconnected/offline command recovery.
- Supervisor outbox/control jobs.
- Dead-process or transcript-only reconnect.
- Durable standalone reconnect descriptors or retry after failed replacement.
- Arbitrary Claude/Pi launch-policy reconstruction.
- Inline or multiple MCP configs.
- `CLAUDE_CONFIG_DIR` support.
- Inventory schema changes or legacy inventory migration.
- New frontend runtime state or overview UI.
- `/type`, raw text entry, arbitrary keys, repeats, or key sequences.
- Starting a fresh native session.
- Creating, replacing, reviving, or unarchiving scratchpads.

## Build protocol

Use `build-feature` with these binding overrides:

- implementer: GPT-5.6 Sol, effort `minimal`, Pi harness only;
- adversarial verifier: GPT-5.6 Sol, effort `high`, Pi harness only;
- per-PR reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- whole-stack reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- do not use Fable, Claude Code, Claude Agent SDK, or any Claude-backed harness;
- use actual `gh stack` branches/PRs and `gh stack submit --auto`/`gh stack view --json`;
- per PR: brief -> implement -> adversarial verify -> fix/reverify -> commit -> stacked PR -> review.

Scope controls:

- Copy binding exclusions and the current PR's implementation budget into every agent brief.
- Classify every review finding as `in-scope` or `follow-up` before fixing it.
- A fix that adds a deferred subsystem, exceeds the budget, or broadens supported launch policy requires a human plan checkpoint.
- After two fix/reverify rounds without a clean result, stop and report concrete remaining findings instead of continuing automatically.
- Agents receive only the current chunk brief plus paths to relevant source/plan files, not an invitation to redesign the whole stack.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787383913&installation_model_id=20758&pr_number=1516&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1516&signature=95f10fbced83270d0a6408cd619f80bdce4c54cb555f26e8b550b0fdb8066406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
