### PR TITLE
docs: tune workflow agent reasoning profiles

### DIFF
--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -10,7 +10,8 @@ Build each plan chunk, verify it once with the strongest useful runtime profile,
 ## Planning and preconditions
 
 - The invoking agent remains the orchestrator at its current, lower reasoning level. It owns sequencing, user checkpoints, agent briefs, gates, and stack state; it does not become the planner.
-- A ratified plan doc in `docs/plans/<feature>.md` containing a PR-stack breakdown is required. No plan → delegate investigation and plan drafting to one fresh high-reasoning planner, then have the user ratify the result before implementation. Do not start building from a chat message.
+- A ratified implementation plan containing a PR-stack breakdown is required. The plan embedded in the PR body by `/sync-plan` is authoritative. Files under `docs/plans/` are optional desired-design context, never implementation truth.
+- No implementation plan → delegate investigation and drafting to one fresh high-reasoning planner, have the user ratify the result, then publish it with `/sync-plan` before implementation. Do not start building from a chat message.
 - The planner writes the candidate plan but never orchestrates implementation or delegates children.
 - Deferred items in the plan are binding: do not build them.
 

--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -7,9 +7,11 @@ description: Build a planned feature as a stacked PR chain with per-chunk implem
 
 Build each plan chunk, verify it once with the strongest useful runtime profile, fix findings in one batch, and create the stacked PR before moving on. Preserve review quality without paying multiple agents to repeat the same lens on the same diff.
 
-## Preconditions
+## Planning and preconditions
 
-- A ratified plan doc in `docs/plans/<feature>.md` containing a PR-stack breakdown. No plan → write one and get it ratified first; do not start building from a chat message.
+- The invoking agent remains the orchestrator at its current, lower reasoning level. It owns sequencing, user checkpoints, agent briefs, gates, and stack state; it does not become the planner.
+- A ratified plan doc in `docs/plans/<feature>.md` containing a PR-stack breakdown is required. No plan → delegate investigation and plan drafting to one fresh high-reasoning planner, then have the user ratify the result before implementation. Do not start building from a chat message.
+- The planner writes the candidate plan but never orchestrates implementation or delegates children.
 - Deferred items in the plan are binding: do not build them.
 
 ## Select one execution profile
@@ -18,6 +20,7 @@ Determine the active harness/provider once and record the profile in the first s
 
 ### Claude profile
 
+- Planner: Fable, effort `high`.
 - Implementer: Opus, effort `medium`.
 - Per-chunk verifier: Opus, effort `xhigh`.
 - Whole-stack reviewer: Fable.
@@ -25,6 +28,7 @@ Determine the active harness/provider once and record the profile in the first s
 
 ### Pi / OpenAI profile
 
+- Planner: one fresh GPT-5.6 Sol agent, effort `high`.
 - Implementer: GPT-5.6 Sol, effort `low`. Pi maps Sol `minimal` to provider `low`, so request `low` explicitly.
 - Per-chunk verifier: one fresh GPT-5.6 Sol agent, effort `high`.
 - Never use `xhigh` per chunk. Reserve it for one final whole-stack review only when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries; otherwise use `high`.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -7,6 +7,11 @@ description: Create a pull request with a dense, verified description. Use when 
 
 Self-review, write a dense verified description, open the PR, subscribe. Invoking this skill is the request for all of it.
 
+## Runtime profile
+
+- Pi / OpenAI: run PR orchestration with GPT-5.6 Sol at effort `low`.
+- Do not raise the orchestration effort for self-review. When Step 3 requires `/code-review`, keep that skill's separate Sol/high reviewer profile.
+
 ## Flow
 
 1. **Context** (parallel): `git branch --show-current` · `git status -sb` · `git log main..HEAD --oneline` · `git diff main...HEAD --stat` · `git diff main...HEAD` (read it). Ticket: `git branch --show-current | grep -oiE 'thr-[0-9]+' | tr '[:lower:]' '[:upper:]'` — if found, in title + linked in body; else cite audit/design ids (`E2EE-22`, `INV-62`) in body.


### PR DESCRIPTION
## Problem

The build-feature workflow made planning an orchestrator responsibility, which requires the parent session to spend its reasoning budget on plan drafting. The PR creation skill also lacked a runtime profile, allowing deterministic orchestration to consume high-reasoning capacity.

## Solution

- Keep the invoking build-feature agent as the lower-reasoning orchestrator and delegate missing-plan investigation and drafting to one fresh planner.
- Use Fable/high for Claude planning and GPT-5.6 Sol/high for Pi/OpenAI planning.
- Run Pi/OpenAI PR orchestration with GPT-5.6 Sol/low while preserving the separate Sol/high profile when `/code-review` is required.
- Prevent planners from delegating or orchestrating implementation; retain user ratification before building.

## Test plan

- [x] `git diff --check`
- [x] pre-commit lint, typecheck, Dockerfile checks, migration checks, public-site checks, and OpenAPI generation check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
