### PR TITLE
refactor(harness): move RemoteSession onto the shared ArchiveGraceController

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1992,7 +1992,7 @@ describe("archived-scratchpad wind-down", () => {
     sessionManager: { getSessionId: () => "runtime" },
     isIdle: () => true,
     cwd: "/tmp",
-    ui: { notify: () => {} },
+    ui: { notify: () => {}, setStatus: () => {}, theme: { fg: (_tone: string, text: string) => text } },
   } as never
 
   function linkConfig() {
@@ -2134,7 +2134,7 @@ describe("archived-scratchpad wind-down", () => {
     })
     try {
       await __testing.probeArchiveState(ctx)
-      const reattach = __testing.reattachAfterArchive(ctx)
+      const reattach = __testing.probeArchiveState(ctx)
       await Bun.sleep(120)
       expect(__testing.archivePendingRootStreamId()).toBeUndefined()
 
@@ -2149,23 +2149,25 @@ describe("archived-scratchpad wind-down", () => {
     }
   })
 
-  test("detaching pulls the poll onto the probe cadence instead of the socket backstop", () => {
+  test("detaching pulls the poll onto the probe cadence instead of the socket backstop", async () => {
     linkConfig()
     // With the socket up the pending tick is 15 minutes out — longer than the
     // whole grace — so a missed restore push would never get a probe.
     expect(__testing.nextQuietPollMs()).not.toBe(45_000)
-    __testing.setArchivePendingForTesting("stream_root")
+    await __testing.setArchivePendingForTesting(ctx, "stream_root")
     expect(__testing.nextQuietPollMs()).toBe(45_000)
   })
 
-  test("an archive event for a retired root does not wind down the scratchpad now linked", () => {
+  test("an archive event for a retired root does not wind down the scratchpad now linked", async () => {
     linkConfig()
     // Cold start replaced archived root A with live root B under the same
     // deterministic runtime identity; A's outbox event arrives late.
     __testing.handleArchivePush(ctx, { runtimeSessionId: "runtime", rootStreamId: "stream_retired" })
+    await Bun.sleep(0)
     expect(__testing.archivePendingRootStreamId()).toBeUndefined()
 
     __testing.handleArchivePush(ctx, { runtimeSessionId: "runtime", rootStreamId: "stream_root" })
+    await Bun.sleep(0)
     expect(__testing.archivePendingRootStreamId()).toBe("stream_root")
   })
 

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -31,8 +31,7 @@ import {
   runHarnessKick,
   parseAllowedTmuxKey,
   sendAllowedTmuxKey,
-  ARCHIVE_RESTORE_GRACE_MS,
-  ARCHIVE_RESTORE_PROBE_MS,
+  ArchiveGraceController,
   scrubSealedError,
   sealReply,
   sealStep,
@@ -318,16 +317,16 @@ let sessionTearingDown = false
 // Set while the linked scratchpad is archived and the session is waiting out
 // the restore grace window: claims are suspended, the poll probes at the
 // reattach cadence, and the deadline runs the worktree wind-down.
-let archivePending: { rootStreamId: string; deadline: ReturnType<typeof setTimeout> } | undefined
-// Set by startPolling so detachForArchive can pull the next tick forward: the
-// pending tick was scheduled with the socket backstop (15 min), which lands
-// ZERO reattach probes inside a 5-minute grace.
+// The archive → grace → wind-down machine, shared with the Claude runtime.
+// Built lazily because every hook needs the extension ctx.
+let archive: ArchiveGraceController | undefined
+// Set by startPolling so a detach can pull the next tick forward: the pending
+// tick was scheduled with the socket backstop (15 min), which lands ZERO
+// reattach probes inside a 5-minute grace.
 let rearmPoll: ((delayMs: number) => void) | undefined
-let archiveProbeInflight = false
-// Overridable so a test can watch the grace actually expire and the wind-down
-// actually run, instead of waiting five minutes and destroying a real worktree.
-// Mirrors RemoteSession's `archiveGraceMs` option.
-let archiveGraceMs: number = ARCHIVE_RESTORE_GRACE_MS
+// Overridable so a test can watch the grace expire and the wind-down run
+// instead of waiting five minutes and destroying a real worktree.
+let archiveGraceMs: number | undefined
 let archiveWindDown: typeof windDownArchivedWorktree = windDownArchivedWorktree
 // Owns the /bot socket + routes presence/renew/steps over it (HTTP fallback
 // when the socket is down). Built lazily once the session ctx is known; torn
@@ -1830,132 +1829,99 @@ function stopPolling(): void {
 }
 
 /**
- * The linked scratchpad is archived. The server has already ended the session,
- * so no more work can arrive: go offline and stop claiming, but hold the
- * destructive wind-down for the grace window — an unarchive inside it
- * reattaches this live session with no restart.
+ * The controller for this Pi session. Hooks carry the Pi-specific effects; the
+ * pending state, deadline, probe guard and post-await identity checks live in
+ * the shared machine.
  */
-async function detachForArchive(ctx: ExtensionContext, rootStreamId: string): Promise<void> {
-  if (archivePending || sessionTearingDown) return
-  archivePending = {
-    rootStreamId,
-    deadline: setTimeout(() => void windDownAfterArchiveGrace(ctx), archiveGraceMs),
-  }
-  // An in-flight poll re-arms at the probe cadence from its own finally block.
-  if (pollInFlightRunId === undefined) rearmPoll?.(Math.min(ARCHIVE_RESTORE_PROBE_MS, archiveGraceMs))
-  const minutes = Math.round(archiveGraceMs / 60_000)
-  setRemoteStatus(ctx, `Threa remote: scratchpad archived; winding down in ${minutes}m`, "error")
-  ctx.ui.notify(
-    `Threa scratchpad archived. Unarchive within ${minutes} minutes to reattach; otherwise this branch is pushed and the worktree removed.`,
-    "warning"
-  )
-  await heartbeat("offline", undefined, ctx).catch(() => undefined)
-}
-
-/**
- * The scratchpad came back inside the grace window: revive the server-side
- * link for this same runtime session and cancel the wind-down. A transient
- * failure keeps the detached state so the probe cadence survives to retry.
- */
-async function reattachAfterArchive(ctx: ExtensionContext): Promise<void> {
-  const pending = archivePending
-  if (!pending || !config) return
-  const rootStreamId = pending.rootStreamId
-  const body = await request<{ data: RuntimeSessionLink }>(
-    `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+function ensureArchiveController(ctx: ExtensionContext): ArchiveGraceController {
+  archive ??= new ArchiveGraceController(
     {
-      method: "POST",
-      body: JSON.stringify({
-        runtimeKind: "pi-local",
-        instanceId: getSessionInstanceId(ctx),
-        runtimeSessionId: getRuntimeSessionId(ctx),
-        displayName: defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName),
-        localCwd: ctx.cwd,
-        ifArchived: "wait",
-        ifMissing: "error",
-      }),
-    }
+      isArchived: async (rootStreamId) => {
+        if (!config) return undefined
+        const body = await request<{ data: { archivedAt?: string | null } }>(
+          `/api/v1/workspaces/${config.workspaceId}/streams/${rootStreamId}`
+        )
+        return Boolean(body.data?.archivedAt)
+      },
+      reattach: async (rootStreamId) => {
+        if (!config) return false
+        const body = await request<{ data: RuntimeSessionLink }>(
+          `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              runtimeKind: "pi-local",
+              instanceId: getSessionInstanceId(ctx),
+              runtimeSessionId: getRuntimeSessionId(ctx),
+              displayName: defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName),
+              localCwd: ctx.cwd,
+              ifArchived: "wait",
+              ifMissing: "error",
+            }),
+          }
+        )
+        return body.data.rootStreamId === rootStreamId
+      },
+      onDetached: async (_rootStreamId, graceMs) => {
+        // An in-flight poll re-arms at the probe cadence from its own finally block.
+        if (pollInFlightRunId === undefined) rearmPoll?.(ensureArchiveController(ctx).probeDelayMs)
+        const minutes = Math.round(graceMs / 60_000)
+        setRemoteStatus(ctx, `Threa remote: scratchpad archived; winding down in ${minutes}m`, "error")
+        ctx.ui.notify(
+          `Threa scratchpad archived. Unarchive within ${minutes} minutes to reattach; otherwise this branch is pushed and the worktree removed.`,
+          "warning"
+        )
+        await heartbeat("offline", undefined, ctx).catch(() => undefined)
+      },
+      onReattached: async () => {
+        setRemoteStatus(ctx, "Threa remote: linked")
+        ctx.ui.notify("Threa scratchpad unarchived; reattached.", "info")
+        await heartbeat("available", undefined, ctx).catch(() => undefined)
+      },
+      onWindDown: () => {
+        stopPolling()
+        stopClaimRenewTimer()
+        const report = archiveWindDown(ctx.cwd, (message) => emitPollDebug(ctx, message))
+        teardownTransport()
+        if (report.windowKilled) return
+        ctx.ui.notify(
+          report.pushed
+            ? "Threa scratchpad archived; branch pushed. This worktree is finished — close the window."
+            : `Threa scratchpad archived, but the wind-down could not preserve the work: ${report.reason ?? "unknown"}`,
+          report.pushed ? "warning" : "error"
+        )
+      },
+      log: (message) => emitPollDebug(ctx, message),
+    },
+    archiveGraceMs === undefined ? {} : { graceMs: archiveGraceMs }
   )
-  if (body.data.rootStreamId !== rootStreamId) return
-  // The grace deadline can fire (or a second reattach can win) while the
-  // request above is in flight — a 30s fetch timeout against a 45s probe
-  // cadence lands squarely inside the window. Reattaching against a session
-  // that already wound down would resurrect a dead worktree; the pinned
-  // identity check is what makes the wind-down terminal.
-  if (archivePending !== pending) return
-  clearTimeout(pending.deadline)
-  archivePending = undefined
-  setRemoteStatus(ctx, "Threa remote: linked")
-  ctx.ui.notify("Threa scratchpad unarchived; reattached.", "info")
-  await heartbeat("available", undefined, ctx).catch(() => undefined)
+  return archive
 }
 
