### PR TITLE
feat: render shared-message pointers from wire hydration

### DIFF
--- a/apps/frontend/src/components/shared-messages/context.test.tsx
+++ b/apps/frontend/src/components/shared-messages/context.test.tsx
@@ -17,6 +17,7 @@ describe("SharedMessagesProvider", () => {
 
   it("returns the hydrated payload keyed by messageId", () => {
     const ok = {
+      type: "sharedMessage" as const,
       state: "ok" as const,
       messageId: "msg_1",
       streamId: "stream_src",
@@ -37,7 +38,9 @@ describe("SharedMessagesProvider", () => {
   it("returns null for a messageId missing from the map", () => {
     const { result } = renderHook(() => useSharedMessageHydration("msg_missing"), {
       wrapper: ({ children }) => (
-        <SharedMessagesProvider map={{ msg_other: { state: "missing", messageId: "msg_other" } }}>
+        <SharedMessagesProvider
+          map={{ msg_other: { type: "sharedMessage", state: "missing", messageId: "msg_other" } }}
+        >
           {children}
         </SharedMessagesProvider>
       ),

--- a/apps/frontend/src/components/shared-messages/context.tsx
+++ b/apps/frontend/src/components/shared-messages/context.tsx
@@ -11,6 +11,7 @@ import type { AttachmentSummary, StreamType, Visibility } from "@threa/types"
  */
 export type HydratedSharedMessage =
   | {
+      type: "sharedMessage"
       state: "ok"
       messageId: string
       streamId: string
@@ -23,15 +24,16 @@ export type HydratedSharedMessage =
       createdAt: string
       attachments: AttachmentSummary[]
     }
-  | { state: "deleted"; messageId: string; deletedAt: string }
-  | { state: "missing"; messageId: string }
+  | { type: "sharedMessage"; state: "deleted"; messageId: string; deletedAt: string }
+  | { type: "sharedMessage"; state: "missing"; messageId: string }
   | {
+      type: "sharedMessage"
       state: "private"
       messageId: string
       sourceStreamKind: StreamType
       sourceVisibility: Visibility
     }
-  | { state: "truncated"; messageId: string; streamId: string }
+  | { type: "sharedMessage"; state: "truncated"; messageId: string; streamId: string }
 
 interface SharedMessagesContextValue {
   get: (messageId: string) => HydratedSharedMessage | null

--- a/apps/frontend/src/hooks/use-shared-message-source.test.tsx
+++ b/apps/frontend/src/hooks/use-shared-message-source.test.tsx
@@ -38,6 +38,7 @@ describe("useSharedMessageSource", () => {
         <SharedMessagesProvider
           map={{
             msg_1: {
+              type: "sharedMessage",
               state: "ok",
               messageId: "msg_1",
               streamId: "stream_src",
@@ -74,8 +75,13 @@ describe("useSharedMessageSource", () => {
       wrapper: ({ children }) => (
         <SharedMessagesProvider
           map={{
-            msg_del: { state: "deleted", messageId: "msg_del", deletedAt: "2026-04-23T10:00:00Z" },
-            msg_missing: { state: "missing", messageId: "msg_missing" },
+            msg_del: {
+              type: "sharedMessage",
+              state: "deleted",
+              messageId: "msg_del",
+              deletedAt: "2026-04-23T10:00:00Z",
+            },
+            msg_missing: { type: "sharedMessage", state: "missing", messageId: "msg_missing" },
           }}
         >
           {children}
@@ -95,6 +101,7 @@ describe("useSharedMessageSource", () => {
         <SharedMessagesProvider
           map={{
             msg_p: {
+              type: "sharedMessage",
               state: "private",
               messageId: "msg_p",
               sourceStreamKind: "channel",
@@ -119,7 +126,7 @@ describe("useSharedMessageSource", () => {
       wrapper: ({ children }) => (
         <SharedMessagesProvider
           map={{
-            msg_t: { state: "truncated", messageId: "msg_t", streamId: "stream_deep" },
+            msg_t: { type: "sharedMessage", state: "truncated", messageId: "msg_t", streamId: "stream_deep" },
           }}
         >
           {children}

--- a/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
@@ -59,6 +59,7 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
     const markdown = "Shared a message from [Ariadne](shared-message:stream_src/msg_abc)"
     renderMarkdown(markdown, {
       msg_abc: {
+        type: "sharedMessage",
         state: "ok",
         messageId: "msg_abc",
         streamId: "stream_src",
@@ -127,6 +128,7 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
     const markdown = "Shared a message from [Ariadne](shared-message:stream_src/msg_abc)"
     renderMarkdown(markdown, {
       msg_abc: {
+        type: "sharedMessage",
         state: "ok",
         messageId: "msg_abc",
         streamId: "stream_src",

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -16,7 +16,13 @@ import {
 import { streamKeys } from "@/hooks/use-streams"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
-import type { BotRuntimePresenceSummary, LinkPreviewSummary, StreamBootstrap, StreamEvent } from "@threa/types"
+import type {
+  BotRuntimePresenceSummary,
+  LinkPreviewSummary,
+  SharedMessageHydration,
+  StreamBootstrap,
+  StreamEvent,
+} from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
 // in-memory IndexedDB. No mocks needed — tests exercise actual queries.
@@ -2488,5 +2494,321 @@ describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
       threadSummary: healSummary,
     })
     expect(row?._patchedAt).toBeUndefined()
+  })
+})
+
+describe("registerStreamSocketHandlers — shared-message wire hydration", () => {
+  // Live events carry the hydration map (chunk 1): pointer cards patch into
+  // the cached bootstrap in the same frame, no bootstrap/events invalidation.
+  // The invalidate-refetch survives only as the deploy-skew fallback for
+  // share-bearing events that arrive WITHOUT a map.
+
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function okEntry(contentMarkdown: string, messageId = "msg_src"): SharedMessageHydration {
+    return {
+      type: "sharedMessage",
+      state: "ok",
+      messageId,
+      streamId: "stream_src",
+      authorId: "usr_9",
+      authorType: "user",
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown,
+      editedAt: null,
+      createdAt: "2026-04-23T10:00:00Z",
+      attachments: [],
+    }
+  }
+
+  const shareNodeContent = {
+    type: "doc",
+    content: [{ type: "sharedMessage", attrs: { messageId: "msg_src", streamId: "stream_src" } }],
+  }
+
+  function seedBootstrap(
+    queryClient: QueryClient,
+    streamId: string,
+    sharedMessages?: Record<string, SharedMessageHydration>
+  ): void {
+    queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId), {
+      ...makeBootstrap([], streamId),
+      ...(sharedMessages && { sharedMessages }),
+      windowVersion: 0,
+    })
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("message:created patches the bootstrap cache from the wire map and skips invalidation", async () => {
+    const streamId = "stream_wire_hydration"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId, { msg_old: okEntry("older", "msg_old") })
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_share",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "msg_new", contentJson: shareNodeContent },
+      }),
+      sharedMessages: { msg_src: okEntry("from the wire") },
+    })
+
+    const cached = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(cached?.sharedMessages).toEqual({
+      msg_old: okEntry("older", "msg_old"),
+      msg_src: okEntry("from the wire"),
+    })
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("message:created treats an empty wire map as authoritative — presence suppresses the fallback", async () => {
+    const streamId = "stream_wire_empty"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_share_empty",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "msg_new", contentJson: shareNodeContent },
+      }),
+      sharedMessages: {},
+    })
+
+    expect(queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))).toBe(before)
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("message:created falls back to invalidating when a share-bearing event carries no map (deploy skew)", async () => {
+    const streamId = "stream_skew_created"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_skew",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "msg_skew", contentJson: shareNodeContent },
+      }),
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.bootstrap("ws_1", streamId) })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.events("ws_1", streamId) })
+
+    cleanup()
+  })
+
+  it("message:created with neither a map nor a share node leaves the cache untouched", async () => {
+    const streamId = "stream_plain"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_plain",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "msg_plain", contentJson: { type: "doc", content: [] } },
+      }),
+    })
+
+    expect(queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))).toBe(before)
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("message:edited patches the bootstrap cache from the wire map and skips invalidation", async () => {
+    const streamId = "stream_wire_edit"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_target",
+        streamId,
+        sequence: "50",
+        payload: { messageId: "msg_target", contentMarkdown: "old" },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 50,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_edit",
+        streamId,
+        sequence: "101",
+        eventType: "message_edited",
+        payload: { messageId: "msg_target", contentJson: shareNodeContent, contentMarkdown: "edited" },
+      }),
+      sharedMessages: { msg_src: okEntry("edited source") },
+    })
+
+    const cached = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(cached?.sharedMessages).toEqual({ msg_src: okEntry("edited source") })
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("message:edited falls back to invalidating when a share-bearing edit carries no map (deploy skew)", async () => {
+    const streamId = "stream_skew_edited"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_edit_skew",
+        streamId,
+        sequence: "101",
+        eventType: "message_edited",
+        payload: { messageId: "msg_target", contentJson: shareNodeContent, contentMarkdown: "edited" },
+      }),
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.bootstrap("ws_1", streamId) })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.events("ws_1", streamId) })
+
+    cleanup()
+  })
+
+  it("pointer:invalidated patches the fresh entry over the stale one without invalidating", async () => {
+    const streamId = "stream_pointer_patch"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId, {
+      msg_src: okEntry("stale content"),
+      msg_other: okEntry("untouched", "msg_other"),
+    })
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("pointer:invalidated", {
+      workspaceId: "ws_1",
+      targetStreamId: streamId,
+      sourceMessageId: "msg_src",
+      sharedMessages: { msg_src: okEntry("fresh content") },
+    })
+
+    const cached = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(cached?.sharedMessages).toEqual({
+      msg_src: okEntry("fresh content"),
+      msg_other: okEntry("untouched", "msg_other"),
+    })
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("pointer:invalidated without a map falls back to invalidating (deploy skew)", async () => {
+    const streamId = "stream_pointer_skew"
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, streamId)
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("pointer:invalidated", {
+      workspaceId: "ws_1",
+      targetStreamId: streamId,
+      sourceMessageId: "msg_src",
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.bootstrap("ws_1", streamId) })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: streamKeys.events("ws_1", streamId) })
+
+    cleanup()
+  })
+
+  it("does not create a bootstrap cache entry when a map arrives with nothing cached", async () => {
+    const streamId = "stream_no_cache"
+    const queryClient = new QueryClient()
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("pointer:invalidated", {
+      workspaceId: "ws_1",
+      targetStreamId: streamId,
+      sourceMessageId: "msg_src",
+      sharedMessages: { msg_src: okEntry("wire") },
+    })
+
+    expect(queryClient.getQueryCache().find({ queryKey: streamKeys.bootstrap("ws_1", streamId) })).toBeUndefined()
+
+    cleanup()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceBootstrap,
   type BotRuntimePresenceSummary,
   type JSONContent,
+  type SharedMessageHydration,
 } from "@threa/types"
 import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
@@ -639,6 +640,7 @@ interface MessageEventPayload {
   workspaceId: string
   streamId: string
   event: StreamEvent
+  sharedMessages?: Record<string, SharedMessageHydration>
 }
 
 interface MessageDeletedPayload {
@@ -885,6 +887,18 @@ function contentHasSharedMessage(contentJson: unknown): boolean {
   return false
 }
 
+function patchSharedMessagesHydration(
+  queryClient: QueryClient,
+  workspaceId: string,
+  streamId: string,
+  map: Record<string, SharedMessageHydration>
+): void {
+  if (Object.keys(map).length === 0) return
+  queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (old) =>
+    old ? { ...old, sharedMessages: { ...old.sharedMessages, ...map } } : old
+  )
+}
+
 /** Plaintext content carried by an optimistic (self-sent) event payload, if present. */
 function readPlaintextContent(
   payload: unknown
@@ -1072,11 +1086,11 @@ export function registerStreamSocketHandlers(
       }
     })
 
-    // If the new event includes a sharedMessage pointer, the cached bootstrap's
-    // sharedMessages hydration map won't contain an entry for the source yet —
-    // without a refetch the pointer renders with no content. Invalidate so the
-    // next response populates the hydration map.
-    if (contentHasSharedMessage(newPayload.contentJson)) {
+    if (payload.sharedMessages) {
+      patchSharedMessagesHydration(queryClient, workspaceId, streamId, payload.sharedMessages)
+    } else if (contentHasSharedMessage(newPayload.contentJson)) {
+      // Deploy skew: pre-hydration outbox rows / old backends emit share-bearing
+      // events without the map — refetch so the pointer still hydrates.
       await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
       await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
     }
@@ -1098,7 +1112,10 @@ export function registerStreamSocketHandlers(
       editedAt: editEvent.createdAt,
     }))
 
-    if (contentHasSharedMessage(editPayload.contentJson)) {
+    if (payload.sharedMessages) {
+      patchSharedMessagesHydration(queryClient, workspaceId, streamId, payload.sharedMessages)
+    } else if (contentHasSharedMessage(editPayload.contentJson)) {
+      // Deploy-skew fallback — see handleMessageCreated.
       await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
       await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
     }
@@ -1390,14 +1407,21 @@ export function registerStreamSocketHandlers(
   }
 
   /**
-   * Invalidate any TanStack Query cache holding this stream's messages when
-   * a pointer-referenced source message in another stream is edited or
-   * deleted. Triggers a refetch so the hydrated share-map on the next
-   * response reflects the new content. The payload's targetStreamId is the
-   * room this emit was scoped to, so we just invalidate bootstrap/events.
+   * A pointer-referenced source message in another stream changed (edit/
+   * delete/move). The payload carries the re-hydrated entry — patch it into
+   * the cached bootstrap so the pointer card updates in place, no refetch.
    */
-  const handlePointerInvalidated = async (payload: { targetStreamId: string; sourceMessageId: string }) => {
+  const handlePointerInvalidated = async (payload: {
+    targetStreamId: string
+    sourceMessageId: string
+    sharedMessages?: Record<string, SharedMessageHydration>
+  }) => {
     if (payload.targetStreamId !== streamId) return
+    if (payload.sharedMessages) {
+      patchSharedMessagesHydration(queryClient, workspaceId, streamId, payload.sharedMessages)
+      return
+    }
+    // Deploy-skew fallback — see handleMessageCreated.
     await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
     await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
   }


### PR DESCRIPTION
## Problem

Chunk 1 (#1526) puts shared-message hydration on the wire; this PR makes the
client use it. Today `stream-sync.ts` invalidates the entire bootstrap +
events queries on any share-bearing `message:created` / `message:edited` and
on every `pointer:invalidated` — the pointer card renders a skeleton for
seconds, then a full refetch delivers the map and the card pops to full
height, lurching the timeline (Pierre's report).

## Solution

Consume the wire map; kill the lazy path.

- `patchSharedMessagesHydration` (`stream-sync.ts`): `setQueryData` merge into
  the cached bootstrap's `sharedMessages` (incoming entries win; empty map and
  absent cache are no-ops — verified against installed
  `@tanstack/query-core@5.99.0`: an updater returning `undefined` returns
  before `queryCache.build`, so no entry is created). The existing
  `mergedSharedMessages` memo in `stream-content.tsx` spreads bootstrap last,
  so wire-patched entries win over stale paged/anchor/parent maps — no
  renderer changes needed.
- `handleMessageCreated` / `handleMessageEdited` / `handlePointerInvalidated`
  patch from `payload.sharedMessages` when present. Invalidate-refetch kept
  **only** as deploy-skew fallback: a share-bearing event arriving without a
  map (pre-#1526 outbox rows, old backend during rollout) still hydrates via
  refetch.
- Local `HydratedSharedMessage` union gains the `type: "sharedMessage"` tag,
  mirroring the wire contract; fixture sweep across the four construction
  sites.
- Residual risk (accepted): a bootstrap fetch in flight when the event lands
  can clobber the patched entry — degrades to the pre-feature pending/IDB
  fallback and self-heals via sequence-gap catch-up (which carries maps
  post-#1526) and INV-53 reconnect invalidate; same accepted pattern as
  `handleBotRuntimePresence`.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/stream-sync.ts` | `MessageEventPayload.sharedMessages?`; `patchSharedMessagesHydration`; three handlers patch-then-fallback; `pointer:invalidated` payload typed |
| `apps/frontend/src/components/shared-messages/context.tsx` | `type` tag on the local union |
| `apps/frontend/src/sync/stream-sync.test.ts` | +9 tests: patch paths (no invalidation), fallback paths (exact keys), empty-map presence authoritative, absent-cache creates no entry |
| `context.test.tsx`, `use-shared-message-source.test.tsx`, `shared-message-block.test.tsx` | fixture tags |

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] targeted frontend suites (stream-sync, shared-messages, use-shared-message-source, shared-message-block, use-thread-anchor) — 107 pass
- [x] adversarial review (Qwen 3.8 preview, high) — SHIP, zero findings ≥80; all 9 flagged edge paths cleared

<details>
<summary>📋 Full implementation plan</summary>

Stack: #1526 (backend wire hydration) → this PR (frontend consumption).
Decisions D-Wire / D-Room / D-Name / D-Fallback per the plan in #1526.

</details>

---

🤖 _PR by [OpenCode](https://opencode.ai)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787472714&installation_model_id=20758&pr_number=1528&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1528&signature=5f5e0435be4a6573128b33662c92a7e197dbe2f299649a281e13be0d4a8e5d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->