### PR TITLE
docs: make CLAUDE.md force a skill read before stack operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Factual repo questions are yours to answer: Grep/Glob/Agent, starting from `docs
 
 "Always X" / "never Y" rules (INV-*, skill rules) are binding — re-read them before acting in their domain. Read a module and its neighbors before editing; features colocate (INV-51), so the answer is usually one directory away. Apply an invariant's intent, not its surface shape: INV-20 means "write paths tolerate concurrent callers", not "sprinkle ON CONFLICT".
 
+**Naming a skill is an instruction to load it.** When this file, the user, or another skill names one, invoke it before the first command in its domain — a summary here or a note in your own memory is a pointer, never the contract, and both go stale as skills gain tooling. A skill routinely ships a script or step its summary omits, so "the summary looked complete" is exactly how the omission stays invisible. If you concluded a capability doesn't exist without reading the skill that owns it, you concluded it from the wrong source; a skill's own fallback rules also override whatever workaround you devised.
+
 ## Runtime
 
 Bun, not Node: `bun <file>`, `bun run test`, `bun install`, `bun run <script>`, `bun build`. Bun auto-loads `.env` — no dotenv.
@@ -45,11 +47,14 @@ Anthropic artifacts don't render for this user; publish on Seer instead. Use it 
 
 Test-first when practical; else run the nearest suite and verify manually. Never ship unexecuted tests: `bun run test`, `bun run test:e2e`. Failing tests get fixed, never dismissed as pre-existing (INV-22).
 
-**Stacked PRs: always `gh stack`** (GitHub-native Stacks; extension installed — verify `gh extension list | grep stack`, never assume absence). Hand-rolling stacks with plain branches + `gh pr create --base` is the recurring failure — don't. `/gh-stack` skill has the full contract; core loop:
+**Stacked PRs: always `gh stack`** (GitHub-native Stacks; extension installed — verify `gh extension list | grep stack`, never assume absence). Hand-rolling stacks with plain branches + `gh pr create --base` is the recurring failure — don't.
+
+**Invoke the `/gh-stack` skill before your first stack command, every session.** The bullets below are a memory jog, NOT the contract — the skill carries operations they do not mention, `merge-stack.ts` chief among them. Anyone who works from this list alone reaches a wrong conclusion and acts on it; that has now happened more than once, always the same way: the summary feels complete, the tool that solves the problem is never discovered, and a forbidden fallback gets used instead. Repo memory is not a substitute either — it goes stale as the skill gains tooling. If you have already formed a plan for a stack without opening the skill, that plan is unvalidated.
 
 - Once: `git config rerere.enabled true` and `git config remote.pushDefault origin`
 - `gh stack init <branches bottom→top>` (adopts existing branches) · `gh stack add <branch>` per layer · `gh stack submit --auto` (recognizes `/create-pr`-made PRs and links them into the Stack)
 - **`submit` is mandatory, not optional.** `/create-pr` (or `gh pr create --base <parent>`) opens the PRs but does NOT make a Stack — running `init`/`add` then skipping `submit` leaves unlinked, chained-base PRs. Finish every stack with `gh stack submit --auto` and confirm `gh stack view --json` shows a `Stack #NNNN`. Already have unlinked PRs? `gh stack submit --auto --open` retrofits the linkage in place.
+- **Merging a Stack: `bun .agents/skills/gh-stack/scripts/merge-stack.ts <top-pr> --yes`** (`--dry-run` first to validate). Lands the whole stack server-side in one operation. `gh pr merge` on a linked Stack is REFUSED by GitHub ("must be merged sequentially using the stack merge API"), `gh stack` has no merge command, and the documented REST API has no merge route — none of that means there is no way to merge, and probing for one is wasted effort. If the wrapper fails, **stop and report**; do NOT `gh stack unstack` and merge per layer. Unstacking deletes base branches on merge, which auto-CLOSES every PR above (GitHub then refuses both reopen and base change, so each must be recreated).
 - After merges: `gh stack sync --prune` — auto-recovers squash-merges; replaces manual rebase-on-main
 - Non-interactive always: branch names as args, `submit --auto`, `view --json`
 


### PR DESCRIPTION
## Problem

Merging Stack #1546 today, I unstacked it and merged bottom-up — the fallback the `gh-stack` skill explicitly forbids ("A failure must stop loudly; do not fall back to unstacking automatically"). The cost: deleting #1543's branch on merge auto-closed #1544, and GitHub refuses both reopen and base change once a base branch is gone, so it had to be recreated as #1547.

The repo already ships the right tool — `bun .agents/skills/gh-stack/scripts/merge-stack.ts <top-pr> --yes`, rule 10 of the skill, with its own "Merge a stack from an agent" section. I never found it because I never opened the skill. Kris reports I'm not the first to do exactly this.

The mechanism is worth naming, because it's why a bare "read the skill" line wouldn't have helped: CLAUDE.md's stack bullets cover `init`/`add`/`submit`/`sync` and read as a complete loop. An agent consults them, forms a plan, and never experiences a gap that would prompt it to open the skill. I then confirmed the wrong conclusion against my own repo memory — written before `merge-stack.ts` existed — and spent effort probing REST routes for a capability I'd already been handed.

## Solution

- **Name the command in the summary.** Even an agent that skips the skill now lands on `merge-stack.ts`, and the bullet says plainly what `gh pr merge`, `gh stack`, and the REST API do *not* offer, so the absence of a documented route stops reading as "no way to merge".
- **State the failure path.** Wrapper fails → stop and report. Never `gh stack unstack`, with the auto-close consequence spelled out.
- **Mark the list as a memory jog, not the contract**, and say the skill carries operations it doesn't mention. A summary that admits it's partial is the part that actually sends someone to the source.
- **One general rule** in Search Before Asking: naming a skill is an instruction to load it; a summary or your own memory is a pointer that goes stale; a conclusion reached without reading the skill that owns the domain was reached from the wrong source.

Deliberately not doing: adding a hook or check. This is a reading-order problem, and the words have to do the work at the point the plan is formed.

## Files

| File | Change |
| ---- | ------ |
| `CLAUDE.md` | merge bullet + "not the contract" framing in Workflow; skill-loading rule in Search Before Asking |

## Test plan

- [x] `bun run lint` unaffected — no markdown linting in the repo lint chain; the MD013 long lines flagged by an ad-hoc markdownlint run are the file's existing style throughout
- [ ] No automated test — the change is instructions. Its real test is whether the next agent asked to merge a stack runs `merge-stack.ts`.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787668802&installation_model_id=20758&pr_number=1548&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1548&signature=5f24f70f58bf60422d18721826636564fdbd14802a8fc30aba0dc6da04c76869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->