### PR TITLE
feat: add standalone stream read-state storage

### DIFF
--- a/apps/backend/src/db/migrations/20260724170957_add_stream_read_state.sql
+++ b/apps/backend/src/db/migrations/20260724170957_add_stream_read_state.sql
@@ -1,0 +1,26 @@
+-- Per-user read watermark re-homed off stream_members into its own table
+-- (membership ≠ access ≠ read state). Keyed by user, not member: a row is
+-- user-private truth that survives membership loss. No FKs (INV-1).
+CREATE TABLE IF NOT EXISTS stream_read_state (
+    workspace_id       TEXT NOT NULL,        -- INV-8 ownership boundary
+    stream_id          TEXT NOT NULL,
+    user_id            TEXT NOT NULL,        -- NOT member_id: not a membership surface
+    last_read_event_id TEXT,                 -- NULL = position before first message
+    last_read_at       TIMESTAMPTZ,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (stream_id, user_id)
+);
+
+-- Bootstrap list: every read position for one user in one workspace.
+CREATE INDEX IF NOT EXISTS idx_stream_read_state_workspace_user
+    ON stream_read_state (workspace_id, user_id);
+
+-- Atomic backfill of all existing watermarks. stream_members carries no
+-- workspace_id, so join streams to derive it; member_id IS the user identity.
+-- Only non-NULL watermarks seed a row (absence = never read, same as today).
+INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+SELECT s.workspace_id, sm.stream_id, sm.member_id, sm.last_read_event_id, sm.last_read_at, NOW()
+FROM stream_members sm
+JOIN streams s ON s.id = sm.stream_id
+WHERE sm.last_read_event_id IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -15,6 +15,7 @@ import {
   StreamMemberRepository,
   StreamRepository,
   SparseReadRepository,
+  ReadStateRepository,
   type StreamEvent,
 } from "../streams"
 import { AttachmentRepository, AttachmentReferenceRepository, AttachmentUploadRepository } from "../attachments"
@@ -1036,6 +1037,92 @@ describe("EventService.createMessage metadata propagation", () => {
   })
 })
 
