### PR TITLE
fix(reads): mark-as-read clears activity for access-without-membership viewers

### DIFF
--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -443,3 +443,80 @@ describe("createStreamHandlers.create — allowedToolCategories", () => {
     expect(create.mock.calls[0]![0].companionPersonaId).toBeUndefined()
   })
 })
+
+describe("createStreamHandlers.markAsRead — access without membership", () => {
+  function makeRes() {
+    const captured: { status: number; body: unknown } = { status: 200, body: undefined }
+    const res = {
+      status(code: number) {
+        captured.status = code
+        return res
+      },
+      json(body: unknown) {
+        captured.body = body
+        return res
+      },
+    }
+    return { res: res as unknown as Response, captured }
+  }
+
+  function makeHandlers(
+    streamService: Partial<StreamService>,
+    activityService: { markStreamActivityAsRead: (userId: string, streamId: string) => Promise<void> }
+  ) {
+    return createStreamHandlers({ streamService, activityService, pool: {} } as unknown as Parameters<
+      typeof createStreamHandlers
+    >[0])
+  }
+
+  function makeReq(): Request {
+    return {
+      user: { id: "usr_viewer" },
+      workspaceId: "ws_1",
+      params: { streamId: "stream_thread" },
+      body: { lastEventId: "evt_1" },
+    } as unknown as Request
+  }
+
+  it("clears stream activity and returns null membership for a non-member viewer", async () => {
+    const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
+    const markAsRead = mock(() => Promise.resolve(null))
+    const markStreamActivityAsRead = mock(() => Promise.resolve())
+    const handlers = makeHandlers({ validateStreamAccess, markAsRead } as Partial<StreamService>, {
+      markStreamActivityAsRead,
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.markAsRead(makeReq(), res)
+
+    // Access (not membership) gates the read: a viewer who inherits thread
+    // access from the root (INV-62) gets an activity-only read, not a 404.
+    expect(captured.status).not.toBe(404)
+    expect(captured.body).toEqual({ membership: null })
+    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "stream_thread")
+  })
+
+  it("returns the membership for a member read and still clears activity", async () => {
+    const membership = {
+      streamId: "stream_thread",
+      memberId: "usr_viewer",
+      notificationLevel: null,
+      lastReadEventId: "evt_1",
+      lastReadAt: null,
+      joinedAt: new Date(),
+    }
+    const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
+    const markAsRead = mock(() => Promise.resolve(membership))
+    const markStreamActivityAsRead = mock(() => Promise.resolve())
+    const handlers = makeHandlers({ validateStreamAccess, markAsRead } as Partial<StreamService>, {
+      markStreamActivityAsRead,
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.markAsRead(makeReq(), res)
+
+    expect(captured.status).toBe(200)
+    expect(captured.body).toEqual({ membership })
+    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "stream_thread")
+  })
+})

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -907,13 +907,17 @@ export function createStreamHandlers({
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
       const membership = await streamService.markAsRead(workspaceId, streamId, userId, data.lastEventId)
-      if (!membership) {
-        return res.status(404).json({ error: "Not a member of this stream" })
-      }
 
+      // Unconditional: thread access is inherited from the root (INV-62), so a
+      // viewer can have access without a membership row (non-member thread leg,
+      // or a public channel never joined). Their activity rows are keyed to this
+      // stream, and viewing is reading for the activity surface — gating the
+      // clear on membership left those rows stuck until clicked one by one in
+      // the Activity feed. A null membership is a successful activity-only read
+      // (no watermark to advance), not a 404; access was validated above.
       await activityService?.markStreamActivityAsRead(userId, streamId)
 
-      res.json({ membership })
+      res.json({ membership: membership ?? null })
     },
 
     async markUnread(req: Request, res: Response) {

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -199,8 +199,8 @@ export const streamsApi = {
     return res.data.membership
   },
 
-  async markAsRead(workspaceId: string, streamId: string, lastEventId: string): Promise<StreamMember> {
-    const res = await api.post<{ membership: StreamMember }>(
+  async markAsRead(workspaceId: string, streamId: string, lastEventId: string): Promise<StreamMember | null> {
+    const res = await api.post<{ membership: StreamMember | null }>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/read`,
       { lastEventId }
     )

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -7,6 +7,7 @@ import { clearAllCachedData, db } from "@/db"
 import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_WORKSPACE_SETTINGS,
+  type Activity,
   type StreamMember,
   type WorkspaceBootstrap,
 } from "@threa/types"
@@ -14,7 +15,8 @@ import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
 import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
-const mockMarkAsRead = vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember>>()
+const mockMarkAsRead =
+  vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember | null>>()
 const mockPostMessage = vi.fn()
 const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
 
@@ -330,5 +332,92 @@ describe("useUnreadCounts", () => {
     })
 
     expect(mockPostMessage).toHaveBeenCalledWith({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId: "stream_1" })
+  })
+
+  it("clears activity without touching membership state when the read returns a null membership", async () => {
+    // A viewer with inherited access but no membership row (INV-62: non-member
+    // thread leg) gets an activity-only read: the server returns 200 with a
+    // null membership. The held activity rows must clear, and no membership-
+    // shaped write may happen (spreading null would junk the IDB row).
+    const activity = (id: string, streamId: string): Activity => ({
+      id,
+      workspaceId: "ws_1",
+      userId: "member_1",
+      activityType: "message",
+      streamId,
+      messageId: `msg_${id}`,
+      actorId: "persona_system_ariadne",
+      actorType: "persona",
+      context: {},
+      readAt: null,
+      createdAt: new Date().toISOString(),
+      isSelf: false,
+      emoji: null,
+    })
+
+    const queryClient = new QueryClient()
+    const bootstrap = makeBootstrap()
+    bootstrap.unreadActivities = [
+      activity("act_1", "stream_thread"),
+      activity("act_2", "stream_thread"),
+      activity("act_3", "stream_2"),
+    ]
+    bootstrap.activityCounts = { stream_thread: 2, stream_2: 1 }
+    bootstrap.unreadActivityCount = 3
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), bootstrap)
+
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_old",
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: { stream_thread: 2, stream_2: 1 },
+      unreadActivityCount: 3,
+      unreadActivities: [
+        activity("act_1", "stream_thread"),
+        activity("act_2", "stream_thread"),
+        activity("act_3", "stream_2"),
+      ],
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    mockMarkAsRead.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.markAsRead("stream_thread", "event_new")
+    })
+
+    await waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadActivities?.map((a) => a.id)).toEqual(["act_3"])
+    })
+
+    // No watermark to persist: no membership row created, no stream row
+    // touched, and unrelated memberships stay put.
+    expect(await db.streamMemberships.get("ws_1:stream_thread")).toBeUndefined()
+    expect(await db.streams.get("stream_thread")).toBeUndefined()
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "event_old" })
+
+    const updated = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(updated?.unreadActivities?.map((a) => a.id)).toEqual(["act_3"])
+    expect(updated?.activityCounts).toEqual({ stream_2: 1 })
+    expect(updated?.unreadActivityCount).toBe(1)
+    expect(updated?.streamMemberships.find((m) => m.streamId === "stream_1")?.lastReadEventId).toBe("event_old")
   })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -83,6 +83,12 @@ export function useUnreadCounts(workspaceId: string) {
     onSuccess: async (membership, { streamId, lastEventId, partial }) => {
       const current = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
       const hadActivity = (current?.activityCounts[streamId] ?? 0) > 0
+      // Null membership = a successful activity-only read by a viewer with
+      // access but no membership row (INV-62: non-member thread leg, public
+      // channel never joined). The activity clear below still applies; there is
+      // no watermark to persist, and the membership-shaped writes must skip —
+      // spreading null would synthesize a junk membership row in IDB.
+      const hasMembership = membership !== null
 
       // Coupling (D2/D4): reading a stream clears its held activity rows on BOTH
       // the partial and full paths — activity (e.g. a reaction) is read by opening
@@ -114,19 +120,23 @@ export function useUnreadCounts(workspaceId: string) {
           unreadActivities: rows,
           ...deriveActivityCounts(rows),
           ...messageCounters,
-          streamMemberships: old.streamMemberships.map((existingMembership) =>
-            existingMembership.streamId === streamId ? { ...existingMembership, ...membership } : existingMembership
-          ),
+          streamMemberships: hasMembership
+            ? old.streamMemberships.map((existingMembership) =>
+                existingMembership.streamId === streamId ? { ...existingMembership, ...membership } : existingMembership
+              )
+            : old.streamMemberships,
         }
       })
 
-      queryClient.setQueryData(
-        streamKeys.bootstrap(workspaceId, streamId),
-        (old: import("@threa/types").StreamBootstrap | undefined) => {
-          if (!old) return old
-          return { ...old, membership: { ...old.membership, lastReadEventId: lastEventId } }
-        }
-      )
+      if (hasMembership) {
+        queryClient.setQueryData(
+          streamKeys.bootstrap(workspaceId, streamId),
+          (old: import("@threa/types").StreamBootstrap | undefined) => {
+            if (!old) return old
+            return { ...old, membership: { ...old.membership, lastReadEventId: lastEventId } }
+          }
+        )
+      }
 
       // Keep both the denormalized stream row and the membership row in sync:
       // stream-content derives the unread divider from membership state.
@@ -154,25 +164,27 @@ export function useUnreadCounts(workspaceId: string) {
           })
         }
 
-        await db.streams.update(streamId, { lastReadEventId: lastEventId, _cachedAt: now })
+        if (hasMembership) {
+          await db.streams.update(streamId, { lastReadEventId: lastEventId, _cachedAt: now })
 
-        const membershipId = `${workspaceId}:${streamId}`
-        const existingMembership = await db.streamMemberships.get(membershipId)
-        if (existingMembership) {
-          await db.streamMemberships.put({
-            ...existingMembership,
-            ...membership,
-            id: membershipId,
-            workspaceId,
-            _cachedAt: now,
-          })
-        } else {
-          await db.streamMemberships.put({
-            ...membership,
-            id: membershipId,
-            workspaceId,
-            _cachedAt: now,
-          })
+          const membershipId = `${workspaceId}:${streamId}`
+          const existingMembership = await db.streamMemberships.get(membershipId)
+          if (existingMembership) {
+            await db.streamMemberships.put({
+              ...existingMembership,
+              ...membership,
+              id: membershipId,
+              workspaceId,
+              _cachedAt: now,
+            })
+          } else {
+            await db.streamMemberships.put({
+              ...membership,
+              id: membershipId,
+              workspaceId,
+              _cachedAt: now,
+            })
+          }
         }
       })
 


### PR DESCRIPTION
## Problem

A viewer with access to a thread but no `stream_members` row — thread membership is participation, access is inherited from the root (INV-62) — could never clear their unread by viewing it. `POST /streams/:id/read` 404d at the membership gate (`StreamMemberRepository.update` matches no row) *before* `markStreamActivityAsRead` ran. Unread for such threads is 100% activity-driven (message-unread is membership-keyed everywhere: bootstrap, socket counters), so the sidebar strip and Activity badge persisted until each row was clicked by hand — and survived force-refresh. Verified against prod: thread `stream_01KY8ECNPS8ZR335YY2S357P5K`, viewer a root-DM member with no thread membership; opening the thread panel 404d silently, clicking the Activity rows cleared it.

## Solution

Access gates the read; membership gates the watermark.

- `streams/handlers.ts markAsRead`: clear stream activity unconditionally after `validateStreamAccess`; respond 200 `{ membership: null }` instead of 404 when `streamService.markAsRead` returns null (no row). Also covers public-channel viewers who never joined (INV-62 grants read without a row).
- `use-unread-counts.ts`: `markAsReadMutation.onSuccess` tolerates a null membership — held activity rows still drop and counts re-derive, but membership-shaped writes skip (query-cache membership merge, per-stream bootstrap merge, `db.streams.lastReadEventId`, `db.streamMemberships` put — spreading null would persist a junk row).
- `api/streams.ts`: `markAsRead` → `StreamMember | null`.
- 200/null over upserting a membership on read — `docs/sparse-read-overlay-design.md` rules out membership upsert on read (membership ≠ access; rows drive notification levels, member lists, joined semantics).
- Out of scope: a watermark/read frontier for non-member threads (design-doc deferred follow-up; message-unread doesn't exist for non-members, so activity is the whole surface). `markUnread` 404s the same way — rarer surface, follow-up.

## Residual risk (adversarially reviewed, acknowledged)

- Non-member reads emit no sync event (no membership → no `stream:read`; `markStreamActivityAsRead` is a bare UPDATE): other devices of the same user converge on next bootstrap, Activity-feed open (A4 reconcile), or re-open — not live. Same semantics as every existing activity-read path (per-row and mark-all are bare UPDATEs too); member stream reads only sync live because the clear rides the watermark's `stream:read`. Optional follow-up: one author-scoped activity-read event covering per-row/per-stream/per-all.
- Insert-between-clear-and-response race: an activity row the notification worker inserts after the server clear but before the HTTP response is dropped client-side by `onSuccess` and can resurrect on refresh (re-open clears it). Members are protected by born-read via watermark (`membersReadThrough`); non-members have no watermark by design — the principled fix is the deferred non-member read-state follow-up. Worst case is a transient badge, vs the pre-fix permanently-stuck state.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/handlers.ts` | `markAsRead`: activity clear unconditional after access validation; 200 `{ membership: null }` for no-row reads |
| `apps/frontend/src/api/streams.ts` | `markAsRead` returns `StreamMember \| null` |
| `apps/frontend/src/hooks/use-unread-counts.ts` | null-membership tolerance: activity clear kept, watermark/membership writes skipped |
| `apps/backend/src/features/streams/handlers.test.ts` | handler: non-member (200/null + activity cleared) and member cases |
| `apps/frontend/src/hooks/use-unread-counts.test.tsx` | hook: null membership clears activity, no junk IDB row, unrelated membership untouched |

## Test plan

- [x] `bun test apps/backend/src/features/streams/handlers.test.ts` — 22 pass (2 new)
- [x] `bun test apps/backend/src/features/streams/service.test.ts` — 86 pass (unchanged; guards service behavior)
- [x] `vitest run src/hooks/use-unread-counts.test.tsx` — 5 pass (1 new)
- [x] `bun run typecheck` — 0 errors; eslint on touched files clean; pre-commit lint+typecheck pass
- [ ] manual E2E on staging — not run; root cause verified against prod data, unit coverage on both sides of the contract

<details>
<summary>📋 Full implementation plan</summary>

Ratified in conversation (delegation `dlg_01KY8FPSEXJV77XQ14G0FPQKSP` diagnosis):

1. Root cause: handler 404s non-member thread viewers at the membership gate, skipping the activity clear; their unread is activity-only (message-unread is membership-keyed), so it sticks until manual Activity clicks and survives refresh.
2. Fix: access gates the read (validateStreamAccess), membership gates the watermark. Activity clear unconditional; null membership → 200 `{ membership: null }`. Client null-tolerance: activity clear kept, membership/watermark writes skipped (no junk IDB rows, no flapping local watermark).
3. Rejected: auto-adding root members to threads / upserting membership on read — corrupts membership≠access (design doc), N×M row growth in channels, no fix for existing stuck threads without migration.
4. Deferred follow-up: principled read frontier for non-member thread legs (own table or watermark column on the membership-free overlay table; bootstrap unread bounded to recently-active accessible threads).

</details>

---

🤖 _PR by pi (Qwen 3.8 Max Preview)_
