### PR TITLE
feat(activity): cross-device activity:read propagation

### DIFF
--- a/apps/backend/src/features/activity/handlers.ts
+++ b/apps/backend/src/features/activity/handlers.ts
@@ -43,7 +43,7 @@ export function createActivityHandlers({ activityService }: Dependencies) {
       const workspaceId = req.workspaceId!
       const activityId = req.params.id
 
-      await activityService.markAsRead(activityId, userId, workspaceId)
+      await activityService.markAsRead(userId, workspaceId, activityId)
 
       res.json({ ok: true })
     },

--- a/apps/backend/src/features/activity/handlers.ts
+++ b/apps/backend/src/features/activity/handlers.ts
@@ -40,9 +40,10 @@ export function createActivityHandlers({ activityService }: Dependencies) {
 
     async markOneAsRead(req: Request, res: Response) {
       const userId = req.user!.id
+      const workspaceId = req.workspaceId!
       const activityId = req.params.id
 
-      await activityService.markAsRead(activityId, userId)
+      await activityService.markAsRead(activityId, userId, workspaceId)
 
       res.json({ ok: true })
     },

--- a/apps/backend/src/features/activity/outbox-handler.test.ts
+++ b/apps/backend/src/features/activity/outbox-handler.test.ts
@@ -270,6 +270,7 @@ describe("ActivityFeedHandler", () => {
     const countsSpy = spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
       new Map([["usr_alice:stream_test", { mentionCount: 3, totalCount: 5 }]])
     )
+    spyOn(ActivityRepository, "findStillUnreadIds").mockResolvedValue(new Set(["activity_test123"]))
 
     spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => {
       return callback({} as any)
@@ -329,6 +330,7 @@ describe("ActivityFeedHandler", () => {
     spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
       new Map([["usr_behind:stream_test", { mentionCount: 0, totalCount: 1 }]])
     )
+    spyOn(ActivityRepository, "findStillUnreadIds").mockResolvedValue(new Set(["act_unread"]))
     spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => callback({} as any))
 
     const { handler, activityService } = createHandler()
@@ -346,6 +348,89 @@ describe("ActivityFeedHandler", () => {
       {},
       "activity:created",
       expect.objectContaining({ targetUserId: "usr_caughtup" })
+    )
+  })
+
+  it("skips activity:created for rows read before publish (activity:read ordering barrier)", async () => {
+    // A row can be read — and its activity:read logged — between the source
+    // commit and this publish. The FOR SHARE re-read sees the committed
+    // read_at and the stale creation is never published, so the sync log
+    // can't order a creation after its read (replay would resurrect the row).
+    const readBeforePublish = {
+      id: "act_read_early",
+      workspaceId: "ws_test",
+      userId: "usr_a",
+      activityType: "message",
+      streamId: "stream_test",
+      messageId: "msg_test",
+      actorId: "usr_author",
+      actorType: "user",
+      context: {},
+      readAt: null,
+      createdAt: new Date("2025-01-01T00:00:00Z"),
+      isSelf: false,
+      emoji: null,
+    }
+    const stillUnread = { ...readBeforePublish, id: "act_still_unread", userId: "usr_b" }
+
+    const event = makeMessageCreatedEvent(1n)
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event] as any)
+    const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(new Map())
+    // The locked re-read reports only one row still unread.
+    spyOn(ActivityRepository, "findStillUnreadIds").mockResolvedValue(new Set(["act_still_unread"]))
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => callback({} as any))
+
+    const { handler, activityService } = createHandler()
+    ;(activityService.processMessageNotifications as any).mockResolvedValue([readBeforePublish, stillUnread])
+
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insertSpy).toHaveBeenCalledWith({}, "activity:created", expect.objectContaining({ targetUserId: "usr_b" }))
+    expect(insertSpy).not.toHaveBeenCalledWith(
+      {},
+      "activity:created",
+      expect.objectContaining({ targetUserId: "usr_a" })
+    )
+  })
+
+  it("still publishes self rows even when the barrier reports nothing unread", async () => {
+    // Self rows are born read (read_at set at insert) so they never appear in
+    // an activity:read delta — the barrier must not suppress their emission.
+    const selfRow = {
+      id: "act_self",
+      workspaceId: "ws_test",
+      userId: "usr_author",
+      activityType: "message",
+      streamId: "stream_test",
+      messageId: "msg_test",
+      actorId: "usr_author",
+      actorType: "user",
+      context: {},
+      readAt: new Date("2025-01-01T00:00:00Z"),
+      createdAt: new Date("2025-01-01T00:00:00Z"),
+      isSelf: true,
+      emoji: null,
+    }
+
+    const event = makeMessageCreatedEvent(1n)
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event] as any)
+    const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(new Map())
+    spyOn(ActivityRepository, "findStillUnreadIds").mockResolvedValue(new Set())
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => callback({} as any))
+
+    const { handler, activityService } = createHandler()
+    ;(activityService.processSelfMessageActivity as any).mockResolvedValue(selfRow)
+
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insertSpy).toHaveBeenCalledWith(
+      {},
+      "activity:created",
+      expect.objectContaining({ targetUserId: "usr_author" })
     )
   })
 