+describe("EventService.createMessage born-read read-state shadow", () => {
+  const baseParams = {
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    authorId: "usr_1",
+    authorType: "user" as const,
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "hello",
+  }
+
+  beforeEach(() => {
+    spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
+      callback({})) as any)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", type: "scratchpad" } as any)
+    spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
+    spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
+    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
+    spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: "evt_1",
+      streamId: params.streamId,
+      sequence: 1n,
+      eventType: params.eventType,
+      payload: params.payload,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: params.id,
+      streamId: params.streamId,
+      sequence: params.sequence,
+      authorId: params.authorId,
+      authorType: params.authorType,
+      contentJson: params.contentJson,
+      contentMarkdown: params.contentMarkdown,
+      replyCount: 0,
+      clientMessageId: params.clientMessageId ?? null,
+      sentVia: params.sentVia ?? null,
+      reactions: {},
+      metadata: params.metadata ?? {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "findById").mockResolvedValue(null)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+    spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
+    spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
+    spyOn(SharedMessageRepository, "insert").mockResolvedValue({} as any)
+    spyOn(ReadStateRepository, "advance").mockResolvedValue(undefined as any)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("advances the author's read state on the same tx client when the membership write lands", async () => {
+    spyOn(StreamMemberRepository, "update").mockResolvedValue({ streamId: "stream_1", memberId: "usr_1" } as any)
+    const service = new EventService({} as any)
+
+    await service.createMessage(baseParams)
+
+    // The born-read watermark write and its read-state shadow land on the same tx
+    // client with the same (stream, author, event) — advance shadows the update.
+    const updateCall = (StreamMemberRepository.update as any).mock.calls[0]
+    expect(updateCall.slice(0, 3)).toEqual([{}, "stream_1", "usr_1"])
+    expect(ReadStateRepository.advance).toHaveBeenCalledWith(
+      updateCall[0],
+      "stream_1",
+      "usr_1",
+      updateCall[3].lastReadEventId
+    )
+  })
+
+  it("does not write read state for a non-member author (membership update no-ops)", async () => {
+    spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const service = new EventService({} as any)
+
+    await service.createMessage(baseParams)
+
+    expect(StreamMemberRepository.update).toHaveBeenCalled()
+    expect(ReadStateRepository.advance).not.toHaveBeenCalled()
+  })
+})
+
 describe("EventService.createMessage conversation declaration (Mechanism C)", () => {
   const baseParams = {
     workspaceId: "ws_1",
@@ -1658,6 +1745,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
     spyOn(MessageRepository, "moveToStream").mockResolvedValue(undefined as any)
     spyOn(SparseReadRepository, "rehomeReads").mockResolvedValue(undefined as any)
     spyOn(StreamMemberRepository, "repointWatermarksForMovedEvents").mockResolvedValue(undefined as any)
+    spyOn(ReadStateRepository, "repointForMovedEvents").mockResolvedValue(undefined as any)
     spyOn(DraftsRepository, "rescopeByScope").mockResolvedValue([])
     spyOn(MessageRepository, "updateStreamScopedReferences").mockResolvedValue(undefined as any)
     spyOn(StreamRepository, "moveChildThreadsToParent").mockResolvedValue(undefined as any)
@@ -1707,6 +1795,19 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
     const moved = (OutboxRepository.insert as any).mock.calls.find((c: unknown[]) => c[1] === "messages:moved")
     expect(moved?.[2].slots).toEqual({ [sharedMessageSlotKey("msg_source")]: hydratedEntry })
     expect(moved?.[2].sharedMessages).toEqual({ msg_source: hydratedEntry })
+
+    // The read-state repoint shadows the membership repoint on the same tx client
+    // with the identical moved set (same source stream, same event+source-sequence pairs).
+    expect(StreamMemberRepository.repointWatermarksForMovedEvents).toHaveBeenCalledWith(
+      {},
+      "stream_src",
+      expect.any(Array)
+    )
+    expect(ReadStateRepository.repointForMovedEvents).toHaveBeenCalledWith(
+      {},
+      "stream_src",
+      (StreamMemberRepository.repointWatermarksForMovedEvents as any).mock.calls[0][2]
+    )
   })
 
   it("omits both maps and skips hydration for a pointer-free move", async () => {

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -2,7 +2,7 @@ import type { Pool, PoolClient } from "pg"
 import { withTransaction, withClient, sql } from "../../db"
 import { StreamEventRepository, type StreamEvent, type MoveEventIdSequenceUpdate } from "../streams"
 import { StreamRepository } from "../streams"
-import { StreamMemberRepository, SparseReadRepository } from "../streams"
+import { StreamMemberRepository, SparseReadRepository, ReadStateRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
 import {
@@ -759,9 +759,14 @@ export class EventService {
 
     // Advance the author's read position so their own message isn't counted unread.
     if (params.authorType === "user") {
-      await StreamMemberRepository.update(client, params.streamId, params.authorId, {
+      const authorMembership = await StreamMemberRepository.update(client, params.streamId, params.authorId, {
         lastReadEventId: evtId,
       })
+      // Shadow the born-read watermark only when a membership row was actually
+      // written (PR 1 shadows membership; non-member read state lands in PR 3 — same tx).
+      if (authorMembership) {
+        await ReadStateRepository.advance(client, params.streamId, params.authorId, evtId)
+      }
     }
 
     if (params.authorType === "persona") {
@@ -1379,6 +1384,12 @@ export class EventService {
         messageIds: uniqueMessageIds,
       })
       await StreamMemberRepository.repointWatermarksForMovedEvents(
+        client,
+        params.sourceStreamId,
+        movableEvents.map((entry) => ({ eventId: entry.event.id, sequence: entry.event.sequence }))
+      )
+      // Shadow the A3 watermark repoint into stream_read_state (same tx, same moved set).
+      await ReadStateRepository.repointForMovedEvents(
         client,
         params.sourceStreamId,
         movableEvents.map((entry) => ({ eventId: entry.event.id, sequence: entry.event.sequence }))

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -63,6 +63,9 @@ export type {
 export { StreamMemberRepository } from "./member-repository"
 export type { StreamMember, UpdateStreamMemberParams } from "./member-repository"
 
+export { ReadStateRepository } from "./read-state-repository"
+export type { StreamReadState } from "./read-state-repository"
+
 export { StreamStateRepository } from "./state-repository"
 export type { MemoStreamState, StreamReadyToProcess } from "./state-repository"
 

--- a/apps/backend/src/features/streams/read-state-repository.test.ts
+++ b/apps/backend/src/features/streams/read-state-repository.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test, mock } from "bun:test"
+import { ReadStateRepository } from "./read-state-repository"
+import { StreamMemberRepository } from "./member-repository"
+import type { Querier } from "../../db"
+
+function makeDb(rows: Record<string, unknown>[] = []) {
+  const query = mock(() => Promise.resolve({ rows, rowCount: rows.length }))
+  return { db: { query } as unknown as Querier, query }
+}
+
+/** Collapse whitespace so multi-line SQL can be matched with plain substrings. */
+function flat(text: unknown): string {
+  return String(text).replace(/\s+/g, " ").trim()
+}
+
+/** First query's SQL text, whether called as (string, values) or (QueryConfig). */
+function sqlText(call: unknown[]): string {
+  const arg = call[0]
+  return typeof arg === "string" ? arg : (arg as { text: string }).text
+}
+
+function sqlValues(call: unknown[]): unknown[] {
+  const arg = call[0]
+  return typeof arg === "string" ? ((call[1] as unknown[]) ?? []) : (arg as { values: unknown[] }).values
+}
+
+describe("ReadStateRepository.advance", () => {
+  test("is a single monotonic upsert keyed on (stream_id, user_id)", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.advance(db, "stream_1", "usr_1", "evt_9")
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("INSERT INTO stream_read_state")
+    expect(text).toContain("ON CONFLICT (stream_id, user_id) DO UPDATE")
+    // Monotonic rule: new event sequence strictly greater than current watermark
+    // sequence, both resolved via stream_events, NULL watermark counting as 0.
+    expect(text).toContain("> COALESCE")
+    expect(text).toMatch(/new_ev\.id = EXCLUDED\.last_read_event_id/)
+    expect(text).toMatch(/cur_ev\.id = stream_read_state\.last_read_event_id/)
+    expect(text).toContain("FROM stream_events new_ev")
+    expect(text).toContain("FROM stream_events cur_ev")
+    // workspace_id derived from streams on insert (INV-8).
+    expect(text).toContain("SELECT s.workspace_id")
+    expect(text).toContain("FROM streams s")
+  })
+
+  test("binds streamId, userId, eventId in order", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.advance(db, "stream_1", "usr_1", "evt_9")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["stream_1", "usr_1", "evt_9"])
+  })
+})
+
+describe("ReadStateRepository.set", () => {
+  test("is an unconditional upsert with no sequence comparison", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.set(db, "stream_1", "usr_1", "evt_3")
+
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("ON CONFLICT (stream_id, user_id) DO UPDATE")
+    // Regress path: no monotonic guard anywhere in the statement.
+    expect(text).not.toContain("stream_events")
+    expect(text).not.toMatch(/DO UPDATE SET .* WHERE/)
+  })
+
+  test("allows a null eventId (park before the first message)", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.set(db, "stream_1", "usr_1", null)
+    expect(sqlValues(query.mock.calls[0])).toEqual(["stream_1", "usr_1", null])
+  })
+})
+
+describe("ReadStateRepository.batchAdvance", () => {
+  test("no-ops without querying on an empty map", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.batchAdvance(db, "usr_1", new Map())
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  test("unnests stream/event pairs with the same monotonic rule as advance", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.batchAdvance(
+      db,
+      "usr_1",
+      new Map([
+        ["stream_1", "evt_a"],
+        ["stream_2", "evt_b"],
+      ])
+    )
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("unnest($1::text[])")
+    expect(text).toContain("ON CONFLICT (stream_id, user_id) DO UPDATE")
+    expect(text).toContain("> COALESCE")
+    expect(sqlValues(query.mock.calls[0])).toEqual([["stream_1", "stream_2"], ["evt_a", "evt_b"], "usr_1"])
+  })
+})
+
+describe("ReadStateRepository.setForUsers", () => {
+  test("no-ops without querying on an empty user list", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.setForUsers(db, "stream_1", [], "evt_1")
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  test("unconditionally sets one event across many users", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.setForUsers(db, "stream_1", ["usr_a", "usr_b"], "evt_1")
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("unnest($3::text[])")
+    expect(text).toContain("ON CONFLICT (stream_id, user_id) DO UPDATE")
+    expect(text).not.toContain("stream_events")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["stream_1", "evt_1", ["usr_a", "usr_b"]])
+  })
+})
+
+describe("ReadStateRepository.repointForMovedEvents", () => {
+  test("no-ops without querying on an empty move set", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.repointForMovedEvents(db, "stream_src", [])
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  test("mirrors the member-repository repoint shape, re-homed to stream_read_state/user_id", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.repointForMovedEvents(db, "stream_src", [
+      { eventId: "evt_m1", sequence: 20n },
+      { eventId: "evt_m2", sequence: 40n },
+    ])
+
+    const text = flat(sqlText(query.mock.calls[0]))
+    // Same CTE skeleton as StreamMemberRepository.repointWatermarksForMovedEvents:
+    // a moved(event_id, src_seq) unnest, a repoint subquery picking the greatest
+    // surviving prior source sequence, then UPDATE ... FROM repoint.
+    expect(text).toContain("WITH moved AS")
+    expect(text).toContain("unnest($2::text[]) AS event_id")
+    expect(text).toContain("unnest($3::bigint[]) AS src_seq")
+    expect(text).toContain("e.sequence < moved.src_seq")
+    expect(text).toContain("ORDER BY e.sequence DESC LIMIT 1")
+    expect(text).toContain("FROM stream_read_state rs")
+    expect(text).toContain("JOIN moved ON moved.event_id = rs.last_read_event_id")
+    expect(text).toContain("UPDATE stream_read_state rs")
+    expect(text).toContain("rs.user_id = repoint.user_id")
+    // last_read_at deliberately untouched (automated correction, not a read).
+    expect(text).not.toContain("last_read_at")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["stream_src", ["evt_m1", "evt_m2"], ["20", "40"]])
+  })
+
+  test("keeps the member-repository repoint SQL identical in everything but the table/key", async () => {
+    // Guard against drift: the two repoints must stay structurally identical so
+    // the shadow tracks membership exactly. Compare the normalized CTE + repoint
+    // subquery, ignoring the table name and the member_id/user_id key column.
+    const memberDb = makeDb()
+    await StreamMemberRepository.repointWatermarksForMovedEvents(memberDb.db, "stream_src", [
+      { eventId: "evt_m1", sequence: 20n },
+    ])
+    const memberText = flat(sqlText(memberDb.query.mock.calls[0]))
+      .replace(/stream_members/g, "stream_read_state")
+      .replace(/member_id/g, "user_id")
+      .replace(/sm\b/g, "rs")
+      // The read-state repoint additionally bumps updated_at (bookkeeping only).
+      .replace(
+        /SET last_read_event_id = repoint.new_event_id/,
+        "SET last_read_event_id = repoint.new_event_id, updated_at = NOW()"
+      )
+
+    const { db, query } = makeDb()
+    await ReadStateRepository.repointForMovedEvents(db, "stream_src", [{ eventId: "evt_m1", sequence: 20n }])
+    const readStateText = flat(sqlText(query.mock.calls[0]))
+
+    expect(readStateText).toBe(memberText)
+  })
+})
+
+describe("ReadStateRepository readers", () => {
+  test("get maps the row to camelCase and returns null when absent", async () => {
+    const row = {
+      workspace_id: "ws_1",
+      stream_id: "stream_1",
+      user_id: "usr_1",
+      last_read_event_id: "evt_9",
+      last_read_at: new Date("2026-01-01T00:00:00.000Z"),
+      updated_at: new Date("2026-01-02T00:00:00.000Z"),
+    }
+    const withRow = makeDb([row])
+    expect(await ReadStateRepository.get(withRow.db, "stream_1", "usr_1")).toEqual({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      userId: "usr_1",
+      lastReadEventId: "evt_9",
+      lastReadAt: row.last_read_at,
+      updatedAt: row.updated_at,
+    })
+
+    const empty = makeDb([])
+    expect(await ReadStateRepository.get(empty.db, "stream_1", "usr_1")).toBeNull()
+  })
+
+  test("getBatch returns [] without querying for an empty stream list", async () => {
+    const { db, query } = makeDb()
+    expect(await ReadStateRepository.getBatch(db, "usr_1", [])).toEqual([])
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  test("listForUser scopes on workspace_id and user_id (bootstrap index)", async () => {
+    const { db, query } = makeDb([])
+    await ReadStateRepository.listForUser(db, "ws_1", "usr_1")
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("workspace_id = $1")
+    expect(text).toContain("user_id = $2")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["ws_1", "usr_1"])
+  })
+})
+
+describe("ReadStateRepository lifecycle deletes", () => {
+  test("deleteForWorkspace filters on workspace_id", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.deleteForWorkspace(db, "ws_1")
+    expect(flat(sqlText(query.mock.calls[0]))).toContain("DELETE FROM stream_read_state WHERE workspace_id = $1")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["ws_1"])
+  })
+
+  test("deleteForUser filters on workspace_id and user_id (INV-8)", async () => {
+    const { db, query } = makeDb()
+    await ReadStateRepository.deleteForUser(db, "ws_1", "usr_1")
+    const text = flat(sqlText(query.mock.calls[0]))
+    expect(text).toContain("workspace_id = $1")
+    expect(text).toContain("user_id = $2")
+    expect(sqlValues(query.mock.calls[0])).toEqual(["ws_1", "usr_1"])
+  })
+})

--- a/apps/backend/src/features/streams/read-state-repository.ts
+++ b/apps/backend/src/features/streams/read-state-repository.ts
@@ -1,0 +1,235 @@
+import type { Querier } from "../../db"
+import { sql } from "../../db"
+
+interface StreamReadStateRow {
+  workspace_id: string
+  stream_id: string
+  user_id: string
+  last_read_event_id: string | null
+  last_read_at: Date | null
+  updated_at: Date
+}
+
+export interface StreamReadState {
+  workspaceId: string
+  streamId: string
+  userId: string
+  lastReadEventId: string | null
+  lastReadAt: Date | null
+  updatedAt: Date
+}
+
+function mapRowToReadState(row: StreamReadStateRow): StreamReadState {
+  return {
+    workspaceId: row.workspace_id,
+    streamId: row.stream_id,
+    userId: row.user_id,
+    lastReadEventId: row.last_read_event_id,
+    lastReadAt: row.last_read_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+const SELECT_FIELDS = "workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at"
+
+/**
+ * The per-user read watermark, re-homed off `stream_members` (membership ≠
+ * access ≠ read state). Keyed by (stream, user); a row exists only after the
+ * user's first read-state write for that stream — absence means "never read",
+ * the same semantics as a NULL `stream_members.last_read_event_id` today.
+ *
+ * Writes are upserts and always safe (INV-20): unlike `stream_members`, reading
+ * never touches a membership surface, so upserting here can't manufacture a
+ * member. `workspace_id` is derived from `streams` on insert (INV-8) — the
+ * callers write inside the same transaction as the membership write they shadow.
+ */
+export const ReadStateRepository = {
+  /**
+   * Monotonic advance: insert when no row exists; on conflict, move the
+   * watermark only when the new event's sequence is strictly greater than the
+   * current watermark's sequence (both resolved via `stream_events`). A NULL or
+   * unresolvable current watermark counts as sequence 0 (before the first
+   * message), so any real event advances past it. Single statement — race-safe
+   * under concurrent readers (INV-20).
+   */
+  async advance(db: Querier, streamId: string, userId: string, eventId: string): Promise<void> {
+    await db.query(
+      `
+      INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+      SELECT s.workspace_id, $1, $2, $3, NOW(), NOW()
+      FROM streams s
+      WHERE s.id = $1
+      ON CONFLICT (stream_id, user_id) DO UPDATE
+      SET last_read_event_id = EXCLUDED.last_read_event_id,
+          last_read_at = EXCLUDED.last_read_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE COALESCE(
+          (SELECT new_ev.sequence FROM stream_events new_ev WHERE new_ev.id = EXCLUDED.last_read_event_id),
+          0
+        ) > COALESCE(
+          (SELECT cur_ev.sequence FROM stream_events cur_ev WHERE cur_ev.id = stream_read_state.last_read_event_id),
+          0
+        )
+      `,
+      [streamId, userId, eventId]
+    )
+  },
+
+  /**
+   * Unconditional set (the regress path — mark-unread). `eventId` may be null to
+   * park the watermark before the first message. No sequence comparison: this
+   * deliberately moves the pointer backward.
+   */
+  async set(db: Querier, streamId: string, userId: string, eventId: string | null): Promise<void> {
+    await db.query(
+      `
+      INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+      SELECT s.workspace_id, $1, $2, $3, NOW(), NOW()
+      FROM streams s
+      WHERE s.id = $1
+      ON CONFLICT (stream_id, user_id) DO UPDATE
+      SET last_read_event_id = EXCLUDED.last_read_event_id,
+          last_read_at = EXCLUDED.last_read_at,
+          updated_at = EXCLUDED.updated_at
+      `,
+      [streamId, userId, eventId]
+    )
+  },
+
+  /**
+   * Batch monotonic advance for one user across many streams (mark-all). Same
+   * per-row sequence rule as {@link advance}; streams whose new event doesn't
+   * out-sequence the current watermark are left untouched.
+   */
+  async batchAdvance(db: Querier, userId: string, updates: Map<string, string>): Promise<void> {
+    if (updates.size === 0) return
+
+    const streamIds = Array.from(updates.keys())
+    const eventIds = Array.from(updates.values())
+
+    await db.query(
+      `
+      INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+      SELECT s.workspace_id, u.stream_id, $3, u.event_id, NOW(), NOW()
+      FROM (SELECT unnest($1::text[]) AS stream_id, unnest($2::text[]) AS event_id) u
+      JOIN streams s ON s.id = u.stream_id
+      ON CONFLICT (stream_id, user_id) DO UPDATE
+      SET last_read_event_id = EXCLUDED.last_read_event_id,
+          last_read_at = EXCLUDED.last_read_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE COALESCE(
+          (SELECT new_ev.sequence FROM stream_events new_ev WHERE new_ev.id = EXCLUDED.last_read_event_id),
+          0
+        ) > COALESCE(
+          (SELECT cur_ev.sequence FROM stream_events cur_ev WHERE cur_ev.id = stream_read_state.last_read_event_id),
+          0
+        )
+      `,
+      [streamIds, eventIds, userId]
+    )
+  },
+
+  /** Batch unconditional set for many users on one stream (channel-creation born-read). */
+  async setForUsers(db: Querier, streamId: string, userIds: string[], eventId: string): Promise<void> {
+    if (userIds.length === 0) return
+
+    await db.query(
+      `
+      INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+      SELECT s.workspace_id, $1, u.user_id, $2, NOW(), NOW()
+      FROM streams s, unnest($3::text[]) AS u(user_id)
+      WHERE s.id = $1
+      ON CONFLICT (stream_id, user_id) DO UPDATE
+      SET last_read_event_id = EXCLUDED.last_read_event_id,
+          last_read_at = EXCLUDED.last_read_at,
+          updated_at = EXCLUDED.updated_at
+      `,
+      [streamId, eventId, userIds]
+    )
+  },
+
+  /**
+   * A3 fix mirror (sparse-read design): after a move relocates events out of a
+   * source stream, any read-state row whose `last_read_event_id` is one of those
+   * moved events now counts unread against a foreign thread-space sequence.
+   * Repoint each to the nearest surviving prior event in the source stream
+   * (greatest sequence strictly below the moved event's original source
+   * sequence), or null when nothing prior survives. Set-based (INV-56); MUST run
+   * AFTER the move so the moved rows are already gone from the source and can't
+   * be chosen as their own predecessor. `last_read_at` is deliberately left
+   * untouched: this is an automated correction, not a read, and the timestamp
+   * feeds the conversation card's time fallback — bumping it would falsely mark
+   * every older sequenceless/non-member-thread row as read.
+   */
+  async repointForMovedEvents(
+    db: Querier,
+    sourceStreamId: string,
+    movedEvents: Array<{ eventId: string; sequence: bigint }>
+  ): Promise<void> {
+    if (movedEvents.length === 0) return
+    const eventIds = movedEvents.map((e) => e.eventId)
+    const sequences = movedEvents.map((e) => e.sequence.toString())
+    await db.query(
+      `
+      WITH moved AS (
+        SELECT unnest($2::text[]) AS event_id, unnest($3::bigint[]) AS src_seq
+      ),
+      repoint AS (
+        SELECT rs.user_id,
+          (SELECT e.id FROM stream_events e
+             WHERE e.stream_id = $1 AND e.sequence < moved.src_seq
+             ORDER BY e.sequence DESC LIMIT 1) AS new_event_id
+        FROM stream_read_state rs
+        JOIN moved ON moved.event_id = rs.last_read_event_id
+        WHERE rs.stream_id = $1
+      )
+      UPDATE stream_read_state rs
+      SET last_read_event_id = repoint.new_event_id, updated_at = NOW()
+      FROM repoint
+      WHERE rs.stream_id = $1 AND rs.user_id = repoint.user_id
+      `,
+      [sourceStreamId, eventIds, sequences]
+    )
+  },
+
+  async get(db: Querier, streamId: string, userId: string): Promise<StreamReadState | null> {
+    const result = await db.query<StreamReadStateRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)}
+      FROM stream_read_state
+      WHERE stream_id = ${streamId} AND user_id = ${userId}
+    `)
+    return result.rows[0] ? mapRowToReadState(result.rows[0]) : null
+  },
+
+  async getBatch(db: Querier, userId: string, streamIds: string[]): Promise<StreamReadState[]> {
+    if (streamIds.length === 0) return []
+    const result = await db.query<StreamReadStateRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)}
+      FROM stream_read_state
+      WHERE user_id = ${userId} AND stream_id = ANY(${streamIds})
+    `)
+    return result.rows.map(mapRowToReadState)
+  },
+
+  /** Every read position for one user in one workspace (bootstrap assembly). */
+  async listForUser(db: Querier, workspaceId: string, userId: string): Promise<StreamReadState[]> {
+    const result = await db.query<StreamReadStateRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)}
+      FROM stream_read_state
+      WHERE workspace_id = ${workspaceId} AND user_id = ${userId}
+    `)
+    return result.rows.map(mapRowToReadState)
+  },
+
+  async deleteForWorkspace(db: Querier, workspaceId: string): Promise<void> {
+    await db.query(sql`
+      DELETE FROM stream_read_state WHERE workspace_id = ${workspaceId}
+    `)
+  },
+
+  async deleteForUser(db: Querier, workspaceId: string, userId: string): Promise<void> {
+    await db.query(sql`
+      DELETE FROM stream_read_state WHERE workspace_id = ${workspaceId} AND user_id = ${userId}
+    `)
+  },
+}

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg"
 import { StreamService } from "./service"
 import { StreamRepository } from "./repository"
 import { StreamMemberRepository, type StreamMember } from "./member-repository"
+import { ReadStateRepository } from "./read-state-repository"
 import { StreamEventRepository } from "./event-repository"
 import { SparseReadRepository } from "./sparse-read-repository"
 import { OutboxRepository } from "../../lib/outbox"
@@ -36,6 +37,16 @@ const mockPruneAtOrBelow = spyOn(SparseReadRepository, "pruneAtOrBelow").mockRes
 const mockDeleteAtOrAbove = spyOn(SparseReadRepository, "deleteAtOrAbove").mockResolvedValue(undefined)
 const mockDeleteAllForStreams = spyOn(SparseReadRepository, "deleteAllForStreams").mockResolvedValue(undefined)
 const mockListOverlayIds = spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue([])
+// Read-state shadow writes run inside every watermark write path; stub against
+// the fake `{}` client so unit tests never touch a real DB.
+const mockReadStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(undefined)
+const mockReadStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+const mockReadStateBatchAdvance = spyOn(ReadStateRepository, "batchAdvance").mockResolvedValue(undefined)
+const mockReadStateSetForUsers = spyOn(ReadStateRepository, "setForUsers").mockResolvedValue(undefined)
+const mockSlugExists = spyOn(StreamRepository, "slugExistsInWorkspace")
+const mockInsertManyEvents = spyOn(StreamEventRepository, "insertMany")
+const mockInsertManyOutbox = spyOn(OutboxRepository, "insertMany")
+const mockSetLastReadForMembers = spyOn(StreamMemberRepository, "setLastReadEventIdForMembers")
 
 spyOn(idModule, "eventId").mockReturnValue("evt_1")
 spyOn(idModule, "streamId").mockReturnValue("stream_new")
@@ -1485,6 +1496,7 @@ describe("StreamService.markAsRead", () => {
     mockMemberUpdate.mockReset()
     mockGetMessageOrdinalForEvent.mockReset()
     mockFindByStreamAndMember.mockReset()
+    mockReadStateAdvance.mockClear()
     mockInsertOutbox.mockReset()
     mockInsertOutbox.mockResolvedValue({} as never)
   })
@@ -1505,6 +1517,9 @@ describe("StreamService.markAsRead", () => {
       lastReadOrdinal: 7,
       readMessageIds: [],
     })
+    // Shadow advance on the same tx client — monotonic from day one (reads
+    // never regress the new store; cutover converges upward only).
+    expect(mockReadStateAdvance).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_9")
   })
 
   test("ignores a read pointer that doesn't resolve to a real event — no watermark write, no stream:read", async () => {
@@ -1522,6 +1537,7 @@ describe("StreamService.markAsRead", () => {
 
     expect(mockMemberUpdate).not.toHaveBeenCalled()
     expect(mockInsertOutbox).not.toHaveBeenCalled()
+    expect(mockReadStateAdvance).not.toHaveBeenCalled()
     expect(result?.lastReadEventId).toBe("evt_real")
   })
 
@@ -1532,6 +1548,7 @@ describe("StreamService.markAsRead", () => {
     await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
 
     expect(mockInsertOutbox).not.toHaveBeenCalled()
+    expect(mockReadStateAdvance).not.toHaveBeenCalled()
   })
 })
 
@@ -1548,6 +1565,7 @@ describe("StreamService.markUnread", () => {
     mockFindByMessageId.mockReset()
     mockFindPreviousMessageEvent.mockReset()
     mockCountMessagesThrough.mockReset()
+    mockReadStateSet.mockClear()
     mockInsertOutbox.mockReset()
     mockInsertOutbox.mockResolvedValue({} as never)
   })
@@ -1572,6 +1590,8 @@ describe("StreamService.markUnread", () => {
       readMessageIds: [],
     })
     expect(mockDeleteAtOrAbove).toHaveBeenCalledWith({}, "stream_1", "usr_1", 50n)
+    // Shadow regress on the same tx client.
+    expect(mockReadStateSet).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_4")
   })
 
   test("clears the read pointer when the target is the first message", async () => {
@@ -1588,6 +1608,8 @@ describe("StreamService.markUnread", () => {
       "stream:read_set",
       expect.objectContaining({ lastReadEventId: null, lastReadSequence: "0", lastReadOrdinal: 0 })
     )
+    // Regress to null (park before the first message) is shadowed too.
+    expect(mockReadStateSet).toHaveBeenCalledWith({}, "stream_1", "usr_1", null)
   })
 
   test("returns null and emits nothing when the message is not in the stream", async () => {
@@ -1611,6 +1633,7 @@ describe("StreamService.markUnread", () => {
     expect(result).toBeNull()
     expect(mockMemberUpdate).toHaveBeenCalled()
     expect(mockInsertOutbox).not.toHaveBeenCalled()
+    expect(mockReadStateSet).not.toHaveBeenCalled()
   })
 })
 
@@ -1629,6 +1652,7 @@ describe("StreamService.markAllAsRead", () => {
     mockLatestEventIds.mockReset()
     mockBatchUpdate.mockReset()
     mockCountMessages.mockReset()
+    mockReadStateBatchAdvance.mockClear()
     mockInsertOutbox.mockReset()
     mockInsertOutbox.mockResolvedValue({} as never)
   })
@@ -1669,6 +1693,15 @@ describe("StreamService.markAllAsRead", () => {
         { streamId: "stream_2", lastReadOrdinal: 3 },
       ],
     })
+    // Shadow batch advance on the same tx client with the same per-stream updates.
+    expect(mockReadStateBatchAdvance).toHaveBeenCalledWith(
+      {},
+      "usr_1",
+      new Map([
+        ["stream_1", "evt_a"],
+        ["stream_2", "evt_b"],
+      ])
+    )
   })
 })
 
@@ -2036,5 +2069,40 @@ describe("StreamService.addBotToStream", () => {
 
     expect(mockInsertEvent).not.toHaveBeenCalled()
     expect(mockInsertOutbox).not.toHaveBeenCalled()
+  })
+})
+
+describe("StreamService.createChannel read-state shadow", () => {
+  let service: StreamService
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockSlugExists.mockReset().mockResolvedValue(false)
+    mockInsertStream.mockReset().mockResolvedValue({ id: "stream_new", workspaceId: "ws_1", type: "channel" } as never)
+    mockInsertMember.mockReset().mockResolvedValue({} as never)
+    mockInsertOutbox.mockReset().mockResolvedValue({} as never)
+    mockFindMembersByIds.mockReset().mockResolvedValue([
+      { id: "usr_a", workspaceId: "ws_1" },
+      { id: "usr_b", workspaceId: "ws_1" },
+    ] as never)
+    mockInsertManyMembers.mockReset().mockResolvedValue([] as never)
+    mockInsertManyEvents.mockReset().mockResolvedValue([{ id: "evt_a" }, { id: "evt_b" }] as never)
+    mockInsertManyOutbox.mockReset().mockResolvedValue(undefined as never)
+    mockSetLastReadForMembers.mockReset().mockResolvedValue(undefined as never)
+    mockReadStateSetForUsers.mockClear()
+  })
+
+  test("shadows the initial-member born-read watermark via setForUsers on the same tx client", async () => {
+    await service.createChannel({
+      workspaceId: "ws_1",
+      slug: "chan",
+      createdBy: "usr_owner",
+      memberIds: ["usr_owner", "usr_a", "usr_b"],
+    } as never)
+
+    // The creator is filtered out of the additional-member batch; the watermark
+    // lands on the last creation event. setForUsers shadows setLastReadEventIdForMembers.
+    expect(mockSetLastReadForMembers).toHaveBeenCalledWith({}, "stream_new", ["usr_a", "usr_b"], "evt_b")
+    expect(mockReadStateSetForUsers).toHaveBeenCalledWith({}, "stream_new", ["usr_a", "usr_b"], "evt_b")
   })
 })

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -2106,3 +2106,45 @@ describe("StreamService.createChannel read-state shadow", () => {
     expect(mockReadStateSetForUsers).toHaveBeenCalledWith({}, "stream_new", ["usr_a", "usr_b"], "evt_b")
   })
 })
+
+describe("StreamService.addMember read-state shadow", () => {
+  let service: StreamService
+  const mockFindByStreamAndMember = spyOn(StreamMemberRepository, "findByStreamAndMember")
+  const mockUpdateMember = spyOn(StreamMemberRepository, "update")
+  const mockUserFindById = spyOn(UserRepository, "findById")
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockFindById.mockReset().mockResolvedValue({ id: "stream_1", workspaceId: "ws_1", type: "channel" } as never)
+    mockFindByStreamAndMember.mockReset().mockResolvedValue(null)
+    mockInsertMember.mockReset().mockResolvedValue({ streamId: "stream_1", memberId: "usr_new" } as never)
+    mockInsertEvent.mockReset().mockResolvedValue({
+      id: "evt_born",
+      streamId: "stream_1",
+      sequence: 5n,
+      eventType: "member_added",
+      payload: {},
+      actorId: "usr_new",
+      actorType: "user",
+      createdAt: new Date(),
+    } as never)
+    mockUpdateMember.mockReset().mockResolvedValue(undefined as never)
+    mockInsertOutbox.mockReset().mockResolvedValue({} as never)
+    mockUserFindById.mockReset().mockResolvedValue({ id: "usr_new", workspaceId: "ws_1" } as never)
+    mockReadStateAdvance.mockClear()
+  })
+
+  test("shadows the born-read watermark via ReadStateRepository.advance on the same tx client", async () => {
+    await service.addMember("stream_1", "usr_new", "ws_1", "usr_actor")
+
+    // addToStream sets the membership watermark to the member_added event, then
+    // shadows it into the standalone read-state store on the same tx client.
+    // The event id comes from eventId(), not the mock return — assert both calls
+    // received the same generated id.
+    const updateCall = mockUpdateMember.mock.calls.find((c) => c[1] === "stream_1" && c[2] === "usr_new")
+    expect(updateCall).toBeDefined()
+    const bornReadEventId = (updateCall![3] as { lastReadEventId: string }).lastReadEventId
+    expect(bornReadEventId).toBeTruthy()
+    expect(mockReadStateAdvance).toHaveBeenCalledWith({}, "stream_1", "usr_new", bornReadEventId)
+  })
+})

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -10,6 +10,7 @@ import {
   type UpdateStreamParams,
 } from "./repository"
 import { StreamMemberRepository, StreamMember } from "./member-repository"
+import { ReadStateRepository } from "./read-state-repository"
 import { StreamEventRepository, type StreamEvent } from "./event-repository"
 import { SparseReadRepository } from "./sparse-read-repository"
 import { MessageRepository } from "../messaging"
@@ -630,6 +631,8 @@ export class StreamService {
           // Set lastReadEventId so initial members don't see creation events as unread
           const lastEvent = events[events.length - 1]
           await StreamMemberRepository.setLastReadEventIdForMembers(client, stream.id, validMemberIds, lastEvent.id)
+          // Shadow the born-read watermark into stream_read_state (same tx).
+          await ReadStateRepository.setForUsers(client, stream.id, validMemberIds, lastEvent.id)
         }
       }
 
@@ -1568,6 +1571,11 @@ export class StreamService {
 
     // Set read cursor *after* inserting the member_added event so it's not shown as unread
     await StreamMemberRepository.update(client, stream.id, memberId, { lastReadEventId: evtId })
+    // Shadow the born-read watermark (same tx) — monotonic: a re-added user
+    // keeps any surviving higher position (plan decision 1, effective in the
+    // new store from day one); membership's reset-on-rejoin is unchanged
+    // during the shadow window and dies with the columns in PR 4.
+    await ReadStateRepository.advance(client, stream.id, memberId, evtId)
 
     await OutboxRepository.insert(client, "stream:member_added", {
       workspaceId: stream.workspaceId,
@@ -1925,6 +1933,13 @@ export class StreamService {
 
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
       if (membership) {
+        // Shadow the advance into stream_read_state (same tx). Monotonic by
+        // design — reads never regress the new store; only explicit
+        // mark-unread and the A3 move-correction may lower it. Membership can
+        // still regress under a stale device during the shadow window (its
+        // semantics, unchanged — the columns die in PR 4); the PR-2 cutover
+        // converges such rows upward only (owner-ratified).
+        await ReadStateRepository.advance(client, streamId, memberId, eventId)
         // Overlay invariant: every overlay row sits strictly above the watermark.
         // Advancing the watermark absorbs the run at/below it, so prune those rows
         // in the same transaction; the remaining overlay is the absolute set the
@@ -1976,6 +1991,8 @@ export class StreamService {
 
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId })
       if (membership) {
+        // Shadow the regress into stream_read_state (unconditional; may be null — same tx).
+        await ReadStateRepository.set(client, streamId, memberId, lastReadEventId)
         // Mark-unread means "this message and everything after it is unread", so
         // overlay rows at/above the target contradict the intent — drop them. The
         // pointer lands just before the target, which can also ADVANCE it (target
@@ -2026,6 +2043,8 @@ export class StreamService {
 
       if (updatesToApply.size > 0) {
         await StreamMemberRepository.batchUpdateLastReadEventId(client, memberId, updatesToApply)
+        // Shadow the mark-all advance into stream_read_state (same tx).
+        await ReadStateRepository.batchAdvance(client, memberId, updatesToApply)
       }
 
       const updatedStreamIds = Array.from(updatesToApply.keys())

--- a/apps/backend/src/features/streams/sparse-read.test.ts
+++ b/apps/backend/src/features/streams/sparse-read.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { applySparseRead, applySparseUnread } from "./sparse-read"
+import { StreamMemberRepository } from "./member-repository"
+import { ReadStateRepository } from "./read-state-repository"
+import { StreamEventRepository } from "./event-repository"
+import { SparseReadRepository } from "./sparse-read-repository"
+import { OutboxRepository } from "../../lib/outbox"
+
+const db = {} as never
+
+describe("applySparseRead read-state shadow", () => {
+  beforeEach(() => {
+    spyOn(SparseReadRepository, "insertReads").mockResolvedValue(undefined as never)
+    spyOn(SparseReadRepository, "pruneAtOrBelow").mockResolvedValue(undefined as never)
+    spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue([])
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => mock.restore())
+
+  it("advances read state on the same client when compaction moves the membership watermark", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "usr_1",
+      lastReadEventId: "evt_old",
+    } as never)
+    // Old watermark resolves to sequence 10; compaction target sits above it at 20.
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue({ sequence: 10n } as never)
+    spyOn(SparseReadRepository, "findCompactionTarget").mockResolvedValue({
+      eventId: "evt_new",
+      sequence: 20n,
+    } as never)
+    spyOn(SparseReadRepository, "findTrailingDeletedRunEnd").mockResolvedValue(null)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(2)
+    const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(undefined)
+
+    await applySparseRead(db, { workspaceId: "ws_1", streamId: "stream_1", memberId: "usr_1", messageIds: ["msg_1"] })
+
+    expect(memberUpdate).toHaveBeenCalledWith(db, "stream_1", "usr_1", { lastReadEventId: "evt_new" })
+    expect(readStateAdvance).toHaveBeenCalledWith(db, "stream_1", "usr_1", "evt_new")
+  })
+
+  it("writes no read state when compaction leaves the watermark unchanged", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "usr_1",
+      lastReadEventId: "evt_old",
+    } as never)
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue({ sequence: 10n } as never)
+    spyOn(SparseReadRepository, "findCompactionTarget").mockResolvedValue(null)
+    spyOn(SparseReadRepository, "findTrailingDeletedRunEnd").mockResolvedValue(null)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
+    const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(undefined)
+
+    await applySparseRead(db, { workspaceId: "ws_1", streamId: "stream_1", memberId: "usr_1", messageIds: ["msg_1"] })
+
+    expect(memberUpdate).not.toHaveBeenCalled()
+    expect(readStateAdvance).not.toHaveBeenCalled()
+  })
+})
+
+describe("applySparseUnread read-state shadow", () => {
+  beforeEach(() => {
+    spyOn(SparseReadRepository, "deleteReads").mockResolvedValue(undefined as never)
+    spyOn(SparseReadRepository, "deleteAtOrAbove").mockResolvedValue(undefined as never)
+    spyOn(SparseReadRepository, "pruneAtOrBelow").mockResolvedValue(undefined as never)
+    spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue([])
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => mock.restore())
+
+  it("regresses read state (set) on the same client when the watermark moves back", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "usr_1",
+      lastReadEventId: "evt_5",
+    } as never)
+    // Watermark at sequence 50 sits past the earliest affected message (30), so it regresses.
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue({ sequence: 50n } as never)
+    spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 30n } as never)
+    spyOn(StreamEventRepository, "findPreviousMessageEvent").mockResolvedValue({ id: "evt_4", sequence: 25n } as never)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(2)
+    const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+
+    await applySparseUnread(db, { workspaceId: "ws_1", streamId: "stream_1", memberId: "usr_1", messageIds: ["msg_5"] })
+
+    expect(memberUpdate).toHaveBeenCalledWith(db, "stream_1", "usr_1", { lastReadEventId: "evt_4" })
+    expect(readStateSet).toHaveBeenCalledWith(db, "stream_1", "usr_1", "evt_4")
+  })
+
+  it("sets read state to null when the target is the first message", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "usr_1",
+      lastReadEventId: "evt_1",
+    } as never)
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue({ sequence: 10n } as never)
+    spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 10n } as never)
+    spyOn(StreamEventRepository, "findPreviousMessageEvent").mockResolvedValue(null)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(0)
+    spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+
+    await applySparseUnread(db, { workspaceId: "ws_1", streamId: "stream_1", memberId: "usr_1", messageIds: ["msg_1"] })
+
+    expect(readStateSet).toHaveBeenCalledWith(db, "stream_1", "usr_1", null)
+  })
+})

--- a/apps/backend/src/features/streams/sparse-read.ts
+++ b/apps/backend/src/features/streams/sparse-read.ts
@@ -2,6 +2,7 @@ import type { Querier } from "../../db"
 import { OutboxRepository } from "../../lib/outbox"
 import { StreamEventRepository } from "./event-repository"
 import { StreamMemberRepository } from "./member-repository"
+import { ReadStateRepository } from "./read-state-repository"
 import { SparseReadRepository } from "./sparse-read-repository"
 
 /**
@@ -89,6 +90,11 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
     }
     if (watermarkEventId !== (membership.lastReadEventId ?? null)) {
       await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: watermarkEventId })
+      // Shadow the compaction advance into stream_read_state (same tx). A
+      // compaction target is always a real event, so the watermark is non-null here.
+      if (watermarkEventId) {
+        await ReadStateRepository.advance(db, streamId, memberId, watermarkEventId)
+      }
       await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
     }
   }
@@ -144,6 +150,8 @@ export async function applySparseUnread(db: Querier, params: ApplySparseReadPara
     const newWatermarkEventId = previous?.id ?? null
     const newWatermarkSeq = previous?.sequence ?? 0n
     await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: newWatermarkEventId })
+    // Shadow the regress into stream_read_state (unconditional; may be null — same tx).
+    await ReadStateRepository.set(db, streamId, memberId, newWatermarkEventId)
 
     const lastReadOrdinal = await ordinalFor(db, streamId, newWatermarkSeq)
     const overlay = await SparseReadRepository.listOverlayIds(db, streamId, memberId)

--- a/apps/backend/src/features/workspaces/service.test.ts
+++ b/apps/backend/src/features/workspaces/service.test.ts
@@ -242,12 +242,14 @@ describe("WorkspaceService.ensureUserProvisioned", () => {
 
 describe("WorkspaceService.removeUser read-state cleanup", () => {
   const mockWithTransaction = spyOn(db, "withTransaction")
+  let transactionClient: PoolClient
 
   beforeEach(() => {
+    transactionClient = {} as PoolClient
     mockWithTransaction
       .mockReset()
       .mockImplementation(((_pool: unknown, fn: (client: PoolClient) => Promise<unknown>) =>
-        fn({} as PoolClient)) as never)
+        fn(transactionClient)) as never)
     spyOn(UserApiKeyRepository, "revokeAllByUser").mockResolvedValue(undefined as never)
     spyOn(UserRepository, "remove").mockResolvedValue(undefined as never)
     spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
@@ -257,11 +259,14 @@ describe("WorkspaceService.removeUser read-state cleanup", () => {
 
   test("deletes the user's read state in the same transaction as account removal", async () => {
     const deleteForUser = spyOn(ReadStateRepository, "deleteForUser").mockResolvedValue(undefined as never)
+    const removeUser = spyOn(UserRepository, "remove").mockResolvedValue(undefined as never)
     const service = createWorkspaceService(false)
 
     await service.removeUser("ws_1", "usr_1")
 
-    expect(UserRepository.remove).toHaveBeenCalledWith({}, "ws_1", "usr_1")
-    expect(deleteForUser).toHaveBeenCalledWith({}, "ws_1", "usr_1")
+    expect(removeUser).toHaveBeenCalledWith(transactionClient, "ws_1", "usr_1")
+    expect(deleteForUser).toHaveBeenCalledWith(transactionClient, "ws_1", "usr_1")
+    expect(removeUser.mock.calls[0]?.[0]).toBe(transactionClient)
+    expect(deleteForUser.mock.calls[0]?.[0]).toBe(transactionClient)
   })
 })

--- a/apps/backend/src/features/workspaces/service.test.ts
+++ b/apps/backend/src/features/workspaces/service.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import type { PoolClient } from "pg"
 import { WorkspaceService } from "./service"
 import { UserRepository } from "./user-repository"
+import { UserApiKeyRepository } from "../user-api-keys"
+import { ReadStateRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
 import * as db from "../../db"
 
 type MockWorkosOrgService = {
@@ -233,5 +237,31 @@ describe("WorkspaceService.ensureUserProvisioned", () => {
     expect(err).toBeInstanceOf(Error)
     expect(err.message).toContain("users row vanished after unique-constraint collision")
     expect(err.cause).toBe(cause)
+  })
+})
+
+describe("WorkspaceService.removeUser read-state cleanup", () => {
+  const mockWithTransaction = spyOn(db, "withTransaction")
+
+  beforeEach(() => {
+    mockWithTransaction
+      .mockReset()
+      .mockImplementation(((_pool: unknown, fn: (client: PoolClient) => Promise<unknown>) =>
+        fn({} as PoolClient)) as never)
+    spyOn(UserApiKeyRepository, "revokeAllByUser").mockResolvedValue(undefined as never)
+    spyOn(UserRepository, "remove").mockResolvedValue(undefined as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => mock.restore())
+
+  test("deletes the user's read state in the same transaction as account removal", async () => {
+    const deleteForUser = spyOn(ReadStateRepository, "deleteForUser").mockResolvedValue(undefined as never)
+    const service = createWorkspaceService(false)
+
+    await service.removeUser("ws_1", "usr_1")
+
+    expect(UserRepository.remove).toHaveBeenCalledWith({}, "ws_1", "usr_1")
+    expect(deleteForUser).toHaveBeenCalledWith({}, "ws_1", "usr_1")
   })
 })

--- a/apps/backend/src/features/workspaces/service.ts
+++ b/apps/backend/src/features/workspaces/service.ts
@@ -3,7 +3,7 @@ import { withTransaction, withClient, type Querier } from "../../db"
 import { WorkspaceRepository, Workspace } from "./repository"
 import { UserRepository, type User } from "./user-repository"
 import { OutboxRepository } from "../../lib/outbox"
-import { StreamRepository, StreamMemberRepository } from "../streams"
+import { StreamRepository, StreamMemberRepository, ReadStateRepository } from "../streams"
 import { EmojiUsageRepository } from "../emoji"
 import { PersonaRepository, type Persona } from "../agents"
 import { workspaceId, userId as generateUserId, streamId, avatarUploadId } from "../../lib/id"
@@ -320,6 +320,10 @@ export class WorkspaceService {
     return withTransaction(this.pool, async (client) => {
       await UserApiKeyRepository.revokeAllByUser(client, workspaceId, userId)
       await UserRepository.remove(client, workspaceId, userId)
+      // Read state is user-private truth; drop it on account removal (same tx).
+      // stream_members is orphaned here rather than deleted, so this is the
+      // user-lifecycle cleanup site, not a mirror of a membership delete.
+      await ReadStateRepository.deleteForUser(client, workspaceId, userId)
 
       await OutboxRepository.insert(client, "workspace_user:removed", {
         workspaceId,


### PR DESCRIPTION
## Problem

Per-user read watermarks live on `stream_members`, although INV-62 permits stream access without membership. That couples participation to read truth, leaves non-member thread legs without a frontier, and makes a membership upsert the tempting—but forbidden—way to persist their reads.

## Solution

Add `stream_read_state` as the user+stream watermark store and shadow every existing membership-watermark writer before any reader cutover.

- Migration backfills existing non-null membership watermarks atomically, deriving `workspace_id` through `streams` (INV-8).
- `ReadStateRepository` provides race-safe monotonic advances, explicit regress/set operations, batch writes, move repair, bootstrap readers, and lifecycle cleanup.
- Every shadow runs on the same transaction client as the membership write. The new store rises monotonically; only explicit unread and A3 move repair may regress it. Membership behavior remains unchanged until its columns are retired.
- Read state survives leave/kick; account removal deletes it. No reader, API, payload, frontend, or sparse-overlay contract changes in this layer.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/db/migrations/20260724170957_add_stream_read_state.sql` | **New:** table, index, atomic backfill |
| `apps/backend/src/features/streams/read-state-repository.ts` | **New:** read-state persistence primitives |
| `apps/backend/src/features/streams/read-state-repository.test.ts` | **New:** repository SQL and edge coverage |
| `apps/backend/src/features/streams/sparse-read.test.ts` | **New:** sparse compaction/regress shadow coverage |
| `apps/backend/src/features/streams/service.ts` | Shadow channel creation, join, read, unread, and read-all writes |
| `apps/backend/src/features/messaging/event-service.ts` | Shadow author born-read and moved-event repoint writes |
| `apps/backend/src/features/workspaces/service.ts` | Delete read state on account removal |
| `*.test.ts` | Pin same-client dual writes and lifecycle cleanup |

