### PR TITLE
fix(agents): drop duplicated reasoning details when replaying a tool turn

### DIFF
--- a/packages/agent-runtime/src/runtime/agent-runtime.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.test.ts
@@ -478,6 +478,91 @@ describe("AgentRuntime source commitment", () => {
   })
 })
 
+describe("AgentRuntime reasoning replay", () => {
+  it("replays the assistant turn with a single copy of reasoning_details", async () => {
+    const detail = {
+      type: "reasoning.text",
+      text: "Thinking about the request.",
+      index: 0,
+      signature: "ErkJCok",
+      format: "anthropic-claude-v1",
+    }
+    const echoTool = defineAgentTool({
+      name: "echo_tool",
+      description: "test",
+      categories: [],
+      inputSchema: z.object({}),
+      execute: async () => ({ output: "ok" }),
+      trace: { stepType: AgentStepTypes.VISIT_PAGE, formatContent: () => "{}" },
+    })
+
+    const calls: Array<Array<{ role: string; content: unknown }>> = []
+    let firstCall = true
+    const generateTextWithTools = async ({ messages }: { messages: Array<{ role: string; content: unknown }> }) => {
+      calls.push(messages)
+      if (firstCall) {
+        firstCall = false
+        return {
+          text: "",
+          toolCalls: [{ toolCallId: "tc_1", toolName: "echo_tool", input: {} }],
+          response: {
+            messages: [
+              {
+                role: "assistant" as const,
+                content: [
+                  {
+                    type: "reasoning",
+                    text: "thinking",
+                    providerOptions: { openrouter: { reasoning_details: [detail] } },
+                  },
+                  {
+                    type: "tool-call",
+                    toolCallId: "tc_1",
+                    toolName: "echo_tool",
+                    input: {},
+                    providerOptions: { openrouter: { reasoning_details: [detail] } },
+                  },
+                ],
+              } as any,
+            ],
+          },
+        }
+      }
+      return {
+        text: "Done.",
+        toolCalls: [],
+        response: { messages: [{ role: "assistant" as const, content: "Done." } as any] },
+      }
+    }
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "do it" }],
+      tools: [echoTool],
+      sendMessage: async () => ({ messageId: "msg_1", operation: "created" }),
+    })
+
+    await runtime.run()
+
+    const replayed = calls[1]?.find((m) => m.role === "assistant")
+    expect(replayed).toEqual({
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "echo_tool",
+          input: {},
+          providerOptions: { openrouter: {} },
+        },
+      ],
+    })
+  })
+})
+
 describe("AgentRuntime tool progress + signal plumbing", () => {
   it("provides toolSignalProvider's signal to the tool's execute opts", async () => {
     const controller = new AbortController()

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -4,6 +4,7 @@ import { AgentToolNames } from "@threa/types"
 import type { AI, CostContext, TelemetryMetadataValue } from "../ai/ai"
 import { logger } from "../logger"
 import { protectToolOutputText } from "./tool-trust-boundary"
+import { sanitizeAssistantReplay } from "./reasoning-replay"
 import { MAX_MESSAGE_CHARS, truncateMessages } from "./truncation"
 import { createKeepResponseTool } from "../tools/keep-response-tool"
 import { createSendMessageTool } from "../tools/send-message-tool"
@@ -354,7 +355,10 @@ export class AgentRuntime {
       }
 
       const assistantMsg = result.response.messages[0]
-      if (assistantMsg) conversation.push(assistantMsg)
+      // @openrouter/ai-sdk-provider 1.5.4 stamps reasoning_details on both the
+      // reasoning part and every tool call, then replays both — Anthropic 400s on
+      // the duplicated thinking block. Strip before the message enters conversation.
+      if (assistantMsg) conversation.push(sanitizeAssistantReplay(assistantMsg))
 
       if (result.toolCalls.length === 0) {
         const currentText = extractAssistantText(result)

--- a/packages/agent-runtime/src/runtime/reasoning-replay.test.ts
+++ b/packages/agent-runtime/src/runtime/reasoning-replay.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test"
+import type { ModelMessage } from "ai"
+import { sanitizeAssistantReplay } from "./reasoning-replay"
+
+const detail = {
+  type: "reasoning.text",
+  text: "Let me think about the user's request carefully.",
+  index: 0,
+  signature: "ErkJCok",
+  format: "anthropic-claude-v1",
+}
+
+describe("sanitizeAssistantReplay", () => {
+  test("keeps only the reasoning part's copy when a tool call duplicates it", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: { openrouter: { reasoning_details: [detail] } },
+        },
+      ],
+    } as unknown as ModelMessage
+
+    expect(sanitizeAssistantReplay(message)).toEqual({
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: { openrouter: {} },
+        },
+      ],
+    } as unknown as ModelMessage)
+  })
+
+  test("strips the copy from every tool call", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: { openrouter: { reasoning_details: [detail] } },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "tc_2",
+          toolName: "fetch",
+          input: {},
+          providerOptions: { openrouter: { reasoning_details: [detail] } },
+        },
+      ],
+    } as unknown as ModelMessage
+
+    expect(sanitizeAssistantReplay(message)).toEqual({
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        { type: "tool-call", toolCallId: "tc_1", toolName: "search", input: {}, providerOptions: { openrouter: {} } },
+        { type: "tool-call", toolCallId: "tc_2", toolName: "fetch", input: {}, providerOptions: { openrouter: {} } },
+      ],
+    } as unknown as ModelMessage)
+  })
+
+  test("returns unchanged when only the tool call carries details", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking" },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: { openrouter: { reasoning_details: [detail] } },
+        },
+      ],
+    } as unknown as ModelMessage
+
+    expect(sanitizeAssistantReplay(message)).toBe(message)
+  })
+
+  test("returns a message with no openrouter options deep-equal to input", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "hello" },
+        { type: "tool-call", toolCallId: "tc_1", toolName: "search", input: {} },
+      ],
+    } as unknown as ModelMessage
+
+    expect(sanitizeAssistantReplay(message)).toEqual(message)
+  })
+
+  test("preserves other openrouter keys and other provider namespaces", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: {
+            openrouter: { reasoning_details: [detail], annotations: [{ type: "url_citation" }] },
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+      ],
+    } as unknown as ModelMessage
+
+    expect(sanitizeAssistantReplay(message)).toEqual({
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: {
+            openrouter: { annotations: [{ type: "url_citation" }] },
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+      ],
+    } as unknown as ModelMessage)
+  })
+
+  test("returns non-assistant and string-content messages as-is", () => {
+    const userMessage = { role: "user", content: "hi" } as ModelMessage
+    const stringAssistant = { role: "assistant", content: "hello" } as ModelMessage
+
+    expect([sanitizeAssistantReplay(userMessage), sanitizeAssistantReplay(stringAssistant)]).toEqual([
+      userMessage,
+      stringAssistant,
+    ])
+  })
+
+  test("does not mutate the input", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking", providerOptions: { openrouter: { reasoning_details: [detail] } } },
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "search",
+          input: {},
+          providerOptions: { openrouter: { reasoning_details: [detail] } },
+        },
+      ],
+    } as unknown as ModelMessage
+    const before = structuredClone(message)
+
+    sanitizeAssistantReplay(message)
+
+    expect(message).toEqual(before)
+  })
+})

