### PR TITLE
docs: add build-feature decomposition checkpoint

### DIFF
--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -56,6 +56,7 @@ Determine the active harness/provider once and record the profile in the first s
 
 ## Gotchas
 
+- **Decomposition checkpoint:** when a chunk exceeds its budget or starts coordinating independent lifecycle/state machines, stop before adding more machinery. Give the user a short split proposal along the ownership/lifecycle boundary, preserve the patch, ratify the revised stack, and continue in smaller PRs.
 - Workflow `args` must be real JSON values, not a stringified blob; briefs go in files.
 - Stacked PRs only run the main CI trio when targeting `main`; run required local gates before submission.
 - Merge/sync stacks through `gh stack`; never hand-roll rebases around squash merges.


### PR DESCRIPTION
## Problem

Large feature chunks can keep accumulating review-driven lifecycle machinery after their original boundary stops being useful.

## Solution

Add a short decomposition checkpoint to `build-feature`: when a chunk exceeds budget or crosses independent lifecycle/state machines, preserve the patch, propose an ownership-boundary split, ratify it, and continue as smaller PRs.

## Test plan

- [x] Documentation-only diff
- [x] `git diff --check`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787396836&installation_model_id=20758&pr_number=1520&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1520&signature=4b910b664508e3fa7110a1cbc0bb808bbd2d5fb90afa5e4cbd0e936e678cf976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->