### PR TITLE
feat/agent prompt caching

### DIFF
--- a/packages/agent-runtime/src/ai/ai.test.ts
+++ b/packages/agent-runtime/src/ai/ai.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from "bun:test"
-import { parseModelId, createAI, AIBudgetExceededError } from "./ai"
+import { parseModelId, createAI, AIBudgetExceededError, applyCacheBreakpoints } from "./ai"
 
 // Import fixture data captured from real OpenRouter API calls (2026-01-06)
 import fixtures from "./fixtures/openrouter-responses.json"
@@ -264,5 +264,101 @@ describe("OpenRouter response fixtures", () => {
         },
       },
     })
+  })
+})
+
+describe("applyCacheBreakpoints", () => {
+  const ANTHROPIC = "openrouter:anthropic/claude-sonnet-5"
+  const EPHEMERAL = { openrouter: { cacheControl: { type: "ephemeral" } } }
+
+  it("moves the system prompt into messages and breaks on it plus the newest message", () => {
+    const result = applyCacheBreakpoints({
+      system: "You are Ariadne.",
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ],
+      modelString: ANTHROPIC,
+    })
+
+    expect(result).toEqual({
+      system: undefined,
+      messages: [
+        { role: "system", content: "You are Ariadne.", providerOptions: EPHEMERAL },
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello", providerOptions: EPHEMERAL },
+      ],
+    })
+  })
+
+  it("places a single breakpoint when the system prompt is the only message", () => {
+    const result = applyCacheBreakpoints({ system: "Prompt.", messages: [], modelString: ANTHROPIC })
+
+    expect(result).toEqual({
+      system: undefined,
+      messages: [{ role: "system", content: "Prompt.", providerOptions: EPHEMERAL }],
+    })
+  })
+
+  it("breaks on the newest message when there is no system prompt", () => {
+    const result = applyCacheBreakpoints({
+      messages: [{ role: "user", content: "hi" }],
+      modelString: ANTHROPIC,
+    })
+
+    expect(result).toEqual({
+      system: undefined,
+      messages: [{ role: "user", content: "hi", providerOptions: EPHEMERAL }],
+    })
+  })
+
+  // A shallow spread over providerOptions would replace the whole `openrouter`
+  // key and silently drop sibling options such as reasoning effort.
+  it("merges alongside sibling openrouter options rather than replacing them", () => {
+    const result = applyCacheBreakpoints({
+      messages: [
+        {
+          role: "user",
+          content: "hi",
+          providerOptions: { openrouter: { reasoning: { effort: "high" } }, anthropic: { foo: "bar" } },
+        },
+      ],
+      modelString: ANTHROPIC,
+    })
+
+    expect(result.messages[0]?.providerOptions).toEqual({
+      anthropic: { foo: "bar" },
+      openrouter: { reasoning: { effort: "high" }, cacheControl: { type: "ephemeral" } },
+    })
+  })
+
+  // Measured 2026-07-26: Gemini caches the marked prefix and caches nothing
+  // without the marker, exactly like Anthropic.
+  it("breaks on Gemini too, which also requires an explicit marker", () => {
+    const result = applyCacheBreakpoints({
+      system: "Prompt.",
+      messages: [{ role: "user", content: "hi" }],
+      modelString: "openrouter:google/gemini-2.5-pro",
+    })
+
+    expect(result.messages.map((m) => m.providerOptions)).toEqual([EPHEMERAL, EPHEMERAL])
+  })
+
+  // OpenAI caching is automatic and needs no marker; personas may run any
+  // registry model, and losing the optimization is the correct degradation.
+  it("leaves the request untouched for providers that need no marker", () => {
+    const request = {
+      system: "Prompt.",
+      messages: [{ role: "user" as const, content: "hi" }],
+      modelString: "openrouter:openai/gpt-5.6-luna",
+    }
+
+    expect(applyCacheBreakpoints(request)).toEqual({ system: request.system, messages: request.messages })
+  })
+
+  it("leaves the request untouched when no model string is available", () => {
+    const request = { system: "Prompt.", messages: [{ role: "user" as const, content: "hi" }] }
+
+    expect(applyCacheBreakpoints(request)).toEqual({ system: request.system, messages: request.messages })
   })
 })

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -223,6 +223,23 @@ export interface GenerateTextWithToolsOptions {
   context?: CostContext
   /** Abort signal for graceful cancellation / per-call timeouts */
   abortSignal?: AbortSignal
+  /**
+   * Place Anthropic prompt-cache breakpoints on this request. Caching is a
+   * prefix match over `tools` → `system` → `messages`, so one breakpoint on the
+   * system message also caches every tool definition ahead of it (~12k tokens
+   * for the companion toolset) and a second on the newest message caches the
+   * conversation an agent loop appends to each iteration.
+   *
+   * Opt-in because a cache write costs 1.25x base input and only pays back from
+   * the second request against the same prefix — true of every agent turn (the
+   * loop re-sends the prefix once per iteration), not of one-shot calls.
+   *
+   * Requires `modelString`: breakpoints are placed only for providers that need
+   * an explicit marker — see `PROVIDERS_REQUIRING_CACHE_BREAKPOINTS`, which is
+   * the single source of truth for that set. Personas may run any registry
+   * model, and a provider that caches automatically needs nothing here.
+   */
+  cachePrefix?: boolean
 }
 
 export interface GenerateTextWithToolsResult {
@@ -276,6 +293,14 @@ export interface UsageWithCost {
   promptTokens?: number
   completionTokens?: number
   totalTokens?: number
+  /**
+   * Prompt tokens served from the provider's cache rather than reprocessed.
+   * A share of `promptTokens`, not an addition to it. Absent when the provider
+   * reports no cache detail. Read this against `promptTokens` to get a hit rate
+   * per call site — the only way to tell whether a cache breakpoint is paying
+   * for its 1.25x write premium on a given surface.
+   */
+  cachedPromptTokens?: number
   /** Cost in USD from OpenRouter, if available */
   cost?: number
 }
@@ -354,6 +379,72 @@ interface BudgetPolicyDecision {
   currentUsageUsd?: number
   budgetUsd?: number
   percentUsed?: number
+}
+
+/**
+ * Model providers whose prompt caching requires an explicit breakpoint on the
+ * request. Measured against OpenRouter, 2026-07-26: both Anthropic and Gemini
+ * cache the marked prefix and cache NOTHING without the marker. OpenAI is
+ * deliberately absent — its caching is automatic and needs no marker, so
+ * marking it would be noise.
+ *
+ * Keyed on `modelProvider` (the segment inside the OpenRouter path), so it is
+ * unaffected by which upstream OpenRouter routes to — an Anthropic model served
+ * via Bedrock still caches on this marker.
+ */
+const PROVIDERS_REQUIRING_CACHE_BREAKPOINTS = new Set(["anthropic", "google"])
+
+/**
+ * Merge a cache breakpoint into a message's provider options. Merges *inside*
+ * the `openrouter` key rather than replacing it — a message may already carry
+ * sibling options there (reasoning effort, transforms) that a shallow spread
+ * would silently drop.
+ */
+function withCacheControl(existing?: ModelMessage["providerOptions"]): ModelMessage["providerOptions"] {
+  return {
+    ...existing,
+    openrouter: { ...existing?.openrouter, cacheControl: { type: "ephemeral" } },
+  }
+}
+
+/**
+ * Rewrite a request to carry Anthropic prompt-cache breakpoints.
+ *
+ * The system prompt has to move into the message list: the AI SDK's top-level
+ * `system` string has nowhere to carry `providerOptions`, and the breakpoint
+ * must ride the message that ends the stable prefix. The AI SDK renders a
+ * top-level `system` into exactly this message anyway, so the wire shape is
+ * unchanged apart from `cache_control`.
+ *
+ * Returns the request untouched for providers that don't take an explicit
+ * breakpoint. Losing the optimization is the correct degradation there — it
+ * changes cost, never behavior.
+ */
+export function applyCacheBreakpoints(params: { system?: string; messages: ModelMessage[]; modelString?: string }): {
+  system?: string
+  messages: ModelMessage[]
+} {
+  const { system, messages, modelString } = params
+  if (!modelString || !PROVIDERS_REQUIRING_CACHE_BREAKPOINTS.has(parseModelId(modelString).modelProvider)) {
+    return { system, messages }
+  }
+
+  const out: ModelMessage[] = []
+  if (system) {
+    out.push({ role: "system", content: system, providerOptions: withCacheControl() })
+  }
+  out.push(...messages)
+
+  // Second breakpoint on the newest message so the conversation an agent loop
+  // grows each iteration is read back rather than reprocessed. Skipped when the
+  // system message IS the last one — that breakpoint is already placed.
+  const lastIsTheSystemBreakpoint = Boolean(system) && out.length === 1
+  const last = out.at(-1)
+  if (last && !lastIsTheSystemBreakpoint) {
+    out[out.length - 1] = { ...last, providerOptions: withCacheControl(last.providerOptions) } as ModelMessage
+  }
+
+  return { system: undefined, messages: out }
 }
 
 /**
@@ -668,6 +759,7 @@ export function createAI(config: AIConfig): AI {
           totalTokens?: number
           promptTokens?: number
           completionTokens?: number
+          promptTokensDetails?: { cachedTokens?: number }
         }
       }
     }
@@ -690,6 +782,7 @@ export function createAI(config: AIConfig): AI {
       promptTokens: openrouterUsage?.promptTokens ?? langUsage.promptTokens,
       completionTokens: openrouterUsage?.completionTokens ?? langUsage.completionTokens,
       totalTokens: openrouterUsage?.totalTokens ?? langUsage.totalTokens,
+      cachedPromptTokens: openrouterUsage?.promptTokensDetails?.cachedTokens,
       cost: openrouterUsage?.cost,
     }
   }
@@ -836,10 +929,18 @@ export function createAI(config: AIConfig): AI {
         modelString: options.modelString,
         metadata: options.telemetry?.metadata as Record<string, unknown> | undefined,
       })
+      const { system, messages } = options.cachePrefix
+        ? applyCacheBreakpoints({
+            system: options.system,
+            messages: options.messages,
+            modelString: options.modelString,
+          })
+        : { system: options.system, messages: options.messages }
+
       const response = await aiGenerateText({
         model: options.model,
-        system: options.system,
-        messages: options.messages,
+        system,
+        messages,
         allowSystemInMessages: true,
         tools: options.tools,
         maxOutputTokens: options.maxTokens,

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -111,6 +111,7 @@ export { createKeepResponseTool } from "./tools/keep-response-tool"
 export {
   createAI,
   parseModelId,
+  applyCacheBreakpoints,
   isAbortError,
   AIBudgetExceededError,
   type AccessLogSink,

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -352,6 +352,16 @@ export class AgentRuntime {
           telemetry: this.config.telemetry,
           context: this.config.costContext,
           abortSignal: this.config.runAbortSignal,
+          // The loop re-sends tools + system prompt + conversation once per
+          // iteration, so from the second iteration onward the prefix is read
+          // back rather than reprocessed.
+          //
+          // One case still misses: `retrievedContext` is folded into the system
+          // prompt above, and workspace research populates it mid-loop, so a
+          // turn that retrieves shifts the breakpointed prefix for its
+          // remaining iterations. Splitting the per-turn tail out of the cached
+          // span is the follow-up that closes it.
+          cachePrefix: true,
         })
       } catch (err) {
         // A Stop that fired mid-call aborts the LLM request. Treat it as a

--- a/packages/agent-runtime/src/tools/web-search-tool.test.ts
+++ b/packages/agent-runtime/src/tools/web-search-tool.test.ts
@@ -67,7 +67,7 @@ describe("web-search-tool", () => {
     expect(body.include_answer).toBe(true)
   })
 
-  it("should expose invocation time in the tool description and output", async () => {
+  it("should carry invocation time in output but never in the definition", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve({
         ok: true,
@@ -83,10 +83,22 @@ describe("web-search-tool", () => {
     const { output } = await tool.config.execute({ query: "AI news 2026" }, toolOpts)
     const parsed = JSON.parse(output)
 
-    expect(tool.config.description).toContain("Current invocation time is 2026-11-15T10:00:00.000Z")
-    expect(tool.config.description).toContain("include the current date/year")
+    expect(tool.config.description).toContain("include it in your query")
     expect(parsed.searchedAt).toBe("2026-11-15T10:00:00.000Z")
     expect(parsed.timezone).toBe("Europe/Stockholm")
+  })
+
+  // Tool definitions render ahead of the system prompt in the prompt-cache
+  // prefix: any per-request value in a description or promptBlock invalidates
+  // the cached prefix on every call, silently dropping the hit rate to zero
+  // for the entire toolset. Guards against reintroducing the invocation time.
+  it("should produce a byte-identical definition across differing invocation times", () => {
+    const define = (currentTime: string) => {
+      const t = createWebSearchTool({ tavilyApiKey: "test-api-key", currentTime, timezone: "Europe/Stockholm" })
+      return { description: t.config.description, promptBlock: t.config.promptBlock }
+    }
+
+    expect(define("2026-11-15T10:00:00.000Z")).toEqual(define("2026-11-15T10:00:31.000Z"))
   })
 
   it("should return error on API failure", async () => {

--- a/packages/agent-runtime/src/tools/web-search-tool.ts
+++ b/packages/agent-runtime/src/tools/web-search-tool.ts
@@ -64,8 +64,14 @@ function redactQuery(query: string): string {
 
 export function createWebSearchTool(params: CreateWebSearchToolParams) {
   const { tavilyApiKey, maxResults = 5, currentTime, timezone } = params
+  // The invocation time is deliberately NOT interpolated into this string.
+  // Tool definitions render ahead of the system prompt in the prompt-cache
+  // prefix, so a per-request value here changes that prefix on every call and
+  // drives the cache hit rate to zero for the whole toolset. The live time
+  // reaches the model through the system prompt's `## Current Time` section
+  // (same indirection `schedule_follow_up` uses) and rides tool output below.
   const recencyHint = currentTime
-    ? ` Current invocation time is ${currentTime}${timezone ? ` (${timezone})` : ""}; for latest, recent, current, or news queries, include the current date/year in your query and judge results against that invocation time.`
+    ? ` For latest, recent, current, or news queries, take the current date/year from the "## Current Time" section, include it in your query, and judge results against that time.`
     : ""
 
   // The system prompt's temporal grounding section only exists when the host


### PR DESCRIPTION
## Why

Agent turns re-send the whole prompt prefix — tool definitions, system prompt, conversation — once per loop iteration, all billed at full input rate. Ariadne's 26-tool surface measures ~12k tokens, so a four-tool-call turn pays for it five times. There were no `cache_control` breakpoints anywhere in `agent-runtime`; caching is opt-in on OpenRouter, so none of it was being reused.

## What changed

`applyCacheBreakpoints` moves the system prompt into the message list (ai v7's `allowSystemInMessages`, already enabled upstream) so it can carry `providerOptions`, then marks the system message and the newest message. Caching is a prefix match rendered `tools → system → messages`, so the system breakpoint covers every tool definition ahead of it. `AgentRuntime` opts in; other callers are unaffected.

`web_search` interpolated the live invocation timestamp into its `description`. Tool definitions render ahead of the system prompt, so that one string changed the cached prefix on every request — the hit rate would have sat at 0% for the entire toolset while looking like caching simply doesn't work on this stack. It now points at the system prompt's `## Current Time` section, the indirection `schedule_follow_up` already uses; `currentTime` still reaches `execute` unchanged.

## Verification

Measured against OpenRouter with the real toolset. Anthropic `claude-sonnet-5`: 22,770/22,772 prompt tokens read from cache, $0.05697 → $0.00460. Gemini 2.5 Flash: 31,406 cached, $0.00356 → $0.00095. Both cache nothing without the marker, so the gate covers both; OpenAI is excluded because its caching is automatic. Also verified under `ai` 7 + provider 3, and when OpenRouter routes Anthropic via Bedrock. A definition-stability test diffs tool definitions across differing invocation times so the timestamp cannot come back. Typecheck clean; 266 + 748 tests pass.

## Residual risk

Cache writes cost 1.25×, so a turn that ends in one iteration with no follow-up inside the 5-minute TTL pays ~25% more on the prefix. `UsageWithCost.cachedPromptTokens` is added to measure the real hit rate per surface before deciding whether to gate caching by stream type.