-/**
- * The grace expired with the scratchpad still archived: preserve the work on
- * the remote and take the tmux window down. Pi dies with the window, so this
- * may never return; recovery is `git fetch` plus the pushed branch.
- */
-async function windDownAfterArchiveGrace(ctx: ExtensionContext): Promise<void> {
-  if (!archivePending) return
-  clearTimeout(archivePending.deadline)
-  archivePending = undefined
-  stopPolling()
-  stopClaimRenewTimer()
-  const report = archiveWindDown(ctx.cwd, (message) => emitPollDebug(ctx, message))
-  teardownTransport()
-  if (!report.windowKilled) {
-    ctx.ui.notify(
-      report.pushed
-        ? "Threa scratchpad archived; branch pushed. This worktree is finished — close the window."
-        : `Threa scratchpad archived, but the wind-down could not preserve the work: ${report.reason ?? "unknown"}`,
-      report.pushed ? "warning" : "error"
-    )
-  }
-}
-
-/**
- * bot:session_archived is a one-shot push with no replay, so a socket that was
- * down when the archive landed would otherwise hold this worktree open
- * forever. Re-derive the state from the server on the poll tick and drive both
- * directions of the transition from it.
- */
+/** The poll-tick backstop: `bot:session_archived` is a one-shot push with no replay. */
 async function probeArchiveState(ctx: ExtensionContext): Promise<void> {
-  if (!config || archiveProbeInflight || sessionTearingDown) return
-  const rootStreamId = archivePending?.rootStreamId ?? getCurrentSessionLink(ctx)?.rootStreamId
-  if (!rootStreamId) return
-  archiveProbeInflight = true
-  try {
-    const body = await request<{ data: { archivedAt?: string | null } }>(
-      `/api/v1/workspaces/${config.workspaceId}/streams/${rootStreamId}`
-    )
-    const archived = Boolean(body.data?.archivedAt)
-    if (archived && !archivePending) await detachForArchive(ctx, rootStreamId)
-    else if (!archived && archivePending) await reattachAfterArchive(ctx)
-  } catch (error) {
-    emitPollDebug(ctx, `archive probe failed: ${summarizeError(error)}`)
-  } finally {
-    archiveProbeInflight = false
-  }
+  if (!config || sessionTearingDown) return
+  await ensureArchiveController(ctx).probe(getCurrentSessionLink(ctx)?.rootStreamId)
 }
 
