### PR TITLE
feat: add reusable GitHub PR watcher skill

### DIFF
--- a/.agents/skills/watch-pr/SKILL.md
+++ b/.agents/skills/watch-pr/SKILL.md
@@ -26,9 +26,9 @@ Wait for the next change:
 bun "$WATCH_PR" 123 --repo owner/repo --interval 20 --timeout 1800 --state "$STATE"
 ```
 
-The PR target may be a number, GitHub PR URL, or omitted to infer the open PR for the current branch. Repository is inferred from `origin` unless `--repo` is passed. Authentication uses `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`.
+The PR target may be a number, GitHub PR URL, or omitted to infer the open PR for the current branch. Repository is inferred from `origin` unless `--repo` is passed. Branch inference matches both branch name and its configured push repository, so fork branches require the base repository via `--repo` when `origin` points to the fork. Authentication uses `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`.
 
-Output is NDJSON. A watch emits a `baseline`, reports retryable network/API failures as `poll_error`, then exits on the first `changes` event. Exit 3 means timeout without changes. The state file makes the next invocation compare against the last observation, closing the gap while the agent handles an event.
+Output is NDJSON. A watch emits a compact `baseline`, reports retryable network/API failures as `poll_error`, then exits on the first `changes` event. Change events include full changed resources and a compact PR summary; use `--once` when the full snapshot is needed. Exit 3 means timeout without changes. The state file makes the next invocation compare against the last observation, closing the gap while the agent handles an event.
 
 ## Event coverage
 

--- a/.agents/skills/watch-pr/SKILL.md
+++ b/.agents/skills/watch-pr/SKILL.md
@@ -28,18 +28,18 @@ bun "$WATCH_PR" 123 --repo owner/repo --interval 20 --timeout 1800 --state "$STA
 
 The PR target may be a number, GitHub PR URL, or omitted to infer the open PR for the current branch. Repository is inferred from `origin` unless `--repo` is passed. Authentication uses `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`.
 
-Output is NDJSON. A watch emits a `baseline`, then exits on the first `changes` event. Exit 3 means timeout without changes. The state file makes the next invocation compare against the last observation, closing the gap while the agent handles an event.
+Output is NDJSON. A watch emits a `baseline`, reports retryable network/API failures as `poll_error`, then exits on the first `changes` event. Exit 3 means timeout without changes. The state file makes the next invocation compare against the last observation, closing the gap while the agent handles an event.
 
 ## Event coverage
 
 Snapshots include:
 
-- PR title, description, open/closed state, draft state, head SHA/ref, base ref, mergeability, and mergeable state
+- PR title, description, open/closed/merged state and timestamps, draft state, head SHA/ref, base ref, mergeability, and mergeable state
 - Issue comments and inline review comments: author, full body, timestamps, URL, file/line, and reply parent
 - Submitted reviews: author, state, body, timestamp, commit, and URL
 - Review threads: resolved/outdated state and up to 100 comments per thread; the separately paginated inline-comment list remains complete
 - Check runs: app, name, queued/in-progress/completed status, conclusion, timestamps, and details URL
-- Legacy commit statuses: context, state, description, timestamps, and target URL
+- Current legacy commit status per context: state, description, timestamps, and target URL
 
 Changes contain both `before` and `after` values for updates. Do not infer CI failures from a check name or conclusion alone; fetch the check's linked job logs before diagnosing.
 

--- a/.agents/skills/watch-pr/SKILL.md
+++ b/.agents/skills/watch-pr/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: watch-pr
+description: Watch a GitHub pull request for comments, reviews, thread resolution, CI check transitions, status updates, description edits, new commits, and merge-state changes. Use when asked to babysit, monitor, wait on, merge when ready, or fix CI on a PR.
+---
+
+# Watch a GitHub PR
+
+Use the bundled Bun watcher instead of hand-written polling loops. Resolve paths relative to this skill directory.
+
+```bash
+WATCH_PR="<skill-directory>/watch-pr.ts"
+STATE="${TMPDIR:-/tmp}/watch-pr-OWNER-REPO-NUMBER.json"
+```
+
+## Commands
+
+Current state:
+
+```bash
+bun "$WATCH_PR" 123 --repo owner/repo --once --state "$STATE"
+```
+
+Wait for the next change:
+
+```bash
+bun "$WATCH_PR" 123 --repo owner/repo --interval 20 --timeout 1800 --state "$STATE"
+```
+
+The PR target may be a number, GitHub PR URL, or omitted to infer the open PR for the current branch. Repository is inferred from `origin` unless `--repo` is passed. Authentication uses `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`.
+
+Output is NDJSON. A watch emits a `baseline`, then exits on the first `changes` event. Exit 3 means timeout without changes. The state file makes the next invocation compare against the last observation, closing the gap while the agent handles an event.
+
+## Event coverage
+
+Snapshots include:
+
+- PR title, description, open/closed state, draft state, head SHA/ref, base ref, mergeability, and mergeable state
+- Issue comments and inline review comments: author, full body, timestamps, URL, file/line, and reply parent
+- Submitted reviews: author, state, body, timestamp, commit, and URL
+- Review threads: resolved/outdated state and up to 100 comments per thread; the separately paginated inline-comment list remains complete
+- Check runs: app, name, queued/in-progress/completed status, conclusion, timestamps, and details URL
+- Legacy commit statuses: context, state, description, timestamps, and target URL
+
+Changes contain both `before` and `after` values for updates. Do not infer CI failures from a check name or conclusion alone; fetch the check's linked job logs before diagnosing.
+
+## Babysitting loop
+
+1. Take a snapshot with `--once`; inspect current blockers.
+2. Act on anything actionable immediately.
+3. Run the watcher in the foreground. A blocking tool call is intentional: its completed output is injected into both Pi and Claude Code context without harness-specific hooks.
+4. On a change, reassess the whole returned snapshot, not only the diff. Handle review feedback with the `respond-to-pr-review` skill.
+5. Re-run with the same state path until the requested terminal condition is true.
+6. Before merging, fetch one final `--once` snapshot and verify:
+   - PR remains open, non-draft, and points at the expected head SHA.
+   - Every required check/status is successful; none queued or in progress.
+   - No unresolved review thread or unhandled new/edited comment remains.
+   - Latest applicable human reviews satisfy repository policy; no current change-request review remains.
+   - Mergeability is acceptable and CodeRabbit is no longer processing.
+7. Merge only when the user's requested condition is satisfied. Never treat a timeout as success.
+
+GitHub has no generic “handled comment” state. Determine handling from thread resolution/replies and project review policy. CodeRabbit's processing marker is bot-specific comment content, so inspect current comments rather than baking wording into the watcher.
+
+## Injection limits
+
+A skill cannot autonomously wake an idle agent. The portable mechanism is a foreground watcher process whose tool result becomes model context when a change occurs. Pi could add an extension that calls `pi.sendUserMessage(..., { deliverAs: "followUp" })`; Claude Code has no equivalent general external-event injection API. Keep the executable as the shared source of truth even if a Pi adapter is added later.

--- a/.agents/skills/watch-pr/watch-pr.test.ts
+++ b/.agents/skills/watch-pr/watch-pr.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test"
+import { diffSnapshots, repositoryFromRemote, type Snapshot } from "./watch-pr"
+
+function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    capturedAt: "2026-01-01T00:00:00Z",
+    repository: "acme/widgets",
+    number: 42,
+    title: "Add widget",
+    body: "Description",
+    state: "open",
+    draft: false,
+    mergeable: true,
+    mergeableState: "clean",
+    headSha: "abc",
+    baseRef: "main",
+    headRef: "feature",
+    updatedAt: "2026-01-01T00:00:00Z",
+    url: "https://github.com/acme/widgets/pull/42",
+    comments: [],
+    reviews: [],
+    reviewThreads: [],
+    checks: [],
+    statuses: [],
+    ...overrides,
+  }
+}
+
+describe("repositoryFromRemote", () => {
+  test.each([
+    ["git@github.com:acme/widgets.git", "acme/widgets"],
+    ["https://github.com/acme/widgets.git", "acme/widgets"],
+    ["http://proxy@127.0.0.1:1234/git/acme/widgets", "acme/widgets"],
+  ])("parses %s", (remote, expected) => {
+    expect(repositoryFromRemote(remote)).toBe(expected)
+  })
+})
+
+describe("diffSnapshots", () => {
+  test("ignores observation and aggregate update timestamps", () => {
+    expect(
+      diffSnapshots(
+        snapshot(),
+        snapshot({
+          capturedAt: "2026-01-01T00:01:00Z",
+          updatedAt: "2026-01-01T00:01:00Z",
+        })
+      )
+    ).toEqual([])
+  })
+
+  test("reports added and edited comments with full context", () => {
+    const original = snapshot({
+      comments: [
+        {
+          id: "1",
+          kind: "issue",
+          author: "reviewer",
+          body: "old",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          url: "https://github.com/acme/widgets/pull/42#issuecomment-1",
+        },
+      ],
+    })
+    const changed = snapshot({
+      comments: [
+        { ...original.comments[0], body: "edited", updatedAt: "2026-01-01T00:02:00Z" },
+        {
+          id: "2",
+          kind: "review",
+          author: "coderabbitai",
+          body: "Finding",
+          createdAt: "2026-01-01T00:03:00Z",
+          updatedAt: "2026-01-01T00:03:00Z",
+          url: "https://github.com/acme/widgets/pull/42#discussion_r2",
+          path: "src/widget.ts",
+          line: 9,
+          inReplyToId: null,
+        },
+      ],
+    })
+
+    expect(diffSnapshots(original, changed)).toEqual([
+      {
+        resource: "comment",
+        action: "updated",
+        id: "issue:1",
+        before: original.comments[0],
+        after: changed.comments[0],
+      },
+      { resource: "comment", action: "added", id: "review:2", after: changed.comments[1] },
+    ])
+  })
+
+  test("reports check transitions and resolved threads", () => {
+    const check = {
+      id: 7,
+      name: "test",
+      app: "github-actions",
+      status: "in_progress",
+      conclusion: null,
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: null,
+      url: "https://github.com/acme/widgets/actions/runs/1",
+    }
+    const thread = { id: "T1", resolved: false, outdated: false, path: "src/widget.ts", line: 2, comments: [] }
+    const before = snapshot({ checks: [check], reviewThreads: [thread] })
+    const after = snapshot({
+      checks: [{ ...check, status: "completed", conclusion: "success", completedAt: "2026-01-01T00:04:00Z" }],
+      reviewThreads: [{ ...thread, resolved: true }],
+    })
+
+    expect(diffSnapshots(before, after).map(({ resource, action, id }) => ({ resource, action, id }))).toEqual([
+      { resource: "review_thread", action: "updated", id: "T1" },
+      { resource: "check", action: "updated", id: "7" },
+    ])
+  })
+})

--- a/.agents/skills/watch-pr/watch-pr.test.ts
+++ b/.agents/skills/watch-pr/watch-pr.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test"
 import {
   currentStatuses,
   diffSnapshots,
+  isRetryableGitHubResponse,
   isTransientPollError,
+  nextPollDelay,
   pullNumbersForBranch,
   repositoryFromRemote,
   type Snapshot,
@@ -51,10 +53,11 @@ describe("PR inference", () => {
     expect(
       pullNumbersForBranch(
         [
-          { number: 41, head: { ref: "other" } },
-          { number: 42, head: { ref: "feature" } },
+          { number: 41, head: { ref: "feature", repo: { full_name: "other/widgets" } } },
+          { number: 42, head: { ref: "feature", repo: { full_name: "acme/widgets" } } },
         ],
-        "feature"
+        "feature",
+        "acme/widgets"
       )
     ).toEqual([42])
   })
@@ -71,10 +74,23 @@ describe("currentStatuses", () => {
   })
 })
 
-describe("poll errors", () => {
+describe("poll lifecycle", () => {
   test("retries transport errors but not arbitrary failures", () => {
     expect(isTransientPollError(new TypeError("fetch failed"))).toBe(true)
     expect(isTransientPollError(new Error("invalid response"))).toBe(false)
+  })
+
+  test("recognizes primary and secondary GitHub rate limits", () => {
+    expect(isRetryableGitHubResponse(403, new Headers({ "x-ratelimit-remaining": "0" }), "")).toBe(true)
+    expect(isRetryableGitHubResponse(403, new Headers({ "retry-after": "60" }), "")).toBe(true)
+    expect(isRetryableGitHubResponse(403, new Headers(), "secondary rate limit")).toBe(true)
+    expect(isRetryableGitHubResponse(403, new Headers(), "forbidden")).toBe(false)
+  })
+
+  test("caps sleep at the deadline and stops once reached", () => {
+    expect(nextPollDelay(1_000, 20_000, 0)).toBe(1_000)
+    expect(nextPollDelay(1_000, 20_000, 1_000)).toBeUndefined()
+    expect(nextPollDelay(Infinity, 20_000, 1_000)).toBe(20_000)
   })
 })
 

--- a/.agents/skills/watch-pr/watch-pr.test.ts
+++ b/.agents/skills/watch-pr/watch-pr.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { diffSnapshots, repositoryFromRemote, type Snapshot } from "./watch-pr"
+import {
+  currentStatuses,
+  diffSnapshots,
+  isTransientPollError,
+  pullNumbersForBranch,
+  repositoryFromRemote,
+  type Snapshot,
+} from "./watch-pr"
 
 function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
   return {
@@ -9,6 +16,9 @@ function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
     title: "Add widget",
     body: "Description",
     state: "open",
+    merged: false,
+    mergedAt: null,
+    closedAt: null,
     draft: false,
     mergeable: true,
     mergeableState: "clean",
@@ -33,6 +43,38 @@ describe("repositoryFromRemote", () => {
     ["http://proxy@127.0.0.1:1234/git/acme/widgets", "acme/widgets"],
   ])("parses %s", (remote, expected) => {
     expect(repositoryFromRemote(remote)).toBe(expected)
+  })
+})
+
+describe("PR inference", () => {
+  test("matches a fork PR by branch without assuming its owner", () => {
+    expect(
+      pullNumbersForBranch(
+        [
+          { number: 41, head: { ref: "other" } },
+          { number: 42, head: { ref: "feature" } },
+        ],
+        "feature"
+      )
+    ).toEqual([42])
+  })
+})
+
+describe("currentStatuses", () => {
+  test("keeps only the newest status per context", () => {
+    const statuses = [
+      { id: 1, context: "deploy", state: "pending", updatedAt: "2026-01-01T00:00:00Z" },
+      { id: 2, context: "deploy", state: "success", updatedAt: "2026-01-01T00:01:00Z" },
+      { id: 3, context: "lint", state: "success", updatedAt: "2026-01-01T00:00:00Z" },
+    ]
+    expect(currentStatuses(statuses).map(({ id }) => id)).toEqual([2, 3])
+  })
+})
+
+describe("poll errors", () => {
+  test("retries transport errors but not arbitrary failures", () => {
+    expect(isTransientPollError(new TypeError("fetch failed"))).toBe(true)
+    expect(isTransientPollError(new Error("invalid response"))).toBe(false)
   })
 })
 
@@ -91,6 +133,21 @@ describe("diffSnapshots", () => {
       },
       { resource: "comment", action: "added", id: "review:2", after: changed.comments[1] },
     ])
+  })
+
+  test("distinguishes a merge from a manual close", () => {
+    const before = snapshot()
+    const after = snapshot({
+      state: "closed",
+      merged: true,
+      mergedAt: "2026-01-01T00:04:00Z",
+      closedAt: "2026-01-01T00:04:00Z",
+    })
+    expect(diffSnapshots(before, after)[0]).toMatchObject({
+      resource: "pull_request",
+      action: "updated",
+      after: { state: "closed", merged: true, mergedAt: "2026-01-01T00:04:00Z" },
+    })
   })
 
   test("reports check transitions and resolved threads", () => {

--- a/.agents/skills/watch-pr/watch-pr.ts
+++ b/.agents/skills/watch-pr/watch-pr.ts
@@ -1,0 +1,457 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+import { dirname, resolve } from "node:path"
+
+export type Comment = {
+  id: string
+  kind: "issue" | "review"
+  author: string
+  body: string
+  createdAt: string
+  updatedAt: string
+  url: string
+  path?: string
+  line?: number | null
+  inReplyToId?: string | null
+}
+
+export type Check = {
+  id: number
+  name: string
+  app: string | null
+  status: string
+  conclusion: string | null
+  startedAt: string | null
+  completedAt: string | null
+  url: string | null
+}
+
+export type Review = {
+  id: number
+  author: string
+  state: string
+  body: string
+  submittedAt: string | null
+  commitId: string | null
+  url: string
+}
+
+export type ReviewThread = {
+  id: string
+  resolved: boolean
+  outdated: boolean
+  path: string | null
+  line: number | null
+  comments: Array<{
+    id: string
+    author: string
+    body: string
+    createdAt: string
+    updatedAt: string
+    url: string
+  }>
+}
+
+export type Snapshot = {
+  capturedAt: string
+  repository: string
+  number: number
+  title: string
+  body: string
+  state: string
+  draft: boolean
+  mergeable: boolean | null
+  mergeableState: string
+  headSha: string
+  baseRef: string
+  headRef: string
+  updatedAt: string
+  url: string
+  comments: Comment[]
+  reviews: Review[]
+  reviewThreads: ReviewThread[]
+  checks: Check[]
+  statuses: Array<{
+    id: number
+    context: string
+    state: string
+    description: string | null
+    url: string | null
+    createdAt: string
+    updatedAt: string
+  }>
+}
+
+export type Change = {
+  resource: "pull_request" | "comment" | "review" | "review_thread" | "check" | "status"
+  action: "added" | "updated" | "removed"
+  id: string
+  before?: unknown
+  after?: unknown
+}
+
+type Api = (path: string, init?: RequestInit) => Promise<unknown>
+
+const pageSize = 100
+
+function usage(exitCode = 2): never {
+  console.error(`Usage: bun watch-pr.ts [PR_NUMBER|PR_URL] [options]
+
+Options:
+  --repo OWNER/REPO   Repository (otherwise inferred from git remote)
+  --once              Print the current snapshot and exit
+  --interval SECONDS  Poll interval (default: 20)
+  --timeout SECONDS   Stop waiting after this duration (default: 1800; 0 = forever)
+  --state PATH        Persist the last snapshot to catch changes between invocations
+  --help              Show this help
+
+Without --once, prints a baseline and waits until the first observed change. Output is NDJSON.`)
+  process.exit(exitCode)
+}
+
+function parseArgs(argv: string[]) {
+  let target: string | undefined
+  let repo: string | undefined
+  let once = false
+  let interval = 20
+  let timeout = 1800
+  let statePath: string | undefined
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === "--help" || arg === "-h") usage(0)
+    if (arg === "--once") once = true
+    else if (arg === "--repo") repo = argv[++i]
+    else if (arg === "--interval") interval = Number(argv[++i])
+    else if (arg === "--timeout") timeout = Number(argv[++i])
+    else if (arg === "--state") statePath = argv[++i]
+    else if (arg.startsWith("-")) usage()
+    else if (!target) target = arg
+    else usage()
+  }
+
+  if (!Number.isFinite(interval) || interval < 5) throw new Error("--interval must be at least 5 seconds")
+  if (!Number.isFinite(timeout) || timeout < 0) throw new Error("--timeout must be non-negative")
+  return { target, repo, once, interval, timeout, statePath }
+}
+
+export function repositoryFromRemote(remote: string): string | undefined {
+  const cleaned = remote.trim().replace(/\.git$/, "")
+  const match = cleaned.match(/(?:github\.com[/:]|\/git\/)([^/]+\/[^/]+)$/)
+  return match?.[1]
+}
+
+async function inferRepository(): Promise<string> {
+  const remote = (await $`git remote get-url origin`.quiet().text()).trim()
+  const repository = repositoryFromRemote(remote)
+  if (!repository) throw new Error(`Cannot infer GitHub repository from origin: ${remote}`)
+  return repository
+}
+
+async function inferPullNumber(repository: string): Promise<number> {
+  const branch = (await $`git branch --show-current`.quiet().text()).trim()
+  if (!branch) throw new Error("Cannot infer PR from detached HEAD; pass a PR number or URL")
+  const owner = repository.split("/")[0]
+  const token = await resolveToken()
+  const response = (await githubFetch(
+    `/repos/${repository}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=2`,
+    token
+  )) as Array<{ number: number }>
+  if (response.length !== 1) {
+    throw new Error(`Expected one open PR for ${branch}, found ${response.length}; pass a PR number or URL`)
+  }
+  return response[0].number
+}
+
+function pullNumberFromTarget(target: string | undefined): number | undefined {
+  if (!target) return undefined
+  if (/^\d+$/.test(target)) return Number(target)
+  const match = target.match(/\/pull\/(\d+)(?:\/|$)/)
+  if (!match) throw new Error(`Invalid PR target: ${target}`)
+  return Number(match[1])
+}
+
+function repositoryFromTarget(target: string | undefined): string | undefined {
+  return target?.match(/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/)?.[1]
+}
+
+async function resolveToken(): Promise<string> {
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+  const result = await $`gh auth token`.quiet().nothrow()
+  const token = result.exitCode === 0 ? result.text().trim() : ""
+  if (token) return token
+  throw new Error("GitHub authentication missing; set GH_TOKEN/GITHUB_TOKEN or run gh auth login")
+}
+
+async function githubFetch(path: string, token: string, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "threa-pr-watcher",
+      ...init?.headers,
+    },
+  })
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`GitHub ${response.status} ${path}: ${body.slice(0, 500)}`)
+  }
+  return response.json()
+}
+
+async function allPages(api: Api, path: string): Promise<any[]> {
+  const results: any[] = []
+  for (let page = 1; ; page++) {
+    const separator = path.includes("?") ? "&" : "?"
+    const batch = (await api(`${path}${separator}per_page=${pageSize}&page=${page}`)) as any[]
+    results.push(...batch)
+    if (batch.length < pageSize) return results
+  }
+}
+
+async function allCheckRuns(api: Api, repository: string, sha: string): Promise<any[]> {
+  const results: any[] = []
+  for (let page = 1; ; page++) {
+    const response = (await api(
+      `/repos/${repository}/commits/${sha}/check-runs?per_page=${pageSize}&page=${page}`
+    )) as { check_runs: any[] }
+    results.push(...response.check_runs)
+    if (response.check_runs.length < pageSize) return results
+  }
+}
+
+async function reviewThreads(api: Api, repository: string, number: number): Promise<ReviewThread[]> {
+  const [owner, name] = repository.split("/")
+  const query = `query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved isOutdated path line comments(first:100){nodes{id author{login} body createdAt updatedAt url}}}}}}}`
+  const threads: ReviewThread[] = []
+  let cursor: string | null = null
+  do {
+    const result = (await api("/graphql", {
+      method: "POST",
+      body: JSON.stringify({ query, variables: { owner, name, number, cursor } }),
+      headers: { "Content-Type": "application/json" },
+    })) as any
+    if (result.errors) throw new Error(`GitHub GraphQL: ${JSON.stringify(result.errors)}`)
+    const connection = result.data.repository.pullRequest.reviewThreads
+    threads.push(
+      ...connection.nodes.map((thread: any) => ({
+        id: thread.id,
+        resolved: thread.isResolved,
+        outdated: thread.isOutdated,
+        path: thread.path,
+        line: thread.line,
+        comments: thread.comments.nodes.map((comment: any) => ({
+          id: comment.id,
+          author: comment.author?.login ?? "ghost",
+          body: comment.body,
+          createdAt: comment.createdAt,
+          updatedAt: comment.updatedAt,
+          url: comment.url,
+        })),
+      }))
+    )
+    cursor = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null
+  } while (cursor)
+  return threads
+}
+
+export async function captureSnapshot(api: Api, repository: string, number: number): Promise<Snapshot> {
+  const pull = (await api(`/repos/${repository}/pulls/${number}`)) as any
+  const [issueComments, inlineComments, reviews, checks, statuses, threads] = await Promise.all([
+    allPages(api, `/repos/${repository}/issues/${number}/comments`),
+    allPages(api, `/repos/${repository}/pulls/${number}/comments`),
+    allPages(api, `/repos/${repository}/pulls/${number}/reviews`),
+    allCheckRuns(api, repository, pull.head.sha),
+    allPages(api, `/repos/${repository}/commits/${pull.head.sha}/statuses`),
+    reviewThreads(api, repository, number),
+  ])
+
+  const comments: Comment[] = [
+    ...issueComments.map((comment: any) => ({
+      id: String(comment.id),
+      kind: "issue" as const,
+      author: comment.user?.login ?? "ghost",
+      body: comment.body ?? "",
+      createdAt: comment.created_at,
+      updatedAt: comment.updated_at,
+      url: comment.html_url,
+    })),
+    ...inlineComments.map((comment: any) => ({
+      id: String(comment.id),
+      kind: "review" as const,
+      author: comment.user?.login ?? "ghost",
+      body: comment.body ?? "",
+      createdAt: comment.created_at,
+      updatedAt: comment.updated_at,
+      url: comment.html_url,
+      path: comment.path,
+      line: comment.line,
+      inReplyToId: comment.in_reply_to_id ? String(comment.in_reply_to_id) : null,
+    })),
+  ].sort((a, b) => `${a.createdAt}:${a.id}`.localeCompare(`${b.createdAt}:${b.id}`))
+
+  return {
+    capturedAt: new Date().toISOString(),
+    repository,
+    number,
+    title: pull.title,
+    body: pull.body ?? "",
+    state: pull.state,
+    draft: pull.draft,
+    mergeable: pull.mergeable,
+    mergeableState: pull.mergeable_state,
+    headSha: pull.head.sha,
+    baseRef: pull.base.ref,
+    headRef: pull.head.ref,
+    updatedAt: pull.updated_at,
+    url: pull.html_url,
+    comments,
+    reviews: reviews.map((review: any) => ({
+      id: review.id,
+      author: review.user?.login ?? "ghost",
+      state: review.state,
+      body: review.body ?? "",
+      submittedAt: review.submitted_at,
+      commitId: review.commit_id,
+      url: review.html_url,
+    })),
+    reviewThreads: threads,
+    checks: checks
+      .map((check: any) => ({
+        id: check.id,
+        name: check.name,
+        app: check.app?.slug ?? null,
+        status: check.status,
+        conclusion: check.conclusion,
+        startedAt: check.started_at,
+        completedAt: check.completed_at,
+        url: check.details_url,
+      }))
+      .sort((a: Check, b: Check) => a.name.localeCompare(b.name) || a.id - b.id),
+    statuses: statuses.map((status: any) => ({
+      id: status.id,
+      context: status.context,
+      state: status.state,
+      description: status.description,
+      url: status.target_url,
+      createdAt: status.created_at,
+      updatedAt: status.updated_at,
+    })),
+  }
+}
+
+function comparable(value: unknown): string {
+  return JSON.stringify(value, (key, item) => (key === "capturedAt" ? undefined : item))
+}
+
+function diffCollection<T>(resource: Change["resource"], before: T[], after: T[], id: (item: T) => string): Change[] {
+  const oldItems = new Map(before.map((item) => [id(item), item]))
+  const newItems = new Map(after.map((item) => [id(item), item]))
+  const changes: Change[] = []
+  for (const [itemId, item] of newItems) {
+    const previous = oldItems.get(itemId)
+    if (!previous) changes.push({ resource, action: "added", id: itemId, after: item })
+    else if (comparable(previous) !== comparable(item))
+      changes.push({ resource, action: "updated", id: itemId, before: previous, after: item })
+  }
+  for (const [itemId, item] of oldItems) {
+    if (!newItems.has(itemId)) changes.push({ resource, action: "removed", id: itemId, before: item })
+  }
+  return changes
+}
+
+export function diffSnapshots(before: Snapshot, after: Snapshot): Change[] {
+  const pullFields = [
+    "title",
+    "body",
+    "state",
+    "draft",
+    "mergeable",
+    "mergeableState",
+    "headSha",
+    "baseRef",
+    "headRef",
+  ] as const
+  const oldPull = Object.fromEntries(pullFields.map((field) => [field, before[field]]))
+  const newPull = Object.fromEntries(pullFields.map((field) => [field, after[field]]))
+  const changes: Change[] =
+    comparable(oldPull) === comparable(newPull)
+      ? []
+      : [{ resource: "pull_request", action: "updated", id: String(after.number), before: oldPull, after: newPull }]
+  return changes.concat(
+    diffCollection("comment", before.comments, after.comments, (item) => `${item.kind}:${item.id}`),
+    diffCollection("review", before.reviews, after.reviews, (item) => String(item.id)),
+    diffCollection("review_thread", before.reviewThreads, after.reviewThreads, (item) => item.id),
+    diffCollection("check", before.checks, after.checks, (item) => String(item.id)),
+    diffCollection("status", before.statuses, after.statuses, (item) => String(item.id))
+  )
+}
+
+async function readState(path: string | undefined): Promise<Snapshot | undefined> {
+  if (!path || !(await Bun.file(path).exists())) return undefined
+  return Bun.file(path).json()
+}
+
+async function writeState(path: string | undefined, snapshot: Snapshot): Promise<void> {
+  if (!path) return
+  await Bun.$`mkdir -p ${dirname(resolve(path))}`.quiet()
+  await Bun.write(path, `${JSON.stringify(snapshot, null, 2)}\n`)
+}
+
+function emit(value: unknown): void {
+  console.log(JSON.stringify(value))
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const repository = options.repo ?? repositoryFromTarget(options.target) ?? (await inferRepository())
+  const number = pullNumberFromTarget(options.target) ?? (await inferPullNumber(repository))
+  const token = await resolveToken()
+  const api: Api = (path, init) => githubFetch(path, token, init)
+  let snapshot = await captureSnapshot(api, repository, number)
+  const saved = await readState(options.statePath)
+
+  if (options.once) {
+    await writeState(options.statePath, snapshot)
+    emit({ type: "snapshot", snapshot })
+    return
+  }
+
+  if (saved && saved.repository === repository && saved.number === number) {
+    const changes = diffSnapshots(saved, snapshot)
+    if (changes.length) {
+      await writeState(options.statePath, snapshot)
+      emit({ type: "changes", capturedAt: snapshot.capturedAt, changes, snapshot })
+      return
+    }
+  }
+
+  await writeState(options.statePath, snapshot)
+  emit({ type: "baseline", snapshot })
+  const startedAt = Date.now()
+  while (options.timeout === 0 || Date.now() - startedAt < options.timeout * 1000) {
+    await Bun.sleep(options.interval * 1000)
+    const next = await captureSnapshot(api, repository, number)
+    const changes = diffSnapshots(snapshot, next)
+    if (changes.length) {
+      await writeState(options.statePath, next)
+      emit({ type: "changes", capturedAt: next.capturedAt, changes, snapshot: next })
+      return
+    }
+    snapshot = next
+    await writeState(options.statePath, snapshot)
+  }
+  emit({ type: "timeout", capturedAt: new Date().toISOString(), snapshot })
+  process.exitCode = 3
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/.agents/skills/watch-pr/watch-pr.ts
+++ b/.agents/skills/watch-pr/watch-pr.ts
@@ -60,6 +60,9 @@ export type Snapshot = {
   title: string
   body: string
   state: string
+  merged: boolean
+  mergedAt: string | null
+  closedAt: string | null
   draft: boolean
   mergeable: boolean | null
   mergeableState: string
@@ -149,19 +152,25 @@ async function inferRepository(): Promise<string> {
   return repository
 }
 
-async function inferPullNumber(repository: string): Promise<number> {
+export function pullNumbersForBranch(
+  pulls: Array<{ number: number; head: { ref: string } }>,
+  branch: string
+): number[] {
+  return pulls.filter((pull) => pull.head.ref === branch).map((pull) => pull.number)
+}
+
+async function inferPullNumber(repository: string, api: Api): Promise<number> {
   const branch = (await $`git branch --show-current`.quiet().text()).trim()
   if (!branch) throw new Error("Cannot infer PR from detached HEAD; pass a PR number or URL")
-  const owner = repository.split("/")[0]
-  const token = await resolveToken()
-  const response = (await githubFetch(
-    `/repos/${repository}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=2`,
-    token
-  )) as Array<{ number: number }>
-  if (response.length !== 1) {
-    throw new Error(`Expected one open PR for ${branch}, found ${response.length}; pass a PR number or URL`)
+  const pulls = (await allPages(api, `/repos/${repository}/pulls?state=open`)) as Array<{
+    number: number
+    head: { ref: string }
+  }>
+  const numbers = pullNumbersForBranch(pulls, branch)
+  if (numbers.length !== 1) {
+    throw new Error(`Expected one open PR for ${branch}, found ${numbers.length}; pass a PR number or URL`)
   }
-  return response[0].number
+  return numbers[0]
 }
 
 function pullNumberFromTarget(target: string | undefined): number | undefined {
@@ -185,6 +194,20 @@ async function resolveToken(): Promise<string> {
   throw new Error("GitHub authentication missing; set GH_TOKEN/GITHUB_TOKEN or run gh auth login")
 }
 
+class GitHubApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryable: boolean
+  ) {
+    super(message)
+  }
+}
+
+export function isTransientPollError(error: unknown): boolean {
+  return error instanceof TypeError || (error instanceof GitHubApiError && error.retryable)
+}
+
 async function githubFetch(path: string, token: string, init?: RequestInit): Promise<unknown> {
   const response = await fetch(`https://api.github.com${path}`, {
     ...init,
