### PR TITLE
fix(calls): simplify desktop call view controls

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -468,7 +468,7 @@ describe("CallDock — desktop surface routing", () => {
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
   })
 
-  it("routes fullscreen joining and connected states as a peer surface and remembers it", () => {
+  it("routes fullscreen joining and connected states as a peer surface and remembers it", async () => {
     setDesktopCallSurface("fullscreen")
     renderDock(makeManager())
     act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
@@ -482,6 +482,12 @@ describe("CallDock — desktop surface routing", () => {
     expect(screen.getByTestId("desktop-call-fullscreen")).toHaveAttribute("data-phase", "connected")
     expect(screen.getByTestId("call-layout-slot")).toBeInTheDocument()
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
+
+    const placementPicker = screen.getByLabelText("Change thumbnail placement. Current: Below video")
+    expect(placementPicker).not.toHaveTextContent("Bottom")
+    await userEvent.click(placementPicker)
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Thumbnails beside video" }))
+    expect(getCallPrefs().filmstripSide).toBe("side")
   })
 
   it("floating pref surfaces the pre-join permission gate inside the square during an active launch", async () => {
@@ -504,13 +510,13 @@ describe("CallDock — desktop surface routing", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
-    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByLabelText(/Change call view/))
     await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
     expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
     expect(screen.queryByTestId("floating-call-square")).toBeNull()
     expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
     expect(getCallPrefs().lastDesktopSurface).toBe("sidebar")
-    expect(screen.getByLabelText("Call surface")).toHaveFocus()
+    expect(screen.getByLabelText(/Change call view/)).toHaveFocus()
   })
 
   it("opens a minimized Sidebar before moving picker focus into it", async () => {
@@ -519,11 +525,11 @@ describe("CallDock — desktop surface routing", () => {
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     act(() => setCallSurfaceMode("min"))
 
-    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByLabelText(/Change call view/))
     await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
 
     expect(screen.getByTestId("desktop-call-dock")).toHaveAttribute("data-mode", "standard")
-    expect(screen.getByLabelText("Call surface")).toHaveFocus()
+    expect(screen.getByLabelText(/Change call view/)).toHaveFocus()
   })
 
   it("does not move focus for a non-picker surface switch", () => {
@@ -545,7 +551,7 @@ describe("CallDock — desktop surface routing", () => {
     renderDock(makeManager())
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     expect(screen.getByTestId("desktop-call-dock")).toBeInTheDocument()
-    await userEvent.click(screen.getByLabelText("Call surface"))
+    await userEvent.click(screen.getByLabelText(/Change call view/))
     await userEvent.click(screen.getByRole("menuitemradio", { name: "Floating" }))
     expect(screen.getByTestId("floating-call-square")).toBeInTheDocument()
     expect(screen.queryByTestId("desktop-call-dock")).toBeNull()

--- a/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
+++ b/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
@@ -1,6 +1,13 @@
 import { useState, type RefObject } from "react"
-import { Users } from "lucide-react"
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { PanelBottom, PanelRight, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { setCallFilmstripSide, useCallPrefs, type DesktopSurface } from "@/stores/call-prefs-store"
@@ -13,28 +20,41 @@ import { LayoutToggle } from "./layout-toggle"
 import { CallJoiningBody } from "./pre-join-gate"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster } from "./call-store-hooks"
 
-function FilmstripSideToggle() {
+function FilmstripPositionPicker() {
   const { filmstripSide } = useCallPrefs()
+  const SelectedIcon = filmstripSide === "bottom" ? PanelBottom : PanelRight
   return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      role="radiogroup"
-      value={filmstripSide}
-      onValueChange={(value) => {
-        if (value === "bottom" || value === "side") setCallFilmstripSide(value)
-      }}
-      aria-label="Filmstrip position"
-      data-testid="call-filmstrip-side-toggle"
-      className="shrink-0 gap-0.5 rounded-md bg-muted p-0.5"
-    >
-      <ToggleGroupItem value="bottom" aria-label="Filmstrip bottom" className="h-7 px-2 text-xs">
-        Bottom
-      </ToggleGroupItem>
-      <ToggleGroupItem value="side" aria-label="Filmstrip side" className="h-7 px-2 text-xs">
-        Side
-      </ToggleGroupItem>
-    </ToggleGroup>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          aria-label={`Change thumbnail placement. Current: ${filmstripSide === "bottom" ? "Below video" : "Beside video"}`}
+          title="Change thumbnail placement"
+          data-testid="call-filmstrip-position-picker"
+        >
+          <SelectedIcon className="h-4 w-4" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={filmstripSide}
+          onValueChange={(value) => {
+            if (value === "bottom" || value === "side") setCallFilmstripSide(value)
+          }}
+        >
+          <DropdownMenuRadioItem value="bottom" className="gap-2">
+            <PanelBottom className="h-4 w-4" aria-hidden />
+            Thumbnails below video
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="side" className="gap-2">
+            <PanelRight className="h-4 w-4" aria-hidden />
+            Thumbnails beside video
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -83,7 +103,7 @@ export function DesktopCallFullscreen({
           </span>
         )}
         <div className="ml-auto flex items-center gap-2">
-          {!joining && layout === "speaker" && <FilmstripSideToggle />}
+          {!joining && layout === "speaker" && <FilmstripPositionPicker />}
           {!joining && (
             <div data-testid="call-layout-slot">
               <LayoutToggle className="bg-muted" />

--- a/apps/frontend/src/components/call/desktop-call-surface-picker.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-surface-picker.test.tsx
@@ -6,12 +6,15 @@ describe("DesktopCallSurfacePicker", () => {
   it("shows the selected surface and selects every peer surface by keyboard", async () => {
     const onValueChange = vi.fn()
     render(<DesktopCallSurfacePicker value="sidebar" onValueChange={onValueChange} />)
-    const trigger = screen.getByLabelText("Call surface")
-    expect(trigger).toHaveTextContent("Sidebar")
+    const trigger = screen.getByLabelText(/Change call view/)
+    expect(trigger).not.toHaveTextContent("Sidebar")
+    expect(trigger.querySelector("svg")).toBeInTheDocument()
 
     trigger.focus()
     await userEvent.keyboard("{Enter}")
-    await userEvent.click(screen.getByRole("menuitemradio", { name: "Floating" }))
+    const floatingOption = screen.getByRole("menuitemradio", { name: "Floating" })
+    expect(floatingOption.querySelector("svg")).toBeInTheDocument()
+    await userEvent.click(floatingOption)
     expect(onValueChange).toHaveBeenCalledWith("floating")
 
     await userEvent.click(trigger)

--- a/apps/frontend/src/components/call/desktop-call-surface-picker.tsx
+++ b/apps/frontend/src/components/call/desktop-call-surface-picker.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from "react"
-import { ChevronDown } from "lucide-react"
+import { Maximize, PanelRight, PictureInPicture2, type LucideIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -10,10 +10,10 @@ import {
 } from "@/components/ui/dropdown-menu"
 import type { DesktopSurface } from "@/stores/call-prefs-store"
 
-const OPTIONS: { value: DesktopSurface; label: string }[] = [
-  { value: "floating", label: "Floating" },
-  { value: "sidebar", label: "Sidebar" },
-  { value: "fullscreen", label: "Fullscreen" },
+const OPTIONS: { value: DesktopSurface; label: string; icon: LucideIcon }[] = [
+  { value: "floating", label: "Floating", icon: PictureInPicture2 },
+  { value: "sidebar", label: "Sidebar", icon: PanelRight },
+  { value: "fullscreen", label: "Fullscreen", icon: Maximize },
 ]
 
 export function DesktopCallSurfacePicker({
@@ -25,28 +25,33 @@ export function DesktopCallSurfacePicker({
   onValueChange: (value: DesktopSurface) => void
   triggerRef?: RefObject<HTMLButtonElement | null>
 }) {
-  const label = OPTIONS.find((option) => option.value === value)?.label ?? "Floating"
+  const selected = OPTIONS.find((option) => option.value === value) ?? OPTIONS[0]
+  const SelectedIcon = selected.icon
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
           ref={triggerRef}
           variant="ghost"
-          size="sm"
-          className="h-7 shrink-0 gap-1 px-2"
-          aria-label="Call surface"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          aria-label={`Change call view. Current: ${selected.label}`}
+          title="Change call view"
         >
-          <span className="w-[4.5rem] text-left">{label}</span>
-          <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+          <SelectedIcon className="h-4 w-4" aria-hidden />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" onPointerDown={(event) => event.stopPropagation()}>
         <DropdownMenuRadioGroup value={value} onValueChange={(next) => onValueChange(next as DesktopSurface)}>
-          {OPTIONS.map((option) => (
-            <DropdownMenuRadioItem key={option.value} value={option.value}>
-              {option.label}
-            </DropdownMenuRadioItem>
-          ))}
+          {OPTIONS.map((option) => {
+            const Icon = option.icon
+            return (
+              <DropdownMenuRadioItem key={option.value} value={option.value} className="gap-2">
+                <Icon className="h-4 w-4" aria-hidden />
+                {option.label}
+              </DropdownMenuRadioItem>
+            )
+          })}
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -163,7 +163,7 @@ describe("FloatingCallSquare — connected", () => {
     expect(square).toHaveAttribute("data-minimized", "false")
     expect(screen.getAllByTestId("call-tile")).toHaveLength(2)
     expect(screen.getByLabelText("Leave call")).toBeInTheDocument()
-    expect(screen.getByLabelText("Call surface")).toBeInTheDocument()
+    expect(screen.getByLabelText(/Change call view/)).toBeInTheDocument()
 
     const header = screen.getByTestId("floating-call-square-header")
     expect(header.firstElementChild).toBe(screen.getByTestId("expanded-call-drag-grip"))
@@ -175,7 +175,7 @@ describe("FloatingCallSquare — connected", () => {
     renderSquare(makeManager(), onDockToSide)
     enterConnected(TWO_PEERS)
     await act(async () => {
-      await userEvent.click(screen.getByLabelText("Call surface"))
+      await userEvent.click(screen.getByLabelText(/Change call view/))
       await userEvent.click(screen.getByRole("menuitemradio", { name: "Sidebar" }))
     })
     expect(onDockToSide).toHaveBeenCalled()
@@ -224,7 +224,7 @@ describe("FloatingCallSquare — minimize / restore", () => {
     expect(compactChildren).toEqual([
       screen.getByTestId("minimized-call-drag-handle"),
       screen.getByTestId("minimized-call-content"),
-      screen.getByLabelText("Call surface"),
+      screen.getByLabelText(/Change call view/),
       screen.getByLabelText("Restore call"),
     ])
     expect(screen.queryByLabelText("Dock to the side")).toBeNull()
@@ -255,7 +255,7 @@ describe("FloatingCallSquare — minimize / restore", () => {
     expect(Array.from(compact.children)).toEqual([
       screen.getByTestId("minimized-call-drag-handle"),
       screen.getByTestId("minimized-call-content"),
-      screen.getByLabelText("Call surface"),
+      screen.getByLabelText(/Change call view/),
       screen.getByLabelText("Restore call"),
     ])
     expect(screen.getByTestId("minimized-call-controls").children).toHaveLength(3)
@@ -351,6 +351,26 @@ describe("FloatingCallSquare — joining", () => {
 })
 
 describe("FloatingCallSquare — drag", () => {
+  it("surface menu options never start dragging the square", async () => {
+    renderSquare()
+    enterConnected(TWO_PEERS)
+    const square = screen.getByTestId("floating-call-square")
+    const header = screen.getByTestId("floating-call-square-header")
+    header.setPointerCapture = vi.fn()
+
+    await userEvent.click(screen.getByLabelText(/Change call view/))
+    fireEvent.pointerDown(screen.getByRole("menuitemradio", { name: "Sidebar" }), {
+      clientX: 700,
+      clientY: 100,
+      pointerId: 1,
+      isPrimary: true,
+    })
+    fireEvent.pointerMove(header, { clientX: 300, clientY: 200, pointerId: 1 })
+
+    expect(square.style.left).toBe("676px")
+    expect(square.style.top).toBe("440px")
+  })
+
   it("dragging the header moves the square and settles without wedging", () => {
     renderSquare()
     enterConnected(TWO_PEERS)


### PR DESCRIPTION
## Problem

Desktop call view controls compete with the call itself. The floating surface picker displays its current mode as prominent header text, and Radix menu events bubble through its portal into the draggable header, so choosing Sidebar or Fullscreen can move the window instead. Fullscreen’s “Bottom / Side” segmented control does not explain that it positions participant thumbnails.

## Solution

Use compact, stateful icon pickers for both choices while keeping their menus explicit:

- The call-view trigger now shows the current surface icon; its menu pairs icons with Floating, Sidebar, and Fullscreen labels.
- The menu content stops pointer-down propagation before it reaches the floating header’s drag handler.
- The fullscreen placement trigger shows the active placement icon; menu choices say “Thumbnails below video” and “Thumbnails beside video.”
- Accessible trigger names include the current choice, and radio-menu semantics continue to expose selection state.

Fullscreen chat behavior is deliberately unchanged; this PR only addresses the reported toolbar and drag issues.

## Verification

- [x] 46 focused call component tests
- [x] Frontend TypeScript typecheck
- [x] ESLint and Prettier
- [x] Full pre-commit monorepo lint and typecheck
- [x] Independent UX, pointer-event, and accessibility review: verified

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606568&installation_model_id=20758&pr_number=1541&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1541&signature=07eeeb11e7f009010c94302b2849cbe6b800de34d03d691fcad6207ee9d63290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->