### PR TITLE
chore: make build-feature remediation bounded and autonomous

### DIFF
--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: build-feature
-description: Build a planned feature as a stacked PR chain with per-chunk implementation, one non-duplicative review gate, bounded fixes, and runtime-specific Claude or Pi/OpenAI profiles.
+description: Build a planned feature as a stacked PR chain with bounded discovery, autonomous remediation, and runtime-specific Claude or Pi/OpenAI profiles.
 ---
 
 # Build a feature as a reviewed stacked-PR chain
 
-Build each plan chunk, verify it once with the strongest useful runtime profile, fix findings in one batch, and create the stacked PR before moving on. Preserve review quality without paying multiple agents to repeat the same lens on the same diff.
+Build each ratified plan chunk, verify it once, remediate one immutable finding set, and create its stacked PR before moving on. Do not pay multiple agents to repeat the same review lens.
 
-## Planning and preconditions
+## Planning and launch
 
-- The invoking agent remains the orchestrator at its current, lower reasoning level. It owns sequencing, user checkpoints, agent briefs, gates, and stack state; it does not become the planner.
-- A ratified implementation plan containing a PR-stack breakdown is required. The plan embedded in the PR body by `/sync-plan` is authoritative. Files under `docs/plans/` are optional desired-design context, never implementation truth.
-- No implementation plan → delegate investigation and drafting to one fresh high-reasoning planner, have the user ratify the result, then publish it with `/sync-plan` before implementation. Do not start building from a chat message.
-- The planner writes the candidate plan but never orchestrates implementation or delegates children.
-- Deferred items in the plan are binding: do not build them.
+- The invoking agent remains the orchestrator at its current, lower reasoning level. It owns sequencing, briefs, gates, checkpoints, and stack state; it does not become the planner.
+- Require a user-ratified implementation plan with a PR-stack breakdown. The plan embedded in the PR body by `/sync-plan` is authoritative. Files under `docs/plans/` are optional desired-design context, never implementation truth.
+- No plan: delegate investigation and drafting to one fresh high-reasoning planner, obtain user ratification, then publish with `/sync-plan`. The planner never orchestrates implementation or delegates children. Do not build from an unratified chat message.
+- Deferred items are immutable and out of scope.
+- At launch, record the selected runtime profile and operating mode. Phrases such as “overnight,” “AFK,” “workflow owns it,” “build all,” or equivalent select **AFK/autonomous mode**. This preauthorizes recommended local choices and reversible, bounded fixer replacement/correction within the ratified plan. Interrupt autonomous work only for a hard stop. Otherwise use interactive mode and request only checkpoints required below.
 
 ## Select one execution profile
 
-Determine the active harness/provider once and record the profile in the first status update.
+Determine the active harness/provider once.
 
 ### Claude profile
 
@@ -25,44 +25,59 @@ Determine the active harness/provider once and record the profile in the first s
 - Implementer: Opus, effort `medium`.
 - Per-chunk verifier: Opus, effort `xhigh`.
 - Whole-stack reviewer: Fable.
-- Preserve the established Claude behavior below, subject to the shared round and read bounds.
 
 ### Pi / OpenAI profile
 
 - Planner: one fresh GPT-5.6 Sol agent, effort `high`.
-- Implementer: GPT-5.6 Sol, effort `low`. Pi maps Sol `minimal` to provider `low`, so request `low` explicitly.
-- Per-chunk verifier: one fresh GPT-5.6 Sol agent, effort `high`.
-- Never use `xhigh` per chunk. Reserve it for one final whole-stack review only when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries; otherwise use `high`.
-- Maximum two children running concurrently. A child never delegates.
+- Implementer: GPT-5.6 Sol, effort `low`; request `low` explicitly because Pi maps Sol `minimal` to provider `low`.
+- Per-chunk verifier: one fresh GPT-5.6 Sol agent, effort `high`; never use `xhigh` per chunk.
+- Whole-stack reviewer: Sol `high`, or the single `xhigh` pass only when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries.
 - Do not run an external Sol pass: Sol already implemented and reviewed the work.
 
-## Shared efficiency contract
+For every profile: at most two children may run concurrently, and a child never delegates.
 
-- One quality gate per diff revision. Adversarial verification and `/code-review` are alternatives, not cumulative rituals.
-- Maximum one batched fix pass and one targeted recheck per chunk. If material findings survive, stop for a human checkpoint; do not start another clean-room review.
-- Run declared typecheck/tests once in the orchestrator after implementation and once after the fix batch when code changed. Review agents do not rerun green gates unless a concrete finding requires a focused reproduction.
+## Shared bounds
+
+- One broad quality gate per diff revision. Adversarial verification and `/code-review` are alternatives, not cumulative rituals.
+- One broad verifier creates the revision's immutable finding set. Later remediation, rechecks, and confirmations cannot start broad review, invent findings, or add unrelated scope.
+- Run declared typecheck/tests in the orchestrator once after implementation and once after remediation when code changed. After a permitted surgical correction, rerun only affected gates once. Review agents do not rerun green gates unless a concrete accepted finding requires focused reproduction.
 - Review from the brief and diff. Read source only to validate a concrete candidate finding; never browse the whole tree for confidence theater.