@@ -198,7 +221,12 @@ async function githubFetch(path: string, token: string, init?: RequestInit): Pro
   })
   if (!response.ok) {
     const body = await response.text()
-    throw new Error(`GitHub ${response.status} ${path}: ${body.slice(0, 500)}`)
+    const rateLimited = response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0"
+    throw new GitHubApiError(
+      `GitHub ${response.status} ${path}: ${body.slice(0, 500)}`,
+      response.status,
+      rateLimited || response.status === 408 || response.status === 429 || response.status >= 500
+    )
   }
   return response.json()
 }
@@ -211,6 +239,15 @@ async function allPages(api: Api, path: string): Promise<any[]> {
     results.push(...batch)
     if (batch.length < pageSize) return results
   }
+}
+
+export function currentStatuses<T extends { context: string; updatedAt: string }>(statuses: T[]): T[] {
+  const latest = new Map<string, T>()
+  for (const status of statuses) {
+    const previous = latest.get(status.context)
+    if (!previous || status.updatedAt > previous.updatedAt) latest.set(status.context, status)
+  }
+  return [...latest.values()].sort((a, b) => a.context.localeCompare(b.context))
 }
 
 async function allCheckRuns(api: Api, repository: string, sha: string): Promise<any[]> {
@@ -301,6 +338,9 @@ export async function captureSnapshot(api: Api, repository: string, number: numb
     title: pull.title,
     body: pull.body ?? "",
     state: pull.state,
+    merged: pull.merged,
+    mergedAt: pull.merged_at,
+    closedAt: pull.closed_at,
     draft: pull.draft,
     mergeable: pull.mergeable,
     mergeableState: pull.mergeable_state,
@@ -332,15 +372,17 @@ export async function captureSnapshot(api: Api, repository: string, number: numb
         url: check.details_url,
       }))
       .sort((a: Check, b: Check) => a.name.localeCompare(b.name) || a.id - b.id),
