### PR TITLE
refactor(agents): make prompt-cache stability structurally enforced

### DIFF
--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -441,22 +441,22 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
       : null
 
   const composeSystemPrompt = (tools: AgentTool[], effectivePurpose: TurnPurpose): SplitSystemPrompt => {
-    const systemPrompt = buildSystemPrompt(
+    const systemPrompt = buildSystemPrompt({
       persona,
-      streamContext,
+      context: streamContext,
       scratchpadCustomPrompt,
-      effectivePurpose,
+      purpose: effectivePurpose,
       mentionerName,
       rollingConversationSummary,
       tools,
       conversationTopic,
       spawnedFromContext,
       followUp,
-      previousSessionsBlock,
-      streamBrief?.content ?? null,
-      resolvePersonaStyleSlots(persona),
-      personaKnowledge
-    )
+      previousSessions: previousSessionsBlock,
+      streamBrief: streamBrief?.content ?? null,
+      styleSlots: resolvePersonaStyleSlots(persona),
+      personaKnowledge,
+    })
     // Prior-turn digests are re-derived each turn, so they belong outside the
     // cached span alongside temporal grounding.
     return turnDigestBlock

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.cache-stability.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.cache-stability.test.ts
@@ -75,6 +75,7 @@ const PER_TURN_SENTINEL_VALUES: Record<string, Partial<SystemPromptInputs>> = {
   rollingConversationSummary: { rollingConversationSummary: SENTINEL },
   conversationTopic: { conversationTopic: SENTINEL },
   spawnedFromContext: { spawnedFromContext: SENTINEL },
+  previousSessions: { previousSessions: SENTINEL },
   followUp: {
     purpose: { kind: "follow_up", followUpId: "fup_1" },
     followUp: { note: SENTINEL, scheduledFor: new Date("2026-07-04T09:00:00.000Z") },
@@ -130,6 +131,7 @@ describe("system prompt cache stability", () => {
       conversationTopic: "topic one",
       rollingConversationSummary: "summary one",
       spawnedFromContext: "parent one",
+      previousSessions: "## Previous Sessions\n\nsession one",
     })
     const turnTwo = buildSystemPrompt({
       ...BASE,
@@ -138,6 +140,7 @@ describe("system prompt cache stability", () => {
       conversationTopic: "topic two",
       rollingConversationSummary: "summary two",
       spawnedFromContext: "parent two",
+      previousSessions: "## Previous Sessions\n\nsession two",
     })
 
     expect(turnOne.stable).toBe(turnTwo.stable)

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.cache-stability.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.cache-stability.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { StreamTypes } from "@threa/types"
+import type { Persona } from "../../persona-repository"
+import type { StreamContext } from "../../context-builder"
+import { buildSystemPrompt, SYSTEM_PROMPT_INPUT_STABILITY, type SystemPromptInputs } from "./system-prompt"
+
+/**
+ * The structural guard for the prompt's cache split.
+ *
+ * Per-turn content leaking into the cached half has shipped four times, and
+ * every time it was invisible: the prompt is still correct, every test still
+ * passes, and the only symptom is a cache hit rate that never materialises.
+ * Each previous fix added an assertion for the specific section that leaked,
+ * which is why the next one was missed too.
+ *
+ * This test is driven by `SYSTEM_PROMPT_INPUT_STABILITY` instead. Because that
+ * table is `Record<keyof SystemPromptInputs, …>`, a new input cannot be added
+ * without classifying it, and every input classified `turn` is proven here to
+ * stay out of the cached half. The failure mode is a build error or a failing
+ * test, not a silent cost regression.
+ */
+
+const SENTINEL = "__PER_TURN_SENTINEL__"
+
+const persona: Persona = {
+  id: "persona_ariadne",
+  workspaceId: null,
+  slug: "ariadne",
+  name: "Ariadne",
+  description: null,
+  avatarEmoji: null,
+  avatarUrl: null,
+  systemPrompt: "Base system prompt",
+  model: "openai/gpt-5.4",
+  escalationModel: null,
+  temperature: 0.2,
+  maxTokens: 1000,
+  enabledTools: null,
+  tonePreset: null,
+  brevityPreset: null,
+  tonePrompt: null,
+  brevityPrompt: null,
+  managedBy: "system",
+  ownerUserId: null,
+  status: "active",
+  visibility: "visible",
+  e2eCapable: false,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+} as Persona
+
+const context: StreamContext = {
+  streamType: StreamTypes.SCRATCHPAD,
+  streamInfo: { id: "stream_test", name: "Ideas", description: null, slug: null },
+  conversationHistory: [],
+  temporal: {
+    currentTime: "2026-07-03T09:00:00.000Z",
+    timezone: "UTC",
+    utcOffset: "UTC+0",
+    dateFormat: "YYYY-MM-DD",
+    timeFormat: "24h",
+  },
+} as unknown as StreamContext
+
+const BASE: SystemPromptInputs = { persona, context }
+
+/**
+ * A value carrying the sentinel, shaped for each per-turn input. Keyed by input
+ * name so a newly-classified `turn` input fails here until it is given one —
+ * the table alone cannot know what a valid value looks like.
+ */
+const PER_TURN_SENTINEL_VALUES: Record<string, Partial<SystemPromptInputs>> = {
+  purpose: { purpose: { kind: "mention" }, mentionerName: SENTINEL },
+  mentionerName: { purpose: { kind: "mention" }, mentionerName: SENTINEL },
+  rollingConversationSummary: { rollingConversationSummary: SENTINEL },
+  conversationTopic: { conversationTopic: SENTINEL },
+  spawnedFromContext: { spawnedFromContext: SENTINEL },
+  followUp: {
+    purpose: { kind: "follow_up", followUpId: "fup_1" },
+    followUp: { note: SENTINEL, scheduledFor: new Date("2026-07-04T09:00:00.000Z") },
+  },
+}
+
+describe("system prompt cache stability", () => {
+  const perTurnInputs = Object.entries(SYSTEM_PROMPT_INPUT_STABILITY)
+    .filter(([, stability]) => stability === "turn")
+    .map(([name]) => name)
+
+  test("every per-turn input has a sentinel case, so none can be silently skipped", () => {
+    expect(perTurnInputs.sort()).toEqual(Object.keys(PER_TURN_SENTINEL_VALUES).sort())
+  })
+
+  for (const name of perTurnInputs) {
+    test(`\`${name}\` never reaches the cached half`, () => {
+      const overrides = PER_TURN_SENTINEL_VALUES[name]
+      expect(overrides).toBeDefined()
+
+      const built = buildSystemPrompt({ ...BASE, ...overrides })
+
+      // Present somewhere — otherwise the assertion below passes vacuously and
+      // the guard silently stops guarding.
+      expect(built.stable + built.volatile).toContain(SENTINEL)
+      expect(built.stable).not.toContain(SENTINEL)
+    })
+  }
+
+  // `context` is the one `mixed` input: stream metadata is conversation-scoped,
+  // `context.temporal` is per-turn. Asserted directly since the table cannot
+  // express a per-field split.
+  test("temporal grounding inside `context` never reaches the cached half", () => {
+    const built = buildSystemPrompt(BASE)
+
+    expect(built.stable).not.toContain("## Current Time")
+    expect(built.volatile).toContain("## Current Time")
+  })
+
+  test("stream metadata inside `context` stays in the cached half", () => {
+    const built = buildSystemPrompt(BASE)
+
+    expect(built.stable).toContain("Ideas")
+  })
+
+  // The property every per-turn classification exists to protect: two turns of
+  // the same conversation must produce a byte-identical cached half.
+  test("the cached half is byte-identical across two fully-different turns", () => {
+    const turnOne = buildSystemPrompt({
+      ...BASE,
+      purpose: { kind: "mention" },
+      mentionerName: "Kris",
+      conversationTopic: "topic one",
+      rollingConversationSummary: "summary one",
+      spawnedFromContext: "parent one",
+    })
+    const turnTwo = buildSystemPrompt({
+      ...BASE,
+      purpose: { kind: "catch_up" },
+      mentionerName: "Sam",
+      conversationTopic: "topic two",
+      rollingConversationSummary: "summary two",
+      spawnedFromContext: "parent two",
+    })
+
+    expect(turnOne.stable).toBe(turnTwo.stable)
+  })
+})

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -4,12 +4,16 @@ import { createReadUrlTool, createWebSearchTool } from "@threa/agent-runtime"
 import type { Persona } from "../../persona-repository"
 import type { StreamContext } from "../../context-builder"
 import { createWorkspaceResearchTool } from "../../tools"
-import { buildSystemPrompt, buildResponseStyleSection, joinSystemPrompt } from "./system-prompt"
+import {
+  buildSystemPrompt,
+  buildResponseStyleSection,
+  joinSystemPrompt,
+  type SystemPromptInputs,
+} from "./system-prompt"
 
-/** The builder now returns a prompt split at its cache boundary; these
- * assertions are about the assembled prompt, so rejoin it. */
-const buildJoinedPrompt = (...args: Parameters<typeof buildSystemPrompt>) =>
-  joinSystemPrompt(buildSystemPrompt(...args))
+/** The builder returns a prompt split at its cache boundary; these assertions
+ * are about the assembled prompt, so rejoin it. */
+const buildJoinedPrompt = (inputs: SystemPromptInputs) => joinSystemPrompt(buildSystemPrompt(inputs))
 
 const persona: Persona = {
   id: "persona_ariadne",
@@ -49,7 +53,11 @@ const scratchpadContext: StreamContext = {
 
 describe("buildSystemPrompt", () => {
   test("injects scratchpad custom instructions immediately after the base system prompt", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, "Be concise and prioritize concrete next steps.")
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: "Be concise and prioritize concrete next steps.",
+    })
 
     expect(prompt).toContain("Base system prompt\n\n## Scratchpad Custom Instructions")
     expect(prompt).toContain("Be concise and prioritize concrete next steps.")
@@ -57,13 +65,19 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the custom instruction section when no scratchpad prompt exists", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null)
+    const prompt = buildJoinedPrompt({ persona, context: scratchpadContext, scratchpadCustomPrompt: null })
 
     expect(prompt).not.toContain("## Scratchpad Custom Instructions")
   })
 
   test("tool sections come from the ACTUAL toolset — no tools means no tool prose", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [])
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+    })
 
     expect(prompt).not.toContain("## Web Search")
     expect(prompt).not.toContain("## Reading URLs")
@@ -80,7 +94,13 @@ describe("buildSystemPrompt", () => {
       createWebSearchTool({ tavilyApiKey: "tvly-test" }),
       createReadUrlTool(),
     ]
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, tools)
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools,
+    })
 
     expect(prompt).toContain("## Workspace Research")
     expect(prompt).toContain("## Web Search")
@@ -93,9 +113,13 @@ describe("buildSystemPrompt", () => {
   })
 
   test("web search recency guidance references tool metadata when the tool has no invocation time", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [
-      createWebSearchTool({ tavilyApiKey: "tvly-test" }),
-    ])
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [createWebSearchTool({ tavilyApiKey: "tvly-test" })],
+    })
 
     expect(prompt).toContain("## Web Search")
     expect(prompt).toContain("ground recency in web_search tool metadata")
