### PR TITLE
feat(calls): make device takeover reachable and notify the displaced device

### DIFF
--- a/apps/backend/src/features/calls/handlers.test.ts
+++ b/apps/backend/src/features/calls/handlers.test.ts
@@ -89,6 +89,45 @@ describe("createCallHandlers.start — gating", () => {
       expect.objectContaining({ call: { id: "call_1" }, rosterVersion: 1, roster: [{ userId: "usr_1" }] })
     )
   })
+
+  it("forwards takeover and notifies the device it displaced", async () => {
+    const notify = spyOn(gatewayModule, "notifyEndpointTakenOver").mockImplementation(() => {})
+    const startCall = mock(async (_p: unknown) => ({
+      call: { id: "call_1" },
+      created: false,
+      participant: { id: "callp_1" },
+      endpoint: { id: "callep_new" },
+      supersededEndpointId: "callep_old",
+    }))
+    const getRosterSnapshot = mock(async () => ({ rosterVersion: 2, roster: [] }))
+    const handlers = makeHandlers({ callService: { startCall, getRosterSnapshot } })
+
+    await handlers.start(
+      fakeReq({ body: { streamId: "stream_1", mode: "video", mediaIncarnation: "inc_1", takeover: true } }),
+      fakeRes()
+    )
+
+    expect(startCall.mock.calls[0][0]).toMatchObject({ takeover: true })
+    expect(notify).toHaveBeenCalledWith(expect.anything(), "call_1", "callep_old")
+  })
+
+  it("notifies nobody when the start displaced no device", async () => {
+    const notify = spyOn(gatewayModule, "notifyEndpointTakenOver").mockImplementation(() => {})
+    const startCall = mock(async () => ({
+      call: { id: "call_1" },
+      created: true,
+      participant: { id: "callp_1" },
+      endpoint: { id: "callep_1" },
+      supersededEndpointId: null,
+    }))
+    const handlers = makeHandlers({
+      callService: { startCall, getRosterSnapshot: mock(async () => ({ rosterVersion: 1, roster: [] })) },
+    })
+
+    await handlers.start(fakeReq({ body: { streamId: "stream_1", mode: "video" } }), fakeRes())
+
+    expect(notify).not.toHaveBeenCalled()
+  })
 })
 
 describe("createCallHandlers.bootstrap", () => {

--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -6,7 +6,7 @@ import { HttpError } from "../../lib/errors"
 import type { FeatureFlagService } from "../feature-flags"
 import { checkCallAccess } from "./access"
 import type { CallService } from "./service"
-import { broadcastRoster } from "./signaling-gateway"
+import { broadcastRoster, notifyEndpointTakenOver } from "./signaling-gateway"
 import { CALL_MODES, PUBLISHED_TRACK_KINDS } from "./config"
 
 const sessionDescriptionSchema = z.object({
@@ -24,6 +24,9 @@ const startSchema = z.object({
   // set and the call it would actually join differs, the ring's call ended in the
   // click window → 409 CALL_ENDED instead of silently joining/starting another.
   expectedCallId: z.string().min(1).optional(),
+  // "Join on this device": retry after a 409 CALL_ENDPOINT_ACTIVE, displacing the
+  // user's own live endpoint on another device instead of being rejected by it.
+  takeover: z.boolean().optional(),
 })
 
 const cfSessionSchema = z.object({
@@ -125,8 +128,14 @@ export function createCallHandlers({ pool, io, callService, featureFlagService, 
         mode: body.mode,
         mediaIncarnation: body.mediaIncarnation,
         expectedCallId: body.expectedCallId,
+        takeover: body.takeover,
       })
       const snapshot = await callService.getRosterSnapshot(workspaceId, result.call.id)
+      // A takeover displaced another of this user's devices: tell it directly
+      // rather than leaving it to discover a dead call on its next lease renew.
+      if (result.supersededEndpointId) {
+        notifyEndpointTakenOver(io, result.call.id, result.supersededEndpointId)
+      }
 
       res.status(result.created ? 201 : 200).json({
         call: result.call,

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -449,6 +449,111 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
     expect(closeSession).toHaveBeenCalledWith("sess_old")
     expect(order).toEqual(["db-close", "cf-close"])
   })
+
+  it("reports the displaced endpoint on a takeover and nothing on a rebind", async () => {
+    stubTransaction()
+    spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
+    spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
+    spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+    spyOn(CallEndpointRepository, "findLiveByParticipant").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 3, mediaIncarnation: "inc_other" })
+    )
+    spyOn(CallEndpointRepository, "close").mockResolvedValue(fakeEndpoint({ id: "callep_old", status: "closed" }))
+    spyOn(CallEndpointRepository, "maxEpochForParticipant").mockResolvedValue(3)
+    spyOn(CallEndpointRepository, "insert").mockResolvedValue(fakeEndpoint({ id: "callep_new", epoch: 4 }))
+    const rebind = spyOn(CallEndpointRepository, "rebind").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 3 })
+    )
+
+    const service = makeService()
+    const takenOver = await service.joinCall({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_a",
+      mediaIncarnation: "inc_new",
+      takeover: true,
+    })
+    // A rebind reuses the endpoint id, so the "another device took this over"
+    // notification would land on the arriving device — it must report nothing.
+    const rebound = await service.joinCall({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_a",
+      mediaIncarnation: "inc_other",
+    })
+
+    expect(rebind).toHaveBeenCalled()
+    expect({ takeover: takenOver.supersededEndpointId, rebind: rebound.supersededEndpointId }).toEqual({
+      takeover: "callep_old",
+      rebind: null,
+    })
+  })
+})
+
+describe("CallService.startCall — takeover", () => {
+  afterEach(() => mock.restore())
+
+  it("forwards takeover into the locked join so a second device can displace the first", async () => {
+    stubTransaction()
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
+    spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
+    spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall())
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallRepository, "findCallStartedEventId").mockResolvedValue("evt_started")
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
+    spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
+    spyOn(CallInvitationRepository, "acceptRingingForUser").mockResolvedValue([])
+    spyOn(CallEndpointRepository, "findLiveByParticipant").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 3, mediaIncarnation: "inc_phone" })
+    )
+    const close = spyOn(CallEndpointRepository, "close").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", status: "closed" })
+    )
+    spyOn(CallEndpointRepository, "maxEpochForParticipant").mockResolvedValue(3)
+    spyOn(CallEndpointRepository, "insert").mockResolvedValue(fakeEndpoint({ id: "callep_new", epoch: 4 }))
+
+    // The client only ever reaches admitEndpoint through REST start, so without
+    // this forwarding "Join on this device" is unreachable.
+    const result = await makeService().startCall({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      userId: "usr_a",
+      mode: "video",
+      mediaIncarnation: "inc_laptop",
+      takeover: true,
+    })
+
+    expect(close).toHaveBeenCalledWith(expect.anything(), "ws_1", "callep_old")
+    expect({ endpointId: result.endpoint.id, superseded: result.supersededEndpointId }).toEqual({
+      endpointId: "callep_new",
+      superseded: "callep_old",
+    })
+  })
+
+  it("still rejects a second device when takeover is not asked for", async () => {
+    stubTransaction()
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
+    spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
+    spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall())
+    spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
+    spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
+    spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
+    spyOn(CallEndpointRepository, "findLiveByParticipant").mockResolvedValue(
+      fakeEndpoint({ id: "callep_old", epoch: 3, mediaIncarnation: "inc_phone" })
+    )
+
+    await expect(
+      makeService().startCall({
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        userId: "usr_a",
+        mode: "video",
+        mediaIncarnation: "inc_laptop",
+      })
+    ).rejects.toMatchObject({ code: "CALL_ENDPOINT_ACTIVE", status: 409 })
+  })
 })
 
 describe("CallService.leaveCall", () => {

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -77,12 +77,21 @@ export interface StartCallResult {
    * only if the started card row is somehow missing (never for a fresh create).
    */
   chatAnchorId: string | null
+  /** See {@link JoinCallResult.supersededEndpointId}. */
+  supersededEndpointId: string | null
 }
 
 export interface JoinCallResult {
   call: Call
   participant: CallParticipant
   endpoint: CallEndpoint
+  /**
+   * The endpoint a `takeover` displaced, or null. Its device is still holding a
+   * call the server has closed under it, so the caller notifies that endpoint's
+   * room after the commit. Never set by a rebind — a rebind keeps the SAME
+   * endpoint id, which is the room the arriving device itself sits in.
+   */
+  supersededEndpointId: string | null
 }
 
 /** A versioned roster snapshot: the per-participant rows plus the version they were read at. */
@@ -143,6 +152,8 @@ export class CallService {
       mode: CallMode
       mediaIncarnation?: string
       expectedCallId?: string
+      /** Displace this user's other device rather than 409 — see {@link admitEndpoint}. */
+      takeover?: boolean
     },
     tx?: PoolClient
   ): Promise<StartCallResult> {
@@ -189,6 +200,7 @@ export class CallService {
         callId: targetCallId,
         userId: params.userId,
         mediaIncarnation: params.mediaIncarnation,
+        takeover: params.takeover,
       })
 
       // A newly created call is a slotted broadcast row on the host stream
@@ -242,6 +254,7 @@ export class CallService {
           participant: admitted.participant,
           endpoint: admitted.endpoint,
           chatAnchorId,
+          supersededEndpointId: admitted.supersededEndpointId,
         },
         closedSessionIds: admitted.closedSessionIds,
       }
