### PR TITLE
feat: unlock read frontiers without membership

### DIFF
--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -425,6 +425,7 @@ describe("ActivityService born-read for already-read recipients", () => {
     expect(captured.readUserIds && [...captured.readUserIds]).toEqual([TARGET_USER_ID])
     expect(streamsBarrel.usersReadThroughEffective).toHaveBeenCalledWith(
       {},
+      WORKSPACE_ID,
       STREAM_ID,
       [TARGET_USER_ID, BEHIND_USER_ID],
       50n

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -116,7 +116,13 @@ export class ActivityService {
       const authorName = await this.resolveAuthorName(client, workspaceId, actorId, actorType)
 
       const recipientIds = [...userIds]
-      const readUserIds = await this.resolveAlreadyReadRecipients(client, streamId, messageId, recipientIds)
+      const readUserIds = await this.resolveAlreadyReadRecipients(
+        client,
+        workspaceId,
+        streamId,
+        messageId,
+        recipientIds
+      )
 
       return ActivityRepository.insertBatch(client, {
         workspaceId,
@@ -264,7 +270,13 @@ export class ActivityService {
         })
         .map((row) => row.memberId)
 
-      const readUserIds = await this.resolveAlreadyReadRecipients(client, streamId, messageId, eligibleUserIds)
+      const readUserIds = await this.resolveAlreadyReadRecipients(
+        client,
+        workspaceId,
+        streamId,
+        messageId,
+        eligibleUserIds
+      )
 
       return ActivityRepository.insertBatch(client, {
         workspaceId,
@@ -318,11 +330,13 @@ export class ActivityService {
    * yet (nothing to compare against), leaving every recipient unread.
    *
    * Read truth is the effective frontier (read cutover): a `stream_read_state`
-   * row wins when present, membership fills absent rows. The recipient universe
-   * stays the caller's member-filtered set — chunk 3 expands non-member coverage.
+   * row wins when present — membership-agnostic, so access-without-membership
+   * viewers (INV-62) are covered — and the membership column fills absent rows.
+   * The recipient universe stays the caller's access-filtered set.
    */
   private async resolveAlreadyReadRecipients(
     client: PoolClient,
+    workspaceId: string,
     streamId: string,
     messageId: string,
     userIds: string[]
@@ -330,7 +344,7 @@ export class ActivityService {
     if (userIds.length === 0) return new Set()
     const messageEvent = await StreamEventRepository.findByMessageId(client, streamId, messageId)
     if (!messageEvent) return new Set()
-    return usersReadThroughEffective(client, streamId, userIds, messageEvent.sequence)
+    return usersReadThroughEffective(client, workspaceId, streamId, userIds, messageEvent.sequence)
   }
 
   /**

--- a/apps/backend/src/features/conversations/service.test.ts
+++ b/apps/backend/src/features/conversations/service.test.ts
@@ -3,6 +3,8 @@ import { ConversationService } from "./service"
 import * as dbModule from "../../db"
 import { ConversationRepository, type Conversation } from "./repository"
 import { StreamRepository } from "../streams"
+import * as streamsModule from "../streams"
+import { MessageRepository, type Message } from "../messaging"
 import * as delivery from "./conversation-delivery"
 import { OutboxRepository } from "../../lib/outbox"
 
@@ -65,5 +67,123 @@ describe("ConversationService.updateConversation — user status lock", () => {
     const params = updateSpy.mock.calls[0]![3] as { topicSummary?: string; statusLockedByUser?: boolean }
     expect(params.topicSummary).toBe("New title")
     expect(params.statusLockedByUser).toBeUndefined()
+  })
+})
+
+function fakeMessage(id: string, streamId: string, createdAt: string): Message {
+  return { id, streamId, createdAt: new Date(createdAt) } as Message
+}
+
+describe("ConversationService.markRead/markUnread — conversation boundary", () => {
+  beforeEach(() => {
+    spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, cb: (client: unknown) => unknown) =>
+      cb({})) as never)
+  })
+
+  afterEach(() => mock.restore())
+
+  test("rejects a foreign target message (not a conversation member) before any sparse write", async () => {
+    spyOn(ConversationRepository, "findById").mockResolvedValue(
+      fakeConversation({ messageIds: ["m1"], secondaryMessageIds: [] })
+    )
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_1",
+      rootStreamId: null,
+      type: "channel",
+      workspaceId: "ws_1",
+    } as never)
+    const applyRead = spyOn(streamsModule, "applySparseRead").mockResolvedValue({} as never)
+    const applyUnread = spyOn(streamsModule, "applySparseUnread").mockResolvedValue({} as never)
+
+    const service = new ConversationService(POOL)
+    await expect(
+      service.markRead({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        throughMessageId: "msg_foreign",
+        userId: "user_1",
+      })
+    ).rejects.toMatchObject({ status: 404, code: "MESSAGE_NOT_FOUND" })
+
+    expect(applyRead).not.toHaveBeenCalled()
+    expect(applyUnread).not.toHaveBeenCalled()
+  })
+
+  test("rejects a stale/corrupt member pointing at a foreign-stream before any sparse write", async () => {
+    spyOn(ConversationRepository, "findById").mockResolvedValue(
+      fakeConversation({ messageIds: ["m1", "m2"], secondaryMessageIds: [] })
+    )
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_1",
+      rootStreamId: null,
+      type: "channel",
+      workspaceId: "ws_1",
+    } as never)
+    // m1 (the target) lives in the conversation's stream; m2 is a corrupt member
+    // whose stream sits in another workspace. m2 is earlier so the read cutoff
+    // (<= target.createdAt) includes it — its stream reaches the boundary guard.
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        ["m1", fakeMessage("m1", "stream_1", "2026-01-02T00:00:00.000Z")],
+        ["m2", fakeMessage("m2", "stream_foreign", "2026-01-01T00:00:00.000Z")],
+      ])
+    )
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      { id: "stream_1", rootStreamId: null, workspaceId: "ws_1" } as never,
+      { id: "stream_foreign", rootStreamId: null, workspaceId: "ws_OTHER" } as never,
+    ])
+    const applyRead = spyOn(streamsModule, "applySparseRead").mockResolvedValue({} as never)
+    const applyUnread = spyOn(streamsModule, "applySparseUnread").mockResolvedValue({} as never)
+
+    const service = new ConversationService(POOL)
+    await expect(
+      service.markRead({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        throughMessageId: "m1",
+        userId: "user_1",
+      })
+    ).rejects.toMatchObject({ status: 404, code: "MESSAGE_NOT_FOUND" })
+
+    expect(applyRead).not.toHaveBeenCalled()
+    expect(applyUnread).not.toHaveBeenCalled()
+  })
+
+  test("rejects a member stream that resolves to a different effective root (INV-62)", async () => {
+    spyOn(ConversationRepository, "findById").mockResolvedValue(
+      fakeConversation({ messageIds: ["m1", "m2"], secondaryMessageIds: [] })
+    )
+    // Conversation lives under root stream_1.
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_1",
+      rootStreamId: null,
+      type: "channel",
+      workspaceId: "ws_1",
+    } as never)
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        ["m1", fakeMessage("m1", "stream_1", "2026-01-02T00:00:00.000Z")],
+        // Same workspace, but a thread under a DIFFERENT root — foreign to this
+        // conversation even though the workspace matches.
+        ["m2", fakeMessage("m2", "thread_other_root", "2026-01-01T00:00:00.000Z")],
+      ])
+    )
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      { id: "stream_1", rootStreamId: null, workspaceId: "ws_1" } as never,
+      { id: "thread_other_root", rootStreamId: "stream_OTHER_ROOT", workspaceId: "ws_1" } as never,
+    ])
+    const applyRead = spyOn(streamsModule, "applySparseRead").mockResolvedValue({} as never)
+
+    const service = new ConversationService(POOL)
+    await expect(
+      service.markRead({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        throughMessageId: "m1",
+        userId: "user_1",
+      })
+    ).rejects.toMatchObject({ status: 404, code: "MESSAGE_NOT_FOUND" })
+
+    expect(applyRead).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -1410,9 +1410,16 @@ export class ConversationService {
       memberSet.add(stream.parentAnchorId)
     }
 
-    const fetchIds = new Set(memberSet)
-    fetchIds.add(targetMessageId)
-    const messagesMap = await MessageRepository.findByIds(client, [...fetchIds])
+    // The target must be one of the conversation's concrete member messages
+    // (including the thread-opening parent added above). A foreign id — a
+    // message that exists but isn't part of this conversation — must not supply
+    // the cross-stream cutoff timestamp (it would read/unread an arbitrary span
+    // of the conversation). Reject before any resolution or write.
+    if (!memberSet.has(targetMessageId)) {
+      throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+    }
+
+    const messagesMap = await MessageRepository.findByIds(client, [...memberSet])
 
     const target = messagesMap.get(targetMessageId)
     if (!target) {
@@ -1430,6 +1437,29 @@ export class ConversationService {
       const list = groups.get(message.streamId)
       if (list) list.push(id)
       else groups.set(message.streamId, [id])
+    }
+
+    // Boundary guard: every distinct stream the resolved messages live in must
+    // belong to this workspace and resolve (INV-62) to the same effective root
+    // as the conversation. A stale/corrupt member pointing at a foreign stream
+    // (cross-workspace, or a different thread root) must not be written. Runs
+    // over distinct streams only (one batch lookup, not per-message) and BEFORE
+    // any applySparseRead/Unread write.
+    const conversationRoot = stream?.rootStreamId ?? conversation.streamId
+    const memberStreams = await StreamRepository.findByIds(client, [...groups.keys()])
+    const memberStreamById = new Map(memberStreams.map((s) => [s.id, s]))
+    for (const memberStreamId of groups.keys()) {
+      const memberStream = memberStreamById.get(memberStreamId)
+      // A missing row, a cross-workspace stream, or a stream whose effective
+      // root (thread → root, same rule as `effectiveRootId`) differs from the
+      // conversation's root is foreign to this conversation.
+      if (
+        !memberStream ||
+        memberStream.workspaceId !== workspaceId ||
+        (memberStream.rootStreamId ?? memberStream.id) !== conversationRoot
+      ) {
+        throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+      }
     }
 
     // Map keys are unique, so a strict less-than comparator totally orders them.

--- a/apps/backend/src/features/streams/effective-read-state.test.ts
+++ b/apps/backend/src/features/streams/effective-read-state.test.ts
@@ -86,46 +86,41 @@ describe("getEffectiveReadState", () => {
 describe("usersReadThroughEffective", () => {
   test("no-ops without querying on an empty user list", async () => {
     const { db, query } = makeDb()
-    expect(await usersReadThroughEffective(db, "stream_1", [], 10n)).toEqual(new Set())
+    expect(await usersReadThroughEffective(db, "ws_1", "stream_1", [], 10n)).toEqual(new Set())
     expect(query).not.toHaveBeenCalled()
   })
 
-  test("membership fallback only applies to users WITHOUT a read-state row", async () => {
+  test("read-state branch is membership-agnostic — access, not membership, gates born-read", async () => {
     const { db, query } = makeDb()
-    await usersReadThroughEffective(db, "stream_1", ["usr_a", "usr_b"], 42n)
+    await usersReadThroughEffective(db, "ws_1", "stream_1", ["usr_a", "usr_b"], 42n)
 
     const text = flat(sqlText(query.mock.calls[0]))
-    // Read-state branch: watermark sequence resolved via stream_events.
-    expect(text).toContain("FROM stream_read_state rs")
-    expect(text).toContain("JOIN stream_events se ON se.id = rs.last_read_event_id")
-    expect(text).toContain("se.sequence >= $3")
+    // Read-state branch: watermark sequence resolved via stream_events, with
+    // NO stream_members join — a non-member viewer's own row qualifies
+    // (INV-62 access without membership), closing the late-insert race.
+    expect(text).toContain("FROM stream_read_state rs JOIN stream_events se ON se.id = rs.last_read_event_id")
+    expect(text).not.toContain("JOIN stream_members sm ON sm.stream_id = rs.stream_id")
+    expect(text).toContain("rs.workspace_id = $1")
     // Membership branch guarded by row absence — a present row (even with a
     // NULL watermark) never falls through to the membership column.
     expect(text).toContain("FROM stream_members sm")
     expect(text).toContain("NOT EXISTS")
     expect(text).toContain("rs.user_id = sm.member_id")
     expect(text).toContain("UNION")
-  })
-
-  test("read-state branch requires a CURRENT stream_members row — retained rows for former/non-members are excluded (chunk 2)", async () => {
-    const { db, query } = makeDb()
-    await usersReadThroughEffective(db, "stream_1", ["usr_a"], 42n)
-
-    const text = flat(sqlText(query.mock.calls[0]))
-    // The read-state branch joins the current membership on (stream_id,
-    // user_id): a retained stream_read_state row for a removed member finds
-    // no stream_members row and drops out of the born-read set. Chunk 3
-    // deliberately removes this gate.
-    expect(text).toContain("JOIN stream_members sm ON sm.stream_id = rs.stream_id AND sm.member_id = rs.user_id")
-    // Row presence stays authoritative WITHIN the member universe: a present
-    // row (even NULL watermark) still blocks the membership fallback.
-    expect(text).toContain("NOT EXISTS")
-    expect(text).toContain("rs.user_id = sm.member_id")
+    // INV-8 hardening on the membership fallback: it joins `streams` on the
+    // membership's stream and requires the workspace match, and binds the
+    // watermark event to that same stream (not just by event id) — a
+    // stale/corrupt cross-workspace watermark can't qualify a member.
+    expect(text).toContain("JOIN streams s ON s.id = sm.stream_id")
+    expect(text).toContain("s.workspace_id =")
+    expect(text).toContain("se.stream_id = sm.stream_id")
+    // Row-presence stays authoritative, now workspace-scoped.
+    expect(text).toContain("rs.user_id = sm.member_id AND rs.workspace_id =")
   })
 
   test("maps the returned user ids into the born-read set", async () => {
     const { db } = makeDb([{ user_id: "usr_a" }, { user_id: "usr_b" }])
-    expect(await usersReadThroughEffective(db, "stream_1", ["usr_a", "usr_b", "usr_c"], 42n)).toEqual(
+    expect(await usersReadThroughEffective(db, "ws_1", "stream_1", ["usr_a", "usr_b", "usr_c"], 42n)).toEqual(
       new Set(["usr_a", "usr_b"])
     )
   })

--- a/apps/backend/src/features/streams/effective-read-state.ts
+++ b/apps/backend/src/features/streams/effective-read-state.ts
@@ -47,17 +47,19 @@ export async function getEffectiveReadState(
  * `stream_read_state` row is consulted first and is authoritative when present
  * (a NULL watermark counts as "before the first message" and never falls
  * through to a non-null membership column); the membership watermark fills only
- * users with no read-state row. The candidate universe is the caller's
- * (member-filtered) — this changes the read-truth source, not the recipients.
- *
- * Chunk 2 scope: the read-state branch ALSO requires a current `stream_members`
- * row for (stream_id, user_id) — a retained row for a removed/non-member is
- * excluded from the born-read set. Row presence stays authoritative within the
- * member universe (a present NULL still joins no event and reads as unread).
- * Chunk 3 deliberately removes this current-membership gate.
+ * users with no read-state row. The candidate universe stays the caller's
+ * access/recipient set — read state is user-anchored, NOT membership-gated
+ * (non-member unlock): a viewer who inherits thread access from the root
+ * (INV-62) reads as born-read off their own row, which closes the late-insert
+ * race where an activity row lands between their read-clear and the response.
+ * The membership fallback leg is workspace-scoped (INV-8): it joins `streams`
+ * on the membership's stream and requires `streams.workspace_id` match, and
+ * binds the watermark event to that same stream (not just by event id) so a
+ * stale/corrupt cross-workspace watermark can't qualify a member.
  */
 export async function usersReadThroughEffective(
   db: Querier,
+  workspaceId: string,
   streamId: string,
   userIds: string[],
   sequence: bigint
@@ -66,21 +68,23 @@ export async function usersReadThroughEffective(
   const result = await db.query<{ user_id: string }>(sql`
     SELECT rs.user_id
     FROM stream_read_state rs
-    JOIN stream_members sm ON sm.stream_id = rs.stream_id AND sm.member_id = rs.user_id
     JOIN stream_events se ON se.id = rs.last_read_event_id
-    WHERE rs.stream_id = ${streamId}
+    WHERE rs.workspace_id = ${workspaceId}
+      AND rs.stream_id = ${streamId}
       AND rs.user_id = ANY(${userIds})
       AND se.sequence >= ${sequence.toString()}
     UNION
     SELECT sm.member_id
     FROM stream_members sm
-    JOIN stream_events se ON se.id = sm.last_read_event_id
+    JOIN streams s ON s.id = sm.stream_id
+    JOIN stream_events se ON se.id = sm.last_read_event_id AND se.stream_id = sm.stream_id
     WHERE sm.stream_id = ${streamId}
+      AND s.workspace_id = ${workspaceId}
       AND sm.member_id = ANY(${userIds})
       AND se.sequence >= ${sequence.toString()}
       AND NOT EXISTS (
         SELECT 1 FROM stream_read_state rs
-        WHERE rs.stream_id = ${streamId} AND rs.user_id = sm.member_id
+        WHERE rs.stream_id = ${streamId} AND rs.user_id = sm.member_id AND rs.workspace_id = ${workspaceId}
       )
   `)
   return new Set(result.rows.map((row) => row.user_id))

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -496,6 +496,53 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "ws_1", "stream_thread")
   })
 
+  it("returns null membership for a non-member unread — the same-class 404 is gone", async () => {
+    const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
+    const markUnread = mock(() => Promise.resolve(null))
+    const handlers = makeHandlers({ validateStreamAccess, markUnread } as Partial<StreamService>, {
+      markStreamActivityAsRead: mock(() => Promise.resolve()),
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.markUnread(
+      {
+        user: { id: "usr_viewer" },
+        workspaceId: "ws_1",
+        params: { streamId: "stream_thread" },
+        body: { messageId: "msg_1" },
+      } as unknown as Request,
+      res
+    )
+
+    // Access (not membership) gates the unread (INV-62): null membership is a
+    // successful standalone-frontier regress, not a 404.
+    expect(captured.status).not.toBe(404)
+    expect(captured.body).toEqual({ membership: null })
+  })
+
+  it("surfaces MESSAGE_NOT_FOUND from the service when the message isn't in the stream", async () => {
+    const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
+    const markUnread = mock(() =>
+      Promise.reject(Object.assign(new Error("Message not found"), { status: 404, code: "MESSAGE_NOT_FOUND" }))
+    )
+    const handlers = makeHandlers({ validateStreamAccess, markUnread } as Partial<StreamService>, {
+      markStreamActivityAsRead: mock(() => Promise.resolve()),
+    })
+    const { res } = makeRes()
+
+    await expect(
+      handlers.markUnread(
+        {
+          user: { id: "usr_viewer" },
+          workspaceId: "ws_1",
+          params: { streamId: "stream_thread" },
+          body: { messageId: "msg_gone" },
+        } as unknown as Request,
+        res
+      )
+    ).rejects.toMatchObject({ status: 404, code: "MESSAGE_NOT_FOUND" })
+  })
+
   it("returns the membership for a member read and still clears activity", async () => {
     const membership = {
       streamId: "stream_thread",

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -931,12 +931,12 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
+      // A null membership is a successful unread by a viewer with access but no
+      // membership row (INV-62) — the service throws MESSAGE_NOT_FOUND itself
+      // when the message isn't in the stream; null here must not 404.
       const membership = await streamService.markUnread(workspaceId, streamId, userId, data.messageId)
-      if (!membership) {
-        throw new HttpError("Message not found in this stream", { status: 404, code: "MESSAGE_NOT_FOUND" })
-      }
 
-      res.json({ membership })
+      res.json({ membership: membership ?? null })
     },
 
     async archive(req: Request, res: Response) {
@@ -1009,21 +1009,23 @@ export function createStreamHandlers({
       // value. See `writeBootstrapEventsAndStream` in stream-sync.ts.
       const snapshotAt = new Date().toISOString()
 
-      const [members, botMemberIds, membership, latestSequence, activityCounts, rootStream] = await Promise.all([
-        streamService.getMembers(streamId),
-        streamService.getBotMemberIds(workspaceId, streamId),
-        streamService.getMembership(streamId, userId),
-        eventService.getLatestSequence(streamId),
-        activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
-        // For a thread, fetch the root so the bootstrap can surface
-        // `rootArchivedAt` — archiving marks only the root row, so the thread's
-        // own `archivedAt` can't tell the client it is sealed. No-op (null) for
-        // non-threads and threads whose root is missing (dangling root_stream_id
-        // is possible under INV-1's FK-less schema).
-        stream.type === StreamTypes.THREAD && stream.rootStreamId
-          ? streamService.getStreamById(stream.rootStreamId)
-          : Promise.resolve(null),
-      ])
+      const [members, botMemberIds, membership, viewerReadState, latestSequence, activityCounts, rootStream] =
+        await Promise.all([
+          streamService.getMembers(streamId),
+          streamService.getBotMemberIds(workspaceId, streamId),
+          streamService.getMembership(streamId, userId),
+          streamService.getViewerReadState(streamId, userId),
+          eventService.getLatestSequence(streamId),
+          activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
+          // For a thread, fetch the root so the bootstrap can surface
+          // `rootArchivedAt` — archiving marks only the root row, so the thread's
+          // own `archivedAt` can't tell the client it is sealed. No-op (null) for
+          // non-threads and threads whose root is missing (dangling root_stream_id
+          // is possible under INV-1's FK-less schema).
+          stream.type === StreamTypes.THREAD && stream.rootStreamId
+            ? streamService.getStreamById(stream.rootStreamId)
+            : Promise.resolve(null),
+        ])
       const botRuntimePresences = await botRuntimeService.findLatestPresences({ workspaceId, botIds: botMemberIds })
       const commands = await commandAvailabilityService.listStreamCommands({ workspaceId, userId, streamId })
       const botRuntimeLinkByBotId =
@@ -1045,10 +1047,20 @@ export function createStreamHandlers({
         })
       )
 
-      // Effective frontier (read cutover): a stream_read_state row wins when
-      // present (a NULL watermark included); the membership column fills an
-      // absent row. Non-members still read as 0 — chunk 3 unlocks their counts.
-      const unreadCount = membership ? await streamService.getEffectiveUnreadCount(streamId, userId, membership) : 0
+      // Effective frontier for EVERY viewer with access (non-member unlock):
+      // a stream_read_state row wins when present (a NULL watermark included);
+      // the membership column fills an absent row; an access-without-membership
+      // viewer (INV-62) with neither reads as never-read (everything unread).
+      const unreadCount = await streamService.getEffectiveUnreadCount(streamId, userId, membership)
+      // The viewer's standalone frontier rides the per-stream response so
+      // non-member legs resolve theirs on open (the workspace bootstrap stays
+      // member-keyed). Sequence resolved off the watermark event, same as the
+      // workspace bootstrap's streamReadState map.
+      const readStateSequence = viewerReadState?.lastReadEventId
+        ? ((await streamService.getSequencesByEventIds([viewerReadState.lastReadEventId])).get(
+            viewerReadState.lastReadEventId
+          ) ?? null)
+        : null
 
       let events = await eventService.listEvents(streamId, {
         limit: afterSequence !== undefined ? EVENTS_DEFAULT_LIMIT + 1 : EVENTS_DEFAULT_LIMIT,
@@ -1143,6 +1155,13 @@ export function createStreamHandlers({
           botRuntimePresence,
           commands,
           membership,
+          readState: viewerReadState
+            ? {
+                lastReadEventId: viewerReadState.lastReadEventId,
+                lastReadSequence: readStateSequence,
+                lastReadAt: viewerReadState.lastReadAt ? viewerReadState.lastReadAt.toISOString() : null,
+              }
+            : null,
           latestSequence: (latestSequence ?? 0n).toString(),
           snapshotAt,
           hasOlderEvents,

--- a/apps/backend/src/features/streams/read-state-repository.test.ts
+++ b/apps/backend/src/features/streams/read-state-repository.test.ts
@@ -266,6 +266,45 @@ describe("ReadStateRepository readers", () => {
   })
 })
 
+describe("ReadStateRepository.ensureForUpdate", () => {
+  test("seeds a never-read row then locks it — the non-member leg's serialization point", async () => {
+    const row = {
+      workspace_id: "ws_1",
+      stream_id: "stream_1",
+      user_id: "usr_1",
+      last_read_event_id: null,
+      last_read_at: null,
+      updated_at: new Date(),
+    }
+    const query = mock()
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [row], rowCount: 1 })
+    const db = { query } as unknown as Querier
+
+    const result = await ReadStateRepository.ensureForUpdate(db, "stream_1", "usr_1")
+
+    expect(query).toHaveBeenCalledTimes(2)
+    const seed = flat(sqlText(query.mock.calls[0]))
+    expect(seed).toContain("INSERT INTO stream_read_state")
+    // DO NOTHING (not DO UPDATE): an existing row's watermark is never touched
+    // by the seed — the lock is the point. Workspace derived from streams (INV-8).
+    expect(seed).toContain("ON CONFLICT (stream_id, user_id) DO NOTHING")
+    expect(seed).toContain("SELECT s.workspace_id")
+    const lock = flat(sqlText(query.mock.calls[1]))
+    expect(lock).toContain("FOR UPDATE")
+    expect(result?.lastReadEventId).toBeNull()
+  })
+
+  test("returns null for a dangling stream id (no row to seed or lock)", async () => {
+    const query = mock()
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    const db = { query } as unknown as Querier
+
+    expect(await ReadStateRepository.ensureForUpdate(db, "stream_gone", "usr_1")).toBeNull()
+  })
+})
+
 describe("ReadStateRepository lifecycle deletes", () => {
   test("deleteForWorkspace filters on workspace_id", async () => {
     const { db, query } = makeDb()

--- a/apps/backend/src/features/streams/read-state-repository.ts
+++ b/apps/backend/src/features/streams/read-state-repository.ts
@@ -198,6 +198,40 @@ export const ReadStateRepository = {
     )
   },
 
+  /**
+   * Ensure a row exists for this (stream, user) and return it locked FOR UPDATE —
+   * the non-member leg's serialization point (INV-20). Members are serialized by
+   * their locked `stream_members` row; a non-member leg has no membership row, so
+   * its read-state row carries the lock instead: concurrent conversation reads on
+   * the same leg take the same single-row lock (conversations processes streams
+   * in sorted order, so no new lock-order hazard). A seeded row carries a NULL
+   * watermark (never read = position before the first message). Two statements:
+   * ON CONFLICT DO NOTHING returns nothing for an existing row, and FOR UPDATE
+   * can't ride the insert. Returns null only for a dangling stream id.
+   */
+  async ensureForUpdate(db: Querier, streamId: string, userId: string): Promise<StreamReadState | null> {
+    await db.query(
+      `
+      INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
+      SELECT s.workspace_id, $1, $2, NULL, NULL, NOW()
+      FROM streams s
+      WHERE s.id = $1
+      ON CONFLICT (stream_id, user_id) DO NOTHING
+      `,
+      [streamId, userId]
+    )
+    const result = await db.query<StreamReadStateRow>(
+      `
+      SELECT ${SELECT_FIELDS}
+      FROM stream_read_state
+      WHERE stream_id = $1 AND user_id = $2
+      FOR UPDATE
+      `,
+      [streamId, userId]
+    )
+    return result.rows[0] ? mapRowToReadState(result.rows[0]) : null
+  },
+
   async get(db: Querier, streamId: string, userId: string): Promise<StreamReadState | null> {
     const result = await db.query<StreamReadStateRow>(sql`
       SELECT ${sql.raw(SELECT_FIELDS)}

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1598,14 +1598,28 @@ describe("StreamService.markAsRead", () => {
     expect(result?.lastReadEventId).toBe("evt_real")
   })
 
-  test("emits nothing for a non-member", async () => {
+  test("advances the standalone frontier and emits stream:read for a non-member — without touching membership", async () => {
+    // Access (validated in the handler) gates the read, not membership (INV-62):
+    // a non-member thread viewer gets the same watermark semantics. The
+    // membership UPDATE runs and returns null — it is NEVER upserted.
     mockGetMessageOrdinalForEvent.mockResolvedValue({ sequence: 42n, messageOrdinal: 7 })
     mockMemberUpdate.mockResolvedValue(null)
 
-    await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
+    const result = await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
 
-    expect(mockInsertOutbox).not.toHaveBeenCalled()
-    expect(mockReadStateAdvance).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+    expect(mockMemberUpdate).toHaveBeenCalledWith({}, "stream_1", "usr_1", { lastReadEventId: "evt_9" })
+    expect(mockReadStateAdvance).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_9")
+    expect(mockPruneAtOrBelow).toHaveBeenCalledWith({}, "stream_1", "usr_1", 42n)
+    expect(mockInsertOutbox).toHaveBeenCalledWith({}, "stream:read", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_9",
+      lastReadSequence: "42",
+      lastReadOrdinal: 7,
+      readMessageIds: [],
+    })
   })
 })
 
@@ -1669,17 +1683,21 @@ describe("StreamService.markUnread", () => {
     expect(mockReadStateSet).toHaveBeenCalledWith({}, "stream_1", "usr_1", null)
   })
 
-  test("returns null and emits nothing when the message is not in the stream", async () => {
+  test("throws MESSAGE_NOT_FOUND when the message is not in the stream", async () => {
     mockFindByMessageId.mockResolvedValue(null)
 
-    const result = await service.markUnread("ws_1", "stream_1", "usr_1", "msg_gone")
-
-    expect(result).toBeNull()
+    await expect(service.markUnread("ws_1", "stream_1", "usr_1", "msg_gone")).rejects.toMatchObject({
+      status: 404,
+      code: "MESSAGE_NOT_FOUND",
+    })
     expect(mockMemberUpdate).not.toHaveBeenCalled()
     expect(mockInsertOutbox).not.toHaveBeenCalled()
   })
 
-  test("does not emit when the membership update returns null (non-member)", async () => {
+  test("sets the standalone frontier and emits stream:read_set for a non-member — without touching membership", async () => {
+    // The same-class 404 is gone: a null membership update is a successful
+    // unread by an access-only viewer, not a missing message. The membership
+    // UPDATE runs and returns null — never upserted (INV-62).
     mockFindByMessageId.mockResolvedValue({ id: "evt_5", sequence: 50n } as never)
     mockFindPreviousMessageEvent.mockResolvedValue({ id: "evt_4", sequence: 40n } as never)
     mockCountMessagesThrough.mockResolvedValue(4)
@@ -1688,9 +1706,18 @@ describe("StreamService.markUnread", () => {
     const result = await service.markUnread("ws_1", "stream_1", "usr_1", "msg_5")
 
     expect(result).toBeNull()
-    expect(mockMemberUpdate).toHaveBeenCalled()
-    expect(mockInsertOutbox).not.toHaveBeenCalled()
-    expect(mockReadStateSet).not.toHaveBeenCalled()
+    expect(mockMemberUpdate).toHaveBeenCalledWith({}, "stream_1", "usr_1", { lastReadEventId: "evt_4" })
+    expect(mockReadStateSet).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_4")
+    expect(mockDeleteAtOrAbove).toHaveBeenCalledWith({}, "stream_1", "usr_1", 50n)
+    expect(mockInsertOutbox).toHaveBeenCalledWith({}, "stream:read_set", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_4",
+      lastReadSequence: "40",
+      lastReadOrdinal: 4,
+      readMessageIds: [],
+    })
   })
 })
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -10,7 +10,7 @@ import {
   type UpdateStreamParams,
 } from "./repository"
 import { StreamMemberRepository, StreamMember } from "./member-repository"
-import { ReadStateRepository } from "./read-state-repository"
+import { ReadStateRepository, type StreamReadState } from "./read-state-repository"
 import { getEffectiveReadState, type EffectiveReadState } from "./effective-read-state"
 import { StreamEventRepository, type StreamEvent } from "./event-repository"
 import { SparseReadRepository } from "./sparse-read-repository"
@@ -1932,48 +1932,49 @@ export class StreamService {
         return StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
       }
 
+      // Membership write is compatibility-only: the UPDATE moves the column when
+      // the row exists and returns null otherwise — it is NEVER upserted (INV-62).
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
-      if (membership) {
-        // Shadow the advance into stream_read_state (same tx) and source the
-        // payload from the post-write row: the standalone store is monotonic
-        // and can sit ABOVE the membership watermark after a stale-device
-        // write regressed membership, so the post-write frontier — not the raw
-        // event — is the read position this user's other sessions adopt.
-        // Membership keeps its regressible semantics until the columns die
-        // (PR 4); the cutover converges such rows upward only (owner-ratified).
-        const postWrite = await ReadStateRepository.advance(client, streamId, memberId, eventId)
-        let readEventId = eventId
-        let readPosition = position
-        if (postWrite?.lastReadEventId && postWrite.lastReadEventId !== eventId) {
-          const resolved = await StreamEventRepository.getMessageOrdinalForEvent(
-            client,
-            streamId,
-            postWrite.lastReadEventId
-          )
-          if (resolved) {
-            readEventId = postWrite.lastReadEventId
-            readPosition = resolved
-          }
-        }
-        // Overlay invariant: every overlay row sits strictly above the watermark.
-        // Advancing the watermark absorbs the run at/below it, so prune those rows
-        // in the same transaction at the effective (post-write) frontier; the
-        // remaining overlay is the absolute set the client keeps.
-        await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, readPosition.sequence)
-        const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
-        // Absolute read position (sync phase 2c): clients derive unread as
-        // latestOrdinal - lastReadOrdinal, so the event carries where this read
-        // lands in message-ordinal space.
-        await OutboxRepository.insert(client, "stream:read", {
-          workspaceId,
-          authorId: memberId,
+      // The standalone advance runs for every viewer with access (validated in
+      // the handler): read state is user-anchored, not membership-gated. Source
+      // the payload from the post-write row: the standalone store is monotonic
+      // and can sit ABOVE the membership watermark after a stale-device write
+      // regressed membership, so the post-write frontier — not the raw event —
+      // is the read position this user's other sessions adopt. Membership keeps
+      // its regressible semantics until the columns die (PR 4); the cutover
+      // converges such rows upward only (owner-ratified).
+      const postWrite = await ReadStateRepository.advance(client, streamId, memberId, eventId)
+      let readEventId = eventId
+      let readPosition = position
+      if (postWrite?.lastReadEventId && postWrite.lastReadEventId !== eventId) {
+        const resolved = await StreamEventRepository.getMessageOrdinalForEvent(
+          client,
           streamId,
-          lastReadEventId: readEventId,
-          lastReadSequence: readPosition.sequence.toString(),
-          lastReadOrdinal: readPosition.messageOrdinal,
-          readMessageIds,
-        })
+          postWrite.lastReadEventId
+        )
+        if (resolved) {
+          readEventId = postWrite.lastReadEventId
+          readPosition = resolved
+        }
       }
+      // Overlay invariant: every overlay row sits strictly above the watermark.
+      // Advancing the watermark absorbs the run at/below it, so prune those rows
+      // in the same transaction at the effective (post-write) frontier; the
+      // remaining overlay is the absolute set the client keeps.
+      await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, readPosition.sequence)
+      const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
+      // Absolute read position (sync phase 2c): clients derive unread as
+      // latestOrdinal - lastReadOrdinal, so the event carries where this read
+      // lands in message-ordinal space.
+      await OutboxRepository.insert(client, "stream:read", {
+        workspaceId,
+        authorId: memberId,
+        streamId,
+        lastReadEventId: readEventId,
+        lastReadSequence: readPosition.sequence.toString(),
+        lastReadOrdinal: readPosition.messageOrdinal,
+        readMessageIds,
+      })
       return membership
     })
   }
@@ -1996,7 +1997,7 @@ export class StreamService {
   ): Promise<StreamMember | null> {
     return withTransaction(this.pool, async (client) => {
       const messageEvent = await StreamEventRepository.findByMessageId(client, streamId, messageId)
-      if (!messageEvent) return null
+      if (!messageEvent) throw new MessageNotFoundError()
 
       const previous = await StreamEventRepository.findPreviousMessageEvent(client, streamId, messageEvent.sequence)
       const lastReadEventId = previous?.id ?? null
@@ -2004,32 +2005,32 @@ export class StreamService {
         ? await StreamEventRepository.countMessagesThrough(client, streamId, previous.sequence)
         : 0
 
+      // Membership write is compatibility-only (null for a non-member — never
+      // upserted, INV-62); the standalone regress runs for every viewer with
+      // access. Explicit unread is one of the sanctioned downward moves.
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId })
-      if (membership) {
-        // Shadow the regress into stream_read_state (unconditional; may be null — same tx).
-        await ReadStateRepository.set(client, streamId, memberId, lastReadEventId)
-        // Mark-unread means "this message and everything after it is unread", so
-        // overlay rows at/above the target contradict the intent — drop them. The
-        // pointer lands just before the target, which can also ADVANCE it (target
-        // above the old watermark, e.g. after board reads left holes): overlay
-        // rows now at/below the new watermark must go too, or they double-subtract
-        // in the effective unread count. `previous` is the message immediately
-        // before the target, so together the two deletes clear the whole overlay.
-        await SparseReadRepository.deleteAtOrAbove(client, streamId, memberId, messageEvent.sequence)
-        if (previous) {
-          await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, previous.sequence)
-        }
-        const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
-        await OutboxRepository.insert(client, "stream:read_set", {
-          workspaceId,
-          authorId: memberId,
-          streamId,
-          lastReadEventId,
-          lastReadSequence: (previous?.sequence ?? 0n).toString(),
-          lastReadOrdinal,
-          readMessageIds,
-        })
+      await ReadStateRepository.set(client, streamId, memberId, lastReadEventId)
+      // Mark-unread means "this message and everything after it is unread", so
+      // overlay rows at/above the target contradict the intent — drop them. The
+      // pointer lands just before the target, which can also ADVANCE it (target
+      // above the old watermark, e.g. after board reads left holes): overlay
+      // rows now at/below the new watermark must go too, or they double-subtract
+      // in the effective unread count. `previous` is the message immediately
+      // before the target, so together the two deletes clear the whole overlay.
+      await SparseReadRepository.deleteAtOrAbove(client, streamId, memberId, messageEvent.sequence)
+      if (previous) {
+        await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, previous.sequence)
       }
+      const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
+      await OutboxRepository.insert(client, "stream:read_set", {
+        workspaceId,
+        authorId: memberId,
+        streamId,
+        lastReadEventId,
+        lastReadSequence: (previous?.sequence ?? 0n).toString(),
+        lastReadOrdinal,
+        readMessageIds,
+      })
       return membership
     })
   }
@@ -2111,17 +2112,33 @@ export class StreamService {
     return getEffectiveReadState(this.pool, userId, memberships)
   }
 
-  /** Per-stream unread count sourced from the effective frontier (standalone read state, membership fallback). */
+  /**
+   * Per-stream unread count sourced from the effective frontier (standalone read
+   * state, membership fallback). Membership is nullable: an access-without-
+   * membership viewer (INV-62) has no fallback column, so an absent read-state
+   * row reads as "never read" (frontier before the first message — everything
+   * unread), the same semantics as a NULL membership watermark.
+   */
   async getEffectiveUnreadCount(
     streamId: string,
     userId: string,
-    membership: { lastReadEventId: string | null; lastReadAt: Date | null }
+    membership: { lastReadEventId: string | null; lastReadAt: Date | null } | null
   ): Promise<number> {
-    const effective = await getEffectiveReadState(this.pool, userId, [{ streamId, ...membership }])
-    const row = effective.get(streamId)
+    const effective = await getEffectiveReadState(this.pool, userId, [
+      {
+        streamId,
+        lastReadEventId: membership?.lastReadEventId ?? null,
+        lastReadAt: membership?.lastReadAt ?? null,
+      },
+    ])
     // Row presence selects the source — a present NULL watermark must not
     // fall through to the membership column.
-    return this.getUnreadCount(streamId, userId, row ? row.lastReadEventId : membership.lastReadEventId)
+    return this.getUnreadCount(streamId, userId, effective.get(streamId)?.lastReadEventId ?? null)
+  }
+
+  /** The viewer's standalone read-state row on one stream (per-stream bootstrap frontier). */
+  async getViewerReadState(streamId: string, userId: string): Promise<StreamReadState | null> {
+    return ReadStateRepository.get(this.pool, streamId, userId)
   }
 
   /** The member's sparse read overlay across `streamIds`, keyed by stream id (bootstrap). */

--- a/apps/backend/src/features/streams/sparse-read.test.ts
+++ b/apps/backend/src/features/streams/sparse-read.test.ts
@@ -141,11 +141,26 @@ describe("applySparseRead effective watermark seed", () => {
     expect(snapshot.lastReadSequence).toBe("0")
   })
 
-  it("keeps a non-member leg overlay-only — no read-state seed, no watermark writes", async () => {
+  it("a non-member leg seeds from its ensured+locked standalone row and compacts into it — never touching membership", async () => {
     spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue(null)
-    const readStateGet = spyOn(ReadStateRepository, "get")
+    // The leg's standalone row (ensured + locked FOR UPDATE — the non-member's
+    // serialization point) carries a NULL watermark: never read.
+    const ensureForUpdate = spyOn(ReadStateRepository, "ensureForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      userId: "usr_1",
+      lastReadEventId: null,
+    } as never)
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue(null)
+    // A contiguous overlay run above the null watermark compacts to evt_new (seq 20).
+    spyOn(SparseReadRepository, "findCompactionTarget").mockResolvedValue({
+      eventId: "evt_new",
+      sequence: 20n,
+    } as never)
+    spyOn(SparseReadRepository, "findTrailingDeletedRunEnd").mockResolvedValue(null)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(2)
     const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
     const readStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(null)
+    const pruneAtOrBelow = spyOn(SparseReadRepository, "pruneAtOrBelow").mockResolvedValue(undefined)
 
     const snapshot = await applySparseRead(db, {
       workspaceId: "ws_1",
@@ -154,13 +169,46 @@ describe("applySparseRead effective watermark seed", () => {
       messageIds: ["msg_1"],
     })
 
-    // Non-member compaction stays deferred to the PR-3 unlock: even a former
-    // member's read-state row doesn't seed the snapshot in this chunk.
-    expect(readStateGet).not.toHaveBeenCalled()
+    expect(ensureForUpdate).toHaveBeenCalledWith(db, "stream_1", "usr_1")
+    // Membership is participation: never written on a non-member read (INV-62).
+    expect(memberUpdate).not.toHaveBeenCalled()
+    expect(readStateAdvance).toHaveBeenCalledWith(db, "stream_1", "usr_1", "evt_new")
+    expect(pruneAtOrBelow).toHaveBeenCalledWith(db, "stream_1", "usr_1", 20n)
+    expect(snapshot.lastReadEventId).toBe("evt_new")
+    expect(snapshot.lastReadSequence).toBe("20")
+  })
+
+  it("a non-member leg with no compaction target leaves the standalone watermark where it stands", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue(null)
+    spyOn(ReadStateRepository, "ensureForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      userId: "usr_1",
+      lastReadEventId: null,
+    } as never)
+    spyOn(SparseReadRepository, "findCompactionTarget").mockResolvedValue(null)
+    spyOn(SparseReadRepository, "findTrailingDeletedRunEnd").mockResolvedValue(null)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(0)
+    spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue(["msg_3"])
+    const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(null)
+
+    const snapshot = await applySparseRead(db, {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "usr_1",
+      messageIds: ["msg_3"],
+    })
+
     expect(memberUpdate).not.toHaveBeenCalled()
     expect(readStateAdvance).not.toHaveBeenCalled()
-    expect(snapshot.lastReadEventId).toBeNull()
-    expect(snapshot.lastReadSequence).toBe("0")
+    expect(snapshot).toEqual({
+      streamId: "stream_1",
+      readMessageIds: ["msg_3"],
+      lastReadEventId: null,
+      lastReadSequence: "0",
+      lastReadOrdinal: 0,
+      markedMessageIds: ["msg_3"],
+    })
   })
 })
 
@@ -230,6 +278,44 @@ describe("applySparseUnread read-state shadow", () => {
 
     expect(memberUpdate).toHaveBeenCalledWith(db, "stream_1", "usr_1", { lastReadEventId: "evt_prev" })
     expect(readStateSet).toHaveBeenCalledWith(db, "stream_1", "usr_1", "evt_prev")
+  })
+
+  it("regresses the standalone store for a non-member leg — never writing membership", async () => {
+    spyOn(StreamMemberRepository, "findByStreamAndMemberForUpdate").mockResolvedValue(null)
+    // The ensured+locked standalone row stands at seq 50, past the earliest
+    // affected message (30) — the explicit unread regresses it.
+    spyOn(ReadStateRepository, "ensureForUpdate").mockResolvedValue({
+      streamId: "stream_1",
+      userId: "usr_1",
+      lastReadEventId: "evt_5",
+    } as never)
+    spyOn(StreamEventRepository, "getMessageOrdinalForEvent").mockResolvedValue({ sequence: 50n } as never)
+    spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 30n } as never)
+    spyOn(StreamEventRepository, "findPreviousMessageEvent").mockResolvedValue({
+      id: "evt_prev",
+      sequence: 25n,
+    } as never)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(2)
+    const memberUpdate = spyOn(StreamMemberRepository, "update").mockResolvedValue(null)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+    const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+    const snapshot = await applySparseUnread(db, {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "usr_1",
+      messageIds: ["msg_5"],
+    })
+
+    expect(memberUpdate).not.toHaveBeenCalled()
+    expect(readStateSet).toHaveBeenCalledWith(db, "stream_1", "usr_1", "evt_prev")
+    expect(snapshot.lastReadEventId).toBe("evt_prev")
+    expect(snapshot.lastReadSequence).toBe("25")
+    expect(outboxInsert).toHaveBeenCalledWith(
+      db,
+      "stream:read_set",
+      expect.objectContaining({ streamId: "stream_1", authorId: "usr_1", lastReadEventId: "evt_prev" })
+    )
   })
 
   it("sets read state to null when the target is the first message", async () => {

--- a/apps/backend/src/features/streams/sparse-read.ts
+++ b/apps/backend/src/features/streams/sparse-read.ts
@@ -39,13 +39,14 @@ async function resolveWatermarkSequence(db: Querier, streamId: string, eventId: 
 }
 
 /**
- * The member's effective watermark seed (read cutover): a `stream_read_state`
- * row wins whenever it exists — including a row whose watermark is NULL
- * (explicit unread-to-zero) — and the locked membership row fills only an
- * absent read-state row. Returns null for a non-member leg: those stay
- * overlay-only in this chunk (non-member compaction lands with the PR-3
- * unlock). Membership is still locked/required for the compaction and regress
- * writes below; this only changes which value seeds them.
+ * The viewer's effective watermark seed (read cutover + non-member unlock): a
+ * `stream_read_state` row wins whenever it exists — including a row whose
+ * watermark is NULL (explicit unread-to-zero) — and the locked membership row
+ * fills only an absent read-state row. A non-member leg (no membership row)
+ * seeds from its standalone row, which is ensured + locked FOR UPDATE here:
+ * members are serialized by the locked `stream_members` row, so the read-state
+ * row is the non-member leg's equivalent single-row lock (INV-20). Never
+ * creates a membership row — read state is not a membership surface (INV-62).
  */
 async function effectiveWatermarkSeed(
   db: Querier,
@@ -53,9 +54,12 @@ async function effectiveWatermarkSeed(
   memberId: string,
   membership: { lastReadEventId: string | null } | null
 ): Promise<string | null> {
-  if (!membership) return null
-  const readState = await ReadStateRepository.get(db, streamId, memberId)
-  return readState ? readState.lastReadEventId : membership.lastReadEventId
+  if (membership) {
+    const readState = await ReadStateRepository.get(db, streamId, memberId)
+    return readState ? readState.lastReadEventId : membership.lastReadEventId
+  }
+  const readState = await ReadStateRepository.ensureForUpdate(db, streamId, memberId)
+  return readState ? readState.lastReadEventId : null
 }
 
 async function ordinalFor(db: Querier, streamId: string, sequence: bigint): Promise<number> {
@@ -64,10 +68,13 @@ async function ordinalFor(db: Querier, streamId: string, sequence: bigint): Prom
 
 /**
  * Apply a conversation "mark read" to one stream: lock the membership row if it
- * exists, insert the overlay rows, compact the contiguous run above the watermark
- * into the watermark (pruning absorbed rows), and emit `stream:read_messages` with
- * the absolute snapshot — all on the caller's transaction (INV-6/7). A non-member
- * thread leg (no membership row) is overlay-only: no watermark, no compaction.
+ * exists (else the standalone read-state row — non-member legs are no longer
+ * overlay-only), insert the overlay rows, compact the contiguous run above the
+ * watermark into the watermark (pruning absorbed rows), and emit
+ * `stream:read_messages` with the absolute snapshot — all on the caller's
+ * transaction (INV-6/7). The compaction advance is monotonic in the standalone
+ * store for every viewer; the membership write stays compatibility-only and
+ * fires only when the row exists — it is NEVER upserted (INV-62).
  * Returns the post-write snapshot.
  */
 export async function applySparseRead(db: Querier, params: ApplySparseReadParams): Promise<ReadStateSnapshot> {
@@ -93,21 +100,22 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
     await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
   }
 
+  const seedEventId = watermarkEventId
+  const target = await SparseReadRepository.findCompactionTarget(db, streamId, memberId, watermarkSeq)
+  if (target) {
+    watermarkEventId = target.eventId
+    watermarkSeq = target.sequence
+  }
+  // The tide also rises over sunken rocks: a trailing run of DELETED messages
+  // just above the (possibly compacted) watermark can never be read by anyone,
+  // so absorb it too — otherwise agent-deleted transients above the watermark
+  // stall it forever and the stream can never fully read from the board.
+  const deletedRun = await SparseReadRepository.findTrailingDeletedRunEnd(db, streamId, watermarkSeq)
+  if (deletedRun) {
+    watermarkEventId = deletedRun.eventId
+    watermarkSeq = deletedRun.sequence
+  }
   if (membership) {
-    const target = await SparseReadRepository.findCompactionTarget(db, streamId, memberId, watermarkSeq)
-    if (target) {
-      watermarkEventId = target.eventId
-      watermarkSeq = target.sequence
-    }
-    // The tide also rises over sunken rocks: a trailing run of DELETED messages
-    // just above the (possibly compacted) watermark can never be read by anyone,
-    // so absorb it too — otherwise agent-deleted transients above the watermark
-    // stall it forever and the stream can never fully read from the board.
-    const deletedRun = await SparseReadRepository.findTrailingDeletedRunEnd(db, streamId, watermarkSeq)
-    if (deletedRun) {
-      watermarkEventId = deletedRun.eventId
-      watermarkSeq = deletedRun.sequence
-    }
     if (watermarkEventId !== (membership.lastReadEventId ?? null)) {
       // Also fires when the read-state seed already sat above a regressed
       // membership row: the write converges membership UPWARD to the effective
@@ -120,6 +128,13 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
       }
       await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
     }
+  } else if (watermarkEventId !== seedEventId) {
+    // Non-member leg: the compaction lands in the standalone store only (locked
+    // by the seed above) — membership is participation, never upserted on read.
+    if (watermarkEventId) {
+      await ReadStateRepository.advance(db, streamId, memberId, watermarkEventId)
+    }
+    await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
   }
 
   const lastReadOrdinal = await ordinalFor(db, streamId, watermarkSeq)
@@ -153,9 +168,11 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
  * from the overlay, and — only when the watermark sits at/past the earliest
  * affected message — regress it to just before that message (existing
  * `stream:read_set` semantics, accepting collateral un-reading of interleaved
- * messages). When the watermark is already behind the affected run, or there's no
- * membership row (thread leg), the overlay delete alone suffices and the absolute
- * `stream:read_messages` snapshot is emitted. Returns the post-write snapshot.
+ * messages). The regress writes the standalone store for every viewer (one of
+ * the sanctioned downward moves) and the membership column only when the row
+ * exists. When the watermark is already behind the affected run, the overlay
+ * delete alone suffices and the absolute `stream:read_messages` snapshot is
+ * emitted. Returns the post-write snapshot.
  */
 export async function applySparseUnread(db: Querier, params: ApplySparseReadParams): Promise<ReadStateSnapshot> {
   const { workspaceId, streamId, memberId, messageIds } = params
@@ -168,12 +185,14 @@ export async function applySparseUnread(db: Querier, params: ApplySparseReadPara
   const watermarkEventId = await effectiveWatermarkSeed(db, streamId, memberId, membership)
   const watermarkSeq = await resolveWatermarkSequence(db, streamId, watermarkEventId)
 
-  if (membership && earliest && watermarkSeq >= earliest.sequence) {
+  if (earliest && watermarkSeq >= earliest.sequence) {
     const previous = await StreamEventRepository.findPreviousMessageEvent(db, streamId, earliest.sequence)
     const newWatermarkEventId = previous?.id ?? null
     const newWatermarkSeq = previous?.sequence ?? 0n
-    await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: newWatermarkEventId })
-    // Shadow the regress into stream_read_state (unconditional; may be null — same tx).
+    if (membership) {
+      await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: newWatermarkEventId })
+    }
+    // The regress lands in stream_read_state unconditionally (may be null — same tx).
     await ReadStateRepository.set(db, streamId, memberId, newWatermarkEventId)
 
     const lastReadOrdinal = await ordinalFor(db, streamId, newWatermarkSeq)

--- a/apps/backend/tests/integration/conversation-read.test.ts
+++ b/apps/backend/tests/integration/conversation-read.test.ts
@@ -6,6 +6,7 @@ import {
   StreamEventRepository,
   StreamMemberRepository,
   SparseReadRepository,
+  ReadStateRepository,
 } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
 import { ConversationService } from "../../src/features/conversations"
@@ -31,6 +32,7 @@ describe("ConversationService read/unread", () => {
 
   beforeEach(async () => {
     await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM stream_read_state")
     await pool.query("DELETE FROM user_activity")
     await pool.query("DELETE FROM conversations")
     await pool.query("DELETE FROM messages")
@@ -134,11 +136,15 @@ describe("ConversationService read/unread", () => {
       markedMessageIds: [msg1, msg2],
     })
 
-    // Thread: non-member leg → overlay-only, only tmsg1 (tmsg2 excluded by cutoff).
+    // Thread: non-member leg → compacted into its OWN standalone frontier
+    // (only tmsg1; tmsg2 excluded by cutoff), membership never upserted.
+    const threadEvents = await eventByMessage(thread)
     const threadSnap = byStream.get(thread)!
-    expect(threadSnap.lastReadEventId).toBeNull()
-    expect(threadSnap.readMessageIds).toEqual([tmsg1])
+    expect(threadSnap.lastReadEventId).toBe(threadEvents.get(tmsg1)!.id)
+    expect(threadSnap.lastReadSequence).toBe(threadEvents.get(tmsg1)!.sequence.toString())
+    expect(threadSnap.readMessageIds).toEqual([])
     expect(await StreamMemberRepository.findByStreamAndMember(pool, thread, reader)).toBeNull()
+    expect((await ReadStateRepository.get(pool, thread, reader))?.lastReadEventId).toBe(threadEvents.get(tmsg1)!.id)
   })
 
   test("markRead clears activity for exactly the marked messages, never the stream's other topics", async () => {
@@ -194,7 +200,7 @@ describe("ConversationService read/unread", () => {
     )
   })
 
-  test("markUnread regresses the watermark on the affected stream and drops overlay-only thread reads", async () => {
+  test("markUnread regresses the watermark on the affected stream and the non-member thread leg's standalone frontier", async () => {
     const wid = workspaceId()
     const root = streamId()
     const author = userId()
@@ -222,14 +228,17 @@ describe("ConversationService read/unread", () => {
     const convId = await insertConversation(wid, root, [msg1, tmsg1, msg2])
     const rootEvents = await eventByMessage(root)
 
-    // Read the whole conversation first.
+    // Read the whole conversation first. The thread leg (non-member) compacts
+    // into its standalone read-state row — no overlay left on the leg.
     await conversationService.markRead({
       workspaceId: wid,
       conversationId: convId,
       throughMessageId: msg2,
       userId: reader,
     })
-    expect(await SparseReadRepository.countOverlay(pool, thread, reader)).toBe(1)
+    expect(await SparseReadRepository.countOverlay(pool, thread, reader)).toBe(0)
+    const threadEvents = await eventByMessage(thread)
+    expect((await ReadStateRepository.get(pool, thread, reader))?.lastReadEventId).toBe(threadEvents.get(tmsg1)!.id)
 
     // Now mark unread from tmsg1 (cutoff 2000): tmsg1 + msg2 affected.
     const { streams } = await conversationService.markUnread({
@@ -242,9 +251,12 @@ describe("ConversationService read/unread", () => {
 
     // Root: watermark was at msg2 (>= msg2's own seq), regress to just before msg2 → msg1.
     expect(byStream.get(root)!.lastReadEventId).toBe(rootEvents.get(msg1)!.id)
-    // Thread: overlay-only, tmsg1 dropped from the overlay.
+    // Thread leg: tmsg1 was the first message, so the regress parks the
+    // standalone frontier before it (null watermark) — membership untouched.
+    expect(byStream.get(thread)!.lastReadEventId).toBeNull()
     expect(byStream.get(thread)!.readMessageIds).toEqual([])
-    expect(await SparseReadRepository.countOverlay(pool, thread, reader)).toBe(0)
+    expect(await ReadStateRepository.get(pool, thread, reader)).toMatchObject({ lastReadEventId: null })
+    expect(await StreamMemberRepository.findByStreamAndMember(pool, thread, reader)).toBeNull()
 
     // Effective root unread: msg2 is unread again (msg1 read).
     const membership = await streamService.getMembership(root, reader)

--- a/apps/backend/tests/integration/read-state-nonmember.test.ts
+++ b/apps/backend/tests/integration/read-state-nonmember.test.ts
@@ -1,0 +1,391 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { Pool } from "pg"
+import { resolve } from "node:path"
+import { setupTestDatabase, testMessageContent, withTestTransaction } from "./setup"
+import {
+  StreamService,
+  StreamEventRepository,
+  StreamMemberRepository,
+  ReadStateRepository,
+  usersReadThroughEffective,
+} from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { streamId, userId, workspaceId } from "../../src/lib/id"
+
+const MIGRATION_PATH = resolve(import.meta.dir, "../../src/db/migrations/20260724170957_add_stream_read_state.sql")
+
+/**
+ * The non-member unlock against a real database: read state is user-anchored,
+ * not membership-gated (INV-62) — access-only viewers get the same watermark
+ * semantics as members, and `stream_members` is NEVER upserted on a read.
+ */
+describe("read state — non-member unlock", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let eventService: EventService
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    eventService = new EventService(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM stream_read_state")
+    await pool.query("DELETE FROM user_activity")
+    await pool.query("DELETE FROM messages")
+    await pool.query("DELETE FROM stream_events")
+    await pool.query("DELETE FROM stream_sequences")
+    await pool.query("DELETE FROM stream_members")
+    await pool.query("DELETE FROM streams")
+    await pool.query(
+      "DELETE FROM outbox WHERE id > (SELECT COALESCE(MAX(last_processed_id), 0) FROM outbox_listeners WHERE listener_id = 'broadcast')"
+    )
+  })
+
+  async function seedChannel(wid: string, sid: string, createdBy: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+      [sid, wid, createdBy]
+    )
+  }
+
+  async function sendMessages(wid: string, sid: string, authorId: string, count: number): Promise<string[]> {
+    const ids: string[] = []
+    for (let i = 1; i <= count; i++) {
+      const m = await eventService.createMessage({
+        workspaceId: wid,
+        streamId: sid,
+        authorId,
+        authorType: "user",
+        ...testMessageContent(`Message ${i}`),
+      })
+      ids.push(m.id)
+    }
+    return ids
+  }
+
+  async function outboxFor(eventType: string, sid: string): Promise<Array<Record<string, unknown>>> {
+    const result = await pool.query(
+      `SELECT payload FROM outbox WHERE event_type = $1 AND payload->>'streamId' = $2 ORDER BY id`,
+      [eventType, sid]
+    )
+    return result.rows.map((r) => r.payload)
+  }
+
+  async function membershipCount(sid: string, uid: string): Promise<number> {
+    const result = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM stream_members WHERE stream_id = $1 AND member_id = $2`,
+      [sid, uid]
+    )
+    return result.rows[0].n
+  }
+
+  describe("usersReadThroughEffective (born-read gate)", () => {
+    test("a non-member's read-state row qualifies — no stream_members row needed", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId() // access-without-membership (INV-62 thread viewer)
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 3)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      // The viewer has NO stream_members row — only their own read-state row,
+      // advanced through the second event (sequence-resolved in SQL).
+      await ReadStateRepository.advance(pool, sid, viewer, events[1].id)
+
+      const readThrough = await usersReadThroughEffective(pool, wid, sid, [viewer], events[1].sequence)
+      expect(readThrough).toEqual(new Set([viewer]))
+
+      // A row below the target sequence does not qualify.
+      const fresh = userId()
+      await ReadStateRepository.advance(pool, sid, fresh, events[0].id)
+      const notYet = await usersReadThroughEffective(pool, wid, sid, [fresh], events[1].sequence)
+      expect(notYet).toEqual(new Set())
+    })
+
+    test("a present NULL watermark does not qualify AND blocks the stale membership fallback", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const member = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 2)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      // Membership watermark sits past the target (stale shadow-window column),
+      // but the authoritative read-state row is an explicit unread-to-zero:
+      // present NULL reads as unread and never falls through to membership.
+      await StreamMemberRepository.insert(pool, sid, member)
+      await StreamMemberRepository.update(pool, sid, member, { lastReadEventId: events[1].id })
+      await ReadStateRepository.set(pool, sid, member, null)
+
+      const readThrough = await usersReadThroughEffective(pool, wid, sid, [member], events[0].sequence)
+      expect(readThrough).toEqual(new Set())
+    })
+
+    test("a missing read-state row falls back to the membership watermark", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const member = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 2)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      await StreamMemberRepository.insert(pool, sid, member)
+      await StreamMemberRepository.update(pool, sid, member, { lastReadEventId: events[1].id })
+
+      const readThrough = await usersReadThroughEffective(pool, wid, sid, [member], events[1].sequence)
+      expect(readThrough).toEqual(new Set([member]))
+    })
+
+    test("a corrupt membership watermark pointing at a foreign-stream event never qualifies (INV-8 workspace join + event bound to stream)", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const member = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 2)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      // A foreign stream in ANOTHER workspace whose second event sits at/above
+      // the target sequence — the shape a stale/corrupt membership watermark
+      // takes when it points outside the member's own stream.
+      const foreignWid = workspaceId()
+      const foreignSid = streamId()
+      await seedChannel(foreignWid, foreignSid, author)
+      await sendMessages(foreignWid, foreignSid, author, 2)
+      const foreignEvents = await StreamEventRepository.list(pool, foreignSid)
+
+      await StreamMemberRepository.insert(pool, sid, member)
+      // Corrupt the watermark directly (bypassing validation) to reference the
+      // foreign-stream event id.
+      await pool.query(`UPDATE stream_members SET last_read_event_id = $1 WHERE stream_id = $2 AND member_id = $3`, [
+        foreignEvents[1].id,
+        sid,
+        member,
+      ])
+
+      // The membership fallback joins `streams` (workspace must match) and binds
+      // the watermark event to the membership's OWN stream — the foreign event
+      // resolves neither, so the member is NOT born-read despite the foreign
+      // sequence sitting past the target. Without the join/binding this row
+      // would falsely qualify.
+      const readThrough = await usersReadThroughEffective(pool, wid, sid, [member], events[1].sequence)
+      expect(readThrough).toEqual(new Set())
+    })
+  })
+
+  describe("markAsRead / markUnread for a viewer with no membership row", () => {
+    test("markAsRead advances the standalone frontier and emits stream:read in the same tx — never upserting membership", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 3)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      const membership = await streamService.markAsRead(wid, sid, viewer, events[1].id)
+
+      expect(membership).toBeNull()
+      expect(await membershipCount(sid, viewer)).toBe(0)
+
+      const row = await ReadStateRepository.get(pool, sid, viewer)
+      expect(row?.lastReadEventId).toBe(events[1].id)
+      expect(row?.workspaceId).toBe(wid)
+
+      const emitted = await outboxFor("stream:read", sid)
+      expect(emitted).toEqual([
+        {
+          workspaceId: wid,
+          authorId: viewer,
+          streamId: sid,
+          lastReadEventId: events[1].id,
+          lastReadSequence: events[1].sequence.toString(),
+          lastReadOrdinal: 2,
+          readMessageIds: [],
+        },
+      ])
+    })
+
+    test("markAsRead is monotonic — a stale advance neither regresses the row nor the payload", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 3)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      await streamService.markAsRead(wid, sid, viewer, events[2].id)
+      await streamService.markAsRead(wid, sid, viewer, events[0].id)
+
+      const row = await ReadStateRepository.get(pool, sid, viewer)
+      expect(row?.lastReadEventId).toBe(events[2].id)
+      // Both writes emit author-scoped stream:read; the stale one carries the
+      // post-write frontier, not the regressed event.
+      const emitted = await outboxFor("stream:read", sid)
+      expect(emitted.map((p) => p.lastReadEventId)).toEqual([events[2].id, events[2].id])
+    })
+
+    test("markUnread regresses the standalone frontier and emits stream:read_set — never upserting membership", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      const [, msg2] = await sendMessages(wid, sid, author, 2)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      await streamService.markAsRead(wid, sid, viewer, events[1].id)
+      const membership = await streamService.markUnread(wid, sid, viewer, msg2)
+
+      expect(membership).toBeNull()
+      expect(await membershipCount(sid, viewer)).toBe(0)
+
+      const row = await ReadStateRepository.get(pool, sid, viewer)
+      expect(row?.lastReadEventId).toBe(events[0].id)
+
+      const emitted = await outboxFor("stream:read_set", sid)
+      expect(emitted).toEqual([
+        {
+          workspaceId: wid,
+          authorId: viewer,
+          streamId: sid,
+          lastReadEventId: events[0].id,
+          lastReadSequence: events[0].sequence.toString(),
+          lastReadOrdinal: 1,
+          readMessageIds: [],
+        },
+      ])
+    })
+
+    test("markUnread on the first message parks the frontier before it (null watermark)", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      const [msg1] = await sendMessages(wid, sid, author, 2)
+
+      const membership = await streamService.markUnread(wid, sid, viewer, msg1)
+
+      expect(membership).toBeNull()
+      const row = await ReadStateRepository.get(pool, sid, viewer)
+      expect(row).not.toBeNull()
+      expect(row?.lastReadEventId).toBeNull()
+    })
+
+    test("markUnread throws MESSAGE_NOT_FOUND for a message outside the stream", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 1)
+
+      await expect(streamService.markUnread(wid, sid, userId(), "msg_elsewhere")).rejects.toMatchObject({
+        status: 404,
+        code: "MESSAGE_NOT_FOUND",
+      })
+    })
+  })
+})
+
+/**
+ * Backfill fidelity: the migration copies every non-NULL membership watermark
+ * (event id AND timestamp) into stream_read_state with the workspace derived
+ * through streams — NULL watermarks seed no row (absence = never read).
+ */
+describe("stream_read_state migration backfill", () => {
+  let pool: Pool
+  let migrationSql: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    migrationSql = await Bun.file(MIGRATION_PATH).text()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("copies member watermarks + timestamps with workspace derived through streams; skips NULLs; never clobbers", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const wid = "ws_backfill_test"
+      const sid = "stream_backfill_1"
+      const sidNull = "stream_backfill_2"
+      const memberWithRead = "usr_backfill_read"
+      const readAt = new Date("2026-03-04T05:06:07.000Z")
+
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES
+           ($1, $2, 'channel', 'private', $4),
+           ($3, $2, 'channel', 'private', $4)`,
+        [sid, wid, sidNull, memberWithRead]
+      )
+      // One member with a watermark, one never-read member (NULL) whose row
+      // must NOT seed a stream_read_state entry (absence = never read).
+      await client.query(
+        `INSERT INTO stream_members (stream_id, member_id, last_read_event_id, last_read_at) VALUES
+           ($1, $2, 'evt_backfill_9', $4),
+           ($3, $2, NULL, NULL)`,
+        [sid, memberWithRead, sidNull, readAt]
+      )
+      // A pre-existing row the backfill must not clobber (ON CONFLICT DO NOTHING).
+      await client.query(
+        `INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at)
+         VALUES ($1, $2, $3, 'evt_pre_existing', NULL)`,
+        [wid, sid, memberWithRead]
+      )
+
+      await client.query(migrationSql)
+
+      const result = await client.query(
+        `SELECT workspace_id, stream_id, user_id, last_read_event_id, last_read_at
+         FROM stream_read_state
+         WHERE workspace_id = $1
+         ORDER BY stream_id`,
+        [wid]
+      )
+
+      // NULL watermark seeded no row; the existing row survived untouched.
+      expect(result.rows).toEqual([
+        {
+          workspace_id: wid,
+          stream_id: sid,
+          user_id: memberWithRead,
+          last_read_event_id: "evt_pre_existing",
+          last_read_at: null,
+        },
+      ])
+
+      // With the conflict out of the way, a fresh backfill carries both the
+      // event id and the membership timestamp.
+      await client.query(`DELETE FROM stream_read_state WHERE workspace_id = $1`, [wid])
+      await client.query(migrationSql)
+      const fresh = await client.query(
+        `SELECT workspace_id, stream_id, user_id, last_read_event_id, last_read_at
+         FROM stream_read_state
+         WHERE workspace_id = $1`,
+        [wid]
+      )
+      expect(fresh.rows).toEqual([
+        {
+          workspace_id: wid,
+          stream_id: sid,
+          user_id: memberWithRead,
+          last_read_event_id: "evt_backfill_9",
+          last_read_at: readAt,
+        },
+      ])
+    })
+  })
+})

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -6,6 +6,7 @@ import {
   StreamEventRepository,
   StreamMemberRepository,
   SparseReadRepository,
+  ReadStateRepository,
   applySparseRead,
   applySparseUnread,
 } from "../../src/features/streams"
@@ -29,6 +30,7 @@ describe("Sparse read overlay", () => {
 
   beforeEach(async () => {
     await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM stream_read_state")
     await pool.query("DELETE FROM messages")
     await pool.query("DELETE FROM stream_events")
     await pool.query("DELETE FROM stream_sequences")
@@ -149,7 +151,7 @@ describe("Sparse read overlay", () => {
     expect(await effectiveUnread(sid, reader)).toBe(0)
   })
 
-  test("a non-member thread leg is overlay-only — no membership row, no watermark", async () => {
+  test("a non-member thread leg compacts into its own standalone read-state row — never into membership", async () => {
     const reader = userId()
     const { wid, sid, authorId } = await seedChannel([reader])
     const [parentMsg] = await sendMessages(wid, sid, authorId, 1)
@@ -168,12 +170,20 @@ describe("Sparse read overlay", () => {
       applySparseRead(client, { workspaceId: wid, streamId: threadId, memberId: reader, messageIds: threadMsgs })
     )
 
-    expect(snapshot.lastReadEventId).toBeNull()
-    expect(snapshot.lastReadSequence).toBe("0")
-    expect(snapshot.readMessageIds.sort()).toEqual([...threadMsgs].sort())
-    // Overlay-only: no membership row was upserted (membership ≠ access, INV-62).
+    // The contiguous run above the null watermark compacted into the leg's own
+    // frontier: watermark at the last read event, absorbed overlay rows pruned.
+    const threadEvents = await StreamEventRepository.list(pool, threadId)
+    const lastEvent = threadEvents[threadEvents.length - 1]
+    expect(snapshot.lastReadEventId).toBe(lastEvent.id)
+    expect(snapshot.lastReadSequence).toBe(lastEvent.sequence.toString())
+    expect(snapshot.readMessageIds).toEqual([])
+    expect(await SparseReadRepository.countOverlay(pool, threadId, reader)).toBe(0)
+    // The frontier landed in stream_read_state — and NO membership row was
+    // upserted (membership ≠ access ≠ read state, INV-62).
     expect(await StreamMemberRepository.findByStreamAndMember(pool, threadId, reader)).toBeNull()
-    expect(await SparseReadRepository.countOverlay(pool, threadId, reader)).toBe(2)
+    const readState = await ReadStateRepository.get(pool, threadId, reader)
+    expect(readState?.lastReadEventId).toBe(lastEvent.id)
+    expect(readState?.workspaceId).toBe(wid)
   })
 
   test("double-applying the same read is idempotent (ON CONFLICT) and order-convergent", async () => {

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -209,8 +209,11 @@ export const streamsApi = {
     return res.membership
   },
 
-  async markUnread(workspaceId: string, streamId: string, messageId: string): Promise<StreamMember> {
-    const res = await api.post<{ membership: StreamMember }>(
+  async markUnread(workspaceId: string, streamId: string, messageId: string): Promise<StreamMember | null> {
+    // Null membership = a successful unread by a viewer with access but no
+    // membership row (INV-62) — the standalone frontier moved; there is no
+    // membership to return.
+    const res = await api.post<{ membership: StreamMember | null }>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/unread`,
       { messageId }
     )

--- a/apps/frontend/src/components/message/conversation-read-context.test.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.test.tsx
@@ -120,14 +120,57 @@ describe("useConversationReadController", () => {
     expect(result.current.hasUnread([msg({ id: "m_reply", sequence: "5" })])).toBe(false)
   })
 
-  it("falls back to the root read-through time for a non-member thread leg", async () => {
+  it("a non-member thread leg resolves through its OWN standalone frontier (lazy-persisted read-state row)", async () => {
+    await seedReadState()
+    // The leg's standalone frontier (persisted by the per-stream bootstrap on
+    // open) — watermark at sequence 2. No membership row exists for the leg.
+    await db.streamReadState.put({
+      id: `${WS}:${THREAD}`,
+      workspaceId: WS,
+      streamId: THREAD,
+      lastReadEventId: "evt_t2",
+      lastReadSequence: "2",
+      lastReadAt: "2026-06-22T12:00:00.000Z",
+      _cachedAt: Date.now(),
+    })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    await waitFor(() =>
+      expect(result.current.value.state(THREAD, "t_new", "5", "2026-06-22T13:00:00.000Z")).toBe("unread")
+    )
+    expect(result.current.value.state(THREAD, "t_old", "1", "2026-06-22T11:00:00.000Z")).toBe("read")
+  })
+
+  it("a resolved never-read leg (null-watermark sentinel) reads every sequenced row as unread", async () => {
+    await seedReadState()
+    await db.streamReadState.put({
+      id: `${WS}:${THREAD}`,
+      workspaceId: WS,
+      streamId: THREAD,
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: null,
+      _cachedAt: Date.now(),
+    })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    // Frontier before the first message: any sequenced row sits above it.
+    await waitFor(() =>
+      expect(result.current.value.state(THREAD, "t_first", "1", "2026-06-22T11:00:00.000Z")).toBe("unread")
+    )
+    expect(result.current.hasUnread([msg({ id: "t_first", streamId: THREAD, sequence: "1" })])).toBe(true)
+  })
+
+  it("an unresolved leg is ungated — the root last_read_at approximation is gone", async () => {
     await seedReadState()
     const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
-    // A thread with no membership row: compare createdAt to the root's lastReadAt (T0).
+
+    // No frontier for the leg (never opened): NOT approximated against the
+    // root's read-through time — ungated until its own frontier resolves.
     await waitFor(() =>
-      expect(result.current.value.state(THREAD, "t_old", undefined, "2026-06-22T11:00:00.000Z")).toBe("read")
+      expect(result.current.value.state(THREAD, "t_old", undefined, "2026-06-22T11:00:00.000Z")).toBe("ungated")
     )
-    expect(result.current.value.state(THREAD, "t_new", undefined, "2026-06-22T13:00:00.000Z")).toBe("unread")
+    expect(result.current.value.state(THREAD, "t_new", "5", "2026-06-22T13:00:00.000Z")).toBe("ungated")
   })
 
   it("reports the card unread when a non-own member message is effectively unread, excluding own rows", async () => {

--- a/apps/frontend/src/components/message/conversation-read-context.test.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.test.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type ConversationService } from "@/contexts"
+import type { ReadStateSnapshot } from "@/hooks/use-unread-counts"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real store-hook read path
 import { clearAllCachedData, db } from "@/db"
 import type { RenderableMessage } from "@/components/message/message-item"
@@ -209,6 +210,55 @@ describe("useConversationReadController", () => {
     // effectively read and the card unread clears live.
     await waitFor(() => expect(result.current.hasUnread([reply])).toBe(false))
     expect(result.current.value.state(ROOT, "m_reply", "5", reply.createdAt)).toBe("read")
+  })
+
+  it("a delayed mark-read response cannot erase an explicit unread that landed after the request departed", async () => {
+    await seedReadState()
+    let resolveMarkRead!: (value: { streams: ReadStateSnapshot[] }) => void
+    markRead.mockReturnValue(new Promise<{ streams: ReadStateSnapshot[] }>((resolve) => (resolveMarkRead = resolve)))
+
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+    const reply = msg({ id: "m_reply", authorId: OTHER, sequence: "5" })
+    await waitFor(() => expect(result.current.hasUnread([reply])).toBe(true))
+
+    result.current.value.markReadUpToHere("m_reply")
+    await waitFor(() => expect(markRead).toHaveBeenCalledWith(WS, CONV, "m_reply"))
+
+    // An explicit conversation unread lands while the read is in flight: its
+    // echo regresses the frontier to the never-read position and stamps the
+    // touched time on the standalone row.
+    await db.streamReadState.put({
+      id: `${WS}:${ROOT}`,
+      workspaceId: WS,
+      streamId: ROOT,
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+
+    // The stale read response finally resolves with its absolute snapshot.
+    await act(async () => {
+      resolveMarkRead({
+        streams: [
+          {
+            streamId: ROOT,
+            readMessageIds: ["m_reply"],
+            lastReadEventId: "evt_5",
+            lastReadSequence: "5",
+            lastReadOrdinal: 5,
+          },
+        ],
+      })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    // The explicit unread survives: no overlay SET, no frontier restore.
+    const row = await db.streamReadState.get(`${WS}:${ROOT}`)
+    expect(row?.lastReadEventId).toBeNull()
+    const unreadState = await db.unreadState.get(WS)
+    expect(unreadState?.readMessageIds?.[ROOT]).toBeUndefined()
+    await waitFor(() => expect(result.current.value.state(ROOT, "m_reply", "5", reply.createdAt)).toBe("unread"))
   })
 
   it("marks unread from a message via the client", async () => {

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -161,10 +161,16 @@ export function useConversationReadController(
   )
 
   const markReadSilently = useCallback(
-    (messageId: string) =>
-      conversationService
+    (messageId: string) => {
+      // Mutation departure time: the response applies per-stream only to legs
+      // NOT touched after this instant (its own socket echo or a later action
+      // — e.g. an explicit unread this stale read must not erase). The echo is
+      // canonical; a delayed response is a no-op on touched legs.
+      const startedAt = Date.now()
+      return conversationService
         .markRead(workspaceId, conversationId, messageId)
-        .then((res) => applyReadStateSnapshots(workspaceId, res.streams)),
+        .then((res) => applyReadStateSnapshots(workspaceId, res.streams, startedAt))
+    },
     [conversationService, workspaceId, conversationId]
   )
 
@@ -191,9 +197,10 @@ export function useConversationReadController(
   const markUnread = useCallback(
     (messageId: string) => {
       explicitUnreadListenerRef.current?.()
+      const startedAt = Date.now()
       conversationService
         .markUnread(workspaceId, conversationId, messageId)
-        .then((res) => applyReadStateSnapshots(workspaceId, res.streams))
+        .then((res) => applyReadStateSnapshots(workspaceId, res.streams, startedAt))
         .catch(() => toast.error("Couldn't mark as unread"))
     },
     [conversationService, workspaceId, conversationId]

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -36,19 +36,23 @@ export function useConversationRowRead(): ConversationRowRead | null {
 export const ConversationReadProvider = ConversationReadContext.Provider
 
 interface ReadFrontierRow {
+  lastReadEventId: string | null
   lastReadSequence?: string | null
   lastReadAt: string | null
 }
 
 /**
  * Derive one row's effective read state against the conversation's spanned
- * streams. A member stream compares the row's per-stream `sequence` to the
- * stream's watermark sequence; a non-member thread leg (no membership row) falls
- * back to the root watermark's `last_read_at` timestamp (the v1 approximation —
- * docs/sparse-read-overlay-design.md § "Card unread derivation"). The overlay
- * makes a row effectively read regardless of sequence. Sequenceless rows
- * (projection/backfill) fall back to the same timestamp comparison; `ungated`
- * when nothing can decide (callers show both actions / don't count unread).
+ * streams. Every leg — member OR access-without-membership (INV-62) — resolves
+ * through its OWN effective frontier: the membership mirror seeds the map and
+ * the standalone read-state rows override it (row presence authoritative), so
+ * a non-member thread leg carries its own watermark sequence once the lazy
+ * per-stream bootstrap persisted its frontier. The overlay makes a row
+ * effectively read regardless of sequence. A resolved null watermark (never
+ * read / explicit unread-to-zero) sits before the first message, so every
+ * sequenced row is unread. Sequenceless rows (projection/backfill) fall back
+ * to the frontier's timestamp; `ungated` when nothing can decide (callers show
+ * both actions / don't count unread).
  */
 function deriveRowState(
   streamId: string,
@@ -57,8 +61,7 @@ function deriveRowState(
   createdAt: string | Date,
   overlay: Record<string, string[]> | undefined,
   unreadCounts: Record<string, number> | undefined,
-  frontierByStream: Map<string, ReadFrontierRow>,
-  rootStreamId: string
+  frontierByStream: Map<string, ReadFrontierRow>
 ): RowReadState {
   if (overlay?.[streamId]?.includes(messageId)) return "read"
 
@@ -67,24 +70,25 @@ function deriveRowState(
   // what keeps the card honest when a watermark advance doesn't carry a
   // sequence the frontier map can see (mark-all-read advances counts to 0
   // without a per-stream sequence payload). Strict === 0: a missing entry means
-  // "no data" (non-member thread legs), which must fall through, not read.
+  // "no data" (a leg with no frontier yet), which must fall through, not read.
   if (unreadCounts?.[streamId] === 0) return "read"
 
-  const membership = frontierByStream.get(streamId)
-  if (membership) {
-    if (sequence != null && membership.lastReadSequence != null) {
-      return BigInt(sequence) > BigInt(membership.lastReadSequence) ? "unread" : "read"
+  const frontier = frontierByStream.get(streamId)
+  if (frontier) {
+    if (sequence != null && frontier.lastReadSequence != null) {
+      return BigInt(sequence) > BigInt(frontier.lastReadSequence) ? "unread" : "read"
     }
-    if (membership.lastReadAt != null) {
-      return new Date(createdAt).getTime() > new Date(membership.lastReadAt).getTime() ? "unread" : "read"
+    if (sequence != null && frontier.lastReadEventId == null) return "unread"
+    if (frontier.lastReadAt != null) {
+      return new Date(createdAt).getTime() > new Date(frontier.lastReadAt).getTime() ? "unread" : "read"
     }
     return "ungated"
   }
 
-  const root = frontierByStream.get(rootStreamId)
-  if (root?.lastReadAt != null) {
-    return new Date(createdAt).getTime() > new Date(root.lastReadAt).getTime() ? "unread" : "read"
-  }
+  // No frontier for this leg yet — it resolves through its own standalone row
+  // once synced (a card only renders rows from streams whose per-stream
+  // bootstrap ran, which persists the frontier). The old root `last_read_at`
+  // time approximation is gone: an unresolved leg is ungated, not approximated.
   return "ungated"
 }
 
@@ -116,8 +120,8 @@ export function useConversationReadController(
   /** One stream's RAW read truth (watermark sequence + overlay ids) — what the
    * auto-read hook diffs to detect a cross-device mark-unread. Raw primitives,
    * not derived row state: derivation flaps (the `unreadCounts === 0`
-   * short-circuit, a stale `lastReadAt` fallback) must never read as a
-   * regression, or auto-read false-pins and wedges on a static board card. */
+   * short-circuit, the timestamp fallback) must never read as a regression, or
+   * auto-read false-pins and wedges on a static board card. */
   getReadTruth: (streamId: string) => { lastReadSequence: string | null; readMessageIds: readonly string[] }
 } {
   const conversationService = useConversationService()
@@ -134,18 +138,26 @@ export function useConversationReadController(
   const frontierByStream = useMemo(() => {
     const map = new Map<string, ReadFrontierRow>()
     for (const m of memberships) {
-      map.set(m.streamId, { lastReadSequence: m.lastReadSequence, lastReadAt: m.lastReadAt })
+      map.set(m.streamId, {
+        lastReadEventId: m.lastReadEventId,
+        lastReadSequence: m.lastReadSequence,
+        lastReadAt: m.lastReadAt,
+      })
     }
     for (const rs of readStates) {
-      map.set(rs.streamId, { lastReadSequence: rs.lastReadSequence, lastReadAt: rs.lastReadAt })
+      map.set(rs.streamId, {
+        lastReadEventId: rs.lastReadEventId,
+        lastReadSequence: rs.lastReadSequence,
+        lastReadAt: rs.lastReadAt,
+      })
     }
     return map
   }, [memberships, readStates])
 
   const state = useCallback<ConversationRowRead["state"]>(
     (streamId, messageId, sequence, createdAt) =>
-      deriveRowState(streamId, messageId, sequence, createdAt, overlay, unreadCounts, frontierByStream, rootStreamId),
-    [overlay, unreadCounts, frontierByStream, rootStreamId]
+      deriveRowState(streamId, messageId, sequence, createdAt, overlay, unreadCounts, frontierByStream),
+    [overlay, unreadCounts, frontierByStream]
   )
 
   const markReadSilently = useCallback(

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -630,7 +630,19 @@ export function StreamContent({
     () => idbReadStates.find((candidate) => candidate.streamId === streamId),
     [idbReadStates, streamId]
   )
-  const lastReadEventId = resolveFrontierEventId(idbReadState, idbStream, membership)
+  // The per-stream bootstrap carries the viewer's standalone frontier (non-
+  // member unlock); IDB catches up a tick after the query resolves, so consult
+  // the in-memory payload for first paint. A confirmed-absent row (null)
+  // resolves an access-without-membership viewer as never-read (frontier
+  // before the first message) — they have no membership mirror to fall back
+  // to; members fall through to the mirrors (shadow-window fallback).
+  const bootstrapReadState = useMemo(() => {
+    const rs = bootstrap?.readState
+    if (rs) return rs
+    if (rs === null && !bootstrap?.membership) return { lastReadEventId: null }
+    return undefined
+  }, [bootstrap?.readState, bootstrap?.membership])
+  const lastReadEventId = resolveFrontierEventId(idbReadState ?? bootstrapReadState, idbStream, membership)
 
   const stream = streamFromProps ?? idbStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD

--- a/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
+++ b/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
@@ -70,6 +70,7 @@ export function useCoordinatedStreamQueries(workspaceId: string, streamIds: stri
               debugBootstrap("Coordinated stream bootstrap queryFn start", { workspaceId, streamId })
               await joinRoomBestEffort(socket, `ws:${workspaceId}:stream:${streamId}`, "CoordinatedStreamBootstrap")
 
+              const fetchStartedAt = Date.now()
               const bootstrap = await streamService.bootstrap(workspaceId, streamId)
               debugBootstrap("Coordinated stream bootstrap fetch success", {
                 workspaceId,
@@ -77,7 +78,7 @@ export function useCoordinatedStreamQueries(workspaceId: string, streamIds: stri
                 eventCount: bootstrap.events.length,
               })
 
-              await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+              await applyStreamBootstrap(workspaceId, streamId, bootstrap, { fetchStartedAt, queryClient })
 
               return toCachedStreamBootstrap(
                 bootstrap,

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -87,6 +87,7 @@ export function useStreamBootstrap(workspaceId: string, streamId: string, option
       }
       await joinRoomBestEffort(socket, `ws:${workspaceId}:stream:${streamId}`, "StreamBootstrap")
 
+      const fetchStartedAt = Date.now()
       const bootstrap = await streamService.bootstrap(workspaceId, streamId)
       debugBootstrap("Stream bootstrap fetch success", {
         workspaceId,
@@ -95,8 +96,11 @@ export function useStreamBootstrap(workspaceId: string, streamId: string, option
       })
 
       // Write events and stream metadata to IndexedDB.
-      // The sync module handles optimistic event cleanup.
-      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+      // The sync module handles optimistic event cleanup. `fetchStartedAt`
+      // guards the standalone frontier: a read-state row touched while this
+      // request was in flight (socket echo / local mutation) is preserved
+      // over the stale snapshot.
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap, { fetchStartedAt, queryClient })
 
       return toCachedStreamBootstrap(
         bootstrap,

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -484,4 +484,141 @@ describe("useUnreadCounts", () => {
     expect(await db.streamMemberships.get("ws_1:stream_thread")).toBeUndefined()
     expect(await db.streamReadState.get("ws_1:stream_thread")).toBeUndefined()
   })
+
+  // Ordering guard: the mutation captures its departure time; a read-state
+  // write that lands while the request is in flight (the request's own socket
+  // echo, or a LATER action) owns the stream, so the stale HTTP success is a
+  // no-op. An old read must not erase a later explicit unread, and vice versa.
+  function memberResponse(lastReadEventId: string): StreamMember {
+    return {
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId,
+      lastReadAt: new Date().toISOString(),
+      joinedAt: new Date().toISOString(),
+    }
+  }
+
+  it("a delayed markAsRead success is a no-op when a later explicit unread touched the stream mid-flight", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_old",
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now() - 5000,
+    })
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 2 },
+      mentionCounts: { stream_1: 0 },
+      activityCounts: { stream_1: 0 },
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      mutedStreamIds: [],
+      _cachedAt: Date.now() - 5000,
+    })
+
+    let resolveRead!: (membership: StreamMember | null) => void
+    mockMarkAsRead.mockReturnValue(new Promise((resolve) => (resolveRead = resolve)))
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_100")
+    })
+    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalledWith("ws_1", "stream_1", "evt_100"))
+
+    // A LATER explicit unread lands while the read is in flight: its
+    // stream:read_set echo SETs frontier + mirror back to evt_50 and stamps
+    // the touched time.
+    const touchedAt = Date.now()
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: new Date().toISOString(),
+      _cachedAt: touchedAt,
+    })
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "evt_50",
+      lastReadAt: new Date().toISOString(),
+      joinedAt: new Date().toISOString(),
+      _cachedAt: touchedAt,
+    })
+
+    // The stale read response finally resolves — it must NOT restore evt_100.
+    await act(async () => {
+      resolveRead(memberResponse("evt_100"))
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "evt_50" })
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "evt_50" })
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    // The stale success wrote nothing: the cache still carries the seeded
+    // mirror (not evt_100) and a full read would have zeroed the badge.
+    expect(bootstrap?.streamMemberships.find((m) => m.streamId === "stream_1")?.lastReadEventId).toBe("event_old")
+    expect(bootstrap?.unreadCounts.stream_1).toBe(2)
+  })
+
+  it("a delayed markUnread success is a no-op when a later read touched the stream mid-flight", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_old",
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now() - 5000,
+    })
+
+    let resolveUnread!: (membership: StreamMember | null) => void
+    mockMarkUnread.mockReturnValue(new Promise((resolve) => (resolveUnread = resolve)))
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markUnread("stream_1", "msg_target")
+    })
+    await waitFor(() => expect(mockMarkUnread).toHaveBeenCalledWith("ws_1", "stream_1", "msg_target"))
+
+    // A LATER read lands while the unread is in flight: its stream:read echo
+    // advances the frontier to evt_150 and stamps the touched time.
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_150",
+      lastReadSequence: "150",
+      lastReadAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+
+    // The stale unread response resolves — it must NOT regress the frontier.
+    await act(async () => {
+      resolveUnread(memberResponse("evt_50"))
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "evt_150" })
+    // The stale success wrote nothing: the mirror keeps its seeded value.
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "event_old" })
+  })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -17,6 +17,8 @@ import { useUnreadCounts } from "./use-unread-counts"
 
 const mockMarkAsRead =
   vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember | null>>()
+const mockMarkUnread =
+  vi.fn<(workspaceId: string, streamId: string, messageId: string) => Promise<StreamMember | null>>()
 const mockPostMessage = vi.fn()
 const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
 
@@ -29,6 +31,7 @@ function createWrapper(queryClient: QueryClient) {
         services: {
           streams: {
             markAsRead: mockMarkAsRead,
+            markUnread: mockMarkUnread,
           } as unknown as StreamService,
         },
         children,
@@ -132,6 +135,7 @@ function makeBootstrap(): WorkspaceBootstrap {
 describe("useUnreadCounts", () => {
   beforeEach(async () => {
     mockMarkAsRead.mockReset()
+    mockMarkUnread.mockReset()
     mockPostMessage.mockReset()
     Object.defineProperty(navigator, "serviceWorker", {
       configurable: true,
@@ -408,16 +412,76 @@ describe("useUnreadCounts", () => {
       expect(state?.unreadActivities?.map((a) => a.id)).toEqual(["act_3"])
     })
 
-    // No watermark to persist: no membership row created, no stream row
-    // touched, and unrelated memberships stay put.
+    // No membership row created, no stream row touched, and unrelated
+    // memberships stay put — but the standalone frontier DOES move: non-member
+    // unlocks get the same optimistic divider advance as members.
     expect(await db.streamMemberships.get("ws_1:stream_thread")).toBeUndefined()
     expect(await db.streams.get("stream_thread")).toBeUndefined()
     expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "event_old" })
+    expect(await db.streamReadState.get("ws_1:stream_thread")).toMatchObject({
+      streamId: "stream_thread",
+      lastReadEventId: "event_new",
+    })
 
     const updated = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
     expect(updated?.unreadActivities?.map((a) => a.id)).toEqual(["act_3"])
     expect(updated?.activityCounts).toEqual({ stream_2: 1 })
     expect(updated?.unreadActivityCount).toBe(1)
     expect(updated?.streamMemberships.find((m) => m.streamId === "stream_1")?.lastReadEventId).toBe("event_old")
+    expect(updated?.streamReadState?.stream_thread?.lastReadEventId).toBe("event_new")
+  })
+
+  it("markUnread with a membership mirrors the pointer into the membership row and the standalone frontier", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_old",
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+
+    mockMarkUnread.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_prev",
+      lastReadAt: "2026-07-24T00:00:00.000Z",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markUnread("stream_1", "msg_target")
+    })
+
+    await waitFor(async () => {
+      expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "event_prev" })
+    })
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "event_prev" })
+  })
+
+  it("markUnread with a null membership writes nothing optimistically — the stream:read_set echo owns the frontier", async () => {
+    // A non-member's unread succeeds with a null membership; the response
+    // carries no watermark, so the optimistic path must not fabricate
+    // membership-shaped rows — the echo SETs the standalone frontier.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+
+    mockMarkUnread.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markUnread("stream_thread", "msg_target")
+    })
+
+    await waitFor(() => expect(mockMarkUnread).toHaveBeenCalledWith("ws_1", "stream_thread", "msg_target"))
+    expect(await db.streamMemberships.get("ws_1:stream_thread")).toBeUndefined()
+    expect(await db.streamReadState.get("ws_1:stream_thread")).toBeUndefined()
   })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -10,6 +10,7 @@ import {
   applyReadStateSnapshotsIdb,
   mergeReadStateIntoBootstrapCache,
   putReadStateIdb,
+  readStateTouchedSince,
   type ReadStateSnapshot,
 } from "@/sync/read-state"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
