### PR TITLE
fix(agents): reject internal syntax in persona replies instead of posting it

### DIFF
--- a/packages/agent-runtime/src/research/general-researcher.test.ts
+++ b/packages/agent-runtime/src/research/general-researcher.test.ts
@@ -140,3 +140,21 @@ describe("runGeneralResearch", () => {
     expect(result.sources).toEqual([{ type: "web", title: "Result", url: "https://example.com/r" }])
   })
 })
+
+describe("runGeneralResearch is not behind the persona output guard", () => {
+  test("returns a brief quoting tool-call markup intact instead of re-prompting to max_iterations", async () => {
+    const brief =
+      'Evidence — the message body was, verbatim:\n<invoke name="workspace_research">\n<parameter name="query">preview bugs</parameter>\n</invoke>'
+    const deps = buildDeps(() => ({
+      text: brief,
+      toolCalls: [],
+      response: { messages: [{ role: "assistant", content: brief }] },
+    }))
+
+    const result = await runGeneralResearch(deps, baseInput())
+
+    expect(result.brief).toBe(brief)
+    expect(result.partial).toBeUndefined()
+    expect(result.partialReason).toBeUndefined()
+  })
+})

--- a/packages/agent-runtime/src/runtime/agent-runtime.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.test.ts
@@ -182,6 +182,47 @@ describe("AgentRuntime message counting", () => {
     expect(result.responseValidationFailed).toBe(true)
   })
 