-    statuses: statuses.map((status: any) => ({
-      id: status.id,
-      context: status.context,
-      state: status.state,
-      description: status.description,
-      url: status.target_url,
-      createdAt: status.created_at,
-      updatedAt: status.updated_at,
-    })),
+    statuses: currentStatuses(
+      statuses.map((status: any) => ({
+        id: status.id,
+        context: status.context,
+        state: status.state,
+        description: status.description,
+        url: status.target_url,
+        createdAt: status.created_at,
+        updatedAt: status.updated_at,
+      }))
+    ),
   }
 }
 
@@ -369,6 +411,9 @@ export function diffSnapshots(before: Snapshot, after: Snapshot): Change[] {
     "title",
     "body",
     "state",
+    "merged",
+    "mergedAt",
+    "closedAt",
     "draft",
     "mergeable",
     "mergeableState",
@@ -387,7 +432,7 @@ export function diffSnapshots(before: Snapshot, after: Snapshot): Change[] {
     diffCollection("review", before.reviews, after.reviews, (item) => String(item.id)),
     diffCollection("review_thread", before.reviewThreads, after.reviewThreads, (item) => item.id),
     diffCollection("check", before.checks, after.checks, (item) => String(item.id)),
-    diffCollection("status", before.statuses, after.statuses, (item) => String(item.id))
+    diffCollection("status", before.statuses, after.statuses, (item) => item.context)
   )
 }
 
