### PR TITLE
fix(calls): open the existing call-chat thread instead of the draft

### DIFF
--- a/apps/frontend/src/components/call/call-control-buttons.tsx
+++ b/apps/frontend/src/components/call/call-control-buttons.tsx
@@ -5,6 +5,7 @@ import { createDraftPanelId } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useAsyncAction } from "@/hooks/use-async-action"
+import { useAnchoredThreadId } from "@/hooks/use-anchored-thread"
 import { useCallManager } from "./call-manager-context"
 import {
   useCallCameraOn,
@@ -102,10 +103,12 @@ export function FlipButton({ className }: { className?: string }) {
 
 /**
  * Opens the call's chat thread — a thread anchored on the `call_started` event
- * (`chatAnchorId` from the start/join response). Opening the draft panel resolves
- * to the real thread once one exists (chunk-3 auto-redirect) and otherwise starts
- * one on first send, so a single target covers both. Navigation, so a <Link>
- * (INV-40); hidden until the anchor is known.
+ * (`chatAnchorId` from the start/join response). Targets the thread directly once
+ * this client knows it exists; otherwise the draft anchor, which starts one on
+ * first send and self-promotes if the thread was created elsewhere. Linking to
+ * the draft unconditionally is what made a second open flash the empty draft
+ * before redirecting. Navigation, so a <Link> (INV-40); hidden until the anchor
+ * is known.
  *
  * The dock mounts ABOVE `PanelProvider` (it survives navigation and takes no URL
  * state), so it can't call `getPanelUrl`. It builds the absolute host-stream URL
@@ -117,8 +120,10 @@ export function ChatButton({ className }: { className?: string }) {
   const streamId = useCallStreamId()
   const chatAnchorId = useCallChatAnchor()
   const isMobile = useIsMobile()
+  const threadId = useAnchoredThreadId(workspaceId ?? undefined, streamId, chatAnchorId)
   if (!workspaceId || !streamId || !chatAnchorId) return null
-  const search = new URLSearchParams({ panel: createDraftPanelId(streamId, chatAnchorId) }).toString()
+  const panel = threadId ?? createDraftPanelId(streamId, chatAnchorId)
+  const search = new URLSearchParams({ panel }).toString()
   return (
     <Button asChild variant="ghost" size="icon" className={cn("h-9 w-9", className)}>
       <Link

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { fireEvent, render, screen, userEvent } from "@/test"
+import { StreamTypes } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
+import * as workspaceStore from "@/stores/workspace-store"
 import {
   clearCallState,
   getCallState,
@@ -22,6 +24,10 @@ import {
 } from "@/stores/call-prefs-store"
 import { CallControls, DevicePickerMenu } from "./call-controls"
 import { CallManagerProvider } from "./call-manager-context"
+
+// The store's own row type, reached through the hook so this component test does
+// not import `@/db` (INV-15).
+type CachedWorkspaceStream = ReturnType<typeof workspaceStore.useWorkspaceStreamsRaw>[number]
 
 function makeManager(overrides: Partial<CallController> = {}): CallController {
   return {
@@ -171,6 +177,32 @@ describe("CallControls — call chat", () => {
     // on the call_started event id.
     expect(href).toContain("/w/ws_1/s/stream_1")
     expect(href).toContain("draft%3Astream_1%3Aevent_chat_1")
+  })
+
+  it("targets the real thread once the chat thread exists, so no draft flashes first", () => {
+    vi.spyOn(workspaceStore, "useWorkspaceStreamsRaw").mockReturnValue([
+      {
+        id: "stream_chat_thread",
+        workspaceId: "ws_1",
+        type: StreamTypes.THREAD,
+        parentStreamId: "stream_1",
+        parentAnchorId: "event_chat_1",
+      } as CachedWorkspaceStream,
+    ])
+    act(() => {
+      setCallSession({
+        callId: "call_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: "video",
+        chatAnchorId: "event_chat_1",
+      })
+      setCallPhase("connected")
+    })
+    renderRouted(makeManager())
+    const href = screen.getByRole("link", { name: "Open call chat" }).getAttribute("href") ?? ""
+    expect(href).toContain("panel=stream_chat_thread")
+    expect(href).not.toContain("draft")
   })
 
   it.each([

--- a/apps/frontend/src/hooks/use-anchored-thread.test.ts
+++ b/apps/frontend/src/hooks/use-anchored-thread.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { StreamTypes } from "@threa/types"
+import type { CachedStream } from "@/db"
+import * as workspaceStore from "@/stores/workspace-store"
+import { useAnchoredThreadId } from "./use-anchored-thread"
+
+function thread(id: string, parentStreamId: string, anchor: Partial<CachedStream>): CachedStream {
+  return { id, workspaceId: "ws_1", type: StreamTypes.THREAD, parentStreamId, ...anchor } as CachedStream
+}
+
+function seed(streams: CachedStream[]) {
+  vi.spyOn(workspaceStore, "useWorkspaceStreamsRaw").mockReturnValue(streams)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useAnchoredThreadId", () => {
+  it("finds the thread anchored on a card event", () => {
+    seed([thread("stream_thread", "stream_host", { parentAnchorId: "event_card" })])
+    const { result } = renderHook(() => useAnchoredThreadId("ws_1", "stream_host", "event_card"))
+    expect(result.current).toBe("stream_thread")
+  })
+
+  it("falls back to the legacy message anchor on rows cached before parentAnchorId", () => {
+    seed([thread("stream_thread", "stream_host", { parentMessageId: "msg_1" })])
+    const { result } = renderHook(() => useAnchoredThreadId("ws_1", "stream_host", "msg_1"))
+    expect(result.current).toBe("stream_thread")
+  })
+
+  it("is null when no thread carries the anchor, when the parent differs, and when the stream is not a thread", () => {
+    seed([
+      thread("stream_other_anchor", "stream_host", { parentAnchorId: "event_other" }),
+      thread("stream_other_parent", "stream_elsewhere", { parentAnchorId: "event_card" }),
+      {
+        id: "stream_channel",
+        workspaceId: "ws_1",
+        type: StreamTypes.CHANNEL,
+        parentStreamId: "stream_host",
+        parentAnchorId: "event_card",
+      } as CachedStream,
+    ])
+    const { result } = renderHook(() => useAnchoredThreadId("ws_1", "stream_host", "event_card"))
+    expect(result.current).toBeNull()
+  })
+
+  it("is null without a parent stream or an anchor", () => {
+    seed([thread("stream_thread", "stream_host", { parentAnchorId: "event_card" })])
+    expect(renderHook(() => useAnchoredThreadId("ws_1", null, "event_card")).result.current).toBeNull()
+    expect(renderHook(() => useAnchoredThreadId("ws_1", "stream_host", null)).result.current).toBeNull()
+  })
+})

--- a/apps/frontend/src/hooks/use-anchored-thread.ts
+++ b/apps/frontend/src/hooks/use-anchored-thread.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react"
+import { StreamTypes } from "@threa/types"
+import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
+
+/**
+ * The id of the thread already anchored on `anchorId` in `parentStreamId`, or
+ * null when there is none. Covers both anchor tracks (`msg_…` and `event_…`) —
+ * unlike the board's structural index, which excludes card anchors on purpose.
+ *
+ * Cache-only: a null means "no thread known on this client", never "no thread
+ * exists". Callers open the draft anchor in that case and let the draft panel's
+ * promotion resolve it, which is the pre-existing path.
+ */
+export function useAnchoredThreadId(
+  workspaceId: string | undefined,
+  parentStreamId: string | null | undefined,
+  anchorId: string | null | undefined
+): string | null {
+  const streams = useWorkspaceStreamsRaw(workspaceId)
+  return useMemo(() => {
+    if (!parentStreamId || !anchorId) return null
+    const thread = streams.find(
+      (stream) =>
+        stream.type === StreamTypes.THREAD &&
+        stream.parentStreamId === parentStreamId &&
+        (stream.parentAnchorId ?? stream.parentMessageId) === anchorId
+    )
+    return thread?.id ?? null
+  }, [streams, parentStreamId, anchorId])
+}


### PR DESCRIPTION
Stacked on #1557.

## Problem

Opening call chat a second time — after the thread already exists — mounts the empty draft panel ("Start a new thread") and only then redirects to the real thread. Reported from a live call as "ugly AF", and it is: the redirect is visible every time.

`ChatButton` (`apps/frontend/src/components/call/call-control-buttons.tsx`) built its target as `draft:<streamId>:<chatAnchorId>` unconditionally. A draft panel resolves to the real thread through `useExternalThreadDraftPromotion` in `stream-panel.tsx`, which fires *after* the panel has mounted and the anchor event has resolved — so the draft is always painted first.

## Solution

Target the thread directly when this client already knows it exists.

- New `useAnchoredThreadId(workspaceId, parentStreamId, anchorId)` (`apps/frontend/src/hooks/use-anchored-thread.ts`) finds a cached thread whose `parentAnchorId ?? parentMessageId` matches the anchor under that parent. It covers both anchor tracks — unlike the board's `threadsByAnchorId` index (`use-conversation-graph.ts`), which excludes `event_`-anchored threads on purpose, so it could not be reused here.
- `ChatButton` uses that id as the panel target and falls back to the draft anchor otherwise.

Cache-only by design: a miss means "no thread known on this client", not "no thread exists", so the fallback keeps the pre-existing draft-promotion path intact — first-ever open, or a thread created elsewhere before the stream row lands. Nothing regresses; the flash just stops in the case that produces it.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-anchored-thread.ts` | **new** — cached anchor → thread id lookup |
| `apps/frontend/src/hooks/use-anchored-thread.test.ts` | **new** — both anchor tracks, parent scoping, non-thread rows, null args |
| `apps/frontend/src/components/call/call-control-buttons.tsx` | `ChatButton` targets the real thread when known |
| `apps/frontend/src/components/call/call-controls.test.tsx` | Asserts the href is the thread id, not a `draft:` anchor |

## Test plan

- [x] Real two-browser call in Chromium (dev-test stack, fake CF + fake media): opened chat on the draft anchor, sent the first message to create the thread, and the control's href flipped from `draft%3A…` to `?panel=stream_01KYG01Q97S863K52XEGYK13G1`. No draft mount, no redirect.
- [x] `bun run --cwd apps/frontend test` — 5043 pass. 6 first-pass failures (`e2e-session-store`, `BoardCard`, `CustomPersonaEditor`, `BillingTimezoneSection`), all green on replay; the known pre-existing vitest localStorage flake, a different subset each run and none in the touched areas.
- [x] `bun run lint` · `bun run typecheck` (monorepo) · `bun run generate:api-docs:check` — clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787689972&installation_model_id=20758&pr_number=1559&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1559&signature=a039aaf593b597d1a3b4042d91c510262e7de69bfe3e52cfa51ccc74adad7dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->