@@ -322,7 +335,12 @@ export class CallService {
 
     const incarnation = params.mediaIncarnation ?? null
     const live = await CallEndpointRepository.findLiveByParticipant(client, params.workspaceId, participant.id)
-    const { endpoint, closedCfSessionId } = await this.admitEndpoint(client, { params, participant, live, incarnation })
+    const { endpoint, closedCfSessionId, supersededEndpointId } = await this.admitEndpoint(client, {
+      params,
+      participant,
+      live,
+      incarnation,
+    })
 
     const accepted = await CallInvitationRepository.acceptRingingForUser(client, {
       workspaceId: params.workspaceId,
@@ -342,7 +360,13 @@ export class CallService {
     await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
     await this.emitParticipantsChanged(client, params.workspaceId, call.streamId, params.callId)
 
-    return { call, participant, endpoint, closedSessionIds: closedCfSessionId ? [closedCfSessionId] : [] }
+    return {
+      call,
+      participant,
+      endpoint,
+      supersededEndpointId,
+      closedSessionIds: closedCfSessionId ? [closedCfSessionId] : [],
+    }
   }
 
   /**
@@ -366,12 +390,17 @@ export class CallService {
       live: CallEndpoint | null
       incarnation: string | null
     }
-  ): Promise<{ endpoint: CallEndpoint; closedCfSessionId: string | null }> {
+  ): Promise<{ endpoint: CallEndpoint; closedCfSessionId: string | null; supersededEndpointId: string | null }> {
     const { params, participant, live, incarnation } = args
     const leaseExpiresAt = new Date(Date.now() + ENDPOINT_LEASE_TTL_MS)
     // The CF session dropped by a takeover/rebind, to close AFTER the tx commits
     // (INV-41). This is the one place the teardown handle was being lost.
     let closedCfSessionId: string | null = null
+    // Set ONLY by the takeover branch: that device keeps rendering a call the
+    // server just closed under it, so the caller pushes it a control event after
+    // the commit. A rebind must never set it — it reuses the endpoint id, so the
+    // notification would land on the arriving device instead.
+    let supersededEndpointId: string | null = null
 
     if (live) {
       // Rebind only applies to the incarnation-aware socket-join path. A caller
@@ -393,7 +422,7 @@ export class CallService {
           // by the join serializes this read). A same-incarnation reconnect keeps
           // the session, so nothing is torn down.
           if (live.cfSessionId && live.mediaIncarnation !== incarnation) closedCfSessionId = live.cfSessionId
-          return { endpoint: rebound, closedCfSessionId }
+          return { endpoint: rebound, closedCfSessionId, supersededEndpointId }
         }
         // Lost the row to a concurrent close between read and CAS; fall through to a fresh mint.
       } else if (!params.takeover) {
@@ -404,6 +433,9 @@ export class CallService {
       } else {
         const closed = await CallEndpointRepository.close(client, params.workspaceId, live.id)
         closedCfSessionId = closed?.cfSessionId ?? null
+        // Only when the close actually landed: a row already closed by a
+        // concurrent leave/reap has no device left to notify.
+        supersededEndpointId = closed?.id ?? null
       }
     }
 
@@ -417,7 +449,7 @@ export class CallService {
       mediaIncarnation: incarnation,
       leaseExpiresAt,
     })
-    return { endpoint, closedCfSessionId }
+    return { endpoint, closedCfSessionId, supersededEndpointId }
   }
 
   /**

--- a/apps/backend/src/features/calls/signaling-gateway.test.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.test.ts
@@ -125,6 +125,47 @@ describe("registerCallGateway call:join", () => {
     expect(callService.joinCall).toHaveBeenCalledWith(expect.objectContaining({ takeover: true }))
   })
 
+  it("tells a displaced device its endpoint was taken over, addressed to that endpoint's room", async () => {
+    const { socket, to, emit } = setup({
+      callService: {
+        joinCall: mock(async () => ({
+          call: { id: "call_1" },
+          participant: { id: "callp_1" },
+          endpoint: { id: "callep_new", epoch: 5, connectionSeq: 0 },
+          supersededEndpointId: "callep_old",
+        })),
+      },
+    })
+
+    await socket.trigger(
+      "call:join",
+      { ...JOIN, takeover: true },
+      mock(() => {})
+    )
+
+    expect(to).toHaveBeenCalledWith("call:call_1:ep:callep_old")
+    expect(emit).toHaveBeenCalledWith("call:endpoint:closed", {
+      callId: "call_1",
+      endpointId: "callep_old",
+      reason: "taken_over",
+    })
+  })
+
+  it("emits no takeover notice on an ordinary join or a rebind", async () => {
+    const { socket, to, emit } = setup()
+
+    await socket.trigger(
+      "call:join",
+      JOIN,
+      mock(() => {})
+    )
+
+    // A rebind returns the SAME endpoint id, so a notice here would tear down the
+    // device that just joined.
+    expect(to).not.toHaveBeenCalledWith("call:call_1:ep:callep_1")
+    expect(emit).not.toHaveBeenCalledWith("call:endpoint:closed", expect.anything())
+  })
+
   it("acks CALLS_UNAVAILABLE when the media plane is unconfigured", async () => {
     const { socket, callService } = setup({ cloudflareEnabled: false })
     const ack = mock(() => {})

--- a/apps/backend/src/features/calls/signaling-gateway.ts
+++ b/apps/backend/src/features/calls/signaling-gateway.ts
@@ -38,6 +38,27 @@ export function broadcastRoster(io: Server, callId: string, snapshot: CallRoster
   })
 }
 
+/**
+ * Tell a displaced device that another of this user's devices took the call over.
+ * Addressed to the superseded endpoint's own room, so only that device hears it.
+ *
+ * Without this the displaced client learns nothing until its next lease renew
+ * fails (`CALL_LEASE_SUPERSEDED`, one TTL/3 away) while its media is already
+ * dead — a silent stretch of "Reconnecting…" ending in the call vanishing. The
+ * renew remains the backstop for a device that has lost the socket.
+ *
+ * Only ever called with `supersededEndpointId` from a takeover: a rebind reuses
+ * the endpoint id, and this event on that room would tear down the very device
+ * that just joined.
+ */
+export function notifyEndpointTakenOver(io: Server, callId: string, endpointId: string): void {
+  io.of(CALLS_NAMESPACE).to(endpointRoom(callId, endpointId)).emit("call:endpoint:closed", {
+    callId,
+    endpointId,
+    reason: "taken_over",
+  })
+}
+
 const joinSchema = z.object({
   workspaceId: z.string().min(1),
   callId: z.string().min(1),
@@ -215,6 +236,7 @@ export function registerCallGateway(io: Server, deps: Dependencies) {
         })
         // Let existing members observe the new arrival.
         broadcastRoster(io, callId, snapshot)
+        if (result.supersededEndpointId) notifyEndpointTakenOver(io, callId, result.supersededEndpointId)
       } catch (err) {
         respondError(err, ack, "call:join", { workspaceId, callId })
       }

--- a/docs/plans/calls-multi-device-participation.md
+++ b/docs/plans/calls-multi-device-participation.md
@@ -1,6 +1,6 @@
 # Calls — same user on multiple devices
 
-Status: **scoped, not ratified.** Inventory only; no code written.
+Status: **Feature 1 (takeover) planned in detail and in build.** Features 2–3 scoped only.
 
 ## Why
 
@@ -37,26 +37,116 @@ CREATE UNIQUE INDEX idx_call_endpoints_live_per_participant
 
 `ActiveElsewhereChip` (`apps/frontend/src/components/call/active-elsewhere-chip.tsx`)
 is _not_ this case — it reports the Web Lock being held by another **tab** in the
-same browser, not another device.
+same browser, not another device. In practice that chip barely fires: the REST
+start runs _before_ `acquireLock`, so a second tab hits the same 409 first.
 
 ## Feature 1 — "Join on this device" (handoff)
 
-**The server already implements it.** `takeover: true` closes the prior endpoint
-under the call-row lock, tears down its CF session after commit (INV-41), and
-mints a higher epoch (`service.ts:399-419`). The signaling gateway accepts the
-flag too (`signaling-gateway.ts:45`).
+The takeover **transition** exists server-side (`admitEndpoint` closes the prior
+endpoint under the call-row lock, tears down its CF session after commit per
+INV-41, and mints a higher epoch). What does not exist: a way to _reach_ it from
+the client, and any signal to the device being displaced.
 
-Work is frontend-only:
+### Reachability — takeover is unreachable from the frontend today
 
-- Catch 409 `CALL_ENDPOINT_ACTIVE` on join/start and, instead of a toast, prompt:
-  **Join on this device** (retry with `takeover: true`) / **Cancel**.
-- The displaced device needs a clear terminal state, not a silent disconnect: it
-  gets its endpoint closed out from under it and must render "This call moved to
-  another device" with a rejoin affordance, not a generic transport error.
+`CallManager.runStart` always begins with the REST start
+(`POST /api/workspaces/:id/calls`), so that is where the 409 lands. But
+`startSchema` (`handlers.ts:19`) has no `takeover` field and `CallService.startCall`
+neither accepts nor forwards one into `joinLockedCall` — only the socket
+`call:join` path (`signaling-gateway.ts:45`) carries the flag, and the client
+never gets there. So the flag is plumbed through REST start:
 
-Open question: whether the displaced device's user should be _asked_ (a
-confirm-on-the-old-device handshake) or simply told. Told is simpler and matches
-the mental model — it is the same person on both ends.
+1. `startSchema` += `takeover: z.boolean().optional()`; handler passes it through.
+2. `CallService.startCall` params += `takeover?: boolean`, forwarded into
+   `joinLockedCall`.
+
+### Telling the displaced device
+
+Today the only signal is the lease renew failing with `CALL_LEASE_SUPERSEDED`,
+and the renew interval is TTL/3 = **15s** (`leaseRenewIntervalMs`, `calls/config.ts`).
+Its media dies the moment the CF session closes, so the displaced device shows
+"Reconnecting…" for up to 15 seconds and then the call silently vanishes. Not
+acceptable as the primary path.
+
+So the server pushes it. `endpointRoom(callId, endpointId)` already exists for
+exactly this ("control events are addressed here, never a user room") and has no
+emitters yet — this is its first use:
+
+3. `admitEndpoint` returns the **superseded endpoint id** alongside
+   `closedCfSessionId`; `startCall`/`joinCall` propagate it up as
+   `supersededEndpointIds` next to `closedSessionIds`.
+4. After commit, the REST handler and the gateway (both hold `io`) emit
+   `call:endpoint:closed { callId, endpointId, reason: "taken_over" }` to that
+   endpoint's room.
+5. **Only for a real takeover, never a rebind.** A rebind reuses the same
+   endpoint id, so the room is the room the _joining_ device is about to sit in —
+   emitting there would kill the device that just arrived. Guard on
+   `closedEndpointId !== newEndpoint.id`.
+
+The lease-renew `CALL_LEASE_SUPERSEDED` path stays as the backstop for a
+partitioned device and routes into the same client handler, so the outcome is
+identical whichever signal wins.
+
+### The displaced device must not emit any leave
+
+Both leave paths are wrong here and would damage the call the user just moved:
+
+- `call:leave` (socket) → `leaveCall` → `cancelRingingByInviter`: on a DM call
+  whose peer has not answered yet, taking over on the laptop would **cancel the
+  ring** the laptop wants live.
+- `leaveCallRest` (`POST /calls/:id/leave`) → `leaveCallAsUser` →
+  `closeByParticipant` closes **every** live endpoint of the user — including the
+  new device's.
+
+So the displaced client tears down **locally only**. That is internal to
+`CallManager` (`teardown()` is private and emits nothing), so no `CallController`
+API change: the manager handles the socket event itself.
+
+### Frontend shape
+
+6. `CallManagerDeps.startCallRest` and `CallManager.startCall` params gain
+   `takeover?: boolean`.
+7. `CallLaunchState` += `{ status: "takeover_prompt"; request }`. In
+   `CallLaunchProvider.run`'s catch, an `ApiError` with code
+   `CALL_ENDPOINT_ACTIVE` sets that state instead of `join_error` + toast; a new
+   `takeOver()` action re-runs the same request with `takeover: true`. The dock
+   already stays mounted for any non-idle launch state
+   (`launching = launch.status !== "idle"`, `call-dock.tsx:61`), so the prompt
+   renders where the join error renders today.
+8. `PreJoinGate` renders it: "You're already in this call on another device" with
+   primary **Join on this device** and ghost **Cancel**. ("Join again" gets a
+   second button here when Feature 2 lands — deliberately absent now.)
+9. `CallManager.wireSocket` handles `call:endpoint:closed`: gate on gen + callId +
+   `endpointId === session.endpointId`, then `teardown()` and record a displaced
+   notice. `clearCallState()` runs inside teardown, so the notice is a separate
+   store field written after it and cleared on the next `setCallSession` / dismiss.
+10. A `CallMovedChip` in `CallDock`'s idle branch (where `ActiveElsewhereChip`
+    sits): "This call moved to another device", **Rejoin here** (launch with
+    `expectedCallId` — which now takes over back) and **Dismiss**. A chip with an
+    action, not a toast (INV-63).
+
+### Also fixed, for free
+
+The second-tab-in-the-same-browser case gets the same prompt instead of a bare
+error toast, because it fails at the same 409.
+
+### Known residual (accepted)
+
+If the new device's capture fails _after_ the takeover commits, `rollbackStart`
+calls the endpoint-free REST leave and the user ends up in the call on neither
+device. The old device already shows the moved chip with **Rejoin here**, so
+there is a way back; not worth a distributed rollback.
+
+### Verification
+
+Unit: service (takeover through REST start; rebind does not supersede), gateway +
+handler (superseded room receives the event; a rebind does not emit), launch
+context (409 → prompt → retry carries `takeover`), manager (endpoint-closed event
+tears down locally and emits **no** leave).
+
+Live: two Playwright contexts as the same user under `dev:test` — A joins, B
+joins → prompt → **Join on this device** → A shows the moved chip within ~1s, B is
+connected, and the roster carries exactly one participant.
 
 ## Feature 2 — "Join again" (two live legs)
 
@@ -91,7 +181,8 @@ join whose publish policy is screen-only. Note the schema already reserves
 
 ## Observed misbehaviour to confirm during the build
 
-- Second-device join → error toast only (explained above: unhandled 409).
+- Second-device join → error toast only (explained above: unhandled 409). Fixed
+  by Feature 1.
 - "Leave call" pressed on the phone while the laptop is the connected device did
   nothing visible. Most likely the phone's endpoint had already been reaped or
   closed, so `leaveCall` 404s on `CALL_ENDPOINT_NOT_FOUND` and the UI stays put —
@@ -103,7 +194,7 @@ join whose publish policy is screen-only. Note the schema already reserves
 
 ## Suggested order
 
-1. Handoff prompt + displaced-device state (frontend-only, server ready).
+1. Handoff prompt + displaced-device state. **In build.**
 2. Stale-endpoint UI audit (the "Leave did nothing" case).
 3. Two live legs (schema + roster; own stack).
 4. Presented mode, after screen share.


### PR DESCRIPTION
## Problem

"Join on this device" was described as frontend-only work because `admitEndpoint` already implements takeover. It isn't reachable. `CallManager.runStart` always begins with `POST /api/workspaces/:id/calls`, and that path drops the flag: `startSchema` (`handlers.ts:19`) has no `takeover` field and `CallService.startCall` neither accepts nor forwards one into `joinLockedCall`. Only the socket `call:join` carries it, and the client never gets there — so a second device's 409 `CALL_ENDPOINT_ACTIVE` is a dead end.

The device being displaced is the other half. Its CF session is closed after commit, so its media dies immediately, but the only signal it gets is its next lease renew failing — TTL/3 = 15s of "Reconnecting…" ending in the call silently vanishing.

## Solution

- `takeover` through the REST start: schema → handler → `startCall` → `joinLockedCall`.
- `admitEndpoint` now reports `supersededEndpointId`, propagated up through `startCall`/`joinCall`. Set **only** by the takeover branch, and only when `close` actually landed (a row already closed by a concurrent leave/reap has no device left to notify).
- Both join paths push `call:endpoint:closed { callId, endpointId, reason: "taken_over" }` to `endpointRoom(callId, endpointId)` — the first use of that room, which existed for exactly this. The lease renew stays as the backstop for a device that lost its socket.
- **A rebind must never report one.** It reuses the endpoint id, so the notice would land on the device that just arrived rather than the one it replaced — the structural reason `supersededEndpointId` is set in the takeover branch and nowhere else. Tested from both directions.

Inert on its own: nothing sends `takeover: true` until [#1566](https://github.com/threahq/threa/pull/1566) lands on top.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/calls/service.ts` | `takeover` param on `startCall`; `supersededEndpointId` on both results |
| `apps/backend/src/features/calls/handlers.ts` | `takeover` in `startSchema`; notify the displaced endpoint after the start |
| `apps/backend/src/features/calls/signaling-gateway.ts` | `notifyEndpointTakenOver`; emit on `call:join` |
| `docs/plans/calls-multi-device-participation.md` | Feature 1 planned in detail |

## Test plan

- [x] `bun test src/features/calls/` — 149 pass (5 new: takeover via REST start, 409 without it, superseded-vs-rebind reporting, gateway emit + non-emit, handler forward + non-notify)
- [x] backend typecheck, monorepo lint, api-docs check — clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