--- a/packages/agent-runtime/src/runtime/reasoning-replay.ts
+++ b/packages/agent-runtime/src/runtime/reasoning-replay.ts
@@ -1,0 +1,35 @@
+import type { ModelMessage } from "ai"
+
+type ProviderOptions = Record<string, Record<string, unknown>>
+
+type ContentPart = { type: string; providerOptions?: ProviderOptions }
+
+function reasoningDetailsOf(part: ContentPart): unknown {
+  return part.providerOptions?.openrouter?.reasoning_details
+}
+
+function carriesDetails(part: ContentPart): boolean {
+  const details = reasoningDetailsOf(part)
+  return Array.isArray(details) && details.length > 0
+}
+
+export function sanitizeAssistantReplay(message: ModelMessage): ModelMessage {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) return message
+
+  const parts = message.content as ContentPart[]
+  const reasoningCarriesDetails = parts.some((part) => part.type === "reasoning" && carriesDetails(part))
+  if (!reasoningCarriesDetails) return message
+
+  let changed = false
+  const content = parts.map((part) => {
+    if (part.type !== "tool-call" || !part.providerOptions?.openrouter) return part
+    if (!("reasoning_details" in part.providerOptions.openrouter)) return part
+
+    const { reasoning_details: _dropped, ...openrouter } = part.providerOptions.openrouter
+    changed = true
+    return { ...part, providerOptions: { ...part.providerOptions, openrouter } }
+  })
+
+  if (!changed) return message
+  return { ...message, content } as ModelMessage
+}


### PR DESCRIPTION
## Problem

Ariadne stopped answering in scratchpads. On 2026-07-25 six of nine sessions hit `AI_APICallError: Provider returned error`; five never posted anything. The provider body, recovered from the Railway deployment live at the time, is an Anthropic 400:

