### PR TITLE
fix: isolate Pi remote test persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       # each is a standalone package with its own bun.lock, linked by file:
       # deps (bot-runtime-client → remote-session → claude-code-remote), so
       # installs must run per-package in dependency order. pi-remote is a
-      # pi-package with no test/typecheck scripts (deferred per #1153).
+      # pi-package with tests but no standalone typecheck (deferred per #1153).
       # The root install is also required: bot-runtime-client's crypto parity
       # test typechecks against the canonical packages/crypto sources, whose
       # deps (@hpke/*) resolve from the root node_modules.
@@ -212,6 +212,7 @@ jobs:
         run: |
           bun install
           bun install --cwd extensions/bot-runtime-client
+          bun install --cwd extensions/pi-remote
           bun install --cwd extensions/remote-session
           bun install --cwd extensions/claude-code-remote
           bun install --cwd extensions/harness-daemon
@@ -228,6 +229,7 @@ jobs:
         if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
         run: |
           bun run --cwd extensions/bot-runtime-client test
+          bun run --cwd extensions/pi-remote test
           bun run --cwd extensions/remote-session test
           bun run --cwd extensions/claude-code-remote test
           bun run --cwd extensions/harness-daemon test

--- a/extensions/pi-remote/package.json
+++ b/extensions/pi-remote/package.json
@@ -9,6 +9,9 @@
     "@threa/bot-runtime-client": "file:../bot-runtime-client",
     "socket.io-client": "^4.8.1"
   },
