### PR TITLE
fix(agents): stop retrying provider errors the provider called non-retryable

### DIFF
--- a/apps/backend/src/features/agents/companion/session.test.ts
+++ b/apps/backend/src/features/agents/companion/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { APICallError } from "ai"
 import * as dbModule from "../../../db"
 import { OutboxRepository } from "../../../lib/outbox"
 import { StreamEventRepository } from "../../streams"
@@ -213,7 +214,10 @@ describe("withCompanionSession", () => {
     expect(insertOutboxSpy).not.toHaveBeenCalled()
   })
 
-  async function runFailingSession(retryAccounting?: { attempt: number; maxAttempts: number }) {
+  async function runFailingSession(
+    retryAccounting?: { attempt: number; maxAttempts: number },
+    thrown: unknown = new Error("boom")
+  ) {
     const session = makeRunningSession()
     mockTransactions()
     spyOn(AgentSessionRepository, "findByTriggerMessage").mockResolvedValue(null)
@@ -240,7 +244,7 @@ describe("withCompanionSession", () => {
         ...retryAccounting,
       },
       async () => {
-        throw new Error("boom")
+        throw thrown
       }
     )
     return { result, insertEventSpy, insertOutboxSpy }
@@ -249,7 +253,7 @@ describe("withCompanionSession", () => {
   it("emits a non-terminal agent_session:interrupted on a retryable failure", async () => {
     const { result, insertEventSpy, insertOutboxSpy } = await runFailingSession({ attempt: 0, maxAttempts: 5 })
 
-    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: true })
+    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: true, retryable: true })
     expect(insertEventSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -263,7 +267,7 @@ describe("withCompanionSession", () => {
   it("emits terminal agent_session:failed on the last attempt", async () => {
     const { result, insertEventSpy, insertOutboxSpy } = await runFailingSession({ attempt: 4, maxAttempts: 5 })
 
-    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: false })
+    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: false, retryable: true })
     expect(insertEventSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: "agent_session:failed" })
@@ -271,10 +275,35 @@ describe("withCompanionSession", () => {
     expect(insertOutboxSpy).toHaveBeenCalledWith(expect.anything(), "agent_session:failed", expect.anything())
   })
 
+  it("fails terminally on the first attempt when the provider says the error is not retryable", async () => {
+    const providerError = new APICallError({
+      message: "Provider returned error",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      isRetryable: false,
+    })
+    const { result, insertEventSpy, insertOutboxSpy } = await runFailingSession(
+      { attempt: 0, maxAttempts: 5 },
+      providerError
+    )
+
+    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: false, retryable: false })
+    expect(insertEventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: "agent_session:failed" })
+    )
+    expect(insertEventSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: "agent_session:interrupted" })
+    )
+    expect(insertOutboxSpy).toHaveBeenCalledWith(expect.anything(), "agent_session:failed", expect.anything())
+  })
+
   it("treats a failure as terminal when retry accounting is absent (non-queue callers)", async () => {
     const { result, insertEventSpy } = await runFailingSession()
 
-    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: false })
+    expect(result).toEqual({ status: "failed", sessionId: "session_1", willRetry: false, retryable: true })
     expect(insertEventSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: "agent_session:failed" })

--- a/apps/backend/src/features/agents/companion/session.ts
+++ b/apps/backend/src/features/agents/companion/session.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "ai"
 import type { Pool } from "pg"
 import type { AgentSessionRerunContext } from "@threa/types"
 import { withTransaction } from "../../../db"
@@ -10,7 +11,7 @@ import { logger } from "../../../lib/logger"
 export type WithSessionResult =
   | { status: "skipped"; sessionId: string | null; reason: string }
   | { status: "completed"; sessionId: string; messagesSent: number; sentMessageIds: string[]; lastSeenSequence: bigint }
