### PR TITLE
docs(skills): rewrite /build-feature for Opus 5 with anti-spiral and anti-stall bounds

### DIFF
--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -44,7 +44,7 @@ Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high
 1. **Brief** — write `.tmp/build-feature-<chunk>-brief.md`: binding plan sections, deliverables, neighbor files to imitate, enumerated tests, what NOT to build, exact `base_ref`. Agents get the path, never a pasted wall.
 2. **Implement** — one implementer in the chunk's working tree, no commits. Then run the brief's typecheck/tests yourself and read the diff.
 3. **Adversarially verify** — one verifier, given the brief, the diff path, and the gate summary. It re-derives behavior from the diff rather than trusting the implementer's report, walks the race and edge paths the plan names, and checks reuse (INV-35/37): name the existing abstraction a duplicate should collapse into. It reports only concrete findings with a failure scenario, self-scored ≥80. It does not rerun green suites.
-4. **Triage and fix** — one disposition per finding (below), one batched fix pass, one targeted recheck. Then save the reviewed patch to the exact paths `/create-pr` looks for, or it will re-audit the diff and fire its own `/code-review`: `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff`, with `base_ref`, dispositions, and gate outcomes in `.tmp/build-feature-review-evidence.md`. Both are per-chunk scratch; overwrite them each chunk.
+4. **Triage and fix** — one disposition per finding (below), one batched fix pass, one targeted recheck. Then save the reviewed patch to the exact paths `/create-pr` looks for, or it will re-audit the diff and fire its own `/code-review`: `git add -A -N` first — without the intent-to-add, new files are untracked and `git diff HEAD` silently omits them, so the reviewer and `/create-pr` both see a chunk with its new source and test files missing — then `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff`, with `base_ref`, dispositions, and gate outcomes in `.tmp/build-feature-review-evidence.md`. Both are per-chunk scratch; overwrite them each chunk.
 5. **Stack the PR** — read the `gh-stack` skill before your first stack command this session; the order below is a memory jog, not the contract.
    - `gh stack add <branch>` **before** `/commit` — `add` creates and switches to the branch, carrying the uncommitted work with it. Commit first and the chunk's diff lands on the previous chunk's branch and its PR.
    - First chunk of a new stack: `gh stack init <branch>` (with `git config rerere.enabled true` and `remote.pushDefault origin` once), not `add` — `add` outside a stack exits 2, and `/create-pr` then silently opens an unstacked PR against `main`.
@@ -71,6 +71,8 @@ The chunk's budget is a count, not a vibe. **Two broad passes: step 3's adversar
 - An unplanned broad pass — anything beyond those two — only if the diff changed materially for a reason other than remediating findings: a scope addition, not a fix.
 - **Tripwire:** if a fix round touches lines a previous round already touched and the accepted set is not strictly smaller than before, you are spiralling. Stop, report the state, ask.
 - Gates run in the orchestrator: once after implement, once after the fix batch, then only affected gates. Reviewers get the summary and do not rerun green suites.
+- **Gates are outside this budget.** A red typecheck or test is fixed however many attempts it takes; an exhausted fix budget never authorizes shipping a red gate. The budget bounds *review* rounds, not correctness.
+- A refutation is void if a later fix changes the code it cited — re-examine that one finding. Nothing else about a frozen set reopens.
 
 A **blocker** is a finding whose consequence is one of: a user sees a wrong result, data is lost or corrupted, authorization is bypassed, or a named plan deliverable is absent. Consequence, not category — every finding that reaches triage is a correctness claim, so "it's a correctness issue" does not make it a blocker. A survivor that is not a blocker is minor by definition: it goes to the PR body's known-issues section and the run continues. There is no third bucket.
 
@@ -90,10 +92,10 @@ Stop and ask only for: a **blocker** surviving the chunk's fix budget; the spira
 
 ## After the last chunk
 
-7. **Whole-stack adversarial review** — one reviewer over `git diff origin/main...<tip>`: cross-PR seams, invariants invisible inside one chunk, and plan conformance — every planned chunk built, nothing deferred smuggled in, PR bodies and `/sync-plan` blocks matching what actually shipped.
-8. **Stack hygiene** — `gh stack view --json` shows every PR linked; `gh stack sync --prune` if `main` moved; CI green; every CodeRabbit thread dispositioned via `/respond-to-pr-review`.
-9. **UI features** — throwaway Playwright pass against the e2e stack: screenshots at 1440px and 390px, scroll inner containers (fullPage misses them), read the PNGs, delete the spec.
-10. **Fold findings into the PR that owns them**, not into the tip branch: `gh stack checkout <branch>` → fix → commit → `gh stack rebase --upstack` → `gh stack push`. A chunk-2 fix committed on the tip ships in chunk 5's PR and leaves the reviewed PR wrong. One batch, same budget as a chunk, run affected gates, then report the per-PR links. No second external model unless the user asks.
+1. **Stack hygiene first** — `git fetch origin main`, `gh stack sync --prune` if `main` moved, then recompute `<tip>`. Reviewing `origin/main...<tip>` before syncing validates a commit set that no longer exists. Confirm `gh stack view --json` lists every PR in the Stack and CI is green.
+2. **Whole-stack adversarial review** — one reviewer over `git diff origin/main...<tip>`: cross-PR seams, invariants invisible inside one chunk, and plan conformance — every planned chunk built, nothing deferred smuggled in, PR bodies and `/sync-plan` blocks matching what actually shipped. Disposition every CodeRabbit thread in the same batch via `/respond-to-pr-review`.
+3. **UI features** — throwaway Playwright pass against the e2e stack: screenshots at 1440px and 390px, scroll inner containers (fullPage misses them), read the PNGs, delete the spec.
+4. **Fold findings into the PR that owns them**, not into the tip branch: `gh stack checkout <branch>` → fix → commit → `gh stack rebase --upstack` → `gh stack push`. A chunk-2 fix committed on the tip ships in chunk 5's PR and leaves the reviewed PR wrong. One batch, same budget as a chunk, run affected gates, then report the per-PR links. No second external model unless the user asks.
 
 ## Gotchas
 

