### PR TITLE
feat: ship shared-message hydration in socket payloads

### DIFF
--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -3,6 +3,7 @@ import { AttachmentSafetyStatuses, ConversationIntents, E2E_PLACEHOLDER_CONTENT_
 import { EventService } from "./event-service"
 import { MessageRepository } from "./repository"
 import { SharedMessageRepository } from "./sharing/repository"
+import * as sharing from "./sharing"
 import { MessageVersionRepository } from "./version-repository"
 import { StreamEventRepository, StreamMemberRepository, StreamRepository, type StreamEvent } from "../streams"
 import { AttachmentRepository, AttachmentReferenceRepository, AttachmentUploadRepository } from "../attachments"
@@ -1395,5 +1396,142 @@ describe("EventService.createMessage parent thread update (reply in thread)", ()
     // No legacy patch for a card anchor.
     const emitted = (OutboxRepository.insert as any).mock.calls.map((c: unknown[]) => c[1])
     expect(emitted).not.toContain("message:updated")
+  })
+})
+
+describe("EventService sharedMessages wire enrichment", () => {
+  const shareNode = { type: "sharedMessage", attrs: { messageId: "msg_source", streamId: "stream_source" } }
+  const hydratedEntry = {
+    type: "sharedMessage",
+    state: "ok",
+    messageId: "msg_source",
+    streamId: "stream_source",
+  }
+
+  beforeEach(() => {
+    spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
+      callback({})) as any)
+    spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
+    // Target stream (create-path E2E check, post-write thread lookup) vs.
+    // source stream (share validation's findStream / checkStreamAccess).
+    spyOn(StreamRepository, "findById").mockImplementation((async (_client: any, id: string) => {
+      if (id === "stream_source") {
+        return {
+          id: "stream_source",
+          workspaceId: "ws_1",
+          type: "channel",
+          visibility: "public",
+          rootStreamId: null,
+        }
+      }
+      return { id: "stream_1", workspaceId: "ws_1", type: "scratchpad", parentStreamId: null, parentAnchorId: null }
+    }) as any)
+    spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: "evt_1",
+      streamId: params.streamId,
+      sequence: 1n,
+      eventType: params.eventType,
+      payload: params.payload,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: params.id,
+      streamId: params.streamId,
+      sequence: params.sequence,
+      authorId: params.authorId,
+      authorType: params.authorType,
+      contentJson: params.contentJson,
+      contentMarkdown: params.contentMarkdown,
+      replyCount: 0,
+      clientMessageId: null,
+      sentVia: null,
+      reactions: {},
+      metadata: {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "findByClientMessageId").mockResolvedValue(null)
+    spyOn(StreamMemberRepository, "update").mockResolvedValue(undefined as any)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+    // Share validation runs over mocked repos (house style — the service
+    // itself is not stubbed).
+    spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
+    spyOn(SharedMessageRepository, "insert").mockResolvedValue({} as any)
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_source", { id: "msg_source", streamId: "stream_source" }]]) as any
+    )
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    spyOn(StreamRepository, "isAncestor").mockResolvedValue(false)
+    // Hydration itself is covered in sharing/hydration.test.ts — stub the
+    // wire entry and assert what rides the outbox payload.
+    spyOn(sharing, "hydrateSharedMessagesForRoom").mockResolvedValue({ msg_source: hydratedEntry } as any)
+    // Edit-path plumbing.
+    spyOn(MessageRepository, "findByIdForUpdate").mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_1",
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "original",
+      authorId: "usr_1",
+      authorType: "user",
+    } as any)
+    spyOn(MessageRepository, "updateContent").mockResolvedValue({ id: "msg_1", editedAt: new Date() } as any)
+    spyOn(MessageVersionRepository, "insert").mockResolvedValue({} as any)
+    spyOn(AttachmentReferenceRepository, "deleteByMessageId").mockResolvedValue(0)
+    spyOn(AttachmentReferenceRepository, "insertMany").mockResolvedValue(0)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("carries the hydrated sharedMessages map on the message:created outbox payload", async () => {
+    const service = new EventService({} as any)
+    await service.createMessage({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "usr_1",
+      authorType: "user",
+      contentJson: { type: "doc", content: [shareNode] },
+      contentMarkdown: "look at this",
+    })
+
+    const created = (OutboxRepository.insert as any).mock.calls.find((c: unknown[]) => c[1] === "message:created")
+    expect(created?.[2].sharedMessages).toEqual({ msg_source: hydratedEntry })
+  })
+
+  it("omits sharedMessages from the message:created payload for pointer-free content", async () => {
+    const service = new EventService({} as any)
+    await service.createMessage({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "usr_1",
+      authorType: "user",
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "plain" }] }] },
+      contentMarkdown: "plain",
+    })
+
+    const created = (OutboxRepository.insert as any).mock.calls.find((c: unknown[]) => c[1] === "message:created")
+    expect(created?.[2]).not.toHaveProperty("sharedMessages")
+    // Cost guard: pointer-free content pays only the content pre-scan.
+    expect(sharing.hydrateSharedMessagesForRoom).not.toHaveBeenCalled()
+  })
+
+  it("carries the hydrated sharedMessages map on the message:edited outbox payload when an edit adds a pointer", async () => {
+    const service = new EventService({} as any)
+    await service.editMessage({
+      workspaceId: "ws_1",
+      messageId: "msg_1",
+      streamId: "stream_1",
+      contentJson: { type: "doc", content: [shareNode] },
+      contentMarkdown: "now with a share",
+      actorId: "usr_1",
+    })
+
+    const edited = (OutboxRepository.insert as any).mock.calls.find((c: unknown[]) => c[1] === "message:edited")
+    expect(edited?.[2].sharedMessages).toEqual({ msg_source: hydratedEntry })
   })
 })

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -5,7 +5,12 @@ import { StreamRepository } from "../streams"
 import { StreamMemberRepository, SparseReadRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
-import { ShareService, type ResolveEffectiveStream } from "./sharing"
+import {
+  collectSharedMessageIds,
+  hydrateSharedMessagesForRoom,
+  ShareService,
+  type ResolveEffectiveStream,
+} from "./sharing"
 import {
   AttachmentRepository,
   AttachmentReferenceRepository,
@@ -805,10 +810,18 @@ export class EventService {
       confirmedPrivacyWarning: params.confirmedPrivacyWarning,
     })
 
+    const sharedMessageIds = new Set<string>()
+    collectSharedMessageIds(params.contentJson, sharedMessageIds)
+    const sharedMessages =
+      sharedMessageIds.size > 0
+        ? await hydrateSharedMessagesForRoom(client, params.workspaceId, params.streamId, sharedMessageIds)
+        : undefined
+
     await OutboxRepository.insert(client, "message:created", {
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       event: serializeBigInt(event),
+      ...(sharedMessages && { sharedMessages }),
     })
 
     // Stream activity for sidebar updates. sequence/messageOrdinal are absolute
@@ -980,10 +993,18 @@ export class EventService {
           )
         }
 
