### PR TITLE
feat(calls): offer "Join on this device" and tell the displaced device where the call went

### DIFF
--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -325,6 +325,59 @@ describe("CallManager", () => {
     expect(socket.emitted.filter((e) => e.event === "call:lease:renew")).toHaveLength(2)
   })
 
+  it("gives the call up when another device takes it over, without leaving server-side", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    const deps = makeDeps(socket, transport)
+    const manager = new CallManager(deps, null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    socket.fire("call:endpoint:closed", { callId: "call_1", endpointId: "ep_1", reason: "taken_over" })
+    await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
+
+    // No leave of any kind: `call:leave` would cancel this user's own outgoing
+    // ring, and the REST self-leave closes EVERY endpoint — including the device
+    // that just took over.
+    expect(socket.emitted.some((e) => e.event === "call:leave")).toBe(false)
+    expect(deps.leaveCallRest).not.toHaveBeenCalled()
+    expect(transport.close).toHaveBeenCalled()
+    // The notice outlives the teardown that cleared the rest of the call state.
+    expect(getCallState().displacedCall).toEqual({
+      callId: "call_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      mode: "video",
+    })
+  })
+
+  it("ignores an endpoint-closed event for another call or another endpoint", async () => {
+    const socket = makeSocket()
+    const manager = new CallManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    socket.fire("call:endpoint:closed", { callId: "call_other", endpointId: "ep_1" })
+    socket.fire("call:endpoint:closed", { callId: "call_1", endpointId: "ep_stale" })
+
+    expect(getCallState().phase).toBe("connected")
+    expect(getCallState().displacedCall).toBeNull()
+  })
+
+  it("lands on the same displaced state when only the lease renew reports the takeover", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const manager = new CallManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // The backstop for a device that lost the socket push.
+    socket.emit = ((event: string, _p: unknown, ack?: (r: unknown) => void) => {
+      if (event === "call:lease:renew") ack?.({ ok: false, code: "CALL_LEASE_SUPERSEDED" })
+    }) as CallSocket["emit"]
+    vi.advanceTimersByTime(15_000)
+    await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
+
+    expect(getCallState().displacedCall).toMatchObject({ callId: "call_1", streamId: "stream_1" })
+  })
+
   it("mute gates track.enabled and emits call:state", async () => {
     const socket = makeSocket()
     const transport = makeTransport()

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -12,6 +12,7 @@ import {
   setCallDevices,
   setCallDiagnostics,
   setCallActiveElsewhere,
+  setDisplacedCall,
   setCallConfirmPending,
   setCallCaptureError,
   bumpCallMediaEpoch,
@@ -130,6 +131,12 @@ export interface CallManagerDeps {
      * know the call they mean to enter; a fresh start-or-join passes none.
      */
     expectedCallId?: string
+    /**
+     * "Join on this device": displace this user's live endpoint on another
+     * device instead of being rejected by it. Only ever set by the retry after a
+     * 409 `CALL_ENDPOINT_ACTIVE` — a first attempt must never take over silently.
+     */
+    takeover?: boolean
   }): Promise<StartCallResponse>
   /**
    * Endpoint-free REST self-leave: closes every live endpoint this user holds on
@@ -231,6 +238,8 @@ export interface CallController {
     mode: CallMode
     expectedCallId?: string
     cameraOn?: boolean
+    /** Displace this user's other device — see {@link CallManagerDeps.startCallRest}. */
+    takeover?: boolean
   }): Promise<void>
   leaveCall(): Promise<void>
   setMuted(muted: boolean): void