## Test plan

- [x] Backend streams/messaging/workspaces/conversations — 509 pass
- [x] Post-fix streams suite — 221 pass
- [x] Monorepo typecheck — 0 errors
- [x] Pre-commit: all workspace lint/typecheck, Dockerfile checks, 237 migrations, API docs
- [ ] DB-backed migration fidelity — deferred to the planned integration chunk with the already-pending FOR SHARE barrier test

<details>
<summary>📋 Full implementation plan</summary>

# Plan: extract read state from `stream_members` (wholesale watermark re-home)

Status: scope/plan only — no code. Requested by Kristoffer 2026-07-24.

## Goal

Move every per-user read watermark off `stream_members` into a dedicated
`stream_read_state` table, for **all** streams — channels, DMs, threads, root +
legs — with a backfill of all existing read positions. Watermark-style only
(single contiguous-prefix frontier per user+stream; no bitmaps).

**Explicitly not re-solved:** the message-granular sparse overlay
(`stream_member_message_reads`) and the whole conversation read geometry from
`docs/sparse-read-overlay-design.md` — that system manages reading *in
conversations* and stays exactly as designed. This work re-homes the watermark
layer the overlay compacts into; it does not touch overlay storage or its wire
contracts.

## Why (what this unlocks)

1. **Non-member thread legs get a real frontier.** INV-62 grants access without
   membership (thread→root resolution, public roots). Today those legs are
   overlay-only: no watermark, no compaction, `markAsRead` is a silent no-op on
   the message side, `markUnread` 404s, the board card frontier falls back to
   the root watermark's `last_read_at` timestamp approximation (explicitly
   flagged in the overlay doc as "a principled thread frontier is a follow-up"
   — this is that follow-up).