@@ -57,9 +58,16 @@ export function useReadMessageIds(workspaceId: string, streamId: string): Readon
  * straight to IDB so the timeline overlay, board card, and badge update at once;
  * the authoritative `stream:read_messages` socket echo reconciles the query
  * cache. One apply path with the socket handler (`sync/read-state.ts`).
+ * `startedAt` (the mutation's departure time) activates the per-stream
+ * touched-at guard: legs touched after the request departed (its own echo, or
+ * a later action) skip this stale response entirely.
  */
-export function applyReadStateSnapshots(workspaceId: string, snapshots: ReadStateSnapshot[]): Promise<void> {
-  return applyReadStateSnapshotsIdb(workspaceId, snapshots)
+export function applyReadStateSnapshots(
+  workspaceId: string,
+  snapshots: ReadStateSnapshot[],
+  startedAt?: number
+): Promise<void> {
+  return applyReadStateSnapshotsIdb(workspaceId, snapshots, startedAt)
 }
 
 export function useUnreadCounts(workspaceId: string) {
@@ -83,9 +91,17 @@ export function useUnreadCounts(workspaceId: string) {
   )
 
   const markAsReadMutation = useMutation({
-    mutationFn: ({ streamId, lastEventId }: { streamId: string; lastEventId: string; partial?: boolean }) =>
-      streamService.markAsRead(workspaceId, streamId, lastEventId),
-    onSuccess: async (membership, { streamId, lastEventId, partial }) => {
+    mutationFn: async ({ streamId, lastEventId }: { streamId: string; lastEventId: string; partial?: boolean }) => {
+      const startedAt = Date.now()
+      const membership = await streamService.markAsRead(workspaceId, streamId, lastEventId)
+      return { membership, startedAt }
+    },
+    onSuccess: async ({ membership, startedAt }, { streamId, lastEventId, partial }) => {
+      // Ordering guard (touched-at): a read-state write that landed after this
+      // mutation departed — the request's own socket echo, or a later action
+      // (an explicit unread this stale read must not erase) — owns the stream.
+      // The server's socket log is canonical; success is a no-op.
+      if (await readStateTouchedSince(workspaceId, streamId, startedAt)) return
       const current = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
       const hadActivity = (current?.activityCounts[streamId] ?? 0) > 0
       // Null membership = a successful activity-only read by a viewer with
@@ -160,6 +176,9 @@ export function useUnreadCounts(workspaceId: string) {
       // standalone read-state row in sync: stream-content derives the unread
       // divider from the effective frontier across those mirrors.
       await db.transaction("rw", [db.unreadState, db.streams, db.streamMemberships, db.streamReadState], async () => {
+        // INV-20 re-check: a touch landing between the guard above and this
+        // transaction still wins over the stale response.
+        if (await readStateTouchedSince(workspaceId, streamId, startedAt)) return
         const now = Date.now()
         const state = await db.unreadState.get(workspaceId)
         if (state) {
@@ -232,14 +251,21 @@ export function useUnreadCounts(workspaceId: string) {
   // (applyStreamReadSet SETs it, which is allowed to move backward). Mirrors the
   // partial markAsRead path, which likewise defers the count to the round-trip.
   const markUnreadMutation = useMutation({
-    mutationFn: ({ streamId, messageId }: { streamId: string; messageId: string }) =>
-      streamService.markUnread(workspaceId, streamId, messageId),
-    onSuccess: async (membership, { streamId }) => {
+    mutationFn: async ({ streamId, messageId }: { streamId: string; messageId: string }) => {
+      const startedAt = Date.now()
+      const membership = await streamService.markUnread(workspaceId, streamId, messageId)
+      return { membership, startedAt }
+    },
+    onSuccess: async ({ membership, startedAt }, { streamId }) => {
       // Null membership = a successful unread by a viewer with access but no
       // membership row (INV-62). The response carries no watermark to apply —
       // the `stream:read_set` echo SETs the standalone frontier and raises the
       // count on the round-trip (the same deferral members get for the count).
       if (!membership) return
+      // Symmetric ordering guard: a read-state write that landed after this
+      // mutation departed (its own read_set echo, or a later read this stale
+      // unread must not erase) owns the stream — success is a no-op.
+      if (await readStateTouchedSince(workspaceId, streamId, startedAt)) return
 
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
@@ -271,6 +297,7 @@ export function useUnreadCounts(workspaceId: string) {
       })
 
       await db.transaction("rw", [db.streams, db.streamMemberships, db.streamReadState], async () => {
+        if (await readStateTouchedSince(workspaceId, streamId, startedAt)) return
         const now = Date.now()
         await db.streams.update(streamId, { lastReadEventId: membership.lastReadEventId, _cachedAt: now })
 

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -141,19 +141,20 @@ export function useUnreadCounts(workspaceId: string) {
             return { ...old, membership: { ...old.membership, lastReadEventId: lastEventId } }
           }
         )
-
-        // Standalone frontier (read cutover): frontier readers prefer the
-        // read-state row, so the optimistic advance must move it too or the
-        // divider stalls until the socket echo. The response carries no
-        // sequence; keep the stored one (the echo reconciles it), matching the
-        // membership mirror's optimistic-write convention.
-        const existingFrontier = current?.streamReadState?.[streamId]
-        mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, {
-          lastReadEventId: lastEventId,
-          lastReadSequence: existingFrontier?.lastReadSequence ?? null,
-          lastReadAt: membership.lastReadAt ?? new Date().toISOString(),
-        })
       }
+
+      // Standalone frontier (read cutover + non-member unlock): frontier
+      // readers prefer the read-state row, so the optimistic advance must move
+      // it for EVERY viewer with access — member or not — or the divider
+      // stalls until the socket echo. The response carries no sequence; keep
+      // the stored one (the echo reconciles it), matching the membership
+      // mirror's optimistic-write convention.
+      const existingFrontier = current?.streamReadState?.[streamId]
+      mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, {
+        lastReadEventId: lastEventId,
+        lastReadSequence: existingFrontier?.lastReadSequence ?? null,
+        lastReadAt: membership?.lastReadAt ?? new Date().toISOString(),
+      })
 
       // Keep the denormalized stream row, the membership row, and the
       // standalone read-state row in sync: stream-content derives the unread
@@ -182,10 +183,10 @@ export function useUnreadCounts(workspaceId: string) {
           })
         }
 
+        const membershipId = `${workspaceId}:${streamId}`
         if (hasMembership) {
           await db.streams.update(streamId, { lastReadEventId: lastEventId, _cachedAt: now })
 
-          const membershipId = `${workspaceId}:${streamId}`
           const existingMembership = await db.streamMemberships.get(membershipId)
           if (existingMembership) {
             await db.streamMemberships.put({
@@ -203,19 +204,20 @@ export function useUnreadCounts(workspaceId: string) {
               _cachedAt: now,
             })
           }
-
-          const existingRow = await db.streamReadState.get(membershipId)
-          await putReadStateIdb(
-            workspaceId,
-            streamId,
-            {
-              lastReadEventId: lastEventId,
-              lastReadSequence: existingRow?.lastReadSequence ?? null,
-              lastReadAt: membership.lastReadAt ?? new Date().toISOString(),
-            },
-            now
-          )
         }
+
+        // The standalone row moves for non-members too (no membership mirror).
+        const existingRow = await db.streamReadState.get(membershipId)
+        await putReadStateIdb(
+          workspaceId,
+          streamId,
+          {
+            lastReadEventId: lastEventId,
+            lastReadSequence: existingRow?.lastReadSequence ?? null,
+            lastReadAt: membership?.lastReadAt ?? new Date().toISOString(),
+          },
+          now
+        )
       })
 
       if (hadActivity) {
@@ -233,6 +235,12 @@ export function useUnreadCounts(workspaceId: string) {
     mutationFn: ({ streamId, messageId }: { streamId: string; messageId: string }) =>
       streamService.markUnread(workspaceId, streamId, messageId),
     onSuccess: async (membership, { streamId }) => {
+      // Null membership = a successful unread by a viewer with access but no
+      // membership row (INV-62). The response carries no watermark to apply —
+      // the `stream:read_set` echo SETs the standalone frontier and raises the
+      // count on the round-trip (the same deferral members get for the count).
+      if (!membership) return
+
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
         return {

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -136,6 +136,165 @@ describe("applyReadStateSnapshotsIdb", () => {
   })
 })
 
+describe("applyReadStateSnapshotsIdb — startedAt freshness guard", () => {
+  // A conversation read/unread response begun at T0 applies per stream only to
+  // legs NOT touched at/after T0 (the request's own socket echo, or a later
+  // action). A delayed earlier read-through-M5 must not regress a later
+  // read-through-M10, and a delayed read must not erase a later explicit
+  // unread — operation order (touched-at), not sequence max, decides.
+
+  beforeEach(async () => {
+    await Promise.all([
+      db.unreadState.clear(),
+      db.streamMemberships.clear(),
+      db.streams.clear(),
+      db.streamReadState.clear(),
+    ])
+  })
+
+  it("skips a stream touched after departure — a delayed earlier read cannot regress a later one", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    // A later read-through-M10 landed AFTER the delayed request departed: its
+    // echo/optimistic apply SET the overlay + frontier and stamped the touch.
+    const touchedAt = Date.now()
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_10",
+      lastReadSequence: "100",
+      lastReadAt: "2026-01-01T00:00:10.000Z",
+      _cachedAt: touchedAt,
+    })
+    const seeded = await db.unreadState.get("ws_1")
+    await db.unreadState.put({
+      ...seeded!,
+      readMessageIds: { stream_1: ["m8", "m9", "m10"] },
+      unreadCounts: { stream_1: 0 },
+    })
+
+    // The delayed earlier read-through-M5 response arrives.
+    await applyReadStateSnapshotsIdb(
+      "ws_1",
+      [snapshot({ readMessageIds: ["m5"], lastReadEventId: "evt_5", lastReadSequence: "50", lastReadOrdinal: 5 })],
+      touchedAt - 1000
+    )
+
+    // Frontier, overlay, and mirror survive EXACTLY — no regression.
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_10",
+      lastReadSequence: "100",
+    })
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toEqual(["m8", "m9", "m10"])
+    expect(state?.unreadCounts.stream_1).toBe(0)
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ lastReadEventId: "evt_0" })
+  })
+
+  it("applies normally when the frontier row predates the mutation departure", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    const startedAt = Date.now()
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_2",
+      lastReadSequence: "20",
+      lastReadAt: "2026-01-01T00:00:02.000Z",
+      _cachedAt: startedAt - 5000,
+    })
+
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()], startedAt)
+
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_4",
+      lastReadSequence: "40",
+    })
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toEqual(["msg_5", "msg_7"])
+  })
+
+  it("applies normally when no frontier row exists yet", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()], Date.now())
+
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_4",
+      lastReadSequence: "40",
+    })
+  })
+
+  it("filters per stream — the untouched leg applies while the touched leg is skipped", async () => {
+    // A conversation spans root + thread legs; ordering is per stream.
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 6, stream_2: 6 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { stream_1: 10, stream_2: 10 },
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    const touchedAt = Date.now()
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_later",
+      lastReadSequence: "90",
+      lastReadAt: "2026-01-01T00:00:09.000Z",
+      _cachedAt: touchedAt,
+    })
+
+    await applyReadStateSnapshotsIdb(
+      "ws_1",
+      [
+        snapshot({
+          streamId: "stream_1",
+          readMessageIds: ["m_old"],
+          lastReadEventId: "evt_old",
+          lastReadSequence: "30",
+          lastReadOrdinal: 3,
+        }),
+        snapshot({
+          streamId: "stream_2",
+          readMessageIds: ["m_2"],
+          lastReadEventId: "evt_2",
+          lastReadSequence: "20",
+          lastReadOrdinal: 2,
+        }),
+      ],
+      touchedAt - 1000
+    )
+
+    // Touched leg skipped entirely; untouched leg applied.
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_later",
+      lastReadSequence: "90",
+    })
+    expect(await db.streamReadState.get("ws_1:stream_2")).toMatchObject({
+      lastReadEventId: "evt_2",
+      lastReadSequence: "20",
+    })
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toBeUndefined()
+    expect(state?.readMessageIds?.stream_2).toEqual(["m_2"])
+    expect(state?.unreadCounts.stream_1).toBe(6)
+    // stream_2: latest 10 − reconstructed read 4 − overlay 1.
+    expect(state?.unreadCounts.stream_2).toBe(5)
+  })
+})
+
 describe("commitReadStateSnapshot", () => {
   beforeEach(async () => {
     await Promise.all([

--- a/apps/frontend/src/sync/read-state.ts
+++ b/apps/frontend/src/sync/read-state.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query"
 import type { StreamBootstrap, StreamReadFrontier, WorkspaceBootstrap } from "@threa/types"
-import { db } from "@/db"
+import { db, type CachedStreamReadState } from "@/db"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import { applyStreamReadMessages, dropMessageActivities } from "./unread-counters"
@@ -27,6 +27,31 @@ export async function putReadStateIdb(
     lastReadAt: fields.lastReadAt,
     _cachedAt: now,
   })
+}
+
+/** The frontier fields of a cached read-state row (drops the IDB bookkeeping). */
+export function toStreamReadFrontier(row: CachedStreamReadState): StreamReadFrontier {
+  return {
+    lastReadEventId: row.lastReadEventId,
+    lastReadSequence: row.lastReadSequence,
+    lastReadAt: row.lastReadAt,
+  }
+}
+
+/**
+ * True when the stream's standalone frontier row was written at/after `since` —
+ * a socket/live write (the caller's own request echo, or a later action) that
+ * postdates the caller's operation. The per-stream read-state `_cachedAt` is
+ * the touched stamp the workspace-bootstrap freshness merge keys off (every
+ * applier in this module stamps it via `putReadStateIdb` /
+ * `writeSnapshotWatermarkIdb`): an HTTP response that observes a touched stream
+ * must not apply there — the snapshot may predate an explicit unread, a
+ * sanctioned downward move no max(sequence) rule can protect. Operation order
+ * (touched-at) decides, not sequence max.
+ */
+export async function readStateTouchedSince(workspaceId: string, streamId: string, since: number): Promise<boolean> {
+  const row = await db.streamReadState.get(`${workspaceId}:${streamId}`)
+  return row !== undefined && row._cachedAt >= since
 }
 
 /** Merge one stream's standalone frontier into the workspace bootstrap query cache. */
@@ -177,13 +202,35 @@ export function commitReadStateSnapshot(
  * through `commitReadStateSnapshot`. Counter math + watermark persistence share
  * the same helpers as the socket path (`snapshotCounterMutator`,
  * `writeSnapshotWatermarkIdb`), so there is one apply path per surface (INV-35).
+ *
+ * `startedAt` (the mutation's departure time) activates the per-stream
+ * touched-at guard: a leg whose frontier row was written at/after `startedAt`
+ * was touched by this request's own socket echo or a later action (e.g. an
+ * explicit unread over a delayed read), so this stale response skips that leg
+ * entirely — no old overlay SET, no frontier regression. Per stream, because a
+ * conversation spans root + thread legs that move independently. The server's
+ * socket log stays canonical; the echo (or the later action's echo) owns the
+ * touched leg.
  */
-export async function applyReadStateSnapshotsIdb(workspaceId: string, snapshots: ReadStateSnapshot[]): Promise<void> {
+export async function applyReadStateSnapshotsIdb(
+  workspaceId: string,
+  snapshots: ReadStateSnapshot[],
+  startedAt?: number
+): Promise<void> {
   if (snapshots.length === 0) return
-  const mutators = snapshots.map(snapshotCounterMutator)
   await db.transaction("rw", [db.unreadState, db.streams, db.streamMemberships, db.streamReadState], async () => {
+    let effective = snapshots
+    if (startedAt !== undefined) {
+      effective = []
+      for (const snapshot of snapshots) {
+        if (await readStateTouchedSince(workspaceId, snapshot.streamId, startedAt)) continue
+        effective.push(snapshot)
+      }
+      if (effective.length === 0) return
+    }
+    const mutators = effective.map(snapshotCounterMutator)
     await putCountersIdb(workspaceId, mutators)
-    for (const snapshot of snapshots) {
+    for (const snapshot of effective) {
       await writeSnapshotWatermarkIdb(workspaceId, snapshot)
     }
   })

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -3099,3 +3099,140 @@ describe("applyStreamBootstrap — slot store ingestion (Amendment A)", () => {
     expect(cached.sharedMessages).toBeUndefined()
   })
 })
+
+describe("applyStreamBootstrap standalone frontier persistence (non-member unlock)", () => {
+  const streamId = "stream_frontier"
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.streamReadState.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("persists the bootstrap's standalone frontier row", async () => {
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([], streamId),
+      readState: { lastReadEventId: "evt_9", lastReadSequence: "42", lastReadAt: "2026-07-24T00:00:00.000Z" },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_9",
+      lastReadSequence: "42",
+      lastReadAt: "2026-07-24T00:00:00.000Z",
+    })
+  })
+
+  it("seeds a never-read sentinel for a confirmed non-member absence — they have no membership mirror to fall back to", async () => {
+    const bootstrap: StreamBootstrap = { ...makeBootstrap([], streamId), readState: null }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      streamId,
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: null,
+    })
+  })
+
+  it("seeds NO sentinel for a member without a standalone row — the membership fallback stays live (shadow window)", async () => {
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: {
+        streamId,
+        memberId: "user_1",
+        notificationLevel: null,
+        lastReadEventId: "evt_m",
+        lastReadAt: null,
+        joinedAt: new Date().toISOString(),
+      },
+      readState: null,
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toBeUndefined()
+  })
+
+  it("clears a prior nonmember sentinel once membership arrives with an absent row — frontier resolves to membership, not the stale sentinel", async () => {
+    // Nonmember open: absent row + no membership seeds the never-read sentinel.
+    await applyStreamBootstrap("ws_1", streamId, { ...makeBootstrap([], streamId), readState: null })
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: null,
+    })
+
+    // Membership gained during the rolling deploy (only the legacy column was
+    // written server-side, so the standalone row is still absent): the sentinel
+    // must be cleared so the frontier falls back to the membership watermark.
+    await applyStreamBootstrap("ws_1", streamId, {
+      ...makeBootstrap([], streamId),
+      membership: {
+        streamId,
+        memberId: "user_1",
+        notificationLevel: null,
+        lastReadEventId: "evt_m",
+        lastReadAt: null,
+        joinedAt: new Date().toISOString(),
+      },
+      readState: null,
+    })
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toBeUndefined()
+  })
+
+  it("never overwrites an explicit unread-to-zero row with a snapshot frontier that may predate the unread", async () => {
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: "2026-07-24T12:00:00.000Z",
+      _cachedAt: Date.now(),
+    })
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([], streamId),
+      readState: { lastReadEventId: "evt_9", lastReadSequence: "42", lastReadAt: "2026-07-24T00:00:00.000Z" },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({ lastReadEventId: null })
+  })
+
+  it("max-merges the incoming row over the stored sequence — a stale snapshot never regresses the frontier", async () => {
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_high",
+      lastReadSequence: "90",
+      lastReadAt: "2026-07-24T00:00:00.000Z",
+      _cachedAt: Date.now(),
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, {
+      ...makeBootstrap([], streamId),
+      readState: { lastReadEventId: "evt_low", lastReadSequence: "42", lastReadAt: "2026-07-24T00:00:00.000Z" },
+    })
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({ lastReadEventId: "evt_high" })
+
+    await applyStreamBootstrap("ws_1", streamId, {
+      ...makeBootstrap([], streamId),
+      readState: { lastReadEventId: "evt_higher", lastReadSequence: "100", lastReadAt: "2026-07-24T01:00:00.000Z" },
+    })
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({ lastReadEventId: "evt_higher" })
+  })
+
+  it("leaves the store untouched when the field is absent (payload cached before it shipped)", async () => {
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([], streamId))
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -14,6 +14,7 @@ import {
   type CachedStreamBootstrap,
 } from "./stream-sync"
 import { streamKeys } from "@/hooks/use-streams"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 import { sharedMessageSlotKey } from "@threa/types"
@@ -24,6 +25,8 @@ import type {
   SlotMap,
   StreamBootstrap,
   StreamEvent,
+  StreamMember,
+  WorkspaceBootstrap,
 } from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
@@ -887,6 +890,242 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     ])
 
     expect(await getLatestPersistedSequence(streamId)).toBe("200")