-- Pi/Sol agents follow the root `AGENTS.md` read-efficiency rules.
-- Briefs, diffs, histories, and test output live in files. Pass paths, not pasted walls.
+- Pi/Sol agents follow root `AGENTS.md` read-efficiency rules. Briefs, diffs, histories, and test output live in files; pass paths, not pasted walls.
 
 ## Per chunk
 
-1. **Brief**: write the chunk implementation brief to `.tmp/` — binding plan sections, deliverables, neighbor files, enumerated tests, exclusions, and the exact diff base.
-2. **Implement**: one agent using the selected profile, directly in the chunk worktree, no commit. The orchestrator inspects the diff and runs the brief's gates.
-3. **Adversarial verification**: one verifier using the selected profile. It re-derives behavior from the brief and diff, checks named race/edge paths, and reports only concrete findings scoring ≥80. It receives the green/failed gate summary; it does not rerun broad gates.
-4. **Fix and recheck**: consolidate all accepted findings into one fix brief. The implementer or one fresh implementation-profile agent applies them as one batch. Rerun affected gates once, then use one targeted verifier recheck limited to the accepted findings and changed lines. No new broad review round. Save the exact reviewed final patch with `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff` and write the exact `base_ref` plus reviewer/recheck outcome to `.tmp/build-feature-review-evidence.md`; `/create-pr` compares the same patch shape after commit to avoid repeating the audit.
-5. **Stacked PR**: commit via `/commit`, then `/gh-stack` + `/create-pr`; each chunk branch is based on the previous chunk, first chunk on `origin/main`. `/create-pr` owns `gh stack submit`; this skill only verifies `gh stack view --json` reports a Stack afterward.
-6. **Additional code review**: do not automatically run `/code-review` when Step 3 reviewed the current final diff. Run it only when the user explicitly requests it, the diff materially changed after the targeted recheck, or Step 3 was skipped. Record the reason.
+1. **Brief**: write `.tmp/` implementation brief with binding plan sections, deliverables, neighbor files, enumerated tests, exclusions, and exact diff base.
+2. **Implement**: one selected-profile implementer works directly in the chunk worktree without committing. The orchestrator inspects the diff and runs the brief's gates.
+3. **Broad verification**: one selected-profile verifier re-derives behavior from the brief and diff, checks named race/edge paths, and reports only concrete findings scoring ≥80. Give it the gate summary; it does not rerun broad gates. Record every finding and its disposition. Accepted findings become the immutable remediation set; disputed or deferred findings cannot re-enter later passes.
+4. **One logical remediation phase**: implement every accepted finding, or record a concrete hard blocker for it. Consolidate the set into one fix brief. Prefer the original implementer; resume or replace any incomplete assignment as needed, or partition the set into non-overlapping assignments. All attempts remain one phase, and at most two children may run concurrently.
+   - A failed or harness-incomplete child, context/capacity exhaustion, compile failure, unfinished test, or “needs investigation” result is incomplete execution, not a consumed remediation phase and not a review loop. Preserve completed work, then resume or replace the unfinished assignment.
+   - Child underperformance is not itself a hard stop. Do not mark remediation complete while an accepted finding lacks either an implementation or a qualifying hard blocker.
+5. **Targeted recheck and correction**: rerun affected gates once, then perform one recheck limited to accepted findings and lines changed for them. The recheck cannot create a new finding set. If it finds a failure traceable to the immutable set, permit one surgical correction, rerun only affected gates once, and perform one final targeted confirmation. No broad rediscovery. If material accepted findings remain, the correction cap is exhausted: stop.
+6. **Review evidence**: save the exact final patch with `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff`. Write exact `base_ref`, finding dispositions, remediation assignments, gate outcomes, recheck/correction outcome, and caveats to `.tmp/build-feature-review-evidence.md`. `/create-pr` compares the same patch shape after commit, avoiding a duplicate audit.
+7. **Stacked PR**: commit via `/commit`, then `/gh-stack` + `/create-pr`. Base each chunk branch on the previous chunk; base the first on `origin/main`. `/create-pr` owns `gh stack submit`; verify afterward that `gh stack view --json` reports a Stack.
+8. **Additional code review**: do not automatically run `/code-review` after Step 3 reviewed the current final diff. Run it only when explicitly requested, the diff materially changed outside accepted-finding remediation after the targeted confirmation, or Step 3 was skipped. Record the reason.
+
+## Hard stops and decomposition
+
+Hard stops are limited to:
+
+- an unratified migration, public-contract, or destructive decision;
+- concrete evidence that scope crosses an ownership/lifecycle boundary and requires plan/stack decomposition;
+- mandatory external proof with no deterministic substitute; or
+- exhausted surgical-correction cap with material accepted findings remaining.
+
+Missing optional live credentials or optional smoke coverage is a recorded caveat, not a stop. Use available deterministic substitutes and continue.
+
+Do not split because implementation is incomplete, gates are red, planned tests remain, an agent underperformed, context ran out, or the diff remains within the ratified budget. Decompose only with concrete scope/ownership evidence: identify the independently owned lifecycle or state machine, show why the current chunk must coordinate it, preserve the patch, and propose the revised stack for ratification. In autonomous mode, this qualifying plan change still requires interruption because it is a hard stop.
 
 ## After the last chunk
 
