### PR TITLE
feat(sidebar): browse files + copy link in the stream row menu

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -20,7 +20,12 @@ const openStreamSettings = vi.fn()
 
 function LocationEcho() {
   const location = useLocation()
-  return <div data-testid="location">{location.pathname}</div>
+  return (
+    <>
+      <div data-testid="location">{location.pathname}</div>
+      <div data-testid="location-search">{location.search}</div>
+    </>
+  )
 }
 
 function renderWithRouter(ui: React.ReactElement, initialPath = "/w/workspace_1/stream/stream_scratchpad_1") {
@@ -177,6 +182,47 @@ describe("ScratchpadItem", () => {
     )
 
     expect(screen.getByText("Labels…")).toBeInTheDocument()
+  })
+
+  it("copies the scratchpad's link", async () => {
+    const writeText = vi.fn(async () => {})
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad()}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    fireEvent.click(screen.getByText("Copy link"))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/workspace_1/s/stream_scratchpad_1`)
+    })
+  })
+
+  it("opens the attachment explorer scoped to the scratchpad", async () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad()}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    fireEvent.click(screen.getByText("Browse files…"))
+
+    await waitFor(() => {
+      const search = new URLSearchParams(screen.getByTestId("location-search").textContent ?? "")
+      expect(search.has("explorer")).toBe(true)
+      expect(search.get("streams")).toBe("stream_scratchpad_1")
+    })
   })
 
   it("shows the AI companion badge on companion-on scratchpads", () => {

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -6,8 +6,10 @@ import {
   BellOff,
   FileEdit,
   FolderPlus,
+  Link2,
   Lock,
   MessageSquareText,
+  Paperclip,
   Plus,
   Settings,
   Sparkles,
@@ -15,6 +17,7 @@ import {
 } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
+import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { SectionPicker } from "./section-picker"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/hooks"
@@ -25,6 +28,7 @@ import { useStreamSettings } from "@/components/stream-settings/use-stream-setti
 import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { streamFallbackLabel } from "@/lib/streams"
+import { copyStreamLink } from "@/lib/stream-links"
 import { CompanionModes, LabelableResourceTypes } from "@threa/types"
 import { useUrgencyTracking } from "./use-urgency-tracking"
 import {
@@ -87,6 +91,7 @@ export function ScratchpadItem({
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const { collapseOnMobile } = useSidebar()
   const { openStreamSettings } = useStreamSettings()
+  const { open: openExplorer } = useExplorerUrlState()
   const itemRef = useRef<HTMLAnchorElement>(null)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
@@ -185,6 +190,18 @@ export function ScratchpadItem({
               onSelect: () => setLabelPickerOpen(true),
             } satisfies SidebarActionItem,
             {
+              id: "copy-link",
+              label: "Copy link",
+              icon: Link2,
+              onSelect: () => void copyStreamLink(workspaceId, streamWithPreview.id),
+            } satisfies SidebarActionItem,
+            {
+              id: "browse-files",
+              label: "Browse files…",
+              icon: Paperclip,
+              onSelect: () => openExplorer({ streamIds: [streamWithPreview.id] }),
+            } satisfies SidebarActionItem,
+            {
               id: "add-to-section",
               label: "Add to section…",
               icon: FolderPlus,
@@ -201,7 +218,7 @@ export function ScratchpadItem({
         separatorBefore: !isDraft || boardActions.length > 0,
       },
     ],
-    [handleArchive, isDraft, openStreamSettings, streamWithPreview.id, boardActions]
+    [handleArchive, isDraft, openStreamSettings, openExplorer, streamWithPreview.id, workspaceId, boardActions]
   )
 
   const drawerPreview: SidebarActionPreview | null =

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -1,6 +1,6 @@
 import { act, type ReactNode } from "react"
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
-import { MemoryRouter } from "react-router-dom"
+import { MemoryRouter, useLocation } from "react-router-dom"
 import { fireEvent, render, screen, spyOnExport } from "@/test"
 import { StreamTypes, Visibilities } from "@threa/types"
 import { Hash } from "lucide-react"
@@ -28,8 +28,18 @@ const touchState = {
   touchCapable: true,
 }
 
+function LocationSearchEcho() {
+  const location = useLocation()
+  return <div data-testid="location-search">{location.search}</div>
+}
+
 function renderWithRouter(ui: React.ReactElement) {
-  return render(<MemoryRouter>{ui}</MemoryRouter>)
+  return render(
+    <MemoryRouter>
+      {ui}
+      <LocationSearchEcho />
+    </MemoryRouter>
+  )
 }
 
 function createStream(overrides: Partial<StreamItemData> = {}): StreamItemData {
@@ -169,6 +179,35 @@ describe("StreamItem", () => {
     fireEvent.click(screen.getByRole("button", { name: "Settings" }))
 
     expect(openStreamSettings).toHaveBeenCalledWith("stream_general")
+  })
+
+  it("opens the attachment explorer scoped to the stream", async () => {
+    const stream = createStream()
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    fireEvent.touchStart(screen.getByRole("link", { name: /general/i }), {
+      touches: [{ clientX: 16, clientY: 16 }],
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse files…" }))
+
+    const search = new URLSearchParams(screen.getByTestId("location-search").textContent ?? "")
+    expect(search.has("explorer")).toBe(true)
+    expect(search.get("streams")).toBe("stream_general")
   })
 
   it("keeps compact hover previews hidden on mobile", () => {

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -10,12 +10,14 @@ import {
   Loader2,
   Lock,
   MessageSquareText,
+  Paperclip,
   Plus,
   Settings,
   Tag,
 } from "lucide-react"
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
+import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { SectionPicker } from "./section-picker"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
@@ -390,6 +392,7 @@ export function StreamItem({
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const { openStreamSettings } = useStreamSettings()
+  const { open: openExplorer } = useExplorerUrlState()
   const { collapseOnMobile } = useSidebar()
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
@@ -498,6 +501,12 @@ export function StreamItem({
             onSelect: () => void copyStreamLink(workspaceId, stream.id),
           },
           {
+            id: "browse-files",
+            label: "Browse files…",
+            icon: Paperclip,
+            onSelect: () => openExplorer({ streamIds: [stream.id] }),
+          },
+          {
             id: "add-to-section",
             label: "Add to section…",
             icon: FolderPlus,
@@ -506,7 +515,7 @@ export function StreamItem({
         ]
     if (boardActions.length === 0) return base
     return [...boardActions, ...base.map((a, i) => (i === 0 ? { ...a, separatorBefore: true } : a))]
-  }, [isVirtualDraft, openStreamSettings, stream.id, workspaceId, boardActions])
+  }, [isVirtualDraft, openStreamSettings, openExplorer, stream.id, workspaceId, boardActions])
 
   let drawerPreview: SidebarActionPreview | null = null
   if (preview?.content) {


### PR DESCRIPTION
## Problem

The sidebar row menu (hover "…", right-click, mobile long-press drawer) exposes a strict subset of the menu on the open stream (`pages/stream.tsx`) and the thread panel (`components/thread/stream-panel.tsx`). Channel/DM/thread rows (`stream-item.tsx`) had no **Browse files…**; scratchpad rows (`scratchpad-item.tsx`) had neither that nor **Copy link** — so the only way to copy a scratchpad's link was to open it first.

## Solution

Both sidebar rows now build the same action set as the stream view, minus two deliberate omissions.

- `stream-item.tsx`: adds `browse-files` → `useExplorerUrlState().open({ streamIds: [stream.id] })`, same call the stream view and thread panel make. Virtual drafts keep their empty action list.
- `scratchpad-item.tsx`: adds `copy-link` (`copyStreamLink`) and `browse-files`, both inside the existing `!isDraft` branch — an unsaved draft has no shareable URL and no attachments.
- Explorer state is URL-only (`?explorer&streams=`, INV-59) and `AttachmentExplorer` mounts in `workspace-layout.tsx`, so the sidebar can open it from any workspace route without new wiring. `sidebar.tsx` already calls `useLocation()`, so the per-row `useSearchParams` subscription adds no re-render surface.
- **Move messages…** stays stream-view-only: it dispatches `dispatchStartBatchSelect`, a timeline batch-select flow with nothing to drive it from a sidebar row (Kris's call).
- **Rename** (scratchpad) also stays out: it drives the header's inline title editor, which the sidebar doesn't have; rename remains reachable via Settings. Say the word and it can open settings instead.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | `Browse files…` action |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx` | `Copy link` + `Browse files…` actions |
| `apps/frontend/src/components/layout/sidebar/stream-item.test.tsx` | explorer-scoping test; router harness echoes `location.search` |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx` | copy-link + explorer-scoping tests |

## Test plan

- [x] `bun run --cwd apps/frontend test -- src/components/layout/sidebar` — 218 pass, 0 fail (3 new)
- [x] monorepo lint + typecheck (pre-commit hook) — clean
- [ ] not manually clicked in the running app

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787689569&installation_model_id=20758&pr_number=1558&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1558&signature=f8d507c1b6e58760bfb28313915dc7fe0fdfd1d56d88e5d653cc3219af2de145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->