### PR TITLE
feat(calls): keep chat beside the video in desktop fullscreen

### DIFF
--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -15,9 +15,7 @@ import {
   useCallStreamId,
   useCallWorkspaceId,
 } from "./call-store-hooks"
-import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
-import { resolveDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
-import { useDesktopSurfaceOverride } from "./call-store-hooks"
+import { getCallState, setCallSurfaceMode } from "@/stores/call-store"
 
 // The mute / camera / flip / leave controls, one component each so the compact
 // island and the (later) desktop pill share one implementation instead of
@@ -119,9 +117,6 @@ export function ChatButton({ className }: { className?: string }) {
   const streamId = useCallStreamId()
   const chatAnchorId = useCallChatAnchor()
   const isMobile = useIsMobile()
-  const desktopSurfaceOverride = useDesktopSurfaceOverride()
-  const { desktopCallSurface, lastDesktopSurface } = useCallPrefs()
-  const desktopSurface = resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, desktopSurfaceOverride)
   if (!workspaceId || !streamId || !chatAnchorId) return null
   const search = new URLSearchParams({ panel: createDraftPanelId(streamId, chatAnchorId) }).toString()
   return (
@@ -131,10 +126,10 @@ export function ChatButton({ className }: { className?: string }) {
         aria-label="Open call chat"
         title="Open call chat"
         onClick={() => {
-          // The fullscreen mobile surface is an opaque route-independent overlay —
-          // without collapsing it the thread panel opens invisibly underneath.
+          // On mobile the fullscreen surface replaces the whole screen and the panel
+          // takes over the main column — without collapsing it the thread panel opens
+          // invisibly underneath.
           if (isMobile && getCallState().surfaceMode === "full") setCallSurfaceMode("standard")
-          if (!isMobile && desktopSurface === "fullscreen") setDesktopSurfaceOverride("sidebar")
         }}
       >
         <MessageSquare className="h-4 w-4" />

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -176,7 +176,7 @@ describe("CallControls — call chat", () => {
   it.each([
     ["configured fullscreen", "fullscreen", "floating"],
     ["keep-last fullscreen", "keep_last", "fullscreen"],
-  ] as const)("reveals chat from %s without rewriting the last-surface preference", (_, pref, last) => {
+  ] as const)("reveals chat from %s without touching the desktop surface", (_, pref, last) => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
     setDesktopCallSurface(pref)
     setLastDesktopSurface(last)
@@ -191,12 +191,17 @@ describe("CallControls — call chat", () => {
       setCallPhase("connected")
     })
     renderRouted(makeManager())
-    fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
-    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
-    expect(getCallPrefs().lastDesktopSurface).toBe(last)
+    const chat = screen.getByRole("link", { name: "Open call chat" })
+    fireEvent.click(chat)
+    // The overlay leaves the panel column free (--panel-inset-right), so chat opens
+    // beside the video instead of ejecting the user out of fullscreen.
+    expect(chat.getAttribute("href") ?? "").toContain("draft%3Astream_1%3Aevent_chat_1")
+    expect(getCallState().desktopSurfaceOverride).toBeNull()
+    expect(getCallPrefs()).toMatchObject({ desktopCallSurface: pref, lastDesktopSurface: last })
   })
 
-  it("collapses the fullscreen surface when chat opens (panel would render under the overlay)", () => {
+  it("keeps the desktop fullscreen surface when chat opens", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
     act(() => {
       setCallSession({
         callId: "call_1",
@@ -211,7 +216,25 @@ describe("CallControls — call chat", () => {
     })
     renderRouted(makeManager())
     fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
-    expect(getCallState().desktopSurfaceOverride).toBe("sidebar")
+    expect(getCallState()).toMatchObject({ desktopSurfaceOverride: "fullscreen", surfaceMode: "standard" })
+  })
+
+  it("collapses the mobile full surface when chat opens (panel takes over the screen there)", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    act(() => {
+      setCallSession({
+        callId: "call_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: "video",
+        chatAnchorId: "event_chat_1",
+      })
+      setCallPhase("connected")
+      setCallSurfaceMode("full")
+    })
+    renderRouted(makeManager())
+    fireEvent.click(screen.getByRole("link", { name: "Open call chat" }))
+    expect(getCallState().surfaceMode).toBe("standard")
   })
 
   it("hides the chat control until the anchor is known", () => {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -490,6 +490,19 @@ describe("CallDock — desktop surface routing", () => {
     expect(getCallPrefs().filmstripSide).toBe("side")
   })
 
+  it("leaves the thread panel's column free so call chat renders beside the fullscreen video", () => {
+    setDesktopCallSurface("fullscreen")
+    renderDock(makeManager())
+    act(() => setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+
+    const overlay = screen.getByTestId("desktop-call-fullscreen")
+    expect(overlay.className).not.toContain("right-0")
+    expect(overlay.getAttribute("style")).toContain("right: var(--panel-inset-right, 0px)")
+    expect(overlay.getAttribute("style")).toContain(
+      "transition: right var(--panel-inset-duration, 0ms) cubic-bezier(0, 0, 0.2, 1)"
+    )
+  })
+
   it("floating pref surfaces the pre-join permission gate inside the square during an active launch", async () => {
     setDesktopCallSurface("floating")
     const startCall = vi.fn(async () => {

--- a/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
+++ b/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
@@ -84,8 +84,15 @@ export function DesktopCallFullscreen({
     <div
       data-testid="desktop-call-fullscreen"
       data-phase={joining ? "joining" : "connected"}
-      className="fixed inset-y-0 right-0 z-40 flex flex-col bg-background text-foreground"
-      style={{ left: "var(--app-content-left, 0px)" }}
+      className="fixed inset-y-0 z-40 flex flex-col bg-background text-foreground"
+      style={{
+        left: "var(--app-content-left, 0px)",
+        right: "var(--panel-inset-right, 0px)",
+        // cubic-bezier is Tailwind's `ease-out`, which the panel slot animates its
+        // width with. The CSS `ease-out` keyword is a different curve — the two edges
+        // would drift ~70px apart mid-transition and flash the timeline between them.
+        transition: "right var(--panel-inset-duration, 0ms) cubic-bezier(0, 0, 0.2, 1)",
+      }}
     >
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
       <div className="flex items-center gap-2 px-3 py-2">

--- a/apps/frontend/src/components/layout/thread-panel-slot.test.tsx
+++ b/apps/frontend/src/components/layout/thread-panel-slot.test.tsx
@@ -5,6 +5,21 @@ import { ThreadPanelSlot } from "./thread-panel-slot"
 
 function noop() {}
 
+const baseProps = {
+  displayWidth: 420,
+  panelWidth: 420,
+  shouldAnimate: false,
+  showContent: true,
+  isResizing: false,
+  minWidth: 280,
+  maxWidth: 640,
+  onTransitionEnd: noop,
+  onResizeStart: noop,
+  onResizeMove: noop,
+  onResizeEnd: noop,
+  onResizeKeyDown: noop,
+}
+
 function renderSlot(overrides: Partial<ComponentProps<typeof ThreadPanelSlot>> = {}) {
   return render(
     <ThreadPanelSlot
@@ -82,5 +97,32 @@ describe("ThreadPanelSlot — panel inset vars", () => {
     const { unmount } = renderSlot({ shouldAnimate: true })
     unmount()
     expect(inset()).toEqual({ right: "0px", duration: "0ms" })
+  })
+})
+
+describe("ThreadPanelSlot — instance swap", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("style")
+  })
+
+  it("keeps the incoming slot's inset when routes swap one instance for another in a commit", () => {
+    // stream.tsx / board.tsx / persona-editor.tsx each mount their own slot, so
+    // navigating between two of them with a panel open on both unmounts one and
+    // mounts the other in the SAME commit. The consumer (the fullscreen call
+    // overlay) outlives the route, so a teardown that lands after the new mount
+    // leaves it reading 0px over an open panel.
+    const { rerender } = render(
+      <ThreadPanelSlot key="from" {...baseProps} displayWidth={420} panelWidth={420}>
+        <div data-testid="panel-content" />
+      </ThreadPanelSlot>
+    )
+    expect(inset()).toEqual({ right: "420px", duration: "0ms" })
+
+    rerender(
+      <ThreadPanelSlot key="to" {...baseProps} displayWidth={360} panelWidth={360}>
+        <div data-testid="panel-content" />
+      </ThreadPanelSlot>
+    )
+    expect(inset()).toEqual({ right: "360px", duration: "0ms" })
   })
 })

--- a/apps/frontend/src/components/layout/thread-panel-slot.test.tsx
+++ b/apps/frontend/src/components/layout/thread-panel-slot.test.tsx
@@ -1,0 +1,86 @@
+import type { ComponentProps } from "react"
+import { describe, it, expect, beforeEach } from "vitest"
+import { render, screen } from "@/test"
+import { ThreadPanelSlot } from "./thread-panel-slot"
+
+function noop() {}
+
+function renderSlot(overrides: Partial<ComponentProps<typeof ThreadPanelSlot>> = {}) {
+  return render(
+    <ThreadPanelSlot
+      displayWidth={420}
+      panelWidth={420}
+      shouldAnimate={false}
+      showContent
+      isResizing={false}
+      minWidth={280}
+      maxWidth={640}
+      onTransitionEnd={noop}
+      onResizeStart={noop}
+      onResizeMove={noop}
+      onResizeEnd={noop}
+      onResizeKeyDown={noop}
+      {...overrides}
+    >
+      <div data-testid="panel-content" />
+    </ThreadPanelSlot>
+  )
+}
+
+function inset() {
+  const style = document.documentElement.style
+  return {
+    right: style.getPropertyValue("--panel-inset-right"),
+    duration: style.getPropertyValue("--panel-inset-duration"),
+  }
+}
+
+describe("ThreadPanelSlot — panel inset vars", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("style")
+  })
+
+  it("publishes the open panel's width with no duration while it isn't animating", () => {
+    renderSlot()
+    expect(screen.getByTestId("panel-content")).toBeInTheDocument()
+    expect(inset()).toEqual({ right: "420px", duration: "0ms" })
+  })
+
+  it("publishes 0px for a closed panel", () => {
+    renderSlot({ displayWidth: 0, showContent: false })
+    expect(inset()).toEqual({ right: "0px", duration: "0ms" })
+  })
+
+  it("publishes the open/close animation duration while the slot animates", () => {
+    const { rerender } = renderSlot({ shouldAnimate: true })
+    expect(inset()).toEqual({ right: "420px", duration: "200ms" })
+
+    // Dragging the resize handle drops shouldAnimate, so a consumer's edge tracks
+    // the drag instead of lagging a transition behind it.
+    rerender(
+      <ThreadPanelSlot
+        displayWidth={500}
+        panelWidth={500}
+        shouldAnimate={false}
+        showContent
+        isResizing
+        minWidth={280}
+        maxWidth={640}
+        onTransitionEnd={noop}
+        onResizeStart={noop}
+        onResizeMove={noop}
+        onResizeEnd={noop}
+        onResizeKeyDown={noop}
+      >
+        <div data-testid="panel-content" />
+      </ThreadPanelSlot>
+    )
+    expect(inset()).toEqual({ right: "500px", duration: "0ms" })
+  })
+
+  it("resets the inset when the slot unmounts", () => {
+    const { unmount } = renderSlot({ shouldAnimate: true })
+    unmount()
+    expect(inset()).toEqual({ right: "0px", duration: "0ms" })
+  })
+})

--- a/apps/frontend/src/components/layout/thread-panel-slot.tsx
+++ b/apps/frontend/src/components/layout/thread-panel-slot.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from "react"
+import { useLayoutEffect } from "react"
 import { cn } from "@/lib/utils"
 import { PanelResizeHandle } from "./panel-resize-handle"
 
@@ -43,7 +43,12 @@ export function ThreadPanelSlot({
     root.style.setProperty("--panel-inset-duration", shouldAnimate ? `${PANEL_TRANSITION_MS}ms` : "0ms")
   }, [displayWidth, shouldAnimate])
 
-  useEffect(
+  // A layout-effect cleanup, not a passive one: routes that each mount their own
+  // slot swap instances within a single commit, and React runs every layout
+  // teardown before any layout setup — so the outgoing reset lands before the
+  // incoming write. As a passive cleanup it would run after paint and blank the
+  // inset the new slot had just published.
+  useLayoutEffect(
     () => () => {
       const root = document.documentElement
       root.style.setProperty("--panel-inset-right", "0px")

--- a/apps/frontend/src/components/layout/thread-panel-slot.tsx
+++ b/apps/frontend/src/components/layout/thread-panel-slot.tsx
@@ -1,5 +1,10 @@
+import { useEffect, useLayoutEffect } from "react"
 import { cn } from "@/lib/utils"
 import { PanelResizeHandle } from "./panel-resize-handle"
+
+// Keep in sync with the `duration-200` class on the slot: consumers of
+// `--panel-inset-duration` animate their edge against this element's width.
+const PANEL_TRANSITION_MS = 200
 
 interface ThreadPanelSlotProps {
   displayWidth: number
@@ -32,6 +37,21 @@ export function ThreadPanelSlot({
   onResizeKeyDown,
   children,
 }: ThreadPanelSlotProps) {
+  useLayoutEffect(() => {
+    const root = document.documentElement
+    root.style.setProperty("--panel-inset-right", `${displayWidth}px`)
+    root.style.setProperty("--panel-inset-duration", shouldAnimate ? `${PANEL_TRANSITION_MS}ms` : "0ms")
+  }, [displayWidth, shouldAnimate])
+
+  useEffect(
+    () => () => {
+      const root = document.documentElement
+      root.style.setProperty("--panel-inset-right", "0px")
+      root.style.setProperty("--panel-inset-duration", "0ms")
+    },
+    []
+  )
+
   return (
     <div
       data-testid="panel"

--- a/docs/plans/calls-fullscreen-chat.md
+++ b/docs/plans/calls-fullscreen-chat.md
@@ -1,6 +1,6 @@
 # Calls — chat while in fullscreen
 
-Status: **scoped, awaiting a pick.** No code written.
+Status: **Option A built.** Ratified by Kris 2026-07-26; implemented in this branch.
 
 ## The complaint
 
@@ -41,23 +41,31 @@ should not ride on this fix. Recorded as its own item, not planned here.
 Publish the panel's live width as a CSS var and have the fullscreen overlay stop
 short of it.
 
-- `usePanelLayout` writes `--panel-inset-right` = effective panel width when open,
-  `0px` when closed — exactly mirroring what `desktop-call-dock` already does with
-  `--call-dock-inset-right`, including the unmount reset.
-- `DesktopCallFullscreen` renders with `right: var(--panel-inset-right, 0px)`.
+- `ThreadPanelSlot` — the single component that owns the desktop panel column, and
+  the one the mobile take-over path never mounts — writes `--panel-inset-right` =
+  its display width, and `--panel-inset-duration` = `200ms` while it animates,
+  `0ms` while the user drags the resize handle. Mirrors what `desktop-call-dock`
+  does with `--call-dock-inset-right`, unmount reset included.
+- `DesktopCallFullscreen` renders with `right: var(--panel-inset-right, 0px)` and
+  transitions that edge over `--panel-inset-duration` using Tailwind's `ease-out`
+  curve — the CSS `ease-out` keyword is a different curve and the two edges drift
+  ~70px apart mid-transition, flashing the timeline between them.
 - `ChatButton` drops the desktop eject. Fullscreen stays fullscreen; the thread
   panel appears in the reserved column.
 
-Why it works cleanly: in fullscreen the dock sets `--call-dock-inset-right` to `0`
-(`desktop-call-dock.tsx:374`), so `<main>` is full-width beneath and its panel
-already sits flush against the viewport's right edge — the gap the overlay leaves
-lands exactly on it. One mount of the panel, no duplicate subscriptions or draft
-state, and the chat is the same `StreamPanel` as everywhere else.
+Why it works cleanly: in fullscreen the side dock unmounts and its cleanup resets
+`--call-dock-inset-right` to `0`, so `<main>` is full-width beneath and its panel
+sits flush against the viewport's right edge — the gap the overlay leaves lands
+exactly on it. One mount of the panel, no duplicate subscriptions or draft state,
+and the chat is the same `StreamPanel` as everywhere else.
 
-Cost: one CSS var, one style line, one deletion. Watch: the panel's resize handle
-sits on the boundary the overlay's edge now occupies (give the overlay a small
-right offset or let the handle own the z-order), and the overlay must animate its
-right edge in step with the panel's open/close transition.
+Cost: one CSS var pair, one style line, one deletion. Browser-verified at 1280px:
+overlay `x=260 w=540` ends exactly where the panel starts (`x=800 w=480`).
+
+`ThreadPanelSlot` has a third mount besides `stream.tsx` and `board.tsx` — the
+persona editor's test-chat pane (`pages/persona-editor.tsx`). It publishes the
+same inset, so a fullscreen call over that route would reserve a column for the
+test pane. Harmless and vanishingly rare; left alone deliberately.
 
 Mobile is unchanged: the panel replaces the main column there, so fullscreen
 collapsing to `standard` stays correct.

--- a/docs/plans/calls-fullscreen-chat.md
+++ b/docs/plans/calls-fullscreen-chat.md
@@ -1,0 +1,86 @@
+# Calls — chat while in fullscreen
+
+Status: **scoped, awaiting a pick.** No code written.
+
+## The complaint
+
+Opening call chat from fullscreen throws you out of fullscreen.
+`ChatButton` (`apps/frontend/src/components/call/call-control-buttons.tsx:117`)
+navigates to `?panel=draft:<streamId>:<chatAnchorId>` and, on the way, forces the
+surface down: `setDesktopSurfaceOverride("sidebar")` on desktop,
+`setCallSurfaceMode("standard")` on mobile.
+
+That eject is deliberate, not sloppy. The fullscreen surface is an opaque overlay
+(`desktop-call-fullscreen.tsx:87`, `fixed inset-y-0 right-0 z-40`, left edge at
+`--app-content-left`) mounted _outside_ `PanelProvider`
+(`workspace-layout.tsx:481-528`: `<CallDock />` sits after the provider closes).
+Without the eject the thread panel opens underneath the overlay, invisible.
+
+## Is a pane revamp the answer?
+
+Partly — the diagnosis is right, the revamp is not needed to fix this.
+
+**Every non-fullscreen case already is the split.** With the side dock, the
+desktop layout is nav | timeline | thread panel | call dock: `<main>` reserves
+room via `--call-dock-inset-right` (`app-shell.tsx:463`,
+`desktop-call-dock.tsx:377`) and the route's own resizable split renders the
+panel (`stream.tsx` + `usePanelLayout`). Call chat there is the ordinary thread
+panel and it works today. Nothing bespoke is warranted; nothing needs building.
+
+**Fullscreen is the single case that opted out of the layout system.** It is an
+overlay because it must survive navigation and carry no URL state. So the fix is
+to make the overlay respect the panel instead of covering it.
+
+The full pane revamp — one owner laying out `{main, panel, call}` so the call
+becomes a pane rather than an overlay — is a genuinely bigger idea (it also gives
+side-by-side threads, call-as-pane on any route, persisted pane geometry). It
+should not ride on this fix. Recorded as its own item, not planned here.
+
+## Option A — reserve the panel column (recommended)
+
+Publish the panel's live width as a CSS var and have the fullscreen overlay stop
+short of it.
+
+- `usePanelLayout` writes `--panel-inset-right` = effective panel width when open,
+  `0px` when closed — exactly mirroring what `desktop-call-dock` already does with
+  `--call-dock-inset-right`, including the unmount reset.
+- `DesktopCallFullscreen` renders with `right: var(--panel-inset-right, 0px)`.
+- `ChatButton` drops the desktop eject. Fullscreen stays fullscreen; the thread
+  panel appears in the reserved column.
+
+Why it works cleanly: in fullscreen the dock sets `--call-dock-inset-right` to `0`
+(`desktop-call-dock.tsx:374`), so `<main>` is full-width beneath and its panel
+already sits flush against the viewport's right edge — the gap the overlay leaves
+lands exactly on it. One mount of the panel, no duplicate subscriptions or draft
+state, and the chat is the same `StreamPanel` as everywhere else.
+
+Cost: one CSS var, one style line, one deletion. Watch: the panel's resize handle
+sits on the boundary the overlay's edge now occupies (give the overlay a small
+right offset or let the handle own the z-order), and the overlay must animate its
+right edge in step with the panel's open/close transition.
+
+Mobile is unchanged: the panel replaces the main column there, so fullscreen
+collapsing to `standard` stays correct.
+
+## Option B — chat pane inside the overlay
+
+Move `<CallDock />` inside `PanelProvider` and let the fullscreen surface render
+`<PanelHost>` itself in a right column.
+
+Rejected: the route underneath still mounts its own panel for the same
+`?panel=` value, so the thread mounts twice — duplicate fetches, duplicate
+composer/draft state. Avoiding that means one owner deciding who renders the
+panel, which is the pane revamp, not this fix.
+
+## Option C — do nothing but make the eject honest
+
+Keep the surface switch, but announce it and restore fullscreen when the chat
+panel closes. Cheapest, still surprising. Only worth it if Option A's edge
+alignment turns out worse in practice than it reads.
+
+## Decision needed
+
+Confirm Option A. Then it is a single small PR: `--panel-inset-right` +
+fullscreen `right` + drop the desktop eject, with tests covering
+fullscreen-with-panel geometry and that the desktop surface no longer changes
+when chat opens.

--- a/docs/plans/calls-multi-device-participation.md
+++ b/docs/plans/calls-multi-device-participation.md
@@ -1,0 +1,109 @@
+# Calls — same user on multiple devices
+
+Status: **scoped, not ratified.** Inventory only; no code written.
+
+## Why
+
+Two real workflows from daily use:
+
+1. **Handoff.** Call in from the phone on the commute, arrive at the desk, join on
+   the laptop — the session should _move_ to the laptop.
+2. **Split roles.** Laptop shares the screen but its mic is broken, so the phone
+   carries audio. Both legs live at once, deliberately.
+
+A third, later: **presented mode** — join only to publish a screen, no mic/camera.
+
+## What happens today
+
+A second device is rejected. `CallService.admitEndpoint`
+(`apps/backend/src/features/calls/service.ts:361`) throws 409
+`CALL_ENDPOINT_ACTIVE` when a `connected` endpoint on a _different_ media
+incarnation already exists for the participant. The frontend never passes
+`takeover`, so the 409 surfaces as an error toast and nothing else.
+
+Same-device reconnects are not affected: a `reconnecting` endpoint, an endpoint
+with no incarnation yet, or one carrying _this_ incarnation is rebound to the
+same row and epoch (`service.ts:380-397`).
+
+The one-live-endpoint rule is enforced in the schema, not just in code:
+
+```sql
+CREATE UNIQUE INDEX idx_call_endpoints_live_per_participant
+  ON call_endpoints (workspace_id, call_id, participant_id)
+  WHERE status IN ('connected', 'reconnecting');
+```
+
+(`apps/backend/src/db/migrations/20260719120000_calls.sql:106`)
+
+`ActiveElsewhereChip` (`apps/frontend/src/components/call/active-elsewhere-chip.tsx`)
+is _not_ this case — it reports the Web Lock being held by another **tab** in the
+same browser, not another device.
+
+## Feature 1 — "Join on this device" (handoff)
+
+**The server already implements it.** `takeover: true` closes the prior endpoint
+under the call-row lock, tears down its CF session after commit (INV-41), and
+mints a higher epoch (`service.ts:399-419`). The signaling gateway accepts the
+flag too (`signaling-gateway.ts:45`).
+
+Work is frontend-only:
+
+- Catch 409 `CALL_ENDPOINT_ACTIVE` on join/start and, instead of a toast, prompt:
+  **Join on this device** (retry with `takeover: true`) / **Cancel**.
+- The displaced device needs a clear terminal state, not a silent disconnect: it
+  gets its endpoint closed out from under it and must render "This call moved to
+  another device" with a rejoin affordance, not a generic transport error.
+
+Open question: whether the displaced device's user should be _asked_ (a
+confirm-on-the-old-device handshake) or simply told. Told is simpler and matches
+the mental model — it is the same person on both ends.
+
+## Feature 2 — "Join again" (two live legs)
+
+This is the real change. It is a schema + roster-model change, not a flag.
+
+- **Schema.** The partial unique index above has to go, replaced by a bounded
+  rule (cap legs per participant; the cap must be enforced under the call-row
+  lock so two racing joins can't both pass).
+- **One-endpoint assumptions.** `CallEndpointRepository.findLiveByParticipant`
+  (`repository.ts:1027`) returns _the_ live endpoint; `admitEndpoint` branches on
+  it; `markLeftIfNoLiveEndpoint` already counts correctly but every caller that
+  treats "the participant's endpoint" as singular needs auditing, including the
+  CF pull allow-list (`assertPullableRefs`) and the roster's track registry.
+- **Roster shape.** The roster is participant-keyed and the frontend renders one
+  tile per participant. Two legs means tiles are endpoint-keyed, with the same
+  human identity on two tiles — self-tile detection, the speaking ring, and the
+  mirror rule (`resolveSelfMirror`) all key off "is this me" today.
+- **Echo.** Two legs in the same room with mics live is a feedback loop. Either
+  the second leg joins muted by default, or the client refuses to render/play
+  audio from an endpoint whose participant is self (the safer rule — it is a
+  local playback decision, and it also fixes hearing yourself on handoff overlap).
+- **Leave semantics.** Leaving is already endpoint-scoped
+  (`leaveCall(..., endpointId)`), so per-leg leave works; what needs deciding is
+  whether "Leave" on one leg should offer "leave all my devices".
+
+## Feature 3 — "Join in presented mode" (later)
+
+Blocked on screen share, which does not exist yet (`getDisplayMedia` appears
+nowhere in the frontend). Once dual-feed screen share lands, presented mode is a
+join whose publish policy is screen-only. Note the schema already reserves
+`calls.sharing_endpoint_id` for a server-owned share claim.
+
+## Observed misbehaviour to confirm during the build
+
+- Second-device join → error toast only (explained above: unhandled 409).
+- "Leave call" pressed on the phone while the laptop is the connected device did
+  nothing visible. Most likely the phone's endpoint had already been reaped or
+  closed, so `leaveCall` 404s on `CALL_ENDPOINT_NOT_FOUND` and the UI stays put —
+  i.e. a stale local in-call state, not a remote-hangup feature. **Reproduce and
+  confirm before designing around it.** Whatever the cause, a device must not
+  present call controls for a call it no longer holds an endpoint on, and no
+  surface should offer hanging up _another_ device (takeover is the sanctioned
+  way to displace one).
+
+## Suggested order
+
+1. Handoff prompt + displaced-device state (frontend-only, server ready).
+2. Stale-endpoint UI audit (the "Leave did nothing" case).
+3. Two live legs (schema + roster; own stack).
+4. Presented mode, after screen share.


### PR DESCRIPTION
## Problem

Opening call chat from the desktop fullscreen call surface throws you out of fullscreen. `ChatButton` (`apps/frontend/src/components/call/call-control-buttons.tsx`) navigated to `?panel=draft:<streamId>:<chatAnchorId>` and, on the way, ran `setDesktopSurfaceOverride("sidebar")`.

That eject was deliberate: `DesktopCallFullscreen` is an opaque overlay (`fixed inset-y-0 right-0 z-40`, left edge at `--app-content-left`) mounted *outside* `PanelProvider` — `<CallDock />` sits after the provider closes in `workspace-layout.tsx`. Without the eject the thread panel opened underneath it, invisible.

Every other desktop case already is the split the chat wants: side dock + thread panel = nav | timeline | panel | call. Fullscreen was the one surface that opted out of the layout system.

## Solution

Make the overlay stop short of the thread panel's column, so the existing `StreamPanel` renders beside the video. No new chat component; one mount of the panel.

- `ThreadPanelSlot` publishes `--panel-inset-right` (its display width) and `--panel-inset-duration` on `document.documentElement`, resetting both on unmount — the same pattern `desktop-call-dock.tsx` uses for `--call-dock-inset-right`. It is the single owner of the desktop panel column and the mobile take-over path never mounts it, so it is the right publisher.
- `DesktopCallFullscreen` renders `right: var(--panel-inset-right, 0px)`, transitioning that edge over `--panel-inset-duration`. The duration is `0ms` while the resize handle is being dragged (`shouldAnimate = enableTransition && !isResizing`) so the overlay's edge tracks the drag instead of lagging a transition behind it.
- The transition uses `cubic-bezier(0, 0, 0.2, 1)` — Tailwind's `ease-out`, which the slot animates its width with — not the CSS `ease-out` keyword. The keyword is a different curve: at mid-transition the two edges sit ~70px apart and flash the timeline between the video and the panel.
- `ChatButton` drops the desktop eject and the now-dead `useDesktopSurfaceOverride` / `useCallPrefs` / `resolveDesktopSurface` reads (INV-38). **Mobile keeps collapsing `full` → `standard`**: there the panel takes over the whole main column, so the overlay genuinely has to yield.

Rendering `PanelHost` inside the overlay was rejected — the route beneath still mounts its own panel for the same `?panel=` value, so the thread would mount twice (duplicate fetches, duplicate composer/draft state). Avoiding that needs one owner of the layout, i.e. the pane revamp, which this fix deliberately does not attempt.

Also lands two scoping docs: `docs/plans/calls-fullscreen-chat.md` (this change, incl. the rejected options) and `docs/plans/calls-multi-device-participation.md` — inventory only, no code, recording that server-side call takeover already exists and what "join again" would actually cost.

Known, left alone: `ThreadPanelSlot` has a third mount in `pages/persona-editor.tsx` (the test-chat pane), so a fullscreen call over that route would reserve a column for it. Harmless and vanishingly rare.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/thread-panel-slot.tsx` | Publishes `--panel-inset-right` / `--panel-inset-duration`; resets on unmount |
| `apps/frontend/src/components/call/desktop-call-fullscreen.tsx` | Overlay reserves the panel column and animates its right edge on Tailwind's `ease-out` |
| `apps/frontend/src/components/call/call-control-buttons.tsx` | Desktop eject deleted with its now-dead reads; mobile collapse kept |
| `apps/frontend/src/components/layout/thread-panel-slot.test.tsx` | **new** — inset publish/reset, drag vs animate duration |
| `apps/frontend/src/components/call/call-controls.test.tsx` | Eject tests rewritten to assert the surface is *untouched*; mobile collapse covered |
| `apps/frontend/src/components/call/call-dock.test.tsx` | Fullscreen overlay's `right` / transition wiring on the real mounted surface |
| `docs/plans/calls-fullscreen-chat.md` | **new** — the plan for this change |
| `docs/plans/calls-multi-device-participation.md` | **new** — multi-device inventory, no code |

## Test plan

- [x] `bun run --cwd apps/frontend test` — 5044 tests. 5 first-pass failures, all in `e2e-session-store` / `pin-unlock-modal`, all green on replay and green in isolation (32/32): the known pre-existing vitest localStorage flake, no causal path to a CSS variable on the panel column.
- [x] `bun run --cwd apps/frontend typecheck` · `lint` — clean
- [x] Real two-browser call in Chromium (dev-test stack, fake CF + fake media): fullscreen → open chat → **stays fullscreen**, panel renders beside the video. Geometry at 1280px: overlay `x=260 w=540` ends exactly where the panel begins (`x=800 w=480`), zero overlap, zero gap.
- [ ] Real-device check over Tailscale (`bun run dev:remote`) — pending, Kris driving.

**Fullscreen, before opening chat**

![before](https://seer.build/ws_vbyzjvdg6g/i/img_c0fk3a7vkw/fs-1-before-chat.webp)

**Chat open, still fullscreen**

![after](https://seer.build/ws_vbyzjvdg6g/i/img_r1ev7h2xzx/fs-2-with-chat.webp)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787686612&installation_model_id=20758&pr_number=1557&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1557&signature=40232143c2b896e1178481e76b4f13e9114c1a8938555e832c8409b4ca116ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->