+  })
+})
+
+describe("applyStreamBootstrap — read-state freshness (stale response guard)", () => {
+  // A bootstrap snapshot begun at T0 may apply its `readState` only when the
+  // local frontier row was NOT touched at/after T0 (socket echo or optimistic
+  // mutation). Operation order — not max(sequence) — decides, so an explicit
+  // unread (a sanctioned downward move) can never be resurrected by a stale
+  // response that was in flight when it landed.
+
+  beforeEach(async () => {
+    await Promise.all([db.events.clear(), db.streams.clear(), db.streamReadState.clear(), db.streamMemberships.clear()])
+  })
+
+  function membership(streamId: string, lastReadEventId: string | null, lastReadSequence: string | null): StreamMember {
+    return {
+      streamId,
+      memberId: "member_1",
+      notificationLevel: null,
+      lastReadEventId,
+      lastReadSequence,
+      lastReadAt: "2026-01-01T00:00:00.000Z",
+      joinedAt: "2026-01-01T00:00:00.000Z",
+    }
+  }
+
+  it("a stale response cannot restore E100 over an explicit unread (read_set E50) that landed during the fetch", async () => {
+    const streamId = "stream_stale_restore"
+    const fetchStartedAt = Date.now() - 5000
+
+    // While the request was in flight, a stream:read_set echo SET the frontier
+    // back to E50 and stamped the touched time.
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+      _cachedAt: Date.now() - 1000, // touched inside the fetch window
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: {
+        lastReadEventId: "evt_100",
+        lastReadSequence: "100",
+        lastReadAt: "2026-01-01T00:00:01.000Z",
+      },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt })
+
+    // Preserved EXACTLY — max(sequence) alone would have "restored" E100 (100 > 50).
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+    })
+    // The envelope carries the preserved row, so the per-stream query cache the
+    // caller writes (toCachedStreamBootstrap) never publishes the stale snapshot.
+    expect(bootstrap.readState).toEqual({
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+    })
+  })
+
+  it("a stale confirmed-ABSENT (null) response cannot delete a frontier touched during the fetch", async () => {
+    const streamId = "stream_stale_absent"
+    const fetchStartedAt = Date.now() - 5000
+
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+      _cachedAt: Date.now() - 1000,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: null, // server snapshot predates the row: "no standalone row"
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt })
+
+    // The member absence-delete semantics do NOT apply — the touched row stays.
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+    })
+    expect(bootstrap.readState).toMatchObject({ lastReadEventId: "evt_50" })
+  })
+
+  it("a later advance during the fetch (E150) is preserved exactly", async () => {
+    const streamId = "stream_stale_advance"
+    const fetchStartedAt = Date.now() - 5000
+
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_150",
+      lastReadSequence: "150",
+      lastReadAt: "2026-01-01T00:00:09.000Z",
+      _cachedAt: Date.now() - 1000,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: {
+        lastReadEventId: "evt_100",
+        lastReadSequence: "100",
+        lastReadAt: "2026-01-01T00:00:01.000Z",
+      },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt })
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      lastReadEventId: "evt_150",
+      lastReadSequence: "150",
+      lastReadAt: "2026-01-01T00:00:09.000Z",
+    })
+  })
+
+  it("an untouched response applies the server row normally", async () => {
+    const streamId = "stream_untouched_apply"
+    const fetchStartedAt = Date.now() - 1000
+
+    // Touched BEFORE the fetch departed — the snapshot is fresher.
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:01.000Z",
+      _cachedAt: Date.now() - 5000,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: {
+        lastReadEventId: "evt_100",
+        lastReadSequence: "100",
+        lastReadAt: "2026-01-01T00:00:03.000Z",
+      },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt })
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toMatchObject({
+      lastReadEventId: "evt_100",
+      lastReadSequence: "100",
+    })
+    expect(bootstrap.readState).toMatchObject({ lastReadEventId: "evt_100" })
+  })
+
+  it("an untouched response applies confirmed absence (member row cleared)", async () => {
+    const streamId = "stream_untouched_absent"
+    const fetchStartedAt = Date.now() - 1000
+
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: null,
+      lastReadSequence: null,
+      lastReadAt: null,
+      _cachedAt: Date.now() - 5000, // stale never-read sentinel
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: null,
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt })
+
+    expect(await db.streamReadState.get(`ws_1:${streamId}`)).toBeUndefined()
+  })
+
+  it("publishes the preserved frontier to the workspace cache and keeps the local stream mirror", async () => {
+    const streamId = "stream_stale_publish"
+    const fetchStartedAt = Date.now() - 5000
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      streamReadState: {},
+      streamMemberships: [],
+    } as unknown as WorkspaceBootstrap)
+
+    // Local stream mirror already carries the touched watermark.
+    await db.streams.put({
+      ...makeBootstrap([], streamId).stream,
+      lastReadEventId: "evt_50",
+      _cachedAt: Date.now() - 1000,
+    })
+    await db.streamReadState.put({
+      id: `ws_1:${streamId}`,
+      workspaceId: "ws_1",
+      streamId,
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+      _cachedAt: Date.now() - 1000,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap([], streamId),
+      membership: membership(streamId, "evt_100", "100"),
+      readState: {
+        lastReadEventId: "evt_100",
+        lastReadSequence: "100",
+        lastReadAt: "2026-01-01T00:00:01.000Z",
+      },
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt, queryClient })
+
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached?.streamReadState?.[streamId]).toEqual({
+      lastReadEventId: "evt_50",
+      lastReadSequence: "50",
+      lastReadAt: "2026-01-01T00:00:05.000Z",
+    })
+    // The stale response's membership watermark must not clobber the mirror.
+    expect(await db.streams.get(streamId)).toMatchObject({ lastReadEventId: "evt_50" })
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -24,6 +24,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import type { QueryClient } from "@tanstack/react-query"
 import { commitCounterMutation } from "./catch-up-batch"