@@ -105,16 +129,14 @@ describe("buildSystemPrompt", () => {
   })
 
   test("injects the Current Topic highlight before Conversation Memory when a topic is provided", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      "Older turns, summarized.",
-      [],
-      "Designing the CSV export pipeline"
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: "Older turns, summarized.",
+      tools: [],
+      conversationTopic: "Designing the CSV export pipeline",
+    })
 
     expect(prompt).toContain("## Current Topic")
     expect(prompt).toContain("The conversation is currently focused on: Designing the CSV export pipeline")
@@ -122,25 +144,37 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the Current Topic section when no topic is provided", () => {
-    const provided = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], null)
-    const blank = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], "   ")
+    const provided = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+    })
+    const blank = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: "   ",
+    })
 
     expect(provided).not.toContain("## Current Topic")
     expect(blank).not.toContain("## Current Topic")
   })
 
   test("injects the spawned-from discussion block before Conversation Memory when context is provided", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      "Older turns, summarized.",
-      [],
-      null,
-      "Topic: Migration timeout\n\nAlice (10:30): The migration keeps timing out"
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: "Older turns, summarized.",
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: "Topic: Migration timeout\n\nAlice (10:30): The migration keeps timing out",
+    })
 
     expect(prompt).toContain("## Discussion This Thread Was Spawned From")
     expect(prompt).toContain("Alice (10:30): The migration keeps timing out")
