### PR TITLE
feat(harness): shared ArchiveGraceController for the archive wind-down

### DIFF
--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -89,6 +89,33 @@ describe("ArchiveGraceController", () => {
     })
   })
 
+  test("a restore push restarts the grace even when the relink fails", async () => {
+    let attempts = 0
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          attempts += 1
+          throw new Error("threa unreachable")
+        },
+      },
+      160
+    )
+
+    await controller.archived("stream_root")
+    await Bun.sleep(120)
+    // Unarchived with the original grace nearly spent: winding down a second
+    // later is exactly the mis-click recovery this window exists for.
+    await controller.restored()
+    await Bun.sleep(100)
+
+    expect({ woundDown: recorded.woundDown, isDetached: controller.detached, attempts }).toEqual({
+      woundDown: [],
+      isDetached: true,
+      attempts: 1,
+    })
+    controller.stop()
+  })
+
   test("a reattach that throws keeps the session detached so the probe retries", async () => {
     const { controller, recorded } = makeController(
       {

--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test"
+import { ArchiveGraceController, type ArchiveGraceHooks } from "./archive-grace"
+
+interface Recorded {
+  detached: string[]
+  reattached: string[]
+  woundDown: string[]
+  logs: string[]
+}
+
+function makeController(
+  overrides: Partial<ArchiveGraceHooks> = {},
+  graceMs = 200
+): { controller: ArchiveGraceController; recorded: Recorded } {
+  const recorded: Recorded = { detached: [], reattached: [], woundDown: [], logs: [] }
+  const controller = new ArchiveGraceController(
+    {
+      isArchived: async () => false,
+      reattach: async () => false,
+      onDetached: (rootStreamId) => void recorded.detached.push(rootStreamId),
+      onReattached: (rootStreamId) => void recorded.reattached.push(rootStreamId),
+      onWindDown: (rootStreamId) => void recorded.woundDown.push(rootStreamId),
+      log: (message) => void recorded.logs.push(message),
+      ...overrides,
+    },
+    { graceMs }
+  )
+  return { controller, recorded }
+}
+
+describe("ArchiveGraceController", () => {
+  test("an archive detaches, holds the grace, then winds down", async () => {
+    const { controller, recorded } = makeController({}, 120)
+
+    await controller.archived("stream_root")
+    expect({ detached: recorded.detached, woundDown: recorded.woundDown, isDetached: controller.detached }).toEqual({
+      detached: ["stream_root"],
+      woundDown: [],
+      isDetached: true,
+    })
+
+    await Bun.sleep(220)
+    expect({ woundDown: recorded.woundDown, isDetached: controller.detached }).toEqual({
+      woundDown: ["stream_root"],
+      isDetached: false,
+    })
+  })
+
+  test("an unarchive inside the grace reattaches and cancels the wind-down", async () => {
+    const { controller, recorded } = makeController({ reattach: async () => true }, 200)
+
+    await controller.archived("stream_root")
+    await controller.restored()
+
+    expect({ reattached: recorded.reattached, isDetached: controller.detached }).toEqual({
+      reattached: ["stream_root"],
+      isDetached: false,
+    })
+    await Bun.sleep(260)
+    expect(recorded.woundDown).toEqual([])
+  })
+
+  test("a reattach resolving after the wind-down already ran does not resurrect the session", async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          await gate
+          return true
+        },
+      },
+      100
+    )
+
+    await controller.archived("stream_root")
+    const restoring = controller.restored()
+    await Bun.sleep(200)
+    expect(recorded.woundDown).toEqual(["stream_root"])
+
+    release()
+    await restoring
+
+    // The wind-down is terminal: the late success must not re-attach a session
+    // whose worktree is already gone.
+    expect({ reattached: recorded.reattached, isDetached: controller.detached }).toEqual({
+      reattached: [],
+      isDetached: false,
+    })
+  })
+
+  test("a reattach that throws keeps the session detached so the probe retries", async () => {
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          throw new Error("threa unreachable")
+        },
+      },
+      10_000
+    )
+
+    await controller.archived("stream_root")
+    await controller.restored()
+
+    expect({ isDetached: controller.detached, reattached: recorded.reattached }).toEqual({
+      isDetached: true,
+      reattached: [],
+    })
+    controller.stop()
+  })
+
+  test("the probe detaches on server truth but never on an inconclusive answer", async () => {
+    for (const [answer, shouldDetach] of [
+      [true, true],
+      [false, false],
+      [undefined, false],
+    ] as const) {
+      const { controller } = makeController({ isArchived: async () => answer }, 10_000)
+      await controller.probe("stream_root")
+      expect(controller.detached).toBe(shouldDetach)
+      controller.stop()
+    }
+  })
+
+  test("a probe whose isArchived throws never detaches", async () => {
+    const { controller, recorded } = makeController(
+      {
+        isArchived: async () => {
+          throw new Error("threa unreachable")
+        },
+      },
+      10_000
+    )
+
+    await controller.probe("stream_root")
+
+    expect(controller.detached).toBe(false)
+    expect(recorded.logs.some((line) => line.includes("archive probe failed"))).toBe(true)
+    controller.stop()
+  })
+
+  test("while detached the probe drives reattach, not a second detach", async () => {
+    const calls: string[] = []
+    const { controller } = makeController(
+      {
+        isArchived: async () => {
+          calls.push("isArchived")
+          return true
+        },
+        reattach: async () => {
+          calls.push("reattach")
+          return false
+        },
+      },
+      10_000
+    )
+
+    await controller.archived("stream_root")
+    await controller.probe("stream_root")
+
+    expect(calls).toEqual(["reattach"])
+    expect(controller.detached).toBe(true)
+    controller.stop()
+  })
+
+  test("concurrent probes do not overlap, and stop() disarms an armed deadline", async () => {
+    let inFlight = 0
+    let overlapped = false
+    const { controller, recorded } = makeController(
+      {
+        isArchived: async () => {
+          inFlight += 1
+          if (inFlight > 1) overlapped = true
+          await Bun.sleep(20)
+          inFlight -= 1
+          return true
+        },
+      },
+      80
+    )
+
+    await Promise.all([controller.probe("stream_root"), controller.probe("stream_root")])
+    expect(overlapped).toBe(false)
+    expect(controller.detached).toBe(true)
+
+    controller.stop()
+    await Bun.sleep(150)
+    expect(recorded.woundDown).toEqual([])
+  })
+
+  test("the probe cadence always fits several probes inside the grace", () => {
+    const { controller } = makeController({}, 200)
+    expect(controller.probeDelayMs).toBe(50)
+    const { controller: production } = makeController({}, 5 * 60 * 1000)
+    expect(production.probeDelayMs).toBe(45_000)
+  })
+})

--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -215,6 +215,20 @@ describe("ArchiveGraceController", () => {
     expect(recorded.woundDown).toEqual([])
   })
 