-7. **Whole-stack review**: one review of `git diff origin/main...<tip>` focused on cross-PR seams, plan conformance, and invariants not fully visible within a chunk. Claude uses Fable. Pi/OpenAI uses Sol `high`, or the single allowed `xhigh` pass for the high-risk boundaries listed above.
-8. Fold surviving findings in one batch, run affected gates once, push, and report per-PR links. No second external model unless the user explicitly requests it. Before launch, report the proposed model, effort, and whole-stack diff line/file counts; obtain confirmation if the request did not already specify them.
+9. **Whole-stack review**: review `git diff origin/main...<tip>` once for cross-PR seams, plan conformance, and invariants not visible within one chunk. Before launch, report proposed model, effort, and whole-stack diff line/file counts; obtain confirmation in interactive mode unless the request already specified them. In autonomous mode, record the selection and proceed without interruption. Claude uses Fable. Pi/OpenAI uses Sol `high`, or its single allowed `xhigh` pass for the high-risk boundaries above.
+10. Record a disposition for every whole-stack finding and fold accepted findings into one immutable batch. Apply Steps 4–5 to that batch: complete or hard-block every accepted finding, run affected gates, and perform the bounded targeted recheck/correction. Do not push while an affected gate is red or a material accepted finding remains; an exhausted correction cap is a hard stop. Otherwise push and report per-PR links. Do not use a second external model unless explicitly requested.
 
-## Gotchas
+## Operational gotchas
 
-- **Decomposition checkpoint:** when a chunk exceeds its budget or starts coordinating independent lifecycle/state machines, stop before adding more machinery. Give the user a short split proposal along the ownership/lifecycle boundary, preserve the patch, ratify the revised stack, and continue in smaller PRs.
-- Workflow `args` must be real JSON values, not a stringified blob; briefs go in files.
-- Stacked PRs only run the main CI trio when targeting `main`; run required local gates before submission.
-- Merge/sync stacks through `gh stack`; never hand-roll rebases around squash merges.
-- Pre-commit runs full monorepo lint+typecheck: use a generous timeout, and fresh worktrees need `bun install` first.
+- Workflow `args` are real JSON values, not a stringified blob; briefs belong in files.
+- Stacked PRs run the main CI trio only when targeting `main`; run required local gates before submission.
+- Merge and sync through `gh stack`; never hand-roll rebases around squash merges.
+- Pre-commit runs full monorepo lint and typecheck. Use a generous timeout; run `bun install` first in fresh worktrees.


### PR DESCRIPTION
## Problem

The `build-feature` protocol bounded review rounds but could still stall or stop prematurely during remediation. A failed replacement could exhaust the written assignment allowance without resolving an accepted finding, AFK runs could pause for a non-hard-stop confirmation, and whole-stack findings did not inherit the per-chunk completion rules.

## Solution

Make discovery immutable and remediation autonomous within explicit bounds:

- One broad verifier owns the revision's immutable finding set; targeted rechecks cannot reopen discovery or add unrelated findings.
- All accepted findings belong to one logical remediation phase. Incomplete child attempts remain unfinished execution—not extra review rounds—and may be resumed, replaced, or partitioned into non-overlapping assignments while preserving the two-concurrent-child cap.
- One targeted recheck permits one surgical correction and one final confirmation. Remaining material findings after that correction are a hard stop.
- Hard stops are limited to unratified migration/public-contract/destructive decisions, proven ownership or lifecycle decomposition needs, mandatory external proof without a deterministic substitute, and exhausted correction capacity.
- AFK/autonomous mode preauthorizes reversible local choices and bounded fixer recovery, interrupts only for those hard stops, and records whole-stack reviewer selection without requesting confirmation.
- Whole-stack findings now use the same disposition, remediation, gate, and bounded recheck rules before push.

## Files

| File | Change |
| ---- | ------ |
| `.agents/skills/build-feature/SKILL.md` | Defines immutable discovery, logical remediation completion, bounded targeted correction, narrow hard stops, and AFK execution. |

## Test plan

- [x] `git diff --check` — passed
- [x] Focused policy assertions and stale-contradiction search — passed
- [x] Final reviewed patch byte comparison before and after commit — passed
- [x] Tracked-change scope — only `.agents/skills/build-feature/SKILL.md`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787639511&installation_model_id=20758&pr_number=1542&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1542&signature=63b850b5a43cadbff88b5d316a87a5082c3be1551c05cacc5c8edf8eb6262c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->