--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -1,68 +1,94 @@
 ---
 name: build-feature
-description: Build a planned feature as a stacked PR chain with per-chunk implementation, one non-duplicative review gate, bounded fixes, and runtime-specific Claude or Pi/OpenAI profiles.
+description: Build a ratified plan as a stacked PR chain — per-chunk Opus-low implement, Opus-high adversarial verify, gh-stack PR, Opus-low PR review, bounded fixes, and a final whole-stack adversarial pass. Use when asked to /build-feature or to build out a plan as stacked PRs.
 ---
 
 # Build a feature as a reviewed stacked-PR chain
 
-Build each plan chunk, verify it once with the strongest useful runtime profile, fix findings in one batch, and create the stacked PR before moving on. Preserve review quality without paying multiple agents to repeat the same lens on the same diff.
+One chunk at a time: implement, adversarially verify, fix, stack the PR, review the PR, fix, next chunk. Then one adversarial pass over the whole stack.
 
-## Planning and preconditions
+Slow is fine — the run is allowed to take hours. Two failure modes are not: reviewing your own fixes in circles until quota dies, and stopping at the first hindrance with nothing shipped. Every bound below exists to block one of those two.
 
-- The invoking agent remains the orchestrator at its current, lower reasoning level. It owns sequencing, user checkpoints, agent briefs, gates, and stack state; it does not become the planner.
-- A ratified implementation plan containing a PR-stack breakdown is required. The plan embedded in the PR body by `/sync-plan` is authoritative. Files under `docs/plans/` are optional desired-design context, never implementation truth.
-- No implementation plan → delegate investigation and drafting to one fresh high-reasoning planner, have the user ratify the result, then publish it with `/sync-plan` before implementation. Do not start building from a chat message.
-- The planner writes the candidate plan but never orchestrates implementation or delegates children.
-- Deferred items in the plan are binding: do not build them.
+## Agents and effort
 
-## Select one execution profile
+Claude default is Opus at every layer. **Use Fable only when the user names it.**
 
-Determine the active harness/provider once and record the profile in the first status update.
+| Role | Model / effort | Owns |
+| --- | --- | --- |
+| Orchestrator | you, current session effort | sequencing, git, gh-stack, triage, gates, checkpoints |
+| Planner | Opus `high`, one fresh agent | plan + PR-stack breakdown; never implements, never delegates |
+| Implementer | Opus `low` | one chunk's diff, in the working tree, no commits |
+| Adversarial verifier | Opus `high` | correctness, races, edge paths, plan conformance |
+| PR reviewer | Opus `low`, `agentType: 'general-purpose'` | runs `/code-review <PR#>` on the opened PR |
+| Whole-stack reviewer | Opus `high` | cross-PR seams, plan conformance, stack hygiene |
 
-### Claude profile
+Reasoning effort is settable **only** through `Workflow`'s `agent(prompt, { effort })`; a plain `Agent` call inherits session effort and silently ignores the intent. So each chunk runs as two `Workflow` invocations — steps 2–4, then step 6 — with the orchestrator doing git, gh-stack, and PR creation in between, because workflow scripts have no shell or filesystem access.
 
-- Planner: Fable, effort `high`.
-- Implementer: Opus, effort `medium`.
-- Per-chunk verifier: Opus, effort `xhigh`.
-- Whole-stack reviewer: Fable.
-- Preserve the established Claude behavior below, subject to the shared round and read bounds.
+Two children concurrent at most; a child never delegates. Put StructuredOutput schemas on verifiers and fixers only — implementers report free text (Opus implementers reliably mangle StructuredOutput after a long file-writing run, and the work is usually already on disk).
 
 ### Pi / OpenAI profile
 