@@ -298,6 +307,7 @@ export class CallManager implements CallController {
     mode: CallMode
     expectedCallId?: string
     cameraOn?: boolean
+    takeover?: boolean
   }): Promise<void> {
     if (this.session || this.starting) throw new Error("A call is already active")
     this.starting = true
@@ -308,7 +318,14 @@ export class CallManager implements CallController {
 
   private async runStart(
     gen: number,
-    params: { workspaceId: string; streamId: string; mode: CallMode; expectedCallId?: string; cameraOn?: boolean }
+    params: {
+      workspaceId: string
+      streamId: string
+      mode: CallMode
+      expectedCallId?: string
+      cameraOn?: boolean
+      takeover?: boolean
+    }
   ): Promise<void> {
     const mediaIncarnation = this.deps.mintIncarnation()
     // Synchronous, in-gesture (see startCall doc). Held on a temp until the session exists.
@@ -708,6 +725,17 @@ export class CallManager implements CallController {
       if (evt.callId !== s.callId) return
       this.applyRoster(s, evt.rosterVersion, evt.roster)
     })
+    // Another of this user's devices took the call over: the server closed this
+    // endpoint and its CF session, so the media here is already dead. Addressed to
+    // this endpoint's own room, so it is always about us — but gate on the ids
+    // anyway, since a rebind reuses an endpoint id across sessions.
+    session.socket.on("call:endpoint:closed", (payload: unknown) => {
+      const s = this.sessionForGen(gen)
+      if (!s) return
+      const evt = payload as { callId?: string; endpointId?: string }
+      if (evt.callId !== s.callId || evt.endpointId !== s.endpointId) return
+      void this.handleTakenOver(s)
+    })
     session.socket.on("disconnect", () => {
       // A socket drop is NOT a call end (the lease holds the slot). Demote to
       // reconnecting; the CF media session survives brief socket loss.
@@ -751,6 +779,30 @@ export class CallManager implements CallController {
           void this.teardown()
         })
     })
+  }
+
+  /**
+   * Give the call up to the device that took it over, and say where it went.
+   *
+   * Local teardown ONLY — this must not leave server-side. `call:leave` would
+   * cancel this user's own outgoing ring (taking over a still-ringing DM call
+   * would kill the ring the new device wants), and the endpoint-free REST leave
+   * closes EVERY live endpoint of the user, including the one that just took
+   * over. The server already closed this endpoint under the call-row lock;
+   * there is nothing left here to settle.
+   *
+   * The notice is written after `teardown` (which clears the store) so it
+   * survives — {@link DisplacedCall}.
+   */
+  private async handleTakenOver(session: CallSession): Promise<void> {
+    const displaced = {
+      callId: session.callId,
+      workspaceId: session.workspaceId,
+      streamId: session.streamId,
+      mode: session.mode,
+    }
+    await this.teardown()
+    setDisplacedCall(displaced)
   }
 
   private applyRoster(session: CallSession, version: number, roster: CallRosterParticipant[]): void {
@@ -1134,8 +1186,13 @@ export class CallManager implements CallController {
         if (!this.sessionForGen(gen)) return
         const ack = result as Ack<{ leaseExpiresAt: string }>
         // A superseded lease means our endpoint was taken over — the call is lost
-        // on this incarnation; tear down rather than pretend we're still in.
-        if (!ack?.ok && ack?.code === "CALL_LEASE_SUPERSEDED") void this.teardown()
+        // on this incarnation. The socket push above normally gets here first;
+        // this is the backstop for a device that lost the socket, and it lands on
+        // the same displaced state so the outcome doesn't depend on which won.
+        if (!ack?.ok && ack?.code === "CALL_LEASE_SUPERSEDED") {
+          const s = this.sessionForGen(gen)
+          if (s) void this.handleTakenOver(s)
+        }
       })
     }, interval)
   }
