### PR TITLE
feat(calls): add desktop call surface picker

### DIFF
--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -15,7 +15,9 @@ import {
   useCallStreamId,
   useCallWorkspaceId,
 } from "./call-store-hooks"
-import { getCallState, setCallSurfaceMode } from "@/stores/call-store"
+import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
+import { resolveDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
+import { useDesktopSurfaceOverride } from "./call-store-hooks"
 
 // The mute / camera / flip / leave controls, one component each so the compact
 // island and the (later) desktop pill share one implementation instead of
@@ -116,6 +118,10 @@ export function ChatButton({ className }: { className?: string }) {
   const workspaceId = useCallWorkspaceId()
   const streamId = useCallStreamId()
   const chatAnchorId = useCallChatAnchor()
+  const isMobile = useIsMobile()
+  const desktopSurfaceOverride = useDesktopSurfaceOverride()
+  const { desktopCallSurface, lastDesktopSurface } = useCallPrefs()
+  const desktopSurface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, desktopSurfaceOverride)
   if (!workspaceId || !streamId || !chatAnchorId) return null
   const search = new URLSearchParams({ panel: createDraftPanelId(streamId, chatAnchorId) }).toString()
   return (
@@ -127,7 +133,8 @@ export function ChatButton({ className }: { className?: string }) {
         onClick={() => {
           // The fullscreen mobile surface is an opaque route-independent overlay —
           // without collapsing it the thread panel opens invisibly underneath.
-          if (getCallState().surfaceMode === "full") setCallSurfaceMode("standard")
+          if (isMobile && getCallState().surfaceMode === "full") setCallSurfaceMode("standard")
+          if (!isMobile && desktopSurface === "fullscreen") setDesktopSurfaceOverride("sidebar")
         }}
       >
         <MessageSquare className="h-4 w-4" />

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -10,9 +10,16 @@ import {
   setCallPhase,
   setCallDevices,
   setCallSurfaceMode,
+  setDesktopSurfaceOverride,
   type CallDeviceState,
 } from "@/stores/call-store"
 import type { CallController } from "@/calls/call-manager"
+import {
+  __resetCallPrefsForTests,
+  getCallPrefs,
+  setDesktopCallSurface,
+  setLastDesktopSurface,
+} from "@/stores/call-prefs-store"
 import { CallControls, DevicePickerMenu } from "./call-controls"
 import { CallManagerProvider } from "./call-manager-context"
 
@@ -74,6 +81,8 @@ function enterVideoCall(overrides: Partial<CallDeviceState> = {}) {
 
 beforeEach(() => {
   clearCallState()
+  localStorage.clear()
+  __resetCallPrefsForTests()
 })
 
 afterEach(() => {
@@ -164,6 +173,29 @@ describe("CallControls — call chat", () => {
     expect(href).toContain("draft%3Astream_1%3Aevent_chat_1")
   })
 
+  it.each([
+    ["configured fullscreen", "fullscreen", "floating"],
+    ["keep-last fullscreen", "keep_last", "fullscreen"],
+  ] as const)("reveals chat from %s without rewriting the last-surface preference", (_, pref, last) => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    setDesktopCallSurface(pref)
+    setLastDesktopSurface(last)
+    act(() => {
+      setCallSession({
+        callId: "call_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: "video",
+        chatAnchorId: "event_chat_1",
+      })
+      setCallPhase("connected")
+    })
+    renderRouted(makeManager())
+    fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
+    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
+    expect(getCallPrefs().lastDesktopSurface).toBe(last)
+  })
+
   it("collapses the fullscreen surface when chat opens (panel would render under the overlay)", () => {
     act(() => {
       setCallSession({
@@ -174,11 +206,12 @@ describe("CallControls — call chat", () => {
         chatAnchorId: "event_chat_1",
       })
       setCallPhase("connected")
-      setCallSurfaceMode("full")
+      setCallSurfaceMode("standard")
+      setDesktopSurfaceOverride("fullscreen")
     })
     renderRouted(makeManager())
     fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
-    expect(getCallState().surfaceMode).toBe("standard")
+    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
   })
 
   it("hides the chat control until the anchor is known", () => {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -16,6 +16,7 @@ import {
   setCallActiveElsewhere,
   setCallCaptureError,
   setCallSurfaceMode,
+  setDesktopSurfaceOverride,
   bumpCallMediaEpoch,
   type CallRosterParticipant,
 } from "@/stores/call-store"
@@ -467,6 +468,22 @@ describe("CallDock — desktop surface routing", () => {
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
   })
 
+  it("routes fullscreen joining and connected states as a peer surface and remembers it", () => {
+    setDesktopCallSurface("fullscreen")
+    renderDock(makeManager())
+    act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    expect(screen.getByTestId("desktop-call-fullscreen")).toHaveAttribute("data-phase", "joining")
+    expect(screen.getByText("Connecting…")).toBeInTheDocument()
+
+    act(() => {
+      setCallPhase("connected")
+      setCallRoster([participant({ userId: "usr_self", endpointId: "callep_self" })], 1)
+    })
+    expect(screen.getByTestId("desktop-call-fullscreen")).toHaveAttribute("data-phase", "connected")
+    expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
+    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+  })
+
   it("floating pref surfaces the pre-join permission gate inside the square during an active launch", async () => {
     setDesktopCallSurface("floating")
     const startCall = vi.fn(async () => {
@@ -487,11 +504,40 @@ describe("CallDock — desktop surface routing", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
-    await userEvent.click(screen.getByLabelText("Dock to the side"))
+    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
     expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
     expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
     expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
+    expect(screen.getByLabelText("Call surface")).toHaveFocus()
+  })
+
+  it("opens a minimized Sidebar before moving picker focus into it", async () => {
+    setDesktopCallSurface("floating")
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    act(() => setCallSurfaceMode("min"))
+
+    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
+
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
+    expect(screen.getByLabelText("Call surface")).toHaveFocus()
+  })
+
+  it("does not move focus for a non-picker surface switch", () => {
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    const externalButton = document.createElement("button")
+    document.body.append(externalButton)
+    externalButton.focus()
+
+    act(() => setDesktopSurfaceOverride("fullscreen"))
+
+    expect(screen.getByTestId("desktop-call-fullscreen")).toBeInTheDocument()
+    expect(externalButton).toHaveFocus()
+    externalButton.remove()
   })
 
   it("the dock's Float flips to the square and records the override + last", async () => {
@@ -499,7 +545,8 @@ describe("CallDock — desktop surface routing", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
-    await userEvent.click(screen.getByLabelText("Pop out to a floating window"))
+    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Floating" }))
     expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
     expect(screen.queryByTestId("desktop-call-dock")).toBeNull()
     expect(getCallState().desktopSurfaceOverride).toBe("floating")

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -2,7 +2,12 @@ import { useCallback, useLayoutEffect, useRef } from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
-import { resolveDesktopSurface, setLastDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
+import {
+  resolveDesktopSurface,
+  setLastDesktopSurface,
+  useCallPrefs,
+  type DesktopSurface,
+} from "@/stores/call-prefs-store"
 import { useCallLaunch } from "./call-launch-context"
 import {
   useCallActiveElsewhere,
@@ -30,6 +35,7 @@ import { MobileCallDrawer } from "./mobile-call-drawer"
 import { MobileCallJoining } from "./call-island"
 import { DesktopCallDock } from "./desktop-call-dock"
 import { FloatingCallSquare } from "./floating-call-square"
+import { DesktopCallFullscreen } from "./desktop-call-fullscreen"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 
 /**
@@ -59,18 +65,27 @@ export function CallDock() {
   if (launch.status !== "idle") joiningModeRef.current = launch.request.cameraOn ? "standard" : "compact"
 
   const surface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, override)
+  const surfacePickerTriggerRef = useRef<HTMLButtonElement>(null)
+  const focusSurfacePicker = useRef(false)
 
-  // An in-call switch moves THIS call (the override) and remembers the choice for
-  // `keep_last` next time; the override clears on teardown, so a pinned surface wins
-  // the next call (interaction model A). Silent — the surface change is its own signal.
-  const dockToSide = useCallback(() => {
-    setDesktopSurfaceOverride("sidebar")
-    setLastDesktopSurface("sidebar")
+  const setSurface = useCallback((next: DesktopSurface) => {
+    setDesktopSurfaceOverride(next)
+    setLastDesktopSurface(next)
   }, [])
-  const float = useCallback(() => {
-    setDesktopSurfaceOverride("floating")
-    setLastDesktopSurface("floating")
-  }, [])
+  const selectSurface = useCallback(
+    (next: DesktopSurface) => {
+      if (next === surface) return
+      focusSurfacePicker.current = true
+      if (next === "sidebar" && getCallState().surfaceMode === "min") setCallSurfaceMode("standard")
+      setSurface(next)
+    },
+    [setSurface, surface]
+  )
+  useLayoutEffect(() => {
+    if (!focusSurfacePicker.current) return
+    focusSurfacePicker.current = false
+    surfacePickerTriggerRef.current?.focus()
+  }, [surface])
 
   // On connect, open to a visible size — `min` (the Tab/Rail) is too minimal a
   // default. Open to the first open state (compact) normally, and the second
@@ -106,9 +121,27 @@ export function CallDock() {
     return <MobileCallJoining />
   }
 
-  // Desktop floating: the square owns the whole lifecycle (launch / join / in-call).
   if (surface === "floating") {
-    return <FloatingCallSquare workspaceId={workspaceId} streamId={streamIdForLabel} onDockToSide={dockToSide} />
+    return (
+      <FloatingCallSquare
+        workspaceId={workspaceId}
+        streamId={streamIdForLabel}
+        onSelectSurface={selectSurface}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
+      />
+    )
+  }
+
+  if (surface === "fullscreen") {
+    return (
+      <DesktopCallFullscreen
+        workspaceId={workspaceId}
+        streamId={streamIdForLabel}
+        joining={!inCall}
+        onSelectSurface={selectSurface}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
+      />
+    )
   }
 
   // Desktop sidebar owns launch, joining, and connected phases. Keeping one
@@ -120,7 +153,9 @@ export function CallDock() {
     <DesktopCallDock
       workspaceId={workspaceId}
       streamId={streamIdForLabel}
-      onFloat={float}
+      onSelectSurface={selectSurface}
+      onDragToFullscreen={() => setSurface("fullscreen")}
+      surfacePickerTriggerRef={surfacePickerTriggerRef}
       joining={!inCall}
       joiningMode={joiningModeRef.current}
     />

--- a/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
+++ b/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
@@ -35,7 +35,7 @@ const RING_INSET = 16
 const EMPTY_RECT = { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, toJSON: () => ({}) }
 
 const EXPANDED_SIZE = { width: 340, height: 320 }
-const MINIMIZED_SIZE = { width: 280, height: 50 }
+const MINIMIZED_SIZE = { width: 380, height: 50 }
 
 function domRect(x: number, y: number, width: number, height: number): DOMRect {
   return { x, y, left: x, top: y, right: x + width, bottom: y + height, width, height, toJSON: () => ({}) } as DOMRect
@@ -157,7 +157,7 @@ function renderBothSurfaces(manager: CallController = makeManager()) {
       <CallManagerProvider manager={manager}>
         <CallLaunchProvider>
           <LaunchButton />
-          <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={vi.fn()} />
+          <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onSelectSurface={vi.fn()} />
           <IncomingCallOverlay workspaceId={WORKSPACE_ID} />
         </CallLaunchProvider>
       </CallManagerProvider>
@@ -179,7 +179,7 @@ function squareRect() {
   return {
     x: Number.parseFloat(square.style.left),
     y: Number.parseFloat(square.style.top),
-    width: minimized ? 280 : 340,
+    width: minimized ? 380 : 340,
     height: minimized ? 50 : 320,
   }
 }

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act, fireEvent } from "@testing-library/react"
-import { render, screen, userEvent } from "@/test"
+import { render, screen } from "@/test"
 import * as authModule from "@/auth"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import {
@@ -112,7 +112,7 @@ function renderDock(manager: CallController = makeManager()) {
 function renderDockWithFloat(onFloat: () => void, manager: CallController = makeManager()) {
   return render(
     <CallManagerProvider manager={manager}>
-      <DesktopCallDock workspaceId={WORKSPACE_ID} streamId="stream_1" onFloat={onFloat} />
+      <DesktopCallDock workspaceId={WORKSPACE_ID} streamId="stream_1" onSelectSurface={onFloat} />
     </CallManagerProvider>
   )
 }
@@ -183,81 +183,6 @@ describe("DesktopCallDock — side dock presentations", () => {
   })
 })
 
-describe("DesktopCallDock — Float action", () => {
-  it("shows the Float button in the open panel and dispatches onFloat", async () => {
-    const onFloat = vi.fn()
-    renderDockWithFloat(onFloat)
-    enterConnected(TWO_PEERS)
-    setMode("compact")
-    const float = screen.getByLabelText("Pop out to a floating window")
-    expect(float).toBeInTheDocument()
-    await userEvent.click(float)
-    expect(onFloat).toHaveBeenCalled()
-  })
-
-  it("renders no Float button when onFloat is absent", () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setMode("compact")
-    expect(screen.queryByLabelText("Pop out to a floating window")).toBeNull()
-    expect(screen.getByLabelText("Minimize call")).toBeInTheDocument()
-  })
-
-  it("keeps the peek header on Pin, not Float", () => {
-    const onFloat = vi.fn()
-    renderDockWithFloat(onFloat)
-    enterConnected(TWO_PEERS)
-    setMode("min")
-    const dock = screen.getByTestId("desktop-call-dock")
-    fireEvent.mouseEnter(dock)
-    expect(screen.getByLabelText("Keep call open")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Pop out to a floating window")).toBeNull()
-  })
-})
-
-describe("DesktopCallDock — fullscreen", () => {
-  it("mounts the ch5 stage, LayoutToggle, and the desktop filmstrip-side toggle", () => {
-    renderDock()
-    enterConnected([
-      participant({ userId: "usr_self" }),
-      participant({ userId: "usr_peer", endpointId: "callep_peer" }),
-      participant({ userId: "usr_third", endpointId: "callep_third" }),
-    ])
-    setMode("full")
-    expect(screen.getByLabelText("Collapse call")).toBeInTheDocument()
-    expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
-    expect(screen.getByTestId("call-stage-speaker")).toBeInTheDocument()
-    expect(screen.getByTestId("call-filmstrip-side-toggle")).toHaveTextContent("BottomSide")
-    expect(screen.getByRole("radio", { name: "Filmstrip bottom" })).toHaveTextContent("Bottom")
-    expect(screen.getByRole("radio", { name: "Filmstrip side" })).toHaveTextContent("Side")
-    expect(screen.getByTestId("call-stage-speaker")).toHaveClass("bg-background")
-    expect(screen.getByLabelText("Collapse call").parentElement?.parentElement).toHaveClass(
-      "bg-background",
-      "text-foreground"
-    )
-    expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-  })
-
-  it("the filmstrip-side toggle writes and persists filmstripSide", async () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setMode("full")
-    expect(getCallPrefs().filmstripSide).toBe("bottom")
-    await userEvent.click(screen.getByRole("radio", { name: "Filmstrip side" }))
-    expect(getCallPrefs().filmstripSide).toBe("side")
-    expect(JSON.parse(localStorage.getItem("threa:callPrefs:v1") ?? "{}")).toMatchObject({ filmstripSide: "side" })
-    expect(screen.getByTestId("call-stage-speaker")).toHaveAttribute("data-filmstrip-side", "side")
-  })
-
-  it("the collapse control lowers fullscreen to standard", async () => {
-    renderDock()
-    enterConnected(TWO_PEERS)
-    setMode("full")
-    await userEvent.click(screen.getByLabelText("Collapse call"))
-    expect(getCallState().surfaceMode).toBe("standard")
-  })
-})
-
 describe("DesktopCallDock — content push var", () => {
   function insetRight() {
     return document.documentElement.style.getPropertyValue("--call-dock-inset-right")
@@ -270,13 +195,6 @@ describe("DesktopCallDock — content push var", () => {
     expect(insetRight()).toBe("360px")
     setMode("standard")
     expect(insetRight()).toBe("520px")
-  })
-
-  it("drops the inset to 0 in fullscreen (the dock overlays, not pushes)", () => {
-    renderDock()
-    enterConnected([participant({ userId: "usr_self" })])
-    setMode("full")
-    expect(insetRight()).toBe("0px")
   })
 
   it("resets the inset to 0 when the dock unmounts", () => {
@@ -308,7 +226,8 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
   }
 
   it("dragging the side handle past the wide→full threshold caps the preview at standard and settles to full", () => {
-    renderDock()
+    const onSelectSurface = vi.fn()
+    renderDockWithFloat(onSelectSurface)
     enterConnected(TWO_PEERS)
     setMode("standard")
     const dock = screen.getByTestId("desktop-call-dock")
@@ -325,9 +244,29 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
     expect(screen.getByTestId("call-dock-handle")).toBeInTheDocument()
     fireEvent.pointerUp(handle, { clientX: 200, pointerId: 1 })
-    expect(getCallState().surfaceMode).toBe("full")
+    expect(onSelectSurface).toHaveBeenCalledWith("fullscreen")
     // The handle is still mounted at rest-fullscreen (drag back out of fullscreen).
     expect(screen.getByTestId("call-dock-handle")).toBeInTheDocument()
+  })
+
+  it("normalizes stale mobile fullscreen state before sidebar cue and selection", () => {
+    const onSelectSurface = vi.fn()
+    renderDockWithFloat(onSelectSurface)
+    enterConnected(TWO_PEERS)
+    setMode("full")
+    expect(getCallState().surfaceMode).toBe("standard")
+    expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
+
+    const dock = screen.getByTestId("desktop-call-dock")
+    stubRect(dock, { width: 520 })
+    stubRect(dock.parentElement as HTMLElement, { width: 900 })
+    const handle = screen.getByTestId("call-dock-handle")
+    handle.setPointerCapture = vi.fn()
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 200, pointerId: 1 })
+    expect(screen.getByTestId("call-dock-fullscreen-cue")).toBeInTheDocument()
+    fireEvent.pointerUp(handle, { clientX: 200, pointerId: 1 })
+    expect(onSelectSurface).toHaveBeenCalledWith("fullscreen")
   })
 
   it("a pointercancel mid-drag settles instead of wedging", () => {
@@ -343,7 +282,7 @@ describe("DesktopCallDock — drag settles (no wedge)", () => {
     fireEvent.pointerMove(handle, { clientX: 100, pointerId: 1 })
     fireEvent.pointerCancel(handle, { clientX: 100, pointerId: 1 })
     // The cancel must settle (onPointerUp ran): surfaceMode moved off "compact".
-    expect(["standard", "full"]).toContain(getCallState().surfaceMode)
+    expect(["compact", "standard"]).toContain(getCallState().surfaceMode)
   })
 
   it("a mid-range drop persists the freeform width (not a detent) and keeps the open mode", () => {

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -5,11 +5,11 @@ import {
   useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from "react"
-import { AlertTriangle, ChevronDown, ChevronLeft, Minimize2, PictureInPicture2, Pin, Users } from "lucide-react"
+import { AlertTriangle, ChevronLeft, Minimize2, Pin } from "lucide-react"
 import { getAvatarUrl } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/initials"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -22,15 +22,14 @@ import {
   type CallRosterParticipant,
   type CallSurfaceMode,
 } from "@/stores/call-store"
-import { useCallPrefs, setCallFilmstripSide, setCallSideDockWidth } from "@/stores/call-prefs-store"
+import { useCallPrefs, setCallSideDockWidth, type DesktopSurface } from "@/stores/call-prefs-store"
 import { CallTile } from "./call-tile"
 import { CallControls } from "./call-controls"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
-import { CallStageLayout } from "./call-stage-layout"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
 import { CallJoiningBody } from "./pre-join-gate"
-import { LayoutToggle } from "./layout-toggle"
+import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
 
 const REDUCED_MOTION =
@@ -72,43 +71,8 @@ interface DockViewProps {
   // Rendered from the minimized hover-overlay (a transient peek) rather than a
   // pinned-open dock — shows the pin affordance to commit the peek.
   peeking?: boolean
-  // Pop the call out to the floating square. Absent in tests / when floating is unreachable.
-  onFloat?: () => void
-}
-
-function FilmstripSideToggle() {
-  const { filmstripSide } = useCallPrefs()
-  return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      role="radiogroup"
-      value={filmstripSide}
-      onValueChange={(next) => {
-        if (next === "bottom" || next === "side") setCallFilmstripSide(next)
-      }}
-      aria-label="Filmstrip position"
-      data-testid="call-filmstrip-side-toggle"
-      className="shrink-0 gap-0.5 rounded-md bg-muted p-0.5"
-    >
-      <ToggleGroupItem
-        value="bottom"
-        aria-label="Filmstrip bottom"
-        title="Filmstrip along the bottom"
-        className="h-7 px-2 text-xs"
-      >
-        Bottom
-      </ToggleGroupItem>
-      <ToggleGroupItem
-        value="side"
-        aria-label="Filmstrip side"
-        title="Filmstrip down the side"
-        className="h-7 px-2 text-xs"
-      >
-        Side
-      </ToggleGroupItem>
-    </ToggleGroup>
-  )
+  onSelectSurface?: (surface: DesktopSurface) => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
 }
 
 function MinimizeButton() {
@@ -120,20 +84,6 @@ function MinimizeButton() {
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
     >
       <Minimize2 className="h-4 w-4" />
-    </button>
-  )
-}
-
-function FloatButton({ onFloat }: { onFloat: () => void }) {
-  return (
-    <button
-      type="button"
-      aria-label="Pop out to a floating window"
-      title="Pop out to a floating window"
-      onClick={onFloat}
-      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-    >
-      <PictureInPicture2 className="h-4 w-4" />
     </button>
   )
 }
@@ -161,25 +111,31 @@ function PinButton() {
 function DockHeaderBar({
   title,
   peeking,
-  onFloat,
+  onSelectSurface,
+  surfacePickerTriggerRef,
   canMinimize = true,
 }: {
   title: string
   peeking?: boolean
-  onFloat?: () => void
+  onSelectSurface?: (surface: DesktopSurface) => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
   canMinimize?: boolean
 }) {
+  let trailingAction = null
+  if (peeking) trailingAction = <PinButton />
+  else if (canMinimize) trailingAction = <MinimizeButton />
+
   return (
     <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      {peeking ? (
-        <PinButton />
-      ) : (
-        <>
-          {onFloat && <FloatButton onFloat={onFloat} />}
-          {canMinimize && <MinimizeButton />}
-        </>
+      {onSelectSurface && (
+        <DesktopCallSurfacePicker
+          value="sidebar"
+          onValueChange={onSelectSurface}
+          triggerRef={surfacePickerTriggerRef}
+        />
       )}
+      {trailingAction}
     </div>
   )
 }
@@ -241,11 +197,25 @@ function SideRailView({ roster, users, workspaceId, connectedAt, captureError }:
 }
 
 /** Side `compact`/`standard`: header + tile grid + controls (the panel width does the sizing). */
-function SideTilesView({ workspaceId, currentUserId, roster, captureError, title, peeking, onFloat }: DockViewProps) {
+function SideTilesView({
+  workspaceId,
+  currentUserId,
+  roster,
+  captureError,
+  title,
+  peeking,
+  onSelectSurface,
+  surfacePickerTriggerRef,
+}: DockViewProps) {
   const joined = roster.filter((p) => p.participantStatus === "joined")
   return (
     <div className="flex h-full w-full flex-col border-l bg-background">
-      <DockHeaderBar title={title} peeking={peeking} onFloat={onFloat} />
+      <DockHeaderBar
+        title={title}
+        peeking={peeking}
+        onSelectSurface={onSelectSurface}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
+      />
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
         {joined.map((p) => (
@@ -264,73 +234,25 @@ function SideTilesView({ workspaceId, currentUserId, roster, captureError, title
   )
 }
 
-function SideJoiningView({ title, onFloat }: Pick<DockViewProps, "title" | "onFloat">) {
+function SideJoiningView({
+  title,
+  onSelectSurface,
+  surfacePickerTriggerRef,
+}: Pick<DockViewProps, "title" | "onSelectSurface" | "surfacePickerTriggerRef">) {
   return (
     <div className="flex h-full w-full flex-col border-l bg-background">
-      <DockHeaderBar title={title} onFloat={onFloat} canMinimize={false} />
+      <DockHeaderBar
+        title={title}
+        onSelectSurface={onSelectSurface}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
+        canMinimize={false}
+      />
       <CallJoiningBody />
     </div>
   )
 }
 
-/** Fullscreen: the ch5 stage with a permanent header of call controls/toggles. */
-function DockFullscreenView({ workspaceId, connectedAt, currentUserId, roster, title, captureError }: DockViewProps) {
-  const { layout, filmstripSide } = useCallPrefs()
-  const joined = roster.filter((p) => p.participantStatus === "joined")
-  // View-only pin (not the store): overrides the default speaker until the call ends.
-  const [pinnedUserId, setPinnedUserId] = useState<string | null>(null)
-
-  return (
-    <div className="flex h-full w-full flex-col bg-background text-foreground">
-      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
-      <div className="flex items-center gap-2 px-3 py-2">
-        <button
-          type="button"
-          aria-label="Collapse call"
-          onClick={() => setCallSurfaceMode("standard")}
-          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          <ChevronDown className="h-5 w-5" />
-        </button>
-        <div className="flex min-w-0 flex-col">
-          <span className="truncate text-sm font-medium">{title}</span>
-          <CallTimer connectedAt={connectedAt} className="text-muted-foreground" />
-        </div>
-        <span
-          className="ml-2 flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
-          aria-label="Participants in call"
-        >
-          <Users className="h-3.5 w-3.5" aria-hidden />
-          {joined.length}
-        </span>
-        <div className="ml-auto flex items-center gap-2">
-          {layout === "speaker" && <FilmstripSideToggle />}
-          <div data-testid="call-layout-slot">
-            <LayoutToggle className="bg-muted" />
-          </div>
-        </div>
-      </div>
-
-      <CallStageLayout
-        layout={layout}
-        filmstripSide={filmstripSide}
-        participants={roster}
-        currentUserId={currentUserId}
-        workspaceId={workspaceId}
-        pinnedUserId={pinnedUserId}
-        onPin={setPinnedUserId}
-        backgroundClassName="bg-background"
-      />
-
-      <div className="shrink-0 px-3 pb-3 pt-1">
-        <CallControls />
-      </div>
-    </div>
-  )
-}
-
 function DockBody({ mode, view }: { mode: CallSurfaceMode; view: DockViewProps }) {
-  if (mode === "full") return <DockFullscreenView {...view} />
   if (mode === "min") return <SideRailView {...view} />
   return <SideTilesView {...view} />
 }
@@ -383,18 +305,26 @@ interface DragState {
 export function DesktopCallDock({
   workspaceId,
   streamId,
-  onFloat,
+  onSelectSurface,
+  onDragToFullscreen,
   joining = false,
   joiningMode = "compact",
+  surfacePickerTriggerRef,
 }: {
   workspaceId: string | null
   streamId: string | null
-  onFloat?: () => void
+  onSelectSurface?: (surface: DesktopSurface) => void
+  onDragToFullscreen?: () => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
   joining?: boolean
   joiningMode?: Extract<CallSurfaceMode, "compact" | "standard">
 }) {
   const surfaceMode = useCallSurfaceMode()
-  const displaySurfaceMode = joining ? joiningMode : surfaceMode
+  const sidebarSurfaceMode = surfaceMode === "full" ? "standard" : surfaceMode
+  const displaySurfaceMode = joining ? joiningMode : sidebarSurfaceMode
+  useLayoutEffect(() => {
+    if (surfaceMode === "full") setCallSurfaceMode("standard")
+  }, [surfaceMode])
   const { sideDockWidth } = useCallPrefs()
   const inputMode = useInputMode()
   const roster = useCallRoster()
@@ -415,8 +345,8 @@ export function DesktopCallDock({
   // with the cursor still inside fires no mouseleave, so clear the flag on the mode
   // change — else a stale `hovering` keeps re-arming the peek and Minimize looks dead.
   useEffect(() => {
-    if (surfaceMode !== "min") setHovering(false)
-  }, [surfaceMode])
+    if (sidebarSurfaceMode !== "min") setHovering(false)
+  }, [sidebarSurfaceMode])
   // The dock root spans the content region (left = sidebar width → right:0); its
   // measured width is the ceiling for the panel + inset so a narrow window / wide
   // sidebar can never push the panel over the sidebar or squash the timeline to 0.
@@ -442,10 +372,7 @@ export function DesktopCallDock({
   // Content push: rail → RAIL_WIDTH, open → openWidth (already ≤ ceil−MIN_CONTENT),
   // fullscreen → 0. Hovering the rail is an overlay, so the inset tracks surfaceMode
   // (still `min`) and never reflows the timeline.
-  let insetRight: number
-  if (displaySurfaceMode === "full") insetRight = 0
-  else if (displaySurfaceMode === "min") insetRight = RAIL_WIDTH
-  else insetRight = openWidth
+  const insetRight = displaySurfaceMode === "min" ? RAIL_WIDTH : openWidth
   useLayoutEffect(() => {
     document.documentElement.style.setProperty("--call-dock-inset-right", `${insetRight}px`)
   }, [insetRight])
@@ -486,19 +413,20 @@ export function DesktopCallDock({
     // Only offer fullscreen when there's a real freeform band below it (else a
     // very narrow content region would send every release to fullscreen).
     if (FULLSCREEN_FRACTION * d.full > MIN_OPEN && d.size > FULLSCREEN_FRACTION * d.full) {
-      setCallSurfaceMode("full")
+      if (onDragToFullscreen) onDragToFullscreen()
+      else onSelectSurface?.("fullscreen")
       return
     }
     setCallSideDockWidth(clampOpen(d.size, d.full))
     // Dragging out of the rail (or out of fullscreen) opens it; an already-open mode keeps its mode.
-    if (surfaceMode === "min" || surfaceMode === "full") setCallSurfaceMode("standard")
+    if (sidebarSurfaceMode === "min") setCallSurfaceMode("standard")
   }
 
   // While dragging, don't MOUNT the fullscreen stage (its heavy per-frame re-render
   // thrashes the drag) — the preview stays on the open tiles; fullscreen mounts on release.
   // Minimized + mouse hover = a transient peek (overlay, no push); it renders the open
   // tiles and shows a pin affordance to commit to a pushing, persisted open dock.
-  const peeking = !joining && surfaceMode === "min" && hovering
+  const peeking = !joining && sidebarSurfaceMode === "min" && hovering
   let cappedDragMode: CallSurfaceMode | null = null
   if (dragging) cappedDragMode = displaySurfaceMode === "compact" ? "compact" : "standard"
   let contentMode: CallSurfaceMode
@@ -507,12 +435,10 @@ export function DesktopCallDock({
   else contentMode = displaySurfaceMode
 
   const dragCeil = drag.current?.full ?? ceilW
-  // No cue while already fullscreen (a drag there is an EXIT — the cue would misread as "go full"),
-  // and none when the region is too narrow to have a freeform band below the fullscreen line.
+  // No cue when the region is too narrow to have a freeform band below the fullscreen line.
   const showFullscreenCue =
     !joining &&
     dragging &&
-    surfaceMode !== "full" &&
     dragSize != null &&
     FULLSCREEN_FRACTION * dragCeil > MIN_OPEN &&
     dragSize > FULLSCREEN_FRACTION * dragCeil
@@ -522,16 +448,8 @@ export function DesktopCallDock({
   else if (displaySurfaceMode === "min") panelWidth = hovering ? openWidth : RAIL_WIDTH
   else panelWidth = openWidth
 
-  const restingFull = !joining && !dragging && surfaceMode === "full"
-  let positionClass: string
-  let sizeStyle: CSSProperties
-  if (restingFull) {
-    positionClass = "inset-0"
-    sizeStyle = {}
-  } else {
-    positionClass = "inset-y-0 right-0"
-    sizeStyle = { width: `${panelWidth}px` }
-  }
+  const positionClass = "inset-y-0 right-0"
+  const sizeStyle: CSSProperties = { width: `${panelWidth}px` }
 
   const view: DockViewProps = {
     workspaceId,
@@ -542,7 +460,8 @@ export function DesktopCallDock({
     captureError,
     title,
     peeking,
-    onFloat,
+    onSelectSurface,
+    surfacePickerTriggerRef,
   }
 
   return (
@@ -562,7 +481,7 @@ export function DesktopCallDock({
           // Preview only arms from the rail (mirrors the nav-sidebar collapsed→preview);
           // entering an open panel — including while minimizing with the cursor over it —
           // must not flip to the overlay.
-          if (inputMode !== "touch" && surfaceMode === "min") setHovering(true)
+          if (inputMode !== "touch" && sidebarSurfaceMode === "min") setHovering(true)
         }}
         onMouseLeave={() => setHovering(false)}
         className={cn(
@@ -572,7 +491,15 @@ export function DesktopCallDock({
         )}
         style={sizeStyle}
       >
-        {joining ? <SideJoiningView title={title} onFloat={onFloat} /> : <DockBody mode={contentMode} view={view} />}
+        {joining ? (
+          <SideJoiningView
+            title={title}
+            onSelectSurface={onSelectSurface}
+            surfacePickerTriggerRef={surfacePickerTriggerRef}
+          />
+        ) : (
+          <DockBody mode={contentMode} view={view} />
+        )}
         {showFullscreenCue && (
           <div
             data-testid="call-dock-fullscreen-cue"

--- a/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
+++ b/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
@@ -1,0 +1,120 @@
+import { useState, type RefObject } from "react"
+import { Users } from "lucide-react"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { setCallFilmstripSide, useCallPrefs, type DesktopSurface } from "@/stores/call-prefs-store"
+import { CallControls } from "./call-controls"
+import { CaptureErrorBanner } from "./call-capture-error"
+import { CallStageLayout } from "./call-stage-layout"
+import { CallTimer } from "./call-timer"
+import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
+import { LayoutToggle } from "./layout-toggle"
+import { CallJoiningBody } from "./pre-join-gate"
+import { useCallCaptureError, useCallConnectedAt, useCallRoster } from "./call-store-hooks"
+
+function FilmstripSideToggle() {
+  const { filmstripSide } = useCallPrefs()
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      role="radiogroup"
+      value={filmstripSide}
+      onValueChange={(value) => {
+        if (value === "bottom" || value === "side") setCallFilmstripSide(value)
+      }}
+      aria-label="Filmstrip position"
+      data-testid="call-filmstrip-side-toggle"
+      className="shrink-0 gap-0.5 rounded-md bg-muted p-0.5"
+    >
+      <ToggleGroupItem value="bottom" aria-label="Filmstrip bottom" className="h-7 px-2 text-xs">
+        Bottom
+      </ToggleGroupItem>
+      <ToggleGroupItem value="side" aria-label="Filmstrip side" className="h-7 px-2 text-xs">
+        Side
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}
+
+export function DesktopCallFullscreen({
+  workspaceId,
+  streamId,
+  joining,
+  onSelectSurface,
+  surfacePickerTriggerRef,
+}: {
+  workspaceId: string | null
+  streamId: string | null
+  joining: boolean
+  onSelectSurface: (surface: DesktopSurface) => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
+}) {
+  const { layout, filmstripSide } = useCallPrefs()
+  const roster = useCallRoster()
+  const connectedAt = useCallConnectedAt()
+  const captureError = useCallCaptureError()
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const title = useStreamName(workspaceId ?? "", streamId ?? "", "generic") ?? "Call"
+  const joined = roster.filter((participant) => participant.participantStatus === "joined")
+  const [pinnedUserId, setPinnedUserId] = useState<string | null>(null)
+
+  return (
+    <div
+      data-testid="desktop-call-fullscreen"
+      data-phase={joining ? "joining" : "connected"}
+      className="fixed inset-y-0 right-0 z-40 flex flex-col bg-background text-foreground"
+      style={{ left: "var(--app-content-left, 0px)" }}
+    >
+      {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium">{title}</span>
+          {!joining && <CallTimer connectedAt={connectedAt} className="text-muted-foreground" />}
+        </div>
+        {!joining && (
+          <span
+            className="ml-2 flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+            aria-label="Participants in call"
+          >
+            <Users className="h-3.5 w-3.5" aria-hidden />
+            {joined.length}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          {!joining && layout === "speaker" && <FilmstripSideToggle />}
+          {!joining && (
+            <div data-testid="call-layout-slot">
+              <LayoutToggle className="bg-muted" />
+            </div>
+          )}
+          <DesktopCallSurfacePicker
+            value="fullscreen"
+            onValueChange={onSelectSurface}
+            triggerRef={surfacePickerTriggerRef}
+          />
+        </div>
+      </div>
+      {joining ? (
+        <CallJoiningBody />
+      ) : (
+        <>
+          <CallStageLayout
+            layout={layout}
+            filmstripSide={filmstripSide}
+            participants={roster}
+            currentUserId={currentUserId}
+            workspaceId={workspaceId}
+            pinnedUserId={pinnedUserId}
+            onPin={setPinnedUserId}
+            backgroundClassName="bg-background"
+          />
+          <div className="shrink-0 px-3 pb-3 pt-1">
+            <CallControls />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/desktop-call-surface-picker.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-surface-picker.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen, userEvent } from "@/test"
+import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
+
+describe("DesktopCallSurfacePicker", () => {
+  it("shows the selected surface and selects every peer surface by keyboard", async () => {
+    const onValueChange = vi.fn()
+    render(<DesktopCallSurfacePicker value="sidebar" onValueChange={onValueChange} />)
+    const trigger = screen.getByLabelText("Call surface")
+    expect(trigger).toHaveTextContent("Sidebar")
+
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Floating" }))
+    expect(onValueChange).toHaveBeenCalledWith("floating")
+
+    await userEvent.click(trigger)
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
+    expect(onValueChange).toHaveBeenCalledWith("sidebar")
+
+    await userEvent.click(trigger)
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Fullscreen" }))
+    expect(onValueChange).toHaveBeenCalledWith("fullscreen")
+  })
+})

--- a/apps/frontend/src/components/call/desktop-call-surface-picker.tsx
+++ b/apps/frontend/src/components/call/desktop-call-surface-picker.tsx
@@ -1,0 +1,54 @@
+import type { RefObject } from "react"
+import { ChevronDown } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { DesktopSurface } from "@/stores/call-prefs-store"
+
+const OPTIONS: { value: DesktopSurface; label: string }[] = [
+  { value: "floating", label: "Floating" },
+  { value: "sidebar", label: "Sidebar" },
+  { value: "fullscreen", label: "Fullscreen" },
+]
+
+export function DesktopCallSurfacePicker({
+  value,
+  onValueChange,
+  triggerRef,
+}: {
+  value: DesktopSurface
+  onValueChange: (value: DesktopSurface) => void
+  triggerRef?: RefObject<HTMLButtonElement | null>
+}) {
+  const label = OPTIONS.find((option) => option.value === value)?.label ?? "Floating"
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={triggerRef}
+          variant="ghost"
+          size="sm"
+          className="h-7 shrink-0 gap-1 px-2"
+          aria-label="Call surface"
+        >
+          <span className="w-[4.5rem] text-left">{label}</span>
+          <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup value={value} onValueChange={(next) => onValueChange(next as DesktopSurface)}>
+          {OPTIONS.map((option) => (
+            <DropdownMenuRadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -102,7 +102,7 @@ function renderSquare(manager: CallController = makeManager(), onDockToSide: () 
   return render(
     <CallManagerProvider manager={manager}>
       <CallLaunchProvider>
-        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={onDockToSide} />
+        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onSelectSurface={onDockToSide} />
       </CallLaunchProvider>
     </CallManagerProvider>
   )
@@ -122,7 +122,7 @@ function renderSquareWithLaunch(manager: CallController) {
     <CallManagerProvider manager={manager}>
       <CallLaunchProvider>
         <LaunchButton />
-        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onDockToSide={vi.fn()} />
+        <FloatingCallSquare workspaceId={WORKSPACE_ID} streamId="stream_1" onSelectSurface={vi.fn()} />
       </CallLaunchProvider>
     </CallManagerProvider>
   )
@@ -151,6 +151,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -162,7 +163,7 @@ describe("FloatingCallSquare — connected", () => {
     expect(square).toHaveAttribute("data-minimized", "false")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByLabelText("Dock to the side")).toBeInTheDocument()
+    expect(screen.getByLabelText("Call surface")).toBeInTheDocument()
 
     const header = screen.getByTestId("floating-call-square-header")
     expect(header.firstElementChild).toBe(screen.getByTestId("expanded-call-drag-grip"))
@@ -174,7 +175,8 @@ describe("FloatingCallSquare — connected", () => {
     renderSquare(makeManager(), onDockToSide)
     enterConnected(TWO_PEERS)
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("Dock to the side"))
+      await userEvent.click(screen.getByLabelText("Call surface"))
+      await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
     })
     expect(onDockToSide).toHaveBeenCalled()
   })
@@ -201,9 +203,9 @@ describe("FloatingCallSquare — minimize / restore", () => {
 
     const compact = screen.getByTestId("floating-call-square")
     expect(compact).toHaveAttribute("data-minimized", "true")
-    expect(compact.style.left).toBe("244px")
+    expect(compact.style.left).toBe("144px")
     expect(compact.style.top).toBe("275px")
-    expect(compact.style.width).toBe("280px")
+    expect(compact.style.width).toBe("380px")
     expect(screen.getByLabelText("Restore call")).toHaveFocus()
     expect(screen.getByLabelText("Call duration")).toBeInTheDocument()
     expect(screen.getByLabelText("Mute")).toBeInTheDocument()
@@ -222,6 +224,7 @@ describe("FloatingCallSquare — minimize / restore", () => {
     expect(compactChildren).toEqual([
       screen.getByTestId("minimized-call-drag-handle"),
       screen.getByTestId("minimized-call-content"),
+      screen.getByLabelText("Call surface"),
       screen.getByLabelText("Restore call"),
     ])
     expect(screen.queryByLabelText("Dock to the side")).toBeNull()
@@ -237,6 +240,27 @@ describe("FloatingCallSquare — minimize / restore", () => {
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
   })
 
+  it("keeps an hour-long timer and every fixed action in the minimized width", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-03-01T10:00:00Z"))
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    fireEvent.click(screen.getByLabelText("Minimize call"))
+
+    act(() => vi.advanceTimersByTime(60 * 60 * 1000))
+
+    const compact = screen.getByTestId("floating-call-square")
+    expect(compact).toHaveStyle({ width: "380px" })
+    expect(screen.getByLabelText("Call duration")).toHaveTextContent("1:00:00")
+    expect(Array.from(compact.children)).toEqual([
+      screen.getByTestId("minimized-call-drag-handle"),
+      screen.getByTestId("minimized-call-content"),
+      screen.getByLabelText("Call surface"),
+      screen.getByLabelText("Restore call"),
+    ])
+    expect(screen.getByTestId("minimized-call-controls").children).toHaveLength(3)
+  })
+
   it("moves the minimized bar by dragging or focused arrow-key controls", async () => {
     renderSquare()
     enterConnected(TWO_PEERS)
@@ -247,18 +271,18 @@ describe("FloatingCallSquare — minimize / restore", () => {
     handle.setPointerCapture = vi.fn()
     fireEvent.pointerDown(handle, { clientX: 500, clientY: 300, pointerId: 1, isPrimary: true })
     fireEvent.pointerMove(handle, { clientX: 600, clientY: 400, pointerId: 1 })
-    expect(compact.style.left).toBe("344px")
+    expect(compact.style.left).toBe("244px")
     expect(compact.style.top).toBe("375px")
 
     handle.focus()
     expect(handle).toHaveFocus()
     await userEvent.keyboard("{ArrowLeft}")
-    expect(compact.style.left).toBe("328px")
+    expect(compact.style.left).toBe("228px")
     expect(compact.style.top).toBe("375px")
 
     window.dispatchEvent(new Event("resize"))
     fireEvent.pointerMove(handle, { clientX: 700, clientY: 500, pointerId: 1 })
-    expect(compact.style.left).toBe("328px")
+    expect(compact.style.left).toBe("228px")
     expect(compact.style.top).toBe("375px")
   })
 
@@ -266,11 +290,11 @@ describe("FloatingCallSquare — minimize / restore", () => {
     renderSquare()
     enterConnected(TWO_PEERS)
     fireEvent.click(screen.getByLabelText("Minimize call"), { clientX: 1000, clientY: 750, detail: 1 })
-    expect(screen.getByTestId("floating-call-square").style.left).toBe("736px")
+    expect(screen.getByTestId("floating-call-square").style.left).toBe("636px")
     expect(screen.getByTestId("floating-call-square").style.top).toBe("710px")
 
     fireEvent.click(screen.getByLabelText("Restore call"))
-    expect(screen.getByTestId("floating-call-square").style.left).toBe("676px")
+    expect(screen.getByTestId("floating-call-square").style.left).toBe("636px")
     expect(screen.getByTestId("floating-call-square").style.top).toBe("440px")
   })
 })

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -9,7 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from "react"
-import { GripHorizontal, Maximize2, Minimize2, PanelRight } from "lucide-react"
+import { GripHorizontal, Maximize2, Minimize2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -31,6 +31,8 @@ import {
   type Size,
 } from "./call-surface-geometry"
 import { publishFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
+import type { DesktopSurface } from "@/stores/call-prefs-store"
+import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
 
 const REDUCED_MOTION =
   typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
@@ -40,7 +42,7 @@ const MARGIN = 8
 // Initial-anchor height estimate before the square measures itself; the mount
 // reclamp refines it against the real `offsetHeight`.
 const NOMINAL_HEIGHT = 320
-const MINIMIZED_SIZE = { width: 280, height: 50 }
+const MINIMIZED_SIZE = { width: 380, height: 50 }
 const MINIMIZED_POINTER_ANCHOR = { x: MINIMIZED_SIZE.width - 24, y: MINIMIZED_SIZE.height / 2 }
 const KEYBOARD_MOVE_STEP = 16
 
@@ -93,23 +95,25 @@ function SquareHeader({
   onPointerDown,
   onPointerMove,
   onPointerUp,
-  onDockToSide,
+  onSelectSurface,
   onMinimize,
   minimizeRef,
   canMinimize,
   dragging,
+  surfacePickerTriggerRef,
 }: {
   title: string
   onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void
   onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void
-  onDockToSide: () => void
+  onSelectSurface: (surface: DesktopSurface) => void
   onMinimize: (e: ReactMouseEvent<HTMLButtonElement>) => void
   minimizeRef: RefObject<HTMLButtonElement | null>
   // Only a connected call may minimize — collapsing the joining/pre-join window would
   // hide the PreJoinGate permission taxonomy (mirrors call-dock.tsx's force-open guard).
   canMinimize: boolean
   dragging: boolean
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
 }) {
   return (
     <div
@@ -133,15 +137,7 @@ function SquareHeader({
         aria-hidden
       />
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-      <button
-        type="button"
-        aria-label="Dock to the side"
-        title="Dock to the side"
-        onClick={onDockToSide}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <PanelRight className="h-4 w-4" />
-      </button>
+      <DesktopCallSurfacePicker value="floating" onValueChange={onSelectSurface} triggerRef={surfacePickerTriggerRef} />
       {canMinimize && (
         <button
           ref={minimizeRef}
@@ -205,6 +201,8 @@ function MinimizedBar({
   onMoveKeyDown,
   onRestore,
   restoreRef,
+  onSelectSurface,
+  surfacePickerTriggerRef,
 }: {
   surfaceRef: (node: HTMLDivElement | null) => void
   pos: Point
@@ -216,6 +214,8 @@ function MinimizedBar({
   onMoveKeyDown: (e: ReactKeyboardEvent<HTMLButtonElement>) => void
   onRestore: () => void
   restoreRef: RefObject<HTMLButtonElement | null>
+  onSelectSurface: (surface: DesktopSurface) => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
 }) {
   return (
     <div
@@ -259,6 +259,7 @@ function MinimizedBar({
           <LeaveButton />
         </div>
       </div>
+      <DesktopCallSurfacePicker value="floating" onValueChange={onSelectSurface} triggerRef={surfacePickerTriggerRef} />
       <Button
         ref={restoreRef}
         type="button"
@@ -285,11 +286,13 @@ function MinimizedBar({
 export function FloatingCallSquare({
   workspaceId,
   streamId,
-  onDockToSide,
+  onSelectSurface,
+  surfacePickerTriggerRef,
 }: {
   workspaceId: string | null
   streamId: string | null
-  onDockToSide: () => void
+  onSelectSurface: (surface: DesktopSurface) => void
+  surfacePickerTriggerRef?: RefObject<HTMLButtonElement | null>
 }) {
   const phase = useCallPhase()
   const roster = useCallRoster()
@@ -475,6 +478,8 @@ export function FloatingCallSquare({
         onMoveKeyDown={moveMinimizedWithKeyboard}
         onRestore={restoreFromMinimized}
         restoreRef={restoreButtonRef}
+        onSelectSurface={onSelectSurface}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
       />
     )
   }
@@ -492,11 +497,12 @@ export function FloatingCallSquare({
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
-        onDockToSide={onDockToSide}
+        onSelectSurface={onSelectSurface}
         onMinimize={minimizeAtPointer}
         minimizeRef={minimizeButtonRef}
         canMinimize={inCall}
         dragging={dragging}
+        surfacePickerTriggerRef={surfacePickerTriggerRef}
       />
       {inCall ? (
         <ConnectedBody

--- a/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
@@ -7,8 +7,11 @@ import { IncomingCallOverlay } from "./incoming-call-overlay"
 import * as launchCtx from "./call-launch-context"
 import * as ringTone from "@/calls/ring-tone"
 import * as workspacesHooks from "@/hooks/use-workspaces"
+import * as useMobileModule from "@/hooks/use-mobile"
 import * as workspaceStore from "@/stores/workspace-store"
 import { api } from "@/api/client"
+import { clearCallState, setCallSurfaceMode } from "@/stores/call-store"
+import { __resetCallPrefsForTests, setDesktopCallSurface } from "@/stores/call-prefs-store"
 import {
   addIncomingCall,
   settleIncomingCall,
@@ -43,6 +46,9 @@ function renderOverlay() {
 
 beforeEach(() => {
   resetIncomingCallStoreCache()
+  clearCallState()
+  localStorage.clear()
+  __resetCallPrefsForTests()
   launch = vi.fn()
   vi.spyOn(launchCtx, "useCallLaunch").mockReturnValue({
     launch: launch as unknown as (request: launchCtx.CallLaunchRequest) => void,
@@ -191,6 +197,44 @@ describe("IncomingCallOverlay", () => {
     )
 
     expect(info).toHaveBeenCalledWith("This call has ended")
+  })
+
+  it("ignores stale mobile fullscreen state when clearing a desktop sidebar", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    setDesktopCallSurface("sidebar")
+    act(() => {
+      setCallSurfaceMode("full")
+      addIncomingCall(makeCall())
+    })
+    ;(launchCtx.useCallLaunch as ReturnType<typeof vi.fn>).mockReturnValue({
+      launch,
+      callActive: true,
+      state: { status: "idle" },
+      retry: vi.fn(),
+      cancel: vi.fn(),
+    })
+    renderOverlay()
+    expect(screen.getByTestId("incoming-call-overlay")).toHaveClass("bottom-[calc(var(--composer-height,5rem)_+_1rem)]")
+  })
+
+  it("uses mobile fullscreen state when clearing the mobile controls", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    setDesktopCallSurface("sidebar")
+    act(() => {
+      setCallSurfaceMode("full")
+      addIncomingCall(makeCall())
+    })
+    ;(launchCtx.useCallLaunch as ReturnType<typeof vi.fn>).mockReturnValue({
+      launch,
+      callActive: true,
+      state: { status: "idle" },
+      retry: vi.fn(),
+      cancel: vi.fn(),
+    })
+    renderOverlay()
+    expect(screen.getByTestId("incoming-call-overlay")).toHaveClass(
+      "bottom-[calc(var(--composer-height,5rem)_+_5.5rem)]"
+    )
   })
 
   it("announces the ring through an alert live region", () => {

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
 import { cn } from "@/lib/utils"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
-import { useCallSurfaceMode } from "./call-store-hooks"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { useCallSurfaceMode, useDesktopSurfaceOverride } from "./call-store-hooks"
 import { useWorkspaceUserPreferences } from "@/stores/workspace-store"
 import { useIncomingCalls, settleIncomingCall, type IncomingCall } from "@/stores/incoming-call-store"
 import { installRingAudioWarmup, startRing, stopRing } from "@/calls/ring-tone"
@@ -15,6 +16,7 @@ import { useCallLaunch } from "./call-launch-context"
 import { DOCK_BOTTOM, RING_ABOVE_DOCK_BOTTOM } from "./call-dock"
 import { placementOverlapsProtected, resolveAvoidanceOffset, type Point } from "./call-surface-geometry"
 import { useFloatingSurfaceGeometry } from "@/stores/floating-surface-geometry-store"
+import { resolveDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
 
 interface RingPlacement {
   offset: Point
@@ -118,6 +120,10 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   const calls = useIncomingCalls()
   const { launch, callActive } = useCallLaunch()
   const surfaceMode = useCallSurfaceMode()
+  const desktopSurfaceOverride = useDesktopSurfaceOverride()
+  const { desktopCallSurface, lastDesktopSurface } = useCallPrefs()
+  const desktopSurface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, desktopSurfaceOverride)
+  const isMobile = useIsMobile()
   const [searchParams, setSearchParams] = useSearchParams()
   const notifiedRef = useRef<Set<string>>(new Set())
   const containerRef = useRef<HTMLDivElement>(null)
@@ -228,7 +234,7 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
   // lift above the bottom only when a call surface covers it — mobile or desktop
   // fullscreen (both put their control bar at the bottom). Non-fullscreen docks leave
   // the bottom free (mobile drawer is at the top; a side dock is cleared horizontally).
-  const liftAboveDock = callActive && surfaceMode === "full"
+  const liftAboveDock = callActive && (isMobile ? surfaceMode === "full" : desktopSurface === "fullscreen")
 
   return (
     <div

--- a/apps/frontend/src/components/settings/call-settings.tsx
+++ b/apps/frontend/src/components/settings/call-settings.tsx
@@ -46,6 +46,7 @@ const DESKTOP_SURFACE_OPTIONS: { value: DesktopCallSurface; label: string; descr
     description: "A movable square you can drag anywhere and minimize.",
   },
   { value: "sidebar", label: "Sidebar", description: "Docked down the right side, resizable." },
+  { value: "fullscreen", label: "Fullscreen", description: "Fills the desktop area beside navigation." },
 ]
 
 /**

--- a/apps/frontend/src/stores/call-prefs-store.ts
+++ b/apps/frontend/src/stores/call-prefs-store.ts
@@ -17,7 +17,7 @@ export type CallFilmstripSide = "bottom" | "side"
 /** Local self-view mirroring. `auto` = mirror a front/desktop camera, not a mobile back camera. */
 export type CallSelfMirror = "auto" | "on" | "off"
 /** A concrete desktop call surface. */
-export type DesktopSurface = "sidebar" | "floating"
+export type DesktopSurface = "sidebar" | "floating" | "fullscreen"
 /** The desktop-surface preference: `keep_last` reopens wherever the last call was. */
 export type DesktopCallSurface = "keep_last" | DesktopSurface
 
@@ -46,7 +46,7 @@ const STORAGE_KEY = "threa:callPrefs:v1"
 const isLayout = (v: unknown): v is CallLayout => v === "speaker" || v === "grid"
 const isFilmstripSide = (v: unknown): v is CallFilmstripSide => v === "bottom" || v === "side"
 const isSelfMirror = (v: unknown): v is CallSelfMirror => v === "auto" || v === "on" || v === "off"
-const isDesktopSurface = (v: unknown): v is DesktopSurface => v === "sidebar" || v === "floating"
+const isDesktopSurface = (v: unknown): v is DesktopSurface => v === "sidebar" || v === "floating" || v === "fullscreen"
 const isDesktopCallSurface = (v: unknown): v is DesktopCallSurface => v === "keep_last" || isDesktopSurface(v)
 const parseSideDockWidth = (v: unknown): number | null =>
   typeof v === "number" && Number.isFinite(v) && v > 0 ? v : null

--- a/docs/features/calls.md
+++ b/docs/features/calls.md
@@ -113,9 +113,10 @@ participantUserIds, endedReason}` so the historical card renders with no fetch).
   workspace-agnostic; owns the `/calls` socket, the single CF `RTCPeerConnection`
   behind `MediaTransport`, the per-session renegotiation queue, local capture,
   leases, and one AudioContext per call (created in the join gesture).
-- Components (`apps/frontend/src/components/call/`): `CallDock` (on `side-panel`,
-  non-modal), `CallTile`, `CallControls`, `IncomingCallOverlay`, `PreJoinGate`,
-  `RejoinBar`, plus `CallCard` in the timeline.
+- Components (`apps/frontend/src/components/call/`): `CallDock` routes desktop calls among
+  peer floating, sidebar, and fullscreen surfaces (all non-modal) while mobile keeps its
+  drawer; `CallTile`, `CallControls`, `IncomingCallOverlay`, `PreJoinGate`, `RejoinBar`,
+  plus `CallCard` in the timeline.
 
 ## The flag
 

--- a/docs/plans/calls-desktop-dock-redesign.md
+++ b/docs/plans/calls-desktop-dock-redesign.md
@@ -1,16 +1,16 @@
 # Calls — Desktop dock redesign
 
-Status: **draft, awaiting ratification**. Approved visual direction: the [desktop dock mock](https://seer.build/ws_vbyzjvdg6g/b/calls-deskdock-1ca712/).
+Status: **ratified; implementation in progress**. Approved visual direction: the [desktop dock mock](https://seer.build/ws_vbyzjvdg6g/b/calls-deskdock-1ca712/).
 
 Desktop-only. Mobile surfaces (`mobile-call-drawer.tsx`, `call-island.tsx`) are unchanged. Reference files: `apps/frontend/src/components/call/desktop-call-dock.tsx` (628 lines — top/side dock, `nearestStep` snaps, `--call-dock-inset-*` content push, `ResizeObserver` ceiling), `call-dock.tsx` (phase router), `stores/call-prefs-store.ts`.
 
 ## Goals (from Kris's desktop feedback)
 
-1. **Kill the top dock** — it felt awkward; drop the top orientation entirely. Desktop is **side** or **floating** only.
+1. **Kill the top dock** — it felt awkward; drop the top orientation entirely. Desktop has three peer surfaces: **side**, **floating**, and **fullscreen**.
 2. **Floating square = effective default** — a small draggable, minimizable call widget (grip to move anywhere, minimize to a bubble), with a **"dock to side"** action. Joining renders **in the same square** (no bottom-right→dock jump).
 3. **Side dock behaves like the nav sidebar** — **hover-to-overlay** when minimized (opens over the content, doesn't push, like the nav sidebar's closed-hover), plus an open/pinned draggable mode; **freeform width** (remove the width snap detents — snaps control layout/things, not width); **75% max**; a **drop-to-fullscreen indication** past 75% on release; a **"float"** action to switch to the square.
 4. **Collapsed side rail** — put controls (mute / camera / leave) in the wasted vertical space above the timer.
-5. **Surface pref** `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`). `keep_last` remembers the last-used surface; the floating square is the effective default. A control in **Calls settings**.
+5. **Surface pref** `desktopCallSurface: keep_last | sidebar | floating | fullscreen` (default `keep_last`). `keep_last` remembers the last-used surface; the floating square is the effective default. A control in **Calls settings**.
 
 ## Invariants in play
 
@@ -47,7 +47,7 @@ Each chunk is one PR, based on the previous branch (chunk 1 on `origin/main`).
 
 ### Chunk 4 — `desktopCallSurface` pref + surface switching + Calls settings
 
-- `call-prefs-store.ts`: `desktopCallSurface: keep_last | sidebar | floating` (default `keep_last`) + `lastDesktopSurface: sidebar | floating` + `resolveDesktopSurface(pref, last)`; remove the vestigial `dockPosition` if still present.
+- `call-prefs-store.ts`: `desktopCallSurface: keep_last | sidebar | floating | fullscreen` (default `keep_last`) + matching `lastDesktopSurface` + `resolveDesktopSurface(pref, last)`; remove the vestigial `dockPosition` if still present.
 - `call-dock.tsx`: on desktop, render the resolved surface — `FloatingCallSquare` or `DesktopCallDock` (side). Joining routes to whichever surface is active (both now render joining in-place).
 - Wire the **"dock to side"** (square → sidebar, updates `lastDesktopSurface`) and **"float"** (sidebar → square) actions.
 - `call-settings.tsx`: a "Desktop video" radio (Keep last / Sidebar / Floating square).


### PR DESCRIPTION
## Problem

Desktop fullscreen was encoded as a sidebar size rather than a peer surface. Users switched surfaces through unrelated icon buttons, so the current mode and available destinations were unclear.

## Solution

- Extend desktop surface preferences to Floating, Sidebar, and Fullscreen; Keep last can reopen fullscreen.
- Route fullscreen as its own desktop component while preserving joining, controls, stage layout, and theme behavior.
- Use one Shadcn radio dropdown on every desktop surface; explicit selection persists the last surface.
- Preserve chat visibility, incoming-call clearance, stale mobile-state normalization, compact geometry, and keyboard focus across transitions.

## Test plan

- [x] Focused desktop-call suites — 111 passed
- [x] Frontend typecheck
- [x] Full frontend suite — 4,910 passed; one unrelated billing-timezone test passed automatic replay and targeted 5/5 rerun
- [x] Repository pre-commit lint, typecheck, migration, Dockerfile, and API-doc checks

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make Floating, Sidebar, and Fullscreen equal desktop call states selected through one consistent control.

## What Was Built

### Three-surface model

`call-prefs-store.ts` accepts and persists `fullscreen`. `CallDock` resolves all three surfaces and routes them directly. Sidebar no longer owns desktop fullscreen through `surfaceMode="full"`; mobile retains that state.

### Surface picker

`desktop-call-surface-picker.tsx` provides a Shadcn dropdown radio group for Floating, Sidebar, and Fullscreen. Floating, sidebar, joining, and fullscreen headers use the same picker. Cross-surface keyboard focus transfers to the newly mounted trigger.

### Peer fullscreen

`desktop-call-fullscreen.tsx` owns desktop fullscreen joining and connected rendering. Sidebar drag threshold selects this same peer state.

### Edge behavior

Opening chat from desktop fullscreen temporarily reveals Sidebar without rewriting the saved preference. Incoming-call clearance resolves the effective platform-specific surface. Explicit picker selection opens a minimized Sidebar before transferring focus.

## What's NOT Included

No browser Document PiP/Fullscreen API, mobile picker redesign, backend preference sync, or floating geometry persistence.

## Status

- [x] Three peer desktop surfaces
- [x] Shared picker on every surface
- [x] Settings and Keep last support
- [x] Chat, incoming-overlay, compact geometry, and focus regressions covered

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787431833&installation_model_id=20758&pr_number=1524&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1524&signature=bb4ae95f60c31b346377e864e0e7c61b81c3edc22df318de733d4bbf88956e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->