-- Planner: one fresh GPT-5.6 Sol agent, effort `high`.
-- Implementer: GPT-5.6 Sol, effort `low`. Pi maps Sol `minimal` to provider `low`, so request `low` explicitly.
-- Per-chunk verifier: one fresh GPT-5.6 Sol agent, effort `high`.
-- Never use `xhigh` per chunk. Reserve it for one final whole-stack review only when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries; otherwise use `high`.
-- Maximum two children running concurrently. A child never delegates.
-- Do not run an external Sol pass: Sol already implemented and reviewed the work.
+Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high`. Implementer: Sol `low` (request `low` explicitly — Pi maps Sol `minimal` to provider `low`). Whole-stack: Sol `high`, or one `xhigh` pass when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries. No external second-model pass — Sol already implemented and reviewed. Follow root `AGENTS.md` read-efficiency rules. Everything else on this page applies unchanged.
 
-## Shared efficiency contract
+## Plan first
 
-- One quality gate per diff revision. Adversarial verification and `/code-review` are alternatives, not cumulative rituals.
-- Maximum one batched fix pass and one targeted recheck per chunk. If material findings survive, stop for a human checkpoint; do not start another clean-room review.
-- Run declared typecheck/tests once in the orchestrator after implementation and once after the fix batch when code changed. Review agents do not rerun green gates unless a concrete finding requires a focused reproduction.
-- Review from the brief and diff. Read source only to validate a concrete candidate finding; never browse the whole tree for confidence theater.
-- Pi/Sol agents follow the root `AGENTS.md` read-efficiency rules.
-- Briefs, diffs, histories, and test output live in files. Pass paths, not pasted walls.
+- Build only from a plan with an explicit PR-stack breakdown: each chunk is one PR with deliverables, enumerated tests, exclusions, and its base branch. A chat message is not a plan.
+- No plan → dispatch one planner to investigate and draft it. Publish the plan to Seer and share the URL; embed it in each PR body with `/sync-plan`. Files under `docs/plans/` are desired-design context, never implementation truth.
+- Start building as soon as the plan is published — no ratification round-trip — unless the plan contains a stop-class decision (schema migration, public API contract, data deletion, anything hard to reverse) or the user asked for a checkpoint. Then wait.
+- Deferred items in the plan are binding: do not build them.
 
 ## Per chunk
 
-1. **Brief**: write the chunk implementation brief to `.tmp/` — binding plan sections, deliverables, neighbor files, enumerated tests, exclusions, and the exact diff base.
-2. **Implement**: one agent using the selected profile, directly in the chunk worktree, no commit. The orchestrator inspects the diff and runs the brief's gates.
-3. **Adversarial verification**: one verifier using the selected profile. It re-derives behavior from the brief and diff, checks named race/edge paths, and reports only concrete findings scoring ≥80. It receives the green/failed gate summary; it does not rerun broad gates.
-4. **Fix and recheck**: consolidate all accepted findings into one fix brief. The implementer or one fresh implementation-profile agent applies them as one batch. Rerun affected gates once, then use one targeted verifier recheck limited to the accepted findings and changed lines. No new broad review round. Save the exact reviewed final patch with `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff` and write the exact `base_ref` plus reviewer/recheck outcome to `.tmp/build-feature-review-evidence.md`; `/create-pr` compares the same patch shape after commit to avoid repeating the audit.
-5. **Stacked PR**: commit via `/commit`, then `/gh-stack` + `/create-pr`; each chunk branch is based on the previous chunk, first chunk on `origin/main`. `/create-pr` owns `gh stack submit`; this skill only verifies `gh stack view --json` reports a Stack afterward.
-6. **Additional code review**: do not automatically run `/code-review` when Step 3 reviewed the current final diff. Run it only when the user explicitly requests it, the diff materially changed after the targeted recheck, or Step 3 was skipped. Record the reason.
+1. **Brief** — write `.tmp/build-feature-<chunk>-brief.md`: binding plan sections, deliverables, neighbor files to imitate, enumerated tests, what NOT to build, exact `base_ref`. Agents get the path, never a pasted wall.
+2. **Implement** — one implementer in the chunk's working tree, no commits. Then run the brief's typecheck/tests yourself and read the diff.
+3. **Adversarially verify** — one verifier, given the brief, the diff path, and the gate summary. It re-derives behavior from the diff rather than trusting the implementer's report, walks the race and edge paths the plan names, and checks reuse (INV-35/37): name the existing abstraction a duplicate should collapse into. It reports only concrete findings with a failure scenario, self-scored ≥80. It does not rerun green suites.
+4. **Triage and fix** — one disposition per finding (below), one batched fix pass, one targeted recheck. Then save the reviewed patch: `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-<chunk>.diff`, with dispositions and gate outcomes in `.tmp/build-feature-<chunk>-evidence.md`.
+5. **Stack the PR** — `/commit`, then `gh stack add <branch>` and `/create-pr`; each chunk branches off the previous chunk, the first off `origin/main`. `/create-pr` owns `gh stack submit --auto`. **Confirm `gh stack view --json` reports a `Stack #NNNN` before continuing.** Chained-base PRs without a Stack are a failed step, not a variant — retrofit with `gh stack submit --auto --open`. Read the `gh-stack` skill before your first stack command this session; this list is a memory jog, not the contract.
+6. **Review the PR** — one PR reviewer runs `/code-review <PR#>` (PR mode posts the report as a comment). Triage its findings the same way, fix accepted ones in one batch, push. Do not wait on CodeRabbit here; its threads get swept once at the whole-stack stage.
+
+## Triage is yours
+
+Every finding from every reviewer gets exactly one disposition, recorded in the chunk's evidence file:
+
+- **Accept** — real, in scope; fix it in this chunk.
+- **Refute** — wrong; write the one-line evidence (code path, test, invariant id). Refuting with evidence is expected and healthy; blind fixes have caused real regressions here.
+- **Defer** — real but outside the ratified scope; note it in the PR body and carry it into the whole-stack review.
+
+Reviewers advise; you decide. A refuted finding does not get a rematch in a later pass.
+
+## Don't spiral
+
+- One batched fix pass per review pass — all accepted findings at once, never one at a time.
+- The recheck sees only the accepted findings and the lines changed for them. It may report exactly two things: an accepted finding that isn't actually fixed, and a regression the fix introduced. Anything else is out of bounds — discard it, no matter how interesting.
+- At most one surgical round after that recheck. Then the gate is closed for this diff revision.
+- A fresh broad review pass only when the diff changed materially for a reason other than remediating findings.
+- **Tripwire:** two consecutive rounds touching the same lines without the accepted-blocker count dropping means you are spiralling. Stop, report the state, ask.
+- Gates run in the orchestrator: once after implement, once after the fix batch, then only affected gates. Reviewers get the summary and do not rerun green suites.
+
+## Don't stall
+
+Keep going. None of these is a reason to stop, hand back, or split the chunk:
+
+- Red gates you haven't yet tried to fix; a failed, timed-out, or truncated child. Check `git status` first — the work is usually already on disk. Preserve it, resume or replace the agent. **A dead child is not a consumed fix round.**
+- A reviewer you disagree with → refute with evidence and move on.
+- The chunk is bigger or messier than the plan implied but stays inside its ownership boundary → build it.
+- Missing optional credentials, no live smoke path, behavior unverifiable locally → use a deterministic substitute, record the caveat in the PR body.
+- Minor or deferred findings that survived the cap → PR body known-issues section, continue.
+- Pre-existing failures you surfaced → fix them in-branch (INV-22).
+
+Stop and ask only for: a blocker surviving the round cap; the spiral tripwire; a plan change touching schema, public contract, or deletion; the same failure signature twice with no new hypothesis; or concrete evidence the chunk must coordinate a second independently-owned lifecycle or state machine — then preserve the patch and propose a split along that boundary. Chunk size alone is not that evidence.
 
 ## After the last chunk
 
