### PR TITLE
feat(enclave): cache the prompt prefix on the E2EE path

### DIFF
--- a/apps/backend/src/features/agents/enclave-system-prompt.test.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.test.ts
@@ -26,13 +26,17 @@ describe("buildEnclaveSystemPrompt", () => {
       persona: PERSONA,
     })
 
-    // The shared prompt is preserved verbatim and leads — the enclave receives
-    // it rejoined, so the split never reaches the encrypted wire.
-    expect(result.startsWith("BASE_PROMPT_BODY")).toBe(true)
-    // …followed by the limits section that names the boundary and the guidance.
-    expect(result).toContain("## Encrypted scratchpad limits")
-    expect(result).toContain("workspace memory (GAM)")
-    expect(result).toMatch(/do not guess or invent/i)
+    // The shared prompt's stable half leads, and the limits clause joins it —
+    // the clause holds for the stream's lifetime, so it belongs above the
+    // cache breakpoint rather than after the per-turn tail.
+    expect(result.stable.startsWith("BASE_PROMPT")).toBe(true)
+    expect(result.stable).toContain("## Encrypted scratchpad limits")
+    expect(result.stable).toContain("workspace memory (GAM)")
+    expect(result.stable).toMatch(/do not guess or invent/i)
+    // The per-turn half is passed through untouched and stays out of the
+    // cacheable region.
+    expect(result.volatile).toBe("_BODY")
+    expect(result.stable).not.toContain("_BODY")
   })
 
   it("builds the prompt with NO tool sections — the enclave appends them from its real toolset", async () => {
@@ -68,7 +72,7 @@ describe("buildEnclaveSystemPrompt", () => {
 
     const result = await buildEnclaveSystemPrompt({ pool: {} as Pool, stream: STREAM, preferences: PREFS, persona })
 
-    expect(result).toContain(
+    expect(result.stable + result.volatile).toContain(
       `## Response Style\n\n${BREVITY_PRESET_FRAGMENTS.thorough} ${TONE_PRESET_FRAGMENTS.direct}`
     )
   })

--- a/apps/backend/src/features/agents/enclave-system-prompt.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.ts
@@ -2,7 +2,7 @@ import type { Pool } from "pg"
 import type { UserPreferences } from "@threa/types"
 import type { Stream } from "../streams"
 import { buildStreamContext } from "./context-builder"
-import { buildSystemPrompt, joinSystemPrompt } from "./companion/prompt/system-prompt"
+import { buildSystemPrompt, type SplitSystemPrompt } from "./companion/prompt/system-prompt"
 import { resolvePersonaStyleSlots } from "./companion/config"
 import type { Persona } from "./persona-repository"
 import type { BuiltInAgentConfig } from "./built-in-agents"
@@ -36,7 +36,7 @@ export async function buildEnclaveSystemPrompt(params: {
   deviceTimezone?: string
   /** The persona (Ariadne) — its base prompt is the seed buildSystemPrompt layers on. */
   persona: BuiltInAgentConfig
-}): Promise<string> {
+}): Promise<SplitSystemPrompt> {
   const { pool, stream, preferences, deviceTimezone, persona } = params
 
   // Same context builder the main app uses. For E2E it can't read message
@@ -85,15 +85,18 @@ export async function buildEnclaveSystemPrompt(params: {
   // her plainly so she can voice the boundary gracefully — kept as a
   // natural-language instruction (the model handles phrasing/locale), not a
   // code-level heuristic.
-  // Rejoined into one string: the enclave receives the prompt as opaque text
-  // over the encrypted channel, so splitting it here would be a wire-shape
-  // change for no gain — the enclave places its own cache breakpoints or none.
-  // In-turn caching is unaffected; only cross-turn reuse is forgone here.
-  return `${joinSystemPrompt(prompt)}
+  // Returned split at its cache boundary, same as the in-process path. The
+  // encrypted-limits clause is stable for the stream's lifetime, so it joins
+  // the cacheable half — which also moves it ahead of temporal grounding, since
+  // every stable section must precede every volatile one.
+  return {
+    stable: `${prompt.stable}
 
 ## Encrypted scratchpad limits
 
 You are running inside an end-to-end-encrypted scratchpad. You can read this conversation and do web research, but the rest of the workspace never enters this encrypted context: you have no access to workspace memory (GAM), other channels or scratchpads, saved knowledge, or any cross-stream search. This is a deliberate privacy boundary, not an error.
 
-If the user asks you to recall, summarize, or look something up from their workspace or another conversation, do not guess or invent it. Briefly explain that you can't see anything outside this encrypted scratchpad, and offer what you *can* do here (work with what's in this conversation, or research the web).`
+If the user asks you to recall, summarize, or look something up from their workspace or another conversation, do not guess or invent it. Briefly explain that you can't see anything outside this encrypted scratchpad, and offer what you *can* do here (work with what's in this conversation, or research the web).`,
+    volatile: prompt.volatile,
+  }
 }

--- a/apps/backend/src/features/enclave-runtimes/claim-service.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/claim-service.test.ts
@@ -90,7 +90,7 @@ function arrangeClaim(invocation: EnclaveInvocation = INVOCATION) {
   spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
   spyOn(StreamPoliciesRepository, "getToolPolicy").mockResolvedValue(null)
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ name: "Kris" }] as never)
-  spyOn(agents, "buildEnclaveSystemPrompt").mockResolvedValue("You are Ariadne.")
+  spyOn(agents, "buildEnclaveSystemPrompt").mockResolvedValue({ stable: "You are Ariadne.", volatile: "" })
 
   const tx = { __tx: true } as never
   spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>