```
messages.31.content.1: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were in
the original response.
```

Reconstructing that request showed why: the assistant turn carrying the `github_pulls` tool call sent the same signed thinking block **twice** (identical 254-char text, both `index: 0`, both signed).

`@openrouter/ai-sdk-provider@1.5.4` stamps `openrouter.reasoning_details` onto both the reasoning part *and* every tool-call part (`dist/index.mjs:1743-1818`), then accumulates from both when serialising the message back (`convertToOpenRouterChatMessages`). One reasoning block + one tool call = two copies. Fixed upstream in `2.0.2` (PR #344), which needs `ai ^6`; `3.0.0` needs `ai ^7`. That bump is worth doing and is its own change — this is the fix on current pins.

Exposure is a turn that needs a second model call on a sample where the model chose to think. Measured live: a prompt that must work out a date window returned reasoning 3/3, "list the PRs" 1/3, "say hi" 0/3. That is why some tool turns worked and others burned five retries.

## Solution

`sanitizeAssistantReplay` strips `reasoning_details` from a message's tool-call parts **only when a reasoning part in the same message already carries them**.

- `agent-runtime.ts:357` is the single seam where an assistant turn re-enters `conversation` and gets re-serialised on the next iteration. `grep -rn "response\.messages"` across `apps/` + `packages/` returns three hits: this one, `extractAssistantText` (read-only), and a pass-through in `ai.ts`. Everything else pushed into `conversation` is `role: "user"` or `role: "tool"`.
- **Conditional, not unconditional, stripping.** When no reasoning part carries the details, the tool-call copy is the only copy, and sending *no* thinking block is rejected just as hard as sending two. That case returns the input by identity.
- Other `openrouter` keys (`annotations`) and other provider namespaces survive; input is never mutated.
- The AI SDK's `toResponseMessages` maps `providerMetadata` → `providerOptions` for both part types (`ai@5.0.172` dist:2076-2140), so this reads the field that the provider will actually re-serialise. Had that been wrong the function would have been a no-op in production with every test still green — it was checked against the dist, not assumed.

Out of scope, deliberately: the five futile retries of a `isRetryable: false` error, and the absent output validation that let malformed model text reach users. Both are separate PRs.

Known constraint: this holds because `generateTextWithTools` is non-streaming. On the provider's streaming path a reasoning part carries only its own delta while tool calls carry the accumulated array, so if this seam ever moves to `streamText`, revisit before assuming the strip is lossless.

## Files

| File | Change |
| ---- | ------ |
| `packages/agent-runtime/src/runtime/reasoning-replay.ts` | **new** — `sanitizeAssistantReplay(message)`, pure |
| `packages/agent-runtime/src/runtime/reasoning-replay.test.ts` | **new** — 7 cases |
| `packages/agent-runtime/src/runtime/agent-runtime.ts` | wrap the pushed assistant message at the replay seam |
| `packages/agent-runtime/src/runtime/agent-runtime.test.ts` | +1 case asserting the second model call sees one copy |

## Test plan

- [x] `cd packages/agent-runtime && bun test src/runtime/` — 88 pass, 0 fail (baseline 80)
- [x] `bun run --cwd packages/agent-runtime typecheck` — clean
- [x] Mutation check — reverting the sanitiser body to `return message` fails 4 tests, so they bite
- [x] Live reproduction against `anthropic/claude-sonnet-5` via OpenRouter — faithful replay 200, duplicated `reasoning_details` 400 with byte-identical error text
- [x] Adversarial review (Opus 5, high) — ship, zero findings
- [ ] CI does not run this suite: `bun run test` only covers `apps/backend`, and `packages/agent-runtime`'s own `test` script is `vitest run` while its tests import `bun:test`. Not fixed here — out of scope.
- [x] **Live A/B on a local full stack** (`dev:test` + real `OPENROUTER_API_KEY`, Ariadne on `claude-sonnet-5`) — the same research-shaped prompt, 3 rounds each: with `sanitizeAssistantReplay` stubbed to identity, **3/3 sessions failed with the production error** `AI_APICallError: Provider returned error`; with it restored, **3/3 completed**. The failing turns made 1 `agent-loop` call, the passing ones 2, i.e. a real tool round-trip with a replayed assistant turn.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787648829&installation_model_id=20758&pr_number=1543&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1543&signature=582bc34daf40ba07e2d85ddab37becb0c35c8f3b72ad73dbc7587de71669a924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