-7. **Whole-stack review**: one review of `git diff origin/main...<tip>` focused on cross-PR seams, plan conformance, and invariants not fully visible within a chunk. Claude uses Fable. Pi/OpenAI uses Sol `high`, or the single allowed `xhigh` pass for the high-risk boundaries listed above.
-8. Fold surviving findings in one batch, run affected gates once, push, and report per-PR links. No second external model unless the user explicitly requests it. Before launch, report the proposed model, effort, and whole-stack diff line/file counts; obtain confirmation if the request did not already specify them.
+7. **Whole-stack adversarial review** — one reviewer over `git diff origin/main...<tip>`: cross-PR seams, invariants invisible inside one chunk, and plan conformance — every ratified chunk built, nothing deferred smuggled in, PR bodies and `/sync-plan` blocks matching what actually shipped.
+8. **Stack hygiene** — `gh stack view --json` shows every PR linked; `gh stack sync --prune` if `main` moved; CI green; every CodeRabbit thread dispositioned via `/respond-to-pr-review`.
+9. **UI features** — throwaway Playwright pass against the e2e stack: screenshots at 1440px and 390px, scroll inner containers (fullPage misses them), read the PNGs, delete the spec.
+10. Fold accepted findings in one batch under the same bounds, run affected gates, push, and report the per-PR links. No second external model unless the user asks.
 
 ## Gotchas
 
-- **Decomposition checkpoint:** when a chunk exceeds its budget or starts coordinating independent lifecycle/state machines, stop before adding more machinery. Give the user a short split proposal along the ownership/lifecycle boundary, preserve the patch, ratify the revised stack, and continue in smaller PRs.
-- Workflow `args` must be real JSON values, not a stringified blob; briefs go in files.
-- Stacked PRs only run the main CI trio when targeting `main`; run required local gates before submission.
-- Merge/sync stacks through `gh stack`; never hand-roll rebases around squash merges.
-- Pre-commit runs full monorepo lint+typecheck: use a generous timeout, and fresh worktrees need `bun install` first.
+- `Workflow` `args` must be real JSON values, not a stringified blob; briefs go in files.
+- Stacked PRs run the main CI trio only when targeting `main` — run required gates locally before submitting.
+- Merge and sync through `gh stack` only; never hand-roll rebases around squash merges.
+- Pre-commit runs full monorepo lint + typecheck: generous timeouts, and fresh worktrees need `bun install` first.
+- Scout `gh pr list` for open PRs touching the same files before starting — a mid-build collision costs a squash and rebase.

--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -24,13 +24,13 @@ Claude default is Opus at every layer. **Use Fable only when the user names it.*
 
 Reasoning effort is settable **only** through `Workflow`'s `agent(prompt, { model, effort, agentType })`; a plain `Agent` call inherits session effort and silently ignores the intent. Every dispatch on this page is therefore a `Workflow` invocation, including the single-agent ones (planner, whole-stack reviewer). Each chunk is two of them — steps 2–4, then step 6 — with the orchestrator doing git, `gh stack`, and PR creation in between, because workflow scripts have no shell or filesystem access.
 
-A child never delegates, with one exception: `/code-review` fans out to its own Sonnet lenses. That is the tool's design, not a violation — the PR reviewer's Opus `low` buys triage and skill orchestration, not the review lenses themselves.
+**Reviewers may delegate; implementers and fixers may not.** An adversarial verifier is free to fan out parallel lenses — correctness and races, invariants, reuse and design — and synthesize them; that fan-out is one broad pass, not several, and its findings land in one frozen set. `/code-review` does this natively with its own Sonnet lenses, which is why the PR reviewer's Opus `low` buys triage and orchestration rather than the lenses themselves. A fixer that delegates is how the spiral starts: it never gets to.
 
 Put StructuredOutput schemas on verifiers and fixers only — implementers report free text (Opus implementers reliably mangle StructuredOutput after a long file-writing run, and the work is usually already on disk).
 
 ### Pi / OpenAI profile
 
-Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high`. Implementer: Sol `low` (request `low` explicitly — Pi maps Sol `minimal` to provider `low`). Whole-stack: Sol `high`, or one `xhigh` pass when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries. Two children concurrent at most. No external second-model pass — Sol already implemented and reviewed. Follow root `AGENTS.md` read-efficiency rules. Everything else on this page applies unchanged.
+Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high`. Implementer: Sol `low` (request `low` explicitly — Pi maps Sol `minimal` to provider `low`). Whole-stack: Sol `high`, or one `xhigh` pass when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries. Two children concurrent at most, and reviewers do not fan out — Pi runs are quota-bound. No external second-model pass — Sol already implemented and reviewed. Follow root `AGENTS.md` read-efficiency rules. Everything else on this page applies unchanged.
 
 ## Plan first
 