+        const sharedMessageIds = new Set<string>()
+        collectSharedMessageIds(params.contentJson, sharedMessageIds)
+        const sharedMessages =
+          sharedMessageIds.size > 0
+            ? await hydrateSharedMessagesForRoom(client, params.workspaceId, params.streamId, sharedMessageIds)
+            : undefined
+
         await OutboxRepository.insert(client, "message:edited", {
           workspaceId: params.workspaceId,
           streamId: params.streamId,
           event: serializeBigInt(event),
+          ...(sharedMessages && { sharedMessages }),
         })
 
         const stream = await StreamRepository.findById(client, params.streamId)

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -3,6 +3,7 @@ import {
   collectSharedMessageIds,
   hydrateSharedMessageIds,
   hydrateSharedMessages,
+  hydrateSharedMessagesForRoom,
   MAX_HYDRATION_DEPTH,
 } from "./hydration"
 import { MessageRepository } from "../repository"
@@ -129,7 +130,7 @@ describe("hydrateSharedMessageIds", () => {
     stubAuthorLookups()
     stubFullAccess()
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
-    expect(result.msg_a).toEqual({ state: "deleted", messageId: "msg_a", deletedAt })
+    expect(result.msg_a).toEqual({ type: "sharedMessage", state: "deleted", messageId: "msg_a", deletedAt })
   })
 
   it("returns missing payloads for ids that resolve to no row", async () => {
@@ -137,7 +138,7 @@ describe("hydrateSharedMessageIds", () => {
     stubAuthorLookups()
     stubFullAccess()
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_missing"])
-    expect(result.msg_missing).toEqual({ state: "missing", messageId: "msg_missing" })
+    expect(result.msg_missing).toEqual({ type: "sharedMessage", state: "missing", messageId: "msg_missing" })
   })
 
   it("returns a private placeholder when viewer can't access the source stream", async () => {
@@ -157,6 +158,7 @@ describe("hydrateSharedMessageIds", () => {
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
     expect(result.msg_a).toEqual({
+      type: "sharedMessage",
       state: "private",
       messageId: "msg_a",
       sourceStreamKind: "channel",
@@ -190,6 +192,7 @@ describe("hydrateSharedMessageIds", () => {
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
     expect(result.msg_a).toEqual({
+      type: "sharedMessage",
       state: "private",
       messageId: "msg_a",
       sourceStreamKind: "channel",
@@ -250,6 +253,7 @@ describe("hydrateSharedMessageIds", () => {
     // stale cached attr — the fix for "shared_messages cached streamId goes
     // stale after batch move-to-thread".
     expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      type: "sharedMessage",
       state: "truncated",
       messageId: `msg_${MAX_HYDRATION_DEPTH}`,
       streamId: "stream_live",
@@ -285,6 +289,7 @@ describe("hydrateSharedMessageIds", () => {
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
     expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      type: "sharedMessage",
       state: "deleted",
       messageId: `msg_${MAX_HYDRATION_DEPTH}`,
       deletedAt: new Date("2026-04-01"),
@@ -316,6 +321,7 @@ describe("hydrateSharedMessageIds", () => {
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
     expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      type: "sharedMessage",
       state: "missing",
       messageId: `msg_${MAX_HYDRATION_DEPTH}`,
     })
@@ -360,6 +366,7 @@ describe("hydrateSharedMessageIds", () => {
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
     expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      type: "sharedMessage",
       state: "private",
       messageId: `msg_${MAX_HYDRATION_DEPTH}`,
       sourceStreamKind: "channel",
@@ -403,6 +410,7 @@ describe("hydrateSharedMessageIds", () => {
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_outer"])
     expect(result.msg_outer).toMatchObject({ state: "ok" })
     expect(result.msg_inner).toEqual({
+      type: "sharedMessage",
       state: "private",
       messageId: "msg_inner",
       sourceStreamKind: "channel",
@@ -484,8 +492,157 @@ describe("hydrateSharedMessageIds", () => {
     const findAttachments = spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_missing"])
-    expect(result.msg_missing).toEqual({ state: "missing", messageId: "msg_missing" })
+    expect(result.msg_missing).toEqual({ type: "sharedMessage", state: "missing", messageId: "msg_missing" })
     expect(findAttachments).not.toHaveBeenCalled()
+  })
+})
+
+describe("hydrateSharedMessagesForRoom", () => {
+  it("hydrates depth-1 grants uniformly without viewer access", async () => {
+    const deletedAt = new Date("2026-02-01")
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([
+        ["msg_ok", makeMessage({ id: "msg_ok", streamId: "stream_private" })],
+        ["msg_deleted", makeMessage({ id: "msg_deleted", streamId: "stream_private", deletedAt })],
+      ])
+    )
+    spyOn(streamsBarrel, "listRoomReadableStreamIds").mockResolvedValue(new Set())
+    spyOn(SharedMessageRepository, "listSourcesGrantedToRoom").mockResolvedValue(new Set(["msg_ok", "msg_deleted"]))
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Ada" } as any])
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+
+    const result = await hydrateSharedMessagesForRoom({} as any, "ws_1", "stream_target", [
+      "msg_ok",
+      "msg_deleted",
+      "msg_missing",
+    ])
+
+    expect(result).toMatchObject({
+      msg_ok: { type: "sharedMessage", state: "ok", messageId: "msg_ok", authorName: "Ada", attachments: [] },
+      msg_deleted: { type: "sharedMessage", state: "deleted", messageId: "msg_deleted", deletedAt },
+      msg_missing: { type: "sharedMessage", state: "missing", messageId: "msg_missing" },
+    })
+  })
+
+  it("hydrates a nested pointer into a public stream as ok with no grant rows", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        if (id === "msg_outer") {
+          map.set(
+            id,
+            makeMessage({
+              id,
+              streamId: "stream_target",
+              contentJson: {
+                type: "doc",
+                content: [{ type: "sharedMessage", attrs: { messageId: "msg_inner", streamId: "stream_public" } }],
+              },
+            })
+          )
+        } else if (id === "msg_inner") {
+          map.set(id, makeMessage({ id, streamId: "stream_public" }))
+        }
+      }
+      return map
+    })
+    stubAuthorLookups()
+    spyOn(streamsBarrel, "listRoomReadableStreamIds").mockImplementation(async (_db, _ws, _room, candidates) => {
+      return new Set([...candidates].filter((id) => id === "stream_target" || id === "stream_public"))
+    })
+    spyOn(SharedMessageRepository, "listSourcesGrantedToRoom").mockResolvedValue(new Set())
+
+    const result = await hydrateSharedMessagesForRoom({} as any, "ws_1", "stream_target", ["msg_outer"])
+    expect(result.msg_outer).toMatchObject({ type: "sharedMessage", state: "ok", messageId: "msg_outer" })
+    expect(result.msg_inner).toMatchObject({
+      type: "sharedMessage",
+      state: "ok",
+      messageId: "msg_inner",
+      streamId: "stream_public",
+    })
+  })
+
+  it("renders a nested pointer into a private stream as a private placeholder reporting the root's kind/visibility", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        if (id === "msg_outer") {
+          map.set(
+            id,
+            makeMessage({
+              id,
+              streamId: "stream_target",
+              contentJson: {
+                type: "doc",
+                content: [{ type: "sharedMessage", attrs: { messageId: "msg_inner", streamId: "stream_thread" } }],
+              },
+            })
+          )
+        } else if (id === "msg_inner") {
+          map.set(id, makeMessage({ id, streamId: "stream_thread" }))
+        }
+      }
+      return map
+    })
+    stubAuthorLookups()
+    spyOn(streamsBarrel, "listRoomReadableStreamIds").mockImplementation(async (_db, _ws, _room, candidates) => {
+      // A thread under a private root is not room-readable; only the room itself is.
+      return new Set([...candidates].filter((id) => id === "stream_target"))
+    })
+    spyOn(SharedMessageRepository, "listSourcesGrantedToRoom").mockResolvedValue(new Set())
+    spyOn(StreamRepository, "findByIds")
+      .mockResolvedValueOnce([
+        { id: "stream_thread", type: "thread", visibility: "private", rootStreamId: "stream_root" } as any,
+      ])
+      .mockResolvedValueOnce([{ id: "stream_root", type: "channel", visibility: "private", rootStreamId: null } as any])
+
+    const result = await hydrateSharedMessagesForRoom({} as any, "ws_1", "stream_target", ["msg_outer"])
+    expect(result.msg_outer).toMatchObject({ type: "sharedMessage", state: "ok", messageId: "msg_outer" })
+    expect(result.msg_inner).toEqual({
+      type: "sharedMessage",
+      state: "private",
+      messageId: "msg_inner",
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    })
+  })
+
+  it("emits truncated with the live streamId for a public chain past MAX_HYDRATION_DEPTH", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        const next = id.replace(/^msg_(\d+)$/, (_m, n) => `msg_${Number(n) + 1}`)
+        map.set(
+          id,
+          makeMessage({
+            id,
+            streamId: id === `msg_${MAX_HYDRATION_DEPTH}` ? "stream_live" : "stream_public",
+            contentJson: {
+              type: "doc",
+              content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_cached" } }],
+            },
+          })
+        )
+      }
+      return map
+    })
+    stubAuthorLookups()
+    // Every source resolves to a public root → room-readable at every level.
+    spyOn(streamsBarrel, "listRoomReadableStreamIds").mockImplementation(async (_db, _ws, _room, candidates) => {
+      return new Set(candidates)
+    })
+    spyOn(SharedMessageRepository, "listSourcesGrantedToRoom").mockResolvedValue(new Set())
+
+    const result = await hydrateSharedMessagesForRoom({} as any, "ws_1", "stream_target", ["msg_0"])
+    for (let i = 0; i < MAX_HYDRATION_DEPTH; i++) {
+      expect(result[`msg_${i}`]).toMatchObject({ state: "ok" })
+    }
+    expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      type: "sharedMessage",
+      state: "truncated",
+      messageId: `msg_${MAX_HYDRATION_DEPTH}`,
+      streamId: "stream_live",
+    })
   })
 })
 

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -2,7 +2,7 @@ import type { Querier } from "../../../db"
 import { type AttachmentSummary, type JSONContent, type StreamType, type Visibility, StreamTypes } from "@threa/types"
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
-import { listAccessibleStreamIds, StreamRepository, type Stream } from "../../streams"
+import { listAccessibleStreamIds, listRoomReadableStreamIds, StreamRepository, type Stream } from "../../streams"
 import { AttachmentRepository, toAttachmentSummary, fetchUploadStatuses } from "../../attachments"
 
 import { SharedMessageRepository } from "./repository"
@@ -33,6 +33,7 @@ export const MAX_HYDRATION_DEPTH = 3
  */
 export type HydratedSharedMessage =
   | {
+      type: "sharedMessage"
       state: "ok"
       messageId: string
       streamId: string
@@ -51,15 +52,21 @@ export type HydratedSharedMessage =
        */
       attachments: AttachmentSummary[]
     }
-  | { state: "deleted"; messageId: string; deletedAt: Date }
-  | { state: "missing"; messageId: string }
+  | { type: "sharedMessage"; state: "deleted"; messageId: string; deletedAt: Date }
+  | { type: "sharedMessage"; state: "missing"; messageId: string }
   | {
+      type: "sharedMessage"
       state: "private"
       messageId: string
       sourceStreamKind: StreamType
       sourceVisibility: Visibility
     }
-  | { state: "truncated"; messageId: string; streamId: string }
+  | { type: "sharedMessage"; state: "truncated"; messageId: string; streamId: string }
+
+type AccessResolvers = {
+  accessibleStreams(db: Querier, workspaceId: string, streamIds: string[]): Promise<Set<string>>
+  grantedSources(db: Querier, workspaceId: string, sourceMessageIds: string[]): Promise<Set<string>>
+}
 
 interface SharedMessageNodeAttrs {
   messageId?: string
@@ -144,11 +151,11 @@ function resolveSourceForPrivatePlaceholder(
  * through will 403 like any other deep link, which is fine; the cap is a
  * pathological-data guard, not a privacy guard.
  */
-export async function hydrateSharedMessageIds(
+async function hydrateSharedMessageIdsWithResolvers(
   db: Querier,
   workspaceId: string,
-  viewerId: string,
-  sourceMessageIds: Iterable<string>
+  sourceMessageIds: Iterable<string>,
+  resolvers: AccessResolvers
 ): Promise<Record<string, HydratedSharedMessage>> {
   const seedIds = Array.from(new Set(sourceMessageIds))
   if (seedIds.length === 0) return {}
@@ -173,15 +180,15 @@ export async function hydrateSharedMessageIds(
     const byId = await MessageRepository.findByIdsInWorkspace(db, workspaceId, ids)
     const fetchedStreamIds = [...byId.values()].map((m) => m.streamId)
     const [accessibleStreams, grantedSources] = await Promise.all([
-      listAccessibleStreamIds(db, workspaceId, viewerId, fetchedStreamIds),
-      SharedMessageRepository.listSourcesGrantedToViewer(db, workspaceId, viewerId, ids),
+      resolvers.accessibleStreams(db, workspaceId, fetchedStreamIds),
+      resolvers.grantedSources(db, workspaceId, ids),
     ])
 
     const nextFrontier = new Map<string, string>()
     for (const id of ids) {
       const source = byId.get(id)
       if (!source) {
-        result[id] = { state: "missing", messageId: id }
+        result[id] = { type: "sharedMessage", state: "missing", messageId: id }
         continue
       }
       const hasAccess = accessibleStreams.has(source.streamId) || grantedSources.has(id)
@@ -190,7 +197,7 @@ export async function hydrateSharedMessageIds(
         continue
       }
       if (source.deletedAt) {
-        result[id] = { state: "deleted", messageId: id, deletedAt: source.deletedAt }
+        result[id] = { type: "sharedMessage", state: "deleted", messageId: id, deletedAt: source.deletedAt }
         continue
       }
       okMessages.set(id, source)
@@ -217,13 +224,13 @@ export async function hydrateSharedMessageIds(
     const truncatedMessages = await MessageRepository.findByIdsInWorkspace(db, workspaceId, truncatedIds)
     const fetchedStreamIds = [...truncatedMessages.values()].map((m) => m.streamId)
     const [accessibleStreams, grantedSources] = await Promise.all([
-      listAccessibleStreamIds(db, workspaceId, viewerId, fetchedStreamIds),
-      SharedMessageRepository.listSourcesGrantedToViewer(db, workspaceId, viewerId, truncatedIds),
+      resolvers.accessibleStreams(db, workspaceId, fetchedStreamIds),
+      resolvers.grantedSources(db, workspaceId, truncatedIds),
     ])
     for (const id of truncatedIds) {
       const msg = truncatedMessages.get(id)
       if (!msg) {
-        result[id] = { state: "missing", messageId: id }
+        result[id] = { type: "sharedMessage", state: "missing", messageId: id }
         continue
       }
       const hasAccess = accessibleStreams.has(msg.streamId) || grantedSources.has(id)
@@ -232,10 +239,10 @@ export async function hydrateSharedMessageIds(
         continue
       }
       if (msg.deletedAt) {
-        result[id] = { state: "deleted", messageId: id, deletedAt: msg.deletedAt }
+        result[id] = { type: "sharedMessage", state: "deleted", messageId: id, deletedAt: msg.deletedAt }
         continue
       }
-      result[id] = { state: "truncated", messageId: id, streamId: msg.streamId }
+      result[id] = { type: "sharedMessage", state: "truncated", messageId: id, streamId: msg.streamId }
     }
   }
 
@@ -257,11 +264,17 @@ export async function hydrateSharedMessageIds(
     for (const [id, streamId] of privateBuckets) {
       const source = byStreamId.get(streamId)
       if (!source) {
-        result[id] = { state: "missing", messageId: id }
+        result[id] = { type: "sharedMessage", state: "missing", messageId: id }
         continue
       }
       const { kind, visibility } = resolveSourceForPrivatePlaceholder(source, byStreamId)
-      result[id] = { state: "private", messageId: id, sourceStreamKind: kind, sourceVisibility: visibility }
+      result[id] = {
+        type: "sharedMessage",
+        state: "private",
+        messageId: id,
+        sourceStreamKind: kind,
+        sourceVisibility: visibility,
+      }
     }
   }
 
@@ -283,6 +296,7 @@ export async function hydrateSharedMessageIds(
         toAttachmentSummary(a, uploadStatuses.get(a.id))
       )
       result[id] = {
+        type: "sharedMessage",
         state: "ok",
         messageId: source.id,
         streamId: source.streamId,
@@ -301,10 +315,36 @@ export async function hydrateSharedMessageIds(
   // Defensive backfill — every requested id should have a result by now;
   // anything left over (e.g. a seed id that hit no path above) is missing.
   for (const id of seedIds) {
-    if (!result[id]) result[id] = { state: "missing", messageId: id }
+    if (!result[id]) result[id] = { type: "sharedMessage", state: "missing", messageId: id }
   }
 
   return result
+}
+
+export function hydrateSharedMessageIds(
+  db: Querier,
+  workspaceId: string,
+  viewerId: string,
+  sourceMessageIds: Iterable<string>
+): Promise<Record<string, HydratedSharedMessage>> {
+  return hydrateSharedMessageIdsWithResolvers(db, workspaceId, sourceMessageIds, {
+    accessibleStreams: (querier, ws, ids) => listAccessibleStreamIds(querier, ws, viewerId, ids),
+    grantedSources: (querier, ws, ids) =>
+      SharedMessageRepository.listSourcesGrantedToViewer(querier, ws, viewerId, ids),
+  })
+}
+
+export function hydrateSharedMessagesForRoom(
+  db: Querier,
+  workspaceId: string,
+  targetStreamId: string,
+  sourceMessageIds: Iterable<string>
+): Promise<Record<string, HydratedSharedMessage>> {
+  return hydrateSharedMessageIdsWithResolvers(db, workspaceId, sourceMessageIds, {
+    accessibleStreams: (querier, ws, ids) => listRoomReadableStreamIds(querier, ws, targetStreamId, ids),
+    grantedSources: (querier, ws, ids) =>
+      SharedMessageRepository.listSourcesGrantedToRoom(querier, ws, targetStreamId, ids),
+  })
 }
 
 /**

--- a/apps/backend/src/features/messaging/sharing/index.ts
+++ b/apps/backend/src/features/messaging/sharing/index.ts
@@ -14,6 +14,7 @@ export { invalidatePointersForEvent, POINTER_INVALIDATED_EVENT } from "./outbox-
 export {
   hydrateSharedMessages,
   hydrateSharedMessageIds,
+  hydrateSharedMessagesForRoom,
   collectSharedMessageIds,
   type HydratedSharedMessage,
 } from "./hydration"

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.test.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.test.ts
@@ -2,9 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import { invalidatePointersForEvent, POINTER_INVALIDATED_EVENT } from "./outbox-handler"
 import { SharedMessageRepository } from "./repository"
 import { E2eStreamsRepository } from "../../e2e-streams"
+import * as hydration from "./hydration"
 
 beforeEach(() => {
   spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+  spyOn(hydration, "hydrateSharedMessagesForRoom").mockImplementation(
+    async (_db, _ws, _target, ids) =>
+      Object.fromEntries(
+        [...ids].map((id) => [id, { type: "sharedMessage", state: "ok", messageId: id, streamId: "stream_src" }])
+      ) as any
+  )
 })
 
 afterEach(() => {
@@ -71,6 +78,9 @@ describe("invalidatePointersForEvent", () => {
     expect(emits[0].payload).toMatchObject({
       workspaceId: "ws_1",
       sourceMessageId: "msg_a",
+      sharedMessages: {
+        msg_a: { type: "sharedMessage", state: "ok", messageId: "msg_a", streamId: "stream_src" },
+      },
     })
   })
 

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
 import { isOutboxEventType, type OutboxEvent } from "../../../lib/outbox"
+import { hydrateSharedMessagesForRoom } from "./hydration"
 import { SharedMessageRepository } from "./repository"
 import { E2eStreamsRepository } from "../../e2e-streams"
 
@@ -84,11 +85,13 @@ export async function invalidatePointersForEvent(event: OutboxEvent, db: Pool, i
     sources.add(share.sourceMessageId)
   }
   for (const [targetStreamId, sources] of sourcesByTarget) {
+    const hydrated = await hydrateSharedMessagesForRoom(db, workspaceId, targetStreamId, sources)
     for (const sourceMessageId of sources) {
       io.to(`ws:${workspaceId}:stream:${targetStreamId}`).emit(POINTER_INVALIDATED_EVENT, {
         workspaceId,
         targetStreamId,
         sourceMessageId,
+        sharedMessages: { [sourceMessageId]: hydrated[sourceMessageId] },
       })
     }
   }

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.ts
@@ -84,8 +84,16 @@ export async function invalidatePointersForEvent(event: OutboxEvent, db: Pool, i
     }
     sources.add(share.sourceMessageId)
   }
-  for (const [targetStreamId, sources] of sourcesByTarget) {
-    const hydrated = await hydrateSharedMessagesForRoom(db, workspaceId, targetStreamId, sources)
+  // Per-target hydration is independent; run them concurrently so a source
+  // shared into many streams doesn't serialize a DB round per target.
+  const hydratedByTarget = await Promise.all(
+    [...sourcesByTarget.entries()].map(async ([targetStreamId, sources]) => ({
+      targetStreamId,
+      sources,
+      hydrated: await hydrateSharedMessagesForRoom(db, workspaceId, targetStreamId, sources),
+    }))
+  )
+  for (const { targetStreamId, sources, hydrated } of hydratedByTarget) {
     for (const sourceMessageId of sources) {
       io.to(`ws:${workspaceId}:stream:${targetStreamId}`).emit(POINTER_INVALIDATED_EVENT, {
         workspaceId,

--- a/apps/backend/src/features/messaging/sharing/repository.test.ts
+++ b/apps/backend/src/features/messaging/sharing/repository.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import * as streams from "../../streams"
+import { SharedMessageRepository } from "./repository"
+
+afterEach(() => mock.restore())
+
+describe("SharedMessageRepository.listSourcesGrantedToRoom", () => {
+  it("keeps grants targeting the room or a public-resolving stream", async () => {
+    const db = {
+      query: mock(async () => ({
+        rows: [
+          { source_message_id: "msg_room", target_stream_id: "stream_room" },
+          { source_message_id: "msg_public", target_stream_id: "stream_public" },
+          { source_message_id: "msg_private", target_stream_id: "stream_private" },
+        ],
+      })),
+    }
+    spyOn(streams, "listRoomReadableStreamIds").mockResolvedValue(new Set(["stream_room", "stream_public"]))
+
+    const result = await SharedMessageRepository.listSourcesGrantedToRoom(db as any, "ws_1", "stream_room", [
+      "msg_room",
+      "msg_public",
+      "msg_private",
+    ])
+
+    expect(result).toEqual(new Set(["msg_room", "msg_public"]))
+  })
+})

--- a/apps/backend/src/features/messaging/sharing/repository.ts
+++ b/apps/backend/src/features/messaging/sharing/repository.ts
@@ -1,7 +1,7 @@
 import type { Querier } from "../../../db"
 import { sql } from "../../../db"
 import { type ShareFlavor } from "@threa/types"
-import { listAccessibleStreamIds } from "../../streams"
+import { listAccessibleStreamIds, listRoomReadableStreamIds } from "../../streams"
 
 // Internal row type (snake_case, not exported)
 interface SharedMessageRow {
@@ -135,6 +135,28 @@ export const SharedMessageRepository = {
     if (accessibleTargets.size === 0) return new Set()
     return new Set(
       candidates.rows.filter((r) => accessibleTargets.has(r.target_stream_id)).map((r) => r.source_message_id)
+    )
+  },
+
+  async listSourcesGrantedToRoom(
+    db: Querier,
+    workspaceId: string,
+    roomStreamId: string,
+    sourceMessageIds: readonly string[]
+  ): Promise<Set<string>> {
+    if (sourceMessageIds.length === 0) return new Set()
+    const candidates = await db.query<{ source_message_id: string; target_stream_id: string }>(sql`
+      SELECT DISTINCT source_message_id, target_stream_id
+      FROM shared_messages
+      WHERE workspace_id = ${workspaceId}
+        AND source_message_id = ANY(${sourceMessageIds as string[]})
+    `)
+    if (candidates.rows.length === 0) return new Set()
+    const targetIds = [...new Set(candidates.rows.map((r) => r.target_stream_id))]
+    const readableTargets = await listRoomReadableStreamIds(db, workspaceId, roomStreamId, targetIds)
+    if (readableTargets.size === 0) return new Set()
+    return new Set(
+      candidates.rows.filter((r) => readableTargets.has(r.target_stream_id)).map((r) => r.source_message_id)
     )
   },
 }

--- a/apps/backend/src/features/streams/access.test.ts
+++ b/apps/backend/src/features/streams/access.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { QueryConfig } from "pg"
+import { Visibilities } from "@threa/types"
+import { listRoomReadableStreamIds } from "./access"
+
+describe("listRoomReadableStreamIds", () => {
+  it("returns no ids without querying for empty input", async () => {
+    const query = mock(async () => ({ rows: [] }))
+    expect(await listRoomReadableStreamIds({ query } as any, "ws_1", "stream_room", [])).toEqual(new Set())
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it("pins the room-readable SQL: thread→root join, room-or-public predicate, workspace and candidate filters", async () => {
+    let captured: QueryConfig | null = null
+    const query = mock(async (q: QueryConfig) => {
+      captured = q
+      return { rows: [{ id: "stream_room" }, { id: "stream_public" }, { id: "thread_public" }] }
+    })
+
+    const result = await listRoomReadableStreamIds({ query } as any, "ws_1", "stream_room", [
+      "stream_room",
+      "stream_public",
+      "stream_private",
+      "thread_public",
+      "thread_private",
+      "stream_missing",
+    ])
+
+    // Thread → root resolution shares the per-viewer predicate's rule (INV-62).
+    expect(captured!.text).toContain("JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)")
+    expect(captured!.text).toContain("s.workspace_id = $1")
+    expect(captured!.text).toContain("s.id = ANY($2)")
+    expect(captured!.text).toContain("s.id = $3 OR root.visibility = $4")
+    expect(captured!.values).toEqual([
+      "ws_1",
+      ["stream_room", "stream_public", "stream_private", "thread_public", "thread_private", "stream_missing"],
+      "stream_room",
+      Visibilities.PUBLIC,
+    ])
+    expect(result).toEqual(new Set(["stream_room", "stream_public", "thread_public"]))
+  })
+})

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -160,6 +160,34 @@ export function streamAccessPredicateSql(workspaceId: string, userId: string, st
 }
 
 /**
+ * Room-uniform readability: the subset of candidate stream ids in the
+ * workspace that are readable by the room as a whole — the room stream
+ * itself, plus candidates whose effective root (thread → root via
+ * `COALESCE(root_stream_id, id)`) is public. No viewer and no
+ * `stream_members` leg: per-user membership grants are meaningless for a
+ * payload delivered to everyone in the room.
+ *
+ * Empty input → empty Set; missing/cross-workspace ids are silently dropped.
+ */
+export async function listRoomReadableStreamIds(
+  db: Querier,
+  workspaceId: string,
+  roomStreamId: string,
+  candidateStreamIds: readonly string[]
+): Promise<Set<string>> {
+  if (candidateStreamIds.length === 0) return new Set()
+  const result = await db.query<{ id: string }>(sql`
+    SELECT s.id
+    FROM streams s
+    JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)
+    WHERE s.workspace_id = ${workspaceId}
+      AND s.id = ANY(${candidateStreamIds as string[]})
+      AND (s.id = ${roomStreamId} OR root.visibility = ${Visibilities.PUBLIC})
+  `)
+  return new Set(result.rows.map((r) => r.id))
+}
+
+/**
  * Batched equivalent of {@link checkStreamAccess}. Given a candidate set
  * of stream ids in a workspace, returns the subset the viewer can read.
  *

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -13,6 +13,7 @@ export type { CreateScratchpadParams, CreateChannelParams, CreateThreadParams } 
 export {
   checkStreamAccess,
   listAccessibleStreamIds,
+  listRoomReadableStreamIds,
   resolveEffectiveAccessStream,
   rootReadableConditionSql,
   streamAccessPredicateSql,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -3,6 +3,7 @@ import type { Stream } from "../../features/streams"
 import type { StreamEvent } from "../../features/streams"
 import type { User } from "../../features/workspaces"
 import type { ConversationWithStaleness } from "../../features/conversations"
+import type { HydratedSharedMessage } from "../../features/messaging/sharing"
 import type {
   Memo as WireMemo,
   StreamEvent as WireStreamEvent,
@@ -198,10 +199,12 @@ interface WorkspaceScopedPayload {
 
 export interface MessageCreatedOutboxPayload extends StreamScopedPayload {
   event: StreamEvent
+  sharedMessages?: Record<string, HydratedSharedMessage>
 }
 
 export interface MessageEditedOutboxPayload extends StreamScopedPayload {
   event: StreamEvent
+  sharedMessages?: Record<string, HydratedSharedMessage>
 }
 
 export interface MessageDeletedOutboxPayload extends StreamScopedPayload {

--- a/apps/frontend/src/hooks/use-thread-anchor-event.test.tsx
+++ b/apps/frontend/src/hooks/use-thread-anchor-event.test.tsx
@@ -47,7 +47,7 @@ describe("useThreadAnchorEvent", () => {
       events: [event("event_before"), anchor],
       hasOlder: true,
       hasNewer: true,
-      sharedMessages: { msg_shared: { state: "missing", messageId: "msg_shared" } },
+      sharedMessages: { msg_shared: { type: "sharedMessage", state: "missing", messageId: "msg_shared" } },
     })
 
     const { result } = renderHook(() => useThreadAnchorEvent("ws_1", "stream_parent", "event_anchor", null), {
@@ -57,7 +57,7 @@ describe("useThreadAnchorEvent", () => {
     await waitFor(() => expect(result.current.event).toBe(anchor))
     expect(getEventsAround).toHaveBeenCalledWith("ws_1", "stream_parent", "event_anchor", 2)
     expect(result.current.sharedMessages).toEqual({
-      msg_shared: { state: "missing", messageId: "msg_shared" },
+      msg_shared: { type: "sharedMessage", state: "missing", messageId: "msg_shared" },
     })
   })
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -287,6 +287,7 @@ export interface StreamBootstrap {
  */
 export type SharedMessageHydration =
   | {
+      type: "sharedMessage"
       state: "ok"
       messageId: string
       streamId: string
@@ -298,15 +299,16 @@ export type SharedMessageHydration =
       createdAt: string
       attachments: AttachmentSummary[]
     }
-  | { state: "deleted"; messageId: string; deletedAt: string }
-  | { state: "missing"; messageId: string }
+  | { type: "sharedMessage"; state: "deleted"; messageId: string; deletedAt: string }
+  | { type: "sharedMessage"; state: "missing"; messageId: string }
   | {
+      type: "sharedMessage"
       state: "private"
       messageId: string
       sourceStreamKind: StreamType
       sourceVisibility: Visibility
     }
-  | { state: "truncated"; messageId: string; streamId: string }
+  | { type: "sharedMessage"; state: "truncated"; messageId: string; streamId: string }
 
 export interface EventsAroundResponse {
   events: StreamEvent[]


### PR DESCRIPTION
## Problem

Shared-message pointer cards lazy-load. Hydration only rides REST responses
(stream bootstrap / events endpoints); live socket events carry none, so
`stream-sync.ts` invalidates the entire bootstrap + events queries on any
share-bearing `message:created` / `message:edited` and on every
`pointer:invalidated`. The card renders a skeleton for seconds, then pops to
full height and the timeline jumps (Pierre's report — a ~900px Pi Remote
message popping in mid-scroll).

## Solution

Hydration ships in the socket payload; nothing on the read path waits for a
refetch.

- **Room-uniform hydration** (`sharing/hydration.ts`): the per-viewer BFS is
  parameterized over two access resolvers; `hydrateSharedMessagesForRoom`
  binds room semantics — "readable" = target stream ∪ streams resolving
  (thread→`root_stream_id`) to public (`listRoomReadableStreamIds`,
  `streams/access.ts`), grants = share rows targeting those
  (`listSourcesGrantedToRoom`). One-payload-per-room can't carry per-viewer
  content: depth-1 is uniform by the D1 share grant; nested private sources
  yield the conservative `private` placeholder and self-heal per-viewer on the
  next REST fetch (bootstrap entries already win the client merge).
- `message:created` / `message:edited` outbox payloads carry `sharedMessages`
  when `collectSharedMessageIds` finds nodes — computed in-txn after
  `validateAndRecordShares` so grants are visible. Outbox payloads persist in
  `sync_log`, so catch-up replay delivers the map for free.
- `pointer:invalidated` carries the re-hydrated entry per (target, source) —
  covers source edits, deletes (tombstone entry), and moves (fresh `streamId`).
- `SharedMessageHydration` members tagged `type: "sharedMessage"` — the slots
  union foundation. Field name stays `sharedMessages` on all surfaces:
  renaming REST to `slots` breaks old clients mid-deploy (stuck skeletons —
  old frontend ignores the field and its refetch never heals). The `slots`
  envelope generalization lands when slot type #2 (range quotes) arrives.
- Out of scope: frontend consumption (next PR in stack), public API (never
  hydrated — markdown wire format, INV-58), link previews (different lifecycle).

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/messaging/sharing/hydration.ts` | BFS parameterized over `AccessResolvers`; per-viewer wrapper unchanged; `hydrateSharedMessagesForRoom` added; `type` tag on every entry |
| `apps/backend/src/features/streams/access.ts` | **new** `listRoomReadableStreamIds` — room stream ∪ public-resolving candidates (COALESCE root join, mirrors INV-62 thread rule) |
| `apps/backend/src/features/messaging/sharing/repository.ts` | **new** `listSourcesGrantedToRoom` — grants targeting room-readable streams |
| `apps/backend/src/features/messaging/event-service.ts` | create + edit enrich outbox payloads with room-hydrated `sharedMessages` (skipped when no share nodes) |
| `apps/backend/src/features/messaging/sharing/outbox-handler.ts` | `pointer:invalidated` emits carry the hydrated entry per target |
| `apps/backend/src/lib/outbox/repository.ts` | optional `sharedMessages` on `MessageCreatedOutboxPayload` / `MessageEditedOutboxPayload` |
| `packages/types/src/api.ts` | `type: "sharedMessage"` tag on the wire union |
| `apps/backend/src/features/streams/access.test.ts` | **new** — pins the emitted SQL (root join, predicate, values order) |
| `apps/backend/src/features/messaging/sharing/repository.test.ts` | **new** — room grant filtering |
| `…/sharing/hydration.test.ts` | room variant: depth-1 uniformity, nested public→ok, nested private-thread→placeholder with root kind/visibility, cap→truncated with live streamId |
| `…/sharing/outbox-handler.test.ts` | invalidation payload carries hydration |
| `…/messaging/event-service.test.ts` | create/edit wire enrichment + pointer-free cost guard |
| `apps/frontend/src/hooks/use-thread-anchor-event.test.tsx` | fixture gains the `type` tag (chunk-1-caused typecheck fix) |
| `sharing/index.ts`, `streams/index.ts` | barrel exports |

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] backend unit suite — 3508 pass
- [x] backend e2e (sharing / access / event-service) — 99 pass
- [x] adversarial review (Qwen 3.8 preview, high) + targeted post-fix recheck — SHIP; no leaks, no runtime bugs

<details>
<summary>📋 Full implementation plan</summary>

Ratified direction (Threa stream, Kristoffer): generic slot-resolution
*pipeline*, shared messages as the only inhabitant for now. Quote ranges /
other slot types deferred (own design docs).

**PR stack**

1. `slots-wire-backend` (this PR, base origin/main): room-uniform hydration +
   wire enrichment + `pointer:invalidated` hydration + types.
2. `slots-wire-frontend` (base #1): consume wire maps, patch bootstrap cache,
   drop invalidations (keep deploy-skew fallback), tests.

**Decisions**

- D-Wire: hydration ships in `message:created` / `message:edited` outbox
  payloads and in `pointer:invalidated`; sync-log replay carries it free.
- D-Room: socket payloads are one-per-room → room-uniform hydration
  (target ∪ public-resolving streams; grants targeting those). Depth-1 exact
  for every room member (D1 grant); nested private sources → conservative
  `private` placeholder, self-heals per-viewer on next REST fetch. Never a
  leak.
- D-Name: keep `sharedMessages` everywhere; `slots` envelope when slot type #2
  arrives (renaming REST now breaks old clients mid-deploy). Values tagged
  `type: "sharedMessage"` as union foundation. Slot key = source messageId
  (dedup semantics); instance-level slotIds deferred with range-quotes.
- D-Fallback: frontend keeps invalidate-refetch only when a share-bearing
  event arrives without a map (deploy skew).

**Gates**: typecheck; backend unit + e2e suites; final whole-stack review.

</details>

---

🤖 _PR by [OpenCode](https://opencode.ai)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787470964&installation_model_id=20758&pr_number=1526&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1526&signature=728d6276ca87aa757310dccaaa8a35a18194b924baec5b6220b99cd01e019fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->