### PR TITLE
feat: add allowlisted session keys

### DIFF
--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -20,6 +20,7 @@ export const SESSION_CONTROL_COMMAND_NAMES = [
   "run",
   "carry-on",
   "reconnect",
+  "key",
 ] as const
 export type SessionControlCommandName = (typeof SESSION_CONTROL_COMMAND_NAMES)[number]
 
@@ -141,6 +142,13 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "--force", required: false, description: "Reconnect despite local runtime activity" }],
+    },
+    {
+      name: "key",
+      description: "Send one allowed key to the linked live session",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+      args: [{ name: "key", required: true, description: "Allowed key name" }],
     },
   ]
 }

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -37,7 +37,7 @@ export function resolveRuntimeInvocationRouting(
     commandName === "stop" ||
     commandName === "kick" ||
     commandName === "carry-on" ||
-    (commandName === "reconnect" && runtimeKind === BotRuntimeKinds.PI_LOCAL)
+    ((commandName === "reconnect" || commandName === "key") && runtimeKind === BotRuntimeKinds.PI_LOCAL)
   ) {
     // Pi advertises `active-scratchpad` while busy. The Claude Code channel
     // instead advertises only `session-control` while busy, so its interrupts

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -4,7 +4,7 @@ import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
   it("routes interrupt commands to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "key"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -13,7 +13,7 @@ describe("resolveRuntimeInvocationRouting", () => {
   })
 
   it("routes interrupt commands to session-control for the Claude Code channel (so a busy channel still claims control)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "key"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.CLAUDE_CODE_CHANNEL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -1,4 +1,12 @@
 export { BotRuntimeTransport } from "./transport"
+export {
+  parseAllowedTmuxKey,
+  sendAllowedTmuxKey,
+  TMUX_KEY_TOKENS,
+  TmuxKeyError,
+  type AllowedTmuxKey,
+  type TmuxKeyFailureCode,
+} from "./tmux-key"
 export { harnessDaemonEntrypoint, runHarnessKick, type HarnessKickResult } from "./harness-kick"
 export {
   harnessReconnectAvailable,

--- a/extensions/bot-runtime-client/src/tmux-key.test.ts
+++ b/extensions/bot-runtime-client/src/tmux-key.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { parseAllowedTmuxKey, sendAllowedTmuxKey, TMUX_KEY_TOKENS } from "./tmux-key"
+
+const originalPane = process.env.TMUX_PANE
+afterEach(() => {
+  if (originalPane === undefined) delete process.env.TMUX_PANE
+  else process.env.TMUX_PANE = originalPane
+})
+
+function result(stdout = "", status = 0) {
+  return { stdout, stderr: "", status, signal: null, pid: 1, output: [], error: undefined } as any
+}
+
+describe("allowlisted tmux keys", () => {
+  it("maps all and only the initial names to fixed tmux tokens", () => {
+    expect(TMUX_KEY_TOKENS).toEqual({
+      escape: "Escape",
+      enter: "Enter",
+      up: "Up",
+      down: "Down",
+      left: "Left",
+      right: "Right",
+      tab: "Tab",
+      backspace: "BSpace",
+      "ctrl-c": "C-c",
+      "ctrl-d": "C-d",
+      "ctrl-u": "C-u",
+    })
+    for (const name of Object.keys(TMUX_KEY_TOKENS))
+      expect(parseAllowedTmuxKey(name)).toBe(name as keyof typeof TMUX_KEY_TOKENS)
+  })
+
+  it("rejects aliases, casing, whitespace, multiple args, unknown names, and tmux-like tokens", () => {
+    for (const value of ["esc", "Escape", " enter", "enter ", "enter down", "space", "C-c", "-t", "%2", ""]) {
+      expect(parseAllowedTmuxKey(value)).toBeUndefined()
+    }
+  })
+
+  it("inspects exact self target then sends one fixed token", () => {
+    process.env.TMUX_PANE = "%7"
+    const calls: unknown[][] = []
+    const spawn = ((...args: unknown[]) => {
+      calls.push(args)
+      return calls.length === 1 ? result("%7\t4242\t0\n") : result()
+    }) as any
+
+    sendAllowedTmuxKey("ctrl-c", 4242, spawn)
+
+    expect(calls).toEqual([
+      ["tmux", ["display-message", "-p", "-t", "%7", "#{pane_id}\t#{pane_pid}\t#{pane_dead}"], { encoding: "utf8" }],
+      ["tmux", ["send-keys", "-t", "%7", "C-c"], { encoding: "utf8" }],
+    ])
+  })
+
+  it("does not send when pane inspection fails", () => {
+    process.env.TMUX_PANE = "%7"
+    let calls = 0
+    const spawn = (() => {
+      calls++
+      return result("", 1)
+    }) as any
+    expect(() => sendAllowedTmuxKey("enter", 4242, spawn)).toThrow("could not inspect tmux pane")
+    expect(calls).toBe(1)
+  })
+
+  it("reports a send failure after exactly one fixed send call", () => {
+    process.env.TMUX_PANE = "%7"
+    let calls = 0
+    const spawn = (() => {
+      calls++
+      return calls === 1 ? result("%7\t4242\t0\n") : result("", 1)
+    }) as any
+    expect(() => sendAllowedTmuxKey("tab", 4242, spawn)).toThrow("could not send key")
+    expect(calls).toBe(2)
+  })
+
+  it("never sends for missing, failed, stale, dead, malformed, or wrong-PID inspection", () => {
+    const cases = [
+      { pane: undefined, inspection: "%7\t4242\t0\n" },
+      { pane: "%7", inspection: "%8\t4242\t0\n" },
+      { pane: "%7", inspection: "%7\t4243\t0\n" },
+      { pane: "%7", inspection: "%7\t4242\t1\n" },
+      { pane: "%7", inspection: "%7\t4242\t0\textra\n" },
+    ]
+    for (const testCase of cases) {
+      if (testCase.pane) process.env.TMUX_PANE = testCase.pane
+      else delete process.env.TMUX_PANE
+      const calls: unknown[][] = []
+      const spawn = ((...args: unknown[]) => {
+        calls.push(args)
+        return result(testCase.inspection)
+      }) as any
+      expect(() => sendAllowedTmuxKey("enter", 4242, spawn)).toThrow()
+      expect(calls.length).toBe(testCase.pane ? 1 : 0)
+    }
+  })
+})

--- a/extensions/bot-runtime-client/src/tmux-key.ts
+++ b/extensions/bot-runtime-client/src/tmux-key.ts
@@ -1,0 +1,67 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+
+export const TMUX_KEY_TOKENS = {
+  escape: "Escape",
+  enter: "Enter",
+  up: "Up",
+  down: "Down",
+  left: "Left",
+  right: "Right",
+  tab: "Tab",
+  backspace: "BSpace",
+  "ctrl-c": "C-c",
+  "ctrl-d": "C-d",
+  "ctrl-u": "C-u",
+} as const
+
+export type AllowedTmuxKey = keyof typeof TMUX_KEY_TOKENS
+export type TmuxKeyFailureCode = "target_unavailable" | "inspection_failed" | "identity_changed" | "send_failed"
+
+export class TmuxKeyError extends Error {
+  constructor(
+    readonly code: TmuxKeyFailureCode,
+    message: string
+  ) {
+    super(message)
+    this.name = "TmuxKeyError"
+  }
+}
+
+type Spawn = (command: string, args: string[], options: { encoding: "utf8" }) => SpawnSyncReturns<string>
+
+export function parseAllowedTmuxKey(args: string): AllowedTmuxKey | undefined {
+  return Object.hasOwn(TMUX_KEY_TOKENS, args) ? (args as AllowedTmuxKey) : undefined
+}
+
+function resolveInspectedPane(output: string, target: string, expectedPid: number): string {
+  const fields = output.match(/^([^\t\r\n]+)\t([1-9]\d*)\t([01])\n?$/)
+  if (!fields) throw new TmuxKeyError("identity_changed", "tmux pane inspection was malformed")
+
+  const [, paneId, panePid, paneDead] = fields
+  if (paneId !== target) throw new TmuxKeyError("identity_changed", "tmux pane id changed")
+  if (panePid !== String(expectedPid)) {
+    throw new TmuxKeyError("identity_changed", "tmux pane process changed")
+  }
+  if (paneDead !== "0") throw new TmuxKeyError("identity_changed", "tmux pane is dead")
+  return paneId
+}
+
+export function sendAllowedTmuxKey(key: AllowedTmuxKey, expectedPid: number, spawn: Spawn = spawnSync): void {
+  const target = process.env.TMUX_PANE
+  if (!target || !Number.isSafeInteger(expectedPid) || expectedPid <= 0) {
+    throw new TmuxKeyError("target_unavailable", "tmux pane is unavailable")
+  }
+
+  const inspected = spawn("tmux", ["display-message", "-p", "-t", target, "#{pane_id}\t#{pane_pid}\t#{pane_dead}"], {
+    encoding: "utf8",
+  })
+  if (inspected.error || inspected.status !== 0) {
+    throw new TmuxKeyError("inspection_failed", "could not inspect tmux pane")
+  }
+  const paneId = resolveInspectedPane(inspected.stdout, target, expectedPid)
+
+  const sent = spawn("tmux", ["send-keys", "-t", paneId, TMUX_KEY_TOKENS[key]], { encoding: "utf8" })
+  if (sent.error || sent.status !== 0) {
+    throw new TmuxKeyError("send_failed", "could not send key to tmux pane")
+  }
+}

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -111,6 +111,8 @@ Open the scratchpad in Threa and type a message. No `@`-mention needed: the bot 
 
 For harness-managed sessions, `/kick` asks harnessd to send Enter to the session's recorded tmux pane. Use it to accept or move past a blocking Claude Code prompt without opening the terminal. `/reconnect [--force]` is offered only while the exact linked Claude runtime is live in tmux; after acknowledging, it asks harnessd to replace the pane process and resume the same native session. It is not offline recovery and is unavailable after the channel disconnects.
 
+`/key <name>` sends one key to the exact live linked Claude pane. Allowed names are `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, and `ctrl-u`. Names are case-sensitive; text, aliases, sequences, and repeats are rejected.
+
 ## Permission relay
 
 Away from the terminal, a tool that needs approval would normally stall the session. With `THREA_PERMISSION_RELAY=1` (default), the approval prompt is posted into the scratchpad as a message:

--- a/extensions/claude-code-remote/install-local.ts
+++ b/extensions/claude-code-remote/install-local.ts
@@ -36,6 +36,7 @@ const VENDORED = [
       "supervisor.ts",
       "harness-kick.ts",
       "harness-reconnect.ts",
+      "tmux-key.ts",
     ],
     dir: "bot-runtime-client",
   },

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -5,6 +5,8 @@ import {
   harnessReconnectAvailable,
   prepareHarnessReconnect,
   runHarnessKick,
+  parseAllowedTmuxKey,
+  sendAllowedTmuxKey,
   type BotRuntimeTransport,
 } from "@threa/bot-runtime-client"
 import {
@@ -54,6 +56,7 @@ const SESSION_CONTROL_COMMANDS = [
   "reload",
   "carry-on",
   "reconnect",
+  "key",
 ] as const
 // Model options for the composer's arg picker: built-in /model aliases plus
 // whatever the local client's own picker cache discovers (see model-catalog).
@@ -179,7 +182,8 @@ export async function runClaudeCommand(
   stopDelegationsForReconnect?: (force: boolean) => Promise<void>,
   restartDelegationsAfterReset?: () => void,
   reconnectTarget?: () => ReconnectTarget,
-  reconnectReady?: () => boolean
+  reconnectReady?: () => boolean,
+  keySender: typeof sendAllowedTmuxKey = sendAllowedTmuxKey
 ): Promise<{
   ok: boolean
   message: string
@@ -187,6 +191,13 @@ export async function runClaudeCommand(
   onHandoffReset?: () => void
 }> {
   switch (name) {
+    case "key": {
+      const key = parseAllowedTmuxKey(args)
+      if (!key) return { ok: false, message: "Usage: `/key <name>`." }
+      if (!runtimeSessionId || !rootStreamId?.()) throw new Error("Key control is unavailable for this session.")
+      keySender(key, process.ppid)
+      return { ok: true, message: `Sent \`${key}\` to the linked Claude session.` }
+    }
     case "reconnect": {
       if (args !== "" && args !== "--force") {
         return { ok: false, message: "Usage: `/reconnect [--force]`." }
@@ -310,10 +321,14 @@ export function createClaudeSessionControl(
   return {
     get commands() {
       return runtimeSessionId
-        ? SESSION_CONTROL_COMMANDS.filter(
-            (command) => command !== "reconnect" || Boolean(rootStreamId?.() && harnessReconnectAvailable())
+        ? SESSION_CONTROL_COMMANDS.filter((command) => {
+            if (command === "reconnect") return Boolean(rootStreamId?.() && harnessReconnectAvailable())
+            if (command === "key") return Boolean(rootStreamId?.() && process.env.TMUX_PANE?.trim())
+            return true
+          })
+        : SESSION_CONTROL_COMMANDS.filter(
+            (command) => command !== "kick" && command !== "reconnect" && command !== "key"
           )
-        : SESSION_CONTROL_COMMANDS.filter((command) => command !== "kick" && command !== "reconnect")
     },
     modelSuggestions: MODEL_SUGGESTIONS,
     thinkingLevels: [...THINKING_LEVELS],

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -23,6 +23,7 @@ import {
   type RemoteSessionStatusSnapshot,
   type SendResult,
   type SessionControlActuator,
+  type SessionControlInvocationContext,
 } from "@threa/remote-session"
 import { z } from "zod"
 import { CarryOnController } from "./carry-on"
@@ -183,7 +184,8 @@ export async function runClaudeCommand(
   restartDelegationsAfterReset?: () => void,
   reconnectTarget?: () => ReconnectTarget,
   reconnectReady?: () => boolean,
-  keySender: typeof sendAllowedTmuxKey = sendAllowedTmuxKey
+  keySender: typeof sendAllowedTmuxKey = sendAllowedTmuxKey,
+  invocationContext?: SessionControlInvocationContext
 ): Promise<{
   ok: boolean
   message: string
@@ -194,7 +196,11 @@ export async function runClaudeCommand(
     case "key": {
       const key = parseAllowedTmuxKey(args)
       if (!key) return { ok: false, message: "Usage: `/key <name>`." }
-      if (!runtimeSessionId || !rootStreamId?.()) throw new Error("Key control is unavailable for this session.")
+      const currentRootStreamId = rootStreamId?.()
+      if (!runtimeSessionId || !currentRootStreamId) throw new Error("Key control is unavailable for this session.")
+      if (invocationContext?.rootStreamId !== currentRootStreamId) {
+        throw new Error("Key control request no longer matches the linked scratchpad.")
+      }
       keySender(key, process.ppid)
       return { ok: true, message: `Sent \`${key}\` to the linked Claude session.` }
     }
@@ -348,7 +354,7 @@ export function createClaudeSessionControl(
       if (absorbed !== undefined) return true
       return steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`)
     },
-    runCommand: (name, args) =>
+    runCommand: (name, args, context) =>
       runClaudeCommand(
         name,
         args,
@@ -360,7 +366,9 @@ export function createClaudeSessionControl(
         stopDelegationsForReconnect,
         restartDelegationsAfterReset,
         reconnectTarget,
-        reconnectReady
+        reconnectReady,
+        sendAllowedTmuxKey,
+        context
       ),
   }
 }

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -221,22 +221,72 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     await expect(outcome.afterAck?.()).rejects.toBe(releaseError)
     outcome.onHandoffReset?.()
     expect(resets).toBe(1)
+  })
+
   it("sends one exact allowed key using Claude's parent PID", async () => {
     const sends: unknown[][] = []
-    const outcome = await runClaudeCommand("key", "ctrl-d", undefined, "runtime", undefined, () => "root", undefined, ((
-      ...args: unknown[]
-    ) => sends.push(args)) as any)
+    const outcome = await runClaudeCommand(
+      "key",
+      "ctrl-d",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ((...args: unknown[]) => sends.push(args)) as any,
+      { rootStreamId: "root" }
+    )
     expect({ outcome, sends }).toEqual({
       outcome: { ok: true, message: "Sent `ctrl-d` to the linked Claude session." },
       sends: [["ctrl-d", process.ppid]],
     })
   })
 
+  it("rejects a key claimed for root A after relinking to root B without sending", async () => {
+    const sends: unknown[][] = []
+    await expect(
+      runClaudeCommand(
+        "key",
+        "enter",
+        undefined,
+        "runtime",
+        undefined,
+        () => "root-b",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ((...args: unknown[]) => sends.push(args)) as any,
+        { rootStreamId: "root-a" }
+      )
+    ).rejects.toThrow("Key control request no longer matches the linked scratchpad")
+    expect(sends).toEqual([])
+  })
+
   it("throws when key inspection or send fails", async () => {
     await expect(
-      runClaudeCommand("key", "enter", undefined, "runtime", undefined, () => "root", undefined, (() => {
-        throw new Error("pane inspection failed")
-      }) as any)
+      runClaudeCommand(
+        "key",
+        "enter",
+        undefined,
+        "runtime",
+        undefined,
+        () => "root",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        (() => {
+          throw new Error("pane inspection failed")
+        }) as any,
+        { rootStreamId: "root" }
+      )
     ).rejects.toThrow("pane inspection failed")
     await expect(runClaudeCommand("key", "enter", undefined, undefined, undefined, () => "root")).rejects.toThrow(
       "Key control is unavailable"
@@ -247,9 +297,23 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     for (const args of ["Enter", " enter", "enter ", "enter down", "-t", "%2", "unknown"]) {
       let sent = false
       expect(
-        await runClaudeCommand("key", args, undefined, "runtime", undefined, () => "root", undefined, (() => {
-          sent = true
-        }) as any)
+        await runClaudeCommand(
+          "key",
+          args,
+          undefined,
+          "runtime",
+          undefined,
+          () => "root",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (() => {
+            sent = true
+          }) as any,
+          { rootStreamId: "root" }
+        )
       ).toEqual({ ok: false, message: "Usage: `/key <name>`." })
       expect(sent).toBe(false)
     }

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -67,6 +67,24 @@ describe("createClaudeSessionControl", () => {
     })
   })
 
+  it("advertises key only with exact runtime, root, and a nonempty TMUX_PANE self-target", () => {
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).toContain("key")
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => undefined)!.commands).not.toContain(
+        "key"
+      )
+      expect(createClaudeSessionControl()!.commands).not.toContain("key")
+    })
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0" }, () => {
+      process.env.THREA_TMUX_TARGET = "%9"
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).not.toContain("key")
+    })
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "   " }, () => {
+      process.env.THREA_TMUX_TARGET = "%9"
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).not.toContain("key")
+    })
+  })
+
   it("does not advertise /kick without a harness runtime identity", () => {
     withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
       expect(createClaudeSessionControl()!.commands).toEqual([
@@ -203,6 +221,38 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     await expect(outcome.afterAck?.()).rejects.toBe(releaseError)
     outcome.onHandoffReset?.()
     expect(resets).toBe(1)
+  it("sends one exact allowed key using Claude's parent PID", async () => {
+    const sends: unknown[][] = []
+    const outcome = await runClaudeCommand("key", "ctrl-d", undefined, "runtime", undefined, () => "root", undefined, ((
+      ...args: unknown[]
+    ) => sends.push(args)) as any)
+    expect({ outcome, sends }).toEqual({
+      outcome: { ok: true, message: "Sent `ctrl-d` to the linked Claude session." },
+      sends: [["ctrl-d", process.ppid]],
+    })
+  })
+
+  it("throws when key inspection or send fails", async () => {
+    await expect(
+      runClaudeCommand("key", "enter", undefined, "runtime", undefined, () => "root", undefined, (() => {
+        throw new Error("pane inspection failed")
+      }) as any)
+    ).rejects.toThrow("pane inspection failed")
+    await expect(runClaudeCommand("key", "enter", undefined, undefined, undefined, () => "root")).rejects.toThrow(
+      "Key control is unavailable"
+    )
+  })
+
+  it("rejects malformed key args without sending", async () => {
+    for (const args of ["Enter", " enter", "enter ", "enter down", "-t", "%2", "unknown"]) {
+      let sent = false
+      expect(
+        await runClaudeCommand("key", args, undefined, "runtime", undefined, () => "root", undefined, (() => {
+          sent = true
+        }) as any)
+      ).toEqual({ ok: false, message: "Usage: `/key <name>`." })
+      expect(sent).toBe(false)
+    }
   })
 
   it("fails loudly when /kick has no harness-managed runtime identity", async () => {

--- a/extensions/pi-remote/README.md
+++ b/extensions/pi-remote/README.md
@@ -37,6 +37,8 @@ Then run `/reload` in Pi. Pass a different target dir as the first argument if n
 
 For harness-managed sessions, `/kick` in the linked scratchpad asks harnessd to send Enter to the session's recorded tmux pane, useful when Pi is waiting on a blocking prompt. `/reconnect [--force]` is offered only to a live, linked Pi running in tmux; it acknowledges first, then asks harnessd to replace the pane process and resume the same Pi session. `--force` may bypass only local Pi activity; an owned pending Threa invocation always fails closed and must be cleared with `/stop` first. The command cannot recover a disconnected runtime. Direct `harnessd reconnect` for Pi has no activity signal, so `--force` is currently inert there; this intentionally does not add IPC, status reporting, or another supervisor.
 
+`/key <name>` sends one key to the exact live linked Pi pane. Allowed names are `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, and `ctrl-u`. Names are case-sensitive; text, aliases, sequences, and repeats are rejected.
+
 The script rebuilds `~/.pi/agent/extensions/threa-remote` from scratch each time, so re-running it is the supported way to update.
 
 ### Why a script and not `cp -R` + `bun install`

--- a/extensions/pi-remote/install-local.ts
+++ b/extensions/pi-remote/install-local.ts
@@ -31,6 +31,7 @@ const VENDOR_FILES = [
   "supervisor.ts",
   "harness-kick.ts",
   "harness-reconnect.ts",
+  "tmux-key.ts",
 ]
 
 // 1. Clean any prior install — both the legacy single-file form and the dir form.

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -995,6 +995,86 @@ describe("Pi reconnect session control", () => {
     ).toBe(false)
   })
 
+  test("advertises and sends an allowed key only for the exact link using Pi's PID", async () => {
+    const commands = __testing.buildRuntimeCapabilities(context(true), () => true).sessionControlCommands as string[]
+    expect(commands).toContain("key")
+
+    const sent: unknown[][] = []
+    const messages: string[] = []
+    await __testing.runKeyCommand(invocation, "ctrl-u", context(true), {
+      send: (...args: unknown[]) => sent.push(args),
+      complete: async (_invocation: unknown, message: string) => {
+        messages.push(message)
+        return true
+      },
+    } as never)
+    expect({ sent, messages }).toEqual({
+      sent: [["ctrl-u", process.pid]],
+      messages: ["Sent `ctrl-u` to the linked Pi session."],
+    })
+
+    delete process.env.TMUX_PANE
+    expect(
+      __testing.buildRuntimeCapabilities(context(true), () => true).sessionControlCommands as string[]
+    ).not.toContain("key")
+  })
+
+  test("stale root, instance, or relinked runtime sends no key", async () => {
+    let sends = 0
+    const staleInvocations = [
+      { ...invocation, rootStreamId: "stream-root-stale" },
+      { ...invocation, claimedInstanceId: "pi-instance-stale" },
+    ]
+    for (const staleInvocation of staleInvocations) {
+      await expect(
+        __testing.runKeyCommand(staleInvocation as never, "enter", context(true), {
+          send: () => sends++,
+          complete: async () => true,
+        } as never)
+      ).rejects.toThrow("Key control is unavailable")
+    }
+
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        "runtime-exact": {
+          enabled: true,
+          instanceId: "pi-instance-new",
+          runtimeSessionId: "runtime-exact",
+          rootStreamId: "stream-root-new",
+          activeStreamId: "stream-root-new",
+          streamUrlPath: "/streams/stream-root-new",
+        },
+      },
+    })
+    await expect(
+      __testing.runKeyCommand(invocation, "enter", context(true), {
+        send: () => sends++,
+        complete: async () => true,
+      } as never)
+    ).rejects.toThrow("Key control is unavailable")
+    expect(sends).toBe(0)
+  })
+
+  test("rejects malformed key args without sending", async () => {
+    const messages: string[] = []
+    let sends = 0
+    for (const args of ["Enter", " enter", "enter ", "enter down", "-t", "%2", "unknown"]) {
+      await __testing.runKeyCommand(invocation, args, context(true), {
+        send: () => {
+          sends++
+        },
+        complete: async (_invocation: unknown, message: string) => {
+          messages.push(message)
+          return true
+        },
+      } as never)
+    }
+    expect({ sends, messages }).toEqual({ sends: 0, messages: Array(7).fill("Usage: `/key <name>`.") })
+  })
+
   test("a claim from link A cannot prepare or ack after relinking to B", async () => {
     let prepared = 0
     let acknowledged = 0

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -27,6 +27,8 @@ import {
   parseSealedTurnContext,
   prepareHarnessReconnect,
   runHarnessKick,
+  parseAllowedTmuxKey,
+  sendAllowedTmuxKey,
   scrubSealedError,
   sealReply,
   sealStep,
@@ -102,6 +104,7 @@ const SESSION_CONTROL_COMMANDS = [
   "kick",
   "carry-on",
   "reconnect",
+  "key",
 ] as const
 type PiSessionControlCommandName = (typeof SESSION_CONTROL_COMMANDS)[number]
 const STEER_DRAIN_LIMIT = 10
@@ -696,10 +699,7 @@ function buildModelSuggestions(ctx: ExtensionContext): Array<{ value: string; la
   return ordered.slice(0, 30)
 }
 
-function currentReconnectLink(
-  ctx: ExtensionContext,
-  reconnectAvailable: () => boolean = harnessReconnectAvailable
-): RuntimeSessionLink | undefined {
+function currentSessionControlLink(ctx: ExtensionContext): RuntimeSessionLink | undefined {
   const link = getCurrentSessionLink(ctx)
   if (
     link?.enabled !== true ||
@@ -707,12 +707,19 @@ function currentReconnectLink(
     link.rootStreamId.trim().length === 0 ||
     link.runtimeSessionId !== getRuntimeSessionId(ctx) ||
     link.instanceId !== getSessionInstanceId(ctx) ||
-    !process.env.TMUX_PANE ||
-    !reconnectAvailable()
+    !process.env.TMUX_PANE
   ) {
     return undefined
   }
   return link
+}
+
+function currentReconnectLink(
+  ctx: ExtensionContext,
+  reconnectAvailable: () => boolean = harnessReconnectAvailable
+): RuntimeSessionLink | undefined {
+  const link = currentSessionControlLink(ctx)
+  return link && reconnectAvailable() ? link : undefined
 }
 
 function buildRuntimeCapabilities(
@@ -724,9 +731,11 @@ function buildRuntimeCapabilities(
     supportsPersistentSessions: true,
     supportsMentionInvocations: true,
     supportsSessionControlCommands: true,
-    sessionControlCommands: SESSION_CONTROL_COMMANDS.filter(
-      (command) => command !== "reconnect" || Boolean(ctx && currentReconnectLink(ctx, reconnectAvailable))
-    ),
+    sessionControlCommands: SESSION_CONTROL_COMMANDS.filter((command) => {
+      if (command === "reconnect") return Boolean(ctx && currentReconnectLink(ctx, reconnectAvailable))
+      if (command === "key") return Boolean(ctx && currentSessionControlLink(ctx))
+      return true
+    }),
     thinkingLevels: [...THINKING_LEVELS],
     preferredModels: [...(config?.preferredModels ?? [])],
     ...(ctx?.model && { currentModel: `${ctx.model.provider}/${ctx.model.id}` }),
@@ -2569,6 +2578,28 @@ async function runKickCommand(invocation: ClaimedInvocation, ctx: ExtensionConte
   await completeInvocationWithMarkdown(invocation, "Kicked the linked Pi session.", ctx)
 }
 
+async function runKeyCommand(
+  invocation: ClaimedInvocation,
+  args: string,
+  ctx: ExtensionContext,
+  deps: {
+    send: typeof sendAllowedTmuxKey
+    complete: typeof completeInvocationWithMarkdown
+  } = { send: sendAllowedTmuxKey, complete: completeInvocationWithMarkdown }
+): Promise<void> {
+  const key = parseAllowedTmuxKey(args)
+  if (!key) {
+    await deps.complete(invocation, "Usage: `/key <name>`.", ctx)
+    return
+  }
+  const link = currentSessionControlLink(ctx)
+  if (!link || invocation.rootStreamId !== link.rootStreamId || invocation.claimedInstanceId !== link.instanceId) {
+    throw new Error("Key control is unavailable for this session.")
+  }
+  deps.send(key, process.pid)
+  await deps.complete(invocation, `Sent \`${key}\` to the linked Pi session.`, ctx)
+}
+
 interface ReconnectCommandDeps {
   available: () => boolean
   prepare: typeof prepareHarnessReconnect
@@ -2793,6 +2824,9 @@ async function handleSessionControlInvocation(
         return
       case "reconnect":
         await runReconnectCommand(invocation, command.args, ctx)
+        return
+      case "key":
+        await runKeyCommand(invocation, command.args, ctx)
         return
       default:
         await failInvocation(invocation, `Unsupported session-control command: ${command.name}`)
@@ -3569,6 +3603,7 @@ export const __testing = {
   claimNextInvocation,
   claimIfIdle,
   runReconnectCommand,
+  runKeyCommand,
   reconnectPending: () => reconnectPending,
   sessionLifecycleGeneration: () => sessionLifecycleGeneration,
   sessionTearingDown: () => sessionTearingDown,

--- a/extensions/remote-session/src/index.ts
+++ b/extensions/remote-session/src/index.ts
@@ -17,6 +17,7 @@ export {
   type RuntimeDescriptor,
   type SendResult,
   type SessionControlActuator,
+  type SessionControlInvocationContext,
 } from "./session"
 export {
   ThreaClient,

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -792,13 +792,13 @@ describe("session control via the actuator", () => {
   test("routes an advertised command to runCommand and acks with its message", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()
-    const ran: Array<{ name: string; args: string }> = []
+    const ran: Array<{ name: string; args: string; rootStreamId: string }> = []
     const session = makeSession(client, transport, {
       sessionControl: {
         commands: ["stop", "steer", "model"],
         interrupt: () => true,
-        runCommand: async (name, args) => {
-          ran.push({ name, args })
+        runCommand: async (name, args, context) => {
+          ran.push({ name, args, rootStreamId: context.rootStreamId })
           return { ok: true, message: "Set model to `opus`." }
         },
       },
@@ -814,7 +814,7 @@ describe("session control via the actuator", () => {
       session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
     ).handleSessionControl(invocation)
 
-    expect(ran).toEqual([{ name: "model", args: "opus" }])
+    expect(ran).toEqual([{ name: "model", args: "opus", rootStreamId: "stream_root" }])
     expect(calls.complete[0]?.body.finalMessageMarkdown).toBe("Set model to `opus`.")
   })
 

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1052,6 +1052,42 @@ describe("session control via the actuator", () => {
     expect(presence.at(-1)).toMatchObject({ status: "busy", acceptingInvocations: false })
   })
 
+  test("a failed /key actuator calls /fail and never /complete", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["key"],
+        interrupt: () => true,
+        runCommand: async () => {
+          throw new Error("tmux pane inspection failed")
+        },
+      },
+    })
+    const invocation = makeInvocation({
+      id: "binv_key",
+      trigger: "session-control",
+      promptMarkdown: "/key enter",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_key", name: "key", args: "enter" } },
+    })
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(invocation)
+
+    expect(calls.complete).toEqual([])
+    expect(calls.fail).toEqual([
+      {
+        id: "binv_key",
+        body: {
+          instanceId: "rt-test",
+          claimToken: "tok",
+          errorMessage: "tmux pane inspection failed",
+        },
+      },
+    ])
+  })
+
   test("a failed actuator command fails the invocation instead of completing it", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -108,6 +108,10 @@ export interface DeliveredTurn {
  * `interrupt()`/`steer()`; every other advertised command is routed to
  * `runCommand`, which returns the user-facing ack markdown.
  */
+export interface SessionControlInvocationContext {
+  rootStreamId: string
+}
+
 export interface SessionControlActuator {
   /** Command names to advertise (must be Threa catalog names, e.g. "model", "thinking", "compact", "run", "reload", "steer", "stop"). */
   commands: readonly string[]
@@ -127,7 +131,8 @@ export interface SessionControlActuator {
   steer?(text: string): Promise<boolean> | boolean
   runCommand(
     name: string,
-    args: string
+    args: string,
+    context: SessionControlInvocationContext
   ): Promise<{
     ok: boolean
     message: string
@@ -870,7 +875,9 @@ export class RemoteSession {
             await this.failInvocation(invocation, `Unsupported session-control command: ${command.name}`)
             return
           }
-          const outcome = await actuator.runCommand(command.name, command.args)
+          const outcome = await actuator.runCommand(command.name, command.args, {
+            rootStreamId: invocation.rootStreamId,
+          })
           if (!outcome.afterAck) {
             await this.completeAck(invocation, outcome.message)
             return


### PR DESCRIPTION
## Problem

Linked Pi and Claude sessions expose high-level controls but cannot receive a small, safe navigation/interrupt key without opening the local tmux pane. Passing arbitrary tmux tokens or text through Threa would create an unsafe input surface.

## Solution

Add `/key <name>` with eleven fixed mappings only:

`escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, and `ctrl-u`.

- Shared `sendAllowedTmuxKey` maps the exact name internally; user input never becomes a tmux token.
- At call time it resolves `TMUX_PANE`, inspects the live pane with `tmux display-message`, requires the expected native PID (`process.pid` for Pi, `process.ppid` for Claude), then performs one fixed-token `tmux send-keys` call.
- Pi additionally pins the command invocation’s root and instance against its exact enabled link immediately before sending.
- Claude advertises only with a real self pane and exact linked runtime/root; inspection/send failures fail the invocation rather than posting false success.
- Pi routes key as a busy-claimable control without changing Claude or other command routing.
- Both standalone installers vendor the shared helper.

Surrounding command whitespace follows the existing canonical parser normalization. Case variants, aliases, extra tokens, multiple keys, literal text, repeats, and raw tmux syntax remain rejected.

## Files

| Area | Change |
| ---- | ------ |
| Backend catalog/routing | Canonical key metadata and Pi busy-control routing |
| `extensions/bot-runtime-client/src/tmux-key.ts` | Exact allowlist, pane/PID re-resolution, and one-send helper (**new**) |
| Claude remote | Capability, expected-parent PID actuation, failure semantics, tests/docs/install |
| Pi remote | Capability, exact invocation/link actuation, tests/docs/install |
| Remote-session tests | Failed key actuation routes through invocation failure |

## Test plan

- [x] Root backend unit + isolated E2E — 3,829 passed
- [x] Bot-runtime client — 70 passed
- [x] Remote-session — 132 passed
- [x] Pi remote — 118 passed
- [x] Claude remote — 120 passed
- [x] Backend focused commands — 20 passed
- [x] Fresh Pi and Claude install/import smoke probes
- [x] Root and extension typechecks, lint, Prettier, Dockerfile/migration checks, and `git diff --check`
- [x] Two Sol/high adversarial rounds; whitespace normalization explicitly dispositioned; post-PR root-binding review clean at 7/7

<details>
<summary>📋 Full implementation plan</summary>

# Live runtime reconnect and safe keys

Status: ratified 2026-07-22.

This replaces the abandoned broad reconnect prototype preserved under `.tmp/oversized-reconnect-*`.

## Goal

Add small, truthful controls for live Threa-linked Pi and Claude sessions:

- `/reconnect [--force]` replaces a live runtime process in the same tmux pane and resumes the same native session.
- `/key <name>` sends one allowlisted tmux key to the exact live pane.

This feature is intentionally limited to channels that remain connected long enough to claim and acknowledge the command. It is not an offline supervisor.

## Shared invariants

- Target the exact routed `instanceId`, `runtimeSessionId`, and root stream.
- Inventory remains authoritative when an exact managed row exists; exact live-pane discovery may supplement it without adoption.
- Missing, ambiguous, stale, or unsupported identity fails closed.
- Never pick the newest session, transcript, pane, or inventory row.
- Preserve cwd, tmux pane/window/session, native runtime session, Threa runtime identity, channel, and the narrow supported launch policy.
- Perform same-root preflight with `ifArchived: wait` and `ifMissing: error` before replacement.
- Never create, replace, revive, or unarchive a scratchpad.
- Never launch a fresh native session as fallback.
- Complete the Threa command acknowledgement before a detached reconnect starts.
- Reconnect acknowledgement says it was accepted, not that the replacement already connected.
- Standalone discovery never writes harness inventory.

## Narrow launch contracts

### Pi

Support only exact Threa Pi forms:

```text
pi --session-id <uuid>
```

The executable may be an absolute path. A leading `env` is allowed only for explicit Threa runtime/instance identity and the existing harness entrypoint/Bun variables, using ordinary values without shell metacharacters. Unknown options, positional prompts, duplicate session IDs, arguments after `--`, exotic shell-dependent values, and unrelated environment assignments fail before tmux is touched.

The native Pi session ID is the validated `--session-id` UUID. No title or recency fallback exists.

### Claude

Support only the ordinary Threa/channel helper form:

- executable basename `claude`;
- optional exact `--name threa.<name>`;
- exactly one `--dangerously-load-development-channels server:<channel>`;
- optional `--dangerously-skip-permissions`;
- optional one file-backed `--mcp-config <path>`;
- optional explicit `THREA_INSTANCE_ID` and `THREA_RUNTIME_SESSION_ID` assignments;
- no positional prompt or arguments after `--`.

Unknown options, inline/variadic MCP JSON, multiple MCP configs, custom config directories, and unrelated environment assignments fail before tmux is touched. Named global channel registration is reused as named; reconnect does not copy or materialize MCP configuration.

Claude native identity comes only from the live `~/.claude/sessions/<pane_pid>.json` registry. Require matching PID, process start, canonical cwd, optional parsed name, valid UUID, idle status unless forced, and existing exact transcript. No dead-process or newest-transcript fallback exists.

## Shared process replacement

The complete replacement command is built and all identity/pane facts are pinned before mutation. Immediately before mutation, revalidate pane ID, PID, cwd, start command, and native identity.

Use exactly:

```text
tmux respawn-pane -k -t <pane-id> -c <cwd> <shell-quoted-command>
```

This keeps pane/window/session identity and avoids kill/wait/recreate, anchor windows, durable descriptors, and retry machinery.

After successful respawn, bounded local verification may confirm a live process with the same native session and cwd. Failure is logged and never falls back to a fresh session.

## PR stack

This is an actual GitHub stack above PR #1501, managed with non-interactive `gh stack` commands.

### PR 1 — Live Pi reconnect primitive

Deliverables:

- Exact Pi launch parser and native session extraction.
- Exact managed-first/live-standalone pane resolution without inventory adoption.
- Small shared `tmux respawn-pane` helper.
- `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` for Pi targets.
- Same-root preflight and generation revalidation.
- CLI/README documentation.

Required tests:

- exact managed and standalone Pi forms;
- malformed UUID, duplicate ID, unknown option/env/positional/`--` rejection;
- missing or ambiguous pane rejection;
- preflight failure and generation change leave pane untouched;
- exact respawn arguments preserve cwd/pane/session ID/Threa identity;
- failure never launches fresh or writes inventory.

Implementation budget: 250–500 lines excluding focused tests. Inventory schema changes, persistent descriptors, runtime extension lifecycle changes, or generic supervisor infrastructure require a plan checkpoint.

### PR 2 — Live Claude reconnect primitive

Deliverables:

- Reuse PR 1's replacement/preflight path.
- Strict live Claude registry resolver with injectable tests.
- Narrow Claude launch parser/reconstructor.
- Managed-first/live-standalone Claude targeting without inventory adoption.
- Same native UUID resume and bounded replacement verification.

Required tests:

- current managed and standalone helper launch forms;
- malformed/stale registry, PID reuse, cwd/name/transcript/status mismatch;
- `--force` behavior;
- unsupported option/env/MCP/`--` rejection;
- preflight and generation races leave pane untouched;
- exact `claude --resume <same-uuid>` respawn;
- no fresh launch or inventory writes on failure.

Implementation budget: 250–500 lines excluding focused tests. Do not add dead-session recovery, descriptor persistence, config-dir abstraction, policy snapshots, or extension-side reconnect evidence.

### PR 3 — Reachable Claude `/reconnect`

Deliverables:

- Canonical command catalog and Claude capability advertisement.
- Empty args or exact `--force` validation.
- Minimal optional post-ack action in remote-session command handling.
- Seal acknowledgement first, suspend claims through handoff, then spawn detached harnessd with exact runtime/root IDs.
- Truthful copy and docs explaining the reachable-channel limitation.

Required tests:

- command advertised only where locally supported;
- routed runtime/root IDs and force flag reach harnessd exactly;
- acknowledgement completion precedes helper spawn;
- failed acknowledgement never spawns;
- preparation failure is returned before acknowledgement;
- existing sealed command completion remains intact;
- shutdown/archive/new-work races never launch or claim across handoff.

Implementation budget: 200–400 lines excluding tests. No Pi polling lifecycle, backend outbox, supervisor delivery, or offline recovery.

### PR 4 — Reachable Pi `/reconnect`

Deliverables:

- Pi capability advertisement and empty/exact `--force` validation.
- Prepare before acknowledgement; spawn the shared detached harness helper only after real sealed/plain completion.
- Serialize Pi claim drains and hold busy/nonaccepting presence through acknowledgement and replacement handoff.
- Default refuses when Pi is busy; `--force` permits replacement while retaining the same handoff guard.
- After successful detached start, the old Pi process stays nonaccepting until replacement; there is no automatic fallback. If the helper later fails, the private log records it and the orchestrator/manual operator restarts Pi.
- Route reconnect through Pi's busy-claimable capability without changing other runtimes.

Required tests:

- exact runtime/root/force arguments and install packaging;
- idle refusal/force behavior;
- sealed/plain ack ordering and failed ack/start paths;
- concurrent poll/socket claims serialize;
- accepted handoff never advertises available or claims more work;
- shutdown/reload races never start reconnect or claim after teardown; a claim returned during teardown is closed explicitly;
- successful handoff has no timer that can restore old-process presence or claims.

Implementation budget: 200–400 lines excluding tests. No RemoteSession/Claude changes, offline supervisor, or outbox.

### PR 5 — Allowlisted `/key`

Deliverables:

- `/key <name>` for reachable supported Pi and Claude tmux sessions.
- Initial allowlist only: `escape`, `enter`, `up`, `down`, `left`, `right`, `tab`, `backspace`, `ctrl-c`, `ctrl-d`, `ctrl-u`.
- Exact pane re-resolution immediately before one `tmux send-keys` call.
- No raw text, key sequences, repeat counts, arbitrary tmux syntax, or shell interpolation.
- Canonical catalog/capability/docs updates.

Required tests:

- every allowed name maps to one exact tmux token;
- casing/aliases/extra args/unknown values fail;
- ambiguity/stale generation leaves pane untouched;
- command sends exactly once to the routed runtime pane;
- acknowledgement is truthful and sealed through the normal command path.

Implementation budget: 150–300 lines excluding tests.

## Binding exclusions

- Fully disconnected/offline command recovery.
- Supervisor outbox/control jobs.
- Dead-process or transcript-only reconnect.
- Durable standalone reconnect descriptors or retry after failed replacement.
- Arbitrary Claude/Pi launch-policy reconstruction.
- Inline or multiple MCP configs.
- `CLAUDE_CONFIG_DIR` support.
- Inventory schema changes or legacy inventory migration.
- New frontend runtime state or overview UI.
- `/type`, raw text entry, arbitrary keys, repeats, or key sequences.
- Starting a fresh native session.
- Creating, replacing, reviving, or unarchiving scratchpads.

## Build protocol

Use `build-feature` with these binding overrides:

- implementer: GPT-5.6 Sol, effort `minimal`, Pi harness only;
- adversarial verifier: GPT-5.6 Sol, effort `high`, Pi harness only;
- per-PR reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- whole-stack reviewer: GPT-5.6 Sol, effort `high`, Pi harness only;
- do not use Fable, Claude Code, Claude Agent SDK, or any Claude-backed harness;
- use actual `gh stack` branches/PRs and `gh stack submit --auto`/`gh stack view --json`;
- per PR: brief -> implement -> adversarial verify -> fix/reverify -> commit -> stacked PR -> review.

Scope controls:

- Copy binding exclusions and the current PR's implementation budget into every agent brief.
- Classify every review finding as `in-scope` or `follow-up` before fixing it.
- A fix that adds a deferred subsystem, exceeds the budget, or broadens supported launch policy requires a human plan checkpoint.
- After two fix/reverify rounds without a clean result, stop and report concrete remaining findings instead of continuing automatically.
- Agents receive only the current chunk brief plus paths to relevant source/plan files, not an invitation to redesign the whole stack.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787388252&installation_model_id=20758&pr_number=1517&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1517&signature=043e9308e2f9ae8bb070c113958283c2f5d2dd84f2dfc15213b2137407cf70dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