--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -49,7 +49,7 @@ Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high
    - `gh stack add <branch>` **before** `/commit` — `add` creates and switches to the branch, carrying the uncommitted work with it. Commit first and the chunk's diff lands on the previous chunk's branch and its PR.
    - First chunk of a new stack: `gh stack init <branch>` (with `git config rerere.enabled true` and `remote.pushDefault origin` once), not `add` — `add` outside a stack exits 2, and `/create-pr` then silently opens an unstacked PR against `main`.
    - Then `/commit`, then `/create-pr`, which owns `gh stack submit --auto`.
-   - **Confirm `gh stack view --json` reports a `Stack #NNNN` before continuing.** Chained-base PRs without a Stack are a failed step, not a variant — retrofit with `gh stack submit --auto --open`.
+   - Confirm before continuing. After chunk 1: `gh stack view --json` lists the branch and the PR's base is `main`. A GitHub Stack object needs two PRs, so `Stack #NNNN` cannot exist yet and its absence means nothing here. **From chunk 2 on, `gh stack view --json` must report a `Stack #NNNN`** — chained-base PRs without one are a failed step, not a variant; retrofit with `gh stack submit --auto --open`.
 6. **Review the PR** — one PR reviewer runs `/code-review <PR#>` (PR mode posts the report as a comment). Triage its findings, fix accepted ones in one batch, push. **One `/code-review` per PR, full stop** — it has no targeted mode, so a "confirmation" re-run is a fresh broad pass that will find new things forever. The pushed fix is covered by the whole-stack pass. Do not wait on CodeRabbit here; its threads get swept once at the whole-stack stage.
 
 ## Triage is yours
@@ -64,15 +64,15 @@ Reviewers advise; you decide. A refuted finding does not get a rematch in a late
 
 ## Don't spiral
 
-The whole chunk gets a fixed budget, in counts, not vibes: **one broad adversarial pass, one batched fix, one targeted recheck, one surgical fix, then done** — plus the single `/code-review` in step 6 and its one fix batch. Nothing in this document authorizes a third fix on the same diff.
+The chunk's budget is a count, not a vibe. **Two broad passes: step 3's adversarial verify and step 6's one `/code-review`. Three fix batches: the batched fix, the surgical fix, and the post-`/code-review` fix.** That is the whole allowance. A third broad pass or a fourth fix on the same diff is not authorized anywhere in this document.
 
-- The broad pass produces the finding set for this chunk. That set is frozen at triage. Later passes cannot add to it, revive a refuted item, or import unrelated scope.
+- Each broad pass produces a finding set, frozen at triage. Nothing later adds to it, revives a refuted item, or imports unrelated scope.
 - The recheck sees only the accepted findings and the lines changed for them. It may report exactly two things: an accepted finding that isn't actually fixed, and a regression the fix introduced. Anything else is out of bounds — discard it, no matter how interesting.
-- A second broad pass only if the diff changed materially for a reason other than remediating findings — a scope addition, not a fix.
+- An unplanned broad pass — anything beyond those two — only if the diff changed materially for a reason other than remediating findings: a scope addition, not a fix.
 - **Tripwire:** if a fix round touches lines a previous round already touched and the accepted set is not strictly smaller than before, you are spiralling. Stop, report the state, ask.
 - Gates run in the orchestrator: once after implement, once after the fix batch, then only affected gates. Reviewers get the summary and do not rerun green suites.
 
-A **blocker** is a finding about correctness, data integrity, security or authorization, or a plan deliverable that was not actually built. Nothing else is a blocker, whatever severity label the reviewer attached.
+A **blocker** is a finding whose consequence is one of: a user sees a wrong result, data is lost or corrupted, authorization is bypassed, or a named plan deliverable is absent. Consequence, not category — every finding that reaches triage is a correctness claim, so "it's a correctness issue" does not make it a blocker. A survivor that is not a blocker is minor by definition: it goes to the PR body's known-issues section and the run continues. There is no third bucket.
 
 ## Don't stall
 

--- a/.agents/skills/build-feature/SKILL.md
+++ b/.agents/skills/build-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-feature
-description: Build a ratified plan as a stacked PR chain — per-chunk Opus-low implement, Opus-high adversarial verify, gh-stack PR, Opus-low PR review, bounded fixes, and a final whole-stack adversarial pass. Use when asked to /build-feature or to build out a plan as stacked PRs.
+description: Build a planned feature as a stacked PR chain — per-chunk Opus-low implement, Opus-high adversarial verify, gh-stack PR, Opus-low PR review, bounded fixes, and a final whole-stack adversarial pass. Use when asked to /build-feature or to build out a plan as stacked PRs.
 ---
 
 # Build a feature as a reviewed stacked-PR chain
@@ -22,19 +22,21 @@ Claude default is Opus at every layer. **Use Fable only when the user names it.*
 | PR reviewer | Opus `low`, `agentType: 'general-purpose'` | runs `/code-review <PR#>` on the opened PR |
 | Whole-stack reviewer | Opus `high` | cross-PR seams, plan conformance, stack hygiene |
 