-  | { status: "failed"; sessionId: string; willRetry: boolean }
+  | { status: "failed"; sessionId: string; willRetry: boolean; retryable: boolean }
 
 /**
  * Manages the complete lifecycle of an agent session.
@@ -248,7 +249,12 @@ export async function withCompanionSession(
     // FAILED→RUNNING) but emit a non-terminal `agent_session:interrupted` so the
     // card shows "Interrupted, retrying…" instead of flashing red. When retry
     // accounting is absent (non-queue callers), treat the failure as terminal.
-    const willRetry = attempt !== undefined && maxAttempts !== undefined && attempt + 1 < maxAttempts
+    // `retryable: false` is the provider's own verdict (an AI SDK APICallError that
+    // says don't retry) — repeating a deterministic rejection only burns tokens. It
+    // is not the same as `willRetry: false`, which also covers the last attempt of
+    // an ordinary failure.
+    const retryable = !(APICallError.isInstance(err) && err.isRetryable === false)
+    const willRetry = retryable && attempt !== undefined && maxAttempts !== undefined && attempt + 1 < maxAttempts
 
     await withTransaction(pool, async (db) => {
       const failed = await AgentSessionRepository.updateStatus(db, session.id, SessionStatuses.FAILED, {
@@ -304,7 +310,7 @@ export async function withCompanionSession(
       }
     }).catch((e) => logger.error({ err: e }, "Failed to mark session as failed"))
 
-    return { status: "failed" as const, sessionId: session.id, willRetry }
+    return { status: "failed" as const, sessionId: session.id, willRetry, retryable }
   } finally {
     if (heartbeatInterval) clearInterval(heartbeatInterval)
   }

--- a/apps/backend/src/features/agents/persona-agent-worker.test.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.test.ts
@@ -77,6 +77,56 @@ describe("createPersonaAgentWorker", () => {
     expect(captured?.purpose).toEqual({ kind: "catch_up" })
   })
 
+  describe("failed sessions", () => {
+    const failedData: PersonaAgentJobData = {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      messageId: "msg_1",
+      personaId: "persona_ariadne",
+      triggeredBy: "user",
+    }
+
+    function makeFailedWorker(result: Partial<PersonaAgentResult>) {
+      return createPersonaAgentWorker({
+        agent: {
+          run: async () =>
+            ({
+              sessionId: "session_1",
+              messagesSent: 0,
+              sentMessageIds: [],
+              status: "failed",
+              ...result,
+            }) satisfies PersonaAgentResult,
+        },
+        serverId: "srv_1",
+        pool: {} as Pool,
+        jobQueue: {} as QueueManager,
+      })
+    }
+
+    it("does not re-throw when the provider said the failure is not retryable", async () => {
+      const worker = makeFailedWorker({ retryable: false })
+
+      expect(await worker({ id: "job_6", name: "persona.agent", data: failedData })).toBeUndefined()
+    })
+
+    it("re-throws a retryable failure so the queue retries", async () => {
+      const worker = makeFailedWorker({ retryable: true })
+
+      await expect(worker({ id: "job_7", name: "persona.agent", data: failedData })).rejects.toThrow(
+        "Persona agent failed for session session_1"
+      )
+    })
+
+    it("re-throws a failure with no retryable verdict", async () => {
+      const worker = makeFailedWorker({})
+
+      await expect(worker({ id: "job_8", name: "persona.agent", data: failedData })).rejects.toThrow(
+        "Persona agent failed for session session_1"
+      )
+    })
+  })
+
   describe("episode-summary enqueue on completion (roadmap 3.1)", () => {
     afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/agents/persona-agent-worker.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.ts
@@ -57,7 +57,17 @@ export function createPersonaAgentWorker(deps: PersonaAgentWorkerDeps): JobHandl
     })
 
     if (result.status === "failed") {
-      // Re-throw to trigger queue system retry
+      // A retryable failure re-throws so the queue retries the same session. When the
+      // provider itself said the error is not retryable, the row is already FAILED and
+      // the terminal `agent_session:failed` event is emitted — a retry could only
+      // repeat the same rejection, so return normally.
+      if (result.retryable === false) {
+        logger.warn(
+          { jobId: job.id, streamId, sessionId: result.sessionId },
+          "Persona agent failed with a non-retryable provider error, not retrying"
+        )
+        return
+      }
       throw new Error(`Persona agent failed for session ${result.sessionId}`)
     }
 

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -282,6 +282,7 @@ export interface PersonaAgentResult {
   status: "completed" | "failed" | "skipped"
   skipReason?: string
   lastSeenSequence?: bigint
+  retryable?: boolean
   streamId?: string
   personaId?: string
 }
@@ -436,11 +437,7 @@ export class PersonaAgent {
       parentStreamId = streamId
       parentMessageId = messageId
       logger.info({ threadId: thread.id, streamId, messageId }, "Created thread for channel mention (eager)")
-    } else if (
-      stream.type === StreamTypes.THREAD &&
-      stream.parentStreamId &&
-      stream.parentAnchorId
-    ) {
+    } else if (stream.type === StreamTypes.THREAD && stream.parentStreamId && stream.parentAnchorId) {
       // Session in an existing thread: viewers of the parent timeline watch it
       // through the thread slot on the anchor (message or card), so the inline
       // indicator events must reach the parent stream's room too — the same
@@ -1313,6 +1310,7 @@ export class PersonaAgent {
           messagesSent: 0,
           sentMessageIds: [],
           status: "failed",
+          retryable: result.retryable,
         }
 
       case "completed":


### PR DESCRIPTION
Recreated from #1544, which GitHub auto-closed when its stacked base branch was deleted on merge of #1543. Same commit, rebased onto `main`; review history and evidence are on #1544.

## Problem

The OpenRouter → Anthropic 400 that stopped Ariadne answering (#1543) carries `isRetryable: false`. We ignored that and retried the whole session up to `maxAttempts`.

Measured across the five terminal failures on 2026-07-25: **25 LLM calls, 617k prompt tokens, $1.34, zero output.** Each failure spent ~75 s showing "Interrupted, retrying…" — four `agent_session:interrupted` events — before the user learned nothing had happened. Because `agent_session_steps` is unique on `(session_id, step_number)`, later attempts overwrite earlier ones, so the stored trace is a blend of attempts: `session_01KYDE26ZZX7B43GTBVST70B02`'s first step starts a full minute after the session did.

Retrying a deterministic 400 cannot succeed.

## Solution

Classify the provider's own verdict at the session failure catch and carry it to the worker.

- `withCompanionSession` computes `retryable = !(APICallError.isInstance(err) && err.isRetryable === false)`. A non-retryable error emits the terminal `agent_session:failed` on the first attempt instead of four `interrupted` events.
- `PersonaAgentResult` forwards `retryable`; `persona-agent-worker` re-throws only when it is not `false`.
- **`retryable` over reusing `willRetry`** — `willRetry: false` is also true on the last attempt of an ordinary failure. Keying the worker off `willRetry` would have stopped throwing there too and silently changed DLQ behaviour for every failure mode. The worker checks `=== false`, so an absent value falls back to today's re-throw.
- Only `APICallError` with an explicit `isRetryable === false` is terminal. `APICallError`'s default is `statusCode === 408 || 409 || 429 || >= 500`, and `handleFetchError` sets `isRetryable: true` for network failures, so 429s, 5xx and dropped connections cannot be misclassified. Verified in `@ai-sdk/provider@2.0.1` rather than assumed.

Two honest limits:

- The fix catches the first-shot case. If a retryable error precedes a non-retryable one inside the same SDK call, `ai` throws `RetryError` rather than the original, which stays classified retryable. That is not the shape seen in production — the persisted `"AI_APICallError: Provider returned error"` is `String(err)` from this catch, so the caught value was the raw `APICallError`.
- Provider 400s now produce a warn log instead of a DLQ row. If anything alerts on the `persona.agent` DLQ, that signal moves.

## Files

| File | Change |
| ---- | ------ |
| `companion/session.ts` | classify `retryable`; gate `willRetry` on it |
| `persona-agent.ts` | forward `retryable` on the failed result |
| `persona-agent-worker.ts` | re-throw only retryable failures |
| `companion/session.test.ts` | non-retryable case; existing expectations extended |
| `persona-agent-worker.test.ts` | **new** block — resolves on non-retryable, throws otherwise |

## Test plan

- [x] `bun run --cwd apps/backend test:unit` — 3591 pass, 0 fail (baseline 3587 on this branch)
- [x] `bun run --cwd apps/backend typecheck` — clean, both tsconfigs
- [x] Mutation check — forcing `retryable` true and disabling the worker guard fails exactly the two new tests
- [x] Adversarial review (Opus 5, high) — ship, zero findings; traced the error path from the provider to this catch to confirm nothing re-wraps it, and confirmed no other consumer of `WithSessionResult` / `PersonaAgentResult` exists
- [ ] Not exercised against a live 400 — that path is covered by #1543's live reproduction
- [x] **Live against the real 400** (`dev:test`, sanitizer from #1543 disabled to reproduce it): each failed session recorded **1 `agent-loop` call, 0 `agent_session:interrupted` events, 1 terminal `agent_session:failed`** — versus production's 5 calls and 4 interrupted events for the identical error.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787649550&installation_model_id=20758&pr_number=1544&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1544&signature=8c7798257b6438e960c1df2d13d7317548df364ef9b14e8cc0ce666639b8514a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