@@ -150,17 +184,33 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the spawned-from discussion block when no context is provided", () => {
-    const provided = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], null, null)
-    const blank = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], null, "   ")
+    const provided = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+    })
+    const blank = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: "   ",
+    })
 
     expect(provided).not.toContain("## Discussion This Thread Was Spawned From")
     expect(blank).not.toContain("## Discussion This Thread Was Spawned From")
   })
 
   test("injects the scheduled-follow-up section when the turn is a fired follow-up", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      {
+      context: {
         ...scratchpadContext,
         temporal: {
           currentTime: "2026-07-03T09:00:00.000Z",
@@ -170,15 +220,14 @@ describe("buildSystemPrompt", () => {
           timeFormat: "24h",
         },
       },
-      null,
-      { kind: "follow_up", followUpId: "agfu_01" },
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      { note: "check whether the deploy went out", scheduledFor: new Date("2026-07-03T09:00:00.000Z") }
-    )
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "follow_up", followUpId: "agfu_01" },
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: { note: "check whether the deploy went out", scheduledFor: new Date("2026-07-03T09:00:00.000Z") },
+    })
 
     expect(prompt).toContain("## Scheduled follow-up firing now")
     // Carries the note and the scheduled time rendered in the user's timezone.
@@ -191,76 +240,83 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the scheduled-follow-up section for a normal turn", () => {
-    const provided = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], null, null)
-    const explicitNull = buildJoinedPrompt(
+    const provided = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+    })
+    const explicitNull = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+    })
 
     expect(provided).not.toContain("## Scheduled follow-up firing now")
     expect(explicitNull).not.toContain("## Scheduled follow-up firing now")
   })
 
   test("injects the Previous sessions block when episode summaries are provided", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      "## Previous sessions\n\nSummaries of your earlier work sessions in this stream, oldest first.\n\n- [2026-06-10T10:00:02.000Z] Concluded deploys happen Fridays only."
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions:
+        "## Previous sessions\n\nSummaries of your earlier work sessions in this stream, oldest first.\n\n- [2026-06-10T10:00:02.000Z] Concluded deploys happen Fridays only.",
+    })
 
     expect(prompt).toContain("## Previous sessions")
     expect(prompt).toContain("Concluded deploys happen Fridays only.")
   })
 
   test("omits the Previous sessions block when none are provided", () => {
-    const provided = buildJoinedPrompt(
+    const provided = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null
-    )
-    const blank = buildJoinedPrompt(
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+    })
+    const blank = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      "   "
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions: "   ",
+    })
 
     expect(provided).not.toContain("## Previous sessions")
     expect(blank).not.toContain("## Previous sessions")
   })
 
   test("injects the mention invocation section, naming the mentioner, for a mention turn", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, { kind: "mention" }, "Kris")
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "mention" },
+      mentionerName: "Kris",
+    })
 
     expect(prompt).toContain("## Invocation Context")
     expect(prompt).toContain("You were explicitly @mentioned by **Kris**")
@@ -269,20 +325,30 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the mention invocation section for a catch-up turn", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, { kind: "catch_up" })
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+    })
 
     expect(prompt).not.toContain("## Invocation Context")
   })
 
   test("injects the supersede reconciliation section last for a supersede rerun", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, {
-      kind: "supersede_rerun",
-      supersedesSessionId: "agsess_prev",
-      rerunContext: {
-        cause: "invoking_message_edited",
-        editedMessageId: "msg_edited",
-        editedMessageBefore: "book me a flight",
-        editedMessageAfter: "book me a train",
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      purpose: {
+        kind: "supersede_rerun",
+        supersedesSessionId: "agsess_prev",
+        rerunContext: {
+          cause: "invoking_message_edited",
+          editedMessageId: "msg_edited",
+          editedMessageBefore: "book me a flight",
+          editedMessageAfter: "book me a train",
+        },
       },
     })
 
@@ -295,15 +361,20 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the supersede reconciliation section for a catch-up turn", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, { kind: "catch_up" })
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+    })
 
     expect(prompt).not.toContain("## Superseded Session Reconciliation")
   })
 
   test("web search recency guidance references Current Time when the tool is temporally grounded", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      {
+      context: {
         ...scratchpadContext,
         temporal: {
           currentTime: "2026-11-15T10:00:00.000Z",
@@ -313,12 +384,12 @@ describe("buildSystemPrompt", () => {
           timeFormat: "24h",
         },
       },
-      null,
-      undefined,
-      undefined,
-      null,
-      [createWebSearchTool({ tavilyApiKey: "tvly-test", currentTime: "2026-11-15T10:00:00.000Z", timezone: "UTC" })]
-    )
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [
+        createWebSearchTool({ tavilyApiKey: "tvly-test", currentTime: "2026-11-15T10:00:00.000Z", timezone: "UTC" }),
+      ],
+    })
 
     expect(prompt).toContain(
       "ground your search and answer against the Current Time section; do not mix stale search results"
@@ -326,20 +397,17 @@ describe("buildSystemPrompt", () => {
   })
 
   test("injects the Stream Brief early — before the stream context — when the stream carries one (roadmap 4.1)", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      undefined,
-      null,
-      "- Goal: ship the CSV export by Friday\n- Prefer Bun over Node"
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      previousSessions: null,
+      streamBrief: "- Goal: ship the CSV export by Friday\n- Prefer Bun over Node",
+    })
 
     expect(prompt).toContain("## Stream Brief")
     expect(prompt).toContain("- Goal: ship the CSV export by Friday")
@@ -368,22 +436,19 @@ describe("buildSystemPrompt", () => {
   ]
 
   test("injects the persona ## Knowledge block after the persona prompt and before the stream context", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      null,
-      null,
-      undefined,
-      knowledge
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions: null,
+      streamBrief: null,
+      personaKnowledge: knowledge,
+    })
 
     expect(prompt).toContain("## Knowledge")
     expect(prompt).toContain("### runbook.md\n\nRUNBOOK CONTENT")
@@ -397,55 +462,51 @@ describe("buildSystemPrompt", () => {
   })
 
   test("no persona attachments → byte-identical to the pre-feature prompt", () => {
-    const base = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [])
-    const withUndefined = buildJoinedPrompt(
+    const base = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      null,
-      null,
-      undefined,
-      undefined
-    )
-    const withEmpty = buildJoinedPrompt(
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+    })
+    const withUndefined = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      null,
-      null,
-      undefined,
-      []
-    )
-    const withNull = buildJoinedPrompt(
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions: null,
+      streamBrief: null,
+    })
+    const withEmpty = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      null,
-      null,
-      null,
-      undefined,
-      null
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions: null,
+      streamBrief: null,
+      personaKnowledge: [],
+    })
+    const withNull = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: null,
+      previousSessions: null,
+      streamBrief: null,
+      personaKnowledge: null,
+    })
 
     expect(withUndefined).toBe(base)
     expect(withEmpty).toBe(base)