+  "scripts": {
+    "test": "bun test"
+  },
   "pi": {
     "extensions": [
       "./src/threa-remote.ts"

--- a/extensions/pi-remote/src/threa-remote.sealed.test.ts
+++ b/extensions/pi-remote/src/threa-remote.sealed.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -58,7 +58,18 @@ function bashResult(output: string, isError = false): ToolResultEvent {
   } as unknown as ToolResultEvent
 }
 
-afterEach(() => __testing.setConfigForTesting(undefined))
+let testStorageDirectory: string
+
+beforeEach(async () => {
+  await __testing.resetRuntimeForTesting()
+  testStorageDirectory = mkdtempSync(join(tmpdir(), "pi-remote-sealed-test-"))
+  await __testing.setStorageDirectoryForTesting(testStorageDirectory)
+})
+
+afterEach(async () => {
+  await __testing.resetRuntimeForTesting()
+  rmSync(testStorageDirectory, { recursive: true, force: true })
+})
 
 const tempDirs: string[] = []
 function tempDir(): string {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1,7 +1,30 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
 import threaRemote, { __testing } from "./threa-remote"
 
+let testStorageDirectory: string
+
+beforeEach(async () => {
+  await __testing.resetRuntimeForTesting()
+  testStorageDirectory = mkdtempSync(join(tmpdir(), "pi-remote-test-"))
+  await __testing.setStorageDirectoryForTesting(testStorageDirectory)
+})
+
+afterEach(async () => {
+  await __testing.resetRuntimeForTesting()
+  rmSync(testStorageDirectory, { recursive: true, force: true })
+})
+
 describe("Pi remote trace safety", () => {
+  test("selects temporary storage only for test entrypoints", () => {
+    expect(__testing.defaultStorageDirectoryForTesting("/repo/src/threa-remote.test.ts")).not.toBe(
+      join(homedir(), ".pi", "agent")
+    )
+    expect(__testing.defaultStorageDirectoryForTesting("/usr/local/bin/pi")).toBe(join(homedir(), ".pi", "agent"))
+  })
+
   test("omits sensitive bash command arguments from tool_call traces", () => {
     const trace = __testing.formatToolCallTrace({
       toolName: "bash",
@@ -1331,6 +1354,64 @@ describe("claim drain serialization", () => {
     expect(requests).toBe(1)
     fetchSpy.mockRestore()
   })
+
+  test("runtime reset drains an in-flight claim before teardown completes", async () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { runtime: { enabled: true, instanceId: "pi-instance", runtimeSessionId: "runtime" } },
+    })
+    let releaseClaim!: () => void
+    const claimGate = new Promise<void>((resolve) => (releaseClaim = resolve))
+    const writes: string[] = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/claim")) {
+        await claimGate
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: "binv_reset",
+              activeStreamId: "stream_1",
+              sourceMessageId: "msg_1",
+              promptMarkdown: "late work",
+              claimToken: "claim_reset",
+              claimExpiresAt: null,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      if (url.endsWith("/bot-invocations/binv_reset/fail")) writes.push("fail")
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => "runtime" },
+      isIdle: () => true,
+      cwd: "/tmp",
+    } as never
+
+    try {
+      const claim = __testing.claimIfIdle({} as never, ctx)
+      await Bun.sleep(0)
+      let resetComplete = false
+      const reset = __testing.resetRuntimeForTesting().then(() => {
+        resetComplete = true
+      })
+      await Bun.sleep(0)
+      expect(resetComplete).toBe(false)
+      releaseClaim()
+      expect(await claim).toBe(false)
+      await reset
+      expect({ resetComplete, writes }).toEqual({ resetComplete: true, writes: ["fail"] })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
 })
 
 describe("session-scoped lifecycle isolation", () => {
@@ -1405,7 +1486,7 @@ describe("session-scoped lifecycle isolation", () => {
     }
   })
 
-  test("child shutdown preserves the parent claim while parent shutdown clears it", async () => {
+  test("child shutdown preserves the parent claim while parent shutdown clears it without touching other storage", async () => {
     const shutdownHandlers: Array<(event: unknown, ctx: unknown) => Promise<void>> = []
     threaRemote({
       registerCommand: () => {},
@@ -1416,6 +1497,17 @@ describe("session-scoped lifecycle isolation", () => {
     const shutdown = shutdownHandlers[0]
     expect(shutdown).toBeDefined()
 
+    const sentinelPath = __testing.storagePaths().configPath
+    const sentinel = `${JSON.stringify({
+      baseUrl: "https://sentinel.invalid",
+      workspaceId: "ws_sentinel",
+      apiKey: "sentinel-fixture-key",
+      linkedSessions: { existing: { runtimeSessionId: "existing" } },
+    })}\n`
+    writeFileSync(sentinelPath, sentinel)
+    const persistenceDirectory = mkdtempSync(join(tmpdir(), "pi-remote-persistence-"))
+    await __testing.setStorageDirectoryForTesting(persistenceDirectory)
+
     __testing.setConfigForTesting({
       baseUrl: "https://app.threa.io",
       workspaceId: "ws_123",
@@ -1423,7 +1515,6 @@ describe("session-scoped lifecycle isolation", () => {
       linkedSessions: {
         parent: {
           enabled: true,
-          instanceId: "pi-parent",
           runtimeSessionId: "parent",
           activeStreamId: "stream_a",
         },
@@ -1465,8 +1556,15 @@ describe("session-scoped lifecycle isolation", () => {
         claimActive: false,
         madeRequests: true,
       })
+
+      expect(readFileSync(sentinelPath, "utf8")).toBe(sentinel)
+      const paths = __testing.storagePaths()
+      const persisted = JSON.parse(readFileSync(paths.configPath, "utf8")) as Record<string, unknown>
+      expect(persisted).toMatchObject({ workspaceId: "ws_123", apiKey: "threa_bk_test" })
+      expect(readdirSync(persistenceDirectory).sort()).toEqual(["threa-remote-bik.json", "threa-remote.json"])
     } finally {
       fetchSpy.mockRestore()
+      rmSync(persistenceDirectory, { recursive: true, force: true })
     }
   })
 })
@@ -1481,11 +1579,6 @@ describe("claim renewal during a turn", () => {
     claimedInstanceId: "pi-test-1",
     claimExpiresAt: null,
   }
-
-  afterEach(() => {
-    __testing.clearPendingForTesting()
-    __testing.setConfigForTesting(undefined)
-  })
 
   test("renew interval is comfortably inside the claim TTL", () => {
     // Two consecutive missed renews must still leave the claim alive — the

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -11,7 +11,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs"
-import { homedir, hostname, platform } from "node:os"
+import { homedir, hostname, platform, tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import {
   BikKeystore,
@@ -46,13 +46,25 @@ import type {
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent"
 
-const CONFIG_PATH = join(homedir(), ".pi", "agent", "threa-remote.json")
+const PRODUCTION_STORAGE_DIRECTORY = join(homedir(), ".pi", "agent")
+const TEST_ENTRYPOINT_PATTERN = /\.(?:test|spec)\.[cm]?[jt]sx?$/
+
+function isTestEntrypoint(entrypoint = process.argv[1]): boolean {
+  return TEST_ENTRYPOINT_PATTERN.test(entrypoint ?? "")
+}
+
+// Bun test runs all selected files with the first test file as argv[1]. Keep
+// the boundary private even when a future test forgets to install its own path.
+const DEFAULT_STORAGE_DIRECTORY = isTestEntrypoint()
+  ? join(tmpdir(), `threa-pi-remote-tests-${process.pid}`)
+  : PRODUCTION_STORAGE_DIRECTORY
+let CONFIG_PATH = join(DEFAULT_STORAGE_DIRECTORY, "threa-remote.json")
 // The Bot Identity Key (BIK): a per-install X25519 keypair the harness registers
 // so an owner can wrap an E2E scratchpad's stream key to it (design §2.6).
 // Persisted separately from the config (private key material, mode 0600) and
 // stable across restarts — the owner's wraps target its `publicKeyId`, so
 // rotating it would orphan every wrap.
-const BIK_PATH = join(homedir(), ".pi", "agent", "threa-remote-bik.json")
+let BIK_PATH = join(DEFAULT_STORAGE_DIRECTORY, "threa-remote-bik.json")
 const STATUS_KEY = "threa-remote"
 const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 /** Server cap on `attachmentIds` per sealed message (`sealedAttachmentIdsSchema` caps at 16). */
@@ -296,10 +308,14 @@ let transport: BotRuntimeTransport | undefined
 // half rides every hello/presence body — the backend's instance upsert
 // overwrites the stored key by default, so omitting it on a heartbeat would
 // clear the registration and break sealed-claim wrap coverage.
-const bikKeystore = new BikKeystore({
-  path: BIK_PATH,
-  log: (message) => console.error(`Threa remote: ${message}`),
-})
+function createBikKeystore(path: string): BikKeystore {
+  return new BikKeystore({
+    path,
+    log: (message) => console.error(`Threa remote: ${message}`),
+  })
+}
+
+let bikKeystore = createBikKeystore(BIK_PATH)
 
 function validateConfig(value: unknown): Config | undefined {
   if (!value || typeof value !== "object") {
@@ -365,7 +381,7 @@ function readConfig(): Config | undefined {
 // into this runtime-loaded package. If the lock can't be acquired the save is
 // skipped (never an unlocked RMW — that would reintroduce the clobber), and
 // the owning instance's next save self-heals.
-const CONFIG_LOCK_PATH = `${CONFIG_PATH}.lock`
+let CONFIG_LOCK_PATH = `${CONFIG_PATH}.lock`
 const CONFIG_LOCK_MAX_ATTEMPTS = 10
 const CONFIG_LOCK_DELAY_MS = 25
 
@@ -3531,6 +3547,51 @@ async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void
   await heartbeat("available", undefined, ctx).catch(() => undefined)
 }
 
+async function setStorageDirectoryForTesting(directory: string): Promise<void> {
+  if (!isTestEntrypoint()) throw new Error("Test storage can only be configured under bun test")
+  await resetRuntimeForTesting()
+  const resolved = resolve(directory)
+  CONFIG_PATH = join(resolved, "threa-remote.json")
+  CONFIG_LOCK_PATH = `${CONFIG_PATH}.lock`
+  BIK_PATH = join(resolved, "threa-remote-bik.json")
+  bikKeystore = createBikKeystore(BIK_PATH)
+}
+
+async function resetRuntimeForTesting(): Promise<void> {
+  sessionTearingDown = true
+  sessionLifecycleGeneration++
+  reconnectPending = false
+  stopPolling()
+  stopClaimRenewTimer()
+  clearPendingRetry()
+  teardownTransport()
+  await claimIfIdleInFlight?.catch(() => undefined)
+  claimIfIdleInFlight = undefined
+  config = undefined
+  pollInFlightRunId = undefined
+  pending = undefined
+  steeredInvocations = []
+  pendingContextCursor = undefined
+  pendingAssistantTexts = []
+  pendingNonAssistantTexts = []
+  pendingToolCalls = new Map()
+  pendingProviderError = undefined
+  pendingModelError = undefined
+  pendingRetryAfterMs = undefined
+  pendingInvocationPrompt = undefined
+  isWaitingForRetry = false
+  carryOnTexts = []
+  lastTraceHeartbeat = undefined
+  consecutivePollFailures = 0
+  consecutiveQuietPolls = 0
+  lastPollFailureSummary = undefined
+  lastBusyHeartbeatAt = 0
+  lastPollDebugSummary = undefined
+  fallbackRuntimeSessionId = undefined
+  supervisedRevivalBlocked = false
+  sessionTearingDown = false
+}
+
 export const __testing = {
   buildRetryPrompt,
   describeToolCall,
@@ -3546,6 +3607,13 @@ export const __testing = {
   setSupervisedRevivalBlockedForTesting: (value: boolean) => {
     supervisedRevivalBlocked = value
   },
+  setStorageDirectoryForTesting,
+  storagePaths: () => ({ configPath: CONFIG_PATH, lockPath: CONFIG_LOCK_PATH, bikPath: BIK_PATH }),
+  defaultStorageDirectoryForTesting: (entrypoint?: string) =>
+    isTestEntrypoint(entrypoint)
+      ? join(tmpdir(), `threa-pi-remote-tests-${process.pid}`)
+      : PRODUCTION_STORAGE_DIRECTORY,
+  resetRuntimeForTesting,
   buildClaimInvocationPayload,
   buildPersistedConfig,
   buildRuntimeCapabilities,


### PR DESCRIPTION
## Problem

`extensions/pi-remote` tests replaced the module-global config with fixture credentials while persistence still targeted `~/.pi/agent/threa-remote.json`. A lifecycle callback could therefore merge fixture credentials into the developer’s real config and initialize or read the production BIK keystore.

## Solution

Route all persistent Pi remote state through one swappable storage directory:

- Production still resolves config, lock, and BIK files under `~/.pi/agent`.
- Bun test entrypoints default to process-private temporary storage; both suites install a fresh directory per test.
- `resetRuntimeForTesting()` marks lifecycle teardown, invalidates and awaits any in-flight claim pass, stops timers and transport, then clears pending claims, buffered turn state, counters, and session fallbacks.
- The parent/child shutdown regression now forces config and BIK persistence, verifies only the injected directory changed, preserves the sentinel config, and checks no lock/temp artifact remains.
- `extensions/pi-remote` now has a test script wired into the extension CI job.

The cross-process lock, atomic rename, on-disk linked-session merge, and parent/child shutdown behavior are unchanged.

## Files

| File | Change |
| ---- | ------ |
| `extensions/pi-remote/src/threa-remote.ts` | Add temp-backed test storage and full runtime reset |
| `extensions/pi-remote/src/*.test.ts` | Isolate every test and cover lifecycle persistence |
| `extensions/pi-remote/package.json` | Add extension test script |
| `.github/workflows/ci.yml` | Install and test `pi-remote` in CI |

## Test plan

- [x] `bun run --cwd extensions/pi-remote test` — 120 pass
- [x] `bun run typecheck` — all workspaces clean
- [x] Pre-commit lint, migration, Dockerfile, OpenAPI, and typecheck hooks
- [x] SHA-256 + byte comparison of real config and BIK before/after suite; unchanged; no real lock file
- [x] Independent reviews; CI coverage, runtime `NODE_ENV=test` leakage, and in-flight claim teardown findings fixed

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787395195&installation_model_id=20758&pr_number=1518&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1518&signature=1d5838ec2fb0c724cb8658297dd8c0bc1a0a91f696c7b77fa22a344b9c0e4cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