@@ -1386,6 +1443,7 @@ export class CallManager implements CallController {
   private removeSocketHandlers(session: CallSession): void {
     try {
       session.socket.off("call:roster")
+      session.socket.off("call:endpoint:closed")
       session.socket.off("disconnect")
       session.socket.off("connect")
     } catch {
@@ -1439,12 +1497,13 @@ function detectSingleActiveCapture(): boolean {
 
 export function defaultCallManagerDeps(): CallManagerDeps {
   return {
-    async startCallRest({ workspaceId, streamId, mode, mediaIncarnation, expectedCallId }) {
+    async startCallRest({ workspaceId, streamId, mode, mediaIncarnation, expectedCallId, takeover }) {
       return api.post<StartCallResponse>(`/api/workspaces/${workspaceId}/calls`, {
         streamId,
         mode,
         mediaIncarnation,
         expectedCallId,
+        takeover,
       })
     },
     async leaveCallRest({ workspaceId, callId }) {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -14,6 +14,7 @@ import {
   setCallRoster,
   patchCallLocal,
   setCallActiveElsewhere,
+  setDisplacedCall,
   setCallCaptureError,
   setCallSurfaceMode,
   setDesktopSurfaceOverride,
@@ -22,6 +23,7 @@ import {
 } from "@/stores/call-store"
 import { __resetCallPrefsForTests, getCallPrefs, setDesktopCallSurface } from "@/stores/call-prefs-store"
 import { CallCaptureError, type CallController } from "@/calls/call-manager"
+import { ApiError } from "@/api/client"
 import { CallDock } from "./call-dock"
 import { CallManagerProvider } from "./call-manager-context"
 import { CallLaunchProvider, useCallLaunch, type CallLaunchRequest } from "./call-launch-context"
@@ -164,6 +166,27 @@ describe("CallDock — idle", () => {
     renderDock(makeManager())
     act(() => setCallActiveElsewhere(true))
     expect(screen.getByText(/Call active in another tab/i)).toBeInTheDocument()
+  })
+
+  it("says where the call went after another device took it over, and offers it back", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    // The manager writes this after its teardown; the surface it was rendering is
+    // already gone, so this chip is the only thing left that explains why.
+    act(() => setDisplacedCall({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+
+    expect(screen.getByText(/moved to another device/i)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Rejoin here" }))
+    expect(manager.startCall).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: "stream_1", expectedCallId: "call_1" })
+    )
+  })
+
+  it("dismisses the moved-call chip", async () => {
+    renderDock(makeManager())
+    act(() => setDisplacedCall({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }))
+    expect(screen.queryByText(/moved to another device/i)).toBeNull()
   })
 })
 
@@ -309,6 +332,35 @@ describe("CallDock — pre-join permission taxonomy", () => {
     enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
     await userEvent.click(screen.getByText("launch"))
     expect(manager.startCall).not.toHaveBeenCalled()
+  })
+
+  it("offers to move the call here when another device holds it, and retries with takeover", async () => {
+    // The server's 409 for "this user already has a live endpoint elsewhere".
+    const startCall = vi.fn(async () => {
+      throw new ApiError(409, "CALL_ENDPOINT_ACTIVE", "An active endpoint already exists for this user")
+    })
+    const manager = makeManager({ startCall })
+    renderDock(manager)
+
+    await userEvent.click(screen.getByText("launch"))
+    expect(await screen.findByText(/in this call on another device/i)).toBeInTheDocument()
+    // A choice, not a failure — no generic retry affordance.
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull()
+
+    await userEvent.click(screen.getByRole("button", { name: "Join on this device" }))
+    expect(startCall).toHaveBeenLastCalledWith({
+      workspaceId: WORKSPACE_ID,
+      streamId: "stream_1",
+      mode: "video",
+      takeover: true,
+    })
+  })
+
+  it("never takes over on a first attempt", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    await userEvent.click(screen.getByText("launch"))
+    expect(manager.startCall).toHaveBeenCalledWith(expect.objectContaining({ takeover: undefined }))
   })
 
   it("shows the pre-join gate on a fresh launch after the prior call was minimized", async () => {

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -15,6 +15,7 @@ import {
   useCallStreamId,
   useCallWorkspaceId,
   useDesktopSurfaceOverride,
+  useDisplacedCall,
 } from "./call-store-hooks"
 
 // Bottom-anchored call surfaces clear the iOS home indicator on desktop (app
@@ -37,6 +38,7 @@ import { DesktopCallDock } from "./desktop-call-dock"
 import { FloatingCallSquare } from "./floating-call-square"
 import { DesktopCallFullscreen } from "./desktop-call-fullscreen"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
+import { CallMovedChip } from "./call-moved-chip"
 
 /**
  * The docked call surface. Mounts at the app-layout level and is driven purely by
@@ -52,6 +54,7 @@ export function CallDock() {
   const phase = useCallPhase()
   const { state: launch } = useCallLaunch()
   const activeElsewhere = useCallActiveElsewhere()
+  const displaced = useDisplacedCall()
   const storeStreamId = useCallStreamId()
   const workspaceId = useCallWorkspaceId()
   const isMobile = useIsMobile()
@@ -98,10 +101,18 @@ export function CallDock() {
     }
   }, [inCall])
 
-  // Nothing to show: idle with no launch in flight. Surface the cross-tab chip if
-  // another tab holds the call, otherwise render nothing.
+  // Nothing to show: idle with no launch in flight. Surface the displaced-call
+  // chip if another device took this call over, then the cross-tab chip if another
+  // tab holds it, otherwise render nothing.
   if (!launching && !inCall && !joining) {
     joiningModeRef.current = "compact"
+    if (displaced) {
+      return (
+        <div className={cn("fixed right-4 z-50", DOCK_BOTTOM)}>
+          <CallMovedChip />
+        </div>
+      )
+    }
     if (activeElsewhere) {
       return (
         <div className={cn("fixed right-4 z-50", DOCK_BOTTOM)}>

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { toast } from "sonner"
+import { ApiError } from "@/api/client"
 import type { CallMode } from "@/calls/config"
 import { CallCaptureError, CallStartCancelledError } from "@/calls/call-manager"
 import { getCallState } from "@/stores/call-store"
@@ -25,13 +26,15 @@ export interface CallLaunchRequest {
  * The pre-join flow state. `requesting` spans the whole join (the dock shows a
  * joining spinner across it); `permission_error` carries the taxonomy class so the
  * gate renders its distinct copy + retry; `join_error` is a non-media failure
- * (REST/socket) with a plain retry.
+ * (REST/socket) with a plain retry; `takeover_prompt` is the user's own other
+ * device already holding this call, which is a choice, not a failure.
  */
 export type CallLaunchState =
   | { status: "idle" }
   | { status: "requesting"; request: CallLaunchRequest }
   | { status: "permission_error"; request: CallLaunchRequest; error: MediaPermissionError }
   | { status: "join_error"; request: CallLaunchRequest; message: string }
+  | { status: "takeover_prompt"; request: CallLaunchRequest }
 
 interface CallLaunchContextValue {
   state: CallLaunchState
@@ -39,6 +42,8 @@ interface CallLaunchContextValue {
   callActive: boolean
   launch: (request: CallLaunchRequest) => void
   retry: () => void
+  /** Answer a `takeover_prompt`: rerun the same launch, displacing the other device. */
+  takeOver: () => void
   cancel: () => void
 }
 
@@ -52,7 +57,7 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
   const runIdRef = useRef(0)
 
   const run = useCallback(
-    async (request: CallLaunchRequest) => {
+    async (request: CallLaunchRequest, opts?: { takeover?: boolean }) => {
       // Already in (or joining) a call: startCall would synchronously reject with
       // a plain Error, which the catch below would surface as a stale join_error
       // carrying the wrong request (and a "Try again" that starts an unintended
@@ -67,7 +72,7 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
       // permission taxonomy is derived from startCall's own typed capture failure
       // instead of a separate pre-flight getUserMedia.
       try {
-        await manager.startCall(request)
+        await manager.startCall({ ...request, takeover: opts?.takeover })
         if (runId !== runIdRef.current) return
         setState({ status: "idle" })
       } catch (err) {
@@ -80,6 +85,13 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
         if (err instanceof CallCaptureError) {
           const error = classifyMediaError((err as { cause?: unknown }).cause ?? err)
           setState({ status: "permission_error", request, error })
+          return
+        }
+        // The user is already in this call on another device (or another tab —
+        // the REST start runs before the Web Lock check, so both land here). Not a
+        // failure: offer to move the call to this device rather than toasting.
+        if (ApiError.isApiError(err) && err.code === "CALL_ENDPOINT_ACTIVE") {
+          setState({ status: "takeover_prompt", request })
           return
         }
         const message = err instanceof Error ? err.message : String(err)
@@ -96,6 +108,12 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
     if (state.status === "permission_error" || state.status === "join_error") void run(state.request)
   }, [run, state])
 
+  // Takeover is only ever reachable from the prompt — never folded into `retry`,
+  // so no other error path can displace another device without being asked.
+  const takeOver = useCallback(() => {
+    if (state.status === "takeover_prompt") void run(state.request, { takeover: true })
+  }, [run, state])
+
   const cancel = useCallback(() => {
     runIdRef.current++
     setState({ status: "idle" })
@@ -106,7 +124,10 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
   // (or connecting), any residual join_error/permission_error is stale — clear it
   // so no unprompted "Try again" survives to a normal call exit.
   useEffect(() => {
-    if (phase !== "idle" && (state.status === "join_error" || state.status === "permission_error")) {
+    if (
+      phase !== "idle" &&
+      (state.status === "join_error" || state.status === "permission_error" || state.status === "takeover_prompt")
+    ) {
       setState({ status: "idle" })
     }
   }, [phase, state.status])
@@ -114,8 +135,8 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
   const callActive = phase !== "idle" || state.status === "requesting"
 
   const value = useMemo<CallLaunchContextValue>(
-    () => ({ state, callActive, launch, retry, cancel }),
-    [state, callActive, launch, retry, cancel]
+    () => ({ state, callActive, launch, retry, takeOver, cancel }),
+    [state, callActive, launch, retry, takeOver, cancel]
   )
 
   return <CallLaunchContext.Provider value={value}>{children}</CallLaunchContext.Provider>

--- a/apps/frontend/src/components/call/call-moved-chip.tsx
+++ b/apps/frontend/src/components/call/call-moved-chip.tsx
@@ -1,0 +1,51 @@
+import { PhoneForwarded, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { setDisplacedCall } from "@/stores/call-store"
+import { useCallLaunch } from "./call-launch-context"
+import { useDisplacedCall } from "./call-store-hooks"
+
+/**
+ * Shown after another of this user's devices took the call over ("Join on this
+ * device" there). The server closed this endpoint, so the dock has already torn
+ * down — without this the call surface would simply vanish mid-conversation.
+ *
+ * A chip with actions rather than a toast (INV-63): it needs a decision, and a
+ * toast would expire before a user who was looking at their other device sees it.
+ * Rejoin runs the ordinary launch, so if the other device is still holding the
+ * call the takeover prompt confirms moving it back.
+ */
+export function CallMovedChip() {
+  const displaced = useDisplacedCall()
+  const { launch } = useCallLaunch()
+  if (!displaced) return null
+  return (
+    <div className="flex items-center gap-1.5 rounded-full border bg-background py-1.5 pl-3 pr-1.5 text-xs shadow-lg">
+      <PhoneForwarded className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+      <span className="text-muted-foreground">Call moved to another device</span>
+      <Button
+        size="sm"
+        variant="secondary"
+        className="h-6 px-2 text-[11px]"
+        onClick={() =>
+          launch({
+            workspaceId: displaced.workspaceId,
+            streamId: displaced.streamId,
+            mode: displaced.mode,
+            expectedCallId: displaced.callId,
+          })
+        }
+      >
+        Rejoin here
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-6 w-6"
+        aria-label="Dismiss"
+        onClick={() => setDisplacedCall(null)}
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -9,6 +9,7 @@ import {
   type CallDeviceState,
   type CallDiagnostics,
   type CallCaptureErrorInfo,
+  type DisplacedCall,
 } from "@/stores/call-store"
 import type { CallMode } from "@/calls/config"
 import type { DesktopSurface } from "@/stores/call-prefs-store"
@@ -95,6 +96,11 @@ export function useCallDiagnostics(): CallDiagnostics {
 
 export function useCallActiveElsewhere(): boolean {
   return useCallSelector((s) => s.activeElsewhere)
+}
+
+/** The call another device took over, or null. See {@link DisplacedCall}. */
+export function useDisplacedCall(): DisplacedCall | null {
+  return useCallSelector((s) => s.displacedCall)
 }
 
 export function useCallCaptureError(): CallCaptureErrorInfo | null {

--- a/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
@@ -55,6 +55,7 @@ beforeEach(() => {
     callActive: false,
     state: { status: "idle" },
     retry: vi.fn(),
+    takeOver: vi.fn(),
     cancel: vi.fn(),
   })
   vi.spyOn(ringTone, "installRingAudioWarmup").mockReturnValue(() => {})

--- a/apps/frontend/src/components/call/pre-join-gate.tsx
+++ b/apps/frontend/src/components/call/pre-join-gate.tsx
@@ -64,7 +64,7 @@ export function CallJoiningBody() {
  * failed pre-connection.
  */
 export function PreJoinGate({ onDark = false }: { onDark?: boolean } = {}) {
-  const { state, retry, cancel } = useCallLaunch()
+  const { state, retry, takeOver, cancel } = useCallLaunch()
   // On the mobile island the gate sits on the dark call surface, so subdue text to
   // white-wash and give the ghost Cancel a dark hover — keeps joining → error one shape.
   const subtle = onDark ? "text-white/70" : "text-muted-foreground"
@@ -93,6 +93,25 @@ export function PreJoinGate({ onDark = false }: { onDark?: boolean } = {}) {
           </Button>
           <Button size="sm" onClick={retry}>
             Try again
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // The user's own other device (or tab) is already in this call. A choice, not a
+  // failure — so no "Try again", and the primary action says where the call ends up.
+  if (state.status === "takeover_prompt") {
+    return (
+      <div {...{ [CALL_SURFACE_PROTECTED_ATTR]: "" }} className="flex flex-col items-center gap-3 py-6 text-center">
+        <p className="text-sm font-medium">You&rsquo;re in this call on another device</p>
+        <p className={cn("text-xs", subtle)}>Joining here will move the call to this device.</p>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" className={cancelClass} onClick={cancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={takeOver}>
+            Join on this device
           </Button>
         </div>
       </div>

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -83,6 +83,20 @@ export interface CallCaptureErrorInfo {
   message: string
 }
 
+/**
+ * The call this device was displaced from when the user joined it on another
+ * device ("Join on this device"). Survives the teardown that removes the call
+ * itself — the manager writes it AFTER `clearCallState` — so the dock can say
+ * where the call went and offer it back instead of the surface silently
+ * vanishing. Cleared by a dismiss, by the next call, and by an account switch.
+ */
+export interface DisplacedCall {
+  callId: string
+  workspaceId: string
+  streamId: string
+  mode: CallMode
+}
+
 export interface CallState {
   phase: CallPhase
   /** Unified surface size ({@link CallSurfaceMode}); "min" until a surface steps it up. */
@@ -115,6 +129,8 @@ export interface CallState {
   local: CallLocalState
   /** True when another tab holds the call's Web Lock (this tab can offer rejoin). */
   activeElsewhere: boolean
+  /** Set when another device took this call over; see {@link DisplacedCall}. */
+  displacedCall: DisplacedCall | null
   /** Set when an account switch is requested with a live call — UI confirms (M1.2). */
   confirmPending: boolean
   diagnostics: CallDiagnostics
@@ -156,6 +172,7 @@ function idleState(): CallState {
     rosterVersion: 0,
     local: { muted: false, cameraOn: false, devices: EMPTY_DEVICES, speakingLevel: 0 },
     activeElsewhere: false,
+    displacedCall: null,
     confirmPending: false,
     diagnostics: { rttMs: null, packetLoss: null, qualityLimitation: null },
     captureError: null,
@@ -217,7 +234,9 @@ export function setCallSession(args: {
   chatAnchorId?: string | null
 }): void {
   const { chatAnchorId = null, ...session } = args
-  setState({ ...state, ...session, chatAnchorId, phase: "joining", connectedAt: null })
+  // A new call supersedes any "this moved to another device" notice, including
+  // the one whose Rejoin started this very call.
+  setState({ ...state, ...session, chatAnchorId, phase: "joining", connectedAt: null, displacedCall: null })
 }
 
 export function setCallRoster(roster: CallRosterParticipant[], rosterVersion: number): void {
@@ -244,6 +263,16 @@ export function setCallDiagnostics(diagnostics: CallDiagnostics): void {
 export function setCallActiveElsewhere(activeElsewhere: boolean): void {
   if (state.activeElsewhere === activeElsewhere) return
   setState({ ...state, activeElsewhere })
+}
+
+/**
+ * Record (or dismiss) the call another device took over. Written by the manager
+ * AFTER its teardown has cleared the call state, which is the only ordering that
+ * survives — see {@link DisplacedCall}.
+ */
+export function setDisplacedCall(displacedCall: DisplacedCall | null): void {
+  if (state.displacedCall === displacedCall) return
+  setState({ ...state, displacedCall })
 }
 
 export function setCallConfirmPending(confirmPending: boolean): void {

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -27,6 +27,9 @@ interface DmPair {
   workspaceId: string
   dmStreamId: string
   inviteeUserId: string
+  /** A's credentials, so a test can log the SAME user in on a second "device". */
+  ownerEmail: string
+  ownerName: string
 }
 
 /** A owner + B member sharing a real DM stream, both viewing it, calls enabled. */
@@ -39,7 +42,7 @@ async function setUpDmPair(browser: Browser): Promise<DmPair> {
   const ownerPage = await ownerContext.newPage()
   const invitee = await loginInNewContext(browser, inviteeEmail, inviteeName)
 
-  await loginAndCreateWorkspace(ownerPage, "calls-a")
+  const owner = await loginAndCreateWorkspace(ownerPage, "calls-a")
   const workspaceId = ownerPage.url().match(/\/w\/([^/]+)/)?.[1]
   if (!workspaceId) throw new Error("Could not resolve workspaceId from owner URL")
 
@@ -90,6 +93,8 @@ async function setUpDmPair(browser: Browser): Promise<DmPair> {
     workspaceId,
     dmStreamId,
     inviteeUserId,
+    ownerEmail: owner.email,
+    ownerName: owner.name,
   }
 }
 
@@ -184,6 +189,48 @@ test.describe("1:1 DM calls", () => {
       const missed = activities.activities.filter((row) => row.activityType === "missed_call")
       expect(missed).toHaveLength(0)
     } finally {
+      await pair.ownerContext.close()
+      await pair.inviteeContext.close()
+    }
+  })
+
+  test("takeover: A's second device moves the call, and the first device is told where it went", async ({
+    browser,
+  }) => {
+    test.setTimeout(120000)
+    const pair = await setUpDmPair(browser)
+    const { ownerPage: a, inviteePage: b, workspaceId, dmStreamId, ownerEmail, ownerName } = pair
+    // A's second device: the SAME user in a fresh context, so the server sees a
+    // second media incarnation on one participant — the CALL_ENDPOINT_ACTIVE case.
+    const second = await loginInNewContext(browser, ownerEmail, ownerName)
+    try {
+      await startCallFromHeader(a)
+      await expect(b.getByText(/is calling/i)).toBeVisible({ timeout: 20000 })
+      await b.getByRole("button", { name: "Accept call" }).click()
+      await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 20000 })
+
+      await second.page.goto(`/w/${workspaceId}/s/${dmStreamId}`)
+      await second.page.getByRole("button", { name: "Start a call" }).click()
+      await second.page.getByRole("menuitem", { name: "Start voice call" }).click()
+
+      // Prompted, not toasted — and nothing has moved until the user says so.
+      await expect(second.page.getByText(/in this call on another device/i)).toBeVisible({ timeout: 20000 })
+      await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 5000 })
+
+      await second.page.getByRole("button", { name: "Join on this device" }).click()
+      await expect(second.page.locator(CALL_TILE)).toHaveCount(2, { timeout: 25000 })
+
+      // The displaced device is told, promptly — not left on a dead call until its
+      // lease renew fails 15s later.
+      await expect(a.getByText(/moved to another device/i)).toBeVisible({ timeout: 15000 })
+      await expect(a.locator(CALL_TILE)).toHaveCount(0, { timeout: 5000 })
+      // B never lost their peer: the identity stayed in the call, only its endpoint moved.
+      await expect(b.locator(CALL_TILE)).toHaveCount(2, { timeout: 20000 })
+
+      await second.page.getByRole("button", { name: "Leave call" }).click()
+      await b.getByRole("button", { name: "Leave call" }).click()
+    } finally {
+      await second.context.close()
       await pair.ownerContext.close()
       await pair.inviteeContext.close()
     }


### PR DESCRIPTION
## Problem

Joining a call from a second device produced an error toast and nothing else — the 409 `CALL_ENDPOINT_ACTIVE` fell through to the generic `join_error` path. Kris's two real workflows (call in from the phone, arrive at the desk and move it to the laptop; laptop shares screen while the phone carries audio) both start here.

The device being displaced had no story at all: its endpoint is closed under it, so the dock simply disappeared mid-conversation.

## Solution

Builds on [#1565](https://github.com/threahq/threa/pull/1565), which makes takeover reachable and pushes `call:endpoint:closed` to the displaced endpoint.

- **The prompt.** `CallLaunchState` gains `takeover_prompt`; the launch catch reads `ApiError.code === "CALL_ENDPOINT_ACTIVE"` as a choice, not a failure — no toast, and the gate offers **Join on this device** / Cancel instead of "Try again". `takeOver()` reruns the same request with `takeover: true` and is reachable only from the prompt, never folded into `retry`, so no error path can displace a device without being asked.
- **The displaced device tears down locally, emitting no leave.** Both leave paths would damage the call the user just moved: `call:leave` → `cancelRingingByInviter` would kill the ring of a DM call the new device is still waiting on, and the REST self-leave (`leaveCallAsUser` → `closeByParticipant`) closes *every* live endpoint of the user, including the one that just took over. The server already closed this endpoint under the call-row lock; there is nothing left to settle.
- **It says where the call went.** `displacedCall` is written after the teardown that clears the store (the only ordering that survives) and the dock renders a chip — "Call moved to another device" with **Rejoin here** and Dismiss — where the cross-tab chip sits. A chip, not a toast (INV-63): it needs a decision, and a toast would expire before someone looking at their other device sees it. Rejoin runs the ordinary launch, so if the other device still holds the call the prompt confirms moving it back.
- Second-tab-in-the-same-browser gets the same prompt for free — it fails at the same 409, which is why `ActiveElsewhereChip` almost never fires (the REST start runs before `acquireLock`).

Not in scope: two live legs, presented mode, "leave all my devices" — see the plan doc.

## Files

| File | Change |
| ---- | ------ |
| `stores/call-store.ts` | `displacedCall` + `setDisplacedCall`; cleared by the next `setCallSession` |
| `calls/call-manager.ts` | `takeover` param; `call:endpoint:closed` handler; `handleTakenOver` (local teardown, no leave); lease-superseded routes to the same place |
| `components/call/call-launch-context.tsx` | `takeover_prompt` state + `takeOver()` |
| `components/call/pre-join-gate.tsx` | The prompt |
| `components/call/call-moved-chip.tsx` | **new** — the displaced-device chip |
| `components/call/call-dock.tsx` | Renders it in the idle branch |
| `tests/browser/calls.spec.ts` | Two-device takeover e2e |

## Test plan

- [x] `bunx vitest run` — 5060 pass, 0 fail, first pass (7 new across manager/dock)
- [x] `bunx playwright test --project=calls --workers=2` — 5 pass, incl. the new two-device takeover
- [x] frontend typecheck + monorepo lint — clean

Honest note: running the `calls` project at the local default worker count (~5) fails all five tests at the shared `setUpDmPair` step — the DM never materializes under that load. Pre-existing and unrelated to this change (it's the setup the four older tests already shared); serial and 2-worker runs, the CI setting, are green.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787694735&installation_model_id=20758&pr_number=1566&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1566&signature=9fca7fe74247a93eb0a38137e4213b8006ed85639df7d2df6965e6ae95299f50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->