@@ -454,21 +515,24 @@ describe("buildSystemPrompt", () => {
   })
 
   test("omits the Stream Brief section when the stream has no brief (or a blank one)", () => {
-    const absent = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [])
-    const blank = buildJoinedPrompt(
+    const absent = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      undefined,
-      null,
-      "   "
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+    })
+    const blank = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      previousSessions: null,
+      streamBrief: "   ",
+    })
 
     expect(absent).not.toContain("## Stream Brief")
     expect(blank).not.toContain("## Stream Brief")
@@ -478,26 +542,29 @@ describe("buildSystemPrompt", () => {
     "Be brief. Default to 1–3 sentences. Match the depth to what was asked — a simple question gets a simple answer. Only go longer when the topic genuinely requires it (step-by-step instructions, complex analysis the user requested, etc.). Avoid preamble, filler, and restating what the user said. Be friendly and warm in tone, but don't pad with extra words."
 
   test("styleSlots absent → Response Style section is the verbatim pre-slot default", () => {
-    const prompt = buildJoinedPrompt(persona, scratchpadContext, null, undefined, undefined, null, [])
+    const prompt = buildJoinedPrompt({
+      persona,
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+    })
     expect(prompt).toContain(`## Response Style\n\n${DEFAULT_STYLE}`)
   })
 
   test("a set styleSlots preset fragment lands in the Response Style section", () => {
-    const prompt = buildJoinedPrompt(
+    const prompt = buildJoinedPrompt({
       persona,
-      scratchpadContext,
-      null,
-      undefined,
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      undefined,
-      null,
-      null,
-      { tone: "TONE_FRAGMENT_MARKER", brevity: "BREVITY_FRAGMENT_MARKER" }
-    )
+      context: scratchpadContext,
+      scratchpadCustomPrompt: null,
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      previousSessions: null,
+      streamBrief: null,
+      styleSlots: { tone: "TONE_FRAGMENT_MARKER", brevity: "BREVITY_FRAGMENT_MARKER" },
+    })
     // Both aspects replaced, brevity-then-tone, still inside the same section.
     expect(prompt).toContain("## Response Style\n\nBREVITY_FRAGMENT_MARKER TONE_FRAGMENT_MARKER")
     expect(prompt).not.toContain(DEFAULT_STYLE)
@@ -552,26 +619,24 @@ describe("buildSystemPrompt cache split", () => {
   // invariant rather than any one section: two turns of the same conversation
   // must produce a byte-identical stable half whatever drifts between them.
   test("produces a byte-identical stable half across differing topics and summaries", () => {
-    const a = buildSystemPrompt(
+    const a = buildSystemPrompt({
       persona,
-      temporalContext,
-      null,
-      { kind: "catch_up" },
-      undefined,
-      "summary A",
-      [],
-      "topic A"
-    )
-    const b = buildSystemPrompt(
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+      rollingConversationSummary: "summary A",
+      tools: [],
+      conversationTopic: "topic A",
+    })
+    const b = buildSystemPrompt({
       persona,
-      temporalContext,
-      null,
-      { kind: "catch_up" },
-      undefined,
-      "summary B",
-      [],
-      "topic B"
-    )
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+      rollingConversationSummary: "summary B",
+      tools: [],
+      conversationTopic: "topic B",
+    })
 
     expect(a.stable).toBe(b.stable)
     // …and both are still present, below the breakpoint.
@@ -581,25 +646,29 @@ describe("buildSystemPrompt cache split", () => {
   })
 
   test("keeps a shrinking cross-surface stitch out of the cacheable half", () => {
-    const withStitch = buildSystemPrompt(
+    const withStitch = buildSystemPrompt({
       persona,
-      temporalContext,
-      null,
-      { kind: "catch_up" },
-      undefined,
-      null,
-      [],
-      null,
-      "PARENT DISCUSSION"
-    )
-    const without = buildSystemPrompt(persona, temporalContext, null, { kind: "catch_up" })
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: "PARENT DISCUSSION",
+    })
+    const without = buildSystemPrompt({
+      persona,
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+    })
 
     expect(withStitch.stable).toBe(without.stable)
     expect(withStitch.volatile).toContain("PARENT DISCUSSION")
   })
 
   test("keeps temporal grounding out of the cacheable half", () => {
-    const split = buildSystemPrompt(persona, temporalContext, null)
+    const split = buildSystemPrompt({ persona, context: temporalContext, scratchpadCustomPrompt: null })
 
     expect(split.stable).not.toContain("## Current Time")
     expect(split.volatile).toContain("## Current Time")
@@ -610,9 +679,26 @@ describe("buildSystemPrompt cache split", () => {
   // Anything per-turn that drifts above the split silently restores the
   // cross-turn cache miss — no test failure, no error, just a 0% hit rate.
   test("produces a byte-identical stable half across differing turn purposes", () => {
-    const mention = buildSystemPrompt(persona, temporalContext, null, { kind: "mention" }, "Kris")
-    const otherMentioner = buildSystemPrompt(persona, temporalContext, null, { kind: "mention" }, "Sam")
-    const catchUp = buildSystemPrompt(persona, temporalContext, null, { kind: "catch_up" })
+    const mention = buildSystemPrompt({
+      persona,
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "mention" },
+      mentionerName: "Kris",
+    })
+    const otherMentioner = buildSystemPrompt({
+      persona,
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "mention" },
+      mentionerName: "Sam",
+    })
+    const catchUp = buildSystemPrompt({
+      persona,
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+    })
 
     expect(mention.stable).toBe(catchUp.stable)
     expect(otherMentioner.stable).toBe(catchUp.stable)
@@ -622,29 +708,33 @@ describe("buildSystemPrompt cache split", () => {
   })
 
   test("keeps a fired follow-up's note and time out of the stable half", () => {
-    const followUp = buildSystemPrompt(
+    const followUp = buildSystemPrompt({
       persona,
-      temporalContext,
-      null,
-      { kind: "follow_up", followUpId: "fup_test" },
-      undefined,
-      null,
-      [],
-      null,
-      null,
-      {
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "follow_up", followUpId: "fup_test" },
+      rollingConversationSummary: null,
+      tools: [],
+      conversationTopic: null,
+      spawnedFromContext: null,
+      followUp: {
         note: "revisit the rollback plan",
         scheduledFor: new Date("2026-07-04T09:00:00.000Z"),
-      }
-    )
-    const catchUp = buildSystemPrompt(persona, temporalContext, null, { kind: "catch_up" })
+      },
+    })
+    const catchUp = buildSystemPrompt({
+      persona,
+      context: temporalContext,
+      scratchpadCustomPrompt: null,
+      purpose: { kind: "catch_up" },
+    })
 
     expect(followUp.stable).toBe(catchUp.stable)
     expect(followUp.volatile).toContain("revisit the rollback plan")
   })
 
   test("rejoins to exactly the prompt a single-string caller would have got", () => {
-    const split = buildSystemPrompt(persona, temporalContext, "Be concise.")
+    const split = buildSystemPrompt({ persona, context: temporalContext, scratchpadCustomPrompt: "Be concise." })
 
     expect(joinSystemPrompt(split)).toBe(split.stable + split.volatile)
     expect(joinSystemPrompt(split)).toContain("## Current Time")

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -95,13 +95,23 @@ export interface SystemPromptInputs {
  * cached half. `turn` — re-derived per turn, so it must not: inside the cached
  * prefix it changes the prefix every turn and the cache is never read back.
  *
- * This misclassification has shipped four times (temporal grounding, the
- * mention/follow-up section, `## Current Topic` + rolling summary, and the
- * cross-surface stitch), every time silently: no error, no failing test, just a
- * hit rate that never materialises. `Record<keyof SystemPromptInputs, …>` is
- * what makes it structural — adding a field to the interface fails the build
- * until it is classified here, and `system-prompt.cache-stability.test.ts`
- * proves each `turn` entry actually stays out of the cached half.
+ * This misclassification has shipped five times (temporal grounding, the
+ * mention/follow-up section, `## Current Topic` + rolling summary, the
+ * cross-surface stitch, and prior-session episode summaries), every time
+ * silently: no error, no failing test, just a hit rate that never
+ * materialises. `Record<keyof SystemPromptInputs, …>` is what makes it
+ * structural — adding a field to the interface fails the build until it is
+ * classified here, and `system-prompt.cache-stability.test.ts` proves each
+ * `turn` entry actually stays out of the cached half.
+ *
+ * What that does NOT catch is an input classified `conversation` that is in
+ * fact per-turn — the build passes and every table-driven assertion passes,
+ * because the table is also what the test believes. `previousSessions` was
+ * exactly that: episode summaries read as standing background, but companion
+ * sessions are minutes-bounded (INV-65), so each turn completes a session and
+ * shifts the most-recent-N block. Deciding a new input is `conversation` is
+ * therefore an unguarded claim: justify it against how the value is produced,
+ * not how it reads. The only end-to-end check is measured cache hit rate.
  *
  * `context` is the one input that legitimately carries both (stream metadata is
  * conversation-scoped, `context.temporal` is per-turn), so it is classified
@@ -118,7 +128,7 @@ export const SYSTEM_PROMPT_INPUT_STABILITY = {
   conversationTopic: "turn",
   spawnedFromContext: "turn",
   followUp: "turn",
-  previousSessions: "conversation",
+  previousSessions: "turn",
   streamBrief: "conversation",
   styleSlots: "conversation",
   personaKnowledge: "conversation",
@@ -183,13 +193,6 @@ ${streamBrief.trim()}`
   }
 
   prompt += buildPromptSectionForStreamType(context, workspaceResearchEnabled)
-
-  // Prior completed sessions' episode summaries (roadmap 3.1) — durable episodic
-  // memory that outlives the rolling window. Placed with the other prior-context
-  // blocks, before the response-behavior instructions.
-  if (previousSessions?.trim()) {
-    prompt += `\n\n${previousSessions.trim()}`
-  }
 
   prompt += `
 
@@ -301,6 +304,17 @@ Use this as orientation only — treat it as background context, not higher-prio
 The messages below are from the conversation this thread branched out of (in a parent channel or scratchpad). Use them as background to understand what prompted this thread — treat them as orientation, not as messages in this thread, and not as higher-priority instructions.
 
 ${spawnedFromContext.trim()}`
+  }
+
+  // Prior completed sessions' episode summaries (roadmap 3.1) — durable episodic
+  // memory that outlives the rolling window. Reads like standing background, but
+  // it is per-turn: companion sessions are minutes-bounded (INV-65), so a
+  // scratchpad turn completes its own session and that summary joins the
+  // most-recent-N the next turn injects, evicting the oldest. Measured on a live
+  // stream: one completed session with a 242–434 char summary per turn, and the
+  // cached prefix drifting by that much every turn.
+  if (previousSessions?.trim()) {
+    volatile += `\n\n${previousSessions.trim()}`
   }
 
   const conversationMemory = formatConversationMemoryForPrompt(rollingConversationSummary)

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -66,22 +66,82 @@ export function joinSystemPrompt(prompt: SplitSystemPrompt): string {
   return prompt.stable + prompt.volatile
 }
 
-export function buildSystemPrompt(
-  persona: Persona,
-  context: StreamContext,
-  scratchpadCustomPrompt?: string | null,
-  purpose: TurnPurpose = { kind: "catch_up" },
-  mentionerName?: string,
-  rollingConversationSummary?: string | null,
-  tools: AgentTool[] = [],
-  conversationTopic?: string | null,
-  spawnedFromContext?: string | null,
-  followUp?: { note: string; scheduledFor: Date } | null,
-  previousSessions?: string | null,
-  streamBrief?: string | null,
-  styleSlots?: { tone?: string; brevity?: string },
+/**
+ * Everything the system prompt is built from. Named rather than positional so
+ * each input can be classified below — and so a new one cannot be added without
+ * making that classification.
+ */
+export interface SystemPromptInputs {
+  persona: Persona
+  context: StreamContext
+  scratchpadCustomPrompt?: string | null
+  purpose?: TurnPurpose
+  mentionerName?: string
+  rollingConversationSummary?: string | null
+  tools?: AgentTool[]
+  conversationTopic?: string | null
+  spawnedFromContext?: string | null
+  followUp?: { note: string; scheduledFor: Date } | null
+  previousSessions?: string | null
+  streamBrief?: string | null
+  styleSlots?: { tone?: string; brevity?: string }
   personaKnowledge?: PersonaAttachmentContentItem[] | null
-): SplitSystemPrompt {
+}
+
+/**
+ * Where a change to each input is allowed to show up.
+ *
+ * `conversation` — holds for the conversation's lifetime, so it may sit in the
+ * cached half. `turn` — re-derived per turn, so it must not: inside the cached
+ * prefix it changes the prefix every turn and the cache is never read back.
+ *
+ * This misclassification has shipped four times (temporal grounding, the
+ * mention/follow-up section, `## Current Topic` + rolling summary, and the
+ * cross-surface stitch), every time silently: no error, no failing test, just a
+ * hit rate that never materialises. `Record<keyof SystemPromptInputs, …>` is
+ * what makes it structural — adding a field to the interface fails the build
+ * until it is classified here, and `system-prompt.cache-stability.test.ts`
+ * proves each `turn` entry actually stays out of the cached half.
+ *
+ * `context` is the one input that legitimately carries both (stream metadata is
+ * conversation-scoped, `context.temporal` is per-turn), so it is classified
+ * `mixed` and covered by its own dedicated assertions in that test.
+ */
+export const SYSTEM_PROMPT_INPUT_STABILITY = {
+  persona: "conversation",
+  context: "mixed",
+  scratchpadCustomPrompt: "conversation",
+  purpose: "turn",
+  mentionerName: "turn",
+  rollingConversationSummary: "turn",
+  tools: "conversation",
+  conversationTopic: "turn",
+  spawnedFromContext: "turn",
+  followUp: "turn",
+  previousSessions: "conversation",
+  streamBrief: "conversation",
+  styleSlots: "conversation",
+  personaKnowledge: "conversation",
+} as const satisfies Record<keyof SystemPromptInputs, "conversation" | "turn" | "mixed">
+
+export function buildSystemPrompt(inputs: SystemPromptInputs): SplitSystemPrompt {
+  const {
+    persona,
+    context,
+    scratchpadCustomPrompt,
+    purpose = { kind: "catch_up" },
+    mentionerName,
+    rollingConversationSummary,
+    tools = [],
+    conversationTopic,
+    spawnedFromContext,
+    followUp,
+    previousSessions,
+    streamBrief,
+    styleSlots,
+    personaKnowledge,
+  } = inputs
+
   if (!persona.systemPrompt) {
     throw new Error(`Persona "${persona.name}" (${persona.id}) has no system prompt configured`)
   }

--- a/apps/backend/src/features/agents/enclave-system-prompt.test.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.test.ts
@@ -45,9 +45,11 @@ describe("buildEnclaveSystemPrompt", () => {
 
     await buildEnclaveSystemPrompt({ pool: {} as Pool, stream: STREAM, preferences: PREFS, persona: PERSONA })
 
-    const [, , , , , rollingSummary, tools] = build.mock.calls[0]!
-    expect(rollingSummary).toBeNull() // no plaintext history to summarize
-    expect(tools).toEqual([]) // tool prose is assembled in-enclave (run-turn)
+    // Named inputs, so the assertion reads as the contract rather than as
+    // positional archaeology.
+    const [inputs] = build.mock.calls[0]!
+    expect(inputs.rollingConversationSummary).toBeNull() // no plaintext history to summarize
+    expect(inputs.tools).toEqual([]) // tool prose is assembled in-enclave (run-turn)
   })
 
   it("carries the persona's tone/brevity preset fragments into the prompt (enclave parity)", async () => {

--- a/apps/backend/src/features/agents/enclave-system-prompt.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.ts
@@ -54,30 +54,22 @@ export async function buildEnclaveSystemPrompt(params: {
     updatedAt: new Date(),
   }
 
-  const prompt = buildSystemPrompt(
-    enclavePersona,
+  const prompt = buildSystemPrompt({
+    persona: enclavePersona,
     context,
-    preferences.scratchpadCustomPrompt,
-    undefined,
-    undefined,
+    scratchpadCustomPrompt: preferences.scratchpadCustomPrompt,
     // No rolling conversation summary — that's derived from plaintext history
     // the backend can't read for an E2E stream.
-    null,
+    rollingConversationSummary: null,
     // No tool sections server-side: the enclave appends them from its real
     // toolset (see the module doc above).
-    [],
-    // ENCLAVE PARITY: the intervening positional args default undefined, but
-    // styleSlots MUST be passed explicitly — the enclave resolves the persona
-    // server-side, so a set tone/brevity preset has to reach the same prompt
-    // builder here or the encrypted turn silently diverges from the in-process
-    // companion's response style.
-    null,
-    null,
-    null,
-    null,
-    null,
-    resolvePersonaStyleSlots(enclavePersona)
-  )
+    tools: [],
+    // ENCLAVE PARITY: styleSlots must be passed — the enclave resolves the
+    // persona server-side, so a set tone/brevity preset has to reach the same
+    // prompt builder here or the encrypted turn silently diverges from the
+    // in-process companion's response style.
+    styleSlots: resolvePersonaStyleSlots(enclavePersona),
+  })
 
   // The shared prompt advertises the reduced toolset but never explains *why*
   // capabilities are missing. Without this, asked to recall something from the

--- a/apps/backend/src/features/agents/tools/tool-definition-stability.test.ts
+++ b/apps/backend/src/features/agents/tools/tool-definition-stability.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { z } from "zod"
+import { buildToolSet } from "../companion/tool-set"
+
+/**
+ * Tool definitions must be byte-identical across requests.
+ *
+ * They render AHEAD of the system prompt in the prompt-cache prefix, so a
+ * per-request value baked into any tool's `description`, `promptBlock`, or
+ * schema changes the prefix on every call — taking the hit rate for the ENTIRE
+ * toolset to zero, not just that tool's share. This has happened: `web_search`
+ * interpolated the live invocation timestamp into its description, which would
+ * have made prompt caching look like it simply does not work on this stack.
+ *
+ * The companion guard (`system-prompt.cache-stability.test.ts`) covers inputs to
+ * the system prompt; this covers the region before it. Both are needed — they
+ * sit on opposite sides of the same cached span.
+ *
+ * Scope, stated plainly: this varies the per-request values the tool set is
+ * actually constructed with today. A tool that interpolated some *other*
+ * per-request value would slip past, because the test cannot vary an input it
+ * does not know about. That residual gap is syntactic rather than behavioural —
+ * see the note in the PR about where a lint rule earns its place.
+ */
+
+const stub: any = new Proxy(() => stub, { get: () => stub, apply: () => stub })
+
+/** Serialize a tool set to exactly what the model would see. */
+function definitions(over: { currentTime: string; timezone: string; briefVersion: number }) {
+  const tools = buildToolSet({
+    enabledTools: null,
+    tavilyApiKey: "test-key",
+    currentTime: over.currentTime,
+    timezone: over.timezone,
+    briefVersion: over.briefVersion,
+    runWorkspaceAgent: stub,
+    runGeneralResearch: stub,
+    workspace: stub,
+    reactions: stub,
+    followUps: stub,
+    brief: stub,
+    delegation: stub,
+    saveMemo: stub,
+    github: stub,
+    linear: stub,
+    supportsVision: true,
+  })
+
+  return new Map(
+    tools.map((t) => [
+      t.name,
+      JSON.stringify({
+        description: t.config.description,
+        promptBlock: t.config.promptBlock ?? null,
+        schema: z.toJSONSchema(t.config.inputSchema as never, { io: "input" }),
+      }),
+    ])
+  )
+}
+
+describe("tool definition cache stability", () => {
+  const a = definitions({ currentTime: "2026-07-26T10:00:00.000Z", timezone: "Europe/Stockholm", briefVersion: 3 })
+  const b = definitions({ currentTime: "2026-07-26T10:00:31.000Z", timezone: "America/New_York", briefVersion: 4 })
+
+  test("builds a non-empty tool set, so the comparison below cannot pass vacuously", () => {
+    expect(a.size).toBeGreaterThan(20)
+    expect([...a.keys()]).toEqual([...b.keys()])
+  })
+
+  for (const name of [...new Set([...a.keys()])]) {
+    test(`\`${name}\` is byte-identical across differing per-request values`, () => {
+      expect(a.get(name)).toBe(b.get(name))
+    })
+  }
+})

--- a/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
+++ b/apps/backend/tests/integration/persona-attachment-knowledge.test.ts
@@ -7,7 +7,11 @@ import { PersonaAttachmentRepository } from "../../src/features/agents/persona-a
 import { PersonaConfigService } from "../../src/features/agents/persona-config-service"
 import { PersonaRepository } from "../../src/features/agents/persona-repository"
 import { AttachmentService, AttachmentExtractionRepository } from "../../src/features/attachments"
-import { buildSystemPrompt, joinSystemPrompt } from "../../src/features/agents/companion/prompt/system-prompt"
+import {
+  buildSystemPrompt,
+  joinSystemPrompt,
+  type SystemPromptInputs,
+} from "../../src/features/agents/companion/prompt/system-prompt"
 import type { Persona } from "../../src/features/agents/persona-repository"
 import type { StreamContext } from "../../src/features/agents/context-builder"
 import { setupTestDatabase, withTestTransaction, withTransaction } from "./setup"
@@ -16,7 +20,7 @@ import { setupTestDatabase, withTestTransaction, withTransaction } from "./setup
  * The builder returns a prompt split at its prompt-cache boundary; these
  * assertions are about the assembled prompt, so rejoin it.
  */
-const buildPrompt = (...args: Parameters<typeof buildSystemPrompt>) => joinSystemPrompt(buildSystemPrompt(...args))
+const buildPrompt = (inputs: SystemPromptInputs) => joinSystemPrompt(buildSystemPrompt(inputs))
 
 /**
  * End-to-end proof of the persona-context-attachments prompt path against a real
@@ -128,22 +132,19 @@ describe("persona context attachments → dispatch prompt (integration)", () => 
       expect(knowledge.map((k) => k.filename)).toEqual(["runbook.md", "draft-notes.txt"])
       expect(knowledge[0]!.fullText).toBe(runbookText)
 
-      const prompt = buildPrompt(
+      const prompt = buildPrompt({
         persona,
-        scratchpadContext,
-        null,
-        undefined,
-        undefined,
-        null,
-        [],
-        null,
-        null,
-        null,
-        null,
-        null,
-        undefined,
-        knowledge
-      )
+        context: scratchpadContext,
+        scratchpadCustomPrompt: null,
+        rollingConversationSummary: null,
+        tools: [],
+        conversationTopic: null,
+        spawnedFromContext: null,
+        followUp: null,
+        previousSessions: null,
+        streamBrief: null,
+        personaKnowledge: knowledge,
+      })
 
       expect(prompt).toContain("## Knowledge")
       expect(prompt).toContain("### runbook.md")
@@ -190,23 +191,26 @@ describe("persona context attachments → dispatch prompt (integration)", () => 
       const leaked = await PersonaAttachmentRepository.listForPersonaWithContent(client, otherWorkspaceId, personaRowId)
       expect(leaked).toEqual([])
 
-      const base = buildPrompt(persona, scratchpadContext, null, undefined, undefined, null, [])
-      const withForeign = buildPrompt(
+      const base = buildPrompt({
         persona,
-        scratchpadContext,
-        null,
-        undefined,
-        undefined,
-        null,
-        [],
-        null,
-        null,
-        null,
-        null,
-        null,
-        undefined,
-        leaked
-      )
+        context: scratchpadContext,
+        scratchpadCustomPrompt: null,
+        rollingConversationSummary: null,
+        tools: [],
+      })
+      const withForeign = buildPrompt({
+        persona,
+        context: scratchpadContext,
+        scratchpadCustomPrompt: null,
+        rollingConversationSummary: null,
+        tools: [],
+        conversationTopic: null,
+        spawnedFromContext: null,
+        followUp: null,
+        previousSessions: null,
+        streamBrief: null,
+        personaKnowledge: leaked,
+      })
       expect(withForeign).toBe(base)
       expect(base).not.toContain("## Knowledge")
     })
@@ -524,22 +528,19 @@ describe("PersonaConfigService.attachFromExisting → copy-on-attach (integratio
 
       // The REAL prompt path carries the copied content under the persona.
       const knowledge = await PersonaAttachmentRepository.listForPersonaWithContent(pool, workspaceId, personaRow.id)
-      const prompt = buildPrompt(
-        { ...persona, id: personaRow.id, workspaceId, systemPrompt: "Base system prompt" },
-        scratchpadContext,
-        null,
-        undefined,
-        undefined,
-        null,
-        [],
-        null,
-        null,
-        null,
-        null,
-        null,
-        undefined,
-        knowledge
-      )
+      const prompt = buildPrompt({
+        persona: { ...persona, id: personaRow.id, workspaceId, systemPrompt: "Base system prompt" },
+        context: scratchpadContext,
+        scratchpadCustomPrompt: null,
+        rollingConversationSummary: null,
+        tools: [],
+        conversationTopic: null,
+        spawnedFromContext: null,
+        followUp: null,
+        previousSessions: null,
+        streamBrief: null,
+        personaKnowledge: knowledge,
+      })
       expect(prompt).toContain("## Knowledge")
       expect(prompt).toContain("### runbook.md")
       expect(prompt).toContain(sourceText)


### PR DESCRIPTION
## Why

Per-turn content leaking into the prompt's **cached half** has now shipped four times in this stack alone:

1. temporal grounding (found while building #1553)
2. the mention / follow-up section (found by both #1553 reviewers, independently)
3. `## Current Topic` + the rolling conversation summary (found by CodeRabbit)
4. the cross-surface stitch (found by a re-review)

Every one was **invisible**. The prompt stays correct, every test passes, nothing errors — the only symptom is a cache hit rate that never materialises. And each fix added an assertion for the section that leaked, which is precisely why the next one was missed: the guard was a list of known cases, not a property.

## What changed

`buildSystemPrompt` takes **named inputs** instead of fourteen positional arguments, and `SYSTEM_PROMPT_INPUT_STABILITY` classifies each one as `conversation` (may sit in the cached half) or `turn` (must not).

Two things make this structural rather than another reminder:

- **The table is compiler-enforced.** Typed `Record<keyof SystemPromptInputs, …>`, so adding an input fails the build until it is classified. Verified by adding an unclassified field and confirming `tsc` rejects it.
- **The test is driven by the table, not by a list of sections.** `system-prompt.cache-stability.test.ts` builds each `turn`-classified input with a sentinel value and proves it absent from the cached half. A cross-check asserts the table and the sentinel cases cover the same set, so neither can drift ahead of the other.

`context` is the one input carrying both kinds (stream metadata is conversation-scoped, `context.temporal` is per-turn). It's classified `mixed` with dedicated assertions, since the table can't express a per-field split.

## Verification

**The guard was verified to actually fail**, which is the part that matters: reintroducing the `## Current Topic` bug fails two tests (the input-specific one and the byte-identity property); restoring it passes all ten. A guard that has never been seen to fail is not evidence of anything.

Typecheck clean; 3,236 backend agent assertions passing.

## Note

Named inputs also retire the enclave call site's comment apologising for its five consecutive `null`s — the positional signature was the ergonomic problem that made the classification easy to get wrong in the first place.


---

## Second guard: tool definitions

Added in the same PR because it is the other half of the same cached span.

Tool definitions render **ahead** of the system prompt in the prefix, so a per-request value in any tool's `description`, `promptBlock`, or schema zeroes the hit rate for the *entire* toolset. That is the bug this whole stack started from — `web_search` interpolating the live invocation timestamp — and until now it was covered only by one hand-written assertion inside `web_search`'s own test, which a newly added tool would not inherit.

`tool-definition-stability.test.ts` builds the real tool set twice with differing `currentTime`, `timezone`, and `briefVersion` and asserts every definition byte-identical, one test per tool so a failure names the offender. **Verified by reintroducing the original bug**: that tool's test fails, the other thirty pass.

## On a lint rule

Considered, and it is a genuine complement rather than a substitute — but it loses on the case that motivated it:

- **`packages/agent-runtime` is not linted.** Only `apps/*` have ESLint configs and appear in the root `lint` script. `web-search-tool.ts` — the file with the original bug — lives there, so a rule targeting tool definitions would not run on it without first adding lint infrastructure to `packages/`.
- **Lint cannot see behaviour.** A tool reading a clock through any indirection is invisible to an AST rule; the test catches it regardless of how the value arrives.

Where a rule *would* earn its place is the residual gap named above: this test varies the per-request inputs it knows about, so a tool interpolating some *other* per-request value slips past. A rule keyed on **scope** rather than value would catch that class — inside a `defineAgentTool({…})` call, `description` and `promptBlock` may only interpolate module-scope bindings. That discriminates correctly on the real cases: `${MAX_FOLLOW_UP_HORIZON_DAYS}` (module const) passes, `${recencyHint}` (derived from a factory parameter) fails.

Not built here: it needs lint coverage for `packages/` first, and the behavioural guard closes the demonstrated gap. Worth doing as its own change if we want the earlier, in-editor feedback.