2. **Closes the late-insert born-read race.** `membersReadThrough`
   (activity born-read) joins `stream_members`; a non-member's read therefore
   can't protect against an activity row inserted between clear and response.
3. **membership ≠ access ≠ read state.** INV-62 keeps membership as pure
   participation; read state becomes user-anchored per stream. Upserting read
   state is always safe — unlike upserting `stream_members` on read, which the
   overlay doc explicitly forbids.
4. Read state can survive leave/rejoin (decision 1 below).

## Verified inventory of watermark usage (current code)

**Writers** (all funnel through `StreamMemberRepository.update` / batch variants):
- `streams/service.ts:1926` markAsRead advance; `:1977` markUnread regress;
  `:1570`/`:630` initial-member born-read on stream/message creation;
  `:295` move-repoint (A3 fix); `batchUpdateLastReadEventId` (mark-all);
  `setLastReadEventIdForMembers`; sparse-read compaction
  (`sparse-read.ts:91`).

**Readers:**
- Bootstrap assembly (`workspaces/handlers.ts:226-263`): memberships →
  `getUnreadCounts` → `countUnreadByStreamBatch` (watermark sequence vs
  `message_created` sequence, minus overlay count) + `lastReadSequence` map +
  `streamMemberships` payload.
- Born-read: `activity/service.resolveAlreadyReadRecipients` →
  `membersReadThrough` (member-keyed).