+  test("the generation moves on every attach/detach transition", async () => {
+    const { controller } = makeController({ reattach: async () => true }, 10_000)
+    const start = controller.generation
+
+    await controller.archived("stream_root")
+    const detached = controller.generation
+    await controller.restored()
+
+    // A caller holding `start` across an await must see BOTH transitions, or a
+    // link created pre-archive gets committed post-archive.
+    expect([detached > start, controller.generation > detached]).toEqual([true, true])
+    controller.stop()
+  })
+
   test("the probe cadence always fits several probes inside the grace", () => {
     const { controller } = makeController({}, 200)
     expect(controller.probeDelayMs).toBe(50)

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -53,6 +53,7 @@ export class ArchiveGraceController {
   private pending: Pending | undefined
   private probing = false
   private stopped = false
+  private transitions = 0
   private readonly graceMs: number
 
   constructor(
@@ -69,6 +70,17 @@ export class ArchiveGraceController {
 
   get pendingRootStreamId(): string | undefined {
     return this.pending?.rootStreamId
+  }
+
+  /**
+   * Bumped on every attach/detach transition. A runtime with a request already
+   * in flight snapshots this before awaiting and drops its result if the value
+   * moved — otherwise a link created before the archive lands is committed
+   * after it, resurrecting a link to a scratchpad that is archived
+   * server-side.
+   */
+  get generation(): number {
+    return this.transitions
   }
 
   /**
@@ -93,6 +105,7 @@ export class ArchiveGraceController {
       deadline: setTimeout(() => void this.windDown(pending), this.graceMs),
     }
     this.pending = pending
+    this.transitions += 1
     this.hooks.log(
       `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.graceMs / 1000)}s)`
     )
@@ -167,6 +180,7 @@ export class ArchiveGraceController {
     if (!reattached || this.stopped || this.pending !== pending) return
     clearTimeout(pending.deadline)
     this.pending = undefined
+    this.transitions += 1
     this.hooks.log(`scratchpad ${pending.rootStreamId} restored — reattached`)
     await this.hooks.onReattached(pending.rootStreamId)
   }
@@ -175,6 +189,7 @@ export class ArchiveGraceController {
     if (this.stopped || this.pending !== pending) return
     clearTimeout(pending.deadline)
     this.pending = undefined
+    this.transitions += 1
     this.hooks.log(`scratchpad ${pending.rootStreamId} stayed archived — winding down`)
     try {
       await this.hooks.onWindDown(pending.rootStreamId)

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -1,0 +1,182 @@
+import { ARCHIVE_RESTORE_GRACE_MS, ARCHIVE_RESTORE_PROBE_MS } from "./archive-wind-down"
+
+/**
+ * The archive → grace → wind-down state machine, shared by every harness
+ * runtime.
+ *
+ * Archiving a scratchpad ends its session server-side, so the worktree behind
+ * it is finished — but archiving is also how a mis-click gets undone, so the
+ * destructive wind-down (push the branch, remove the worktree, kill the tmux
+ * window) waits out a grace window that an unarchive can cancel.
+ *
+ * This is deliberately one implementation rather than one per runtime. Every
+ * bug this machine has produced came from the same shape: state read before an
+ * `await` and acted on after it, once the deadline had already fired or a
+ * second caller had won. The `pending` object is the identity token — every
+ * resumption re-checks `this.pending !== pending` and bails, which is what
+ * makes the wind-down terminal.
+ */
+
+export interface ArchiveGraceHooks {
+  /**
+   * Server truth for the attached direction. `undefined` means "could not
+   * tell" (transient failure, missing scope, outage) and never detaches — a
+   * diagnostic that did not run is not evidence the scratchpad is archived.
+   */
+  isArchived(rootStreamId: string): Promise<boolean | undefined>
+  /**
+   * Server truth for the detached direction: try to revive this runtime's link.
+   * `true` once reattached, `false` while the scratchpad is still archived.
+   * Throwing is treated as `false` — the probe cadence retries.
+   */
+  reattach(rootStreamId: string): Promise<boolean>
+  /** Detach effects: go offline, suspend claiming, pull the poll onto {@link probeDelayMs}. */
+  onDetached(rootStreamId: string, graceMs: number): Promise<void> | void
+  /** Reattach effects: back to available, resume claiming. */
+  onReattached(rootStreamId: string): Promise<void> | void
+  /** Terminal. Preserve the work, then take the window down; the runtime usually dies here. */
+  onWindDown(rootStreamId: string): Promise<void> | void
+  log(message: string): void
+}
+
+export interface ArchiveGraceOptions {
+  /** Override the grace window. Tests use a few hundred ms; production takes the shared default. */
+  graceMs?: number
+}
+
+interface Pending {
+  rootStreamId: string
+  deadline: ReturnType<typeof setTimeout>
+}
+
+export class ArchiveGraceController {
+  private pending: Pending | undefined
+  private probing = false
+  private stopped = false
+  private readonly graceMs: number
+
+  constructor(
+    private readonly hooks: ArchiveGraceHooks,
+    options: ArchiveGraceOptions = {}
+  ) {
+    this.graceMs = options.graceMs ?? ARCHIVE_RESTORE_GRACE_MS
+  }
+
+  /** Detached and waiting out the grace: claims must stay suspended while this is true. */
+  get detached(): boolean {
+    return this.pending !== undefined
+  }
+
+  get pendingRootStreamId(): string | undefined {
+    return this.pending?.rootStreamId
+  }
+
+  /**
+   * Poll cadence while detached, scaled so several probes always fit inside the
+   * grace even when it is shortened for a test. Bounded by the window, so it
+   * cannot become a quota burn.
+   */
+  get probeDelayMs(): number {
+    return Math.min(ARCHIVE_RESTORE_PROBE_MS, Math.max(Math.floor(this.graceMs / 4), 10))
+  }
+
+  /**
+   * This root is archived (a `bot:session_archived` push, or a probe that
+   * found `archivedAt`). Callers scope the event to their own runtime session
+   * and current root before calling — a stale event for a retired root must
+   * never wind down the scratchpad now linked.
+   */
+  async archived(rootStreamId: string): Promise<void> {
+    if (this.stopped || this.pending) return
+    const pending: Pending = {
+      rootStreamId,
+      deadline: setTimeout(() => void this.windDown(pending), this.graceMs),
+    }
+    this.pending = pending
+    this.hooks.log(
+      `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.graceMs / 1000)}s)`
+    )
+    await this.hooks.onDetached(rootStreamId, this.graceMs)
+  }
+
+  /**
+   * The scratchpad came back (a `bot:session_restored` push). Revives the link
+   * and cancels the wind-down; a transient failure keeps the detached state so
+   * the probe cadence retries inside the remaining window.
+   */
+  async restored(): Promise<void> {
+    const pending = this.pending
+    if (this.stopped || !pending) return
+    await this.attemptReattach(pending)
+  }
+
+  /**
+   * The poll-tick backstop. `bot:session_archived` is a one-shot push with no
+   * replay, so a runtime whose socket was down when the archive landed would
+   * otherwise hold its worktree forever. Re-derives from the server and drives
+   * whichever direction applies.
+   */
+  async probe(currentRootStreamId: string | undefined): Promise<void> {
+    if (this.stopped || this.probing) return
+    this.probing = true
+    try {
+      const pending = this.pending
+      if (pending) {
+        await this.attemptReattach(pending)
+        return
+      }
+      if (!currentRootStreamId) return
+      const archived = await this.hooks.isArchived(currentRootStreamId)
+      if (archived !== true) return
+      // The awaits above can race a real push or a relink onto another root.
+      if (this.stopped || this.pending) return
+      this.hooks.log(`archive backstop: ${currentRootStreamId} is archived with no push received`)
+      await this.archived(currentRootStreamId)
+    } catch (error) {
+      this.hooks.log(`archive probe failed: ${describe(error)}`)
+    } finally {
+      this.probing = false
+    }
+  }
+
+  /** Teardown. Disarms the deadline so a shutting-down runtime cannot wind down behind itself. */
+  stop(): void {
+    this.stopped = true
+    if (this.pending) clearTimeout(this.pending.deadline)
+    this.pending = undefined
+  }
+
+  private async attemptReattach(pending: Pending): Promise<void> {
+    let reattached = false
+    try {
+      reattached = await this.hooks.reattach(pending.rootStreamId)
+    } catch (error) {
+      this.hooks.log(`reattach failed, staying detached: ${describe(error)}`)
+      return
+    }
+    // The deadline can fire, or a second caller can win, while the request
+    // above is in flight. Reattaching against a session that already wound
+    // down would resurrect a dead worktree.
+    if (!reattached || this.stopped || this.pending !== pending) return
+    clearTimeout(pending.deadline)
+    this.pending = undefined
+    this.hooks.log(`scratchpad ${pending.rootStreamId} restored — reattached`)
+    await this.hooks.onReattached(pending.rootStreamId)
+  }
+
+  private async windDown(pending: Pending): Promise<void> {
+    if (this.stopped || this.pending !== pending) return
+    clearTimeout(pending.deadline)
+    this.pending = undefined
+    this.hooks.log(`scratchpad ${pending.rootStreamId} stayed archived — winding down`)
+    try {
+      await this.hooks.onWindDown(pending.rootStreamId)
+    } catch (error) {
+      this.hooks.log(`wind-down failed: ${describe(error)}`)
+    }
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -107,6 +107,13 @@ export class ArchiveGraceController {
   async restored(): Promise<void> {
     const pending = this.pending
     if (this.stopped || !pending) return
+    // The server says the scratchpad is back, so restart the clock even if the
+    // relink below fails transiently: winding down 1s after an unarchive push
+    // because the grace happened to be nearly spent is the exact mis-click
+    // recovery this window exists for. Same `pending` object, so every
+    // post-await identity check still holds.
+    clearTimeout(pending.deadline)
+    pending.deadline = setTimeout(() => void this.windDown(pending), this.graceMs)
     await this.attemptReattach(pending)
   }
 

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -7,6 +7,7 @@ export {
   type AllowedTmuxKey,
   type TmuxKeyFailureCode,
 } from "./tmux-key"
+export { ArchiveGraceController, type ArchiveGraceHooks, type ArchiveGraceOptions } from "./archive-grace"
 export {
   ARCHIVE_RESTORE_GRACE_MS,
   ARCHIVE_RESTORE_PROBE_MS,

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1992,7 +1992,7 @@ describe("archived-scratchpad wind-down", () => {
     sessionManager: { getSessionId: () => "runtime" },
     isIdle: () => true,
     cwd: "/tmp",
-    ui: { notify: () => {} },
+    ui: { notify: () => {}, setStatus: () => {}, theme: { fg: (_tone: string, text: string) => text } },
   } as never
 
   function linkConfig() {
@@ -2134,7 +2134,7 @@ describe("archived-scratchpad wind-down", () => {
     })
     try {
       await __testing.probeArchiveState(ctx)
-      const reattach = __testing.reattachAfterArchive(ctx)
+      const reattach = __testing.probeArchiveState(ctx)
       await Bun.sleep(120)
       expect(__testing.archivePendingRootStreamId()).toBeUndefined()
 
@@ -2149,23 +2149,25 @@ describe("archived-scratchpad wind-down", () => {
     }
   })
 
-  test("detaching pulls the poll onto the probe cadence instead of the socket backstop", () => {
+  test("detaching pulls the poll onto the probe cadence instead of the socket backstop", async () => {
     linkConfig()
     // With the socket up the pending tick is 15 minutes out — longer than the
     // whole grace — so a missed restore push would never get a probe.
     expect(__testing.nextQuietPollMs()).not.toBe(45_000)
-    __testing.setArchivePendingForTesting("stream_root")
+    await __testing.setArchivePendingForTesting(ctx, "stream_root")
     expect(__testing.nextQuietPollMs()).toBe(45_000)
   })
 
-  test("an archive event for a retired root does not wind down the scratchpad now linked", () => {
+  test("an archive event for a retired root does not wind down the scratchpad now linked", async () => {
     linkConfig()
     // Cold start replaced archived root A with live root B under the same
     // deterministic runtime identity; A's outbox event arrives late.
     __testing.handleArchivePush(ctx, { runtimeSessionId: "runtime", rootStreamId: "stream_retired" })
+    await Bun.sleep(0)
     expect(__testing.archivePendingRootStreamId()).toBeUndefined()
 
     __testing.handleArchivePush(ctx, { runtimeSessionId: "runtime", rootStreamId: "stream_root" })
+    await Bun.sleep(0)
     expect(__testing.archivePendingRootStreamId()).toBe("stream_root")
   })
 

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -31,8 +31,7 @@ import {
   runHarnessKick,
   parseAllowedTmuxKey,
   sendAllowedTmuxKey,
-  ARCHIVE_RESTORE_GRACE_MS,
-  ARCHIVE_RESTORE_PROBE_MS,
+  ArchiveGraceController,
   scrubSealedError,
   sealReply,
   sealStep,
@@ -318,16 +317,16 @@ let sessionTearingDown = false
 // Set while the linked scratchpad is archived and the session is waiting out
 // the restore grace window: claims are suspended, the poll probes at the
 // reattach cadence, and the deadline runs the worktree wind-down.
-let archivePending: { rootStreamId: string; deadline: ReturnType<typeof setTimeout> } | undefined
-// Set by startPolling so detachForArchive can pull the next tick forward: the
-// pending tick was scheduled with the socket backstop (15 min), which lands
-// ZERO reattach probes inside a 5-minute grace.
+// The archive → grace → wind-down machine, shared with the Claude runtime.
+// Built lazily because every hook needs the extension ctx.
+let archive: ArchiveGraceController | undefined
+// Set by startPolling so a detach can pull the next tick forward: the pending
+// tick was scheduled with the socket backstop (15 min), which lands ZERO
+// reattach probes inside a 5-minute grace.
 let rearmPoll: ((delayMs: number) => void) | undefined
-let archiveProbeInflight = false
-// Overridable so a test can watch the grace actually expire and the wind-down
-// actually run, instead of waiting five minutes and destroying a real worktree.
-// Mirrors RemoteSession's `archiveGraceMs` option.
-let archiveGraceMs: number = ARCHIVE_RESTORE_GRACE_MS
+// Overridable so a test can watch the grace expire and the wind-down run
+// instead of waiting five minutes and destroying a real worktree.
+let archiveGraceMs: number | undefined
 let archiveWindDown: typeof windDownArchivedWorktree = windDownArchivedWorktree
 // Owns the /bot socket + routes presence/renew/steps over it (HTTP fallback
 // when the socket is down). Built lazily once the session ctx is known; torn
@@ -1830,132 +1829,99 @@ function stopPolling(): void {
 }
 
 /**
- * The linked scratchpad is archived. The server has already ended the session,
- * so no more work can arrive: go offline and stop claiming, but hold the
- * destructive wind-down for the grace window — an unarchive inside it
- * reattaches this live session with no restart.
+ * The controller for this Pi session. Hooks carry the Pi-specific effects; the
+ * pending state, deadline, probe guard and post-await identity checks live in
+ * the shared machine.
  */
-async function detachForArchive(ctx: ExtensionContext, rootStreamId: string): Promise<void> {
-  if (archivePending || sessionTearingDown) return
-  archivePending = {
-    rootStreamId,
-    deadline: setTimeout(() => void windDownAfterArchiveGrace(ctx), archiveGraceMs),
-  }
-  // An in-flight poll re-arms at the probe cadence from its own finally block.
-  if (pollInFlightRunId === undefined) rearmPoll?.(Math.min(ARCHIVE_RESTORE_PROBE_MS, archiveGraceMs))
-  const minutes = Math.round(archiveGraceMs / 60_000)
-  setRemoteStatus(ctx, `Threa remote: scratchpad archived; winding down in ${minutes}m`, "error")
-  ctx.ui.notify(
-    `Threa scratchpad archived. Unarchive within ${minutes} minutes to reattach; otherwise this branch is pushed and the worktree removed.`,
-    "warning"
-  )
-  await heartbeat("offline", undefined, ctx).catch(() => undefined)
-}
-
-/**
- * The scratchpad came back inside the grace window: revive the server-side
- * link for this same runtime session and cancel the wind-down. A transient
- * failure keeps the detached state so the probe cadence survives to retry.
- */
-async function reattachAfterArchive(ctx: ExtensionContext): Promise<void> {
-  const pending = archivePending
-  if (!pending || !config) return
-  const rootStreamId = pending.rootStreamId
-  const body = await request<{ data: RuntimeSessionLink }>(
-    `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+function ensureArchiveController(ctx: ExtensionContext): ArchiveGraceController {
+  archive ??= new ArchiveGraceController(
     {
-      method: "POST",
-      body: JSON.stringify({
-        runtimeKind: "pi-local",
-        instanceId: getSessionInstanceId(ctx),
-        runtimeSessionId: getRuntimeSessionId(ctx),
-        displayName: defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName),
-        localCwd: ctx.cwd,
-        ifArchived: "wait",
-        ifMissing: "error",
-      }),
-    }
+      isArchived: async (rootStreamId) => {
+        if (!config) return undefined
+        const body = await request<{ data: { archivedAt?: string | null } }>(
+          `/api/v1/workspaces/${config.workspaceId}/streams/${rootStreamId}`
+        )
+        return Boolean(body.data?.archivedAt)
+      },
+      reattach: async (rootStreamId) => {
+        if (!config) return false
+        const body = await request<{ data: RuntimeSessionLink }>(
+          `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              runtimeKind: "pi-local",
+              instanceId: getSessionInstanceId(ctx),
+              runtimeSessionId: getRuntimeSessionId(ctx),
+              displayName: defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName),
+              localCwd: ctx.cwd,
+              ifArchived: "wait",
+              ifMissing: "error",
+            }),
+          }
+        )
+        return body.data.rootStreamId === rootStreamId
+      },
+      onDetached: async (_rootStreamId, graceMs) => {
+        // An in-flight poll re-arms at the probe cadence from its own finally block.
+        if (pollInFlightRunId === undefined) rearmPoll?.(ensureArchiveController(ctx).probeDelayMs)
+        const minutes = Math.round(graceMs / 60_000)
+        setRemoteStatus(ctx, `Threa remote: scratchpad archived; winding down in ${minutes}m`, "error")
+        ctx.ui.notify(
+          `Threa scratchpad archived. Unarchive within ${minutes} minutes to reattach; otherwise this branch is pushed and the worktree removed.`,
+          "warning"
+        )
+        await heartbeat("offline", undefined, ctx).catch(() => undefined)
+      },
+      onReattached: async () => {
+        setRemoteStatus(ctx, "Threa remote: linked")
+        ctx.ui.notify("Threa scratchpad unarchived; reattached.", "info")
+        await heartbeat("available", undefined, ctx).catch(() => undefined)
+      },
+      onWindDown: () => {
+        stopPolling()
+        stopClaimRenewTimer()
+        const report = archiveWindDown(ctx.cwd, (message) => emitPollDebug(ctx, message))
+        teardownTransport()
+        if (report.windowKilled) return
+        ctx.ui.notify(
+          report.pushed
+            ? "Threa scratchpad archived; branch pushed. This worktree is finished — close the window."
+            : `Threa scratchpad archived, but the wind-down could not preserve the work: ${report.reason ?? "unknown"}`,
+          report.pushed ? "warning" : "error"
+        )
+      },
+      log: (message) => emitPollDebug(ctx, message),
+    },
+    archiveGraceMs === undefined ? {} : { graceMs: archiveGraceMs }
   )
-  if (body.data.rootStreamId !== rootStreamId) return
-  // The grace deadline can fire (or a second reattach can win) while the
-  // request above is in flight — a 30s fetch timeout against a 45s probe
-  // cadence lands squarely inside the window. Reattaching against a session
-  // that already wound down would resurrect a dead worktree; the pinned
-  // identity check is what makes the wind-down terminal.
-  if (archivePending !== pending) return
-  clearTimeout(pending.deadline)
-  archivePending = undefined
-  setRemoteStatus(ctx, "Threa remote: linked")
-  ctx.ui.notify("Threa scratchpad unarchived; reattached.", "info")
-  await heartbeat("available", undefined, ctx).catch(() => undefined)
+  return archive
 }
 
-/**
- * The grace expired with the scratchpad still archived: preserve the work on
- * the remote and take the tmux window down. Pi dies with the window, so this
- * may never return; recovery is `git fetch` plus the pushed branch.
- */
-async function windDownAfterArchiveGrace(ctx: ExtensionContext): Promise<void> {
-  if (!archivePending) return
-  clearTimeout(archivePending.deadline)
-  archivePending = undefined
-  stopPolling()
-  stopClaimRenewTimer()
-  const report = archiveWindDown(ctx.cwd, (message) => emitPollDebug(ctx, message))
-  teardownTransport()
-  if (!report.windowKilled) {
-    ctx.ui.notify(
-      report.pushed
-        ? "Threa scratchpad archived; branch pushed. This worktree is finished — close the window."
-        : `Threa scratchpad archived, but the wind-down could not preserve the work: ${report.reason ?? "unknown"}`,
-      report.pushed ? "warning" : "error"
-    )
-  }
-}
-
-/**
- * bot:session_archived is a one-shot push with no replay, so a socket that was
- * down when the archive landed would otherwise hold this worktree open
- * forever. Re-derive the state from the server on the poll tick and drive both
- * directions of the transition from it.
- */
+/** The poll-tick backstop: `bot:session_archived` is a one-shot push with no replay. */
 async function probeArchiveState(ctx: ExtensionContext): Promise<void> {
-  if (!config || archiveProbeInflight || sessionTearingDown) return
-  const rootStreamId = archivePending?.rootStreamId ?? getCurrentSessionLink(ctx)?.rootStreamId
-  if (!rootStreamId) return
-  archiveProbeInflight = true
-  try {
-    const body = await request<{ data: { archivedAt?: string | null } }>(
-      `/api/v1/workspaces/${config.workspaceId}/streams/${rootStreamId}`
-    )
-    const archived = Boolean(body.data?.archivedAt)
-    if (archived && !archivePending) await detachForArchive(ctx, rootStreamId)
-    else if (!archived && archivePending) await reattachAfterArchive(ctx)
-  } catch (error) {
-    emitPollDebug(ctx, `archive probe failed: ${summarizeError(error)}`)
-  } finally {
-    archiveProbeInflight = false
-  }
+  if (!config || sessionTearingDown) return
+  await ensureArchiveController(ctx).probe(getCurrentSessionLink(ctx)?.rootStreamId)
 }
 
-/** Scoped to this session: a runtime that re-registered must not die to a stale event for the old one. */
+/**
+ * Scoped to this runtime session AND the currently linked root: a cold start
+ * replaces an archived scratchpad under the same deterministic identity, so a
+ * delayed event for the retired root must not wind down the live one.
+ */
 function handleArchivePush(ctx: ExtensionContext, payload: unknown): void {
-  if (!isObject(payload)) return
+  if (!isObject(payload) || sessionTearingDown) return
   if (typeof payload.runtimeSessionId === "string" && payload.runtimeSessionId !== getRuntimeSessionId(ctx)) return
-  // Scope to the CURRENT root too, not just the runtime session: a cold start
-  // with the same deterministic identity replaces an archived scratchpad, and
-  // a delayed event for the retired root would otherwise wind down the live
-  // one — the probe keeps seeing the old root archived, so it never recovers.
   const linked = getCurrentSessionLink(ctx)?.rootStreamId
   const rootStreamId = typeof payload.rootStreamId === "string" ? payload.rootStreamId : linked
   if (!rootStreamId || (linked && rootStreamId !== linked)) return
-  void detachForArchive(ctx, rootStreamId).catch(() => undefined)
+  void ensureArchiveController(ctx).archived(rootStreamId)
 }
 
 function handleRestorePush(ctx: ExtensionContext, payload: unknown): void {
-  if (!isObject(payload)) return
+  if (!isObject(payload) || sessionTearingDown) return
   if (typeof payload.runtimeSessionId === "string" && payload.runtimeSessionId !== getRuntimeSessionId(ctx)) return
-  void reattachAfterArchive(ctx).catch((error) => emitPollDebug(ctx, `reattach failed: ${summarizeError(error)}`))
+  void ensureArchiveController(ctx).restored()
 }
 
 function basePollMs(): number {
@@ -1982,7 +1948,7 @@ function nextQuietPollMs(): number {
   // Detached-pending-restore: probe at a fixed cadence so a missed
   // bot:session_restored push still reattaches inside the grace window. The
   // window bounds the total probes, so this cannot become a quota burn.
-  if (archivePending) return ARCHIVE_RESTORE_PROBE_MS
+  if (archive?.detached) return archive.probeDelayMs
   if (transport?.socketConnected || pending || steeredInvocations.length > 0) {
     consecutiveQuietPolls = 0
     return basePollMs()
@@ -3440,7 +3406,7 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
     return false
   // No claims while detached: the scratchpad is archived, so any claimable work
   // predates it and would answer into a closed stream. A reattach re-drains.
-  if (archivePending) return false
+  if (archive?.detached) return false
   if (pending) await renewActiveClaims()
 
   if (isWaitingForRetry) {
@@ -4145,21 +4111,20 @@ export const __testing = {
     supervisedRevivalBlocked = value
   },
   probeArchiveState,
-  reattachAfterArchive,
   handleArchivePush,
-  setArchivePendingForTesting: (rootStreamId: string) => {
-    archivePending = { rootStreamId, deadline: setTimeout(() => {}, 60_000) }
-  },
-  archivePendingRootStreamId: () => archivePending?.rootStreamId,
+  handleRestorePush,
+  archiveDetached: () => archive?.detached ?? false,
+  archivePendingRootStreamId: () => archive?.pendingRootStreamId,
+  setArchivePendingForTesting: (ctx: ExtensionContext, rootStreamId: string) =>
+    ensureArchiveController(ctx).archived(rootStreamId),
   setArchiveWindDownForTesting: (graceMs: number, windDown: typeof windDownArchivedWorktree) => {
     archiveGraceMs = graceMs
     archiveWindDown = windDown
   },
   clearArchivePendingForTesting: () => {
-    if (archivePending) clearTimeout(archivePending.deadline)
-    archivePending = undefined
-    archiveProbeInflight = false
-    archiveGraceMs = ARCHIVE_RESTORE_GRACE_MS
+    archive?.stop()
+    archive = undefined
+    archiveGraceMs = undefined
     archiveWindDown = windDownArchivedWorktree
   },
   setRateLimitWaitForTesting: (value: boolean) => {

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -417,7 +417,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
       nextPollDelay: (claimed: boolean) => number
       probeArchiveBackstop: () => Promise<void>
       link: { rootStreamId: string } | undefined
-      archivePending: unknown
+      archive: { detached: boolean }
     }
 
   test("detaches on archive: goes offline, fails in-flight turns, but does NOT wind down within the grace window", async () => {
@@ -443,7 +443,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     expect(failed).toEqual(["binv_running"])
     // The wind-down is deferred: an unarchive within the grace window reattaches instead.
     expect(archived).toEqual([])
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     // Detached: no claims while the scratchpad is archived, and the poll probes at the reattach cadence.
     expect(await asInternal(session).claimDrain()).toBe(false)
     expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
@@ -484,7 +484,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // The probe WAITS on the archived scratchpad (grace-window reattach) — it
     // must never ask the server to replace it with a fresh one.
     expect((created[0] as Record<string, unknown>).ifArchived).toBe("wait")
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
     expect(archived).toEqual([])
     await session.shutdown()
@@ -539,7 +539,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // bot:session_archived never arrived — only the probe knows.
     await asInternal(session).probeArchiveBackstop()
 
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     expect(presence.at(-1)?.status).toBe("offline")
     // Still archived when the grace expires (the reattach probe re-links, but
     // handleSessionRestored never fires), so the connector wind-down runs.
@@ -567,7 +567,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
 
       await asInternal(session).probeArchiveBackstop()
 
-      expect(asInternal(session).archivePending).toBeUndefined()
+      expect(asInternal(session).archive.detached).toBe(false)
       expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
       expect(archived).toEqual([])
       await session.shutdown()
@@ -683,7 +683,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     await inflightLink
 
     expect(asInternal(session).link).toBeUndefined()
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     await session.shutdown()
   })
 
@@ -719,7 +719,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // Reattached: session-create re-issued (the server revives the same link),
     // presence back to available, wind-down cancelled, claims live again.
     expect(created).toHaveLength(1)
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
     expect(session.statusSnapshot.linkGeneration).toBe(2)
     expect(presence.at(-1)?.status).toBe("available")
@@ -747,7 +747,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // Still detached-pending: probe cadence + claim suppression survive the
     // transient failure instead of dropping to the 15-min backstop unlinked.
     expect(asInternal(session).link).toBeUndefined()
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
     await session.shutdown()
   })
@@ -816,7 +816,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
 
     expect(archived).toEqual([])
     expect(presence).toEqual([])
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
   })
 })
 

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -1,8 +1,7 @@
 import { homedir } from "node:os"
 import { join } from "node:path"
 import {
-  ARCHIVE_RESTORE_GRACE_MS,
-  ARCHIVE_RESTORE_PROBE_MS,
+  ArchiveGraceController,
   BikKeystore,
   BotRuntimeTransport,
   mintStreamKeyWraps,
@@ -348,15 +347,7 @@ export class RemoteSession {
   private reconnectResetTimer: ReturnType<typeof setTimeout> | undefined
   private reconnectFallbackTask: Promise<unknown> | undefined
   private stopped = false
-  private readonly archiveGraceMs: number
-  /**
-   * Set while the linked scratchpad is archived and the session is waiting out
-   * the restore grace window. Claims are suspended; the poll probes
-   * session-create at ARCHIVE_RESTORE_PROBE_MS; the deadline runs the
-   * connector wind-down that used to fire immediately on archive.
-   */
-  private archivePending: { rootStreamId: string; deadline: ReturnType<typeof setTimeout> } | undefined
-  private archiveProbeInflight = false
+  private readonly archive: ArchiveGraceController
   private pollTimer: ReturnType<typeof setTimeout> | undefined
   private renewTimer: ReturnType<typeof setInterval> | undefined
   /** Consecutive empty poll ticks while the socket is down; drives the poll backoff. */
@@ -375,7 +366,17 @@ export class RemoteSession {
     this.delegate = options.delegate
     this.runtime = options.runtime
     this.log = options.log ?? (() => undefined)
-    this.archiveGraceMs = options.archiveGraceMs ?? ARCHIVE_RESTORE_GRACE_MS
+    this.archive = new ArchiveGraceController(
+      {
+        isArchived: async (rootStreamId) => Boolean(await this.client.getStreamArchivedAt(rootStreamId)),
+        reattach: () => this.relinkAfterRestore(),
+        onDetached: (rootStreamId) => this.detachForArchive(rootStreamId),
+        onReattached: () => this.claimDrain().then(() => undefined),
+        onWindDown: (rootStreamId) => this.windDownForArchive(rootStreamId),
+        log: this.log,
+      },
+      options.archiveGraceMs === undefined ? {} : { graceMs: options.archiveGraceMs }
+    )
     this.bik = new BikKeystore({
       path: this.config.bikPath ?? join(homedir(), ".threa", `bik-${sanitizeId(this.runtime.kind)}.json`),
       log: this.log,
@@ -433,12 +434,12 @@ export class RemoteSession {
   }
 
   get statusSnapshot(): RemoteSessionStatusSnapshot {
-    const linkState = this.archivePending ? "detached" : this.link ? "linked" : "unlinked"
+    const linkState = this.archive.detached ? "detached" : this.link ? "linked" : "unlinked"
     return {
       stopped: this.stopped,
       linkGeneration: this.linkGeneration,
       linkState,
-      rootStreamId: this.link?.rootStreamId ?? this.archivePending?.rootStreamId,
+      rootStreamId: this.link?.rootStreamId ?? this.archive.pendingRootStreamId,
       activeStreamId: this.link?.activeStreamId,
       socketConnected: this.transport.socketConnected,
       inflightCount: this.inflight.size,
@@ -464,34 +465,43 @@ export class RemoteSession {
 
   /** Create (or recover) the scratchpad link. Best-effort so a transient Threa outage self-heals on the next poll tick. */
   private async ensureLink(): Promise<void> {
-    if (this.link || this.stopped) return
-    // Snapshot the detach state so a response that raced an archive push is
-    // dropped: a createSession issued BEFORE the archive can resolve with the
-    // pre-archive link after archivePending was set — accepting it would cancel
-    // the wind-down against a scratchpad that is still archived server-side.
-    const pendingAtStart = this.archivePending
+    // While detached the controller's reattach is the ONLY path allowed to
+    // relink: a link created here would cancel a wind-down against a
+    // scratchpad that is still archived server-side.
+    if (this.link || this.stopped || this.archive.detached) return
     try {
-      const link = await this.createSession()
-      if (this.stopped) return
-      if (this.archivePending !== pendingAtStart) {
-        this.log("link response raced an archive state change — dropped; the next probe decides")
-        return
-      }
-      this.link = link
-      this.linkGeneration += 1
-      // A successful link while detached-pending-restore is the reattach (the
-      // server revived the archived link for this runtime session) — the probe
-      // beat the bot:session_restored push. Cancel the wind-down.
-      if (this.archivePending) {
-        clearTimeout(this.archivePending.deadline)
-        this.archivePending = undefined
-        this.log("scratchpad restored — reattached")
-      }
-      this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
-      await this.syncPresence()
+      await this.createLink()
     } catch (error) {
       this.log(`could not link to Threa (will retry): ${this.summarize(error)}${this.linkErrorHint(error)}`)
     }
+  }
+
+  /** The reattach hook: a confirmed link is what cancels the grace, so failure must read as "still archived". */
+  private async relinkAfterRestore(): Promise<boolean> {
+    try {
+      return await this.createLink()
+    } catch (error) {
+      this.log(`reattach link failed: ${this.summarize(error)}${this.linkErrorHint(error)}`)
+      return false
+    }
+  }
+
+  private async createLink(): Promise<boolean> {
+    const generation = this.archive.generation
+    const link = await this.createSession()
+    // A pre-archive session-create can resolve AFTER the archive lands;
+    // committing it would resurrect a link to a scratchpad that is archived
+    // server-side and hide the detach from the next probe.
+    if (this.stopped) return false
+    if (this.archive.generation !== generation) {
+      this.log("link response raced an archive state change — dropped; the next probe decides")
+      return false
+    }
+    this.link = link
+    this.linkGeneration += 1
+    this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
+    await this.syncPresence()
+    return true
   }
 
   /** Actionable next step for the link failures a retry alone will never fix. */
@@ -500,7 +510,7 @@ export class RemoteSession {
     if (error.status === 401 || error.status === 403) {
       return " — check THREA_API_KEY (must be a bot key, threa_bk_…) and THREA_WORKSPACE_ID"
     }
-    if (error.code === "SCRATCHPAD_ARCHIVED" && !this.archivePending) {
+    if (error.code === "SCRATCHPAD_ARCHIVED" && !this.archive.detached) {
       return " — the server does not support ifArchived replace yet; unarchive the scratchpad in Threa to link"
     }
     return ""
@@ -511,10 +521,7 @@ export class RemoteSession {
     this.stopped = true
     if (this.pollTimer) clearTimeout(this.pollTimer)
     if (this.renewTimer) clearInterval(this.renewTimer)
-    if (this.archivePending) {
-      clearTimeout(this.archivePending.deadline)
-      this.archivePending = undefined
-    }
+    this.archive.stop()
     this.resetReconnectHandoff()
     await this.reconnectFallbackTask
     // Fast, idempotent teardown first so SIGTERM cleanup isn't held hostage by
@@ -562,7 +569,7 @@ export class RemoteSession {
       // default, but supervisors reviving a known stream can force wait so an
       // archive between their preflight and process launch cannot mint another
       // scratchpad.
-      ifArchived: this.archivePending ? "wait" : (this.config.coldStartIfArchived ?? "replace"),
+      ifArchived: this.archive.detached ? "wait" : (this.config.coldStartIfArchived ?? "replace"),
       ifMissing: this.config.expectedRootStreamId ? "error" : (this.config.coldStartIfMissing ?? "create"),
       ...(this.config.defaultLabel && { labelName: this.config.defaultLabel }),
       ...(e2e ? { e2e: { ownerKeyId: e2e.ownerKeyId } } : {}),
@@ -652,7 +659,7 @@ export class RemoteSession {
     // No claims while detached-pending-restore: the scratchpad is archived, so
     // any claimable work predates the archive and would reply into a closed
     // stream. Restore re-runs the drain.
-    if (this.stopped || this.claiming || this.archivePending || this.reconnectHandoff) return false
+    if (this.stopped || this.claiming || this.archive.detached || this.reconnectHandoff) return false
     let claimedAny = false
     this.claiming = true
     try {
@@ -882,7 +889,7 @@ export class RemoteSession {
           this.onHandoffReset = outcome.onHandoffReset
           await this.syncPresence()
           const completed = await this.completeAck(invocation, outcome.message)
-          if (!completed || this.stopped || !this.link || this.archivePending) {
+          if (!completed || this.stopped || !this.link || this.archive.detached) {
             this.resetReconnectHandoff()
             return
           }
@@ -1485,41 +1492,55 @@ export class RemoteSession {
   }
 
   /**
-   * The linked scratchpad was archived. The server has already ended the
-   * session link, so no more work can arrive: fail any in-flight turn (its
-   * reply could no longer land), go offline, and detach — but do NOT wind down
-   * yet. An unarchive within the grace window revives the link server-side and
-   * reattaches this live session (bot:session_restored, or the ensureLink
-   * probe); only when the grace expires does the connector's destructive
-   * wind-down run. Scoped to this session: the event is room-targeted, but a
-   * runtime that re-registered under a new session id must not die to a stale
-   * event for the old one.
+   * A `bot:session_archived` push. Scoped to this session AND this root: a
+   * runtime that re-registered under a new session id, or a cold start that
+   * replaced an archived scratchpad with a fresh one, must not die to a stale
+   * event for the retired root.
    */
   private async handleSessionArchived(payload: unknown): Promise<void> {
     const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
     if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
-    if (this.stopped || this.archivePending) return
-    const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : (this.link?.rootStreamId ?? "")
-    this.log(
-      `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.archiveGraceMs / 1000)}s)`
-    )
+    const linked = this.link?.rootStreamId
+    const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : linked
+    if (!rootStreamId || (linked && rootStreamId !== linked)) return
+    await this.archive.archived(rootStreamId)
+  }
+
+  /** A `bot:session_restored` push: the server revived this session's link. */
+  private async handleSessionRestored(payload: unknown): Promise<void> {
+    const data = (payload ?? {}) as { runtimeSessionId?: unknown }
+    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
+    await this.archive.restored()
+  }
+
+  /**
+   * `bot:session_archived` is a one-shot push with no replay: a socket that was
+   * down when the archive landed never learns of it, and the runtime then holds
+   * a link to a dead scratchpad forever — taking its tmux window and worktree
+   * with it. Re-derive from the server on every poll tick and socket bootstrap.
+   */
+  private async probeArchiveBackstop(): Promise<void> {
+    await this.archive.probe(this.link?.rootStreamId)
+  }
+
+  /**
+   * Detach effects. No more work can arrive, so fail any in-flight turn (its
+   * reply could no longer land), drop the link, and go offline — but the
+   * worktree survives until the grace expires.
+   */
+  private async detachForArchive(rootStreamId: string): Promise<void> {
     const inflight = [...this.inflight]
     for (const [, entry] of inflight) clearTimeout(entry.deadline)
     this.inflight.clear()
     this.activeTurnStream = undefined
     this.link = undefined
     this.linkGeneration += 1
-    const pending = {
-      rootStreamId,
-      deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
-    }
-    this.archivePending = pending
     this.resetReconnectHandoff()
     await this.reconnectFallbackTask
     // Pull the next poll tick onto the probe cadence NOW — the pending tick was
-    // scheduled with the slow socket-backstop delay (15 min), which could land
+    // scheduled with the slow socket-backstop delay (15 min), which would land
     // zero probes inside the grace window if the restore push is then missed.
-    this.reschedulePoll(this.archiveProbeDelayMs)
+    this.reschedulePoll(this.archive.probeDelayMs)
     await Promise.allSettled(
       inflight.map(([id, entry]) =>
         this.client.fail(id, {
@@ -1531,78 +1552,14 @@ export class RemoteSession {
     )
     // A restore can reattach and publish 'available' during the awaits above —
     // don't overwrite it with a stale 'offline'.
-    if (this.stopped || this.archivePending !== pending) return
+    if (this.stopped || this.archive.pendingRootStreamId !== rootStreamId) return
     await this.transport.updatePresence(this.presenceBody("offline")).catch(() => undefined)
   }
 
-  /**
-   * bot:session_archived is a one-shot push with no replay: a socket that was
-   * down when the archive landed never learns of it, and the runtime then holds
-   * a link to a dead scratchpad forever — taking its tmux window and worktree
-   * with it. Re-derive the state from the server on every poll tick and on
-   * every socket (re)connect, and route a confirmed archive through the same
-   * grace-window path the push takes, so an unarchive still reattaches.
-   */
-  private async probeArchiveBackstop(): Promise<void> {
-    const rootStreamId = this.link?.rootStreamId
-    if (this.stopped || this.archivePending || this.archiveProbeInflight || !rootStreamId) return
-    this.archiveProbeInflight = true
-    try {
-      const archivedAt = await this.client.getStreamArchivedAt(rootStreamId)
-      // The awaits above can race a real push or a relink onto another root;
-      // re-check rather than detach on a snapshot that is no longer current.
-      if (!archivedAt) return
-      if (this.stopped || this.archivePending || this.link?.rootStreamId !== rootStreamId) return
-      this.log(`archive backstop: scratchpad ${rootStreamId} archived at ${archivedAt} with no push received`)
-      await this.handleSessionArchived({ runtimeSessionId: this.config.runtimeSessionId, rootStreamId })
-    } catch (error) {
-      this.log(`archive backstop probe failed: ${this.summarize(error)}`)
-    } finally {
-      this.archiveProbeInflight = false
-    }
-  }
-
-  /** The grace expired with the scratchpad still archived: run the wind-down that used to fire on archive. */
-  private async windDownAfterGrace(rootStreamId: string): Promise<void> {
-    if (this.stopped || !this.archivePending) return
-    this.archivePending = undefined
-    this.log(`scratchpad ${rootStreamId} stayed archived — winding down`)
+  /** The grace expired with the scratchpad still archived: hand the connector its terminal wind-down. */
+  private async windDownForArchive(rootStreamId: string): Promise<void> {
     await this.shutdown()
-    try {
-      await this.delegate.onArchived?.({ rootStreamId })
-    } catch (error) {
-      this.log(`onArchived hook failed: ${this.summarize(error)}`)
-    }
-  }
-
-  /**
-   * The archived scratchpad was unarchived and the server revived this
-   * session's link: cancel the pending wind-down, re-establish the link (the
-   * session-create path returns the revived link for the SAME scratchpad), and
-   * resume claiming — the live agent reattaches with no restart.
-   */
-  private async handleSessionRestored(payload: unknown): Promise<void> {
-    const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
-    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
-    if (this.stopped) return
-    if (this.archivePending) {
-      // Don't clear the pending state yet — only ensureLink's confirmed link
-      // does that. If the createSession below fails transiently, the probe
-      // cadence and claim suppression must survive; clearing here would drop
-      // the session onto the 15-min backstop unlinked. The restore does cancel
-      // the CURRENT wind-down, but a fresh grace deadline re-arms so a
-      // reattach that never succeeds still winds down bounded.
-      clearTimeout(this.archivePending.deadline)
-      const rootStreamId = this.archivePending.rootStreamId
-      this.archivePending = {
-        rootStreamId,
-        deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
-      }
-      this.log(`scratchpad ${rootStreamId} restored — reattaching`)
-    }
-    if (!this.link) await this.ensureLink()
-    else await this.syncPresence()
-    await this.claimDrain()
+    await this.delegate.onArchived?.({ rootStreamId })
   }
 
   // --- Timers ---------------------------------------------------------------
@@ -1646,18 +1603,16 @@ export class RemoteSession {
 
   private async pollTick(): Promise<void> {
     if (this.stopped) return
+    // Always first: while detached this is the reattach attempt (ensureLink
+    // refuses to relink during the grace), and while linked it is the
+    // missed-push backstop.
+    await this.probeArchiveBackstop()
     if (!this.link) await this.ensureLink()
-    else await this.probeArchiveBackstop()
     if (!this.transport.socketConnected) await this.transport.connect()
     const claimed = await this.claimDrain()
     // shutdown() can land during the awaits above; re-arming then would leave
     // a live timer past teardown.
     if (!this.stopped) this.reschedulePoll(this.nextPollDelay(claimed))
-  }
-
-  /** Reattach-probe cadence while detached: scaled to the grace window so several probes always fit inside it. */
-  private get archiveProbeDelayMs(): number {
-    return Math.min(ARCHIVE_RESTORE_PROBE_MS, Math.max(Math.floor(this.archiveGraceMs / 4), 10))
   }
 
   /**
@@ -1670,7 +1625,7 @@ export class RemoteSession {
     // Detached-pending-restore: probe at a fixed cadence so a missed
     // bot:session_restored push still reattaches within the grace window. The
     // window bounds the total probes, so this cannot become a quota burn.
-    if (this.archivePending) return this.archiveProbeDelayMs
+    if (this.archive.detached) return this.archive.probeDelayMs
     if (this.transport.socketConnected) {
       this.emptyNoSocketPolls = 0
       return WS_BACKSTOP_POLL_MS
@@ -1704,7 +1659,7 @@ export class RemoteSession {
         this.log(`session-control handoff reset failed: ${this.summarize(error)}`)
       }
     }
-    if (this.stopped || !this.link || this.archivePending) {
+    if (this.stopped || !this.link || this.archive.detached) {
       if (callbackTask) this.reconnectFallbackTask = callbackTask
       return
     }


### PR DESCRIPTION
Stacked on #1561.

## Problem

Both harness runtimes implement the same archive → grace → wind-down machine, and they had drifted. Of the four CRITICAL findings on #1561's adversarial review, **three were in Pi's copy and none were in `RemoteSession`** — same logic, one copy hardened by review, the other written fresh. Every one of those bugs had the identical shape: state read before an `await` and acted on after it, once the deadline had already fired or a second caller had won.

## Solution

`ArchiveGraceController` in `@threa/bot-runtime-client` — the package both runtimes already depend on. It owns the parts that keep getting this wrong: the pending state, the deadline, the probe-inflight guard, and the post-await identity re-checks. The `pending` object is the identity token; every resumption re-checks `this.pending !== pending` and bails, which is what makes the wind-down terminal.

Runtime-specific effects go through hooks, chosen so neither runtime gains a request it wasn't already making: `isArchived` drives the attached direction (Claude's `getStreamArchivedAt`, Pi's stream GET), `reattach` drives the detached one (both a session-create that fails while still archived).

Two behaviors that were only in one copy are now in both by construction:

- **A restore push restarts the grace.** Previously an unarchive at t=4:59 whose relink failed transiently still wound the worktree down a second later — the exact mis-click recovery the window exists for.
- **`generation` for in-flight callers.** A session-create issued before the archive can resolve after it; committing that link resurrects a link to an archived scratchpad and hides the detach from the next probe. Callers snapshot the counter and drop the result if it moved.

No consumers in this layer — the two migrations are the layers above. It ships with its own tests rather than waiting for them.

## Test plan

- [x] `bun test ./extensions/bot-runtime-client/` — 91 pass, including wind-down-is-terminal, restore-restarts-grace, inconclusive-probe-never-detaches, and no-overlapping-probes
- [x] `typecheck` clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787695466&installation_model_id=20758&pr_number=1568&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1568&signature=54f10b2851df9131288cfdbaa557329c9ff4b27cab29bd14997afceb7522eb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->