@@ -399,6 +484,7 @@ describe("ActivityFeedHandler", () => {
     spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
       new Map([["usr_bob:stream_test", { mentionCount: 1, totalCount: 1 }]])
     )
+    spyOn(ActivityRepository, "findStillUnreadIds").mockResolvedValue(new Set(["activity_existing"]))
 
     spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => {
       return callback({} as any)

--- a/apps/backend/src/features/activity/outbox-handler.test.ts
+++ b/apps/backend/src/features/activity/outbox-handler.test.ts
@@ -387,7 +387,23 @@ describe("ActivityFeedHandler", () => {
     handler.handle()
     await new Promise((r) => setTimeout(r, 300))
 
-    expect(insertSpy).toHaveBeenCalledWith({}, "activity:created", expect.objectContaining({ targetUserId: "usr_b" }))
+    expect(insertSpy).toHaveBeenCalledWith({}, "activity:created", {
+      workspaceId: "ws_test",
+      targetUserId: "usr_b",
+      counts: { mentionCount: 0, activityCount: 0 },
+      activity: {
+        id: "act_still_unread",
+        activityType: "message",
+        streamId: "stream_test",
+        messageId: "msg_test",
+        actorId: "usr_author",
+        actorType: "user",
+        context: {},
+        createdAt: "2025-01-01T00:00:00.000Z",
+        isSelf: false,
+        emoji: null,
+      },
+    })
     expect(insertSpy).not.toHaveBeenCalledWith(
       {},
       "activity:created",
@@ -427,11 +443,23 @@ describe("ActivityFeedHandler", () => {
     handler.handle()
     await new Promise((r) => setTimeout(r, 300))
 
-    expect(insertSpy).toHaveBeenCalledWith(
-      {},
-      "activity:created",
-      expect.objectContaining({ targetUserId: "usr_author" })
-    )
+    expect(insertSpy).toHaveBeenCalledWith({}, "activity:created", {
+      workspaceId: "ws_test",
+      targetUserId: "usr_author",
+      counts: { mentionCount: 0, activityCount: 0 },
+      activity: {
+        id: "act_self",
+        activityType: "message",
+        streamId: "stream_test",
+        messageId: "msg_test",
+        actorId: "usr_author",
+        actorType: "user",
+        context: {},
+        createdAt: "2025-01-01T00:00:00.000Z",
+        isSelf: true,
+        emoji: null,
+      },
+    })
   })
 
   it("should return no_events when batch is empty", async () => {

--- a/apps/backend/src/features/activity/outbox-handler.ts
+++ b/apps/backend/src/features/activity/outbox-handler.ts
@@ -338,16 +338,31 @@ export class ActivityFeedHandler implements OutboxHandler {
       }
 
       for (const [workspaceId, group] of byWorkspace) {
+        // Ordering barrier against activity:read (see findStillUnreadIds): a
+        // row can be read — and its activity:read logged — between the source
+        // transaction's commit and this publish. Re-read under FOR SHARE and
+        // skip non-self rows that are already read; a concurrent read UPDATE
+        // blocks on the lock until this transaction commits, so the sync log
+        // can never order a creation after its read. Self rows are born read
+        // and never appear in a read delta — published unconditionally.
+        const stillUnread = await ActivityRepository.findStillUnreadIds(
+          client,
+          workspaceId,
+          group.map((a) => a.id)
+        )
+        const publishable = group.filter((a) => a.isSelf || stillUnread.has(a.id))
+        if (publishable.length === 0) continue
+
         // Stream-less rows (standalone saved-item reminders) have no
         // per-stream unread counts; their lookup below misses and falls back
         // to zeros, which is correct — there's no stream badge to update.
         const counts = await ActivityRepository.countUnreadForPairs(
           client,
           workspaceId,
-          group.flatMap((a) => (a.streamId ? [{ userId: a.userId, streamId: a.streamId }] : []))
+          publishable.flatMap((a) => (a.streamId ? [{ userId: a.userId, streamId: a.streamId }] : []))
         )
 
-        for (const activity of group) {
+        for (const activity of publishable) {
           const pairCounts = counts.get(`${activity.userId}:${activity.streamId}`)
           await OutboxRepository.insert(client, "activity:created", {
             workspaceId: activity.workspaceId,

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -434,12 +434,12 @@ export const ActivityRepository = {
     return result.rows.map((row) => ({ activityId: row.activity_id, streamId: row.stream_id }))
   },
 
-  async markAllAsRead(db: Querier, userId: string, workspaceId: string): Promise<ClearedActivity[]> {
+  async markAllAsRead(db: Querier, workspaceId: string, userId: string): Promise<ClearedActivity[]> {
     const result = await db.query<ClearedActivityRow>(sql`
       UPDATE user_activity
       SET read_at = NOW()
-      WHERE user_id = ${userId}
-        AND workspace_id = ${workspaceId}
+      WHERE workspace_id = ${workspaceId}
+        AND user_id = ${userId}
         AND read_at IS NULL
       RETURNING id AS activity_id, stream_id
     `)

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -36,6 +36,17 @@ export interface Activity {
   emoji: string | null
 }
 
+/** A row flipped from unread to read by a mark-read UPDATE (its RETURNING content). */
+export interface ClearedActivity {
+  activityId: string
+  streamId: string | null
+}
+
+interface ClearedActivityRow {
+  activity_id: string
+  stream_id: string | null
+}
+
 export interface InsertActivityParams {
   workspaceId: string
   userId: string
@@ -343,14 +354,23 @@ export const ActivityRepository = {
     }
   },
 
-  async markAsRead(db: Querier, activityId: string, userId: string): Promise<void> {
-    await db.query(sql`
+  async markAsRead(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    activityId: string
+  ): Promise<ClearedActivity | null> {
+    const result = await db.query<ClearedActivityRow>(sql`
       UPDATE user_activity
       SET read_at = NOW()
-      WHERE id = ${activityId}
+      WHERE workspace_id = ${workspaceId}
+        AND id = ${activityId}
         AND user_id = ${userId}
         AND read_at IS NULL
+      RETURNING id AS activity_id, stream_id
     `)
+    const row = result.rows[0]
+    return row ? { activityId: row.activity_id, streamId: row.stream_id } : null
   },
 
   /**
@@ -396,26 +416,55 @@ export const ActivityRepository = {
     return result.rowCount ?? 0
   },
 
-  async markStreamAsRead(db: Querier, userId: string, streamId: string): Promise<number> {
-    const result = await db.query(sql`
+  async markStreamAsRead(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    streamId: string
+  ): Promise<ClearedActivity[]> {
+    const result = await db.query<ClearedActivityRow>(sql`
       UPDATE user_activity
       SET read_at = NOW()
-      WHERE user_id = ${userId}
+      WHERE workspace_id = ${workspaceId}
+        AND user_id = ${userId}
         AND stream_id = ${streamId}
         AND read_at IS NULL
+      RETURNING id AS activity_id, stream_id
     `)
-    return result.rowCount ?? 0
+    return result.rows.map((row) => ({ activityId: row.activity_id, streamId: row.stream_id }))
   },
 
-  async markAllAsRead(db: Querier, userId: string, workspaceId: string): Promise<number> {
-    const result = await db.query(sql`
+  async markAllAsRead(db: Querier, userId: string, workspaceId: string): Promise<ClearedActivity[]> {
+    const result = await db.query<ClearedActivityRow>(sql`
       UPDATE user_activity
       SET read_at = NOW()
       WHERE user_id = ${userId}
         AND workspace_id = ${workspaceId}
         AND read_at IS NULL
+      RETURNING id AS activity_id, stream_id
     `)
-    return result.rowCount ?? 0
+    return result.rows.map((row) => ({ activityId: row.activity_id, streamId: row.stream_id }))
+  },
+
+  /**
+   * Of `activityIds`, which are still unread — under FOR SHARE, as the
+   * activity:created publisher's ordering barrier against activity:read: a row
+   * can be read (and its activity:read logged) between the source transaction's
+   * commit and the publish. The share lock serializes the two — a concurrent
+   * read UPDATE blocks until this transaction commits, so the sync log orders
+   * created before read; a read committed first shows up here as already read
+   * and the stale creation is never published.
+   */
+  async findStillUnreadIds(db: Querier, workspaceId: string, activityIds: string[]): Promise<Set<string>> {
+    if (activityIds.length === 0) return new Set()
+    const result = await db.query<{ id: string }>(sql`
+      SELECT id FROM user_activity
+      WHERE workspace_id = ${workspaceId}
+        AND id = ANY(${activityIds}::text[])
+        AND read_at IS NULL
+      FOR SHARE
+    `)
+    return new Set(result.rows.map((row) => row.id))
   },
 
   /**

--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@threa/types"
 import { ActivityService } from "./service"
 import { ActivityRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
 import {
   StreamRepository,
@@ -1045,5 +1046,85 @@ describe("ActivityService mention extraction", () => {
       userIds: [TARGET_USER_ID],
       activityType: ActivityTypes.MENTION,
     })
+  })
+})
+
+describe("ActivityService activity:read emission", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  function setupEmit() {
+    const clients: unknown[] = []
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => {
+      const client = { tag: "tx-client" }
+      clients.push(client)
+      return fn(client)
+    })
+    const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new ActivityService({ pool: {} as any })
+    return { service, insertSpy, clients }
+  }
+
+  it("emits activity:read with the flipped id and empty streamIds on a per-row read", async () => {
+    const { service, insertSpy, clients } = setupEmit()
+    const markSpy = spyOn(ActivityRepository, "markAsRead").mockResolvedValue({
+      activityId: "act_1",
+      streamId: STREAM_ID,
+    })
+
+    await service.markAsRead("act_1", USER_ID, WORKSPACE_ID)
+
+    expect(markSpy).toHaveBeenCalledWith(clients[0], WORKSPACE_ID, USER_ID, "act_1")
+    expect(insertSpy).toHaveBeenCalledWith(clients[0], "activity:read", {
+      workspaceId: WORKSPACE_ID,
+      targetUserId: USER_ID,
+      activityIds: ["act_1"],
+      streamIds: [],
+    })
+  })
+
+  it("emits nothing when a per-row read flips no row", async () => {
+    const { service, insertSpy } = setupEmit()
+    spyOn(ActivityRepository, "markAsRead").mockResolvedValue(null)
+
+    await service.markAsRead("act_gone", USER_ID, WORKSPACE_ID)
+
+    expect(insertSpy).not.toHaveBeenCalled()
+  })
+
+  it("emits deduplicated non-null streamIds on a stream-scope read", async () => {
+    const { service, insertSpy, clients } = setupEmit()
+    const markSpy = spyOn(ActivityRepository, "markStreamAsRead").mockResolvedValue([
+      { activityId: "act_1", streamId: STREAM_ID },
+      { activityId: "act_2", streamId: STREAM_ID },
+      { activityId: "act_3", streamId: null },
+    ])
+
+    await service.markStreamActivityAsRead(USER_ID, WORKSPACE_ID, STREAM_ID)
+
+    expect(markSpy).toHaveBeenCalledWith(clients[0], WORKSPACE_ID, USER_ID, STREAM_ID)
+    expect(insertSpy).toHaveBeenCalledWith(clients[0], "activity:read", {
+      workspaceId: WORKSPACE_ID,
+      targetUserId: USER_ID,
+      activityIds: ["act_1", "act_2", "act_3"],
+      streamIds: [STREAM_ID],
+    })
+  })
+
+  it("chunks mark-all emission at 500 ids, covering every id exactly once", async () => {
+    const { service, insertSpy } = setupEmit()
+    const cleared = Array.from({ length: 501 }, (_, i) => ({ activityId: `act_${i}`, streamId: STREAM_ID }))
+    spyOn(ActivityRepository, "markAllAsRead").mockResolvedValue(cleared)
+
+    await service.markAllAsRead(USER_ID, WORKSPACE_ID)
+
+    expect(insertSpy).toHaveBeenCalledTimes(2)
+    const first = (insertSpy.mock.calls[0] as unknown[])[2] as { activityIds: string[]; streamIds: string[] }
+    const second = (insertSpy.mock.calls[1] as unknown[])[2] as { activityIds: string[]; streamIds: string[] }
+    expect(first.activityIds).toHaveLength(500)
+    expect(second.activityIds).toEqual(["act_500"])
+    expect(new Set([...first.activityIds, ...second.activityIds]).size).toBe(501)
+    expect(first.streamIds).toEqual([STREAM_ID])
   })
 })

--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -1061,40 +1061,45 @@ describe("ActivityService activity:read emission", () => {
       clients.push(client)
       return fn(client)
     })
-    const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const insertManySpy = spyOn(OutboxRepository, "insertMany").mockResolvedValue([] as any)
     const service = new ActivityService({ pool: {} as any })
-    return { service, insertSpy, clients }
+    return { service, insertManySpy, clients }
   }
 
   it("emits activity:read with the flipped id and empty streamIds on a per-row read", async () => {
-    const { service, insertSpy, clients } = setupEmit()
+    const { service, insertManySpy, clients } = setupEmit()
     const markSpy = spyOn(ActivityRepository, "markAsRead").mockResolvedValue({
       activityId: "act_1",
       streamId: STREAM_ID,
     })
 
-    await service.markAsRead("act_1", USER_ID, WORKSPACE_ID)
+    await service.markAsRead(USER_ID, WORKSPACE_ID, "act_1")
 
     expect(markSpy).toHaveBeenCalledWith(clients[0], WORKSPACE_ID, USER_ID, "act_1")
-    expect(insertSpy).toHaveBeenCalledWith(clients[0], "activity:read", {
-      workspaceId: WORKSPACE_ID,
-      targetUserId: USER_ID,
-      activityIds: ["act_1"],
-      streamIds: [],
-    })
+    expect(insertManySpy).toHaveBeenCalledWith(clients[0], [
+      {
+        eventType: "activity:read",
+        payload: {
+          workspaceId: WORKSPACE_ID,
+          targetUserId: USER_ID,
+          activityIds: ["act_1"],
+          streamIds: [],
+        },
+      },
+    ])
   })
 
   it("emits nothing when a per-row read flips no row", async () => {
-    const { service, insertSpy } = setupEmit()
+    const { service, insertManySpy } = setupEmit()
     spyOn(ActivityRepository, "markAsRead").mockResolvedValue(null)
 
-    await service.markAsRead("act_gone", USER_ID, WORKSPACE_ID)
+    await service.markAsRead(USER_ID, WORKSPACE_ID, "act_gone")
 
-    expect(insertSpy).not.toHaveBeenCalled()
+    expect(insertManySpy).not.toHaveBeenCalled()
   })
 
   it("emits deduplicated non-null streamIds on a stream-scope read", async () => {
-    const { service, insertSpy, clients } = setupEmit()
+    const { service, insertManySpy, clients } = setupEmit()
     const markSpy = spyOn(ActivityRepository, "markStreamAsRead").mockResolvedValue([
       { activityId: "act_1", streamId: STREAM_ID },
       { activityId: "act_2", streamId: STREAM_ID },
@@ -1104,27 +1109,35 @@ describe("ActivityService activity:read emission", () => {
     await service.markStreamActivityAsRead(USER_ID, WORKSPACE_ID, STREAM_ID)
 
     expect(markSpy).toHaveBeenCalledWith(clients[0], WORKSPACE_ID, USER_ID, STREAM_ID)
-    expect(insertSpy).toHaveBeenCalledWith(clients[0], "activity:read", {
-      workspaceId: WORKSPACE_ID,
-      targetUserId: USER_ID,
-      activityIds: ["act_1", "act_2", "act_3"],
-      streamIds: [STREAM_ID],
-    })
+    expect(insertManySpy).toHaveBeenCalledWith(clients[0], [
+      {
+        eventType: "activity:read",
+        payload: {
+          workspaceId: WORKSPACE_ID,
+          targetUserId: USER_ID,
+          activityIds: ["act_1", "act_2", "act_3"],
+          streamIds: [STREAM_ID],
+        },
+      },
+    ])
   })
 
-  it("chunks mark-all emission at 500 ids, covering every id exactly once", async () => {
-    const { service, insertSpy } = setupEmit()
+  it("chunks mark-all emission at 500 ids in one insertMany, covering every id exactly once", async () => {
+    const { service, insertManySpy } = setupEmit()
     const cleared = Array.from({ length: 501 }, (_, i) => ({ activityId: `act_${i}`, streamId: STREAM_ID }))
     spyOn(ActivityRepository, "markAllAsRead").mockResolvedValue(cleared)
 
     await service.markAllAsRead(USER_ID, WORKSPACE_ID)
 
-    expect(insertSpy).toHaveBeenCalledTimes(2)
-    const first = (insertSpy.mock.calls[0] as unknown[])[2] as { activityIds: string[]; streamIds: string[] }
-    const second = (insertSpy.mock.calls[1] as unknown[])[2] as { activityIds: string[]; streamIds: string[] }
-    expect(first.activityIds).toHaveLength(500)
-    expect(second.activityIds).toEqual(["act_500"])
-    expect(new Set([...first.activityIds, ...second.activityIds]).size).toBe(501)
-    expect(first.streamIds).toEqual([STREAM_ID])
+    expect(insertManySpy).toHaveBeenCalledTimes(1)
+    const entries = (insertManySpy.mock.calls[0] as unknown[])[1] as Array<{
+      eventType: string
+      payload: { activityIds: string[]; streamIds: string[] }
+    }>
+    expect(entries).toHaveLength(2)
+    expect(entries[0].payload.activityIds).toHaveLength(500)
+    expect(entries[1].payload.activityIds).toEqual(["act_500"])
+    expect(new Set([...entries[0].payload.activityIds, ...entries[1].payload.activityIds]).size).toBe(501)
+    expect(entries[0].payload.streamIds).toEqual([STREAM_ID])
   })
 })

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -23,7 +23,7 @@ import {
   type JSONContent,
 } from "@threa/types"
 import { withClient, withTransaction } from "../../db"
-import { OutboxRepository } from "../../lib/outbox"
+import { OutboxRepository, type ActivityReadOutboxPayload } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 
 /** activity:read batches at most this many ids per event (mark-all is unbounded). */
@@ -624,7 +624,7 @@ export class ActivityService {
     return ActivityRepository.countUnreadForStream(this.pool, userId, workspaceId, streamId)
   }
 
-  async markAsRead(activityId: string, userId: string, workspaceId: string): Promise<void> {
+  async markAsRead(userId: string, workspaceId: string, activityId: string): Promise<void> {
     await withTransaction(this.pool, async (client) => {
       const cleared = await ActivityRepository.markAsRead(client, workspaceId, userId, activityId)
       if (!cleared) return
@@ -645,7 +645,7 @@ export class ActivityService {
 
   async markAllAsRead(userId: string, workspaceId: string): Promise<void> {
     await withTransaction(this.pool, async (client) => {
-      const cleared = await ActivityRepository.markAllAsRead(client, userId, workspaceId)
+      const cleared = await ActivityRepository.markAllAsRead(client, workspaceId, userId)
       if (cleared.length === 0) return
       logger.debug({ userId, workspaceId, count: cleared.length }, "Marked all activity as read")
       await this.emitActivityRead(client, workspaceId, userId, cleared, true)
@@ -667,18 +667,26 @@ export class ActivityService {
     cleared: ClearedActivity[],
     includeStreamIds: boolean
   ): Promise<void> {
+    // One insertMany for every chunk: a single statement instead of a round
+    // trip per chunk, shortening the transaction that holds the read's row
+    // locks (matters for an unbounded mark-all).
+    const entries: Array<{ eventType: "activity:read"; payload: ActivityReadOutboxPayload }> = []
     for (let i = 0; i < cleared.length; i += ACTIVITY_READ_EVENT_CHUNK) {
       const chunk = cleared.slice(i, i + ACTIVITY_READ_EVENT_CHUNK)
       const streamIds = includeStreamIds
         ? [...new Set(chunk.flatMap((row) => (row.streamId ? [row.streamId] : [])))]
         : []
-      await OutboxRepository.insert(client, "activity:read", {
-        workspaceId,
-        targetUserId: userId,
-        activityIds: chunk.map((row) => row.activityId),
-        streamIds,
+      entries.push({
+        eventType: "activity:read",
+        payload: {
+          workspaceId,
+          targetUserId: userId,
+          activityIds: chunk.map((row) => row.activityId),
+          streamIds,
+        },
       })
     }
+    await OutboxRepository.insertMany(client, entries)
   }
 }
 

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -1,5 +1,5 @@
 import type { Pool, PoolClient } from "pg"
-import { ActivityRepository, type Activity } from "./repository"
+import { ActivityRepository, type Activity, type ClearedActivity } from "./repository"
 import { UserRepository } from "../workspaces"
 import {
   StreamRepository,
@@ -22,8 +22,12 @@ import {
   MENTION_BROADCAST_CHANNEL,
   type JSONContent,
 } from "@threa/types"
-import { withClient } from "../../db"
+import { withClient, withTransaction } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
+
+/** activity:read batches at most this many ids per event (mark-all is unbounded). */
+const ACTIVITY_READ_EVENT_CHUNK = 500
 
 interface ActivityServiceDeps {
   pool: Pool
@@ -620,21 +624,60 @@ export class ActivityService {
     return ActivityRepository.countUnreadForStream(this.pool, userId, workspaceId, streamId)
   }
 
-  async markAsRead(activityId: string, userId: string): Promise<void> {
-    await ActivityRepository.markAsRead(this.pool, activityId, userId)
+  async markAsRead(activityId: string, userId: string, workspaceId: string): Promise<void> {
+    await withTransaction(this.pool, async (client) => {
+      const cleared = await ActivityRepository.markAsRead(client, workspaceId, userId, activityId)
+      if (!cleared) return
+      // Per-row read: streamIds stays empty — dismissing a stream-wide push
+      // banner here could hide sibling unread rows it still represents.
+      await this.emitActivityRead(client, workspaceId, userId, [cleared], false)
+    })
   }
 
-  async markStreamActivityAsRead(userId: string, streamId: string): Promise<void> {
-    const count = await ActivityRepository.markStreamAsRead(this.pool, userId, streamId)
-    if (count > 0) {
-      logger.debug({ userId, streamId, count }, "Marked stream activity as read")
-    }
+  async markStreamActivityAsRead(userId: string, workspaceId: string, streamId: string): Promise<void> {
+    await withTransaction(this.pool, async (client) => {
+      const cleared = await ActivityRepository.markStreamAsRead(client, workspaceId, userId, streamId)
+      if (cleared.length === 0) return
+      logger.debug({ userId, streamId, count: cleared.length }, "Marked stream activity as read")
+      await this.emitActivityRead(client, workspaceId, userId, cleared, true)
+    })
   }
 
   async markAllAsRead(userId: string, workspaceId: string): Promise<void> {
-    const count = await ActivityRepository.markAllAsRead(this.pool, userId, workspaceId)
-    if (count > 0) {
-      logger.debug({ userId, workspaceId, count }, "Marked all activity as read")
+    await withTransaction(this.pool, async (client) => {
+      const cleared = await ActivityRepository.markAllAsRead(client, userId, workspaceId)
+      if (cleared.length === 0) return
+      logger.debug({ userId, workspaceId, count: cleared.length }, "Marked all activity as read")
+      await this.emitActivityRead(client, workspaceId, userId, cleared, true)
+    })
+  }
+
+  /**
+   * Emit activity:read for the flipped rows, chunked so a mark-all (unbounded
+   * server state) can't produce an oversized socket/sync-log payload. Same
+   * transaction as the UPDATE (INV-4/7): the event exists iff the rows flipped.
+   * `includeStreamIds` populates the distinct non-null streams (stream/all
+   * scope — drives push-banner dismissal on other devices); per-row reads pass
+   * false so their banners stay.
+   */
+  private async emitActivityRead(
+    client: PoolClient,
+    workspaceId: string,
+    userId: string,
+    cleared: ClearedActivity[],
+    includeStreamIds: boolean
+  ): Promise<void> {
+    for (let i = 0; i < cleared.length; i += ACTIVITY_READ_EVENT_CHUNK) {
+      const chunk = cleared.slice(i, i + ACTIVITY_READ_EVENT_CHUNK)
+      const streamIds = includeStreamIds
+        ? [...new Set(chunk.flatMap((row) => (row.streamId ? [row.streamId] : [])))]
+        : []
+      await OutboxRepository.insert(client, "activity:read", {
+        workspaceId,
+        targetUserId: userId,
+        activityIds: chunk.map((row) => row.activityId),
+        streamIds,
+      })
     }
   }
 }

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -493,7 +493,7 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     // access from the root (INV-62) gets an activity-only read, not a 404.
     expect(captured.status).not.toBe(404)
     expect(captured.body).toEqual({ membership: null })
-    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "stream_thread")
+    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "ws_1", "stream_thread")
   })
 
   it("returns the membership for a member read and still clears activity", async () => {
@@ -517,6 +517,6 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
 
     expect(captured.status).toBe(200)
     expect(captured.body).toEqual({ membership })
-    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "stream_thread")
+    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "ws_1", "stream_thread")
   })
 })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -915,7 +915,7 @@ export function createStreamHandlers({
       // clear on membership left those rows stuck until clicked one by one in
       // the Activity feed. A null membership is a successful activity-only read
       // (no watermark to advance), not a 404; access was validated above.
-      await activityService?.markStreamActivityAsRead(userId, streamId)
+      await activityService?.markStreamActivityAsRead(userId, workspaceId, streamId)
 
       res.json({ membership: membership ?? null })
     },

--- a/apps/backend/src/lib/outbox/broadcast-handler.test.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.test.ts
@@ -119,6 +119,27 @@ describe("BroadcastHandler", () => {
     })
   })
 
+  it("should emit activity:read to the target user's room", async () => {
+    const event = makeEvent(1n, "activity:read", {
+      workspaceId: "ws_1",
+      targetUserId: "usr_alice",
+      activityIds: ["act_1"],
+      streamIds: ["stream_1"],
+    })
+
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
+
+    const { handler, emitChains } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(emitChains).toContainEqual({
+      room: "ws:ws_1:user:usr_alice",
+      eventType: "activity:read",
+      payload: event.payload,
+    })
+  })
+
   it("should emit command event to stream room", async () => {
     const event = makeEvent(1n, "command:dispatched", {
       workspaceId: "ws_1",

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -376,3 +376,17 @@ describe("resolveDeliveryGroups — stream archive lifecycle", () => {
     expect(groups).toEqual([streamGroup("stream_root")])
   })
 })
+
+describe("resolveDeliveryGroups — activity:read", () => {
+  it("routes to the target user's room only, like activity:created", () => {
+    const groups = resolveDeliveryGroups(
+      event("activity:read", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_alice",
+        activityIds: ["act_1"],
+        streamIds: ["stream_1"],
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_alice")])
+  })
+})

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -64,6 +64,7 @@ export {
   type BudgetAlertOutboxPayload,
   type InvitationAcceptedOutboxPayload,
   type ActivityCreatedOutboxPayload,
+  type ActivityReadOutboxPayload,
   type SavedUpsertedOutboxPayload,
   type SavedDeletedOutboxPayload,
   type SavedReminderFiredOutboxPayload,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -92,6 +92,7 @@ export type OutboxEventType =
   | "invitation:accepted"
   | "invitation:revoked"
   | "activity:created"
+  | "activity:read"
   | "saved:upserted"
   | "saved:deleted"
   | "saved_reminder:fired"
@@ -785,6 +786,20 @@ export interface ActivityCreatedOutboxPayload extends WorkspaceScopedPayload {
   }
 }
 
+/**
+ * A batch of the target user's activity rows flipped to read (per-row click,
+ * stream open, or mark-all). A delta of the flipped ids — drops are idempotent
+ * and commute on the client, so replays/duplicates converge. `streamIds` is the
+ * distinct non-null streams of those rows: populated for stream/all-scope
+ * clears (drives push-banner dismissal), empty for per-row reads, which must
+ * not dismiss a grouped banner that may still represent sibling unread rows.
+ */
+export interface ActivityReadOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  activityIds: string[]
+  streamIds: string[]
+}
+
 export interface SavedUpsertedOutboxPayload extends WorkspaceScopedPayload {
   targetUserId: string
   saved: SavedMessageView
@@ -1166,6 +1181,7 @@ export interface OutboxEventPayloadMap {
   "invitation:accepted": InvitationAcceptedOutboxPayload
   "invitation:revoked": InvitationRevokedOutboxPayload
   "activity:created": ActivityCreatedOutboxPayload
+  "activity:read": ActivityReadOutboxPayload
   "saved:upserted": SavedUpsertedOutboxPayload
   "saved:deleted": SavedDeletedOutboxPayload
   "saved_reminder:fired": SavedReminderFiredOutboxPayload
@@ -1312,6 +1328,7 @@ export function isAuthorScopedEvent(event: OutboxEvent): event is OutboxEvent<Au
 /** Events that are scoped to a specific target user (delivered to that user's sockets) */
 export type UserScopedEventType =
   | "activity:created"
+  | "activity:read"
   | "saved:upserted"
   | "saved:deleted"
   | "saved_reminder:fired"
@@ -1330,6 +1347,7 @@ export type UserScopedEventType =
 
 const USER_SCOPED_EVENTS: UserScopedEventType[] = [
   "activity:created",
+  "activity:read",
   "saved:upserted",
   "saved:deleted",
   "saved_reminder:fired",

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -9,6 +9,7 @@ import {
   applyMovedSourceOrdinal,
   deriveActivityCounts,
   upsertActivity,
+  dropActivitiesById,
   dropActivitiesForStream,
   dropMessageActivities,
   dropReactionActivity,
@@ -284,6 +285,24 @@ describe("dropActivitiesForStream", () => {
   it("is a no-op (same reference) when the stream has no rows", () => {
     const state = makeState({ unreadActivities: [act("a1", "s2")] })
     expect(dropActivitiesForStream(state, "s1")).toBe(state)
+  })
+})
+
+describe("dropActivitiesById", () => {
+  it("drops only the listed ids across streams and re-derives counts", () => {
+    const state = makeState({
+      unreadActivities: [act("a1", "s1"), act("a2", "s1"), act("a3", "s2"), act("a4", null)],
+    })
+    const next = dropActivitiesById(state, ["a1", "a3", "a_unknown"])
+    expect(next.unreadActivities.map((a) => a.id)).toEqual(["a2", "a4"])
+    expect(next.activityCounts).toEqual({ s1: 1 })
+    expect(next.unreadActivityCount).toBe(2)
+  })
+
+  it("is idempotent — dropping already-absent ids is a same-reference no-op", () => {
+    const state = makeState({ unreadActivities: [act("a2", "s1")] })
+    expect(dropActivitiesById(state, ["a1"])).toBe(state)
+    expect(dropActivitiesById(state, [])).toBe(state)
   })
 })
 

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -116,6 +116,21 @@ export function dropActivitiesForStream(state: UnreadCounterState, streamId: str
   )
 }
 
+/**
+ * Drop held rows by id — applied on `activity:read` (a read performed on
+ * another device/session). Idempotent with this device's own optimistic
+ * mutations: dropping ids already absent is a same-reference no-op.
+ */
+export function dropActivitiesById(state: UnreadCounterState, activityIds: readonly string[]): UnreadCounterState {
+  if (activityIds.length === 0) return state
+  const ids = new Set(activityIds)
+  if (!state.unreadActivities.some((a) => ids.has(a.id))) return state
+  return withActivities(
+    state,
+    state.unreadActivities.filter((a) => !ids.has(a.id))
+  )
+}
+
 /** Drop the held reaction row matching a `reaction:removed` (message + actor + emoji). */
 export function dropReactionActivity(
   state: UnreadCounterState,

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2307,7 +2307,7 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     emit("activity:read", {
       workspaceId: "ws_1",
       targetUserId: "member_1",
-      activityIds: ["act_late"],
+      activityIds: ["act_read_elsewhere"],
       streamIds: ["stream_1"],
     })
     emit("activity:created", {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2257,6 +2257,82 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
 
     cleanup()
   })
+
+  it("activity:read drops held rows by id, re-derives counts, and is idempotent on replay", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    // A read performed on another device drops exactly the listed ids;
+    // unknown ids (already dropped, or outside the capped held set) no-op.
+    emit("activity:read", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activityIds: ["act_s1", "act_unknown"],
+      streamIds: ["stream_1"],
+    })
+
+    let bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadActivities?.map((a) => a.id)).toEqual(["act_s2"])
+    expect(bootstrap?.activityCounts).toEqual({ stream_2: 1 })
+    expect(bootstrap?.mentionCounts).toEqual({})
+    expect(bootstrap?.unreadActivityCount).toBe(1)
+
+    // Duplicate/replayed event is a no-op.
+    emit("activity:read", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activityIds: ["act_s1"],
+      streamIds: ["stream_1"],
+    })
+    bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadActivityCount).toBe(1)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadActivities?.map((a) => a.id)).toEqual(["act_s2"])
+      expect(state?.unreadActivityCount).toBe(1)
+    })
+
+    cleanup()
+  })
+
+  it("catch-up ordering: a creation replayed after a read settles held (snapshot semantics)", async () => {
+    // A row created after the read (its id absent from the delta) stays unread:
+    // replay applies the read first (unknown-id no-op), then the creation.
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    emit("activity:read", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activityIds: ["act_late"],
+      streamIds: ["stream_1"],
+    })
+    emit("activity:created", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activity: {
+        id: "act_late",
+        activityType: "message",
+        streamId: "stream_1",
+        messageId: "msg_late",
+        actorId: "member_2",
+        actorType: "user",
+        context: {},
+        createdAt: new Date().toISOString(),
+        isSelf: false,
+        emoji: null,
+      },
+    })
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadActivities?.map((a) => a.id)).toContain("act_late")
+    expect(bootstrap?.unreadActivityCount).toBe(3)
+
+    cleanup()
+  })
 })
 
 describe("latest ordinal seeding and reconnect merge (sync phase 2c)", () => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -32,6 +32,7 @@ import type {
   AgentActivityStartedPayload,
   AgentActivityEndedPayload,
   ActivityCreatedPayload,
+  ActivityReadPayload,
   SavedUpsertedPayload,
   SavedDeletedPayload,
   SavedReminderFiredPayload,
@@ -81,6 +82,7 @@ import {
   applyStreamReadSet,
   applyStreamsReadAllOrdinals,
   bootstrapActivityCacheFields,
+  dropActivitiesById,
   mergeBootstrapUnreadFields,
   pruneCounterTouches,
   upsertActivity,
@@ -1667,6 +1669,25 @@ export function registerWorkspaceSocketHandlers(
     invalidateActivityFeed(true)
   }
 
+  // Cross-device activity-read propagation: rows flipped to read in another
+  // session (per-row click, stream open, mark-all). Drop by id — idempotent
+  // with this device's own optimistic mutations — and always invalidate the
+  // feed: a mounted feed page can show rows the 200-cap held set doesn't.
+  // Push banners dismiss per distinct stream only when the server populated
+  // streamIds (stream/all scope); per-row reads carry none so a grouped
+  // banner representing sibling unread rows stays.
+  const handleActivityRead = (payload: ActivityReadPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+    if (payload.activityIds.length === 0) return
+
+    commitCounter((state) => dropActivitiesById(state, payload.activityIds))
+    invalidateActivityFeed(true)
+
+    for (const streamId of new Set(payload.streamIds)) {
+      navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })
+    }
+  }
+
   // GAM memo extraction: surface new memos in the memory explorer without a
   // manual refresh. memo:created is workspace-group routed (sync log + emit),
   // so registering here puts memos on the sync catch-up path like every
@@ -2120,6 +2141,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("bot:updated", handleBotUpdated)
   socket.on("agent_config:updated", handleAgentConfigUpdated)
   socket.on("activity:created", handleActivityCreated)
+  socket.on("activity:read", handleActivityRead)
   socket.on("memo:created", handleMemoCreated)
   socket.on("invitation:sent", handleInvitationChanged)
   socket.on("invitation:accepted", handleInvitationChanged)
@@ -2189,6 +2211,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("bot:updated", handleBotUpdated)
     socket.off("agent_config:updated", handleAgentConfigUpdated)
     socket.off("activity:created", handleActivityCreated)
+    socket.off("activity:read", handleActivityRead)
     socket.off("memo:created", handleMemoCreated)
     socket.off("invitation:sent", handleInvitationChanged)
     socket.off("invitation:accepted", handleInvitationChanged)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1862,12 +1862,31 @@ export interface ActivityCreatedPayload {
   }
 }
 
+/** Socket event payload for activity:read */
+export interface ActivityReadPayload {
+  workspaceId: string
+  targetUserId: string
+  /**
+   * Delta: ids of the rows that flipped to read. Drops are idempotent and
+   * commute, so replays/duplicates converge.
+   */
+  activityIds: string[]
+  /**
+   * Distinct non-null streams of the flipped rows. Populated for stream/all
+   * clears (drives push-banner dismissal on other devices); empty for per-row
+   * reads, which must not dismiss a grouped banner that may still represent
+   * sibling unread rows.
+   */
+  streamIds: string[]
+}
+
 export interface MarkAsReadInput {
   lastEventId: string
 }
 
 export interface MarkAsReadResponse {
-  membership: StreamMember
+  /** Null when the viewer has access but no membership row (INV-62: non-member thread leg, unjoined public channel) — an activity-only read. */
+  membership: StreamMember | null
 }
 
 export interface MarkAllAsReadResponse {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -566,6 +566,7 @@ export type {
   // Activity
   Activity,
   ActivityCreatedPayload,
+  ActivityReadPayload,
   // Saved messages
   SavedMessageView,
   SavedMessageSnapshot,


### PR DESCRIPTION
## Problem

Activity reads never propagated cross-device. All three read paths — per-row `markAsRead`, per-stream `markStreamAsRead`, `markAllAsRead` (`activity/service.ts`) — were bare UPDATEs with no outbox event. A read on the phone updated that device optimistically; the laptop kept its held rows, badge, and push banner until a bootstrap refetch, an unrelated `activity:created` invalidation, or the Activity-page unread-tab reconcile (A4 backstop). In a quiet workspace: stale until refresh. The non-member thread reads enabled by the layer below (#1527) joined the same broken semantics — `markStreamActivityAsRead` cleared the acting device only.

## Solution

One user-scoped `activity:read` event, modeled on how `stream:read` propagates stream reads — the client clear is event-driven.

- **Wire:** `{ workspaceId, targetUserId, activityIds: string[], streamIds: string[] }` — a delta of the rows whose `read_at` flipped (drops are idempotent and commute; an absolute remaining-set would be unbounded). Rides `activity:created`'s exact user-scoped routing (`delivery-groups` → `user:<targetUserId>`, sync log, catch-up) — zero new machinery.
- **Server:** the three repo UPDATEs now `WHERE … AND read_at IS NULL RETURNING id, stream_id` — the RETURNING set is exactly what flipped, so no-op/concurrent-duplicate reads emit nothing; per-row and per-stream also gain the `workspace_id` filter they were missing (INV-8). Each service path wraps UPDATE + outbox insert in one `withTransaction` (INV-4/7), chunked at 500 ids (server unread rows are uncapped).
- **Banner scope (owner ruling):** `streamIds` populated only for stream/all clears — SW dismissal is stream-wide, so a per-row read must not hide a grouped banner that still represents sibling unread rows. Per-row emits `streamIds: []`.
- **Ordering barrier:** activity rows commit in the messaging transaction, but `activity:created` publishes later in a worker transaction — a bootstrap-visible row could be read (and its `activity:read` logged) before its creation event existed, so replay would drop an unknown id and then resurrect the row. `publishActivityCreated` now re-reads candidates `read_at IS NULL FOR SHARE` and publishes non-self rows only while still unread: read-first → the stale creation is suppressed; publish-first → the read UPDATE blocks on the lock until the creation commits. Self rows (born read, never in a read delta) publish unconditionally.
- **Client:** `dropActivitiesById` pure helper (same-reference no-op when nothing matches); `handleActivityRead` — `commitCounter` drop (cache + IDB, catch-up batched), feed invalidation always (a mounted feed page can show rows outside the 200-cap held set), SW dismissal per distinct payload `streamId`. Optimistic mutations unchanged; echoes are no-ops. `stream:read`'s D2 activity-drop and this are both filters — commute.
- Out of scope: the non-member watermark/read frontier (agreed follow-up); Sol's late-insert race from #1527 (row inserted after the clear isn't in the delta — correctly stays unread; the principled fix is the watermark work); the 200-row bootstrap held-set cap.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/outbox/repository.ts` | `activity:read` in the user-scoped registry (union + array + payload map) + `ActivityReadOutboxPayload` |
| `apps/backend/src/features/activity/repository.ts` | mark-read methods `RETURNING` flipped rows + workspace scoping; new `findStillUnreadIds` (FOR SHARE barrier query) |
| `apps/backend/src/features/activity/service.ts` | read paths emit `activity:read` in-tx, chunked 500; signatures gain `workspaceId` |
| `apps/backend/src/features/activity/handlers.ts` | per-row handler passes `workspaceId` |
| `apps/backend/src/features/activity/outbox-handler.ts` | `publishActivityCreated` ordering barrier |
| `apps/backend/src/features/streams/handlers.ts` | `markStreamActivityAsRead` call updated (from #1527) |
| `packages/types/src/api.ts`, `index.ts` | `ActivityReadPayload`; `MarkAsReadResponse.membership` nullable (contract honesty for #1527) |
| `apps/frontend/src/sync/unread-counters.ts` | `dropActivitiesById` |
| `apps/frontend/src/sync/workspace-sync.ts` | `handleActivityRead` + registration |
| 7 test files | service emit/chunking/no-op, barrier (skip read-before-publish, self rows still publish), delivery group, broadcast routing, pure-state drop, handler + catch-up ordering, #1527 handler arg update |

## Test plan

- [x] `bun test` activity service + outbox-handler — 44 pass (barrier + emit cases new)
- [x] `bun test` delivery-groups + broadcast-handler — 68 pass (routing cases new)
- [x] `bun test` streams handlers — 22 pass (#1527 assertions updated)
- [x] `vitest` unread-counters + workspace-sync + sync-engine + use-unread-counts — 205 pass (drop helper, handler, catch-up created→read ordering new)
- [x] `bun run typecheck` — 0 errors; eslint clean; pre-commit lint+typecheck+api-docs pass
- [x] Sol (high) adversarial verification of the diff — no findings ≥80; barrier lock semantics, emit races, client convergence traced and hold
- [ ] integration suites (unread-counts / sparse-read-overlay / phantom-unread) — not run: test-DB port occupied by another worktree; this diff doesn't touch those flows (membership watermarks, sparse overlay)
- [ ] manual multi-device E2E on staging — not run

<details>
<summary>📋 Full implementation plan</summary>

Ratified in conversation, scoped by Sol (high):

1. One user-scoped `activity:read` event; delta of flipped ids; chunked 500; emitted in-tx with the read UPDATE.
2. `streamIds` only for stream/all scope (owner ruling) — per-row reads never touch banners.
3. Ordering barrier in `publishActivityCreated` (FOR SHARE re-read) so the sync log can never order a creation after its read.
4. Client: event-driven clear like `stream:read` — idempotent id-drop, feed invalidation, per-stream push dismissal.
5. Stacked on #1527 via gh-stack; merge in one fell swoop. Deferred: non-member watermark/read frontier; late-insert born-read protection (needs the watermark).

</details>

---

🤖 _PR by pi (Qwen 3.8 Max Preview)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787478822&installation_model_id=20758&pr_number=1530&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1530&signature=6568e480287612617ad838711a98da9ed23774d1237e441e115ec4d778735a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->