### PR TITLE
fix(dev): make dev:remote print the URL you should actually open

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -403,7 +403,7 @@ async function main() {
     }
     remoteOrigin =
       tailscaleHttpsPort === 443 ? `https://${tailscale.host}` : `https://${tailscale.host}:${tailscaleHttpsPort}`
-    console.log(`Remote mode: ${remoteOrigin}  (auth callbacks)`)
+    console.log(`Remote mode: ${remoteOrigin}`)
   } else if (lanMode) {
     for (const host of lanHosts) {
       console.log(`LAN mode: http://${host}:3000${host === primaryLanHost ? "  (auth callbacks)" : ""}`)
@@ -583,7 +583,54 @@ async function main() {
   ]
   installDevLifecycle(processes)
 
+  // Printed LAST, and only once the frontend actually answers. Ordering is the
+  // whole point: Vite prints its own `Local:`/`Network:` URLs during startup,
+  // and in remote mode those are the raw port BEHIND the Tailscale proxy. They
+  // serve HTML, so they look right, but the app cannot work there — auth
+  // callbacks are registered against the HTTPS origin and the CSP's
+  // `upgrade-insecure-requests` rewrites the API/socket calls an http page
+  // makes. Anyone reading the last URL on screen would pick the wrong one, so
+  // the correct one has to be the last URL on screen.
+  if (remoteOrigin) {
+    void announceRemoteReady(remoteOrigin)
+  }
+
   await Promise.all(processes.map((child) => child.exited))
+}
+
+/**
+ * Wait for the frontend to answer, then print the one URL to open.
+ *
+ * `tailscale serve status` reports "No serve config" while this is running —
+ * foreground Serve keeps its listener in-process and only `--bg` writes config.
+ * That reads as broken, so the banner says otherwise before anyone checks.
+ */
+async function announceRemoteReady(origin: string): Promise<void> {
+  const deadline = Date.now() + 120_000
+  while (Date.now() < deadline) {
+    try {
+      await fetch("http://127.0.0.1:3000/", { signal: AbortSignal.timeout(2_000) })
+      break
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 1_000))
+    }
+  }
+
+  const lines = [
+    `Open:  ${origin}`,
+    "",
+    "Ignore the localhost / 192.168.* / 100.* URLs above.",
+    "In remote mode those are the port behind the proxy, and",
+    "the app cannot work there.",
+    "",
+    '"tailscale serve status" reporting "No serve config" is',
+    "expected: foreground Serve writes none.",
+  ]
+  const width = Math.max(...lines.map((l) => l.length)) + 2
+  const rule = "─".repeat(width)
+  console.log(`\n┌${rule}┐`)
+  for (const l of lines) console.log(`│ ${l.padEnd(width - 1)}│`)
+  console.log(`└${rule}┘\n`)
 }
 
 main()


### PR DESCRIPTION
## Why

`dev:remote` tells you the wrong URL, and two people have now lost time to it.

Remote mode announces its origin **once, before any service starts**, annotated `(auth callbacks)` — which reads as *"this URL is for auth callbacks"*, not *"open this"*. Then forty lines of startup follow, ending with Vite printing its own `Local:` and `Network:` URLs.

Those Vite URLs are the raw port **behind** the Tailscale proxy. They serve HTML, so they look right and a smoke test against them passes — but the app cannot work there: auth callbacks are registered against the HTTPS origin, and the CSP's `upgrade-insecure-requests` rewrites the API and socket calls an http page makes. Anyone who reads the last URL on screen picks the wrong one.

## What changed

The correct URL is now the **last thing printed**: a banner emitted once the frontend actually answers, naming the one URL to open and explicitly disclaiming the `localhost` / `192.168.*` / `100.*` lines above it.

It also pre-empts the second red herring — `tailscale serve status` reports `No serve config` the whole time, because foreground Serve keeps its listener in-process and only `--bg` writes config. That reads as broken to anyone who goes looking.

```
┌──────────────────────────────────────────────────────────┐
│ Open:  https://<host>.ts.net                             │
│                                                          │
│ Ignore the localhost / 192.168.* / 100.* URLs above.     │
│ In remote mode those are the port behind the proxy, and  │
│ the app cannot work there.                               │
│                                                          │
│ "tailscale serve status" reporting "No serve config" is  │
│ expected: foreground Serve writes none.                  │
└──────────────────────────────────────────────────────────┘
```

The pre-flight line drops its `(auth callbacks)` annotation, which was the thing that made the URL look incidental.

## Verification

Rendered against a running remote stack — the banner returns as soon as `:3000` answers, so it lands after Vite's output rather than before. Box alignment confirmed; the em dash was dropped because its ambiguous width broke the frame in some terminals. `scripts/dev.ts` parses cleanly.

Ordering is the entire fix, so it is worth stating plainly: the failure mode was never a missing URL, it was a *later, wronger* one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787691348&installation_model_id=20758&pr_number=1562&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1562&signature=65286ede88665fc03db05bc0a65670baaac04c67df6e26bd7526f73195fd1588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->