@@ -409,9 +454,9 @@ function emit(value: unknown): void {
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const repository = options.repo ?? repositoryFromTarget(options.target) ?? (await inferRepository())
-  const number = pullNumberFromTarget(options.target) ?? (await inferPullNumber(repository))
   const token = await resolveToken()
   const api: Api = (path, init) => githubFetch(path, token, init)
+  const number = pullNumberFromTarget(options.target) ?? (await inferPullNumber(repository, api))
   let snapshot = await captureSnapshot(api, repository, number)
   const saved = await readState(options.statePath)
 
@@ -435,7 +480,18 @@ async function main() {
   const startedAt = Date.now()
   while (options.timeout === 0 || Date.now() - startedAt < options.timeout * 1000) {
     await Bun.sleep(options.interval * 1000)
-    const next = await captureSnapshot(api, repository, number)
+    let next: Snapshot
+    try {
+      next = await captureSnapshot(api, repository, number)
+    } catch (error) {
+      if (!isTransientPollError(error)) throw error
+      emit({
+        type: "poll_error",
+        capturedAt: new Date().toISOString(),
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
     const changes = diffSnapshots(snapshot, next)
     if (changes.length) {
       await writeState(options.statePath, next)

--- a/.agents/skills/watch-pr/watch-pr.ts
+++ b/.agents/skills/watch-pr/watch-pr.ts
@@ -153,20 +153,32 @@ async function inferRepository(): Promise<string> {
 }
 
 export function pullNumbersForBranch(
-  pulls: Array<{ number: number; head: { ref: string } }>,
-  branch: string
+  pulls: Array<{ number: number; head: { ref: string; repo: { full_name: string } | null } }>,
+  branch: string,
+  headRepository: string
 ): number[] {
-  return pulls.filter((pull) => pull.head.ref === branch).map((pull) => pull.number)
+  return pulls
+    .filter((pull) => pull.head.ref === branch && pull.head.repo?.full_name === headRepository)
+    .map((pull) => pull.number)
+}
+
+async function inferHeadRepository(branch: string, fallback: string): Promise<string> {
+  const configuredRemote = await $`git config --get ${`branch.${branch}.remote`}`.quiet().nothrow()
+  const remote = configuredRemote.exitCode === 0 ? configuredRemote.text().trim() : "origin"
+  if (!remote || remote === ".") return fallback
+  const remoteUrl = await $`git remote get-url --push ${remote}`.quiet().nothrow()
+  return remoteUrl.exitCode === 0 ? (repositoryFromRemote(remoteUrl.text()) ?? fallback) : fallback
 }
 
 async function inferPullNumber(repository: string, api: Api): Promise<number> {
   const branch = (await $`git branch --show-current`.quiet().text()).trim()
   if (!branch) throw new Error("Cannot infer PR from detached HEAD; pass a PR number or URL")
+  const headRepository = await inferHeadRepository(branch, repository)
   const pulls = (await allPages(api, `/repos/${repository}/pulls?state=open`)) as Array<{
     number: number
-    head: { ref: string }
+    head: { ref: string; repo: { full_name: string } | null }
   }>
-  const numbers = pullNumbersForBranch(pulls, branch)
+  const numbers = pullNumbersForBranch(pulls, branch, headRepository)
   if (numbers.length !== 1) {
     throw new Error(`Expected one open PR for ${branch}, found ${numbers.length}; pass a PR number or URL`)
   }
@@ -221,14 +233,23 @@ async function githubFetch(path: string, token: string, init?: RequestInit): Pro
   })
   if (!response.ok) {
     const body = await response.text()
-    const rateLimited = response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0"
     throw new GitHubApiError(
       `GitHub ${response.status} ${path}: ${body.slice(0, 500)}`,
       response.status,
-      rateLimited || response.status === 408 || response.status === 429 || response.status >= 500
+      isRetryableGitHubResponse(response.status, response.headers, body)
     )
   }
   return response.json()
+}
+
+export function isRetryableGitHubResponse(status: number, headers: Headers, body: string): boolean {
+  if (status === 408 || status === 429 || status >= 500) return true
+  if (status !== 403) return false
+  return (
+    headers.get("x-ratelimit-remaining") === "0" ||
+    headers.has("retry-after") ||
+    /secondary rate limit|abuse detection/i.test(body)
+  )
 }
 
 async function allPages(api: Api, path: string): Promise<any[]> {
@@ -451,38 +472,37 @@ function emit(value: unknown): void {
   console.log(JSON.stringify(value))
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2))
-  const repository = options.repo ?? repositoryFromTarget(options.target) ?? (await inferRepository())
-  const token = await resolveToken()
-  const api: Api = (path, init) => githubFetch(path, token, init)
-  const number = pullNumberFromTarget(options.target) ?? (await inferPullNumber(repository, api))
-  let snapshot = await captureSnapshot(api, repository, number)
-  const saved = await readState(options.statePath)
+export function nextPollDelay(deadline: number, intervalMs: number, now = Date.now()): number | undefined {
+  if (deadline !== Infinity && now >= deadline) return undefined
+  return deadline === Infinity ? intervalMs : Math.min(intervalMs, deadline - now)
+}
 
-  if (options.once) {
-    await writeState(options.statePath, snapshot)
-    emit({ type: "snapshot", snapshot })
-    return
+function snapshotSummary(snapshot: Snapshot) {
+  return {
+    repository: snapshot.repository,
+    number: snapshot.number,
+    state: snapshot.state,
+    merged: snapshot.merged,
+    draft: snapshot.draft,
+    mergeable: snapshot.mergeable,
+    mergeableState: snapshot.mergeableState,
+    headSha: snapshot.headSha,
+    comments: snapshot.comments.length,
+    unresolvedThreads: snapshot.reviewThreads.filter((thread) => !thread.resolved).map((thread) => thread.id),
+    checks: snapshot.checks,
+    statuses: snapshot.statuses,
   }
+}
 
-  if (saved && saved.repository === repository && saved.number === number) {
-    const changes = diffSnapshots(saved, snapshot)
-    if (changes.length) {
-      await writeState(options.statePath, snapshot)
-      emit({ type: "changes", capturedAt: snapshot.capturedAt, changes, snapshot })
-      return
-    }
-  }
-
-  await writeState(options.statePath, snapshot)
-  emit({ type: "baseline", snapshot })
-  const startedAt = Date.now()
-  while (options.timeout === 0 || Date.now() - startedAt < options.timeout * 1000) {
-    await Bun.sleep(options.interval * 1000)
-    let next: Snapshot
+async function retryPollOperation<T>(
+  operation: () => Promise<T>,
+  deadline: number,
+  intervalMs: number
+): Promise<T | undefined> {
+  while (true) {
     try {
-      next = await captureSnapshot(api, repository, number)
+      const result = await operation()
+      return deadline !== Infinity && Date.now() >= deadline ? undefined : result
     } catch (error) {
       if (!isTransientPollError(error)) throw error
       emit({
@@ -490,18 +510,72 @@ async function main() {
         capturedAt: new Date().toISOString(),
         error: error instanceof Error ? error.message : String(error),
       })
-      continue
+      const delay = nextPollDelay(deadline, intervalMs)
+      if (delay === undefined) return undefined
+      await Bun.sleep(delay)
     }
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const repository = options.repo ?? repositoryFromTarget(options.target) ?? (await inferRepository())
+  const token = await resolveToken()
+  const api: Api = (path, init) => githubFetch(path, token, init)
+  const intervalMs = options.interval * 1000
+
+  if (options.once) {
+    const number = pullNumberFromTarget(options.target) ?? (await inferPullNumber(repository, api))
+    const snapshot = await captureSnapshot(api, repository, number)
+    await writeState(options.statePath, snapshot)
+    emit({ type: "snapshot", snapshot })
+    return
+  }
+
+  const deadline = options.timeout === 0 ? Infinity : Date.now() + options.timeout * 1000
+  const explicitNumber = pullNumberFromTarget(options.target)
+  const number =
+    explicitNumber ?? (await retryPollOperation(() => inferPullNumber(repository, api), deadline, intervalMs))
+  if (number === undefined) {
+    emit({ type: "timeout", capturedAt: new Date().toISOString() })
+    process.exitCode = 3
+    return
+  }
+  let snapshot = await retryPollOperation(() => captureSnapshot(api, repository, number), deadline, intervalMs)
+  if (!snapshot) {
+    emit({ type: "timeout", capturedAt: new Date().toISOString(), repository, number })
+    process.exitCode = 3
+    return
+  }
+  const saved = await readState(options.statePath)
+
+  if (saved && saved.repository === repository && saved.number === number) {
+    const changes = diffSnapshots(saved, snapshot)
+    if (changes.length) {
+      await writeState(options.statePath, snapshot)
+      emit({ type: "changes", capturedAt: snapshot.capturedAt, changes, summary: snapshotSummary(snapshot) })
+      return
+    }
+  }
+
+  await writeState(options.statePath, snapshot)
+  emit({ type: "baseline", capturedAt: snapshot.capturedAt, summary: snapshotSummary(snapshot) })
+  while (true) {
+    const delay = nextPollDelay(deadline, intervalMs)
+    if (delay === undefined) break
+    await Bun.sleep(delay)
+    const next = await retryPollOperation(() => captureSnapshot(api, repository, number), deadline, intervalMs)
+    if (!next) break
     const changes = diffSnapshots(snapshot, next)
     if (changes.length) {
       await writeState(options.statePath, next)
-      emit({ type: "changes", capturedAt: next.capturedAt, changes, snapshot: next })
+      emit({ type: "changes", capturedAt: next.capturedAt, changes, summary: snapshotSummary(next) })
       return
     }
     snapshot = next
     await writeState(options.statePath, snapshot)
   }
-  emit({ type: "timeout", capturedAt: new Date().toISOString(), snapshot })
+  emit({ type: "timeout", capturedAt: new Date().toISOString(), summary: snapshotSummary(snapshot) })
   process.exitCode = 3
 }
 


### PR DESCRIPTION
## Problem

Agents repeatedly rebuild GitHub polling loops when waiting for CI or review activity. Harness-specific wake-up APIs are also uneven: Pi can inject follow-ups, while Claude Code has no general external-event injection API.

## Solution

Add a shared `watch-pr` skill and Bun executable. The executable snapshots PR metadata, paginated comments/reviews/checks/statuses, and review-thread state; emits structured before/after changes; persists state across invocations; and blocks in the foreground so its result enters either harness context without an adapter.

- Watches description, head SHA, merge state, comments and edits, reviews, thread resolution, check-run transitions, and legacy statuses.
- Uses `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`; infers the repository and current-branch PR when omitted.
- Documents final merge-readiness checks and the limit of portable idle-agent wake-up.

## Files

| File | Change |
| ---- | ------ |
| `.agents/skills/watch-pr/SKILL.md` | Agent workflow and merge-readiness rules |
| `.agents/skills/watch-pr/watch-pr.ts` | Poller, snapshot normalization, state persistence, and diff output |
| `.agents/skills/watch-pr/watch-pr.test.ts` | Remote parsing and event-diff tests |

## Test plan

- [x] `bun test ./.agents/skills/watch-pr/watch-pr.test.ts` (12 pass)
- [x] strict standalone TypeScript check
- [x] repository pre-commit lint and monorepo typecheck
- [x] live snapshot of GitHub PR #1534 (comments, reviews, threads, 21 checks, and statuses)

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787604518&installation_model_id=20758&pr_number=1540&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1540&signature=d3268e46dbb92d43a501edb770a689e11ed102ae468b61a261b35c992e2d61c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