- `streams/handlers.ts:1047` markUnread response count.
- Board card frontier derivation (root watermark sequence; non-member legs →
  root `last_read_at` fallback).
- Sparse-read compaction (`sparse-read.ts:64-92`): reads + locks the
  membership row, advances the watermark.
- Outbox payloads `stream:read` / `stream:read_set` / `stream:read_all`
  (source = membership update result; **wire shapes unchanged by this work**).
- Frontend: `stream-content.tsx` frontier seed, `use-unread-divider`,
  `use-last-seen-event`, `unread-counters` readOrdinal, `workspace-sync`
  `stream:read*` appliers, IDB `streams.lastReadEventId` + `streamMemberships`.

No cross-user "seen-by" surface exists (verified) — nothing to migrate there.

## Design

### Table

```sql
CREATE TABLE stream_read_state (
    workspace_id       TEXT NOT NULL,        -- INV-8
    stream_id          TEXT NOT NULL,
    user_id            TEXT NOT NULL,        -- NOT member_id: not a membership surface
    last_read_event_id TEXT,                 -- NULL = position before first message (mark-unread-to-zero)
    last_read_at       TIMESTAMPTZ,
    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    PRIMARY KEY (stream_id, user_id)
);
CREATE INDEX ON stream_read_state (workspace_id, user_id);  -- bootstrap list
```