-Reasoning effort is settable **only** through `Workflow`'s `agent(prompt, { effort })`; a plain `Agent` call inherits session effort and silently ignores the intent. So each chunk runs as two `Workflow` invocations — steps 2–4, then step 6 — with the orchestrator doing git, gh-stack, and PR creation in between, because workflow scripts have no shell or filesystem access.
+Reasoning effort is settable **only** through `Workflow`'s `agent(prompt, { model, effort, agentType })`; a plain `Agent` call inherits session effort and silently ignores the intent. Every dispatch on this page is therefore a `Workflow` invocation, including the single-agent ones (planner, whole-stack reviewer). Each chunk is two of them — steps 2–4, then step 6 — with the orchestrator doing git, `gh stack`, and PR creation in between, because workflow scripts have no shell or filesystem access.
 
-Two children concurrent at most; a child never delegates. Put StructuredOutput schemas on verifiers and fixers only — implementers report free text (Opus implementers reliably mangle StructuredOutput after a long file-writing run, and the work is usually already on disk).
+A child never delegates, with one exception: `/code-review` fans out to its own Sonnet lenses. That is the tool's design, not a violation — the PR reviewer's Opus `low` buys triage and skill orchestration, not the review lenses themselves.
+
+Put StructuredOutput schemas on verifiers and fixers only — implementers report free text (Opus implementers reliably mangle StructuredOutput after a long file-writing run, and the work is usually already on disk).
 
 ### Pi / OpenAI profile
 
-Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high`. Implementer: Sol `low` (request `low` explicitly — Pi maps Sol `minimal` to provider `low`). Whole-stack: Sol `high`, or one `xhigh` pass when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries. No external second-model pass — Sol already implemented and reviewed. Follow root `AGENTS.md` read-efficiency rules. Everything else on this page applies unchanged.
+Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high`. Implementer: Sol `low` (request `low` explicitly — Pi maps Sol `minimal` to provider `low`). Whole-stack: Sol `high`, or one `xhigh` pass when the stack crosses security, authorization, migration, concurrency, or data-integrity boundaries. Two children concurrent at most. No external second-model pass — Sol already implemented and reviewed. Follow root `AGENTS.md` read-efficiency rules. Everything else on this page applies unchanged.
 
 ## Plan first
 
 - Build only from a plan with an explicit PR-stack breakdown: each chunk is one PR with deliverables, enumerated tests, exclusions, and its base branch. A chat message is not a plan.
 - No plan → dispatch one planner to investigate and draft it. Publish the plan to Seer and share the URL; embed it in each PR body with `/sync-plan`. Files under `docs/plans/` are desired-design context, never implementation truth.
-- Start building as soon as the plan is published — no ratification round-trip — unless the plan contains a stop-class decision (schema migration, public API contract, data deletion, anything hard to reverse) or the user asked for a checkpoint. Then wait.
+- Start building as soon as the plan is published. No ratification round-trip: the user asked for a plan and a stack, not for a quiz. Wait only if the user asked for a checkpoint, or the plan requires a decision that cannot be undone by reverting the PRs — dropping or rewriting production data, a breaking public API change, deleting a user-facing surface. Append-only migrations, new tables, new endpoints, and feature-flagged rollouts are routine here (INV-17, INV-67): build them.
 - Deferred items in the plan are binding: do not build them.
 
 ## Per chunk
@@ -42,9 +44,13 @@ Only when the harness is Pi, not Claude. Planner and verifier: GPT-5.6 Sol `high
 1. **Brief** — write `.tmp/build-feature-<chunk>-brief.md`: binding plan sections, deliverables, neighbor files to imitate, enumerated tests, what NOT to build, exact `base_ref`. Agents get the path, never a pasted wall.
 2. **Implement** — one implementer in the chunk's working tree, no commits. Then run the brief's typecheck/tests yourself and read the diff.
 3. **Adversarially verify** — one verifier, given the brief, the diff path, and the gate summary. It re-derives behavior from the diff rather than trusting the implementer's report, walks the race and edge paths the plan names, and checks reuse (INV-35/37): name the existing abstraction a duplicate should collapse into. It reports only concrete findings with a failure scenario, self-scored ≥80. It does not rerun green suites.
-4. **Triage and fix** — one disposition per finding (below), one batched fix pass, one targeted recheck. Then save the reviewed patch: `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-<chunk>.diff`, with dispositions and gate outcomes in `.tmp/build-feature-<chunk>-evidence.md`.
-5. **Stack the PR** — `/commit`, then `gh stack add <branch>` and `/create-pr`; each chunk branches off the previous chunk, the first off `origin/main`. `/create-pr` owns `gh stack submit --auto`. **Confirm `gh stack view --json` reports a `Stack #NNNN` before continuing.** Chained-base PRs without a Stack are a failed step, not a variant — retrofit with `gh stack submit --auto --open`. Read the `gh-stack` skill before your first stack command this session; this list is a memory jog, not the contract.
-6. **Review the PR** — one PR reviewer runs `/code-review <PR#>` (PR mode posts the report as a comment). Triage its findings the same way, fix accepted ones in one batch, push. Do not wait on CodeRabbit here; its threads get swept once at the whole-stack stage.
+4. **Triage and fix** — one disposition per finding (below), one batched fix pass, one targeted recheck. Then save the reviewed patch to the exact paths `/create-pr` looks for, or it will re-audit the diff and fire its own `/code-review`: `{ git diff "$base_ref"...HEAD; git diff HEAD; } > .tmp/build-feature-reviewed.diff`, with `base_ref`, dispositions, and gate outcomes in `.tmp/build-feature-review-evidence.md`. Both are per-chunk scratch; overwrite them each chunk.
+5. **Stack the PR** — read the `gh-stack` skill before your first stack command this session; the order below is a memory jog, not the contract.
+   - `gh stack add <branch>` **before** `/commit` — `add` creates and switches to the branch, carrying the uncommitted work with it. Commit first and the chunk's diff lands on the previous chunk's branch and its PR.
+   - First chunk of a new stack: `gh stack init <branch>` (with `git config rerere.enabled true` and `remote.pushDefault origin` once), not `add` — `add` outside a stack exits 2, and `/create-pr` then silently opens an unstacked PR against `main`.
+   - Then `/commit`, then `/create-pr`, which owns `gh stack submit --auto`.
+   - **Confirm `gh stack view --json` reports a `Stack #NNNN` before continuing.** Chained-base PRs without a Stack are a failed step, not a variant — retrofit with `gh stack submit --auto --open`.
+6. **Review the PR** — one PR reviewer runs `/code-review <PR#>` (PR mode posts the report as a comment). Triage its findings, fix accepted ones in one batch, push. **One `/code-review` per PR, full stop** — it has no targeted mode, so a "confirmation" re-run is a fresh broad pass that will find new things forever. The pushed fix is covered by the whole-stack pass. Do not wait on CodeRabbit here; its threads get swept once at the whole-stack stage.
 
 ## Triage is yours
 