+  it("keeps revising past the ordinary cap when a rerun's rejected drafts differ", async () => {
+    // Supersede reruns get the full iteration budget: an LLM judge's reason
+    // text varies, so drafts are never byte-identical and the ordinary
+    // 3-rejection cap would kill a turn that is still converging.
+    let calls = 0
+    const generateTextWithTools = mock(async () => {
+      calls++
+      return {
+        text: "",
+        toolCalls: [
+          {
+            toolCallId: `tool_${calls}`,
+            toolName: AgentToolNames.SEND_MESSAGE,
+            input: { content: `Draft ${calls}` },
+          },
+        ],
+        response: { messages: [{ role: "assistant", content: "" } as any] },
+      }
+    })
+    const sendMessage = mock(async () => ({ messageId: "msg_final", operation: "created" as const }))
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "Reply three times with numbers." }],
+      tools: [],
+      allowNoMessageOutput: true,
+      validateFinalResponse: async (content: string) =>
+        content === "Draft 4" ? null : `Rejected ${content}: needs the actual answer.`,
+      sendMessage,
+    })
+
+    const result = await runtime.run()
+
+    expect(generateTextWithTools).toHaveBeenCalledTimes(4)
+    expect(result.messagesSent).toBe(1)
+    expect(result.sentMessageIds).toEqual(["msg_final"])
+    expect(result.responseValidationFailed).toBeFalsy()
+  })
+
   it("forwards model config and cost context to generateTextWithTools", async () => {
     const captured: Array<{
       modelString?: string

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -15,6 +15,7 @@ import type { AgentObserver } from "./agent-observer"
 
 const DEFAULT_MAX_ITERATIONS = 20
 const KEEP_RESPONSE_TOOL_NAME = "keep_response"
+const MAX_INVALID_DRAFTS = 3
 const MAX_REPEATED_INVALID_DRAFTS = 3
 const MAX_EMPTY_FINAL_DECISION_ATTEMPTS = 3
 
@@ -178,6 +179,18 @@ export function mergeSourceItems(existing: SourceItem[], incoming: SourceItem[])
   return merged
 }
 
+function buildRevisionPrompt(reason: string, pendingMessages: PendingMessage[]): string {
+  const drafts = pendingMessages.map((p) => p.content).join("\n---\n")
+  const multiple = pendingMessages.length > 1
+  return (
+    `[Final response needs revision]\n\n` +
+    `${reason}\n\n` +
+    `Your proposed response${multiple ? "s were" : " was"}:\n"${drafts}"\n\n` +
+    `Please provide ${multiple ? "revised final responses" : "a revised final response"} and call send_message again` +
+    `${multiple ? ` for every part — all ${pendingMessages.length} drafts above were discarded, so resend each one.` : "."}`
+  )
+}
+
 function makeToolResult(tc: { toolCallId: string; toolName: string }, value: string): ToolResultPart {
   return {
     type: "tool-result",
@@ -268,19 +281,24 @@ export class AgentRuntime {
     let hasTextReconsidered = false
     let lastProcessedSequence = nm?.lastProcessedSequence ?? BigInt(0)
     let keptResponseReason: string | null = null
+    let invalidDraftCount = 0
     let repeatedInvalidDraftCount = 0
     let lastInvalidDraft: string | null = null
     let emptyFinalDecisionAttempts = 0
     let stoppedByUser = false
     let validationFailureTerminal = false
+    let invalidDraftTerminal = false
 
-    // Counts repeated invalid final drafts across BOTH finalization paths —
-    // plain assistant text and send_message tool calls (the path the
-    // supersede-rerun prompt mandates), so neither can loop on revision
-    // prompts past the cap. Returns true when the terminal is reached: keep
-    // the previous response and record that this turn could not produce a
-    // valid revision (the roadmap 2.3 escalation marker).
+    // Two thresholds because the two turn kinds have different fallbacks. A
+    // supersede rerun (allowNoMessageOutput) already has a committed reply to
+    // fall back on, so it gets the full iteration budget to revise and only
+    // stops when the model is provably stuck — repeating the SAME rejected
+    // draft MAX_REPEATED_INVALID_DRAFTS times. An ordinary reply has nothing to
+    // fall back on and its failure mode is burning the whole budget on varied
+    // rejected drafts, so it is capped at MAX_INVALID_DRAFTS rejections total.
+    // Both paths cover plain assistant text and send_message tool calls.
     const registerInvalidDraft = (draft: string): boolean => {
+      invalidDraftCount += 1
       if (lastInvalidDraft === draft) {
         repeatedInvalidDraftCount += 1
       } else {
@@ -288,16 +306,22 @@ export class AgentRuntime {
         repeatedInvalidDraftCount = 1
       }
 
-      if (this.config.allowNoMessageOutput && repeatedInvalidDraftCount >= MAX_REPEATED_INVALID_DRAFTS) {
+      if (this.config.allowNoMessageOutput) {
+        if (repeatedInvalidDraftCount < MAX_REPEATED_INVALID_DRAFTS) return false
         keptResponseReason =
           "Kept the previous response because revised drafts repeatedly failed validation after context updates."
         validationFailureTerminal = true
         return true
       }
-      return false
+
+      if (invalidDraftCount < MAX_INVALID_DRAFTS) return false
+      invalidDraftTerminal = true
+      return true
     }
 
+    let iterationsRun = 0
     for (let iteration = 0; iteration < this.maxIterations; iteration++) {
+      iterationsRun = iteration + 1
       const abortReason = await this.config.shouldAbort?.()
       if (abortReason) {
         throw new Error(`Agent session aborted: ${abortReason}`)
@@ -459,10 +483,7 @@ export class AgentRuntime {
 
               this.pushRuntimePrompt(
                 conversation,
-                `[Final response needs revision]\n\n` +
-                  `${invalidPending.reason}\n\n` +
-                  `Your proposed response was:\n"${invalidPending.content}"\n\n` +
-                  `Please provide a revised final response and call send_message again.`
+                buildRevisionPrompt(invalidPending.reason, execResult.pendingMessages)
               )
               continue
             }
@@ -533,13 +554,7 @@ export class AgentRuntime {
           if (invalidPending) {
             if (registerInvalidDraft(invalidPending.content)) break
 
-            this.pushRuntimePrompt(
-              conversation,
-              `[Final response needs revision]\n\n` +
-                `${invalidPending.reason}\n\n` +
-                `Your proposed response was:\n"${invalidPending.content}"\n\n` +
-                `Please provide a revised final response and call send_message again.`
-            )
+            this.pushRuntimePrompt(conversation, buildRevisionPrompt(invalidPending.reason, execResult.pendingMessages))
             continue
           }
 
@@ -569,7 +584,7 @@ export class AgentRuntime {
     // would silently emit nothing.
     // Skip this salvage on a user Stop: committing a half-formed thinking step
     // the user just interrupted would surface content they chose to cut off.
-    if (sent.ids.length === 0 && lastContentStep && !stoppedByUser) {
+    if (sent.ids.length === 0 && lastContentStep && !stoppedByUser && !invalidDraftTerminal) {
       const validationError = this.config.validateFinalResponse
         ? await this.config.validateFinalResponse(lastContentStep)
         : null
@@ -593,7 +608,7 @@ export class AgentRuntime {
         })
 
         logger.info(
-          { sessionId: nm?.sessionId, streamId: nm?.streamId, iterations: this.maxIterations },
+          { sessionId: nm?.sessionId, streamId: nm?.streamId, iterations: iterationsRun },
           "Agent run completed without sending a message"
         )
         return {
@@ -611,10 +626,16 @@ export class AgentRuntime {
       }
 
       logger.error(
-        { sessionId: nm?.sessionId, streamId: nm?.streamId, iterations: this.maxIterations },
-        "Agent loop exhausted iterations without sending a message"
+        { sessionId: nm?.sessionId, streamId: nm?.streamId, iterations: iterationsRun },
+        invalidDraftTerminal
+          ? "Agent loop stopped after repeated invalid final drafts without sending a message"
+          : "Agent loop exhausted iterations without sending a message"
       )
-      throw new Error("Agent loop completed without sending a message")
+      throw new Error(
+        invalidDraftTerminal
+          ? "Agent loop stopped after repeated invalid final drafts without sending a message"
+          : "Agent loop completed without sending a message"
+      )
     }
 
     return { messagesSent, sentMessageIds: sent.ids, sentContents: sent.contents, lastProcessedSequence, sources }

--- a/packages/agent-runtime/src/runtime/output-guard.test.ts
+++ b/packages/agent-runtime/src/runtime/output-guard.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test"
+import { composeOutputValidator, findInternalSyntax } from "./output-guard"
+
+describe("findInternalSyntax", () => {
+  test("rejects a leading msg pointer tag", () => {
+    expect(findInternalSyntax("[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Hi")).toContain(
+      "input-only"
+    )
+  })
+
+  test("rejects a leading msg pointer tag on a longer reply", () => {
+    expect(
+      findInternalSyntax(
+        "[msg:msg_01KYDDWNJ13KRK99YRJ13JRVK author:persona_system_ariadne] Something did seem off there — let me look again."
+      )
+    ).toContain("input-only")
+  })
+
+  test("rejects tool-call markup", () => {
+    const content = `<invoke name="workspace_research">
+<parameter name="query">preview buggy lazy loading</parameter>
+</invoke>`
+    expect(findInternalSyntax(content)).toContain("tool-call markup")
+  })
+
+  test("rejects a markdown link targeting a tool name", () => {
+    expect(
+      findInternalSyntax("Handover's up: [message-share preview bug](delegate_task)", {
+        toolNames: ["delegate_task", "send_message"],
+      })
+    ).toContain("delegate_task")
+  })
+
+  test("passes a message that discusses pointer tags mid-sentence", () => {
+    const content =
+      "Those `[msg:msg_… author:…]` tags aren't something I'm meant to output — they're metadata the system stamps onto each message in my context so I can reference/quote things structurally (that's what powers the forwarding/quoting feature). They show up prefixing messages in what I *see*, including my own prior replies."
+    expect(findInternalSyntax(content, { toolNames: ["delegate_task"] })).toBeNull()
+  })
+
+  test("passes legitimate pointer links", () => {
+    const content =
+      "Here's the screenshot: [Image #1](attachment:attach_01K…) and [Pierre](quote:stream_x/msg_y/usr_z/user) plus [a memo](memo:memo_01K…)"
+    expect(findInternalSyntax(content, { toolNames: ["delegate_task"] })).toBeNull()
+  })
+
+  test("passes tool-call markup inside a fenced code block", () => {
+    const content = `Here's what it looked like:
+
+\`\`\`
+<invoke name="workspace_research">
+<parameter name="query">preview buggy lazy loading</parameter>
+</invoke>
+\`\`\`
+
+That shouldn't have been sent.`
+    expect(findInternalSyntax(content)).toBeNull()
+  })
+
+  test("rule 3 is opt-in", () => {
+    expect(findInternalSyntax("Handover's up: [message-share preview bug](delegate_task)")).toBeNull()
+    expect(
+      findInternalSyntax("Handover's up: [message-share preview bug](delegate_task)", { toolNames: [] })
+    ).toBeNull()
+  })
+
+  test("passes prose containing 'parameter' and an angle-bracket comparison", () => {
+    expect(findInternalSyntax("The parameter is off: we need a < b for the invoke to make sense.")).toBeNull()
+  })
+})
+
+describe("findInternalSyntax code-quoting forms", () => {
+  const sample = '<invoke name="workspace_research">\n<parameter name="query">preview bugs</parameter>\n</invoke>'
+
+  test("accepts a four-backtick fence wrapping an inner triple-backtick block", () => {
+    expect(findInternalSyntax("Like this:\n\n````markdown\n```\n" + sample + "\n```\n````\n")).toBeNull()
+  })
+
+  test("accepts a tilde fence", () => {
+    expect(findInternalSyntax("Like this:\n\n~~~\n" + sample + "\n~~~\n")).toBeNull()
+  })
+
+  test("accepts a four-space indented code block", () => {
+    const indented = sample
+      .split("\n")
+      .map((line) => "    " + line)
+      .join("\n")
+    expect(findInternalSyntax("Like this:\n\n" + indented + "\n")).toBeNull()
+  })
+
+  test("accepts an unclosed fence, which swallows to the end", () => {
+    expect(findInternalSyntax("Like this:\n\n```\n" + sample)).toBeNull()
+  })
+
+  test("still rejects the markup quoted only in a blockquote", () => {
+    expect(findInternalSyntax("> " + sample.split("\n")[0]!)).toContain("fenced code block")
+  })
+
+  test("does not let a stray unpaired backtick pair across the markup", () => {
+    expect(findInternalSyntax('The `x` op, a stray ` here, then <invoke name="y"> and `code`.')).toContain("<invoke")
+  })
+
+  test("names the fenced-code escape hatch in the tool-markup reason", () => {
+    const reason = findInternalSyntax(sample)
+    expect(reason).toContain("never written into a message")
+    expect(reason).toContain("fenced code block")
+  })
+})
+
+describe("composeOutputValidator", () => {
+  test("runs the built-in guard first, then the caller's validator, then passes", async () => {
+    const next = (content: string) => (content === "summary" ? "not a summary" : null)
+    const validate = composeOutputValidator(["delegate_task"], next)
+
+    expect(await validate("[msg:msg_1 author:persona_x] Hi")).toContain("input-only")
+    expect(await validate("See [x](delegate_task)")).toContain("delegate_task")
+    expect(await validate("summary")).toBe("not a summary")
+    expect(await validate("All good.")).toBeNull()
+  })
+
+  test("passes clean content when no next validator is given", async () => {
+    expect(await composeOutputValidator([])("All good.")).toBeNull()
+  })
+})

--- a/packages/agent-runtime/src/runtime/output-guard.ts
+++ b/packages/agent-runtime/src/runtime/output-guard.ts
@@ -1,0 +1,112 @@
+const LEADING_POINTER_TAG = /^\s*\[(msg|attach|memo):/
+const TOOL_MARKUP = ["<invoke", "</invoke>", "<parameter name=", "<function_calls>", "</function_calls>"]
+const MARKDOWN_LINK = /\[[^\]]*\]\(([^)\s]+)\)/g
+const FENCE = /^\s{0,3}(`{3,}|~{3,})/
+const INDENTED_CODE = /^(?: {4}|\t)/
+
+/**
+ * Strips inline spans only where the line's backtick runs pair unambiguously: a
+ * run length occurring an odd number of times has a stray delimiter somewhere in
+ * it, and positional pairing would then swallow whatever sits between the stray
+ * and the next opener — which is exactly how real markup escapes the scan.
+ */
+function stripInlineSpans(line: string): string {
+  const runs: Array<{ start: number; length: number }> = []
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== "`") continue
+    const start = i
+    while (i < line.length && line[i] === "`") i++
+    runs.push({ start, length: i - start })
+    i--
+  }
+
+  const counts = new Map<number, number>()
+  for (const run of runs) counts.set(run.length, (counts.get(run.length) ?? 0) + 1)
+
+  let out = ""
+  let cursor = 0
+  let index = 0
+  while (index < runs.length) {
+    const open = runs[index]!
+    if ((counts.get(open.length) ?? 0) % 2 !== 0) {
+      index++
+      continue
+    }
+    const close = runs.slice(index + 1).find((run) => run.length === open.length)
+    if (!close) {
+      index++
+      continue
+    }
+    out += line.slice(cursor, open.start) + " "
+    cursor = close.start + close.length
+    index = runs.indexOf(close) + 1
+  }
+
+  return out + line.slice(cursor)
+}
+
+function stripCode(content: string): string {
+  const out: string[] = []
+  let fence: { char: string; length: number } | null = null
+
+  for (const line of content.split("\n")) {
+    if (fence) {
+      const close = FENCE.exec(line)
+      if (close?.[1] && close[1][0] === fence.char && close[1].length >= fence.length) fence = null
+      out.push(" ")
+      continue
+    }
+
+    const open = FENCE.exec(line)
+    if (open?.[1]) {
+      fence = { char: open[1][0]!, length: open[1].length }
+      out.push(" ")
+      continue
+    }
+
+    if (INDENTED_CODE.test(line)) {
+      out.push(" ")
+      continue
+    }
+
+    out.push(stripInlineSpans(line))
+  }
+
+  return out.join("\n")
+}
+
+export function findInternalSyntax(content: string, options?: { toolNames?: readonly string[] }): string | null {
+  if (LEADING_POINTER_TAG.test(content)) {
+    return "Your response began with an internal `[msg:…]` context tag. Those tags are input-only metadata — rewrite the reply without it."
+  }
+
+  const withoutCode = stripCode(content)
+  const markup = TOOL_MARKUP.find((token) => withoutCode.includes(token))
+  if (markup) {
+    return `Your response contained internal tool-call markup (\`${markup}\`). Tool calls go through the tool interface and are never written into a message. If you meant to show the markup to the user, put it inside a fenced code block.`
+  }
+
+  const toolNames = options?.toolNames
+  if (toolNames && toolNames.length > 0) {
+    for (const match of withoutCode.matchAll(MARKDOWN_LINK)) {
+      const target = match[1]
+      if (target && toolNames.includes(target)) {
+        return `Your response contained a markdown link whose target is the tool name \`${target}\`. Link targets must be real pointer URLs — rewrite the reply without that link.`
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Turn-level output validation: the built-in guard first, then the caller's own
+ * validator. Wired where a turn commits user-visible messages, never onto every
+ * `AgentRuntime` host — internal-brief hosts quote evidence legitimately.
+ */
+export function composeOutputValidator(
+  toolNames: readonly string[],
+  next?: (content: string) => Promise<string | null> | string | null
+): (content: string) => Promise<string | null> {
+  return async (content: string) => findInternalSyntax(content, { toolNames }) ?? (await next?.(content)) ?? null
+}

--- a/packages/agent-runtime/src/runtime/turn-driver.test.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.test.ts
@@ -170,3 +170,234 @@ describe("declaredUnsupported", () => {
     expect(isDeclaredUnsupported({ check: async () => [] })).toBe(false)
   })
 })
+
+describe("turn-level output guard", () => {
+  function scriptedAI(contents: string[], seen?: Array<Array<{ role: string; content: string }>>) {
+    let call = 0
+    return {
+      generateTextWithTools: async ({ messages }: { messages: Array<{ role: string; content: string }> }) => {
+        seen?.push(messages)
+        const content = contents[call++]!
+        return {
+          text: "",
+          toolCalls: [{ toolCallId: `tool_${call}`, toolName: AgentToolNames.SEND_MESSAGE, input: { content } }],
+          response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+        }
+      },
+    } as any
+  }
+
+  it("re-prompts a send_message draft carrying a leaked pointer tag and commits only the clean retry", async () => {
+    const commits: TurnCommit[] = []
+    const driver = new InProcessTurnDriver({
+      ai: scriptedAI(["[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Hi", "Hi"]),
+    })
+
+    const result = await driver.runTurn(plaintextRequest(), {
+      commitMessage: async (commit) => {
+        commits.push(commit)
+        return { messageId: "msg_1", operation: "created" }
+      },
+    })
+
+    expect(commits).toEqual([{ content: "Hi", sources: [] }])
+    expect(result.messagesSent).toBe(1)
+  })
+
+  it("re-prompts a draft whose body is tool-call markup", async () => {
+    const commits: TurnCommit[] = []
+    const driver = new InProcessTurnDriver({
+      ai: scriptedAI([
+        '<invoke name="workspace_research">\n<parameter name="query">preview bugs</parameter>\n</invoke>',
+        "Looking into the preview bugs now.",
+      ]),
+    })
+
+    const result = await driver.runTurn(plaintextRequest(), {
+      commitMessage: async (commit) => {
+        commits.push(commit)
+        return { messageId: "msg_1", operation: "created" }
+      },
+    })
+
+    expect(commits).toEqual([{ content: "Looking into the preview bugs now.", sources: [] }])
+    expect(result.messagesSent).toBe(1)
+  })
+
+  it("falls through to the request's own validator, and the built-in reason wins", async () => {
+    const prompts: Array<Array<{ role: string; content: string }>> = []
+    const commits: TurnCommit[] = []
+    const driver = new InProcessTurnDriver({
+      ai: scriptedAI(
+        ["[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Hi", "An action summary.", "Hi there."],
+        prompts
+      ),
+    })
+
+    const result = await driver.runTurn(
+      plaintextRequest({
+        validateFinalResponse: async (content: string) =>
+          content === "An action summary." ? "Send the requested reply content, not an action summary." : null,
+      }),
+      {
+        commitMessage: async (commit) => {
+          commits.push(commit)
+          return { messageId: "msg_1", operation: "created" }
+        },
+      }
+    )
+
+    expect(commits).toEqual([{ content: "Hi there.", sources: [] }])
+    expect(result.messagesSent).toBe(1)
+    expect(prompts[1]!.at(-1)!.content).toContain("input-only")
+    expect(prompts[2]!.at(-1)!.content).toContain("not an action summary")
+  })
+
+  it("re-prompts with every pending draft when one part trips the guard", async () => {
+    const prompts: Array<Array<{ role: string; content: string }>> = []
+    const commits: TurnCommit[] = []
+    let call = 0
+    const driver = new InProcessTurnDriver({
+      ai: {
+        generateTextWithTools: async ({ messages }: { messages: Array<{ role: string; content: string }> }) => {
+          prompts.push(messages)
+          call++
+          const contents =
+            call === 1
+              ? ["Part one is clean.", "[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Part two."]
+              : ["Part one is clean.", "Part two."]
+          return {
+            text: "",
+            toolCalls: contents.map((content, i) => ({
+              toolCallId: `tool_${call}_${i}`,
+              toolName: AgentToolNames.SEND_MESSAGE,
+              input: { content },
+            })),
+            response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+          }
+        },
+      } as any,
+    })
+
+    const result = await driver.runTurn(plaintextRequest(), {
+      commitMessage: async (commit) => {
+        commits.push(commit)
+        return { messageId: `msg_${commits.length}`, operation: "created" }
+      },
+    })
+
+    const revisePrompt = prompts[1]!.at(-1)!.content
+    expect(revisePrompt).toContain("Part one is clean.")
+    expect(revisePrompt).toContain("resend each one")
+    expect(commits.map((c) => c.content)).toEqual(["Part one is clean.", "Part two."])
+    expect(result.messagesSent).toBe(2)
+  })
+
+  it("gives up after the invalid-draft cap when every draft is rejected", async () => {
+    const commits: TurnCommit[] = []
+    let calls = 0
+    const driver = new InProcessTurnDriver({
+      ai: {
+        generateTextWithTools: async () => {
+          calls++
+          return {
+            text: "",
+            toolCalls: [
+              {
+                toolCallId: `tool_${calls}`,
+                toolName: AgentToolNames.SEND_MESSAGE,
+                input: { content: "[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Hi" },
+              },
+            ],
+            response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+          }
+        },
+      } as any,
+    })
+
+    await expect(
+      driver.runTurn(plaintextRequest(), {
+        commitMessage: async (commit) => {
+          commits.push(commit)
+          return { messageId: "msg_1", operation: "created" }
+        },
+      })
+    ).rejects.toThrow("Agent loop stopped after repeated invalid final drafts without sending a message")
+
+    expect(commits).toEqual([])
+    expect(calls).toBe(3)
+  })
+
+  it("gives up on the cap even when every rejected draft differs", async () => {
+    const commits: TurnCommit[] = []
+    let calls = 0
+    const driver = new InProcessTurnDriver({
+      ai: {
+        generateTextWithTools: async () => {
+          calls++
+          return {
+            text: "",
+            toolCalls: [
+              {
+                toolCallId: `tool_${calls}`,
+                toolName: AgentToolNames.SEND_MESSAGE,
+                input: {
+                  content: `[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Draft ${calls}`,
+                },
+              },
+            ],
+            response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+          }
+        },
+      } as any,
+    })
+
+    await expect(
+      driver.runTurn(plaintextRequest(), {
+        commitMessage: async (commit) => {
+          commits.push(commit)
+          return { messageId: "msg_1", operation: "created" }
+        },
+      })
+    ).rejects.toThrow("Agent loop stopped after repeated invalid final drafts without sending a message")
+
+    expect(commits).toEqual([])
+    expect(calls).toBe(3)
+  })
+  it("commits nothing when assistant preamble accompanies every rejected draft", async () => {
+    const commits: TurnCommit[] = []
+    let calls = 0
+    const driver = new InProcessTurnDriver({
+      ai: {
+        generateTextWithTools: async () => {
+          calls++
+          return {
+            text: "Let me answer that.",
+            toolCalls: [
+              {
+                toolCallId: `tool_${calls}`,
+                toolName: AgentToolNames.SEND_MESSAGE,
+                input: {
+                  content: `[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Draft ${calls}`,
+                },
+              },
+            ],
+            response: { messages: [{ role: "assistant", content: "Let me answer that." } as any] },
+          }
+        },
+      } as any,
+    })
+
+    await expect(
+      driver.runTurn(plaintextRequest(), {
+        commitMessage: async (commit) => {
+          commits.push(commit)
+          return { messageId: "msg_1", operation: "created" }
+        },
+      })
+    ).rejects.toThrow("Agent loop stopped after repeated invalid final drafts without sending a message")
+
+    expect(commits).toEqual([])
+    expect(calls).toBe(3)
+  })
+})

--- a/packages/agent-runtime/src/runtime/turn-driver.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.ts
@@ -10,6 +10,7 @@ import {
 } from "./agent-runtime"
 import type { AgentObserver } from "./agent-observer"
 import type { AgentTool } from "./agent-tool"
+import { composeOutputValidator } from "./output-guard"
 
 // The turn contract's structural spine: dispatch mints a TurnRequest, routes it
 // to the driver matching its delivery, and the driver runs the turn against the
@@ -271,7 +272,10 @@ function runTurnOnAgentRuntime(ai: AgentRuntimeAI, request: TurnRequest, sink: T
     telemetry: request.telemetry,
     costContext: request.costContext,
     allowNoMessageOutput: request.allowNoMessageOutput,
-    validateFinalResponse: request.validateFinalResponse,
+    validateFinalResponse: composeOutputValidator(
+      request.tools.map((t) => t.name),
+      request.validateFinalResponse
+    ),
     sendMessage: sink.commitMessage,
     observers: sink.observers,
     // A declared-unsupported interjection edge is a real "no provider" to the


### PR DESCRIPTION
Stacked on #1544 (which is on #1543) — review those first.

## Problem

Three of Ariadne's messages in production were internal syntax the model imitated and the runtime posted verbatim:

- `[msg:msg_01KYCCZYDQQNMR18Q5VRTGX0C4 author:persona_system_ariadne] Hi` — reuses *the user's* message id under a persona author
- `[msg:msg_01KYDDWNJ13KRK99YRJ13JRVK author:persona_system_ariadne] Something did seem off there…` — that id does not exist
- a message whose entire body was `<invoke name="workspace_research"><parameter name="query">…</parameter></invoke>` (kept in `message_versions` for `msg_01KY8FH269EZETBW5SNZ2ZH501`)

Plus two messages linking `[message-share preview bug](delegate_task)` — a markdown link whose target is a tool name.

The runtime already had reject-and-re-prompt machinery: `findInvalidPendingMessage` and the revise prompts. Every one of them is conditional on `config.validateFinalResponse`, which `persona-agent.ts:1003` wires **only** for supersede reruns. That is why `response_validation_failed` is `false` on all three sessions — the check never ran.

## Solution

`findInternalSyntax` — three structural rules, no heuristics — composed at `turn-driver.ts:274` ahead of any caller-supplied validator.

- **Rule 1** content begins with `[msg:` / `[attach:` / `[memo:`. **Rule 2** tool-call markup (`<invoke`, `<parameter name=`, `<function_calls>`, …) outside code. **Rule 3** a markdown link whose target exactly equals one of the turn's tool names.
- **Composed at the turn seam, not inside `AgentRuntime`.** There are two `AgentRuntime` construction sites; the other is `general-researcher.ts:126`, whose "message" is an internal research brief that quotes evidence and never reaches a user. Wiring the guard one layer down silently discarded such briefs and reported `partialReason: "max_iterations"`. Review caught this; `general-researcher.test.ts` now pins it. `runTurnOnAgentRuntime` is the correct seam — a `TurnRequest` is by definition a turn that commits user-visible messages, and both the plaintext companion driver and the enclave driver pass through it.
- **Rejected, never rewritten.** The guard returns a reason; the existing revise loop re-prompts. Nothing sanitises or edits model output.
- **Code-aware stripping.** Fences of 3+ backticks or tildes, indented blocks, and inline spans are stripped before rules 2 and 3, so a reply that deliberately *shows* the markup passes. Inline spans strip only where a line's backtick runs pair unambiguously — positional pairing let a stray backtick swallow real markup. Blockquotes are deliberately not stripped; rule 2's reason tells the model to use a fenced block when quoting is intentional.
- A rejected multi-part reply now re-prompts with **all** staged drafts, not just the offender, so its clean parts aren't lost.
- **The new failure mode is bounded, per turn kind.** An ordinary reply stops after **3** rejections and commits nothing — including via the post-loop salvage, which previously posted any stray assistant preamble that accompanied the rejected draft. A supersede rerun keeps the revision budget it had: its terminal still needs 3 byte-identical drafts, because its validator is an LLM judge whose reason text varies, so a total cap would have cut a rerun that succeeds on attempt 4 down to the stale pre-edit reply. Two thresholds, one per turn kind, because the fallbacks differ.
- Before this bound, a model that varied its rejected draft ran the full 20-iteration budget and #1544 (correctly) classified the resulting plain `Error` as retryable, so the queue re-ran the whole turn five times: ~100 model calls for one message. Now 3 calls per attempt, 15 worst case.

Deliberately not here: removing the `[msg:… author:…]` tag from assistant-role history in `message-format.ts`. That is the likely root cause, but it can regress self-quoting and needs an eval rather than a patch. Known false negatives kept: rule 3 misses `[a](tool "title")` and reference-style links; rule 1's `[attach:`/`[memo:` alternatives are inert because the real internal forms are paren-delimited.

If a model never produces clean output, the turn ends after 3 rejections with no message — a visibly failed turn over a malformed one.

## Files

| File | Change |
| ---- | ------ |
| `runtime/output-guard.ts` | **new** — `findInternalSyntax`, `composeOutputValidator` |
| `runtime/output-guard.test.ts` | **new** — rules, code-stripping shapes |
| `runtime/turn-driver.ts` | compose the guard for every persona turn |
| `runtime/turn-driver.test.ts` | guard reached through the real wiring |
| `runtime/agent-runtime.ts` | cap rejections per turn; `buildRevisionPrompt` quotes every staged draft |
| `research/general-researcher.test.ts` | pins that internal briefs stay unguarded |

## Test plan

- [x] `cd packages/agent-runtime && bun test src/` — 258 pass, 0 fail
- [x] `bun run --cwd apps/backend test:unit` — 3591 pass, 0 fail (unchanged)
- [x] Both typechecks clean
- [x] **False positives, against production data** — all 288 non-deleted persona messages in the prod workspace run through the guard with Ariadne's real tool list: 4 flagged, and all 4 are the known-bad messages above. Zero false positives, including the real message where Ariadne *explains* what `[msg:…]` tags are.
- [x] Adversarial review (Opus 5, high) — 4 findings, all fixed; targeted recheck returned ship with none outstanding
- [x] Whole-stack review (Opus 5, high) — found the retry amplification; the fix for it regressed supersede reruns, which a stack-level recheck caught and a third round repaired
- [x] Final recheck (Opus 5, high) — supersede behaviour proved equivalent to the pre-regression baseline by running the real runtime at both versions and deep-comparing; each new test verified to fail before its fix
- [ ] Not covered: multi-part `send_message` turns and non-backtick code presentations have unit fixtures but no production corpus — the 288 messages predate the guard's steering
- [x] **Live end-to-end** (`dev:test` + real inference): simple and research-shaped turns both replied cleanly; Playwright render of the stream shows no pointer tag and no tool markup in the DOM.

![smoke](https://seer.build/ws_vbyzjvdg6g/i/img_m4adg9k8e5/ariadne-smoke-457ed5.webp)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