+import { putReadStateIdb } from "./read-state"
 import {
   applyMovedSourceOrdinal,
   dropMessageActivities,
@@ -501,6 +502,8 @@ async function writeBootstrapEventsAndStream(
     contextBag: bootstrap.contextBag,
     _cachedAt: now,
   }
+  await persistBootstrapReadState(workspaceId, streamId, bootstrap, now)
+
   const isDmWithNullName = stream.type === StreamTypes.DM && stream.displayName == null
   if (isDmWithNullName) {
     const { displayName: _, ...withoutDisplayName } = fullStreamData
@@ -514,6 +517,67 @@ async function writeBootstrapEventsAndStream(
   const updated = await db.streams.update(stream.id, fullStreamData)
   if (updated === 0) {
     await db.streams.put(fullStreamData)
+  }
+}
+
+/**
+ * Persist the bootstrap's additive standalone frontier (non-member unlock).
+ * A present row is max-merged over any stored row so a snapshot can't regress
+ * a fresher socket echo — with one hard rule: an explicit unread-to-zero row
+ * (null watermark, non-null lastReadAt — a sanctioned downward move) is never
+ * clobbered by a non-null snapshot frontier, since the snapshot may predate
+ * the unread. A confirmed ABSENT row (null) seeds a never-read sentinel for
+ * access-without-membership viewers ONLY: they have no membership mirror to
+ * fall back to, and "no row" IS the "before the first message" frontier — the
+ * sentinel is what resolves their divider/card frontier on open. Members keep
+ * the membership fallback for an absent row (shadow window), so no sentinel
+ * there — and when a member's absent-row snapshot arrives, any standalone row
+ * already in IDB (a never-read sentinel seeded earlier when this viewer was a
+ * nonmember, or a legacy-column-only row from the rolling deploy) is CLEARED so
+ * the frontier resolves through the membership watermark instead of a stale
+ * sentinel that would poison it back to "never read". A non-null snapshot row
+ * is still a later write the snapshot lacks — keep it. Absent field (payloads
+ * cached before it shipped) changes nothing.
+ */
+async function persistBootstrapReadState(
+  workspaceId: string,
+  streamId: string,
+  bootstrap: StreamBootstrap,
+  now: number
+): Promise<void> {
+  if (bootstrap.readState === undefined) return
+  const existingRow = await db.streamReadState.get(`${workspaceId}:${streamId}`)
+  if (bootstrap.readState === null) {
+    if (bootstrap.membership) {
+      // Server has no standalone row AND the viewer is a member: the membership
+      // watermark is the frontier fallback (shadow window). Clear any standalone
+      // row — e.g. a never-read sentinel seeded earlier when this viewer was a
+      // nonmember, or a legacy-column-only row from the rolling deploy — so the
+      // read layer resolves through the membership instead of a stale sentinel
+      // that would poison the frontier back to "never read".
+      if (existingRow) {
+        await db.streamReadState.delete(`${workspaceId}:${streamId}`)
+      }
+      return
+    }
+    if (!existingRow) {
+      await putReadStateIdb(
+        workspaceId,
+        streamId,
+        { lastReadEventId: null, lastReadSequence: null, lastReadAt: null },
+        now
+      )
+    }
+    return
+  }
+  const incoming = bootstrap.readState
+  const storedExplicitUnread =
+    existingRow != null && existingRow.lastReadEventId == null && existingRow.lastReadAt != null
+  if (incoming.lastReadEventId != null && storedExplicitUnread) return
+  const incomingSeq = incoming.lastReadSequence != null ? BigInt(incoming.lastReadSequence) : null
+  const storedSeq = existingRow?.lastReadSequence != null ? BigInt(existingRow.lastReadSequence) : null
+  if (!existingRow || storedSeq == null || incomingSeq == null || incomingSeq >= storedSeq) {
+    await putReadStateIdb(workspaceId, streamId, incoming, now)
   }
 }
 
@@ -614,9 +678,13 @@ export async function applyStreamBootstrap(
   bootstrap: StreamBootstrap
 ): Promise<void> {
   const now = Date.now()
-  await db.transaction("rw", [db.events, db.streams, db.pendingMessages, db.pendingOperations, db.slots], async () => {
-    await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
-  })
+  await db.transaction(
+    "rw",
+    [db.events, db.streams, db.streamReadState, db.pendingMessages, db.pendingOperations, db.slots],
+    async () => {
+      await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
+    }
+  )
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -5,6 +5,7 @@ import {
   type StreamEvent,
   type Stream,
   type StreamBootstrap,
+  type StreamReadFrontier,
   type LastMessagePreview,
   type LinkPreviewSummary,
   type ThreadSummary,
@@ -24,7 +25,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import type { QueryClient } from "@tanstack/react-query"
 import { commitCounterMutation } from "./catch-up-batch"
-import { putReadStateIdb } from "./read-state"
+import { mergeReadStateIntoBootstrapCache, putReadStateIdb, toStreamReadFrontier } from "./read-state"
 import {
   applyMovedSourceOrdinal,
   dropMessageActivities,
@@ -282,12 +283,18 @@ function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
   )
 }
 
+/**
+ * Returns the standalone frontier preserved because the local row was touched
+ * at/after `fetchStartedAt` (undefined when the response's readState applied
+ * normally) — `applyStreamBootstrap` republishes it to the query caches.
+ */
 async function writeBootstrapEventsAndStream(
   workspaceId: string,
   streamId: string,
   bootstrap: StreamBootstrap,
-  now: number
-): Promise<void> {
+  now: number,
+  fetchStartedAt?: number
+): Promise<StreamReadFrontier | undefined> {
   await cleanupStaleOptimisticEvents(streamId)
 
   if (bootstrap.syncMode !== "append") {
@@ -492,17 +499,24 @@ async function writeBootstrapEventsAndStream(
   // is the sidebar's activity sort key). Use update() for existing records
   // and fall back to put() if the stream doesn't exist in IDB yet.
   const stream = preserveDmDisplayName(bootstrap.stream)
+  const preservedReadState = await persistBootstrapReadState(workspaceId, streamId, bootstrap, now, fetchStartedAt)
+  // A preserved local frontier is what the envelope must carry into the
+  // per-stream query cache (callers write it via `toCachedStreamBootstrap`
+  // after this returns) — same reflect-the-preserved-local-value precedent as
+  // `applyReconnectBootstrapBatch`'s sidebarConfig.
+  if (preservedReadState) bootstrap.readState = preservedReadState
   const fullStreamData = {
     ...stream,
     notificationLevel: bootstrap.membership?.notificationLevel,
-    lastReadEventId: bootstrap.membership?.lastReadEventId,
+    // A frontier preserved as touched during the fetch window keeps its local
+    // mirror too — the stale response's membership watermark predates it.
+    ...(preservedReadState ? {} : { lastReadEventId: bootstrap.membership?.lastReadEventId }),
     // Mirror the persisted ContextBag into IDB so the timeline can read it
     // synchronously on first paint via the `useWorkspaceStreams` cache —
     // matches how attachments live on the message payload (sync from IDB).
     contextBag: bootstrap.contextBag,
     _cachedAt: now,
   }
-  await persistBootstrapReadState(workspaceId, streamId, bootstrap, now)
 
   const isDmWithNullName = stream.type === StreamTypes.DM && stream.displayName == null
   if (isDmWithNullName) {
@@ -511,13 +525,14 @@ async function writeBootstrapEventsAndStream(
     if (updated === 0) {
       await db.streams.put(fullStreamData)
     }
-    return
+    return preservedReadState
   }
 
   const updated = await db.streams.update(stream.id, fullStreamData)
   if (updated === 0) {
     await db.streams.put(fullStreamData)
   }
+  return preservedReadState
 }
 
 /**
@@ -538,15 +553,28 @@ async function writeBootstrapEventsAndStream(
  * sentinel that would poison it back to "never read". A non-null snapshot row
  * is still a later write the snapshot lacks — keep it. Absent field (payloads
  * cached before it shipped) changes nothing.
+ *
+ * Freshness gate first (PR2 touched-at architecture): when `fetchStartedAt` is
+ * given and the stored row was written at/after it — a socket read/read_set/
+ * read_messages echo or an optimistic mutation landed while this request was
+ * in flight — the local row postdates the snapshot and is preserved EXACTLY:
+ * no merge, no absence-delete, no sentinel seed. The preserved frontier is
+ * returned so the caller republishes it to the per-stream/workspace caches;
+ * sequence max alone cannot decide here, since an explicit unread is a
+ * sanctioned downward move — operation order (touched-at) decides.
  */
 async function persistBootstrapReadState(
   workspaceId: string,
   streamId: string,
   bootstrap: StreamBootstrap,
-  now: number
-): Promise<void> {
-  if (bootstrap.readState === undefined) return
+  now: number,
+  fetchStartedAt?: number
+): Promise<StreamReadFrontier | undefined> {
+  if (bootstrap.readState === undefined) return undefined
   const existingRow = await db.streamReadState.get(`${workspaceId}:${streamId}`)
+  if (fetchStartedAt !== undefined && existingRow && existingRow._cachedAt >= fetchStartedAt) {
+    return toStreamReadFrontier(existingRow)
+  }
   if (bootstrap.readState === null) {
     if (bootstrap.membership) {
       // Server has no standalone row AND the viewer is a member: the membership
@@ -558,7 +586,7 @@ async function persistBootstrapReadState(
       if (existingRow) {
         await db.streamReadState.delete(`${workspaceId}:${streamId}`)
       }
-      return
+      return undefined
     }
     if (!existingRow) {
       await putReadStateIdb(
@@ -568,17 +596,18 @@ async function persistBootstrapReadState(
         now
       )
     }
-    return
+    return undefined
   }
   const incoming = bootstrap.readState
   const storedExplicitUnread =
     existingRow != null && existingRow.lastReadEventId == null && existingRow.lastReadAt != null
-  if (incoming.lastReadEventId != null && storedExplicitUnread) return
+  if (incoming.lastReadEventId != null && storedExplicitUnread) return undefined
   const incomingSeq = incoming.lastReadSequence != null ? BigInt(incoming.lastReadSequence) : null
   const storedSeq = existingRow?.lastReadSequence != null ? BigInt(existingRow.lastReadSequence) : null
   if (!existingRow || storedSeq == null || incomingSeq == null || incomingSeq >= storedSeq) {
     await putReadStateIdb(workspaceId, streamId, incoming, now)
   }
+  return undefined
 }
 
 /**
@@ -658,6 +687,18 @@ async function applyBootstrapThreadStates(streamId: string, bootstrap: StreamBoo
   }
 }
 
+export interface StreamBootstrapApplyOptions {
+  /** Local epoch ms when the bootstrap request departed. A standalone
+   * read-state row touched at/after this instant (socket echo or optimistic
+   * mutation) postdates the snapshot and is preserved exactly — the same
+   * fetch-window freshness rule as the workspace bootstrap merge. */
+  fetchStartedAt?: number
+  /** When given, a preserved local frontier is also mirrored into the
+   * workspace bootstrap query cache so the in-memory frontier map never lags
+   * the preserved IDB row (the per-stream cache rides the patched envelope). */
+  queryClient?: QueryClient
+}
+
 /**
  * Write stream bootstrap data to IndexedDB (merge, not replace).
  *
@@ -675,16 +716,27 @@ async function applyBootstrapThreadStates(streamId: string, bootstrap: StreamBoo
 export async function applyStreamBootstrap(
   workspaceId: string,
   streamId: string,
-  bootstrap: StreamBootstrap
+  bootstrap: StreamBootstrap,
+  options?: StreamBootstrapApplyOptions
 ): Promise<void> {
   const now = Date.now()
+  let preservedReadState: StreamReadFrontier | undefined
   await db.transaction(
     "rw",
     [db.events, db.streams, db.streamReadState, db.pendingMessages, db.pendingOperations, db.slots],
     async () => {
-      await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
+      preservedReadState = await writeBootstrapEventsAndStream(
+        workspaceId,
+        streamId,
+        bootstrap,
+        now,
+        options?.fetchStartedAt
+      )
     }
   )
+  if (preservedReadState && options?.queryClient) {
+    mergeReadStateIntoBootstrapCache(options.queryClient, workspaceId, streamId, preservedReadState)
+  }
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 
@@ -718,9 +770,10 @@ export async function applyStreamBootstrapInCurrentTransaction(
   workspaceId: string,
   streamId: string,
   bootstrap: StreamBootstrap,
-  now = Date.now()
+  now = Date.now(),
+  fetchStartedAt?: number
 ): Promise<void> {
-  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
+  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, fetchStartedAt)
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -567,9 +567,10 @@ export class SyncEngine {
     const { workspaceId, streamService, queryClient } = this.deps
     const promise = (async () => {
       try {
+        const fetchStartedAt = Date.now()
         const bootstrap = await streamService.bootstrap(workspaceId, streamId, { after: afterSequence })
         if (this.isDestroyed) return
-        await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+        await applyStreamBootstrap(workspaceId, streamId, bootstrap, { fetchStartedAt, queryClient })
         queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (current) =>
           current
             ? toCachedStreamBootstrap(bootstrap, current, {
@@ -1109,8 +1110,9 @@ export class SyncEngine {
       // fetch the full latest window instead of an append from the cursor.
       const after = previousBootstrap ? cursor : null
 
+      const fetchStartedAt = Date.now()
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
-      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap, { fetchStartedAt, queryClient })
 
       queryClient.setQueryData<CachedStreamBootstrap>(queryKey, (currentBootstrap) =>
         toCachedStreamBootstrap(bootstrap, currentBootstrap ?? previousBootstrap, {
@@ -1166,9 +1168,10 @@ export class SyncEngine {
       const after = await getLatestPersistedSequence(streamId)
       if (after === null || this.isDestroyed) return
 
+      const fetchStartedAt = Date.now()
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, { after })
       if (this.isDestroyed) return
-      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap, { fetchStartedAt, queryClient })
 
       // Merge into the query-cache bridge ONLY when an entry already exists —
       // same guard as backfillStreamGap. Seeding an append-mode delta as the

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -97,7 +97,12 @@ import {
 } from "./unread-counters"
 import { isAutoReadAttentiveNow } from "@/lib/auto-read-attention"
 import { commitCounterMutation, commitStreamPreview, type CatchUpBatch, type CounterMutator } from "./catch-up-batch"
-import { commitReadStateSnapshot, mergeReadStateIntoBootstrapCache, putReadStateIdb } from "./read-state"
+import {
+  commitReadStateSnapshot,
+  mergeReadStateIntoBootstrapCache,
+  putReadStateIdb,
+  toStreamReadFrontier,
+} from "./read-state"
 
 /** Workspace user shape from backend user repository. */
 interface WorkspaceUserPayload {
@@ -337,14 +342,6 @@ function toWorkspaceBootstrapMembership(membership: CachedStreamMembership): Str
     lastReadSequence: membership.lastReadSequence,
     lastReadAt: membership.lastReadAt,
     joinedAt: membership.joinedAt,
-  }
-}
-
-function toStreamReadFrontier(row: CachedStreamReadState): StreamReadFrontier {
-  return {
-    lastReadEventId: row.lastReadEventId,
-    lastReadSequence: row.lastReadSequence,
-    lastReadAt: row.lastReadAt,
   }
 }
 
@@ -2889,7 +2886,10 @@ export async function applyReconnectBootstrapBatch(
       }
 
       for (const [streamId, bootstrap] of streamBootstraps) {
-        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now)
+        // Carry the fetch window so a per-stream envelope's stale `readState`
+        // never clobbers a frontier touched during the reconnect (same rule
+        // the workspace map merge above applies).
+        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, fetchStartedAt)
       }
 
       if (terminalStreamIds.size > 0) {

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -215,16 +215,21 @@ the two callbacks; rows stay UI-focused (INV-15). The label page sets neither
 → the actions hide there (the same field-one-side-sets gate as
 `conversationId`).
 
-### Card unread derivation (v1 scope decision)
+### Card unread derivation
 
 Per spanned stream, a member message is unread iff it's past that stream's
-read frontier and not in the overlay. Frontiers: the root and member-threads
-by watermark sequence; **non-member thread legs fall back to the root
-watermark's `last_read_at` timestamp** (no row → no sequence frontier; the
-time fallback bounds false-quiet without a wall of false-unread on ship day).
-Documented approximation — a principled thread frontier is a follow-up. The
-board card rail must retain `sequence` on its rows (`eventToRenderable`
-currently drops it).
+read frontier and not in the overlay. Every leg — root, member-thread, and
+non-member thread leg alike — resolves through its OWN effective frontier
+(standalone `stream_read_state` row wins when present, membership mirror
+fills an absent row during the rollout). Non-member legs get theirs lazily:
+the per-stream bootstrap carries the viewer's standalone frontier and the
+client persists it on open (a confirmed-absent row seeds a never-read
+sentinel — for a non-member, "no row" IS "before the first message"). A leg
+with no frontier yet is ungated, not approximated: the v1 root
+`last_read_at` time fallback was removed with the non-member unlock (read
+state re-homed off `stream_members`) — a card only renders rows from streams
+whose bootstrap ran, so rendered legs resolve. The board card rail must
+retain `sequence` on its rows (`eventToRenderable` currently drops it).
 
 The stable-view "N new" pill (`use-stable-board-view`) is ordering-buffer
 state and stays fully independent of read state.
@@ -301,7 +306,7 @@ newestSeenRow)` per conversation; the gate re-checks effective unread at
   or overlay ids removed without a compensating watermark advance, exposing
   a row the surface shows. Never derived row state: derivation flaps (the
   `unreadCounts === 0` short-circuit falling back to a stale frontier when a
-  count leaves zero, the stale-`lastReadAt` time fallback) read as mass
+  count leaves zero, the timestamp fallback for sequenceless rows) read as mass
   read → unread regressions, and a false pin on a static board card never
   releases — that wedge was the first dogfood failure. Pinning unsees
   everything and suppresses **every eligible row** — not just the
@@ -325,5 +330,6 @@ newestSeenRow)` per conversation; the gate re-checks effective unread at
   stream path).
 - Offline queueing for read actions (existing read mutations are not queued;
   the new ones match — parity, not a regression).
-- A principled read frontier for non-member threads (v1 uses the root
-  `last_read_at` time fallback on cards).
+- A principled read frontier for non-member threads — delivered with the
+  read-state re-home: legs carry their own standalone frontier (v1 used the
+  root `last_read_at` time fallback on cards).

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -199,6 +199,18 @@ export interface StreamBootstrap {
   /** Complete slash-command list effective for this stream. Live backend returns this. */
   commands?: CommandInfo[]
   membership: StreamMember | null
+  /**
+   * The viewer's standalone read frontier on this stream (non-member unlock):
+   * the same data the workspace bootstrap's `streamReadState` map carries for
+   * member streams, served per-stream so access-without-membership viewers
+   * (INV-62 thread legs, public roots never joined) resolve their frontier on
+   * open — the workspace bootstrap stays member-keyed. `null` = no row (never
+   * read: frontier before the first message, distinct from a row whose
+   * `lastReadEventId` is null — an explicit mark-unread-to-zero). Optional:
+   * payloads cached before this field shipped lack it (fall back to the
+   * membership mirror).
+   */
+  readState?: StreamReadFrontier | null
   latestSequence: string
   /**
    * Server wall-clock (ISO) captured immediately before the bootstrap's


### PR DESCRIPTION
## Problem

Read-state cutover remained membership-gated: access-authorized thread viewers still could not own a message frontier, regress it explicitly, compact conversation overlay rows, or protect delayed activity inserts with born-read state.

## Solution

Make standalone read state user+stream truth after canonical access validation, without ever creating membership.

- Non-member mark-read/unread advances or explicitly regresses `stream_read_state` and emits existing author-scoped events in the same transaction.
- Sparse conversation legs ensure+lock standalone state and compact overlays; membership writes remain compatibility-only.
- Existing stream bootstrap lazily carries the viewer frontier; frontend persists it for divider/card placement without workspace-wide thread enumeration.
- Born-read becomes membership-independent but workspace/stream scoped; conversation targets and every leg are validated against the same effective root before writes.

## Test plan

- [x] Backend unit — 394 pass
- [x] PostgreSQL integration — 27 pass (born-read, migration backfill, no-membership read/unread, sparse conversation legs)
- [x] Frontend targeted — 115 pass
- [x] Monorepo typecheck + pre-commit lint/typecheck/migration/API-doc gates

<details>
<summary>📋 Full implementation plan</summary>

# Plan: extract read state from `stream_members` (wholesale watermark re-home)

Status: scope/plan only — no code. Requested by Kristoffer 2026-07-24.

## Goal

Move every per-user read watermark off `stream_members` into a dedicated
`stream_read_state` table, for **all** streams — channels, DMs, threads, root +
legs — with a backfill of all existing read positions. Watermark-style only
(single contiguous-prefix frontier per user+stream; no bitmaps).

**Explicitly not re-solved:** the message-granular sparse overlay
(`stream_member_message_reads`) and the whole conversation read geometry from
`docs/sparse-read-overlay-design.md` — that system manages reading *in
conversations* and stays exactly as designed. This work re-homes the watermark
layer the overlay compacts into; it does not touch overlay storage or its wire
contracts.

## Why (what this unlocks)

1. **Non-member thread legs get a real frontier.** INV-62 grants access without
   membership (thread→root resolution, public roots). Today those legs are
   overlay-only: no watermark, no compaction, `markAsRead` is a silent no-op on
   the message side, `markUnread` 404s, the board card frontier falls back to
   the root watermark's `last_read_at` timestamp approximation (explicitly
   flagged in the overlay doc as "a principled thread frontier is a follow-up"
   — this is that follow-up).
2. **Closes the late-insert born-read race.** `membersReadThrough`
   (activity born-read) joins `stream_members`; a non-member's read therefore
   can't protect against an activity row inserted between clear and response.
3. **membership ≠ access ≠ read state.** INV-62 keeps membership as pure
   participation; read state becomes user-anchored per stream. Upserting read
   state is always safe — unlike upserting `stream_members` on read, which the
   overlay doc explicitly forbids.
4. Read state can survive leave/rejoin (decision 1 below).

## Verified inventory of watermark usage (current code)

**Writers** (all funnel through `StreamMemberRepository.update` / batch variants):
- `streams/service.ts:1926` markAsRead advance; `:1977` markUnread regress;
  `:1570`/`:630` initial-member born-read on stream/message creation;
  `:295` move-repoint (A3 fix); `batchUpdateLastReadEventId` (mark-all);
  `setLastReadEventIdForMembers`; sparse-read compaction
  (`sparse-read.ts:91`).

**Readers:**
- Bootstrap assembly (`workspaces/handlers.ts:226-263`): memberships →
  `getUnreadCounts` → `countUnreadByStreamBatch` (watermark sequence vs
  `message_created` sequence, minus overlay count) + `lastReadSequence` map +
  `streamMemberships` payload.
- Born-read: `activity/service.resolveAlreadyReadRecipients` →
  `membersReadThrough` (member-keyed).
- `streams/handlers.ts:1047` markUnread response count.
- Board card frontier derivation (root watermark sequence; non-member legs →
  root `last_read_at` fallback).
- Sparse-read compaction (`sparse-read.ts:64-92`): reads + locks the
  membership row, advances the watermark.
- Outbox payloads `stream:read` / `stream:read_set` / `stream:read_all`
  (source = membership update result; **wire shapes unchanged by this work**).
- Frontend: `stream-content.tsx` frontier seed, `use-unread-divider`,
  `use-last-seen-event`, `unread-counters` readOrdinal, `workspace-sync`
  `stream:read*` appliers, IDB `streams.lastReadEventId` + `streamMemberships`.

No cross-user "seen-by" surface exists (verified) — nothing to migrate there.

## Design

### Table

```sql
CREATE TABLE stream_read_state (
    workspace_id       TEXT NOT NULL,        -- INV-8
    stream_id          TEXT NOT NULL,
    user_id            TEXT NOT NULL,        -- NOT member_id: not a membership surface
    last_read_event_id TEXT,                 -- NULL = position before first message (mark-unread-to-zero)
    last_read_at       TIMESTAMPTZ,
    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    PRIMARY KEY (stream_id, user_id)
);
CREATE INDEX ON stream_read_state (workspace_id, user_id);  -- bootstrap list
```

No FKs (INV-1). No membership-row requirement. A row exists only after the
user's first read-state write for that stream; absence = never read (same
semantics as a NULL watermark today).

### Repository & locking

New `ReadStateRepository` (streams feature): `get`, `getBatch`,
`listForUser(workspaceId, userId)` (bootstrap), `advance` (monotonic,
max-merge by sequence — resolve event→sequence in SQL), `set` (regress;
mark-unread only), `deleteForWorkspace/User` (lifecycle cascades).
Sparse-read compaction locks the **read-state** row `FOR UPDATE` (INV-20);
for non-members it upserts then locks — non-member legs stop being
overlay-only. Single-row lock either way; no new lock-order hazard
(conversations already process streams in sorted order).

### Rollout — one stack, 4 PRs

**PR 1 — storage + shadow writes (no behavior change).**
Migration (table + backfill from `stream_members` where
`last_read_event_id IS NOT NULL`, carrying `last_read_at`), repository + unit
tests, and every writer above dual-writes read-state in the same transaction.
Readers untouched. Backfill is atomic in the migration; dual-write covers the
rolling-deploy window.

**PR 2 — read cutover.**
Every reader switches to read-state with membership fallback (read-state row
wins; absent → membership column — covers the deploy window). Bootstrap gains
`streamReadState: Record<streamId, { lastReadEventId, lastReadSequence,
lastReadAt }>` for member streams (same data, new home);
`streamMemberships` keeps its fields for compat. Frontend: IDB
`streamReadState` store (version bump); frontier seed + divider + counters
prefer it, fall back to membership/`db.streams`; sync appliers write both
stores during transition.

**Post-drain reconciliation (PR 2 migration,
`20260724190000_reconcile_stream_read_state.sql`).** PR 1's backfill copied
every membership watermark that existed when it ran; old binaries still
draining afterwards wrote the membership column only. PR 2 ships a second
migration that re-folds every non-NULL membership watermark into
`stream_read_state` with the `advance` rule (workspace through streams,
insert missing rows, advance only on STRICTLY greater event sequence,
NULL/unresolvable = 0, never regress, `last_read_at` carried only when the
membership frontier wins). DEPLOYMENT ORDERING: PR 1 must be deployed and all
pre-PR-1 binaries drained BEFORE PR 2 deploys — running the reconciliation
before drain leaves a gap the next old-binary write reopens. Frontend
freshness rule that goes with it: the bootstrap `streamReadState` map
enumerates MEMBER streams only, so it is never a deletion authority over IDB
rows it omits (nonmember thread lazy state); and a bootstrap begun at T0
preserves any standalone row touched locally/socket at T1>T0 (explicit unread
included — no max(sequence) there), per stream, like the counter triple.

**PR 3 — the non-member unlock (behavior change).**
- `markAsRead`: after `validateStreamAccess`, upsert read-state advance
  whether or not a membership row exists (the #1527 activity path stays).
  Non-members get real unread counts, divider placement, and cross-device
  `stream:read` with a real payload.

**Monotonicity rule (owner-ratified 2026-07-24):** the new store only ever
rises — reads never regress it. The ONLY downward moves are explicit
mark-unread (`markUnread`, sparse `applySparseUnread`) and the A3
move-correction repoint. This applies from PR 1 in the shadow store:
`markAsRead`/`addToStream`/born-read/mark-all/compaction all use `advance`
(monotonic). The membership store keeps its regressible semantics untouched
throughout the shadow window (stale-device `markAsRead`, reset-on-rejoin,
last-commit-wins races) — those columns die in PR 4. Consequence for PR 2:
the cutover converges regressed rows UPWARD only (users whose membership
watermark regressed during the shadow window pop back to their true
position) — never downward. Call this out in the PR 2 description.
- `markUnread`: upsert regress — fixes the same-class 404.
- `resolveAlreadyReadRecipients` reads read-state → born-read covers
  non-members; late-insert race closed.
- Compaction upserts+locks read-state for non-member legs; overlay invariant
  restated against read-state instead of membership.
- Card frontier: non-member thread legs use their own watermark sequence;
  the root `last_read_at` time fallback is deleted.

**PR 4 — cleanup (after bake).**
Stop dual-writing, drop fallback reads, migration drops
`stream_members.last_read_event_id` / `last_read_at`, `StreamMember` API type
loses the fields (breaking for stale clients — gate on a refresh window).
CLAUDE.md gains: "Read state lives in `stream_read_state`, never on
`stream_members`. Upserting read state is always safe; upserting membership
on read is forbidden (membership ≠ access ≠ read state)."

### Decision points (recommendations inline)

1. **Read-state lifetime:** keep on leave/kick (user-private truth; rejoin
   restores position). Delete only on workspace/account deletion via the
   existing cascades. *Behavior change vs today (membership delete destroys
   the watermark) — flagging explicitly.*
2. Keep `last_read_at` (display + any time-based derivations).
3. Bootstrap stays member-stream-keyed; non-member thread unread is computed
   on open (threads aren't in the sidebar). Revisit only if threads join the
   sidebar.
4. Wire payloads unchanged; the bootstrap `streamReadState` map is the only
   additive field. `stream:read*` contracts untouched — the source changes,
   not the contract.
5. `activity:read` (shipped in #1530) is a different axis (per-row `read_at`)
   — untouched.

### Testing

- Unit: repository (advance monotonic / set regress / batch / bootstrap
  list); dual-write equivalence; compaction upsert-and-lock; born-read via
  read-state including non-members.
- Integration (needs the test-DB ports free — same blocker as the pending
  FOR SHARE barrier test; run together): unread-counts, sparse-read-overlay,
  phantom-unread-fixes, conversation-read, **plus new**: non-member thread
  frontier (divider placement, late-insert born-read, markUnread regress,
  two-device propagation, leave/rejoin position retained).
- Migration test: backfill fidelity (row counts, event mapping, NULLs).
- E2E on staging after PR 3: two-device thread read.

### Risks

- Rolling-deploy skew (old binary writes membership only) → dual-write +
  fallback window; bounded by the PR 4 gate. Late writes between PR 1's
  backfill and drain are folded in by PR 2's post-drain reconciliation
  migration (deploy ordering: PR 1 drained before PR 2 deploys).
- Backfill volume: one `INSERT … SELECT`; check prod counts first, batch if
  huge.
- IDB version bump; stale cached memberships still carry watermarks →
  fallback covers until first fresh bootstrap.

### Out of scope

Sparse overlay storage/wire (`stream:read_messages`, conversation read APIs);
sidebar unread for non-member threads; read receipts for other users (no such
surface); offline queueing of read mutations (parity with existing).


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787509429&installation_model_id=20758&pr_number=1538&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1538&signature=3f3baced928a72733e9b4aecad230edfa44b2a92005283620e6671f813adf3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