@@ -52,38 +58,42 @@ Every finding from every reviewer gets exactly one disposition, recorded in the 
 
 - **Accept** — real, in scope; fix it in this chunk.
 - **Refute** — wrong; write the one-line evidence (code path, test, invariant id). Refuting with evidence is expected and healthy; blind fixes have caused real regressions here.
-- **Defer** — real but outside the ratified scope; note it in the PR body and carry it into the whole-stack review.
+- **Defer** — real but outside the plan's scope; note it in the PR body and carry it into the whole-stack review.
 
 Reviewers advise; you decide. A refuted finding does not get a rematch in a later pass.
 
 ## Don't spiral
 
-- One batched fix pass per review pass — all accepted findings at once, never one at a time.
+The whole chunk gets a fixed budget, in counts, not vibes: **one broad adversarial pass, one batched fix, one targeted recheck, one surgical fix, then done** — plus the single `/code-review` in step 6 and its one fix batch. Nothing in this document authorizes a third fix on the same diff.
+
+- The broad pass produces the finding set for this chunk. That set is frozen at triage. Later passes cannot add to it, revive a refuted item, or import unrelated scope.
 - The recheck sees only the accepted findings and the lines changed for them. It may report exactly two things: an accepted finding that isn't actually fixed, and a regression the fix introduced. Anything else is out of bounds — discard it, no matter how interesting.
-- At most one surgical round after that recheck. Then the gate is closed for this diff revision.
-- A fresh broad review pass only when the diff changed materially for a reason other than remediating findings.
-- **Tripwire:** two consecutive rounds touching the same lines without the accepted-blocker count dropping means you are spiralling. Stop, report the state, ask.
+- A second broad pass only if the diff changed materially for a reason other than remediating findings — a scope addition, not a fix.
+- **Tripwire:** if a fix round touches lines a previous round already touched and the accepted set is not strictly smaller than before, you are spiralling. Stop, report the state, ask.
 - Gates run in the orchestrator: once after implement, once after the fix batch, then only affected gates. Reviewers get the summary and do not rerun green suites.
+
+A **blocker** is a finding about correctness, data integrity, security or authorization, or a plan deliverable that was not actually built. Nothing else is a blocker, whatever severity label the reviewer attached.
 
 ## Don't stall
 
 Keep going. None of these is a reason to stop, hand back, or split the chunk:
 
-- Red gates you haven't yet tried to fix; a failed, timed-out, or truncated child. Check `git status` first — the work is usually already on disk. Preserve it, resume or replace the agent. **A dead child is not a consumed fix round.**
+- A red gate. Fixing it is the job, not a reason to escalate. Keep trying genuinely different hypotheses; a repeat of a failure you already tried to fix the same way is not a new attempt. Escalate only after three distinct hypotheses have each failed, with all three written down.
+- A failed, timed-out, or truncated child. Check `git status` first — the work is usually already on disk. Preserve it, resume or replace the agent. **A dead child is not a consumed fix round.**
 - A reviewer you disagree with → refute with evidence and move on.
 - The chunk is bigger or messier than the plan implied but stays inside its ownership boundary → build it.
 - Missing optional credentials, no live smoke path, behavior unverifiable locally → use a deterministic substitute, record the caveat in the PR body.
-- Minor or deferred findings that survived the cap → PR body known-issues section, continue.
+- Minor or deferred findings that survived the budget → PR body known-issues section, continue.
 - Pre-existing failures you surfaced → fix them in-branch (INV-22).
 
-Stop and ask only for: a blocker surviving the round cap; the spiral tripwire; a plan change touching schema, public contract, or deletion; the same failure signature twice with no new hypothesis; or concrete evidence the chunk must coordinate a second independently-owned lifecycle or state machine — then preserve the patch and propose a split along that boundary. Chunk size alone is not that evidence.
+Stop and ask only for: a **blocker** surviving the chunk's fix budget; the spiral tripwire; three failed hypotheses on one gate; a mid-flight plan change that drops data, breaks a public contract, or removes a user-facing surface; or concrete evidence the chunk must coordinate a second independently-owned lifecycle or state machine — then preserve the patch and propose a split along that boundary. Chunk size alone is not that evidence. That list is closed. If the reason you want to stop is not on it, you are stalling; finish the chunk and put the concern in the PR body.
 
 ## After the last chunk
 
