### PR TITLE
feat: align threadable card actions across input modes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -493,6 +493,7 @@ Avatar-as-toggle (Gmail Android pattern). On non-continuation rows the avatar sl
 - `MovedMessagesDrawer`, `MovedFromIndicator`, `MessagesMovedEvent`.
 - `SavedIndicator`, `EditedIndicator`.
 - `JoinChannelBar` (CTA bar above the composer when viewing a stream you can join).
+- Delegation and call cards use `TimelineCardQuickActions` plus one shared action list: mouse users get a floating quick-action cluster, overflow menu, and row right-click menu; touch users long-press the card for a vaul drawer. Keyboard focus reveals the otherwise hidden overflow trigger on touch layouts. Delegation cards keep Copy prompt on the card on mobile. Live call cards keep Join on the card. Interactive controls do not start the row long-press gesture.
 
 ### 8.7 Inline edit composer-hide
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ bun run db:start   # PostgreSQL + MinIO via Docker
 bun run dev        # control-plane, workspace-router, backend, frontend, backoffice
 ```
 
-The app comes up at `http://localhost:3000`.
+The app comes up at `http://localhost:3000`. For device testing, use
+`bun run dev:mobile` on the local network or `bun run dev:remote` for a temporary
+HTTPS Tailscale Serve URL.
 
 ```bash
 bun run test       # unit/integration (backend)

--- a/apps/frontend/src/components/timeline/call-card.test.tsx
+++ b/apps/frontend/src/components/timeline/call-card.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent } from "@threa/types"
@@ -11,6 +11,8 @@ import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls
 import { CallCard } from "./call-card"
 
 const launch = vi.fn()
+
+afterEach(() => vi.useRealTimers())
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -26,6 +28,8 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof launchModule.useCallLaunch>)
   vi.spyOn(callHooksModule, "useCallPhase").mockReturnValue("idle")
   vi.spyOn(callHooksModule, "useCallStreamId").mockReturnValue(null)
+  vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(false)
+  vi.spyOn(hooksModule, "useInputMode").mockReturnValue("mouse")
 })
 
 const STARTED: CallStartedEventPayload = {
@@ -137,26 +141,25 @@ describe("CallCard", () => {
     expect(screen.queryByRole("button", { name: "Join" })).toBeNull()
   })
 
-  it("shows a Chat affordance opening the draft thread on the call_started event when no replies exist", () => {
+  it("shows a desktop quick action opening draft call chat on the call_started event", () => {
     renderCard(
       { callId: "call_1", durationMs: 1000, participantUserIds: ["usr_a"], endedReason: "completed" },
       startedEvent()
     )
-    const chat = screen.getByRole("link", { name: /Discuss this call/i })
-    // Draft panel keyed on the card's event id — the call chat anchor.
+    const chat = screen.getByRole("link", { name: "Start call chat" })
     expect(chat.getAttribute("href")).toContain("draft%3Astream_1%3Aevt_call")
-    expect(chat).toHaveClass("min-h-9", "min-w-9")
   })
 
-  it("renders the thread chip and hides Chat once the call has replies (live and ended)", () => {
-    // Ended card with a healed thread on its event: chip shows, Chat is the
-    // duplicate entry point so it's hidden.
+  it("keeps call chat in the quick toolbar when the reply chip is present", () => {
     renderCard(
       { callId: "call_1", durationMs: 1000, participantUserIds: ["usr_a"], endedReason: "completed" },
       startedEvent({ threadId: "stream_thread", replyCount: 2 })
     )
     expect(screen.getByText("2 replies")).toBeTruthy()
-    expect(screen.queryByRole("link", { name: /Discuss this call/i })).toBeNull()
+    expect(screen.getByRole("link", { name: "Open call chat" })).toHaveAttribute(
+      "href",
+      "/w/ws_1/s/stream_1?panel=stream_thread"
+    )
   })
 
   it("as thread parent: suppresses the reply chip AND Chat (would loop back to the open panel)", () => {
@@ -166,6 +169,69 @@ describe("CallCard", () => {
       true
     )
     expect(screen.queryByText("2 replies")).toBeNull()
-    expect(screen.queryByRole("link", { name: /Discuss this call/i })).toBeNull()
+    expect(screen.queryByRole("link", { name: /call chat/i })).toBeNull()
+  })
+
+  it("offers Join, chat, and copy link from the desktop row context menu", async () => {
+    upsertActiveCall("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      mode: "video",
+      participantCount: 1,
+      participantUserIds: ["usr_a"],
+    })
+    renderCard()
+
+    fireEvent.contextMenu(screen.getByText("Call in progress"))
+
+    expect(await screen.findByRole("menuitem", { name: "Join call" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Start call chat" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Copy link to call" })).toBeInTheDocument()
+  })
+
+  it("opens the mobile action drawer on long press while keeping Join on the card", () => {
+    vi.useFakeTimers()
+    vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
+    vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
+    upsertActiveCall("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      mode: "video",
+      participantCount: 1,
+      participantUserIds: ["usr_a"],
+    })
+    renderCard()
+
+    const join = screen.getByRole("button", { name: "Join" })
+    expect(join).toHaveClass("min-h-9")
+    const title = screen.getByText("Call in progress")
+    fireEvent.touchStart(title, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.getByRole("button", { name: "Join call" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Start call chat" })).toBeInTheDocument()
+  })
+
+  it("holding Join does not open the card drawer", () => {
+    vi.useFakeTimers()
+    vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
+    vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
+    upsertActiveCall("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      mode: "video",
+      participantCount: 1,
+      participantUserIds: ["usr_a"],
+    })
+    renderCard()
+
+    const join = screen.getByRole("button", { name: "Join" })
+    fireEvent.touchStart(join, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.queryByRole("button", { name: "Join call" })).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/timeline/call-card.tsx
+++ b/apps/frontend/src/components/timeline/call-card.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useState } from "react"
-import { Link } from "react-router-dom"
-import { MessageSquareReply, Phone, Video } from "lucide-react"
+import { Link2, LogIn, MessageSquareReply, Phone, Video } from "lucide-react"
+import { toast } from "sonner"
 import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent, ThreadSummary } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { useActors } from "@/hooks"
 import { useActiveCall } from "@/stores/active-calls-store"
 import { useCallLaunch } from "@/components/call/call-launch-context"
 import { useCallPhase, useCallStreamId } from "@/components/call/call-store-hooks"
+import { buildStreamLink } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
 import { ThreadSlot } from "./thread-slot"
+import {
+  TimelineCardActionDrawer,
+  TimelineCardContextMenu,
+  TimelineCardQuickActions,
+  type TimelineCardAction,
+  useTimelineCardActionSurface,
+} from "./timeline-card-actions"
 import { useThreadAnchor } from "./use-thread-anchor"
 
 interface CallCardProps {
@@ -112,6 +120,7 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   // Shared thread affordance keyed on the card's event id: `replyUrl` opens the
   // real thread when one exists, else the draft panel to start the call chat.
   const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
+  const actionSurface = useTimelineCardActionSurface()
 
   if (!payload) return null
 
@@ -121,16 +130,59 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   // is up and their local session is on this stream.
   const selfInThisCall = callPhase !== "idle" && inCallStreamId === streamId
 
-  // Chat opens (or starts) the call's discussion thread. Live and ended cards
-  // both carry it — the discussion is the call's persistent home. Hidden only
-  // when the footer chip already links the thread (a duplicate entry point),
-  // mirroring the delegation card.
   const replyCount = payload.replyCount ?? 0
-  const threadChipShowing = replyCount > 0 && !!threadHref && !isThreadParent
-  const showChat = !threadChipShowing && !isThreadParent
+  const hasThread = !!payload.threadId || replyCount > 0
 
-  return (
-    <div className="px-3 sm:px-6 py-1.5">
+  async function handleCopyLink() {
+    try {
+      await navigator.clipboard.writeText(`${buildStreamLink(workspaceId, streamId)}?m=${event.id}`)
+      toast.success("Call link copied") // INV-63-allow: closing menu/drawer leaves no inline trigger
+    } catch {
+      toast.error("Couldn't copy the call link")
+    }
+  }
+
+  const actions: TimelineCardAction[] = []
+  if (isLive && !selfInThisCall) {
+    actions.push({
+      id: "join",
+      label: "Join call",
+      icon: LogIn,
+      onSelect: () => launch({ workspaceId, streamId, mode: payload.mode, expectedCallId: payload.callId }),
+      disabled: callActive,
+      disabledReason: callActive ? "You're already in another call" : undefined,
+    })
+  }
+  if (!isThreadParent) {
+    actions.push({
+      id: "thread",
+      label: hasThread ? "Open call chat" : "Start call chat",
+      icon: MessageSquareReply,
+      href: replyUrl,
+      quick: true,
+    })
+  }
+  actions.push({
+    id: "copy-link",
+    label: "Copy link to call",
+    icon: Link2,
+    onSelect: handleCopyLink,
+    separatorBefore: actions.length > 0,
+  })
+
+  let subtitle = "Call ended"
+  if (isLive) subtitle = "Call in progress"
+  else if (endedPatch) subtitle = `Call ended · ${formatDuration(endedPatch.durationMs)}`
+
+  const card = (
+    <div
+      className={cn(
+        "group reveal-host relative px-3 py-1.5 sm:px-6",
+        actionSurface.isTouchInput && "select-none",
+        actionSurface.longPress.isPressed && "opacity-70 transition-opacity duration-100"
+      )}
+      {...(actionSurface.touchCapable ? actionSurface.longPress.handlers : {})}
+    >
       <div
         className={cn(
           "flex items-center gap-3 rounded-[10px] border px-3 py-2 transition-colors",
@@ -176,17 +228,6 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
-          {showChat && (
-            <Link
-              to={replyUrl}
-              aria-label="Discuss this call"
-              title="Discuss this call in a thread"
-              className="inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:min-h-0 sm:min-w-0 sm:justify-start"
-            >
-              <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
-              <span className="hidden sm:inline">Chat</span>
-            </Link>
-          )}
           {isLive &&
             (selfInThisCall ? (
               <span className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground">In this call</span>
@@ -220,6 +261,24 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
           workspaceId={workspaceId}
         />
       )}
+      <TimelineCardQuickActions actions={actions} />
     </div>
+  )
+
+  return (
+    <>
+      <TimelineCardContextMenu actions={actions} disabled={actionSurface.isTouchInput}>
+        {card}
+      </TimelineCardContextMenu>
+      {actionSurface.touchCapable && (
+        <TimelineCardActionDrawer
+          open={actionSurface.drawerOpen}
+          onOpenChange={actionSurface.setDrawerOpen}
+          actions={actions}
+          title={payload.mode === "audio_only" ? "Voice call" : "Video call"}
+          subtitle={subtitle}
+        />
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import type { DelegationCreatedEventPayload, DelegationStatusChangedEventPayload, StreamEvent } from "@threa/types"
@@ -9,11 +9,15 @@ import { PanelProvider } from "@/contexts"
 import { delegationsApi } from "@/api"
 import { buildDelegationPrompt, DelegationEvent } from "./delegation-event"
 
+afterEach(() => vi.useRealTimers())
+
 beforeEach(() => {
   vi.restoreAllMocks()
   vi.spyOn(hooksModule, "useActors").mockReturnValue({
     getActorName: () => "Ariadne",
   } as unknown as ReturnType<typeof hooksModule.useActors>)
+  vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(false)
+  vi.spyOn(hooksModule, "useInputMode").mockReturnValue("mouse")
 })
 
 /** Healed thread stats (chunk-2) ride alongside the created payload on the card event. */
@@ -42,6 +46,11 @@ const CREATED_PAYLOAD: DelegationCreatedEventPayload = {
   brief: "Implement a token bucket. Done when the e2e suite passes.",
   contextRefs: ["memo:memo_1"],
   sourceConversationId: null,
+}
+
+async function selectCardAction(name: string | RegExp) {
+  await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+  await userEvent.click(await screen.findByRole("menuitem", { name }))
 }
 
 function renderCard(
@@ -85,21 +94,25 @@ describe("buildDelegationPrompt", () => {
 })
 
 describe("DelegationEvent", () => {
-  it("renders the open state: title, actor · status meta, Copy prompt, and Cancel", () => {
+  it("renders the open state with persistent mobile Copy and the full desktop action menu", async () => {
     renderCard()
 
     expect(screen.getByText("Add rate limiting to the webhook endpoint")).toBeInTheDocument()
     expect(screen.getByText(/Ariadne · Open/)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Copy prompt/ })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: "View result" })).not.toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: /Copy prompt/ })[0]).toHaveClass("min-h-9", "sm:hidden")
+
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.getByRole("menuitem", { name: "Mark done" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Cancel delegation" })).toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "View result" })).not.toBeInTheDocument()
   })
 
-  it("advances with the authoritative status patch: claimed shows the claimer label", () => {
+  it("advances with the authoritative status patch: claimed shows the claimer label", async () => {
     renderCard({ delegationId: "dlg_1", status: "claimed", claimedByLabel: "Kris's MacBook / Claude Code" })
 
     expect(screen.getByText(/Ariadne · Claimed · Kris's MacBook \/ Claude Code/)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.getByRole("menuitem", { name: "Cancel delegation" })).toBeInTheDocument()
   })
 
   it("shows the running progress note", () => {
@@ -109,7 +122,7 @@ describe("DelegationEvent", () => {
     expect(screen.getByText("tests are compiling")).toBeInTheDocument()
   })
 
-  it("completed with threadStreamId: chip + View result reach the thread, no Discuss duplicate", () => {
+  it("completed with threadStreamId: chip, quick action, and menu reach the thread", async () => {
     renderCard(
       {
         delegationId: "dlg_1",
@@ -120,16 +133,18 @@ describe("DelegationEvent", () => {
       { threadId: "stream_thread", replyCount: 3 }
     )
 
-    const link = screen.getByRole("link", { name: "View result" })
-    expect(link).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
     const chip = screen.getByRole("link", { name: /replies/ })
     expect(chip).toHaveTextContent("3 replies")
     expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
-    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "View result" })).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
+    expect(screen.queryByRole("link", { name: "Open thread" })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.getByRole("menuitem", { name: "View result" })).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
+    expect(screen.queryByRole("menuitem", { name: "Cancel delegation" })).not.toBeInTheDocument()
   })
 
-  it("completed thread parent suppresses self-links and nested thread affordances", () => {
+  it("completed thread parent suppresses self-links in every action surface", async () => {
     renderCard(
       {
         delegationId: "dlg_1",
@@ -141,24 +156,28 @@ describe("DelegationEvent", () => {
       true
     )
 
-    expect(screen.queryByRole("link", { name: "View result" })).not.toBeInTheDocument()
     expect(screen.queryByRole("link", { name: /replies/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: "Discuss this delegation" })).not.toBeInTheDocument()
-    expect(screen.getByText("Add rate limiting to the webhook endpoint")).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Open thread" })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.queryByRole("menuitem", { name: "View result" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: /thread/i })).not.toBeInTheDocument()
   })
 
-  it("completed (legacy shape): no threadStreamId falls back to the ?m= result deep-link", () => {
+  it("completed (legacy shape): menu falls back to the ?m= result deep-link", async () => {
     renderCard({ delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" })
 
-    const link = screen.getByRole("link", { name: "View result" })
-    expect(link).toHaveAttribute("href", "/w/ws_1/s/stream_1?m=msg_result")
-    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.getByRole("menuitem", { name: "View result" })).toHaveAttribute(
+      "href",
+      "/w/ws_1/s/stream_1?m=msg_result"
+    )
+    expect(screen.queryByRole("menuitem", { name: "Cancel delegation" })).not.toBeInTheDocument()
   })
 
-  it("open card: Discuss opens a draft thread panel keyed on the card's event id", () => {
+  it("open card: desktop quick action opens a draft thread keyed on the card event", () => {
     renderCard()
 
-    const discuss = screen.getByRole("link", { name: "Discuss this delegation" })
+    const discuss = screen.getByRole("link", { name: "Discuss in thread" })
     expect(discuss).toHaveAttribute("href", "/w/ws_1?panel=draft%3Astream_1%3Aevt_dlg")
   })
 
@@ -170,29 +189,31 @@ describe("DelegationEvent", () => {
     expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
   })
 
-  it.each(["failed", "expired"] as const)("%s is terminal: no Cancel, status in meta", (status) => {
+  it.each(["failed", "expired"] as const)("%s is terminal: no Cancel action, status in meta", async (status) => {
     renderCard({ delegationId: "dlg_1", status })
 
     expect(screen.getByText(new RegExp(`Ariadne · ${status}`, "i"))).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /Cancel/ })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.queryByRole("menuitem", { name: /Cancel delegation/ })).not.toBeInTheDocument()
   })
 
   it.each(["failed", "cancelled", "expired"] as const)(
-    "%s card is discussion-worthy: Discuss stays available when there's no thread yet",
+    "%s card remains discussion-worthy when there's no thread yet",
     (status) => {
       renderCard({ delegationId: "dlg_1", status })
 
-      const discuss = screen.getByRole("link", { name: "Discuss this delegation" })
+      const discuss = screen.getByRole("link", { name: "Discuss in thread" })
       expect(discuss).toHaveAttribute("href", "/w/ws_1?panel=draft%3Astream_1%3Aevt_dlg")
     }
   )
 
-  it("cancelled keeps the relabeled button in place (follow-up card pattern: focus retained, announced)", () => {
+  it("cancelled reports terminal status and removes mutation actions", async () => {
     renderCard({ delegationId: "dlg_1", status: "cancelled" })
 
-    const button = screen.getByRole("button", { name: "Cancelled" })
-    expect(button).toHaveAttribute("aria-disabled", "true")
-    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    expect(screen.getByText(/Ariadne · Cancelled/)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.queryByRole("menuitem", { name: "Mark done" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "Cancel delegation" })).not.toBeInTheDocument()
   })
 
   it("copies the compiled prompt and confirms in place with a checkmark (INV-63/21: no toast, same footprint)", async () => {
@@ -201,38 +222,38 @@ describe("DelegationEvent", () => {
     const success = vi.spyOn(toast, "success")
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: /Copy prompt/ }))
+    await userEvent.click(screen.getAllByRole("button", { name: /Copy prompt/ })[0])
 
     expect(writeText).toHaveBeenCalledWith(
       buildDelegationPrompt(CREATED_PAYLOAD, { workspaceId: "ws_1", origin: window.location.origin })
     )
-    await screen.findByRole("button", { name: "Prompt copied" })
+    expect(await screen.findAllByRole("button", { name: "Prompt copied" })).toHaveLength(2)
     expect(success).not.toHaveBeenCalled()
   })
 
-  it("copies a shareable delegation link and confirms in place with a checkmark (INV-63/21: no toast)", async () => {
+  it("copies a shareable delegation link from the menu and confirms after the menu closes", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
     const success = vi.spyOn(toast, "success")
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: /Copy link/ }))
+    await selectCardAction("Copy delegation link")
 
     expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/ws_1/delegations/dlg_1`)
