### PR TITLE
fix: preserve Pi remote claims across reload

### DIFF
--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -164,8 +164,9 @@ describe("WS frame sent but ack timed out (idempotency)", () => {
         },
       }),
     }
-    ;(transport as unknown as { socket: unknown; connected: boolean }).socket = socket
+    ;(transport as unknown as { socket: unknown; connected: boolean; helloReady: boolean }).socket = socket
     ;(transport as unknown as { connected: boolean }).connected = true
+    ;(transport as unknown as { helloReady: boolean }).helloReady = true
   }
 
   it("does NOT re-POST steps on a timed-out ack — the in-flight frame would duplicate the trace row", async () => {
@@ -226,8 +227,11 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
         socket.handlers[event] = cb
         return socket
       },
-      emit: () => {},
-      timeout: () => ({ emit: () => {} }),
+      emit: (...args) => {
+        const callback = args.at(-1)
+        if (args[0] === "bot:hello" && typeof callback === "function") callback(null, { ok: true })
+      },
+      timeout: () => ({ emit: (...args) => socket.emit(...args) }),
     }
     return socket
   }
@@ -249,8 +253,11 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
   it("refreshes the initial and reconnect hello payloads immediately before emission", async () => {
     const fake = makeFakeSocket()
     const hellos: unknown[] = []
-    fake.emit = (event, payload) => {
-      if (event === "bot:hello") hellos.push(structuredClone(payload))
+    fake.emit = (event, payload, callback) => {
+      if (event === "bot:hello") {
+        hellos.push(structuredClone(payload))
+        if (typeof callback === "function") callback(null, { ok: true })
+      }
     }
     const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
     try {
@@ -285,6 +292,64 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
         },
         { ...HELLO, capabilities: { sessionControlCommands: ["stop", "reconnect"] } },
       ])
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
+
+  it("does not send a second hello while the first acknowledgement is in flight", async () => {
+    const fake = makeFakeSocket()
+    let helloCalls = 0
+    let acknowledge: ((error: unknown, ack: unknown) => void) | undefined
+    fake.timeout = () => ({
+      emit: (...args) => {
+        helloCalls++
+        acknowledge = args.at(-1) as (error: unknown, ack: unknown) => void
+      },
+    })
+    const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      const transport = makeSelfHealTransport(3 * 60 * 1000)
+      await transport.connect()
+      fake.handlers.connect!()
+      await transport.connect()
+
+      expect(helloCalls).toBe(1)
+      expect(transport.socketConnected).toBe(false)
+
+      acknowledge!(null, { ok: true })
+      expect(transport.socketConnected).toBe(true)
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
+
+  it("tears down a connected socket whose hello is rejected instead of treating it as healthy", async () => {
+    const first = makeFakeSocket()
+    const second = makeFakeSocket()
+    first.timeout = () => ({
+      emit: (...args) => {
+        const callback = args.at(-1)
+        if (typeof callback === "function") callback(null, { ok: false, error: "not registered" })
+      },
+    })
+    const ioSpy = spyOn(socketIoClient, "io")
+      .mockReturnValueOnce(first as unknown as ReturnType<typeof socketIoClient.io>)
+      .mockReturnValueOnce(second as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      const transport = makeSelfHealTransport(3 * 60 * 1000)
+      await transport.connect()
+      first.handlers.connect!()
+
+      expect(transport.socketConnected).toBe(false)
+      expect(first.disconnect).toHaveBeenCalledTimes(1)
+
+      await transport.connect()
+      expect(ioSpy).toHaveBeenCalledTimes(2)
+      second.handlers.connect!()
+      expect(transport.socketConnected).toBe(true)
     } finally {
       ioSpy.mockRestore()
     }

--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -240,13 +240,14 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
     return stubFetch(() => new Response(JSON.stringify({ wsUrl: "https://ws.example.test" }), { status: 200 }))
   }
 
-  function makeSelfHealTransport(staleSocketRedialMs: number): BotRuntimeTransport {
+  function makeSelfHealTransport(staleSocketRedialMs: number, reconnectionDelayMaxMs?: number): BotRuntimeTransport {
     return new BotRuntimeTransport({
       baseUrl: "https://app.example.test",
       workspaceId: "ws_1",
       apiKey: "threa_bk_test",
       hello: HELLO,
       staleSocketRedialMs,
+      reconnectionDelayMaxMs,
     })
   }
 
@@ -350,6 +351,34 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
       expect(ioSpy).toHaveBeenCalledTimes(2)
       second.handlers.connect!()
       expect(transport.socketConnected).toBe(true)
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
+
+  it("schedules a fresh connection when hello is rejected", async () => {
+    const first = makeFakeSocket()
+    const second = makeFakeSocket()
+    first.timeout = () => ({
+      emit: (...args) => {
+        const callback = args.at(-1)
+        if (typeof callback === "function") callback(null, { ok: false, error: "not registered" })
+      },
+    })
+    const ioSpy = spyOn(socketIoClient, "io")
+      .mockReturnValueOnce(first as unknown as ReturnType<typeof socketIoClient.io>)
+      .mockReturnValueOnce(second as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      const transport = makeSelfHealTransport(3 * 60 * 1000, 1)
+      await transport.connect()
+      first.handlers.connect!()
+      await Bun.sleep(10)
+
+      expect(ioSpy).toHaveBeenCalledTimes(2)
+      second.handlers.connect!()
+      expect(transport.socketConnected).toBe(true)
+      transport.disconnect()
     } finally {
       ioSpy.mockRestore()
     }

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -56,6 +56,7 @@ export class BotRuntimeTransport {
   private helloInFlight = false
   private connecting = false
   private stopped = false
+  private redialTimer: ReturnType<typeof setTimeout> | undefined
   /** When the current outage started: set at attach and on disconnect, cleared on connect. */
   private disconnectedAt: number | undefined
   /** The cursor echoed by the last hello ack; re-sent on the next hello so the bootstrap only replays unseen events. */
@@ -194,6 +195,7 @@ export class BotRuntimeTransport {
           if (error || !isObject(ack) || ack.ok !== true) {
             this.logFn(`bot:hello rejected: ${error ? summarize(error) : isObject(ack) ? String(ack.error) : "no ack"}`)
             this.teardownSocket()
+            this.scheduleRedial()
             return
           }
           this.helloReady = true
@@ -211,7 +213,17 @@ export class BotRuntimeTransport {
   /** Tear the socket down (idempotent). After this the transport is HTTP-only and won't reconnect. */
   disconnect(): void {
     this.stopped = true
+    if (this.redialTimer) clearTimeout(this.redialTimer)
+    this.redialTimer = undefined
     this.teardownSocket()
+  }
+
+  private scheduleRedial(): void {
+    if (this.stopped || this.redialTimer) return
+    this.redialTimer = setTimeout(() => {
+      this.redialTimer = undefined
+      void this.connect()
+    }, this.reconnectionDelayMaxMs)
   }
 
   /** Drop the current socket without stopping the transport — the next `connect()` dials fresh. */

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -52,6 +52,8 @@ export class BotRuntimeTransport {
 
   private socket: Socket | undefined
   private connected = false
+  private helloReady = false
+  private helloInFlight = false
   private connecting = false
   private stopped = false
   /** When the current outage started: set at attach and on disconnect, cleared on connect. */
@@ -75,7 +77,7 @@ export class BotRuntimeTransport {
 
   /** Whether the `/bot` socket is currently connected. */
   get socketConnected(): boolean {
-    return this.connected
+    return this.connected && this.helloReady
   }
 
   // --- Socket lifecycle -----------------------------------------------------
@@ -96,7 +98,10 @@ export class BotRuntimeTransport {
   async connect(): Promise<void> {
     if (this.connecting || this.stopped) return
     if (this.socket) {
-      if (this.connected) return
+      if (this.connected) {
+        if (!this.helloReady) this.sendHello()
+        return
+      }
       const outageMs = Date.now() - (this.disconnectedAt ?? Date.now())
       if (outageMs < this.staleSocketRedialMs) return
       this.logFn(`socket disconnected for ${Math.round(outageMs / 1000)}s; redialing from a fresh hint`)
@@ -135,11 +140,14 @@ export class BotRuntimeTransport {
     this.disconnectedAt = Date.now()
     socket.on("connect", () => {
       this.connected = true
+      this.helloReady = false
       this.disconnectedAt = undefined
       this.sendHello()
     })
     socket.on("disconnect", (reason: string) => {
       this.connected = false
+      this.helloReady = false
+      this.helloInFlight = false
       this.disconnectedAt ??= Date.now()
       // Socket.IO's auto-reconnect covers every disconnect reason EXCEPT a
       // server-initiated one (deploy drain, kick) — there the client stays down
@@ -149,6 +157,8 @@ export class BotRuntimeTransport {
     })
     socket.on("connect_error", (error: unknown) => {
       this.connected = false
+      this.helloReady = false
+      this.helloInFlight = false
       this.disconnectedAt ??= Date.now()
       this.logFn(`socket connect_error: ${summarize(error)}`)
     })
@@ -161,33 +171,41 @@ export class BotRuntimeTransport {
     socket.on("bot:session_archived", (payload: unknown) => this.callbacks.onSessionArchived?.(payload))
     socket.on("bot:session_restored", (payload: unknown) => this.callbacks.onSessionRestored?.(payload))
     socket.on("bot:resync", () => {
-      this.sendHello()
       this.callbacks.onResync?.()
+      this.teardownSocket()
+      void this.connect()
     })
   }
 
   /** (Re)announce this instance + capabilities and pull the bootstrap snapshot. */
   sendHello(): void {
     const socket = this.socket
-    if (!socket) return
+    if (!socket || this.helloInFlight) return
+    this.helloInFlight = true
     this.beforeHello?.(this.hello)
-    socket.emit(
-      "bot:hello",
-      { ...this.hello, ...(this.cursor ? { sinceCursor: this.cursor } : {}) },
-      (ack: unknown) => {
-        if (!isObject(ack) || ack.ok !== true) {
-          this.logFn(`bot:hello rejected: ${isObject(ack) ? String(ack.error) : "no ack"}`)
-          return
+    socket
+      .timeout(this.wsAckTimeoutMs)
+      .emit(
+        "bot:hello",
+        { ...this.hello, ...(this.cursor ? { sinceCursor: this.cursor } : {}) },
+        (error: unknown, ack: unknown) => {
+          if (socket !== this.socket) return
+          this.helloInFlight = false
+          if (error || !isObject(ack) || ack.ok !== true) {
+            this.logFn(`bot:hello rejected: ${error ? summarize(error) : isObject(ack) ? String(ack.error) : "no ack"}`)
+            this.teardownSocket()
+            return
+          }
+          this.helloReady = true
+          if (typeof ack.serverGeneratedAt === "string") this.cursor = ack.serverGeneratedAt
+          const bootstrap: BotHelloBootstrap = {
+            serverGeneratedAt: typeof ack.serverGeneratedAt === "string" ? ack.serverGeneratedAt : undefined,
+            availableInvocations: Array.isArray(ack.availableInvocations) ? ack.availableInvocations : [],
+            ownedClaims: Array.isArray(ack.ownedClaims) ? ack.ownedClaims : [],
+          }
+          this.callbacks.onBootstrap?.(bootstrap)
         }
-        if (typeof ack.serverGeneratedAt === "string") this.cursor = ack.serverGeneratedAt
-        const bootstrap: BotHelloBootstrap = {
-          serverGeneratedAt: typeof ack.serverGeneratedAt === "string" ? ack.serverGeneratedAt : undefined,
-          availableInvocations: Array.isArray(ack.availableInvocations) ? ack.availableInvocations : [],
-          ownedClaims: Array.isArray(ack.ownedClaims) ? ack.ownedClaims : [],
-        }
-        this.callbacks.onBootstrap?.(bootstrap)
-      }
-    )
+      )
   }
 
   /** Tear the socket down (idempotent). After this the transport is HTTP-only and won't reconnect. */
@@ -199,6 +217,8 @@ export class BotRuntimeTransport {
   /** Drop the current socket without stopping the transport — the next `connect()` dials fresh. */
   private teardownSocket(): void {
     this.connected = false
+    this.helloReady = false
+    this.helloInFlight = false
     this.disconnectedAt = undefined
     const socket = this.socket
     this.socket = undefined
@@ -346,7 +366,7 @@ export class BotRuntimeTransport {
    */
   private emitWrite(event: string, payload: unknown): Promise<{ sent: boolean; ack: BotWriteAck | null }> {
     const socket = this.socket
-    if (!socket || !this.connected) return Promise.resolve({ sent: false, ack: null })
+    if (!socket || !this.connected || !this.helloReady) return Promise.resolve({ sent: false, ack: null })
     return new Promise((resolve) => {
       let settled = false
       const done = (result: { sent: boolean; ack: BotWriteAck | null }) => {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import threaRemote, { __testing } from "./threa-remote"
@@ -1671,6 +1671,113 @@ describe("session-scoped lifecycle isolation", () => {
     } finally {
       fetchSpy.mockRestore()
       rmSync(persistenceDirectory, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("reload claim continuity", () => {
+  test("restores, renews, and completes the in-flight claim after the extension cache is cleared", async () => {
+    const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
+    const pi = {
+      registerCommand: () => {},
+      on: (event: string, handler: (event: unknown, ctx: any) => Promise<void>) => handlers.set(event, handler),
+      sendUserMessage: () => {},
+    }
+    threaRemote(pi as never)
+
+    const runtimeSessionId = "runtime_reload"
+    const config = {
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        [runtimeSessionId]: {
+          enabled: true,
+          instanceId: "pi-reload",
+          runtimeSessionId,
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    }
+    let idle = false
+    const ctx = {
+      sessionManager: { getSessionId: () => runtimeSessionId, getBranch: () => [] },
+      isIdle: () => idle,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        setStatus: () => {},
+        notify: () => {},
+        theme: { fg: (_tone: string, text: string) => text },
+      },
+    }
+    const writes: Array<{ url: string; body?: Record<string, unknown> }> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      const url = String(input)
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined
+      writes.push({ url, body })
+      if (url.endsWith(`/api/workspaces/${config.workspaceId}/config`)) {
+        return new Response("", { status: 404 })
+      }
+      const data = url.endsWith("/bot-invocations/claim") ? null : {}
+      return new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+
+    try {
+      __testing.setConfigForTesting(config)
+      __testing.beginPendingInvocation({
+        id: "binv_reload",
+        activeStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        sourceMessageId: "msg_1",
+        promptMarkdown: "keep working",
+        claimToken: "claim_reload",
+        claimedInstanceId: "pi-reload",
+        claimExpiresAt: null,
+      } as never)
+
+      await handlers.get("session_shutdown")!({ reason: "reload" }, ctx)
+      const snapshotPath = __testing.pendingSnapshotPathForTesting(runtimeSessionId)
+      expect(existsSync(snapshotPath)).toBe(true)
+
+      await __testing.resetRuntimeForTesting()
+      __testing.setConfigForTesting(config)
+      expect(__testing.pendingInvocationId()).toBeUndefined()
+
+      await handlers.get("session_start")!({ reason: "reload" }, ctx)
+      expect(__testing.pendingInvocationId()).toBe("binv_reload")
+      expect(__testing.claimRenewTimerActive()).toBe(true)
+      expect(writes.some((write) => write.url.endsWith("/bot-invocations/binv_reload/renew"))).toBe(true)
+
+      idle = true
+      await handlers.get("agent_end")!(
+        {
+          messages: [
+            { role: "user", content: "keep working" },
+            { role: "assistant", content: "Finished after reload." },
+          ],
+        },
+        ctx
+      )
+
+      const completion = writes.find((write) => write.url.endsWith("/bot-invocations/binv_reload/complete"))
+      expect(completion?.body).toMatchObject({
+        instanceId: "pi-reload",
+        claimToken: "claim_reload",
+        finalMessageMarkdown: "Finished after reload.",
+      })
+      expect(__testing.pendingInvocationId()).toBeUndefined()
+      expect(__testing.claimRenewTimerActive()).toBe(false)
+      expect(existsSync(snapshotPath)).toBe(false)
+    } finally {
+      fetchSpy.mockRestore()
     }
   })
 })

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -910,6 +910,70 @@ describe("buildPersistedConfig", () => {
   })
 })
 
+describe("Pi reload session control", () => {
+  test("completes the control claim then queues reload through a command context", async () => {
+    const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>()
+    const followUps: Array<{ text: string; options: unknown }> = []
+    const pi = {
+      registerCommand: (name: string, options: { handler: (args: string, ctx: any) => Promise<void> }) =>
+        commands.set(name, options),
+      on: () => {},
+      sendUserMessage: (text: string, options: unknown) => followUps.push({ text, options }),
+    }
+    threaRemote(pi as never)
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+    })
+    const writes: string[] = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      writes.push(String(input))
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+    const eventContext = {
+      isIdle: () => true,
+      cwd: "/tmp",
+      sessionManager: { getSessionId: () => "runtime_reload_control" },
+      modelRegistry: { getAvailable: () => [] },
+    }
+
+    try {
+      await __testing.runReloadCommand(
+        pi as never,
+        {
+          id: "binv_reload_control",
+          activeStreamId: "stream_1",
+          sourceMessageId: "msg_1",
+          promptMarkdown: "/reload",
+          claimToken: "claim_reload_control",
+          claimedInstanceId: "pi-test",
+          claimExpiresAt: null,
+        } as never,
+        eventContext as never
+      )
+
+      expect(writes.some((url) => url.endsWith("/bot-invocations/binv_reload_control/complete"))).toBe(true)
+      expect(followUps).toEqual([{ text: "/threa-remote-reload", options: { deliverAs: "followUp" } }])
+      expect(__testing.reloadPending()).toBe(true)
+
+      let reloads = 0
+      await commands.get("threa-remote-reload")!.handler("", {
+        reload: async () => {
+          reloads++
+        },
+      })
+      expect(reloads).toBe(1)
+      expect(__testing.reloadPending()).toBe(false)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
 describe("Pi reconnect session control", () => {
   const invocation = {
     id: "binv_reconnect",
@@ -1776,6 +1840,68 @@ describe("reload claim continuity", () => {
       expect(__testing.pendingInvocationId()).toBeUndefined()
       expect(__testing.claimRenewTimerActive()).toBe(false)
       expect(existsSync(snapshotPath)).toBe(false)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
+describe("recovered completion retry", () => {
+  test("keeps the restored claim and retries a transient completion failure", async () => {
+    const runtimeSessionId = "runtime_recovered_completion"
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        [runtimeSessionId]: {
+          enabled: true,
+          instanceId: "pi-recovery",
+          runtimeSessionId,
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    })
+    __testing.beginPendingInvocation({
+      id: "binv_recovered_completion",
+      activeStreamId: "stream_1",
+      rootStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "finish me",
+      claimToken: "claim_recovery",
+      claimedInstanceId: "pi-recovery",
+      claimExpiresAt: null,
+    } as never)
+    const ctx = {
+      sessionManager: { getSessionId: () => runtimeSessionId },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+    }
+    let completionAttempts = 0
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/binv_recovered_completion/complete")) {
+        completionAttempts++
+        if (completionAttempts === 1) {
+          return new Response(JSON.stringify({ error: "temporary" }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          })
+        }
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+
+    try {
+      __testing.scheduleRecoveredCompletion("Recovered reply.", ctx as never)
+      await Bun.sleep(1200)
+      expect(completionAttempts).toBe(2)
+      expect(__testing.pendingInvocationId()).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
     }

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -111,6 +111,7 @@ const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000
 const MAX_RETRY_ATTEMPTS = 3
 const PI_TOOL_TRACE_FORMAT = "pi_tool_trace"
 const SESSION_CONTROL_CAPABILITY = "session-control"
+const RELOAD_HANDOFF_COMMAND = "threa-remote-reload"
 const SESSION_CONTROL_COMMANDS = [
   "compact",
   "model",
@@ -304,8 +305,10 @@ let pollingRunId = 0
 let fallbackRuntimeSessionId: string | undefined
 let supervisedRevivalBlocked = false
 let reconnectPending = false
+let reloadPending = false
 let claimIfIdleInFlight: Promise<boolean> | undefined
 let pendingSettlement: Promise<void> | undefined
+let recoveredCompletionTimer: ReturnType<typeof setTimeout> | undefined
 let claimIfIdleRerunRequested = false
 let sessionLifecycleGeneration = 0
 let sessionTearingDown = false
@@ -781,7 +784,7 @@ function buildRuntimeCapabilities(
 }
 
 function presenceBody(status: "available" | "busy" | "offline" | "error", statusText?: string, ctx?: ExtensionContext) {
-  const effectiveStatus = status === "available" && reconnectPending ? "busy" : status
+  const effectiveStatus = status === "available" && (reconnectPending || reloadPending) ? "busy" : status
   return {
     runtimeKind: "pi-local",
     instanceId: ctx ? getSessionInstanceId(ctx) : ensureInstanceId(),
@@ -1668,9 +1671,16 @@ function recoverFinalTextFromBranch(ctx: ExtensionContext): string | undefined {
     .at(-1)?.text
 }
 
+function clearRecoveredCompletionTimer(): void {
+  if (!recoveredCompletionTimer) return
+  clearTimeout(recoveredCompletionTimer)
+  recoveredCompletionTimer = undefined
+}
+
 function discardRestoredPending(ctx: ExtensionContext): void {
   stopClaimRenewTimer()
   clearPendingRetry()
+  clearRecoveredCompletionTimer()
   pending = undefined
   steeredInvocations = []
   pendingContextCursor = undefined
@@ -1685,6 +1695,40 @@ function discardRestoredPending(ctx: ExtensionContext): void {
   carryOnTexts = []
   lastTraceHeartbeat = undefined
   clearPendingSnapshot(ctx)
+}
+
+function scheduleRecoveredCompletion(finalText: string, ctx: ExtensionContext, delayMs = 0, attempt = 1): void {
+  const lifecycleGeneration = sessionLifecycleGeneration
+  clearRecoveredCompletionTimer()
+  recoveredCompletionTimer = setTimeout(() => {
+    recoveredCompletionTimer = undefined
+    if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration || !pending) return
+    const settlement = (async () => {
+      try {
+        await completePending(finalText, ctx)
+      } catch (error) {
+        if (error instanceof ThreaApiError && error.status === 404) {
+          discardRestoredPending(ctx)
+          return
+        }
+        const permanentClientError = error instanceof ThreaApiError && error.status >= 400 && error.status < 500
+        const hasAttachments = extractAttachmentDirectives(finalText).paths.length > 0
+        if (permanentClientError || hasAttachments) {
+          try {
+            await failPending(`Recovered completion failed: ${summarizeError(error)}`, ctx)
+          } catch {
+            discardRestoredPending(ctx)
+          }
+          return
+        }
+        scheduleRecoveredCompletion(finalText, ctx, Math.min(30_000, 1000 * 2 ** Math.min(attempt - 1, 5)), attempt + 1)
+      }
+    })()
+    pendingSettlement = settlement
+    void settlement.finally(() => {
+      if (pendingSettlement === settlement) pendingSettlement = undefined
+    })
+  }, delayMs)
 }
 
 async function restorePendingAfterReload(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
@@ -1741,7 +1785,7 @@ async function restorePendingAfterReload(pi: ExtensionAPI, ctx: ExtensionContext
 
   if (ctx.isIdle()) {
     const finalText = recoverFinalTextFromBranch(ctx)
-    if (finalText) await completePending(finalText, ctx)
+    if (finalText) scheduleRecoveredCompletion(finalText, ctx)
     else await failPending("Pi reloaded as the turn finished; the final response could not be recovered.", ctx)
     return
   }
@@ -2154,7 +2198,7 @@ function buildClaimInvocationBody(ctx: ExtensionContext): Record<string, unknown
 }
 
 async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvocation | null> {
-  if (!config || reconnectPending || sessionTearingDown) return null
+  if (!config || reconnectPending || reloadPending || sessionTearingDown) return null
   const startedAt = Date.now()
   try {
     const body = await request<{ data: (ClaimedInvocation & { sealedContext?: unknown }) | null }>(
@@ -2671,12 +2715,25 @@ async function runThinkingCommand(
   await completeInvocationWithMarkdown(invocation, `Thinking level changed: \`${before}\` → \`${after}\``, ctx)
 }
 
-async function runReloadCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
-  // Complete the invocation before reload — `await ctx.reload()` emits session_shutdown
-  // for this runtime, so any acknowledgement after the await would run against a
-  // pre-reload extension instance and may not survive.
-  await completeInvocationWithMarkdown(invocation, "Reloading Pi extensions, skills, prompts, and themes…", ctx)
-  await ctx.reload()
+async function runReloadCommand(pi: ExtensionAPI, invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
+  reloadPending = true
+  try {
+    const completed = await completeInvocationWithMarkdown(
+      invocation,
+      "Reloading Pi extensions, skills, prompts, and themes…",
+      ctx
+    )
+    if (!completed) {
+      reloadPending = false
+      const busy = pending !== undefined || !ctx.isIdle()
+      await heartbeat(busy ? "busy" : "available", busy ? "Busy in Pi…" : undefined, ctx).catch(() => undefined)
+      return
+    }
+    pi.sendUserMessage(`/${RELOAD_HANDOFF_COMMAND}`, { deliverAs: "followUp" })
+  } catch (error) {
+    reloadPending = false
+    throw error
+  }
 }
 
 type ShellExecResult = {
@@ -3098,7 +3155,7 @@ async function handleSessionControlInvocation(
         await runSkillCommand(pi, invocation, command.args, ctx)
         return
       case "reload":
-        await runReloadCommand(invocation, ctx)
+        await runReloadCommand(pi, invocation, ctx)
         return
       case "shell":
         await runShellCommand(invocation, command.args, ctx)
@@ -3291,7 +3348,7 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
     if (isSessionControlInvocation(invocation)) {
       const command = resolveSessionControlCommand(invocation)
       await handleSessionControlInvocation(pi, ctx, invocation)
-      if (command?.name === "stop" || reconnectPending) return true
+      if (command?.name === "stop" || reconnectPending || reloadPending) return true
     } else {
       await injectInvocation(pi, ctx, invocation, steer)
     }
@@ -3819,6 +3876,7 @@ async function completePending(markdown: string, ctx: ExtensionContext): Promise
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
   clearPendingSnapshot(ctx)
+  clearRecoveredCompletionTimer()
   await heartbeat("available", undefined, ctx)
 }
 
@@ -3851,6 +3909,7 @@ async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
   if (ctx) clearPendingSnapshot(ctx)
+  clearRecoveredCompletionTimer()
   await heartbeat("available", undefined, ctx).catch(() => undefined)
 }
 
@@ -3869,9 +3928,11 @@ async function resetRuntimeForTesting(): Promise<void> {
   sessionTearingDown = true
   sessionLifecycleGeneration++
   reconnectPending = false
+  reloadPending = false
   stopPolling()
   stopClaimRenewTimer()
   clearPendingRetry()
+  clearRecoveredCompletionTimer()
   teardownTransport()
   await claimIfIdleInFlight?.catch(() => undefined)
   await pendingSettlement?.catch(() => undefined)
@@ -3988,8 +4049,11 @@ export const __testing = {
   claimNextInvocation,
   claimIfIdle,
   runReconnectCommand,
+  runReloadCommand,
+  scheduleRecoveredCompletion,
   runKeyCommand,
   reconnectPending: () => reconnectPending,
+  reloadPending: () => reloadPending,
   sessionLifecycleGeneration: () => sessionLifecycleGeneration,
   sessionTearingDown: () => sessionTearingDown,
   teardownTransport,
@@ -3999,6 +4063,17 @@ export const __testing = {
 }
 
 export default function (pi: ExtensionAPI): void {
+  pi.registerCommand(RELOAD_HANDOFF_COMMAND, {
+    description: "Complete a Threa reload handoff",
+    handler: async (_args, ctx) => {
+      try {
+        await ctx.reload()
+      } finally {
+        reloadPending = false
+      }
+    },
+  })
+
   pi.registerCommand("remote-control", {
     description:
       "Link this Pi session to a Threa scratchpad: configure | status | open | rename <name> | on | off | debug | debug-polls [on|off]",
@@ -4130,6 +4205,7 @@ export default function (pi: ExtensionAPI): void {
     if (!config || !shouldHandleSessionEvents(ctx)) return
     sessionLifecycleGeneration++
     reconnectPending = false
+    reloadPending = false
     sessionTearingDown = false
     if (!isCurrentSessionEnabled(ctx)) {
       setRemoteStatus(ctx, getCurrentSessionLink(ctx) ? "Threa remote: off" : "Threa remote: not linked")
@@ -4303,6 +4379,7 @@ export default function (pi: ExtensionAPI): void {
     stopPolling()
     stopClaimRenewTimer()
     cancelPendingRetryTimer()
+    clearRecoveredCompletionTimer()
     await claimIfIdleInFlight?.catch(() => undefined)
     await pendingSettlement?.catch(() => undefined)
     if (event.reason === "reload" && config && isEnabled(ctx)) {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -17,6 +17,8 @@ import {
   BikKeystore,
   BotRuntimeTransport,
   THREA_CALLBACK_TOKEN_HEADER,
+  base64ToBytes,
+  bytesToBase64,
   decryptAttachmentBytes,
   encryptAttachmentBytes,
   mintStreamKeyWraps,
@@ -65,6 +67,11 @@ let CONFIG_PATH = join(DEFAULT_STORAGE_DIRECTORY, "threa-remote.json")
 // stable across restarts — the owner's wraps target its `publicKeyId`, so
 // rotating it would orphan every wrap.
 let BIK_PATH = join(DEFAULT_STORAGE_DIRECTORY, "threa-remote-bik.json")
+// Per-session sidecar (`threa-remote-pending-<runtimeSessionId>.json`) carrying
+// the in-flight claim across `/reload`: Pi clears the extension module cache on
+// reload, so every top-level binding (pending, the renew timer, captured texts)
+// is wiped and only disk state crosses the boundary.
+let PENDING_SNAPSHOT_DIRECTORY = DEFAULT_STORAGE_DIRECTORY
 const STATUS_KEY = "threa-remote"
 const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 /** Server cap on `attachmentIds` per sealed message (`sealedAttachmentIdsSchema` caps at 16). */
@@ -281,7 +288,7 @@ let pendingProviderError: string | undefined
 let pendingModelError: string | undefined
 let pendingRetryAfterMs: number | undefined
 let pendingInvocationPrompt: string | undefined
-let pendingRetry: { timer: ReturnType<typeof setTimeout>; retryAt: number; attempts: number } | undefined
+let pendingRetry: { timer?: ReturnType<typeof setTimeout>; retryAt: number; attempts: number } | undefined
 let isWaitingForRetry = false
 // User texts queued via /carry-on (and messages swept while rate-limited),
 // folded into the retry prompt when the wait ends.
@@ -298,6 +305,7 @@ let fallbackRuntimeSessionId: string | undefined
 let supervisedRevivalBlocked = false
 let reconnectPending = false
 let claimIfIdleInFlight: Promise<boolean> | undefined
+let pendingSettlement: Promise<void> | undefined
 let claimIfIdleRerunRequested = false
 let sessionLifecycleGeneration = 0
 let sessionTearingDown = false
@@ -653,6 +661,15 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
   }
 }
 
+class ThreaApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message)
+  }
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!config) throw new Error("Threa remote config not loaded")
   const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData
@@ -696,7 +713,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       }
     }
     detail = detail.slice(0, 500)
-    throw new Error(`Threa API ${response.status}: ${response.statusText}${detail ? ` — ${detail}` : ""}`)
+    throw new ThreaApiError(
+      response.status,
+      `Threa API ${response.status}: ${response.statusText}${detail ? ` — ${detail}` : ""}`
+    )
   }
   return (await response.json()) as T
 }
@@ -1424,8 +1444,8 @@ async function tryRebindLegacySessionInstance(ctx: ExtensionContext): Promise<vo
   }
 }
 
-async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<void> {
-  if (!config) return
+async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<boolean | undefined> {
+  if (!config) return undefined
   // pi runs the turn locally, so a `notFound` (claim gone server-side) does NOT
   // drop it — the turn completes and surfaces the gone claim at complete() (404);
   // we just log it so that loss isn't silent.
@@ -1437,17 +1457,23 @@ async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<void
       .catch(() => ({ notFound: false }))
     if (notFound) {
       console.error(`[threa-remote] renew ${invocation.id}: claim gone server-side; turn will close on completion`)
+      return false
     }
-    return
+    return true
   }
-  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/renew`, {
-    method: "POST",
-    body: JSON.stringify({
-      instanceId: getInvocationInstanceId(invocation),
-      claimToken: invocation.claimToken,
-      claimTtlSeconds: CLAIM_TTL_SECONDS,
-    }),
-  }).catch(() => undefined)
+  try {
+    await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/renew`, {
+      method: "POST",
+      body: JSON.stringify({
+        instanceId: getInvocationInstanceId(invocation),
+        claimToken: invocation.claimToken,
+        claimTtlSeconds: CLAIM_TTL_SECONDS,
+      }),
+    })
+    return true
+  } catch (error) {
+    return error instanceof ThreaApiError && error.status === 404 ? false : undefined
+  }
 }
 
 async function renewActiveClaims(): Promise<void> {
@@ -1469,6 +1495,257 @@ function stopClaimRenewTimer(): void {
   if (!claimRenewTimer) return
   clearInterval(claimRenewTimer)
   claimRenewTimer = undefined
+}
+
+type PendingTurnSnapshot = {
+  version: 1
+  savedAt: number
+  runtimeSessionId: string
+  workspaceId: string
+  instanceId: string
+  rootStreamId?: string
+  invocation: Record<string, unknown>
+  steered: Array<{ invocation: Record<string, unknown>; cursor?: string }>
+  contextCursor?: string
+  invocationPrompt?: string
+  waitingForRetry?: { retryAt: number; attempts: number; carryOnTexts: string[] }
+}
+
+function pendingSnapshotPath(runtimeSessionId: string): string {
+  return join(PENDING_SNAPSHOT_DIRECTORY, `threa-remote-pending-${runtimeSessionId}.json`)
+}
+
+function serializeInvocationForSnapshot(invocation: ClaimedInvocation): Record<string, unknown> {
+  const { sealing, ...rest } = invocation
+  if (!sealing) return rest
+  return {
+    ...rest,
+    sealing: {
+      ...sealing,
+      replySsk: bytesToBase64(sealing.replySsk),
+    },
+  }
+}
+
+function deserializeInvocationFromSnapshot(value: unknown): ClaimedInvocation | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const candidate = value as Record<string, unknown>
+  if (
+    typeof candidate.id !== "string" ||
+    typeof candidate.activeStreamId !== "string" ||
+    typeof candidate.sourceMessageId !== "string" ||
+    typeof candidate.promptMarkdown !== "string" ||
+    typeof candidate.claimToken !== "string"
+  ) {
+    return undefined
+  }
+  const invocation = { ...candidate } as unknown as ClaimedInvocation
+  if (candidate.sealing !== undefined) {
+    if (!candidate.sealing || typeof candidate.sealing !== "object") return undefined
+    const sealing = candidate.sealing as Record<string, unknown>
+    if (
+      typeof sealing.streamId !== "string" ||
+      typeof sealing.replyKeyGeneration !== "number" ||
+      typeof sealing.replySenderId !== "string" ||
+      typeof sealing.callbackToken !== "string" ||
+      typeof sealing.replySsk !== "string"
+    ) {
+      return undefined
+    }
+    invocation.sealing = {
+      streamId: sealing.streamId,
+      replyKeyGeneration: sealing.replyKeyGeneration,
+      replySenderId: sealing.replySenderId,
+      callbackToken: sealing.callbackToken,
+      replySsk: base64ToBytes(sealing.replySsk),
+    }
+  }
+  return invocation
+}
+
+function savePendingSnapshot(ctx: ExtensionContext): void {
+  if (!pending) return
+  const runtimeSessionId = getRuntimeSessionId(ctx)
+  const link = getCurrentSessionLink(ctx)
+  const snapshot: PendingTurnSnapshot = {
+    version: 1,
+    savedAt: Date.now(),
+    runtimeSessionId,
+    workspaceId: config?.workspaceId ?? "",
+    instanceId: getInvocationInstanceId(pending),
+    ...(link?.rootStreamId ? { rootStreamId: link.rootStreamId } : {}),
+    invocation: serializeInvocationForSnapshot(pending),
+    steered: steeredInvocations.map((item) => ({
+      invocation: serializeInvocationForSnapshot(item.invocation),
+      ...(item.cursor ? { cursor: item.cursor } : {}),
+    })),
+    ...(pendingContextCursor ? { contextCursor: pendingContextCursor } : {}),
+    ...(pendingInvocationPrompt ? { invocationPrompt: pendingInvocationPrompt } : {}),
+    ...(isWaitingForRetry && pendingRetry
+      ? {
+          waitingForRetry: {
+            retryAt: pendingRetry.retryAt,
+            attempts: pendingRetry.attempts,
+            carryOnTexts: [...carryOnTexts],
+          },
+        }
+      : {}),
+  }
+  try {
+    mkdirSync(PENDING_SNAPSHOT_DIRECTORY, { recursive: true })
+    const path = pendingSnapshotPath(runtimeSessionId)
+    const tmp = `${path}.${process.pid}.tmp`
+    writeFileSync(tmp, `${JSON.stringify(snapshot)}\n`, { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch (error) {
+    console.error(`Threa remote: pending snapshot save failed: ${summarizeError(error)}`)
+  }
+}
+
+function clearPendingSnapshot(ctx: ExtensionContext): void {
+  try {
+    unlinkSync(pendingSnapshotPath(getRuntimeSessionId(ctx)))
+  } catch {
+    // Already absent.
+  }
+}
+
+function readPendingSnapshot(ctx: ExtensionContext): PendingTurnSnapshot | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(pendingSnapshotPath(getRuntimeSessionId(ctx)), "utf8"))
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== "object") return undefined
+  const snapshot = parsed as Partial<PendingTurnSnapshot>
+  const link = getCurrentSessionLink(ctx)
+  if (
+    snapshot.version !== 1 ||
+    typeof snapshot.savedAt !== "number" ||
+    Date.now() - snapshot.savedAt > CLAIM_TTL_SECONDS * 1000 ||
+    snapshot.runtimeSessionId !== getRuntimeSessionId(ctx) ||
+    snapshot.workspaceId !== config?.workspaceId ||
+    snapshot.rootStreamId !== link?.rootStreamId ||
+    !snapshot.invocation ||
+    !Array.isArray(snapshot.steered)
+  ) {
+    return undefined
+  }
+  return snapshot as PendingTurnSnapshot
+}
+
+function recoverFinalTextFromBranch(ctx: ExtensionContext): string | undefined {
+  const messages: Array<{ role: string; text: string }> = []
+  for (const entry of ctx.sessionManager.getBranch()) {
+    if (entry.type !== "message") continue
+    const role = String(entry.message.role)
+    if (role !== "user" && role !== "assistant") continue
+    const text = textFromContent(entry.message.content).trim()
+    if (text) messages.push({ role, text })
+  }
+  let anchor = -1
+  if (pendingInvocationPrompt) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user" && messages[i]?.text === pendingInvocationPrompt) {
+        anchor = i
+        break
+      }
+    }
+  }
+  if (anchor < 0) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user") {
+        anchor = i
+        break
+      }
+    }
+  }
+  if (anchor < 0) return undefined
+  return messages
+    .slice(anchor + 1)
+    .filter((message) => message.role === "assistant")
+    .at(-1)?.text
+}
+
+function discardRestoredPending(ctx: ExtensionContext): void {
+  stopClaimRenewTimer()
+  clearPendingRetry()
+  pending = undefined
+  steeredInvocations = []
+  pendingContextCursor = undefined
+  pendingAssistantTexts = []
+  pendingNonAssistantTexts = []
+  pendingToolCalls = new Map()
+  pendingProviderError = undefined
+  pendingModelError = undefined
+  pendingRetryAfterMs = undefined
+  pendingInvocationPrompt = undefined
+  isWaitingForRetry = false
+  carryOnTexts = []
+  lastTraceHeartbeat = undefined
+  clearPendingSnapshot(ctx)
+}
+
+async function restorePendingAfterReload(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  const snapshot = readPendingSnapshot(ctx)
+  if (!snapshot) {
+    clearPendingSnapshot(ctx)
+    return
+  }
+  const invocation = deserializeInvocationFromSnapshot(snapshot.invocation)
+  if (
+    !invocation ||
+    snapshot.instanceId !== getInvocationInstanceId(invocation) ||
+    (await renewInvocationClaim(invocation)) === false
+  ) {
+    clearPendingSnapshot(ctx)
+    return
+  }
+  const restoredSteers = snapshot.steered.flatMap((item) => {
+    const restored = deserializeInvocationFromSnapshot(item.invocation)
+    return restored ? [{ invocation: restored, cursor: item.cursor }] : []
+  })
+  const steerRenewals = await Promise.all(restoredSteers.map((item) => renewInvocationClaim(item.invocation)))
+  pending = invocation
+  steeredInvocations = restoredSteers.filter((_, index) => steerRenewals[index] !== false)
+  pendingContextCursor = typeof snapshot.contextCursor === "string" ? snapshot.contextCursor : undefined
+  pendingInvocationPrompt = typeof snapshot.invocationPrompt === "string" ? snapshot.invocationPrompt : undefined
+  startClaimRenewTimer()
+  await recordTraceStep(
+    "context_received",
+    "Pi reloaded its extensions; resuming the in-flight invocation.",
+    "Resumed after reload…"
+  ).catch(() => undefined)
+
+  const waiting = snapshot.waitingForRetry
+  if (waiting && typeof waiting.retryAt === "number") {
+    isWaitingForRetry = true
+    carryOnTexts = Array.isArray(waiting.carryOnTexts)
+      ? waiting.carryOnTexts.filter((text): text is string => typeof text === "string")
+      : []
+    const attempts = typeof waiting.attempts === "number" ? waiting.attempts : 1
+    const retryAt = Math.max(Date.now(), waiting.retryAt)
+    const lifecycleGeneration = sessionLifecycleGeneration
+    pendingRetry = {
+      timer: setTimeout(
+        () => void executeProviderRetry(pi, ctx, attempts, lifecycleGeneration).catch(() => undefined),
+        retryAt - Date.now()
+      ),
+      retryAt,
+      attempts,
+    }
+    setRemoteStatus(ctx, `Threa remote: retry ${formatLocalTime(new Date(retryAt))}`)
+    return
+  }
+
+  if (ctx.isIdle()) {
+    const finalText = recoverFinalTextFromBranch(ctx)
+    if (finalText) await completePending(finalText, ctx)
+    else await failPending("Pi reloaded as the turn finished; the final response could not be recovered.", ctx)
+    return
+  }
+  setRemoteStatus(ctx, `Threa remote: running ${invocation.id}`)
 }
 
 function isEnabled(ctx: ExtensionContext): boolean {
@@ -2189,9 +2466,14 @@ function beginPendingInvocation(invocation: ClaimedInvocation, cursor?: string):
   lastTraceHeartbeat = undefined
 }
 
-function clearPendingRetry(): void {
-  if (!pendingRetry) return
+function cancelPendingRetryTimer(): void {
+  if (!pendingRetry?.timer) return
   clearTimeout(pendingRetry.timer)
+  pendingRetry.timer = undefined
+}
+
+function clearPendingRetry(): void {
+  cancelPendingRetryTimer()
   pendingRetry = undefined
 }
 
@@ -2867,25 +3149,34 @@ async function scheduleProviderRetry(
   if (!pending) return
   const retryAt = Date.now() + retryAfterMs
   const notice = formatRetryNotice(retryAfterMs, attempt)
+  const lifecycleGeneration = sessionLifecycleGeneration
+  isWaitingForRetry = true
+  pendingRetry = { retryAt, attempts: attempt }
   await recordTraceStep("rate_limited", notice, "Rate limited; waiting…").catch(() => undefined)
+  if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) return
   setRemoteStatus(ctx, `Threa remote: retry ${formatLocalTime(new Date(retryAt))}`)
   lastBusyHeartbeatAt = 0
   await heartbeat("busy", notice.slice(0, 160), ctx).catch(() => undefined)
-  isWaitingForRetry = true
-  pendingRetry = {
-    timer: setTimeout(() => {
-      void executeProviderRetry(pi, ctx, attempt)
-    }, retryAfterMs),
-    retryAt,
-    attempts: attempt,
-  }
+  if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration || !pendingRetry) return
+  pendingRetry.timer = setTimeout(
+    () => {
+      void executeProviderRetry(pi, ctx, attempt, lifecycleGeneration).catch(() => undefined)
+    },
+    Math.max(0, retryAt - Date.now())
+  )
 }
 
-async function executeProviderRetry(pi: ExtensionAPI, ctx: ExtensionContext, attempt: number): Promise<void> {
-  pendingRetry = undefined
+async function executeProviderRetry(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  attempt: number,
+  lifecycleGeneration: number
+): Promise<void> {
+  if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) return
   const invocation = pending
   const prompt = pendingInvocationPrompt
   if (!invocation) {
+    pendingRetry = undefined
     isWaitingForRetry = false
     return
   }
@@ -2898,16 +3189,19 @@ async function executeProviderRetry(pi: ExtensionAPI, ctx: ExtensionContext, att
     return
   }
   resetPendingTurnTexts()
-  isWaitingForRetry = false
   await recordTraceStep(
     "rate_limit_retry",
     `Retrying after rate limit (attempt ${attempt} of ${MAX_RETRY_ATTEMPTS}).`,
     "Retrying…"
   ).catch(() => undefined)
+  if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) return
   setRemoteStatus(ctx, `Threa remote: running ${invocation.id}`)
   lastBusyHeartbeatAt = 0
   await heartbeat("busy", "Retrying after rate limit…", ctx).catch(() => undefined)
+  if (sessionTearingDown || lifecycleGeneration !== sessionLifecycleGeneration) return
   const queued = carryOnTexts
+  pendingRetry = undefined
+  isWaitingForRetry = false
   carryOnTexts = []
   pi.sendUserMessage(buildRetryPrompt(prompt, queued))
 }
@@ -3524,6 +3818,7 @@ async function completePending(markdown: string, ctx: ExtensionContext): Promise
   carryOnTexts = []
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
+  clearPendingSnapshot(ctx)
   await heartbeat("available", undefined, ctx)
 }
 
@@ -3555,6 +3850,7 @@ async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void
   isWaitingForRetry = false
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
+  if (ctx) clearPendingSnapshot(ctx)
   await heartbeat("available", undefined, ctx).catch(() => undefined)
 }
 
@@ -3562,6 +3858,7 @@ async function setStorageDirectoryForTesting(directory: string): Promise<void> {
   if (!isTestEntrypoint()) throw new Error("Test storage can only be configured under bun test")
   await resetRuntimeForTesting()
   const resolved = resolve(directory)
+  PENDING_SNAPSHOT_DIRECTORY = resolved
   CONFIG_PATH = join(resolved, "threa-remote.json")
   CONFIG_LOCK_PATH = `${CONFIG_PATH}.lock`
   BIK_PATH = join(resolved, "threa-remote-bik.json")
@@ -3577,7 +3874,9 @@ async function resetRuntimeForTesting(): Promise<void> {
   clearPendingRetry()
   teardownTransport()
   await claimIfIdleInFlight?.catch(() => undefined)
+  await pendingSettlement?.catch(() => undefined)
   claimIfIdleInFlight = undefined
+  pendingSettlement = undefined
   claimIfIdleRerunRequested = false
   config = undefined
   pollInFlightRunId = undefined
@@ -3624,6 +3923,8 @@ export const __testing = {
   },
   setStorageDirectoryForTesting,
   storagePaths: () => ({ configPath: CONFIG_PATH, lockPath: CONFIG_LOCK_PATH, bikPath: BIK_PATH }),
+  pendingSnapshotPathForTesting: (runtimeSessionId: string) => pendingSnapshotPath(runtimeSessionId),
+  pendingInvocationId: () => pending?.id,
   defaultStorageDirectoryForTesting: (entrypoint?: string) =>
     isTestEntrypoint(entrypoint)
       ? join(tmpdir(), `threa-pi-remote-tests-${process.pid}`)
@@ -3840,7 +4141,17 @@ export default function (pi: ExtensionAPI): void {
       return
     }
     lastBusyHeartbeatAt = 0
-    await heartbeat("available", undefined, ctx)
+    if (event.reason === "reload") {
+      try {
+        await restorePendingAfterReload(pi, ctx)
+      } catch (error) {
+        discardRestoredPending(ctx)
+        ctx.ui.notify(`Threa reload claim recovery failed: ${summarizeError(error)}`, "warning")
+      }
+    } else {
+      clearPendingSnapshot(ctx)
+    }
+    await heartbeat(pending ? "busy" : "available", pending ? "Working on Threa invocation…" : undefined, ctx)
     await ensureTransport(pi, ctx)?.connect()
     startPolling(pi, ctx)
     if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")
@@ -3922,7 +4233,7 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("agent_end", async (event, ctx) => {
-    if (!shouldHandleSessionEvents(ctx)) return
+    if (!shouldHandleSessionEvents(ctx) || sessionTearingDown) return
     if (!pending) {
       if (config && isEnabled(ctx)) {
         lastBusyHeartbeatAt = 0
@@ -3931,38 +4242,46 @@ export default function (pi: ExtensionAPI): void {
       return
     }
     if (isWaitingForRetry) return
-    if (pendingRetryAfterMs !== undefined && pendingAssistantTexts.length === 0) {
-      const attempt = (pendingRetry?.attempts ?? 0) + 1
-      if (attempt <= MAX_RETRY_ATTEMPTS) {
-        await scheduleProviderRetry(pi, ctx, pendingRetryAfterMs, attempt)
-        return
+    const settlement = (async () => {
+      if (pendingRetryAfterMs !== undefined && pendingAssistantTexts.length === 0) {
+        const attempt = (pendingRetry?.attempts ?? 0) + 1
+        if (attempt <= MAX_RETRY_ATTEMPTS) {
+          await scheduleProviderRetry(pi, ctx, pendingRetryAfterMs, attempt)
+          return
+        }
       }
-    }
+      try {
+        const finalText = resolveFinalText(event, {
+          assistantTexts: pendingAssistantTexts,
+          otherTexts: pendingNonAssistantTexts,
+          providerError: pendingProviderError,
+          modelError: pendingModelError,
+        })
+        // When the reply is the model's final assistant message, it was already
+        // recorded as the last `thinking` trace step in `message_end` — recording
+        // a `message_sent` step too would duplicate it in the trace dialog. Only
+        // record `message_sent` for the fallback paths (provider error, event
+        // error, non-assistant text) where there is no preceding thinking step.
+        if (pendingAssistantTexts.length === 0) {
+          const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
+          await recordTraceStep(
+            "message_sent",
+            `Final response:\n\n${sanitizeTraceText(traceFinalText)}`,
+            "Sent response"
+          )
+        }
+        await completePending(finalText, ctx)
+        setRemoteStatus(ctx, "Threa remote: linked")
+      } catch (error) {
+        ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
+        await failPending(error, ctx)
+      }
+    })()
+    pendingSettlement = settlement
     try {
-      const finalText = resolveFinalText(event, {
-        assistantTexts: pendingAssistantTexts,
-        otherTexts: pendingNonAssistantTexts,
-        providerError: pendingProviderError,
-        modelError: pendingModelError,
-      })
-      // When the reply is the model's final assistant message, it was already
-      // recorded as the last `thinking` trace step in `message_end` — recording
-      // a `message_sent` step too would duplicate it in the trace dialog. Only
-      // record `message_sent` for the fallback paths (provider error, event
-      // error, non-assistant text) where there is no preceding thinking step.
-      if (pendingAssistantTexts.length === 0) {
-        const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
-        await recordTraceStep(
-          "message_sent",
-          `Final response:\n\n${sanitizeTraceText(traceFinalText)}`,
-          "Sent response"
-        )
-      }
-      await completePending(finalText, ctx)
-      setRemoteStatus(ctx, "Threa remote: linked")
-    } catch (error) {
-      ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
-      await failPending(error, ctx)
+      await settlement
+    } finally {
+      if (pendingSettlement === settlement) pendingSettlement = undefined
     }
   })
 
@@ -3983,7 +4302,13 @@ export default function (pi: ExtensionAPI): void {
     reconnectPending = false
     stopPolling()
     stopClaimRenewTimer()
+    cancelPendingRetryTimer()
     await claimIfIdleInFlight?.catch(() => undefined)
+    await pendingSettlement?.catch(() => undefined)
+    if (event.reason === "reload" && config && isEnabled(ctx)) {
+      if (pending) savePendingSnapshot(ctx)
+      else clearPendingSnapshot(ctx)
+    }
     teardownTransport()
     if (event.reason === "reload" && config && isEnabled(ctx)) {
       setRemoteStatus(ctx, "Threa remote: reloading…")


### PR DESCRIPTION
**Problem**

Pi remote `/reload` had two independent failure modes. The control path acknowledged the invocation and then called `reload()` on an `ExtensionContext` that does not expose it; calling reload directly inside the claim drain would also deadlock because shutdown waits for that drain. Separately, a connected Socket.IO transport was treated as healthy before `bot:hello` registration succeeded, switching HTTP polling from seconds to the 15-minute backstop and stranding exact-session messages.

**Solution**

- Persist in-flight claim credentials and turn/retry/sealed state per runtime session across genuine extension cache resets; fence and drain claim/completion races before snapshot.
- Complete the `/reload` control claim, gate intake, then queue a private follow-up Pi command. Its `ExtensionCommandContext` performs reload only after the claim drain unwinds.
- Track `helloReady` separately from raw socket connectivity. Failed/timed-out hello tears down the socket; HTTP polling stays fast until registration succeeds; resync uses a fresh connection.
- Retry transient recovered completions while renewing the claim; discard definitive 404s and fail permanent/attachment completion errors without duplicate uploads.
- Preserve exact `runtimeSessionId` routing. Backend claim/presence semantics required no change.

**Files**

| File | Change |
| ---- | ------ |
| `extensions/pi-remote/src/threa-remote.ts` | Claim checkpointing, reload command handoff, intake fencing, settlement/retry recovery. |
| `extensions/pi-remote/src/threa-remote.test.ts` | Cache-reset, command-context handoff, original-token completion, transient recovery tests. |
| `extensions/bot-runtime-client/src/transport.ts` | Hello readiness, rejection/redial, and fresh resync connection. |
| `extensions/bot-runtime-client/src/transport.test.ts` | Slow/rejected hello and polling-readiness regressions. |

**Test plan**

- [x] `bun test ./extensions/bot-runtime-client/src ./extensions/pi-remote/src` — 197 pass
- [x] `bun run typecheck` — all workspaces clean
- [x] pre-commit lint, Dockerfile/migration checks, API docs check, and typecheck
- [x] local standalone install via `bun run extensions/pi-remote/install-local.ts`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