No FKs (INV-1). No membership-row requirement. A row exists only after the
user's first read-state write for that stream; absence = never read (same
semantics as a NULL watermark today).

### Repository & locking

New `ReadStateRepository` (streams feature): `get`, `getBatch`,
`listForUser(workspaceId, userId)` (bootstrap), `advance` (monotonic,
max-merge by sequence — resolve event→sequence in SQL), `set` (regress;
mark-unread only), `deleteForWorkspace/User` (lifecycle cascades).
Sparse-read compaction locks the **read-state** row `FOR UPDATE` (INV-20);
for non-members it upserts then locks — non-member legs stop being
overlay-only. Single-row lock either way; no new lock-order hazard
(conversations already process streams in sorted order).

### Rollout — one stack, 4 PRs

**PR 1 — storage + shadow writes (no behavior change).**
Migration (table + backfill from `stream_members` where
`last_read_event_id IS NOT NULL`, carrying `last_read_at`), repository + unit
tests, and every writer above dual-writes read-state in the same transaction.
Readers untouched. Backfill is atomic in the migration; dual-write covers the
rolling-deploy window.

**PR 2 — read cutover.**
Every reader switches to read-state with membership fallback (read-state row
wins; absent → membership column — covers the deploy window). Bootstrap gains
`streamReadState: Record<streamId, { lastReadEventId, lastReadSequence,
lastReadAt }>` for member streams (same data, new home);
`streamMemberships` keeps its fields for compat. Frontend: IDB
`streamReadState` store (version bump); frontier seed + divider + counters
prefer it, fall back to membership/`db.streams`; sync appliers write both
stores during transition.