-/** Scoped to this session: a runtime that re-registered must not die to a stale event for the old one. */
+/**
+ * Scoped to this runtime session AND the currently linked root: a cold start
+ * replaces an archived scratchpad under the same deterministic identity, so a
+ * delayed event for the retired root must not wind down the live one.
+ */
 function handleArchivePush(ctx: ExtensionContext, payload: unknown): void {
-  if (!isObject(payload)) return
+  if (!isObject(payload) || sessionTearingDown) return
   if (typeof payload.runtimeSessionId === "string" && payload.runtimeSessionId !== getRuntimeSessionId(ctx)) return
-  // Scope to the CURRENT root too, not just the runtime session: a cold start
-  // with the same deterministic identity replaces an archived scratchpad, and
-  // a delayed event for the retired root would otherwise wind down the live
-  // one — the probe keeps seeing the old root archived, so it never recovers.
   const linked = getCurrentSessionLink(ctx)?.rootStreamId
   const rootStreamId = typeof payload.rootStreamId === "string" ? payload.rootStreamId : linked
   if (!rootStreamId || (linked && rootStreamId !== linked)) return
-  void detachForArchive(ctx, rootStreamId).catch(() => undefined)
+  void ensureArchiveController(ctx).archived(rootStreamId)
 }
 
 function handleRestorePush(ctx: ExtensionContext, payload: unknown): void {
-  if (!isObject(payload)) return
+  if (!isObject(payload) || sessionTearingDown) return
   if (typeof payload.runtimeSessionId === "string" && payload.runtimeSessionId !== getRuntimeSessionId(ctx)) return
-  void reattachAfterArchive(ctx).catch((error) => emitPollDebug(ctx, `reattach failed: ${summarizeError(error)}`))
+  void ensureArchiveController(ctx).restored()
 }
 
 function basePollMs(): number {
@@ -1982,7 +1948,7 @@ function nextQuietPollMs(): number {
   // Detached-pending-restore: probe at a fixed cadence so a missed
   // bot:session_restored push still reattaches inside the grace window. The
   // window bounds the total probes, so this cannot become a quota burn.
-  if (archivePending) return ARCHIVE_RESTORE_PROBE_MS
+  if (archive?.detached) return archive.probeDelayMs
   if (transport?.socketConnected || pending || steeredInvocations.length > 0) {
     consecutiveQuietPolls = 0
     return basePollMs()
@@ -3440,7 +3406,7 @@ async function claimIfIdlePass(pi: ExtensionAPI, ctx: ExtensionContext, lifecycl
     return false
   // No claims while detached: the scratchpad is archived, so any claimable work
   // predates it and would answer into a closed stream. A reattach re-drains.
-  if (archivePending) return false
+  if (archive?.detached) return false
   if (pending) await renewActiveClaims()
 
   if (isWaitingForRetry) {
@@ -4145,21 +4111,20 @@ export const __testing = {
     supervisedRevivalBlocked = value
   },
   probeArchiveState,
-  reattachAfterArchive,
   handleArchivePush,
-  setArchivePendingForTesting: (rootStreamId: string) => {
-    archivePending = { rootStreamId, deadline: setTimeout(() => {}, 60_000) }
-  },
-  archivePendingRootStreamId: () => archivePending?.rootStreamId,
+  handleRestorePush,
+  archiveDetached: () => archive?.detached ?? false,
+  archivePendingRootStreamId: () => archive?.pendingRootStreamId,
+  setArchivePendingForTesting: (ctx: ExtensionContext, rootStreamId: string) =>
+    ensureArchiveController(ctx).archived(rootStreamId),
   setArchiveWindDownForTesting: (graceMs: number, windDown: typeof windDownArchivedWorktree) => {
     archiveGraceMs = graceMs
     archiveWindDown = windDown
   },
   clearArchivePendingForTesting: () => {
-    if (archivePending) clearTimeout(archivePending.deadline)
-    archivePending = undefined
-    archiveProbeInflight = false
-    archiveGraceMs = ARCHIVE_RESTORE_GRACE_MS
+    archive?.stop()
+    archive = undefined
+    archiveGraceMs = undefined
     archiveWindDown = windDownArchivedWorktree
   },
   setRateLimitWaitForTesting: (value: boolean) => {

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -417,7 +417,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
       nextPollDelay: (claimed: boolean) => number
       probeArchiveBackstop: () => Promise<void>
       link: { rootStreamId: string } | undefined
-      archivePending: unknown
+      archive: { detached: boolean }
     }
 
   test("detaches on archive: goes offline, fails in-flight turns, but does NOT wind down within the grace window", async () => {
@@ -443,7 +443,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     expect(failed).toEqual(["binv_running"])
     // The wind-down is deferred: an unarchive within the grace window reattaches instead.
     expect(archived).toEqual([])
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     // Detached: no claims while the scratchpad is archived, and the poll probes at the reattach cadence.
     expect(await asInternal(session).claimDrain()).toBe(false)
     expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
@@ -484,7 +484,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // The probe WAITS on the archived scratchpad (grace-window reattach) — it
     // must never ask the server to replace it with a fresh one.
     expect((created[0] as Record<string, unknown>).ifArchived).toBe("wait")
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
     expect(archived).toEqual([])
     await session.shutdown()
@@ -539,7 +539,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // bot:session_archived never arrived — only the probe knows.
     await asInternal(session).probeArchiveBackstop()
 
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     expect(presence.at(-1)?.status).toBe("offline")
     // Still archived when the grace expires (the reattach probe re-links, but
     // handleSessionRestored never fires), so the connector wind-down runs.
@@ -567,7 +567,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
 
       await asInternal(session).probeArchiveBackstop()
 
-      expect(asInternal(session).archivePending).toBeUndefined()
+      expect(asInternal(session).archive.detached).toBe(false)
       expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
       expect(archived).toEqual([])
       await session.shutdown()
@@ -683,7 +683,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     await inflightLink
 
     expect(asInternal(session).link).toBeUndefined()
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     await session.shutdown()
   })
 
@@ -719,7 +719,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // Reattached: session-create re-issued (the server revives the same link),
     // presence back to available, wind-down cancelled, claims live again.
     expect(created).toHaveLength(1)
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
     expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
     expect(session.statusSnapshot.linkGeneration).toBe(2)
     expect(presence.at(-1)?.status).toBe("available")
@@ -747,7 +747,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     // Still detached-pending: probe cadence + claim suppression survive the
     // transient failure instead of dropping to the 15-min backstop unlinked.
     expect(asInternal(session).link).toBeUndefined()
-    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).archive.detached).toBe(true)
     expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
     await session.shutdown()
   })
@@ -816,7 +816,7 @@ describe("RemoteSession session-archived handling (grace window)", () => {
 
     expect(archived).toEqual([])
     expect(presence).toEqual([])
-    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).archive.detached).toBe(false)
   })
 })
 

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -1,8 +1,7 @@
 import { homedir } from "node:os"
 import { join } from "node:path"
 import {
-  ARCHIVE_RESTORE_GRACE_MS,
-  ARCHIVE_RESTORE_PROBE_MS,
+  ArchiveGraceController,
   BikKeystore,
   BotRuntimeTransport,
   mintStreamKeyWraps,
@@ -348,15 +347,7 @@ export class RemoteSession {
   private reconnectResetTimer: ReturnType<typeof setTimeout> | undefined
   private reconnectFallbackTask: Promise<unknown> | undefined
   private stopped = false
-  private readonly archiveGraceMs: number
-  /**
-   * Set while the linked scratchpad is archived and the session is waiting out
-   * the restore grace window. Claims are suspended; the poll probes
-   * session-create at ARCHIVE_RESTORE_PROBE_MS; the deadline runs the
-   * connector wind-down that used to fire immediately on archive.
-   */
-  private archivePending: { rootStreamId: string; deadline: ReturnType<typeof setTimeout> } | undefined
-  private archiveProbeInflight = false
+  private readonly archive: ArchiveGraceController
   private pollTimer: ReturnType<typeof setTimeout> | undefined
   private renewTimer: ReturnType<typeof setInterval> | undefined
   /** Consecutive empty poll ticks while the socket is down; drives the poll backoff. */
@@ -375,7 +366,17 @@ export class RemoteSession {
     this.delegate = options.delegate
     this.runtime = options.runtime
     this.log = options.log ?? (() => undefined)
-    this.archiveGraceMs = options.archiveGraceMs ?? ARCHIVE_RESTORE_GRACE_MS
+    this.archive = new ArchiveGraceController(
+      {
+        isArchived: async (rootStreamId) => Boolean(await this.client.getStreamArchivedAt(rootStreamId)),
+        reattach: () => this.relinkAfterRestore(),
+        onDetached: (rootStreamId) => this.detachForArchive(rootStreamId),
+        onReattached: () => this.claimDrain().then(() => undefined),
+        onWindDown: (rootStreamId) => this.windDownForArchive(rootStreamId),
+        log: this.log,
+      },
+      options.archiveGraceMs === undefined ? {} : { graceMs: options.archiveGraceMs }
+    )
     this.bik = new BikKeystore({
       path: this.config.bikPath ?? join(homedir(), ".threa", `bik-${sanitizeId(this.runtime.kind)}.json`),
       log: this.log,
@@ -433,12 +434,12 @@ export class RemoteSession {
   }
 
   get statusSnapshot(): RemoteSessionStatusSnapshot {
-    const linkState = this.archivePending ? "detached" : this.link ? "linked" : "unlinked"
+    const linkState = this.archive.detached ? "detached" : this.link ? "linked" : "unlinked"
     return {
       stopped: this.stopped,
       linkGeneration: this.linkGeneration,
       linkState,
-      rootStreamId: this.link?.rootStreamId ?? this.archivePending?.rootStreamId,
+      rootStreamId: this.link?.rootStreamId ?? this.archive.pendingRootStreamId,
       activeStreamId: this.link?.activeStreamId,
       socketConnected: this.transport.socketConnected,
       inflightCount: this.inflight.size,
@@ -464,34 +465,43 @@ export class RemoteSession {
 
   /** Create (or recover) the scratchpad link. Best-effort so a transient Threa outage self-heals on the next poll tick. */
   private async ensureLink(): Promise<void> {
-    if (this.link || this.stopped) return
-    // Snapshot the detach state so a response that raced an archive push is
-    // dropped: a createSession issued BEFORE the archive can resolve with the
-    // pre-archive link after archivePending was set — accepting it would cancel
-    // the wind-down against a scratchpad that is still archived server-side.
-    const pendingAtStart = this.archivePending
+    // While detached the controller's reattach is the ONLY path allowed to
+    // relink: a link created here would cancel a wind-down against a
+    // scratchpad that is still archived server-side.
+    if (this.link || this.stopped || this.archive.detached) return
     try {
-      const link = await this.createSession()
-      if (this.stopped) return
-      if (this.archivePending !== pendingAtStart) {
-        this.log("link response raced an archive state change — dropped; the next probe decides")
-        return
-      }
-      this.link = link
-      this.linkGeneration += 1
-      // A successful link while detached-pending-restore is the reattach (the
-      // server revived the archived link for this runtime session) — the probe
-      // beat the bot:session_restored push. Cancel the wind-down.
-      if (this.archivePending) {
-        clearTimeout(this.archivePending.deadline)
-        this.archivePending = undefined
-        this.log("scratchpad restored — reattached")
-      }
-      this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
-      await this.syncPresence()
+      await this.createLink()
     } catch (error) {
       this.log(`could not link to Threa (will retry): ${this.summarize(error)}${this.linkErrorHint(error)}`)
     }
+  }
+
+  /** The reattach hook: a confirmed link is what cancels the grace, so failure must read as "still archived". */
+  private async relinkAfterRestore(): Promise<boolean> {
+    try {
+      return await this.createLink()
+    } catch (error) {
+      this.log(`reattach link failed: ${this.summarize(error)}${this.linkErrorHint(error)}`)
+      return false
+    }
+  }
+
+  private async createLink(): Promise<boolean> {
+    const generation = this.archive.generation
+    const link = await this.createSession()
+    // A pre-archive session-create can resolve AFTER the archive lands;
+    // committing it would resurrect a link to a scratchpad that is archived
+    // server-side and hide the detach from the next probe.
+    if (this.stopped) return false
+    if (this.archive.generation !== generation) {
+      this.log("link response raced an archive state change — dropped; the next probe decides")
+      return false
+    }
+    this.link = link
+    this.linkGeneration += 1
+    this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
+    await this.syncPresence()
+    return true
   }
 
   /** Actionable next step for the link failures a retry alone will never fix. */
@@ -500,7 +510,7 @@ export class RemoteSession {
     if (error.status === 401 || error.status === 403) {
       return " — check THREA_API_KEY (must be a bot key, threa_bk_…) and THREA_WORKSPACE_ID"
     }
-    if (error.code === "SCRATCHPAD_ARCHIVED" && !this.archivePending) {
+    if (error.code === "SCRATCHPAD_ARCHIVED" && !this.archive.detached) {
       return " — the server does not support ifArchived replace yet; unarchive the scratchpad in Threa to link"
     }
     return ""
@@ -511,10 +521,7 @@ export class RemoteSession {
     this.stopped = true
     if (this.pollTimer) clearTimeout(this.pollTimer)
     if (this.renewTimer) clearInterval(this.renewTimer)
-    if (this.archivePending) {
-      clearTimeout(this.archivePending.deadline)
-      this.archivePending = undefined
-    }
+    this.archive.stop()
     this.resetReconnectHandoff()
     await this.reconnectFallbackTask
     // Fast, idempotent teardown first so SIGTERM cleanup isn't held hostage by
@@ -562,7 +569,7 @@ export class RemoteSession {
       // default, but supervisors reviving a known stream can force wait so an
       // archive between their preflight and process launch cannot mint another
       // scratchpad.
-      ifArchived: this.archivePending ? "wait" : (this.config.coldStartIfArchived ?? "replace"),
+      ifArchived: this.archive.detached ? "wait" : (this.config.coldStartIfArchived ?? "replace"),
       ifMissing: this.config.expectedRootStreamId ? "error" : (this.config.coldStartIfMissing ?? "create"),
       ...(this.config.defaultLabel && { labelName: this.config.defaultLabel }),
       ...(e2e ? { e2e: { ownerKeyId: e2e.ownerKeyId } } : {}),
@@ -652,7 +659,7 @@ export class RemoteSession {
     // No claims while detached-pending-restore: the scratchpad is archived, so
     // any claimable work predates the archive and would reply into a closed
     // stream. Restore re-runs the drain.
-    if (this.stopped || this.claiming || this.archivePending || this.reconnectHandoff) return false
+    if (this.stopped || this.claiming || this.archive.detached || this.reconnectHandoff) return false
     let claimedAny = false
     this.claiming = true
     try {
@@ -882,7 +889,7 @@ export class RemoteSession {
           this.onHandoffReset = outcome.onHandoffReset
           await this.syncPresence()
           const completed = await this.completeAck(invocation, outcome.message)
-          if (!completed || this.stopped || !this.link || this.archivePending) {
+          if (!completed || this.stopped || !this.link || this.archive.detached) {
             this.resetReconnectHandoff()
             return
           }
@@ -1485,41 +1492,55 @@ export class RemoteSession {
   }
 
   /**
-   * The linked scratchpad was archived. The server has already ended the
-   * session link, so no more work can arrive: fail any in-flight turn (its
-   * reply could no longer land), go offline, and detach — but do NOT wind down
-   * yet. An unarchive within the grace window revives the link server-side and
-   * reattaches this live session (bot:session_restored, or the ensureLink
-   * probe); only when the grace expires does the connector's destructive
-   * wind-down run. Scoped to this session: the event is room-targeted, but a
-   * runtime that re-registered under a new session id must not die to a stale
-   * event for the old one.
+   * A `bot:session_archived` push. Scoped to this session AND this root: a
+   * runtime that re-registered under a new session id, or a cold start that
+   * replaced an archived scratchpad with a fresh one, must not die to a stale
+   * event for the retired root.
    */
   private async handleSessionArchived(payload: unknown): Promise<void> {
     const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
     if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
-    if (this.stopped || this.archivePending) return
-    const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : (this.link?.rootStreamId ?? "")
-    this.log(
-      `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.archiveGraceMs / 1000)}s)`
-    )
+    const linked = this.link?.rootStreamId
+    const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : linked
+    if (!rootStreamId || (linked && rootStreamId !== linked)) return
+    await this.archive.archived(rootStreamId)
+  }
+
+  /** A `bot:session_restored` push: the server revived this session's link. */
+  private async handleSessionRestored(payload: unknown): Promise<void> {
+    const data = (payload ?? {}) as { runtimeSessionId?: unknown }
+    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
+    await this.archive.restored()
+  }
+
+  /**
+   * `bot:session_archived` is a one-shot push with no replay: a socket that was
+   * down when the archive landed never learns of it, and the runtime then holds
+   * a link to a dead scratchpad forever — taking its tmux window and worktree
+   * with it. Re-derive from the server on every poll tick and socket bootstrap.
+   */
+  private async probeArchiveBackstop(): Promise<void> {
+    await this.archive.probe(this.link?.rootStreamId)
+  }
+
+  /**
+   * Detach effects. No more work can arrive, so fail any in-flight turn (its
+   * reply could no longer land), drop the link, and go offline — but the
+   * worktree survives until the grace expires.
+   */
+  private async detachForArchive(rootStreamId: string): Promise<void> {
     const inflight = [...this.inflight]
     for (const [, entry] of inflight) clearTimeout(entry.deadline)
     this.inflight.clear()
     this.activeTurnStream = undefined
     this.link = undefined
     this.linkGeneration += 1
-    const pending = {
-      rootStreamId,
-      deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
-    }
-    this.archivePending = pending
     this.resetReconnectHandoff()
     await this.reconnectFallbackTask
     // Pull the next poll tick onto the probe cadence NOW — the pending tick was
-    // scheduled with the slow socket-backstop delay (15 min), which could land
+    // scheduled with the slow socket-backstop delay (15 min), which would land
     // zero probes inside the grace window if the restore push is then missed.
-    this.reschedulePoll(this.archiveProbeDelayMs)
+    this.reschedulePoll(this.archive.probeDelayMs)
     await Promise.allSettled(
       inflight.map(([id, entry]) =>
         this.client.fail(id, {
@@ -1531,78 +1552,14 @@ export class RemoteSession {
     )
     // A restore can reattach and publish 'available' during the awaits above —
     // don't overwrite it with a stale 'offline'.
-    if (this.stopped || this.archivePending !== pending) return
+    if (this.stopped || this.archive.pendingRootStreamId !== rootStreamId) return
     await this.transport.updatePresence(this.presenceBody("offline")).catch(() => undefined)
   }
 
-  /**
-   * bot:session_archived is a one-shot push with no replay: a socket that was
-   * down when the archive landed never learns of it, and the runtime then holds
-   * a link to a dead scratchpad forever — taking its tmux window and worktree
-   * with it. Re-derive the state from the server on every poll tick and on
-   * every socket (re)connect, and route a confirmed archive through the same
-   * grace-window path the push takes, so an unarchive still reattaches.
-   */
-  private async probeArchiveBackstop(): Promise<void> {
-    const rootStreamId = this.link?.rootStreamId
-    if (this.stopped || this.archivePending || this.archiveProbeInflight || !rootStreamId) return
-    this.archiveProbeInflight = true
-    try {
-      const archivedAt = await this.client.getStreamArchivedAt(rootStreamId)
-      // The awaits above can race a real push or a relink onto another root;
-      // re-check rather than detach on a snapshot that is no longer current.
-      if (!archivedAt) return
-      if (this.stopped || this.archivePending || this.link?.rootStreamId !== rootStreamId) return
-      this.log(`archive backstop: scratchpad ${rootStreamId} archived at ${archivedAt} with no push received`)
-      await this.handleSessionArchived({ runtimeSessionId: this.config.runtimeSessionId, rootStreamId })
-    } catch (error) {
-      this.log(`archive backstop probe failed: ${this.summarize(error)}`)
-    } finally {
-      this.archiveProbeInflight = false
-    }
-  }
-
-  /** The grace expired with the scratchpad still archived: run the wind-down that used to fire on archive. */
-  private async windDownAfterGrace(rootStreamId: string): Promise<void> {
-    if (this.stopped || !this.archivePending) return
-    this.archivePending = undefined
-    this.log(`scratchpad ${rootStreamId} stayed archived — winding down`)
+  /** The grace expired with the scratchpad still archived: hand the connector its terminal wind-down. */
+  private async windDownForArchive(rootStreamId: string): Promise<void> {
     await this.shutdown()
-    try {
-      await this.delegate.onArchived?.({ rootStreamId })
-    } catch (error) {
-      this.log(`onArchived hook failed: ${this.summarize(error)}`)
-    }
-  }
-
-  /**
-   * The archived scratchpad was unarchived and the server revived this
-   * session's link: cancel the pending wind-down, re-establish the link (the
-   * session-create path returns the revived link for the SAME scratchpad), and
-   * resume claiming — the live agent reattaches with no restart.
-   */
-  private async handleSessionRestored(payload: unknown): Promise<void> {
-    const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
-    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
-    if (this.stopped) return
-    if (this.archivePending) {
-      // Don't clear the pending state yet — only ensureLink's confirmed link
-      // does that. If the createSession below fails transiently, the probe
-      // cadence and claim suppression must survive; clearing here would drop
-      // the session onto the 15-min backstop unlinked. The restore does cancel
-      // the CURRENT wind-down, but a fresh grace deadline re-arms so a
-      // reattach that never succeeds still winds down bounded.
-      clearTimeout(this.archivePending.deadline)
-      const rootStreamId = this.archivePending.rootStreamId
-      this.archivePending = {
-        rootStreamId,
-        deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
-      }
-      this.log(`scratchpad ${rootStreamId} restored — reattaching`)
-    }
-    if (!this.link) await this.ensureLink()
-    else await this.syncPresence()
-    await this.claimDrain()
+    await this.delegate.onArchived?.({ rootStreamId })
   }
 
   // --- Timers ---------------------------------------------------------------
@@ -1646,18 +1603,16 @@ export class RemoteSession {
 
   private async pollTick(): Promise<void> {
     if (this.stopped) return
+    // Always first: while detached this is the reattach attempt (ensureLink
+    // refuses to relink during the grace), and while linked it is the
+    // missed-push backstop.
+    await this.probeArchiveBackstop()
     if (!this.link) await this.ensureLink()
-    else await this.probeArchiveBackstop()
     if (!this.transport.socketConnected) await this.transport.connect()
     const claimed = await this.claimDrain()
     // shutdown() can land during the awaits above; re-arming then would leave
     // a live timer past teardown.
     if (!this.stopped) this.reschedulePoll(this.nextPollDelay(claimed))
-  }
-
-  /** Reattach-probe cadence while detached: scaled to the grace window so several probes always fit inside it. */
-  private get archiveProbeDelayMs(): number {
-    return Math.min(ARCHIVE_RESTORE_PROBE_MS, Math.max(Math.floor(this.archiveGraceMs / 4), 10))
   }
 
   /**
@@ -1670,7 +1625,7 @@ export class RemoteSession {
     // Detached-pending-restore: probe at a fixed cadence so a missed
     // bot:session_restored push still reattaches within the grace window. The
     // window bounds the total probes, so this cannot become a quota burn.
-    if (this.archivePending) return this.archiveProbeDelayMs
+    if (this.archive.detached) return this.archive.probeDelayMs
     if (this.transport.socketConnected) {
       this.emptyNoSocketPolls = 0
       return WS_BACKSTOP_POLL_MS
@@ -1704,7 +1659,7 @@ export class RemoteSession {
         this.log(`session-control handoff reset failed: ${this.summarize(error)}`)
       }
     }
-    if (this.stopped || !this.link || this.archivePending) {
+    if (this.stopped || !this.link || this.archive.detached) {
       if (callbackTask) this.reconnectFallbackTask = callbackTask
       return
     }


### PR DESCRIPTION
Stacked on #1568.

## Problem

`RemoteSession` hand-rolled the archive grace machine: `archivePending`, `archiveProbeInflight`, `archiveGraceMs`, a probe-delay getter, and four handlers that each re-derived the same post-await identity checks.

## Solution

Delegate to `ArchiveGraceController`. `RemoteSession` keeps only the effects that are genuinely its own — failing in-flight turns so their replies can't land in a closed stream, dropping the link, pulling the poll onto the probe cadence, and the connector wind-down. Net **45 lines lighter** (152 removed, 107 added).

Two deliberate behavior changes:

- **`ensureLink` now refuses to relink while detached.** The reattach hook is the only path allowed to cancel a grace, so `pollTick` probes *before* it links — otherwise a plain `ensureLink` during the window would silently reattach without going through the controller.
- **`createLink` drops its result when the archive generation moved under it.** This replaces the old `pendingAtStart` snapshot and additionally covers the reattach direction, which the snapshot did not.

`handleSessionArchived` also now scopes to the currently linked root, not just the runtime session — the same stale-retired-root hole that was fixed in Pi on #1561 existed here in latent form (Claude self-healed via `createSession` where Pi could not, so it was survivable rather than fatal).

Tests assert through the controller rather than a private field; the scenarios they cover are unchanged.

## Test plan

- [x] `bun test ./extensions/` — 580 pass, 0 fail
- [x] `typecheck` clean for all four extension packages

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787695489&installation_model_id=20758&pr_number=1569&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1569&signature=8b5fbf9a2e45edb720f56da3398a9cbfc37b37390bdfe12f02ea3a3de311d39e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->