-    await screen.findByRole("button", { name: "Link copied" })
-    expect(success).not.toHaveBeenCalled()
+    expect(success).toHaveBeenCalledWith("Delegation link copied")
   })
 
   it("marks the delegation done for paste-path work and relabels in place", async () => {
     const markDone = vi.spyOn(delegationsApi, "markDone").mockResolvedValue({ completed: true })
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: "Mark done" }))
+    await selectCardAction("Mark done")
 
     expect(markDone).toHaveBeenCalledWith("ws_1", "dlg_1")
     await waitFor(() => expect(screen.getByText(/Ariadne · Completed/)).toBeInTheDocument())
-    expect(screen.getByRole("button", { name: /Done/ })).toHaveAttribute("aria-disabled", "true")
-    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.queryByRole("menuitem", { name: "Mark done" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "Cancel delegation" })).not.toBeInTheDocument()
   })
 
   it("does not flip when mark-done lost the race; informs instead", async () => {
@@ -240,7 +261,7 @@ describe("DelegationEvent", () => {
     const info = vi.spyOn(toast, "info")
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: "Mark done" }))
+    await selectCardAction("Mark done")
 
     await waitFor(() => expect(info).toHaveBeenCalled())
     expect(screen.getByText(/Ariadne · Open/)).toBeInTheDocument()
@@ -258,14 +279,12 @@ describe("DelegationEvent", () => {
     const cancel = vi.spyOn(delegationsApi, "cancel").mockResolvedValue({ cancelled: true })
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    await selectCardAction("Cancel delegation")
 
     expect(cancel).toHaveBeenCalledWith("ws_1", "dlg_1")
     await waitFor(() => expect(screen.getByText(/Ariadne · Cancelled/)).toBeInTheDocument())
-    // Same element throughout — relabeled and aria-disabled, never unmounted,
-    // so the clicker's focus doesn't drop to <body>.
-    expect(screen.getByRole("button", { name: "Cancelled" })).toHaveAttribute("aria-disabled", "true")
-    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.queryByRole("menuitem", { name: "Cancel delegation" })).not.toBeInTheDocument()
   })
 
   it("does not flip when the cancel lost the race — the authoritative patch will land", async () => {
@@ -273,7 +292,7 @@ describe("DelegationEvent", () => {
     vi.spyOn(delegationsApi, "cancel").mockResolvedValue({ cancelled: false })
 
     renderCard()
-    await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    await selectCardAction("Cancel delegation")
 
     await waitFor(() => expect(info).toHaveBeenCalled())
     expect(screen.getByText(/Ariadne · Open/)).toBeInTheDocument()
@@ -285,6 +304,67 @@ describe("DelegationEvent", () => {
     await userEvent.click(screen.getByRole("button", { name: /Show hand-off prompt/ }))
     expect(screen.getByText(/# Add rate limiting to the webhook endpoint/)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Hide hand-off prompt/ })).toBeInTheDocument()
+  })
+
+  it("opens the complete action list from a desktop row context menu", async () => {
+    renderCard()
+
+    fireEvent.contextMenu(screen.getByText("Add rate limiting to the webhook endpoint"))
+
+    expect(await screen.findByRole("menuitem", { name: "Discuss in thread" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Copy prompt" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Mark done" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Cancel delegation" })).toBeInTheDocument()
+  })
+
+  it("restores focus to the overflow trigger after a desktop action", async () => {
+    renderCard()
+    const trigger = screen.getByRole("button", { name: "Card actions" })
+
+    await userEvent.click(trigger)
+    await userEvent.click(screen.getByRole("menuitem", { name: "Show hand-off prompt" }))
+
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it("keeps the complete menu keyboard-accessible when touch hides its chrome", async () => {
+    vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
+    vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
+    renderCard()
+
+    const trigger = screen.getByRole("button", { name: "Card actions" })
+    expect(trigger.closest(".reveal-actions-hover-only")).not.toHaveClass("hidden")
+    await userEvent.click(trigger)
+    expect(screen.getByRole("menuitem", { name: "Mark done" })).toBeInTheDocument()
+  })
+
+  it("opens the mobile action drawer on card long press", () => {
+    vi.useFakeTimers()
+    vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
+    vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
+    renderCard()
+
+    const title = screen.getByText("Add rate limiting to the webhook endpoint")
+    fireEvent.touchStart(title, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.getByRole("button", { name: "Mark done" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cancel delegation" })).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it("holding the persistent mobile Copy button does not open the row drawer", () => {
+    vi.useFakeTimers()
+    vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
+    vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
+    renderCard()
+
+    const copy = screen.getAllByRole("button", { name: "Copy prompt" })[0]
+    fireEvent.touchStart(copy, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.queryByRole("button", { name: "Mark done" })).not.toBeInTheDocument()
+    vi.useRealTimers()
   })
 
   it("renders nothing without a payload", () => {

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -1,15 +1,17 @@
-import { useRef, useState, type ReactNode } from "react"
-import { Link } from "react-router-dom"
+import { useRef, useState } from "react"
 import { toast } from "sonner"
 import {
+  ArrowUpRight,
   Check,
   ChevronDown,
   ChevronRight,
   Copy,
+  FileText,
   Link2,
   Loader2,
   MessageSquareReply,
   TerminalSquare,
+  X,
 } from "lucide-react"
 import {
   DelegationStatuses,
@@ -26,6 +28,13 @@ import { DELEGATION_STATUS_LABEL, DELEGATION_TERMINAL } from "@/lib/delegation-d
 import { buildDelegationLink } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
 import { ThreadSlot } from "./thread-slot"
+import {
+  TimelineCardActionDrawer,
+  TimelineCardContextMenu,
+  TimelineCardQuickActions,
+  type TimelineCardAction,
+  useTimelineCardActionSurface,
+} from "./timeline-card-actions"
 import { useThreadAnchor } from "./use-thread-anchor"
 
 interface DelegationEventProps {
@@ -91,19 +100,10 @@ export function buildDelegationPrompt(
 }
 
 /**
- * Timeline card for `delegation:created` (roadmap 5.1/5.2), in the follow-up
- * card's vocabulary (icon tile · content · right-slot actions). One component
- * renders every status (INV-29/43): the created row is the card; each
- * `delegation:status_changed` patch advances it via `statusPatch`.
- *
- * Copy prompt confirms in place by swapping the icon to a checkmark — same
- * footprint, no toast, no layout shift (INV-63/21). Cancel and Mark done are
- * buttons (they mutate — INV-40) shown only while non-terminal; Mark done
- * closes the loop for work executed outside the API path (copy-paste), which
- * previously had no honest terminal transition. "View result" is a link
- * (navigation — INV-40) shown when completed with a linked result message.
- * The status from `statusPatch` is authoritative; the local optimistic flips
- * only fast-path the clicking member's own action.
+ * Timeline card for `delegation:created`. One action list drives the desktop
+ * quick toolbar, overflow/right-click menus, and mobile long-press drawer. Copy
+ * prompt stays on the mobile card and confirms in place (INV-63/21). Status
+ * patches remain authoritative; local flips only fast-path the clicker's action.
  */
 export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isThreadParent }: DelegationEventProps) {
   const { getActorName } = useActors(workspaceId)
@@ -122,10 +122,9 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
   const [cancelling, setCancelling] = useState(false)
   const [markingDone, setMarkingDone] = useState(false)
   const [copyDone, setCopyDone] = useState(false)
-  const [copyLinkDone, setCopyLinkDone] = useState(false)
   const [briefOpen, setBriefOpen] = useState(false)
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const copyLinkResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const actionSurface = useTimelineCardActionSurface()
 
   if (!payload) return null
 
@@ -154,21 +153,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
 
   const replyCount = payload.replyCount ?? 0
 
-  // Discuss starts (or opens) a thread on this card. Failure cards are
-  // discussion-worthy too ("why did this fail"), so it shows on every state
-  // EXCEPT when the card already exposes its thread another way: a completed
-  // card's thread opens via "View result" (threadStreamId), and any card with
-  // replies shows the footer thread chip. Either would make Discuss a duplicate
-  // entry point.
-  const threadChipShowing = replyCount > 0 && !!threadHref && !isThreadParent
-  const showDiscuss = !threadStreamId && !threadChipShowing && !isThreadParent
-
-  // Icon-only below `sm` (labels appear at `sm`). Force a ~36px square hit area
-  // on narrow viewports so three adjacent targets aren't sub-30px mis-taps;
-  // desktop footprint is unchanged (min sizing reset at `sm`).
-  const iconActionClass =
-    "inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:min-h-0 sm:min-w-0 sm:justify-start"
-
+  const hasThread = !!payload.threadId || replyCount > 0
   const promptText = () => buildDelegationPrompt(payload, { workspaceId, origin: window.location.origin })
 
   async function handleCopy() {
@@ -188,13 +173,10 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
     if (!payload) return
     try {
       await navigator.clipboard.writeText(buildDelegationLink(workspaceId, payload.delegationId))
+      toast.success("Delegation link copied") // INV-63-allow: closing menu/drawer leaves no inline trigger
     } catch {
       toast.error("Couldn't copy the link")
-      return
     }
-    setCopyLinkDone(true)
-    if (copyLinkResetRef.current) clearTimeout(copyLinkResetRef.current)
-    copyLinkResetRef.current = setTimeout(() => setCopyLinkDone(false), 1200)
   }
 
   async function handleMarkDone() {
@@ -215,8 +197,6 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
   }
 
   async function handleCancel() {
-    // Re-entrancy guard instead of `disabled` (disable would blur the focused
-    // button); `aria-disabled` keeps it in the focus tree.
     if (!payload || cancelling || terminal) return
     setCancelling(true)
     try {
@@ -235,26 +215,74 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
     }
   }
 
-  // Cancelled keeps the SAME button element relabeled (the follow-up card's
-  // pattern): the clicker's focus stays on it instead of dropping to <body>,
-  // and aria-live announces the flip. Other terminal statuses hide Cancel —
-  // a "Cancelled" label under a Completed/Failed/Expired card would lie.
-  const cancelled = status === DelegationStatuses.CANCELLED
-  const showCancelSlot = !terminal || cancelled
-  let cancelIcon: ReactNode = null
-  if (cancelling) cancelIcon = <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
-  else if (cancelled) cancelIcon = <Check className="h-3 w-3" aria-hidden="true" />
+  const actions: TimelineCardAction[] = []
+  if (viewResultHref) {
+    actions.push({
+      id: "view-result",
+      label: "View result",
+      icon: ArrowUpRight,
+      href: viewResultHref,
+      quick: !!threadStreamId,
+    })
+  }
+  if (!isThreadParent && !threadStreamId) {
+    actions.push({
+      id: "thread",
+      label: hasThread ? "Open thread" : "Discuss in thread",
+      icon: MessageSquareReply,
+      href: replyUrl,
+      quick: true,
+    })
+  }
+  actions.push(
+    {
+      id: "copy-prompt",
+      label: copyDone ? "Prompt copied" : "Copy prompt",
+      icon: copyDone ? Check : Copy,
+      onSelect: handleCopy,
+      quick: true,
+      separatorBefore: actions.length > 0,
+    },
+    { id: "copy-link", label: "Copy delegation link", icon: Link2, onSelect: handleCopyLink },
+    {
+      id: "toggle-prompt",
+      label: briefOpen ? "Hide hand-off prompt" : "Show hand-off prompt",
+      icon: FileText,
+      onSelect: () => setBriefOpen((open) => !open),
+    }
+  )
+  if (!terminal) {
+    actions.push(
+      {
+        id: "mark-done",
+        label: markingDone ? "Marking done…" : "Mark done",
+        icon: markingDone ? Loader2 : Check,
+        onSelect: handleMarkDone,
+        disabled: markingDone,
+        loading: markingDone,
+        separatorBefore: true,
+      },
+      {
+        id: "cancel",
+        label: cancelling ? "Cancelling…" : "Cancel delegation",
+        icon: cancelling ? Loader2 : X,
+        onSelect: handleCancel,
+        disabled: cancelling,
+        loading: cancelling,
+        variant: "destructive",
+      }
+    )
+  }
 
-  // Mark done relabels in place only for the clicker's OWN flip; an API/other
-  // completion already shows the Completed pill (and View result), so adding a
-  // disabled "Done" chip there would be noise.
-  const showDoneSlot = !terminal || optimisticallyDone
-  let doneIcon: ReactNode = null
-  if (markingDone) doneIcon = <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
-  else if (optimisticallyDone) doneIcon = <Check className="h-3 w-3" aria-hidden="true" />
-
-  return (
-    <div className="px-3 sm:px-6 py-1.5">
+  const card = (
+    <div
+      className={cn(
+        "group reveal-host relative px-3 py-1.5 sm:px-6",
+        actionSurface.isTouchInput && "select-none",
+        actionSurface.longPress.isPressed && "opacity-70 transition-opacity duration-100"
+      )}
+      {...(actionSurface.touchCapable ? actionSurface.longPress.handlers : {})}
+    >
       <div
         className={cn(
           "rounded-[10px] border px-3 py-2 transition-colors",
@@ -285,95 +313,23 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
             <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{metaParts.join(" · ")}</p>
           </div>
 
-          <div className="flex shrink-0 items-center gap-1">
-            {viewResultHref && (
-              <Link
-                to={viewResultHref}
-                className="inline-flex items-center rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                View result
-              </Link>
+          {/* Copy remains a persistent, finger-sized mobile affordance. Every
+              other action lives in the long-press drawer; desktop gets the
+              message-style hover toolbar + overflow menu. */}
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={copyDone ? "Prompt copied" : "Copy prompt"}
+            aria-live="polite"
+            title="Copy the hand-off prompt for a local agent"
+            className="inline-flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors active:bg-muted sm:hidden"
+          >
+            {copyDone ? (
+              <Check className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Copy className="h-4 w-4" aria-hidden="true" />
             )}
-            {/* Discuss the card: start (or open) a thread anchored on this
-                event. Hidden only when the card already has a thread entry
-                (View result / footer chip) — see `showDiscuss`. Navigation, so
-                a <Link> to the draft/thread panel (INV-40). */}
-            {showDiscuss && (
-              <Link
-                to={replyUrl}
-                aria-label="Discuss this delegation"
-                title="Discuss this delegation in a thread"
-                className={iconActionClass}
-              >
-                <MessageSquareReply className="h-3 w-3" aria-hidden="true" />
-                <span className="hidden sm:inline">Discuss</span>
-              </Link>
-            )}
-            <button
-              type="button"
-              onClick={handleCopy}
-              aria-label={copyDone ? "Prompt copied" : "Copy prompt"}
-              aria-live="polite"
-              title="Copy the hand-off prompt for a local agent"
-              className={iconActionClass}
-            >
-              {copyDone ? (
-                <Check className="h-3 w-3" aria-hidden="true" />
-              ) : (
-                <Copy className="h-3 w-3" aria-hidden="true" />
-              )}
-              {/* Icon-only below sm: four text buttons crush the title column at 390px. */}
-              <span className="hidden sm:inline">Copy prompt</span>
-            </button>
-            <button
-              type="button"
-              onClick={handleCopyLink}
-              aria-label={copyLinkDone ? "Link copied" : "Copy link"}
-              aria-live="polite"
-              title="Copy a shareable link to this delegation"
-              className={iconActionClass}
-            >
-              {copyLinkDone ? (
-                <Check className="h-3 w-3" aria-hidden="true" />
-              ) : (
-                <Link2 className="h-3 w-3" aria-hidden="true" />
-              )}
-              <span className="hidden sm:inline">Copy link</span>
-            </button>
-            {showDoneSlot && (
-              <button
-                type="button"
-                onClick={handleMarkDone}
-                aria-disabled={optimisticallyDone || markingDone}
-                aria-busy={markingDone}
-                aria-live="polite"
-                title="Close the loop for work done outside the API (e.g. a pasted prompt)"
-                className={cn(
-                  "inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors",
-                  optimisticallyDone || markingDone ? "cursor-default" : "hover:bg-muted hover:text-foreground"
-                )}
-              >
-                {doneIcon}
-                {optimisticallyDone ? "Done" : "Mark done"}
-              </button>
-            )}
-            {showCancelSlot && (
-              <button
-                type="button"
-                onClick={handleCancel}
-                aria-disabled={cancelled || cancelling}
-                aria-busy={cancelling}
-                aria-live="polite"
-                className={cn(
-                  "inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors",
-                  cancelled || cancelling ? "cursor-default" : "hover:bg-muted hover:text-foreground"
-                )}
-              >
-                {cancelIcon}
-                {cancelled ? "Cancelled" : "Cancel"}
-              </button>
-            )}
-          </div>
+          </button>
         </div>
 
         {statusNote && <p className="mt-1.5 pl-10 text-[11px] text-muted-foreground">{statusNote}</p>}
@@ -382,7 +338,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
           type="button"
           onClick={() => setBriefOpen((open) => !open)}
           aria-expanded={briefOpen}
-          className="mt-1.5 inline-flex items-center gap-1 pl-10 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+          className="mt-1.5 hidden items-center gap-1 pl-10 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
         >
           {briefOpen ? (
             <ChevronDown className="h-3 w-3" aria-hidden="true" />
@@ -419,6 +375,24 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
           workspaceId={workspaceId}
         />
       )}
+      <TimelineCardQuickActions actions={actions} />
     </div>
+  )
+
+  return (
+    <>
+      <TimelineCardContextMenu actions={actions} disabled={actionSurface.isTouchInput}>
+        {card}
+      </TimelineCardContextMenu>
+      {actionSurface.touchCapable && (
+        <TimelineCardActionDrawer
+          open={actionSurface.drawerOpen}
+          onOpenChange={actionSurface.setDrawerOpen}
+          actions={actions}
+          title={payload.title}
+          subtitle={metaParts.join(" · ")}
+        />
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/timeline/timeline-card-actions.tsx
+++ b/apps/frontend/src/components/timeline/timeline-card-actions.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useState, type ReactNode } from "react"
+import { Link } from "react-router-dom"
+import { MoreHorizontal, type LucideIcon } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from "@/components/ui/drawer"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Separator } from "@/components/ui/separator"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { useInputMode, useTouchCapable } from "@/hooks"
+import { useLongPress } from "@/hooks/use-long-press"
+import { cn } from "@/lib/utils"
+
+export interface TimelineCardAction {
+  id: string
+  label: string
+  icon: LucideIcon
+  href?: string
+  onSelect?: () => void | Promise<void>
+  variant?: "default" | "destructive"
+  separatorBefore?: boolean
+  disabled?: boolean
+  disabledReason?: string
+  loading?: boolean
+  /** Show as an icon in the desktop hover toolbar before the overflow menu. */
+  quick?: boolean
+}
+
+async function runTimelineCardAction(action: TimelineCardAction) {
+  if (!action.onSelect || action.disabled) return
+
+  try {
+    await action.onSelect()
+  } catch (error) {
+    console.error(`Timeline card action "${action.id}" failed:`, error)
+    toast.error(error instanceof Error ? error.message : `Failed to complete ${action.label.toLowerCase()}`)
+  }
+}
+
+function ActionContent({ action, iconClassName }: { action: TimelineCardAction; iconClassName: string }) {
+  const Icon = action.icon
+  return (
+    <>
+      <Icon className={cn(iconClassName, action.loading && "animate-spin")} aria-hidden="true" />
+      <span className="flex min-w-0 flex-col">
+        <span>{action.label}</span>
+        {action.disabledReason && (
+          <span className="text-xs font-normal text-muted-foreground">{action.disabledReason}</span>
+        )}
+      </span>
+    </>
+  )
+}
+
+function DropdownAction({ action, onClose }: { action: TimelineCardAction; onClose?: () => void }) {
+  const destructive = action.variant === "destructive"
+  const className = cn("gap-2", destructive && "text-destructive focus:text-destructive")
+  const content = (
+    <ActionContent
+      action={action}
+      iconClassName={cn("h-4 w-4", destructive ? "text-destructive" : "text-muted-foreground")}
+    />
+  )
+
+  return (
+    <>
+      {action.separatorBefore && <DropdownMenuSeparator />}
+      {action.href ? (
+        <DropdownMenuItem asChild disabled={action.disabled} className={className}>
+          <Link to={action.href} onClick={onClose}>
+            {content}
+          </Link>
+        </DropdownMenuItem>
+      ) : (
+        <DropdownMenuItem
+          disabled={action.disabled}
+          className={className}
+          onSelect={() => {
+            onClose?.()
+            void runTimelineCardAction(action)
+          }}
+        >
+          {content}
+        </DropdownMenuItem>
+      )}
+    </>
+  )
+}
+
+export function TimelineCardActionMenu({ actions }: { actions: TimelineCardAction[] }) {
+  const [open, setOpen] = useState(false)
+  if (actions.length === 0) return null
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-6 w-6 shrink-0 text-muted-foreground shadow-sm hover:border-primary/30"
+          aria-label="Card actions"
+        >
+          <MoreHorizontal className="h-3.5 w-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[220px]">
+        {actions.map((action) => (
+          <DropdownAction key={action.id} action={action} onClose={() => setOpen(false)} />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function ContextAction({ action }: { action: TimelineCardAction }) {
+  const destructive = action.variant === "destructive"
+  const className = cn("gap-2", destructive && "text-destructive focus:text-destructive")
+  const content = (
+    <ActionContent
+      action={action}
+      iconClassName={cn("h-4 w-4", destructive ? "text-destructive" : "text-muted-foreground")}
+    />
+  )
+
+  return (
+    <>
+      {action.separatorBefore && <ContextMenuSeparator />}
+      {action.href ? (
+        <ContextMenuItem asChild disabled={action.disabled} className={className}>
+          <Link to={action.href}>{content}</Link>
+        </ContextMenuItem>
+      ) : (
+        <ContextMenuItem
+          disabled={action.disabled}
+          className={className}
+          onSelect={() => void runTimelineCardAction(action)}
+        >
+          {content}
+        </ContextMenuItem>
+      )}
+    </>
+  )
+}
+
+export function TimelineCardContextMenu({
+  actions,
+  disabled,
+  children,
+}: {
+  actions: TimelineCardAction[]
+  disabled?: boolean
+  children: ReactNode
+}) {
+  if (disabled || actions.length === 0) return <>{children}</>
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="min-w-[220px]">
+        {actions.map((action) => (
+          <ContextAction key={action.id} action={action} />
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+function DrawerAction({ action, onClose }: { action: TimelineCardAction; onClose: () => void }) {
+  const destructive = action.variant === "destructive"
+  const className = cn(
+    "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
+    destructive ? "text-destructive active:bg-destructive/10" : "active:bg-muted/80",
+    action.disabled && "cursor-default opacity-50"
+  )
+  const content = (
+    <ActionContent
+      action={action}
+      iconClassName={cn("h-[18px] w-[18px] shrink-0", destructive ? "text-destructive" : "text-muted-foreground")}
+    />
+  )
+
+  const handleAction = () => {
+    if (action.disabled) return
+    onClose()
+    void runTimelineCardAction(action)
+  }
+
+  return (
+    <>
+      {action.separatorBefore && <Separator className="mx-3 my-1 bg-border/50" />}
+      {action.href ? (
+        <Link to={action.href} className={className} aria-disabled={action.disabled} onClick={handleAction}>
+          {content}
+        </Link>
+      ) : (
+        <button type="button" className={className} disabled={action.disabled} onClick={handleAction}>
+          {content}
+        </button>
+      )}
+    </>
+  )
+}
+
+export function TimelineCardActionDrawer({
+  open,
+  onOpenChange,
+  actions,
+  title,
+  subtitle,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  actions: TimelineCardAction[]
+  title: string
+  subtitle?: string
+}) {
+  if (!open && actions.length === 0) return null
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[85dvh]">
+        <DrawerTitle className="sr-only">Actions for {title}</DrawerTitle>
+        <DrawerDescription className="sr-only">Choose an action for this card.</DrawerDescription>
+        <div className="min-h-0 overflow-y-auto">
+          <div className="px-4 pb-3 pt-2">
+            <p className="break-words text-base font-semibold text-foreground">{title}</p>
+            {subtitle && <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+          <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
+            {actions.map((action) => (
+              <DrawerAction key={action.id} action={action} onClose={() => onOpenChange(false)} />
+            ))}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function QuickAction({ action }: { action: TimelineCardAction }) {
+  const Icon = action.icon
+  const control = action.href ? (
+    <Button
+      asChild
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+    >
+      <Link to={action.href} aria-label={action.label}>
+        <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      </Link>
+    </Button>
+  ) : (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      disabled={action.disabled}
+      className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+      aria-label={action.label}
+      onClick={() => void runTimelineCardAction(action)}
+    >
+      <Icon className={cn("h-3.5 w-3.5", action.loading && "animate-spin")} aria-hidden="true" />
+    </Button>
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{control}</TooltipTrigger>
+      <TooltipContent>{action.disabledReason ?? action.label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function TimelineCardQuickActions({ actions }: { actions: TimelineCardAction[] }) {
+  const quickActions = actions.filter((action) => action.quick)
+  if (actions.length === 0) return null
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="reveal-actions-hover-only absolute right-4 top-0 z-10 -translate-y-1/2">
+        <div className="flex items-center gap-0.5 rounded-md border border-border/60 bg-popover/95 px-1 py-1 shadow-md backdrop-blur-sm">
+          {quickActions.map((action) => (
+            <span key={action.id} className="hidden sm:contents">
+              <QuickAction action={action} />
+            </span>
+          ))}
+          {/* Invisible for ordinary touch input, but still focusable: keyboard
+              focus reveals this toolbar through `.reveal-actions-hover-only`,
+              giving assistive input the same complete list as long-press. */}
+          <TimelineCardActionMenu actions={actions} />
+        </div>
+      </div>
+    </TooltipProvider>
+  )
+}
+
+export function useTimelineCardActionSurface() {
+  const touchCapable = useTouchCapable()
+  const isTouchInput = useInputMode() === "touch"
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const openDrawer = useCallback(() => setDrawerOpen(true), [])
+  const longPress = useLongPress({
+    onLongPress: openDrawer,
+    enabled: touchCapable,
+    deferToNativeLinks: true,
+    deferToInteractiveElements: true,
+  })
+
+  return {
+    touchCapable,
+    isTouchInput,
+    drawerOpen,
+    setDrawerOpen,
+    longPress,
+  }
+}

--- a/apps/frontend/src/hooks/use-long-press.ts
+++ b/apps/frontend/src/hooks/use-long-press.ts
@@ -18,6 +18,12 @@ interface UseLongPressOptions {
    * link itself (e.g. a sidebar stream row). Default: false.
    */
   deferToNativeLinks?: boolean
+  /**
+   * When true, do not start a container-level long press from an interactive
+   * descendant. Card rows use this so holding a persistent Copy or Join button
+   * activates that control's native behavior instead of opening the row drawer.
+   */
+  deferToInteractiveElements?: boolean
 }
 
 interface LongPressHandlers {
@@ -39,6 +45,7 @@ export function useLongPress({
   onLongPress,
   enabled = true,
   deferToNativeLinks = false,
+  deferToInteractiveElements = false,
 }: UseLongPressOptions): UseLongPressReturn {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const startPos = useRef<{ x: number; y: number } | null>(null)
@@ -70,12 +77,16 @@ export function useLongPress({
       // (e.g. code blocks) so long-press surfaces "Open in Firefox" / "Copy
       // link" for links, or native text selection for code, instead of the
       // app's drawer.
-      if (
-        deferToNativeLinks &&
-        e.target instanceof Element &&
-        e.target.closest('a[href], [data-native-context="true"]') !== null
-      ) {
-        return
+      if (e.target instanceof Element) {
+        if (deferToNativeLinks && e.target.closest('a[href], [data-native-context="true"]') !== null) return
+        if (
+          deferToInteractiveElements &&
+          e.target.closest(
+            'button, a[href], input, select, textarea, [role="button"], [role="link"], [contenteditable="true"]'
+          ) !== null
+        ) {
+          return
+        }
       }
       firedRef.current = false
       const touch = e.touches[0]
@@ -95,7 +106,7 @@ export function useLongPress({
         onLongPressRef.current()
       }, threshold)
     },
-    [enabled, threshold, deferToNativeLinks]
+    [enabled, threshold, deferToNativeLinks, deferToInteractiveElements]
   )
 
   const onTouchEnd = useCallback(() => {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -7,8 +7,10 @@ import path from "path"
 
 // Ports can be configured via env vars for browser E2E tests
 const backendPort = process.env.VITE_BACKEND_PORT || "3001"
+const socketPort = process.env.VITE_SOCKET_PORT || "3002"
 const frontendPort = parseInt(process.env.VITE_PORT || "3000", 10)
 const backendTarget = `http://localhost:${backendPort}`
+const socketTarget = `http://localhost:${socketPort}`
 const allowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? "")
   .split(",")
   .map((host) => host.trim())
@@ -74,9 +76,10 @@ function withForwardedHostHeaders() {
 }
 
 function buildProxyConfig() {
-  // /api and /test-auth-login are proxied to the backend (the workspace-router
-  // in E2E). Socket.io connects directly to the backend's wsUrl, so it does not
-  // need a proxy entry here. Shared by the dev server and the E2E preview server.
+  // /api and /test-auth-login go through the workspace router. Socket.IO
+  // normally connects directly to the region URL, but Tailscale remote mode
+  // deliberately uses the frontend origin so one HTTPS Serve listener can
+  // carry the app, API, and WebSocket without exposing extra ports.
   return {
     "/api": {
       target: backendTarget,
@@ -88,6 +91,13 @@ function buildProxyConfig() {
       target: backendTarget,
       changeOrigin: true,
       xfwd: true,
+      ...withForwardedHostHeaders(),
+    },
+    "/socket.io": {
+      target: socketTarget,
+      changeOrigin: true,
+      xfwd: true,
+      ws: true,
       ...withForwardedHostHeaders(),
     },
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "bun scripts/dev.ts",
     "dev:mobile": "LAN_MODE=true bun scripts/dev.ts",
+    "dev:remote": "TAILSCALE_MODE=true bun scripts/dev.ts",
     "dev:test": "bun scripts/dev-test.ts",
     "dev:backend": "bun --hot apps/backend/src/index.ts",
     "dev:frontend": "bun run --cwd apps/frontend dev",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -104,13 +104,17 @@ function getDefaultLanHost(): string | undefined {
     .find((i) => i && i.family === "IPv4" && !i.internal)?.address
 }
 
+interface TailscaleNode {
+  bin: string
+  host: string
+}
+
 /**
- * Best-effort Tailscale MagicDNS hostname so LAN mode also serves devices on
- * the tailnet (e.g. a phone off the home WiFi). Tries the CLI on PATH first,
- * then the macOS app-bundle binary. Returns undefined when Tailscale is
- * absent or not running — LAN mode then behaves exactly as before.
+ * Best-effort Tailscale node discovery so mobile mode can include the
+ * MagicDNS hostname and remote mode can launch `tailscale serve`. Tries the
+ * CLI on PATH first, then the macOS app-bundle binary.
  */
-async function getTailscaleHost(): Promise<string | undefined> {
+async function getTailscaleNode(): Promise<TailscaleNode | undefined> {
   const candidates = ["tailscale", "/Applications/Tailscale.app/Contents/MacOS/Tailscale"]
   for (const bin of candidates) {
     const result = await $`${bin} status --json`.quiet().nothrow()
@@ -120,13 +124,27 @@ async function getTailscaleHost(): Promise<string | undefined> {
       const dnsName: unknown = status?.Self?.DNSName
       if (status?.BackendState === "Running" && typeof dnsName === "string" && dnsName.length > 0) {
         // MagicDNS names come back fully qualified with a trailing dot.
-        return dnsName.replace(/\.$/, "")
+        return { bin, host: dnsName.replace(/\.$/, "") }
       }
     } catch {
       // Unparseable output — try the next candidate.
     }
   }
   return undefined
+}
+
+function replaceUrlOrigin(value: string, origin: string): string {
+  try {
+    const url = new URL(value)
+    const nextOrigin = new URL(origin)
+    url.protocol = nextOrigin.protocol
+    url.hostname = nextOrigin.hostname
+    url.port = nextOrigin.port
+    return url.toString()
+  } catch {
+    console.error(`Invalid URL while configuring remote auth callback: ${value}`)
+    process.exit(1)
+  }
 }
 
 async function ensureWorktreeEnv(): Promise<void> {
@@ -349,27 +367,44 @@ async function main() {
     }
   }
 
-  // LAN mode: make the app reachable from phones. Every detected host gets
-  // CORS + Vite allowedHosts coverage; auth callbacks can only bind to ONE
-  // host (WORKOS_REDIRECT_URI is a single value), so an explicit LAN_HOST
-  // wins, then the Tailscale MagicDNS name (works away from the home
-  // network), then the WiFi IP.
+  // Mobile mode exposes the ordinary HTTP dev ports to LAN/tailnet devices.
+  // Remote mode adds a temporary HTTPS Tailscale Serve origin and routes the
+  // browser-facing socket through the frontend proxy.
   const explicitLanHost = getExplicitLanHost()
-  const lanMode = process.env.LAN_MODE === "true" || process.argv.includes("--lan") || !!explicitLanHost
+  const remoteMode = process.env.TAILSCALE_MODE === "true" || process.argv.includes("--remote")
+  const lanMode = remoteMode || process.env.LAN_MODE === "true" || process.argv.includes("--lan") || !!explicitLanHost
+  const tailscale = lanMode ? await getTailscaleNode() : undefined
+  const tailscaleHttpsPort = Number(process.env.TAILSCALE_HTTPS_PORT ?? "443")
+  if (remoteMode && (!Number.isInteger(tailscaleHttpsPort) || tailscaleHttpsPort < 1 || tailscaleHttpsPort > 65535)) {
+    console.error(`Invalid TAILSCALE_HTTPS_PORT: ${process.env.TAILSCALE_HTTPS_PORT}`)
+    process.exit(1)
+  }
+
   let lanHosts: string[] = []
   let primaryLanHost: string | undefined
+  let remoteOrigin: string | undefined
 
   if (lanMode) {
-    const tailscaleHost = await getTailscaleHost()
     const defaultLanIp = getDefaultLanHost()
-    lanHosts = [...new Set([explicitLanHost, tailscaleHost, defaultLanIp].filter((h): h is string => !!h))]
+    lanHosts = [...new Set([explicitLanHost, tailscale?.host, defaultLanIp].filter((h): h is string => !!h))]
 
     if (lanHosts.length === 0) {
-      console.error("LAN_MODE enabled but no LAN IP or Tailscale host found — are you connected to WiFi?")
+      console.error("LAN mode enabled but no LAN IP or Tailscale host found — are you connected to a network?")
       process.exit(1)
     }
 
-    primaryLanHost = explicitLanHost ?? tailscaleHost ?? defaultLanIp
+    primaryLanHost = explicitLanHost ?? tailscale?.host ?? defaultLanIp
+  }
+
+  if (remoteMode) {
+    if (!tailscale) {
+      console.error("Remote mode requires a running Tailscale client")
+      process.exit(1)
+    }
+    remoteOrigin =
+      tailscaleHttpsPort === 443 ? `https://${tailscale.host}` : `https://${tailscale.host}:${tailscaleHttpsPort}`
+    console.log(`Remote mode: ${remoteOrigin}  (auth callbacks)`)
+  } else if (lanMode) {
     for (const host of lanHosts) {
       console.log(`LAN mode: http://${host}:3000${host === primaryLanHost ? "  (auth callbacks)" : ""}`)
     }
@@ -382,10 +417,21 @@ async function main() {
     "http://127.0.0.1:5173",
   ]
   for (const host of lanHosts) corsOrigins.push(`http://${host}:3000`)
+  if (remoteOrigin) corsOrigins.push(remoteOrigin)
 
   const cpEnvOverrides: Record<string, string> = {}
-  if (primaryLanHost && cpEnv.WORKOS_REDIRECT_URI) {
-    cpEnvOverrides.WORKOS_REDIRECT_URI = cpEnv.WORKOS_REDIRECT_URI.replace("localhost", primaryLanHost)
+  const authOrigin = remoteOrigin ?? (primaryLanHost ? `http://${primaryLanHost}:3000` : undefined)
+  if (authOrigin && cpEnv.WORKOS_REDIRECT_URI) {
+    cpEnvOverrides.WORKOS_REDIRECT_URI = replaceUrlOrigin(cpEnv.WORKOS_REDIRECT_URI, authOrigin)
+  }
+
+  if (remoteMode) {
+    console.log("Building frontend for reliable Tailscale delivery...")
+    const build = await $`bun run --cwd apps/frontend build`.nothrow()
+    if (build.exitCode !== 0) {
+      console.error("Frontend build failed")
+      process.exit(build.exitCode)
+    }
   }
 
   // Dev convenience: auto-seed a platform admin for the default stub email so
@@ -434,7 +480,12 @@ async function main() {
   })
 
   const routerDir = path.join(process.cwd(), "apps/workspace-router")
-  const router = Bun.spawn(["bunx", "wrangler", "dev", "--port", "3001"], {
+  const routerArgs = ["bunx", "wrangler", "dev", "--port", "3001"]
+  if (remoteOrigin) {
+    const regions = JSON.stringify({ local: { apiUrl: "http://localhost:3002", wsUrl: remoteOrigin } })
+    routerArgs.push("--var", `REGIONS:${regions}`)
+  }
+  const router = Bun.spawn(routerArgs, {
     cwd: routerDir,
     stdout: "inherit",
     stderr: "inherit",
@@ -447,7 +498,7 @@ async function main() {
     stderr: "inherit",
   })
 
-  const frontend = Bun.spawn(["bun", "run", "--cwd", "apps/frontend", "dev"], {
+  const frontend = Bun.spawn(["bun", "run", "--cwd", "apps/frontend", remoteMode ? "preview" : "dev"], {
     stdout: "inherit",
     stderr: "inherit",
     env: {
@@ -459,6 +510,7 @@ async function main() {
         .map((host) => host.trim())
         .filter(Boolean)
         .join(","),
+      ...(tailscale?.host ? { __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: tailscale.host } : {}),
     },
   })
 
@@ -507,18 +559,30 @@ async function main() {
     },
   })
 
-  installDevLifecycle([controlPlane, backend, router, backofficeRouter, frontend, backoffice, enclaveBuilder, enclave])
+  // Foreground Serve removes its temporary HTTPS listener when the dev stack
+  // exits, unlike `tailscale serve --bg`, which strands a proxy to dead ports.
+  const tailscaleServe =
+    remoteOrigin && tailscale
+      ? Bun.spawn([tailscale.bin, "serve", `--https=${tailscaleHttpsPort}`, "http://127.0.0.1:3000"], {
+          stdout: "inherit",
+          stderr: "inherit",
+        })
+      : null
 
-  await Promise.all([
-    controlPlane.exited,
-    backend.exited,
-    router.exited,
-    backofficeRouter.exited,
-    frontend.exited,
-    backoffice.exited,
-    enclaveBuilder.exited,
-    enclave.exited,
-  ])
+  const processes = [
+    controlPlane,
+    backend,
+    router,
+    backofficeRouter,
+    frontend,
+    backoffice,
+    enclaveBuilder,
+    enclave,
+    ...(tailscaleServe ? [tailscaleServe] : []),
+  ]
+  installDevLifecycle(processes)
+
+  await Promise.all(processes.map((child) => child.exited))
 }
 
 main()

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -421,8 +421,9 @@ async function main() {
 
   const cpEnvOverrides: Record<string, string> = {}
   const authOrigin = remoteOrigin ?? (primaryLanHost ? `http://${primaryLanHost}:3000` : undefined)
-  if (authOrigin && cpEnv.WORKOS_REDIRECT_URI) {
-    cpEnvOverrides.WORKOS_REDIRECT_URI = replaceUrlOrigin(cpEnv.WORKOS_REDIRECT_URI, authOrigin)
+  const configuredWorkosRedirectUri = cpEnv.WORKOS_REDIRECT_URI ?? process.env.WORKOS_REDIRECT_URI
+  if (authOrigin && configuredWorkosRedirectUri) {
+    cpEnvOverrides.WORKOS_REDIRECT_URI = replaceUrlOrigin(configuredWorkosRedirectUri, authOrigin)
   }
 
   if (remoteMode) {


### PR DESCRIPTION
## Problem

Delegation and call cards expose different actions depending on input mode. Desktop cards lack message-style hover and right-click actions, while mobile users must rely on small inline controls with no long-press action surface. The existing mobile dev command also configured raw HTTP ports rather than a complete Tailscale Serve HTTPS path, leaving remote demos stuck behind failed frontend modules or a disconnected socket.

## Solution

Drive every delegation or call surface from one card-specific `TimelineCardAction[]` list, then render that list through shared desktop quick actions, overflow/context menus, and a mobile long-press drawer.

- Delegations keep Copy prompt inline on mobile; result/thread navigation, link copying, hand-off prompt visibility, completion, and cancellation move into the shared action model.
- Calls keep Join inline on mobile; call chat and permalink copying are available from the drawer/menu, with Join omitted for ended calls and disabled when another call is active.
- `useLongPress` can defer to interactive descendants, so holding Copy, Join, links, or inputs preserves their native interaction instead of opening the card drawer.
- Hidden desktop controls remain keyboard and screen-reader reachable, keyboard focus reveals them, and Radix restores focus after non-navigation menu actions.
- `bun run dev:remote` builds the frontend, starts a temporary foreground Tailscale HTTPS proxy, supplies the public workspace socket URL, and routes Socket.IO through Vite to the local backend. HTTPS CORS and WorkOS callback origins are derived from the detected MagicDNS host.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/timeline-card-actions.tsx` | **New:** shared quick-action, overflow, context-menu, and mobile-drawer renderers. |
| `apps/frontend/src/components/timeline/delegation-event.tsx` | Defines one state-aware delegation action list and keeps only Copy prompt persistent on mobile. |
| `apps/frontend/src/components/timeline/call-card.tsx` | Defines Join/chat/permalink actions and keeps Join persistent on mobile. |
| `apps/frontend/src/hooks/use-long-press.ts` | Adds opt-in deferral for interactive descendants. |
| `apps/frontend/src/components/timeline/delegation-event.test.tsx` | Covers action gating, desktop menus, long press, focus restoration, and self-link suppression. |
| `apps/frontend/src/components/timeline/call-card.test.tsx` | Covers call state actions, mobile behavior, and keyboard access. |
| `apps/frontend/vite.config.ts` | Proxies same-origin remote Socket.IO traffic to the local backend. |
| `scripts/dev.ts` | Adds production-preview Tailscale mode with HTTPS origins, remote socket configuration, and foreground cleanup. |
| `package.json` | Adds `dev:remote`. |
| `README.md` | Documents mobile and remote device-testing commands. |
| `DESIGN.md` | Records the cross-input card-action pattern. |

## Test plan

- [x] Timeline component tests — 78 passed
- [x] Frontend typecheck
- [x] Focused frontend ESLint
- [x] Dev lifecycle tests — 5 passed
- [x] `dev:remote` smoke test — frontend, API config, browser-origin Socket.IO handshake, and WorkOS redirect verified over Tailscale HTTPS
- [x] Repository commit hooks — lint, package/app typechecks, Dockerfile checks, 236 migration checks, Astro checks, and generated API-doc checks
- [x] `git diff --check`

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Give delegation and call cards the same action discoverability as messages across mouse, keyboard, assistive technology, and touch without duplicating action behavior between surfaces.

## What Was Built

### Shared card action surfaces

`timeline-card-actions.tsx` renders a card-owned action list as desktop hover controls, an overflow menu, a row context menu, or a mobile drawer. Labels, icons, disabled/destructive state, mutations, and navigation stay in the owning card's single list.

### Delegation actions

`delegation-event.tsx` exposes result/thread navigation, Copy prompt, Copy delegation link, hand-off prompt visibility, Mark done, and Cancel delegation according to delegation state. Mobile keeps Copy prompt inline; a thread parent suppresses links back to itself.

### Call actions

`call-card.tsx` exposes Join while live, Start/Open call chat, and Copy link to call card. Mobile keeps Join inline. Joining is disabled when the viewer is already in another call, and ended calls do not offer Join.

### Input and accessibility behavior

`use-long-press.ts` retains the existing 500 ms gesture and scroll cancellation while allowing cards to defer long press from interactive descendants. Touch-hidden overflow controls remain keyboard and screen-reader reachable, reveal on focus, and restore focus after menu actions.

### Tailscale demo mode

`bun run dev:remote` discovers the local MagicDNS hostname, builds and previews the frontend to avoid dev-module proxy failures, starts `tailscale serve` in the foreground, configures the workspace router to return the HTTPS origin, and proxies `/socket.io` to the backend. The foreground Serve process is part of the normal dev lifecycle, so stopping the stack removes the listener.

## Design Decisions

- **One action model per card:** avoids separate hover, context-menu, and drawer behavior drifting apart.
- **Persistent mobile actions stay task-specific:** Copy prompt remains on delegations and Join remains on calls; secondary actions move to the drawer.
- **Live-call controls stay out of historical cards:** mute, leave/end, and participant controls remain in the call dock.
- **One Tailscale HTTPS origin:** app, API, auth, and Socket.IO share the registered MagicDNS origin; Vite owns the local socket hop instead of exposing backend ports.

## Schema Changes

None.

## What's NOT Included

Message action behavior and live call-dock controls are unchanged. Ordinary `dev` and raw-network `dev:mobile` behavior remain available.

## Status

- [x] Shared action surfaces
- [x] Delegation integration
- [x] Call integration
- [x] Accessibility and interaction regressions
- [x] Tailscale HTTPS demo command
- [x] Focused tests, typecheck, lint, and repository commit hooks

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787395683&installation_model_id=20758&pr_number=1519&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1519&signature=b4711902b7f28af2300f1baa16d737b2d73d2d958d8a7d463d55dd29722a2bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->