**Post-drain reconciliation (PR 2 migration,
`20260724190000_reconcile_stream_read_state.sql`).** PR 1's backfill copied
every membership watermark that existed when it ran; old binaries still
draining afterwards wrote the membership column only. PR 2 ships a second
migration that re-folds every non-NULL membership watermark into
`stream_read_state` with the `advance` rule (workspace through streams,
insert missing rows, advance only on STRICTLY greater event sequence,
NULL/unresolvable = 0, never regress, `last_read_at` carried only when the
membership frontier wins). DEPLOYMENT ORDERING: PR 1 must be deployed and all
pre-PR-1 binaries drained BEFORE PR 2 deploys — running the reconciliation
before drain leaves a gap the next old-binary write reopens. Frontend
freshness rule that goes with it: the bootstrap `streamReadState` map
enumerates MEMBER streams only, so it is never a deletion authority over IDB
rows it omits (nonmember thread lazy state); and a bootstrap begun at T0
preserves any standalone row touched locally/socket at T1>T0 (explicit unread
included — no max(sequence) there), per stream, like the counter triple.

**PR 3 — the non-member unlock (behavior change).**
- `markAsRead`: after `validateStreamAccess`, upsert read-state advance
  whether or not a membership row exists (the #1527 activity path stays).
  Non-members get real unread counts, divider placement, and cross-device
  `stream:read` with a real payload.

**Monotonicity rule (owner-ratified 2026-07-24):** the new store only ever
rises — reads never regress it. The ONLY downward moves are explicit
mark-unread (`markUnread`, sparse `applySparseUnread`) and the A3
move-correction repoint. This applies from PR 1 in the shadow store:
`markAsRead`/`addToStream`/born-read/mark-all/compaction all use `advance`
(monotonic). The membership store keeps its regressible semantics untouched
throughout the shadow window (stale-device `markAsRead`, reset-on-rejoin,
last-commit-wins races) — those columns die in PR 4. Consequence for PR 2:
the cutover converges regressed rows UPWARD only (users whose membership
watermark regressed during the shadow window pop back to their true
position) — never downward. Call this out in the PR 2 description.
- `markUnread`: upsert regress — fixes the same-class 404.
- `resolveAlreadyReadRecipients` reads read-state → born-read covers
  non-members; late-insert race closed.
- Compaction upserts+locks read-state for non-member legs; overlay invariant
  restated against read-state instead of membership.
- Card frontier: non-member thread legs use their own watermark sequence;
  the root `last_read_at` time fallback is deleted.

**PR 4 — cleanup (after bake).**
Stop dual-writing, drop fallback reads, migration drops
`stream_members.last_read_event_id` / `last_read_at`, `StreamMember` API type
loses the fields (breaking for stale clients — gate on a refresh window).
CLAUDE.md gains: "Read state lives in `stream_read_state`, never on
`stream_members`. Upserting read state is always safe; upserting membership
on read is forbidden (membership ≠ access ≠ read state)."

### Decision points (recommendations inline)

1. **Read-state lifetime:** keep on leave/kick (user-private truth; rejoin
   restores position). Delete only on workspace/account deletion via the
   existing cascades. *Behavior change vs today (membership delete destroys
   the watermark) — flagging explicitly.*
2. Keep `last_read_at` (display + any time-based derivations).
3. Bootstrap stays member-stream-keyed; non-member thread unread is computed
   on open (threads aren't in the sidebar). Revisit only if threads join the
   sidebar.
4. Wire payloads unchanged; the bootstrap `streamReadState` map is the only
   additive field. `stream:read*` contracts untouched — the source changes,
   not the contract.
5. `activity:read` (shipped in #1530) is a different axis (per-row `read_at`)
   — untouched.

### Testing

- Unit: repository (advance monotonic / set regress / batch / bootstrap
  list); dual-write equivalence; compaction upsert-and-lock; born-read via
  read-state including non-members.
- Integration (needs the test-DB ports free — same blocker as the pending
  FOR SHARE barrier test; run together): unread-counts, sparse-read-overlay,
  phantom-unread-fixes, conversation-read, **plus new**: non-member thread
  frontier (divider placement, late-insert born-read, markUnread regress,
  two-device propagation, leave/rejoin position retained).
- Migration test: backfill fidelity (row counts, event mapping, NULLs).
- E2E on staging after PR 3: two-device thread read.

### Risks

- Rolling-deploy skew (old binary writes membership only) → dual-write +
  fallback window; bounded by the PR 4 gate. Late writes between PR 1's
  backfill and drain are folded in by PR 2's post-drain reconciliation
  migration (deploy ordering: PR 1 drained before PR 2 deploys).
- Backfill volume: one `INSERT … SELECT`; check prod counts first, batch if
  huge.
- IDB version bump; stale cached memberships still carry watermarks →
  fallback covers until first fresh bootstrap.

### Out of scope

Sparse overlay storage/wire (`stream:read_messages`, conversation read APIs);
sidebar unread for non-member threads; read receipts for other users (no such
surface); offline queueing of read mutations (parity with existing).


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787502298&installation_model_id=20758&pr_number=1534&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1534&signature=d686e570c5eca56c687fc1859055a56fd1bd45220e1a3171ac83661fbb8d31bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