--- a/apps/backend/src/features/enclave-runtimes/claim-service.ts
+++ b/apps/backend/src/features/enclave-runtimes/claim-service.ts
@@ -429,7 +429,8 @@ export class EnclaveClaimService {
       triggerAuthorName,
       priorMessages: surrounding.filter((m) => m.id !== triggerId),
       persona: {
-        systemPrompt,
+        systemPrompt: systemPrompt.stable,
+        systemVolatilePrompt: systemPrompt.volatile,
         model: persona.model,
         temperature: persona.temperature,
         maxTokens: persona.maxTokens,

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -40,6 +40,7 @@ function msg(id: string, authorType: "user" | "persona", text: string, gen = 1):
 
 const PERSONA = {
   systemPrompt: "You are Ariadne.",
+  systemVolatilePrompt: "",
   model: "openrouter:anthropic/claude-sonnet-4.6",
   temperature: 0.7,
   maxTokens: null,

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -16,7 +16,10 @@ import type { Message } from "../../messaging"
  */
 
 export interface PersonaInvokeConfig {
+  /** The stable half of the prompt — what the enclave's cache breakpoint covers. */
   systemPrompt: string
+  /** The per-turn half, kept outside the cached prefix. */
+  systemVolatilePrompt: string
   /** May carry the `openrouter:` provider prefix; stripped to the bare model id. */
   model: string
   temperature: number | null
@@ -138,6 +141,7 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): Enclav
     // The claim service assembles the full system prompt via the shared
     // `buildEnclaveSystemPrompt` and passes it through here as `systemPrompt`.
     system: persona.systemPrompt,
+    ...(persona.systemVolatilePrompt ? { systemVolatile: persona.systemVolatilePrompt } : {}),
     model: persona.model.replace(/^openrouter:/, ""),
     ...(persona.temperature !== null ? { temperature: persona.temperature } : {}),
     ...(persona.maxTokens !== null ? { maxTokens: persona.maxTokens } : {}),

--- a/apps/enclave/src/agent/enclave-ai.test.ts
+++ b/apps/enclave/src/agent/enclave-ai.test.ts
@@ -34,8 +34,10 @@ describe("createEnclaveAI", () => {
     })
 
     expect(chat.seen[0]?.model).toBe("anthropic/claude-sonnet-4.6")
+    // The stable system message now rides a content part so it can carry the
+    // cache breakpoint; anthropic/* is in the set that needs an explicit one.
     expect(chat.seen[0]?.messages).toEqual([
-      { role: "system", content: "sys" },
+      { role: "system", content: [{ type: "text", text: "sys", cache_control: { type: "ephemeral" } }] },
       { role: "user", content: "capital of France?" },
     ])
     expect(result.text).toBe("Paris.")
@@ -99,5 +101,44 @@ describe("createEnclaveAI", () => {
     await ai.generateTextWithTools(opts)
     await ai.generateTextWithTools(opts)
     expect(usage).toEqual({ promptTokens: 8, completionTokens: 4, cost: 0.5 })
+  })
+})
+
+describe("createEnclaveAI cache breakpoints", () => {
+  const reply = { message: { content: "ok" }, model: "stub", usage: { prompt_tokens: 1, completion_tokens: 1 } }
+
+  it("emits the volatile half as an unmarked system message after the breakpoint", async () => {
+    const chat = stub(reply)
+    const ai = createEnclaveAI(chat.fn, { promptTokens: 0, completionTokens: 0, cost: 0 })
+
+    await ai.generateTextWithTools({
+      model: MODEL,
+      modelString: "anthropic/claude-sonnet-4.6",
+      system: "stable",
+      volatileSystem: "## Current Time\n\n10:00",
+      messages: [{ role: "user", content: "hi" }],
+    })
+
+    expect(chat.seen[0]?.messages).toEqual([
+      { role: "system", content: [{ type: "text", text: "stable", cache_control: { type: "ephemeral" } }] },
+      { role: "system", content: "## Current Time\n\n10:00" },
+      { role: "user", content: "hi" },
+    ])
+  })
+
+  // OpenAI caches automatically, so marking it would be noise. The provider set
+  // lives in agent-runtime so host and enclave cannot drift to different lists.
+  it("omits the breakpoint for a provider that needs no explicit marker", async () => {
+    const chat = stub(reply)
+    const ai = createEnclaveAI(chat.fn, { promptTokens: 0, completionTokens: 0, cost: 0 })
+
+    await ai.generateTextWithTools({
+      model: MODEL,
+      modelString: "openai/gpt-5-mini",
+      system: "stable",
+      messages: [{ role: "user", content: "hi" }],
+    })
+
+    expect(chat.seen[0]?.messages[0]).toEqual({ role: "system", content: "stable" })
   })
 })

--- a/apps/enclave/src/agent/enclave-ai.ts
+++ b/apps/enclave/src/agent/enclave-ai.ts
@@ -1,4 +1,5 @@
 import type { AgentRuntimeAI } from "@threa/agent-runtime/runtime"
+import { providerRequiresCacheBreakpoints } from "@threa/agent-runtime"
 import type { RawChatFn } from "../llm"
 import { buildAssistantMessage, toOpenAiMessages, toOpenAiTools } from "./openai-format"
 
@@ -29,11 +30,21 @@ function parseArguments(raw: string): unknown {
 export function createEnclaveAI(rawChat: RawChatFn, usage: UsageAccumulator): AgentRuntimeAI {
   return {
     async generateTextWithTools(options) {
+      // The enclave holds only the bare OpenRouter path ("anthropic/claude-sonnet-5"),
+      // never the `provider:model` form, so the provider segment is read off the
+      // front. The predicate itself lives in agent-runtime so host and enclave
+      // cannot drift to different provider sets.
+      const modelId = options.modelString ?? String(options.model)
+      const cacheBreakpoint = providerRequiresCacheBreakpoints(modelId.split("/")[0] ?? "")
+
       const result = await rawChat({
         // The loop resolves the model once and passes it as `modelString`; the
         // opaque `model` object is only meaningful to the SDK provider we don't use.
-        model: options.modelString ?? String(options.model),
-        messages: toOpenAiMessages(options.system, options.messages),
+        model: modelId,
+        messages: toOpenAiMessages(options.system, options.messages, {
+          volatileSystem: options.volatileSystem,
+          cacheBreakpoint,
+        }),
         tools: toOpenAiTools(options.tools),
         temperature: options.temperature,
         maxTokens: options.maxTokens,

--- a/apps/enclave/src/agent/openai-format.ts
+++ b/apps/enclave/src/agent/openai-format.ts
@@ -25,8 +25,14 @@ export interface OpenAiToolCall {
  * models like Claude — that's how the enclave feeds decrypted attachments to the
  * model without ever giving the server the plaintext.
  */
+/**
+ * A cache breakpoint in OpenRouter's OpenAI-compatible shape. Only text parts
+ * carry it, and only on providers that need an explicit marker.
+ */
+export type OpenAiCacheControl = { type: "ephemeral" }
+
 export type OpenAiContentPart =
-  | { type: "text"; text: string }
+  | { type: "text"; text: string; cache_control?: OpenAiCacheControl }
   | { type: "image_url"; image_url: { url: string } }
   | { type: "file"; file: { filename: string; file_data: string } }
 
@@ -123,9 +129,29 @@ function toolResultText(part: ToolResultPart): string {
  * `ToolResultPart`s; OpenAI wants one `tool` message per result, keyed by
  * `tool_call_id`, so those fan out.
  */
-export function toOpenAiMessages(system: string | undefined, messages: ModelMessage[]): OpenAiMessage[] {
+export function toOpenAiMessages(
+  system: string | undefined,
+  messages: ModelMessage[],
+  opts?: {
+    /** Per-turn system content, emitted UNMARKED after the breakpoint. */
+    volatileSystem?: string
+    /** Mark the stable system message as a cache breakpoint. */
+    cacheBreakpoint?: boolean
+  }
+): OpenAiMessage[] {
   const out: OpenAiMessage[] = []
-  if (system) out.push({ role: "system", content: system })
+  if (system) {
+    // The breakpoint rides a content part, since `cache_control` has nowhere to
+    // live on a plain string content.
+    out.push(
+      opts?.cacheBreakpoint
+        ? { role: "system", content: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }] }
+        : { role: "system", content: system }
+    )
+  }
+  // Never marked: this is re-derived every turn, so caching it would buy a
+  // write premium for a span nothing can reuse.
+  if (opts?.volatileSystem) out.push({ role: "system", content: opts.volatileSystem })
 
   for (const m of messages) {
     switch (m.role) {

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -147,6 +147,86 @@ function baseRequest(over: Partial<EnclaveSessionAssignment>): EnclaveSessionAss
   }
 }
 
+/**
+ * The system prompt as the model receives it. The stable half now rides content
+ * parts so it can carry a cache breakpoint, and the per-turn half follows as a
+ * second system message — so reconstruct across every leading system message
+ * rather than reading `messages[0].content` as a string.
+ */
+function systemText(req: { messages: { role: string; content: unknown }[] } | undefined): string {
+  const out: string[] = []
+  for (const m of req?.messages ?? []) {
+    if (m.role !== "system") break
+    out.push(
+      typeof m.content === "string"
+        ? m.content
+        : ((m.content as { type: string; text?: string }[] | null) ?? [])
+            .map((part) => (part.type === "text" ? (part.text ?? "") : ""))
+            .join("")
+    )
+  }
+  return out.join("\n\n")
+}
+
+/** Messages after the leading system block(s). */
+function nonSystemMessages(req: { messages: { role: string }[] } | undefined) {
+  return (req?.messages ?? []).filter((m) => m.role !== "system")
+}
+
+describe("runEnclaveTurn prompt cache split", () => {
+  it("caches the stable half plus tool prose, leaving the per-turn tail unmarked", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "hi", "msg_user", "usr_owner")
+    const chat = stubChat(textReply("hey"))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({
+        wraps: [wrap],
+        prompt,
+        system: "You are Ariadne.",
+        systemVolatile: "## Current Time\n\nIt is 10:00.",
+      })
+    )
+
+    const [stableMsg, volatileMsg] = chat.seen[0]?.messages ?? []
+    // Stable half is marked and carries the enclave's own tool prose, which
+    // holds for the stream's lifetime.
+    expect(Array.isArray(stableMsg?.content)).toBe(true)
+    const stable = systemText({ messages: [stableMsg!] })
+    expect(stable).toMatch(/^You are Ariadne\./)
+    expect(stable).toContain("## Reading URLs")
+    expect(stable).not.toContain("## Current Time")
+
+    // Per-turn tail follows as a SECOND, unmarked system message — marking it
+    // would buy a cache write for a span that changes every turn.
+    expect(volatileMsg?.role).toBe("system")
+    expect(typeof volatileMsg?.content).toBe("string")
+    expect(String(volatileMsg?.content)).toContain("## Current Time")
+  })
+
+  // A turn with no per-turn content emits one system message, not an empty second.
+  it("omits the per-turn message when the turn has no volatile content", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "hi", "msg_user", "usr_owner")
+    const chat = stubChat(textReply("hey"))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({ wraps: [wrap], prompt, system: "You are Ariadne." })
+    )
+
+    expect(chat.seen[0]?.messages.filter((m) => m.role === "system")).toHaveLength(1)
+    expect(systemText(chat.seen[0])).toMatch(/^You are Ariadne\./)
+  })
+})
+
 describe("runEnclaveTurn", () => {
   it("opens the forwarded turn and seals a reply the owner's SSK can recover", async () => {
     const keyPair = await createEnclaveKeyPair()
@@ -164,11 +244,10 @@ describe("runEnclaveTurn", () => {
     // The model saw the system prompt then the decrypted user turn — never ciphertext —
     // and was offered the send_message tool. The shipped prompt leads; the
     // wired tools' prose (read_url + general_research here) is appended in-enclave.
-    const systemMessage = chat.seen[0]?.messages[0]
-    expect(systemMessage?.role).toBe("system")
-    expect(String(systemMessage?.content)).toMatch(/^You are Ariadne\./)
-    expect(String(systemMessage?.content)).toContain("## Reading URLs")
-    expect(chat.seen[0]?.messages.slice(1)).toEqual([{ role: "user", content: "What's the capital of France?" }])
+    expect(chat.seen[0]?.messages[0]?.role).toBe("system")
+    expect(systemText(chat.seen[0])).toMatch(/^You are Ariadne\./)
+    expect(systemText(chat.seen[0])).toContain("## Reading URLs")
+    expect(nonSystemMessages(chat.seen[0])).toEqual([{ role: "user", content: "What's the capital of France?" }])
     expect(chat.seen[0]?.tools?.some((t) => t.function.name === "send_message")).toBe(true)
 
     // Exactly one reply, streamed via onMessage, sealed under the same SSK and
@@ -358,7 +437,7 @@ describe("runEnclaveTurn", () => {
       baseRequest({ wraps: [wrap], prompt, priorSummary })
     )
 
-    const system = String(chat.seen[0]?.messages[0]?.content)
+    const system = systemText(chat.seen[0])
     expect(system).toContain("## Conversation Memory")
     expect(system).toContain("We decided to ship on Friday.")
   })
@@ -542,8 +621,8 @@ describe("runEnclaveTurn", () => {
       })
     )
 
-    expect(String(chat.seen[0]?.messages[0]?.content)).toMatch(/^You are Ariadne\./)
-    expect(chat.seen[0]?.messages.slice(1)).toEqual([
+    expect(systemText(chat.seen[0])).toMatch(/^You are Ariadne\./)
+    expect(nonSystemMessages(chat.seen[0])).toEqual([
       { role: "assistant", content: "Earlier, you greeted me." },
       { role: "user", content: "Continue." },
     ])
@@ -596,7 +675,7 @@ describe("runEnclaveTurn", () => {
 
     // The system message the model saw carries the opened digest (shared
     // formatter output), but never the one we couldn't open.
-    const system = String(chat.seen[0]?.messages[0]?.content ?? "")
+    const system = systemText(chat.seen[0])
     expect(system).toContain("You are Ariadne.")
     expect(system).toContain("## Prior Tool Work (Turn Digests)")
     expect(system).toContain("Spring tides align sun and moon.")
@@ -619,7 +698,7 @@ describe("runEnclaveTurn", () => {
 
     // No Tavily key in deps → web_search is not wired, so its section must not
     // be advertised; read_url + general_research are. No digest block.
-    const system = String(chat.seen[0]?.messages[0]?.content)
+    const system = systemText(chat.seen[0])
     expect(system).toMatch(/^You are Ariadne\./)
     expect(system).toContain("## Reading URLs")
     expect(system).toContain("## General Research")

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -338,9 +338,19 @@ export async function runEnclaveTurn(
   // policy above). Advertise exactly the built toolset, then fold in prior
   // turns' digests.
   const toolSections = buildToolPromptSections(turnTools)
-  const systemPrompt = [request.system, toolSections, memoryBlock, digestBlock]
-    .filter((block): block is string => Boolean(block))
-    .join("\n\n")
+
+  // Regrouped stable-first so the cache breakpoint has something reusable to
+  // cover. The backend ships its prompt already split; the enclave's own
+  // additions sort the same way — tool prose holds for the stream's lifetime,
+  // while the rolling conversation summary and prior-turn digests are
+  // re-derived every turn. Assembling in source order instead would leave the
+  // backend's per-turn tail between two stable regions, and nothing before the
+  // breakpoint would survive to the next turn.
+  const stableSystem = [request.system, toolSections].filter((block): block is string => Boolean(block)).join("\n\n")
+  const volatileSystem =
+    [request.systemVolatile, memoryBlock, digestBlock]
+      .filter((block): block is string => Boolean(block))
+      .join("\n\n") || undefined
 
   // Split the turn into what it IS (the request: model binding, prompt, history,
   // toolset, sampling) and what it touches in the host (the sink: the sealing
@@ -352,7 +362,8 @@ export async function runEnclaveTurn(
     delivery: TurnDeliveries.SEALED,
     model,
     modelString: request.model,
-    systemPrompt,
+    systemPrompt: stableSystem,
+    volatileSystemPrompt: volatileSystem,
     messages,
     tools: turnTools,
     maxTokens: request.maxTokens,

--- a/apps/enclave/src/assignment.test.ts
+++ b/apps/enclave/src/assignment.test.ts
@@ -63,3 +63,27 @@ describe("sessionAssignmentSchema", () => {
     expect(sessionAssignmentSchema.parse(BASE).allowedToolCategories).toBeUndefined()
   })
 })
+
+describe("sessionAssignmentSchema system prompt bounds", () => {
+  it("accepts the two halves when their combined length is within the cap", () => {
+    const result = sessionAssignmentSchema.safeParse({
+      ...BASE,
+      system: "a".repeat(60_000),
+      systemVolatile: "b".repeat(39_000),
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  // Capping each half independently would double the bound the single `system`
+  // field used to enforce — the split must not loosen the input limit.
+  it("rejects halves that individually fit but jointly exceed the cap", () => {
+    const result = sessionAssignmentSchema.safeParse({
+      ...BASE,
+      system: "a".repeat(80_000),
+      systemVolatile: "b".repeat(80_000),
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/enclave/src/assignment.ts
+++ b/apps/enclave/src/assignment.ts
@@ -49,114 +49,128 @@ const sealedMessageSchema = z.object({
   envelope: streamEnvelopeSchema,
 })
 
-export const sessionAssignmentSchema = z.object({
-  sessionId: z.string().min(1),
-  /**
-   * Claim-minted callback-binding secret (Phase 2.4b, E2EE-21), echoed on
-   * every session callback. Required: the backend rejects tokenless
-   * callbacks outright, so an assignment without it could never report a
-   * single result — better to fail the parse loudly here than run a turn
-   * whose every callback 403s.
-   */
-  callbackToken: z.string().min(1),
-  streamId: z.string().min(1),
-  /** One SSK wrap per generation referenced by `history`/`prompt`, addressed to this EIK. */
-  wraps: z
-    .array(
-      z.object({
-        keyGeneration: z.number().int().min(0),
-        wrapEnc: z.string().min(1),
-        wrapCt: z.string().min(1),
+export const sessionAssignmentSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    /**
+     * Claim-minted callback-binding secret (Phase 2.4b, E2EE-21), echoed on
+     * every session callback. Required: the backend rejects tokenless
+     * callbacks outright, so an assignment without it could never report a
+     * single result — better to fail the parse loudly here than run a turn
+     * whose every callback 403s.
+     */
+    callbackToken: z.string().min(1),
+    streamId: z.string().min(1),
+    /** One SSK wrap per generation referenced by `history`/`prompt`, addressed to this EIK. */
+    wraps: z
+      .array(
+        z.object({
+          keyGeneration: z.number().int().min(0),
+          wrapEnc: z.string().min(1),
+          wrapCt: z.string().min(1),
+        })
+      )
+      .min(1)
+      .max(MAX_WRAP_RECIPIENTS),
+    /**
+     * Prior turns, oldest→newest. Each item's role tells the model who spoke;
+     * `sequence` (base-10) is the message's clear stream sequence, which the
+     * enclave uses to advance the rolling summary cursor over folded messages
+     * (C-2). MUST be declared — Zod strips unknown keys, and a missing sequence
+     * would silently break the cursor.
+     */
+    history: z
+      .array(sealedMessageSchema.extend({ role: z.enum(["user", "assistant"]), sequence: z.string().regex(/^\d+$/) }))
+      .max(MAX_HISTORY_MESSAGES),
+    /** The user message that triggered this invocation (always the latest `user` turn). */
+    prompt: sealedMessageSchema,
+    /** Ariadne's system prompt — non-secret persona text the backend supplies in the clear. */
+    system: z.string().min(1).max(MAX_SYSTEM_PROMPT_CHARS),
+    /**
+     * The per-turn half of the prompt, kept out of the cached prefix. Absent when
+     * the turn has none.
+     */
+    systemVolatile: z.string().max(MAX_SYSTEM_PROMPT_CHARS).optional(),
+    /** OpenRouter model id, e.g. `anthropic/claude-sonnet-4.6`. */
+    model: z.string().min(1).max(MAX_MODEL_ID_CHARS),
+    temperature: z.number().min(0).max(2).optional(),
+    maxTokens: z.number().int().min(1).max(MAX_COMPLETION_TOKENS).optional(),
+    /** Where to seal replies: current generation + Ariadne's sender id. */
+    reply: z.object({
+      keyGeneration: z.number().int().min(0),
+      senderId: z.string().min(1),
+    }),
+    /**
+     * Per-stream tool-privacy policy. MUST be in the schema: Zod strips unknown
+     * keys, so omitting it here silently drops the policy and the enclave runs its
+     * full web surface regardless of the stream's setting. Optional → unrestricted.
+     */
+    allowedToolCategories: z.array(z.enum(TOOL_PRIVACY_CATEGORIES)).optional(),
+    /**
+     * Non-secret trigger metadata for the "Triggered by" CONTEXT trace step. Same
+     * reason it must be declared: an unschema'd field never reaches `run-turn`, so
+     * the context step would silently never render. The body is the decrypted
+     * prompt, sealed enclave-side.
+     */
+    trigger: z
+      .object({
+        messageId: z.string().min(1),
+        authorName: z.string(),
+        authorType: z.enum(AUTHOR_TYPES),
+        createdAt: z.string().min(1),
       })
-    )
-    .min(1)
-    .max(MAX_WRAP_RECIPIENTS),
-  /**
-   * Prior turns, oldest→newest. Each item's role tells the model who spoke;
-   * `sequence` (base-10) is the message's clear stream sequence, which the
-   * enclave uses to advance the rolling summary cursor over folded messages
-   * (C-2). MUST be declared — Zod strips unknown keys, and a missing sequence
-   * would silently break the cursor.
-   */
-  history: z
-    .array(sealedMessageSchema.extend({ role: z.enum(["user", "assistant"]), sequence: z.string().regex(/^\d+$/) }))
-    .max(MAX_HISTORY_MESSAGES),
-  /** The user message that triggered this invocation (always the latest `user` turn). */
-  prompt: sealedMessageSchema,
-  /** Ariadne's system prompt — non-secret persona text the backend supplies in the clear. */
-  system: z.string().min(1).max(MAX_SYSTEM_PROMPT_CHARS),
-  /** OpenRouter model id, e.g. `anthropic/claude-sonnet-4.6`. */
-  model: z.string().min(1).max(MAX_MODEL_ID_CHARS),
-  temperature: z.number().min(0).max(2).optional(),
-  maxTokens: z.number().int().min(1).max(MAX_COMPLETION_TOKENS).optional(),
-  /** Where to seal replies: current generation + Ariadne's sender id. */
-  reply: z.object({
-    keyGeneration: z.number().int().min(0),
-    senderId: z.string().min(1),
-  }),
-  /**
-   * Per-stream tool-privacy policy. MUST be in the schema: Zod strips unknown
-   * keys, so omitting it here silently drops the policy and the enclave runs its
-   * full web surface regardless of the stream's setting. Optional → unrestricted.
-   */
-  allowedToolCategories: z.array(z.enum(TOOL_PRIVACY_CATEGORIES)).optional(),
-  /**
-   * Non-secret trigger metadata for the "Triggered by" CONTEXT trace step. Same
-   * reason it must be declared: an unschema'd field never reaches `run-turn`, so
-   * the context step would silently never render. The body is the decrypted
-   * prompt, sealed enclave-side.
-   */
-  trigger: z
-    .object({
-      messageId: z.string().min(1),
-      authorName: z.string(),
-      authorType: z.enum(AUTHOR_TYPES),
-      createdAt: z.string().min(1),
-    })
-    .optional(),
-  /**
-   * Inline ciphertext for the conversation's attachments (base64; the
-   * trigger's plus recent history's), keyed by attachment id — the enclave
-   * can't reach S3 (egress is backend + OpenRouter only), so the backend
-   * relays the opaque bytes and the per-file keys arrive sealed inside the
-   * messages. MUST be declared here: Zod strips unknown keys, and omitting
-   * this is exactly how the first attachment slice shipped broken — the
-   * backend sent the bytes and this parse silently deleted them, so every
-   * file showed up as "unavailable".
-   */
-  attachmentCiphertexts: z
-    .array(z.object({ attachmentId: z.string().min(1), ciphertext: z.string().min(1) }))
-    .max(MAX_INLINE_ATTACHMENTS)
-    .optional(),
-  // Whether to auto-title this scratchpad (declared so Zod doesn't strip it —
-  // the same failure mode the attachment slice hit).
-  autoTitle: z.boolean().optional(),
-  /**
-   * Prior turns' sealed turn_digest steps (C-1), oldest→newest. MUST be
-   * declared — Zod strips unknown keys, and silently dropping these would
-   * just quietly bring the tool-work amnesia back. `completedAt` is clear
-   * timing metadata; the digest body opens only here.
-   */
-  recentDigests: z
-    .array(sealedMessageSchema.extend({ completedAt: z.string().min(1) }))
-    .max(MAX_RECENT_DIGESTS)
-    .optional(),
-  /**
-   * Char budget for the verbatim window (C-2). The enclave fills history
-   * newest-first up to this and folds the overflow into the rolling summary.
-   * MUST be declared — Zod strips unknown keys, and dropping it would silently
-   * disable the budget so the enclave kept the whole window verbatim.
-   */
-  maxChars: z.number().int().min(1).max(MAX_WINDOW_CHARS).optional(),
-  /**
-   * The stream's prior sealed rolling summary (C-2): opaque ciphertext the
-   * enclave opens with its SSK wrap, folds the overflow into, and re-seals.
-   * Declared for the same Zod-strips-unknown reason.
-   */
-  priorSummary: sealedMessageSchema.optional(),
-  /**
-   * The prior summary's `last_summarized_sequence` (base-10) — the highest
-   * sequence already folded, so the enclave only summarizes newer history.
-   */
-  summaryCursor: z.string().regex(/^\d+$/).optional(),
-})
+      .optional(),
+    /**
+     * Inline ciphertext for the conversation's attachments (base64; the
+     * trigger's plus recent history's), keyed by attachment id — the enclave
+     * can't reach S3 (egress is backend + OpenRouter only), so the backend
+     * relays the opaque bytes and the per-file keys arrive sealed inside the
+     * messages. MUST be declared here: Zod strips unknown keys, and omitting
+     * this is exactly how the first attachment slice shipped broken — the
+     * backend sent the bytes and this parse silently deleted them, so every
+     * file showed up as "unavailable".
+     */
+    attachmentCiphertexts: z
+      .array(z.object({ attachmentId: z.string().min(1), ciphertext: z.string().min(1) }))
+      .max(MAX_INLINE_ATTACHMENTS)
+      .optional(),
+    // Whether to auto-title this scratchpad (declared so Zod doesn't strip it —
+    // the same failure mode the attachment slice hit).
+    autoTitle: z.boolean().optional(),
+    /**
+     * Prior turns' sealed turn_digest steps (C-1), oldest→newest. MUST be
+     * declared — Zod strips unknown keys, and silently dropping these would
+     * just quietly bring the tool-work amnesia back. `completedAt` is clear
+     * timing metadata; the digest body opens only here.
+     */
+    recentDigests: z
+      .array(sealedMessageSchema.extend({ completedAt: z.string().min(1) }))
+      .max(MAX_RECENT_DIGESTS)
+      .optional(),
+    /**
+     * Char budget for the verbatim window (C-2). The enclave fills history
+     * newest-first up to this and folds the overflow into the rolling summary.
+     * MUST be declared — Zod strips unknown keys, and dropping it would silently
+     * disable the budget so the enclave kept the whole window verbatim.
+     */
+    maxChars: z.number().int().min(1).max(MAX_WINDOW_CHARS).optional(),
+    /**
+     * The stream's prior sealed rolling summary (C-2): opaque ciphertext the
+     * enclave opens with its SSK wrap, folds the overflow into, and re-seals.
+     * Declared for the same Zod-strips-unknown reason.
+     */
+    priorSummary: sealedMessageSchema.optional(),
+    /**
+     * The prior summary's `last_summarized_sequence` (base-10) — the highest
+     * sequence already folded, so the enclave only summarizes newer history.
+     */
+    summaryCursor: z.string().regex(/^\d+$/).optional(),
+  })
+  // The prompt's two halves are bounded TOGETHER. Capping each at
+  // MAX_SYSTEM_PROMPT_CHARS independently would quietly double the input bound
+  // the single `system` field used to enforce, which is the opposite of what
+  // splitting the prompt was for.
+  .refine((a) => a.system.length + (a.systemVolatile?.length ?? 0) <= MAX_SYSTEM_PROMPT_CHARS, {
+    message: `system + systemVolatile must not exceed ${MAX_SYSTEM_PROMPT_CHARS} characters`,
+    path: ["systemVolatile"],
+  })

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -400,6 +400,18 @@ interface BudgetPolicyDecision {
 const PROVIDERS_REQUIRING_CACHE_BREAKPOINTS = new Set(["anthropic", "google"])
 
 /**
+ * Whether a model provider needs an explicit cache breakpoint. Takes the bare
+ * provider segment rather than a `provider:model` string because the enclave —
+ * which places its own breakpoints over a hand-rolled OpenAI transport — only
+ * ever holds the OpenRouter path (`anthropic/claude-sonnet-5`), never the
+ * prefixed form `parseModelId` expects. Exported so that host and enclave read
+ * the same set instead of keeping two copies that can drift apart (INV-33).
+ */
+export function providerRequiresCacheBreakpoints(modelProvider: string): boolean {
+  return PROVIDERS_REQUIRING_CACHE_BREAKPOINTS.has(modelProvider)
+}
+
+/**
  * Merge a cache breakpoint into a message's provider options. Merges *inside*
  * the `openrouter` key rather than replacing it — a message may already carry
  * sibling options there (reasoning effort, transforms) that a shallow spread
@@ -441,7 +453,7 @@ export function applyCacheBreakpoints(params: {
   messages: ModelMessage[]
 } {
   const { system, volatileSystem, messages, modelString } = params
-  if (!modelString || !PROVIDERS_REQUIRING_CACHE_BREAKPOINTS.has(parseModelId(modelString).modelProvider)) {
+  if (!modelString || !providerRequiresCacheBreakpoints(parseModelId(modelString).modelProvider)) {
     // No breakpoint to split on, so the halves must be rejoined — returning
     // only `system` would silently drop the volatile tail from the prompt.
     const joined = [system, volatileSystem].filter(Boolean).join("\n\n")

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -111,6 +111,7 @@ export { createKeepResponseTool } from "./tools/keep-response-tool"
 export {
   createAI,
   parseModelId,
+  providerRequiresCacheBreakpoints,
   applyCacheBreakpoints,
   isAbortError,
   AIBudgetExceededError,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -831,7 +831,23 @@ export interface EnclaveSessionAssignment {
    */
   history: (EnclaveSealedMessage & { role: "user" | "assistant"; sequence: string })[]
   prompt: EnclaveSealedMessage
+  /**
+   * The stable half of Ariadne's system prompt — everything that holds for the
+   * conversation's lifetime. This is what the enclave's prompt-cache breakpoint
+   * covers, so it must not carry per-turn content.
+   */
   system: string
+  /**
+   * The per-turn half of the prompt as the BACKEND derives it — temporal
+   * grounding and invocation purpose. Kept separate so it lands after the cache
+   * breakpoint: inside it, the cached prefix would change every turn and
+   * nothing would be reused. Absent when a turn has no per-turn content.
+   *
+   * The enclave appends its own per-turn sections (rolling conversation
+   * summary, prior-turn digests) to this half locally; they are never shipped
+   * here, since only the enclave can decrypt them.
+   */
+  systemVolatile?: string
   model: string
   temperature?: number
   maxTokens?: number


### PR DESCRIPTION
## Why

Builds on #1553. **The enclave has no prompt caching at all today** — not "in-turn but not cross-turn", none. It implements `AgentRuntimeAI` itself (`createEnclaveAI`) and speaks OpenAI chat-completions to OpenRouter through its own `toOpenAiMessages`, so it never passes through `applyCacheBreakpoints` and emits no `cache_control`. Neither PR below it changes that.

E2EE scratchpads are the surface where invocation is implicit on every message — closest to ordinary AI chat — so cross-turn reuse matters more here than anywhere else.

## What changed

**Wire.** The assignment carries the prompt's two halves as separate fields (`system` = stable, `systemVolatile` = per-turn) rather than one combined string.

**Assembly order.** The enclave built `[backend prompt, tool sections, memory, digests]`, putting the per-turn tail *in the middle* of the prefix — a breakpoint at the end would have covered nothing reusable. Now regrouped stable-first, with the rolling conversation summary and prior-turn digests classified volatile alongside temporal grounding.

**Transport.** `toOpenAiMessages` emits the stable half as a marked content part (`cache_control` has nowhere to live on plain string content) and the per-turn half as a second, **unmarked** system message. The provider gate is imported from agent-runtime via the new `providerRequiresCacheBreakpoints` rather than copied, so host and enclave cannot drift to different provider sets (INV-33).

## A design that was reverted, deliberately

An earlier revision shipped a `systemStableChars` offset into a single combined string, so an enclave predating the field would keep working unchanged. That guarded a rollout window the enclave's actual usage doesn't warrant — and it bought the very risk it was meant to avoid: producer and consumer computing the boundary differently would silently mis-slice the prompt, with no error.

Two explicit fields remove the offset arithmetic, the compatibility branch, and the ordering fallback that came with it — **36 fewer lines**. A backend sending only the stable field degrades to no cross-turn reuse, never to a wrong prompt.

## Verification

Typecheck clean across types, agent-runtime, enclave, backend. 99 enclave (vitest), 3,571 backend agent/enclave-runtime, 538 agent-runtime assertions — all passing. Tests cover the marked/unmarked split, the provider gate in both directions, and a turn with no per-turn content.

## Residual risk

Live cache-hit numbers on a sealed stream aren't measured here — the probe used for #1552/#1553 can't reach inside the enclave. `cachedPromptTokens` from #1552 is the way to confirm in production.

Worth noting for anyone touching the enclave: its tests are **vitest**, not `bun:test`. Running them under `bun test` reports ~33 phantom failures.
