### PR TITLE
fix: drain pending Pi remote invocations

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1394,7 +1394,8 @@ describe("claim drain serialization", () => {
       apiKey: "threa_bk_test",
       linkedSessions: { runtime: { enabled: true, instanceId: "pi-instance", runtimeSessionId: "runtime" } },
     })
-    const queued = Array.from({ length: 12 }, (_, index) => `message-${index + 1}`)
+    const expectedMessages = Array.from({ length: 12 }, (_, index) => `message-${index + 1}`)
+    const queued = [...expectedMessages]
     let claimRequests = 0
     const deliveries: Array<{ text: string; options?: { deliverAs: string } }> = []
     const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
@@ -1441,11 +1442,20 @@ describe("claim drain serialization", () => {
     } as never
 
     try {
-      expect(await __testing.claimIfIdle(pi, ctx)).toBe(true)
-      expect(claimRequests).toBe(13)
-      expect(deliveries).toHaveLength(12)
-      expect(deliveries[0]?.options).toBeUndefined()
-      expect(deliveries.slice(1).every(({ options }) => options?.deliverAs === "steer")).toBe(true)
+      const result = await __testing.claimIfIdle(pi, ctx)
+      expect({
+        result,
+        claimRequests,
+        firstDeliveryEndsWithPrompt: deliveries[0]?.text.endsWith(`\n${expectedMessages[0]}`),
+        deliveryOptions: deliveries.map(({ options }) => options),
+        steeredTexts: deliveries.slice(1).map(({ text }) => text),
+      }).toEqual({
+        result: true,
+        claimRequests: 13,
+        firstDeliveryEndsWithPrompt: true,
+        deliveryOptions: [undefined, ...Array.from({ length: 11 }, () => ({ deliverAs: "steer" }))],
+        steeredTexts: expectedMessages.slice(1),
+      })
     } finally {
       fetchSpy.mockRestore()
     }

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1321,7 +1321,7 @@ describe("claim drain serialization", () => {
     __testing.setConfigForTesting(undefined)
   })
 
-  test("shares one claim pass between concurrent callers", async () => {
+  test("serializes concurrent callers and reruns after a coalesced wakeup", async () => {
     __testing.setConfigForTesting({
       baseUrl: "https://app.threa.io",
       workspaceId: "ws_123",
@@ -1351,8 +1351,72 @@ describe("claim drain serialization", () => {
     expect(first).toBe(second)
     release()
     expect(await Promise.all([first, second])).toEqual([true, true])
-    expect(requests).toBe(1)
+    expect(requests).toBe(2)
     fetchSpy.mockRestore()
+  })
+
+  test("drains all pending invocations from one wakeup", async () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { runtime: { enabled: true, instanceId: "pi-instance", runtimeSessionId: "runtime" } },
+    })
+    const queued = Array.from({ length: 12 }, (_, index) => `message-${index + 1}`)
+    let claimRequests = 0
+    const deliveries: Array<{ text: string; options?: { deliverAs: string } }> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/claim")) {
+        const promptMarkdown = queued.shift()
+        claimRequests++
+        return new Response(
+          JSON.stringify({
+            data: promptMarkdown
+              ? {
+                  id: `binv_${promptMarkdown}`,
+                  activeStreamId: "stream_1",
+                  sourceMessageId: `msg_${promptMarkdown}`,
+                  promptMarkdown,
+                  claimToken: `claim_${promptMarkdown}`,
+                  claimExpiresAt: null,
+                }
+              : null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      if (url.includes("/streams/stream_1/messages?")) {
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => "runtime" },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: { notify: () => {}, setStatus: () => {}, theme: { fg: (_tone: string, text: string) => text } },
+    } as never
+    const pi = {
+      sendUserMessage: (text: string, options?: { deliverAs: string }) => deliveries.push({ text, options }),
+    } as never
+
+    try {
+      expect(await __testing.claimIfIdle(pi, ctx)).toBe(true)
+      expect(claimRequests).toBe(13)
+      expect(deliveries).toHaveLength(12)
+      expect(deliveries[0]?.options).toBeUndefined()
+      expect(deliveries.slice(1).every(({ options }) => options?.deliverAs === "steer")).toBe(true)
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 
   test("runtime reset drains an in-flight claim before teardown completes", async () => {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1355,6 +1355,38 @@ describe("claim drain serialization", () => {
     fetchSpy.mockRestore()
   })
 
+  test("stops draining on an empty claim during a rate-limit wait", async () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: { runtime: { enabled: true, instanceId: "pi-instance", runtimeSessionId: "runtime" } },
+    })
+    __testing.setRateLimitWaitForTesting(true)
+    let claimRequests = 0
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (String(input).endsWith("/bot-invocations/claim")) claimRequests++
+      return new Response(JSON.stringify({ data: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => "runtime" },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: { notify: () => {}, setStatus: () => {}, theme: { fg: (_tone: string, text: string) => text } },
+    } as never
+
+    try {
+      expect(await __testing.claimIfIdle({} as never, ctx)).toBe(true)
+      expect(claimRequests).toBe(1)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("drains all pending invocations from one wakeup", async () => {
     __testing.setConfigForTesting({
       baseUrl: "https://app.threa.io",

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -2950,7 +2950,7 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
         if (invocation) await failInvocation(invocation, "Pi session lifecycle changed while claiming")
         return false
       }
-      if (!invocation) break
+      if (!invocation) return true
       if (isSessionControlInvocation(invocation)) {
         await handleSessionControlInvocation(pi, ctx, invocation)
         // A /stop cancelled the wait (and possibly the turn) — stop sweeping.
@@ -3618,6 +3618,9 @@ export const __testing = {
   },
   setSupervisedRevivalBlockedForTesting: (value: boolean) => {
     supervisedRevivalBlocked = value
+  },
+  setRateLimitWaitForTesting: (value: boolean) => {
+    isWaitingForRetry = value
   },
   setStorageDirectoryForTesting,
   storagePaths: () => ({ configPath: CONFIG_PATH, lockPath: CONFIG_LOCK_PATH, bikPath: BIK_PATH }),

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -298,6 +298,7 @@ let fallbackRuntimeSessionId: string | undefined
 let supervisedRevivalBlocked = false
 let reconnectPending = false
 let claimIfIdleInFlight: Promise<boolean> | undefined
+let claimIfIdleRerunRequested = false
 let sessionLifecycleGeneration = 0
 let sessionTearingDown = false
 // Owns the /bot socket + routes presence/renew/steps over it (HTTP fallback
@@ -2913,7 +2914,15 @@ async function executeProviderRetry(pi: ExtensionAPI, ctx: ExtensionContext, att
 
 function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boolean> {
   if (sessionTearingDown) return Promise.resolve(false)
-  claimIfIdleInFlight ??= claimIfIdlePass(pi, ctx, sessionLifecycleGeneration).finally(() => {
+  claimIfIdleRerunRequested = true
+  claimIfIdleInFlight ??= (async () => {
+    let result = false
+    while (claimIfIdleRerunRequested && !sessionTearingDown) {
+      claimIfIdleRerunRequested = false
+      result = await claimIfIdlePass(pi, ctx, sessionLifecycleGeneration)
+    }
+    return result
+  })().finally(() => {
     claimIfIdleInFlight = undefined
   })
   return claimIfIdleInFlight
@@ -2965,6 +2974,9 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
         }
       }
     }
+    if (isWaitingForRetry && !sessionTearingDown && lifecycleGeneration === sessionLifecycleGeneration) {
+      claimIfIdleRerunRequested = true
+    }
     return true
   }
 
@@ -2989,9 +3001,8 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
     } else {
       await injectInvocation(pi, ctx, invocation, steer)
     }
-    if (!steer) return true
-    if (!pending && ctx.isIdle()) return true
   }
+  if (!sessionTearingDown && lifecycleGeneration === sessionLifecycleGeneration) claimIfIdleRerunRequested = true
   return true
 }
 
@@ -3567,6 +3578,7 @@ async function resetRuntimeForTesting(): Promise<void> {
   teardownTransport()
   await claimIfIdleInFlight?.catch(() => undefined)
   claimIfIdleInFlight = undefined
+  claimIfIdleRerunRequested = false
   config = undefined
   pollInFlightRunId = undefined
   pending = undefined
@@ -3662,6 +3674,7 @@ export const __testing = {
     steeredInvocations = []
     reconnectPending = false
     claimIfIdleInFlight = undefined
+    claimIfIdleRerunRequested = false
     sessionLifecycleGeneration++
     sessionTearingDown = false
   },
@@ -3950,12 +3963,20 @@ export default function (pi: ExtensionAPI): void {
     }
   })
 
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (!config || !isEnabled(ctx) || !shouldHandleSessionEvents(ctx)) return
+    await claimIfIdle(pi, ctx).catch((error) => {
+      ctx.ui.notify(`Threa remote claim failed: ${String(error)}`, "warning")
+    })
+  })
+
   pi.on("session_shutdown", async (event, ctx) => {
     // In-process Pi child sessions can discover this global extension. Never
     // let an unlinked child tear down or complete the linked parent's claim.
     if (!shouldHandleSessionEvents(ctx)) return
     sessionTearingDown = true
     sessionLifecycleGeneration++
+    claimIfIdleRerunRequested = false
     reconnectPending = false
     stopPolling()
     stopClaimRenewTimer()


### PR DESCRIPTION
**Problem**

Pi remote stopped its claim loop after the first invocation claimed from idle. Wakeups arriving during that claim shared the same pass without scheduling another, so queued work could remain pending until a later message or the 15-minute polling backstop.

**Solution**

- Continue `claimIfIdlePass` until the backend returns no claim; the existing 10-claim bound now schedules an immediate continuation.
- Add a rerun latch around `claimIfIdleInFlight`, preserving single-flight serialization without dropping concurrent wakeups.
- Run another claim drain from `agent_settled` so work excluded while Pi was busy is collected once the turn is genuinely idle.
- Keep lifecycle generation, teardown, `/stop`, and reconnect boundaries unchanged.

**Verification**

- [x] `bun test ./extensions/pi-remote/src/threa-remote.test.ts` — 107 passed
- [x] Commit hooks — repository lint, typecheck, Dockerfile checks, migration checks, API docs check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787408775&installation_model_id=20758&pr_number=1522&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1522&signature=0d46a44c40de6a4c8e76080a8e0c407851fa9aa36c621dff8aae00a4ac2e7e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->