-7. **Whole-stack adversarial review** — one reviewer over `git diff origin/main...<tip>`: cross-PR seams, invariants invisible inside one chunk, and plan conformance — every ratified chunk built, nothing deferred smuggled in, PR bodies and `/sync-plan` blocks matching what actually shipped.
+7. **Whole-stack adversarial review** — one reviewer over `git diff origin/main...<tip>`: cross-PR seams, invariants invisible inside one chunk, and plan conformance — every planned chunk built, nothing deferred smuggled in, PR bodies and `/sync-plan` blocks matching what actually shipped.
 8. **Stack hygiene** — `gh stack view --json` shows every PR linked; `gh stack sync --prune` if `main` moved; CI green; every CodeRabbit thread dispositioned via `/respond-to-pr-review`.
 9. **UI features** — throwaway Playwright pass against the e2e stack: screenshots at 1440px and 390px, scroll inner containers (fullPage misses them), read the PNGs, delete the spec.
-10. Fold accepted findings in one batch under the same bounds, run affected gates, push, and report the per-PR links. No second external model unless the user asks.
+10. **Fold findings into the PR that owns them**, not into the tip branch: `gh stack checkout <branch>` → fix → commit → `gh stack rebase --upstack` → `gh stack push`. A chunk-2 fix committed on the tip ships in chunk 5's PR and leaves the reviewed PR wrong. One batch, same budget as a chunk, run affected gates, then report the per-PR links. No second external model unless the user asks.
 
 ## Gotchas
 


### PR DESCRIPTION
## Why

`/build-feature` predates Opus 5. Its Claude profile still routed planning and whole-stack review to Fable and mid-tier work to Opus `medium`/`xhigh`, and two Sol-authored passes (#1515, #1521) rewrote it into an efficiency-lawyer document that deleted the per-PR `/code-review` gate under a "one quality gate per diff revision" rule.

That framing produced both failure modes Kris hit in practice: an agent that reviewed its own poor fix, re-fixed it, re-reviewed it, and burned a day of quota; and, once told not to do that, an agent that stopped dead after chunk 1 because something "needed doing". The rewrite targets that middle ground directly — every bound below exists to block one of those two.

## What changed

- **Opus at every layer.** Orchestrator at session effort; planner `high`; implementer `low`; per-chunk adversarial verifier `high`; PR reviewer `low`; whole-stack reviewer `high`. Fable only when the user names it.
- **Effort plumbing stated.** Reasoning effort is settable only via `Workflow`'s `agent(prompt, { model, effort, agentType })` — a plain `Agent` call silently inherits session effort. Every dispatch is therefore a `Workflow` invocation; each chunk is two of them, with the orchestrator doing git, `gh stack`, and PR creation in between, since workflow scripts have no shell.
- **`/code-review` gate restored** as a distinct post-PR lens at Opus `low`, capped at one run per PR (it has no targeted mode, so a "confirmation" re-run is a fresh broad pass that finds new things forever).
- **Reviewers may fan out lenses and synthesize; implementers and fixers never delegate.** A reviewer's fan-out is one broad pass, not several.
- **Triage ownership is explicit.** Accept / refute-with-evidence / defer, one disposition per finding, recorded. Reviewers advise; the orchestrator decides; a refuted finding gets no rematch.
- **Anti-spiral budget as a count:** two broad passes, three fix batches, per chunk. Frozen finding sets; a recheck that may report only "not actually fixed" and "regression the fix introduced"; a tripwire when a round re-touches lines without the accepted set shrinking.
- **Anti-stall list, explicitly closed.** Dead children, red gates, oversized chunks, missing optional credentials, and disagreeable reviewers are not stop conditions; a dead child is not a consumed fix round. `blocker` is defined by consequence (wrong user-visible result, data loss, auth bypass, missing plan deliverable), and any survivor that is not a blocker is minor by definition — known-issues, keep going.
- Planning publishes to Seer and proceeds without a ratification round-trip; only genuinely irreversible decisions wait, and append-only migrations are named as routine (INV-17/67) so they can't be used as an excuse to stall.
- Stack hygiene, the CodeRabbit sweep, and the UI screenshot pass moved to the whole-stack stage; whole-stack fixes go to the PR that owns them via `gh stack checkout` → `rebase --upstack`.

## Verification

Docs only; pre-commit lint/typecheck green. Reviewed adversarially rather than with `/code-review` — correctness here is agent behavior, not code. Two passes: 12 findings, then a targeted recheck that found 4 more. All accepted and fixed except one, refuted below. Every mechanical claim was checked against the sibling skill it names.

The defects that mattered, all of which would have fired on the next real run:

- `gh stack init` was missing entirely — `gh stack add` outside a stack exits 2, `/create-pr` then sees no stack and opens chunk 1 unstacked against `main`. The one thing Kris said matters most.
- `/commit` was ordered before `gh stack add`, which creates and switches to the branch carrying uncommitted work — every chunk's diff would have landed on the previous chunk's PR.
- The evidence filenames didn't match the literals `/create-pr` checks for, so it would have re-audited and fired its own `/code-review` on top of step 6's.
- The Stack confirmation gate was unsatisfiable after chunk 1 (a GitHub Stack object needs two PRs), with no sanctioned exit — a stall at the earliest possible point.

Refuted: the recheck flagged the `Workflow` `agent()` signature as unverified because that tool isn't exposed to subagents. It is exposed to the orchestrator, and the tool description lists `label`, `phase`, `schema`, `model`, `effort`, `isolation`, `agentType` — the three names used here are correct.

## Residual risk

The bounds are prescriptive. A genuinely novel problem needing a fourth fix now escalates instead of self-resolving; that is the intended trade. Whether the anti-stall list is closed tightly enough only shows up on the next real overnight run.
