### PR TITLE
feat(harness): shared ArchiveGraceController for the archive wind-down

### DIFF
--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -89,6 +89,33 @@ describe("ArchiveGraceController", () => {
     })
   })
 
+  test("a restore push restarts the grace even when the relink fails", async () => {
+    let attempts = 0
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          attempts += 1
+          throw new Error("threa unreachable")
+        },
+      },
+      160
+    )
+
+    await controller.archived("stream_root")
+    await Bun.sleep(120)
+    // Unarchived with the original grace nearly spent: winding down a second
+    // later is exactly the mis-click recovery this window exists for.
+    await controller.restored()
+    await Bun.sleep(100)
+
+    expect({ woundDown: recorded.woundDown, isDetached: controller.detached, attempts }).toEqual({
+      woundDown: [],
+      isDetached: true,
+      attempts: 1,
+    })
+    controller.stop()
+  })
+
   test("a reattach that throws keeps the session detached so the probe retries", async () => {
     const { controller, recorded } = makeController(
       {

--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test"
+import { ArchiveGraceController, type ArchiveGraceHooks } from "./archive-grace"
+
+interface Recorded {
+  detached: string[]
+  reattached: string[]
+  woundDown: string[]
+  logs: string[]
+}
+
+function makeController(
+  overrides: Partial<ArchiveGraceHooks> = {},
+  graceMs = 200
+): { controller: ArchiveGraceController; recorded: Recorded } {
+  const recorded: Recorded = { detached: [], reattached: [], woundDown: [], logs: [] }
+  const controller = new ArchiveGraceController(
+    {
+      isArchived: async () => false,
+      reattach: async () => false,
+      onDetached: (rootStreamId) => void recorded.detached.push(rootStreamId),
+      onReattached: (rootStreamId) => void recorded.reattached.push(rootStreamId),
+      onWindDown: (rootStreamId) => void recorded.woundDown.push(rootStreamId),
+      log: (message) => void recorded.logs.push(message),
+      ...overrides,
+    },
+    { graceMs }
+  )
+  return { controller, recorded }
+}
+
+describe("ArchiveGraceController", () => {
+  test("an archive detaches, holds the grace, then winds down", async () => {
+    const { controller, recorded } = makeController({}, 120)
+
+    await controller.archived("stream_root")
+    expect({ detached: recorded.detached, woundDown: recorded.woundDown, isDetached: controller.detached }).toEqual({
+      detached: ["stream_root"],
+      woundDown: [],
+      isDetached: true,
+    })
+
+    await Bun.sleep(220)
+    expect({ woundDown: recorded.woundDown, isDetached: controller.detached }).toEqual({
+      woundDown: ["stream_root"],
+      isDetached: false,
+    })
+  })
+
+  test("an unarchive inside the grace reattaches and cancels the wind-down", async () => {
+    const { controller, recorded } = makeController({ reattach: async () => true }, 200)
+
+    await controller.archived("stream_root")
+    await controller.restored()
+
+    expect({ reattached: recorded.reattached, isDetached: controller.detached }).toEqual({
+      reattached: ["stream_root"],
+      isDetached: false,
+    })
+    await Bun.sleep(260)
+    expect(recorded.woundDown).toEqual([])
+  })
+
+  test("a reattach resolving after the wind-down already ran does not resurrect the session", async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          await gate
+          return true
+        },
+      },
+      100
+    )
+
+    await controller.archived("stream_root")
+    const restoring = controller.restored()
+    await Bun.sleep(200)
+    expect(recorded.woundDown).toEqual(["stream_root"])
+
+    release()
+    await restoring
+
+    // The wind-down is terminal: the late success must not re-attach a session
+    // whose worktree is already gone.
+    expect({ reattached: recorded.reattached, isDetached: controller.detached }).toEqual({
+      reattached: [],
+      isDetached: false,
+    })
+  })
+
+  test("a reattach that throws keeps the session detached so the probe retries", async () => {
+    const { controller, recorded } = makeController(
+      {
+        reattach: async () => {
+          throw new Error("threa unreachable")
+        },
+      },
+      10_000
+    )
+
+    await controller.archived("stream_root")
+    await controller.restored()
+
+    expect({ isDetached: controller.detached, reattached: recorded.reattached }).toEqual({
+      isDetached: true,
+      reattached: [],
+    })
+    controller.stop()
+  })
+
+  test("the probe detaches on server truth but never on an inconclusive answer", async () => {
+    for (const [answer, shouldDetach] of [
+      [true, true],
+      [false, false],
+      [undefined, false],
+    ] as const) {
+      const { controller } = makeController({ isArchived: async () => answer }, 10_000)
+      await controller.probe("stream_root")
+      expect(controller.detached).toBe(shouldDetach)
+      controller.stop()
+    }
+  })
+
+  test("a probe whose isArchived throws never detaches", async () => {
+    const { controller, recorded } = makeController(
+      {
+        isArchived: async () => {
+          throw new Error("threa unreachable")
+        },
+      },
+      10_000
+    )
+
+    await controller.probe("stream_root")
+
+    expect(controller.detached).toBe(false)
+    expect(recorded.logs.some((line) => line.includes("archive probe failed"))).toBe(true)
+    controller.stop()
+  })
+
+  test("while detached the probe drives reattach, not a second detach", async () => {
+    const calls: string[] = []
+    const { controller } = makeController(
+      {
+        isArchived: async () => {
+          calls.push("isArchived")
+          return true
+        },
+        reattach: async () => {
+          calls.push("reattach")
+          return false
+        },
+      },
+      10_000
+    )
+
+    await controller.archived("stream_root")
+    await controller.probe("stream_root")
+
+    expect(calls).toEqual(["reattach"])
+    expect(controller.detached).toBe(true)
+    controller.stop()
+  })
+
+  test("concurrent probes do not overlap, and stop() disarms an armed deadline", async () => {
+    let inFlight = 0
+    let overlapped = false
+    const { controller, recorded } = makeController(
+      {
+        isArchived: async () => {
+          inFlight += 1
+          if (inFlight > 1) overlapped = true
+          await Bun.sleep(20)
+          inFlight -= 1
+          return true
+        },
+      },
+      80
+    )
+
+    await Promise.all([controller.probe("stream_root"), controller.probe("stream_root")])
+    expect(overlapped).toBe(false)
+    expect(controller.detached).toBe(true)
+
+    controller.stop()
+    await Bun.sleep(150)
+    expect(recorded.woundDown).toEqual([])
+  })
+
+  test("the probe cadence always fits several probes inside the grace", () => {
+    const { controller } = makeController({}, 200)
+    expect(controller.probeDelayMs).toBe(50)
+    const { controller: production } = makeController({}, 5 * 60 * 1000)
+    expect(production.probeDelayMs).toBe(45_000)
+  })
+})

--- a/extensions/bot-runtime-client/src/archive-grace.test.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.test.ts
@@ -215,6 +215,20 @@ describe("ArchiveGraceController", () => {
     expect(recorded.woundDown).toEqual([])
   })
 
+  test("the generation moves on every attach/detach transition", async () => {
+    const { controller } = makeController({ reattach: async () => true }, 10_000)
+    const start = controller.generation
+
+    await controller.archived("stream_root")
+    const detached = controller.generation
+    await controller.restored()
+
+    // A caller holding `start` across an await must see BOTH transitions, or a
+    // link created pre-archive gets committed post-archive.
+    expect([detached > start, controller.generation > detached]).toEqual([true, true])
+    controller.stop()
+  })
+
   test("the probe cadence always fits several probes inside the grace", () => {
     const { controller } = makeController({}, 200)
     expect(controller.probeDelayMs).toBe(50)

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -53,6 +53,7 @@ export class ArchiveGraceController {
   private pending: Pending | undefined
   private probing = false
   private stopped = false
+  private transitions = 0
   private readonly graceMs: number
 
   constructor(
@@ -69,6 +70,17 @@ export class ArchiveGraceController {
 
   get pendingRootStreamId(): string | undefined {
     return this.pending?.rootStreamId
+  }
+
+  /**
+   * Bumped on every attach/detach transition. A runtime with a request already
+   * in flight snapshots this before awaiting and drops its result if the value
+   * moved — otherwise a link created before the archive lands is committed
+   * after it, resurrecting a link to a scratchpad that is archived
+   * server-side.
+   */
+  get generation(): number {
+    return this.transitions
   }
 
   /**
@@ -93,6 +105,7 @@ export class ArchiveGraceController {
       deadline: setTimeout(() => void this.windDown(pending), this.graceMs),
     }
     this.pending = pending
+    this.transitions += 1
     this.hooks.log(
       `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.graceMs / 1000)}s)`
     )
@@ -167,6 +180,7 @@ export class ArchiveGraceController {
     if (!reattached || this.stopped || this.pending !== pending) return
     clearTimeout(pending.deadline)
     this.pending = undefined
+    this.transitions += 1
     this.hooks.log(`scratchpad ${pending.rootStreamId} restored — reattached`)
     await this.hooks.onReattached(pending.rootStreamId)
   }
@@ -175,6 +189,7 @@ export class ArchiveGraceController {
     if (this.stopped || this.pending !== pending) return
     clearTimeout(pending.deadline)
     this.pending = undefined
+    this.transitions += 1
     this.hooks.log(`scratchpad ${pending.rootStreamId} stayed archived — winding down`)
     try {
       await this.hooks.onWindDown(pending.rootStreamId)

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -1,0 +1,182 @@
+import { ARCHIVE_RESTORE_GRACE_MS, ARCHIVE_RESTORE_PROBE_MS } from "./archive-wind-down"
+
+/**
+ * The archive → grace → wind-down state machine, shared by every harness
+ * runtime.
+ *
+ * Archiving a scratchpad ends its session server-side, so the worktree behind
+ * it is finished — but archiving is also how a mis-click gets undone, so the
+ * destructive wind-down (push the branch, remove the worktree, kill the tmux
+ * window) waits out a grace window that an unarchive can cancel.
+ *
+ * This is deliberately one implementation rather than one per runtime. Every
+ * bug this machine has produced came from the same shape: state read before an
+ * `await` and acted on after it, once the deadline had already fired or a
+ * second caller had won. The `pending` object is the identity token — every
+ * resumption re-checks `this.pending !== pending` and bails, which is what
+ * makes the wind-down terminal.
+ */
+
+export interface ArchiveGraceHooks {
+  /**
+   * Server truth for the attached direction. `undefined` means "could not
+   * tell" (transient failure, missing scope, outage) and never detaches — a
+   * diagnostic that did not run is not evidence the scratchpad is archived.
+   */
+  isArchived(rootStreamId: string): Promise<boolean | undefined>
+  /**
+   * Server truth for the detached direction: try to revive this runtime's link.
+   * `true` once reattached, `false` while the scratchpad is still archived.
+   * Throwing is treated as `false` — the probe cadence retries.
+   */
+  reattach(rootStreamId: string): Promise<boolean>
+  /** Detach effects: go offline, suspend claiming, pull the poll onto {@link probeDelayMs}. */
+  onDetached(rootStreamId: string, graceMs: number): Promise<void> | void
+  /** Reattach effects: back to available, resume claiming. */
+  onReattached(rootStreamId: string): Promise<void> | void
+  /** Terminal. Preserve the work, then take the window down; the runtime usually dies here. */
+  onWindDown(rootStreamId: string): Promise<void> | void
+  log(message: string): void
+}
+
+export interface ArchiveGraceOptions {
+  /** Override the grace window. Tests use a few hundred ms; production takes the shared default. */
+  graceMs?: number
+}
+
+interface Pending {
+  rootStreamId: string
+  deadline: ReturnType<typeof setTimeout>
+}
+
+export class ArchiveGraceController {
+  private pending: Pending | undefined
+  private probing = false
+  private stopped = false
+  private readonly graceMs: number
+
+  constructor(
+    private readonly hooks: ArchiveGraceHooks,
+    options: ArchiveGraceOptions = {}
+  ) {
+    this.graceMs = options.graceMs ?? ARCHIVE_RESTORE_GRACE_MS
+  }
+
+  /** Detached and waiting out the grace: claims must stay suspended while this is true. */
+  get detached(): boolean {
+    return this.pending !== undefined
+  }
+
+  get pendingRootStreamId(): string | undefined {
+    return this.pending?.rootStreamId
+  }
+
+  /**
+   * Poll cadence while detached, scaled so several probes always fit inside the
+   * grace even when it is shortened for a test. Bounded by the window, so it
+   * cannot become a quota burn.
+   */
+  get probeDelayMs(): number {
+    return Math.min(ARCHIVE_RESTORE_PROBE_MS, Math.max(Math.floor(this.graceMs / 4), 10))
+  }
+
+  /**
+   * This root is archived (a `bot:session_archived` push, or a probe that
+   * found `archivedAt`). Callers scope the event to their own runtime session
+   * and current root before calling — a stale event for a retired root must
+   * never wind down the scratchpad now linked.
+   */
+  async archived(rootStreamId: string): Promise<void> {
+    if (this.stopped || this.pending) return
+    const pending: Pending = {
+      rootStreamId,
+      deadline: setTimeout(() => void this.windDown(pending), this.graceMs),
+    }
+    this.pending = pending
+    this.hooks.log(
+      `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.graceMs / 1000)}s)`
+    )
+    await this.hooks.onDetached(rootStreamId, this.graceMs)
+  }
+
+  /**
+   * The scratchpad came back (a `bot:session_restored` push). Revives the link
+   * and cancels the wind-down; a transient failure keeps the detached state so
+   * the probe cadence retries inside the remaining window.
+   */
+  async restored(): Promise<void> {
+    const pending = this.pending
+    if (this.stopped || !pending) return
+    await this.attemptReattach(pending)
+  }
+
+  /**
+   * The poll-tick backstop. `bot:session_archived` is a one-shot push with no
+   * replay, so a runtime whose socket was down when the archive landed would
+   * otherwise hold its worktree forever. Re-derives from the server and drives
+   * whichever direction applies.
+   */
+  async probe(currentRootStreamId: string | undefined): Promise<void> {
+    if (this.stopped || this.probing) return
+    this.probing = true
+    try {
+      const pending = this.pending
+      if (pending) {
+        await this.attemptReattach(pending)
+        return
+      }
+      if (!currentRootStreamId) return
+      const archived = await this.hooks.isArchived(currentRootStreamId)
+      if (archived !== true) return
+      // The awaits above can race a real push or a relink onto another root.
+      if (this.stopped || this.pending) return
+      this.hooks.log(`archive backstop: ${currentRootStreamId} is archived with no push received`)
+      await this.archived(currentRootStreamId)
+    } catch (error) {
+      this.hooks.log(`archive probe failed: ${describe(error)}`)
+    } finally {
+      this.probing = false
+    }
+  }
+
+  /** Teardown. Disarms the deadline so a shutting-down runtime cannot wind down behind itself. */
+  stop(): void {
+    this.stopped = true
+    if (this.pending) clearTimeout(this.pending.deadline)
+    this.pending = undefined
+  }
+
+  private async attemptReattach(pending: Pending): Promise<void> {
+    let reattached = false
+    try {
+      reattached = await this.hooks.reattach(pending.rootStreamId)
+    } catch (error) {
+      this.hooks.log(`reattach failed, staying detached: ${describe(error)}`)
+      return
+    }
+    // The deadline can fire, or a second caller can win, while the request
+    // above is in flight. Reattaching against a session that already wound
+    // down would resurrect a dead worktree.
+    if (!reattached || this.stopped || this.pending !== pending) return
+    clearTimeout(pending.deadline)
+    this.pending = undefined
+    this.hooks.log(`scratchpad ${pending.rootStreamId} restored — reattached`)
+    await this.hooks.onReattached(pending.rootStreamId)
+  }
+
+  private async windDown(pending: Pending): Promise<void> {
+    if (this.stopped || this.pending !== pending) return
+    clearTimeout(pending.deadline)
+    this.pending = undefined
+    this.hooks.log(`scratchpad ${pending.rootStreamId} stayed archived — winding down`)
+    try {
+      await this.hooks.onWindDown(pending.rootStreamId)
+    } catch (error) {
+      this.hooks.log(`wind-down failed: ${describe(error)}`)
+    }
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/extensions/bot-runtime-client/src/archive-grace.ts
+++ b/extensions/bot-runtime-client/src/archive-grace.ts
@@ -107,6 +107,13 @@ export class ArchiveGraceController {
   async restored(): Promise<void> {
     const pending = this.pending
     if (this.stopped || !pending) return
+    // The server says the scratchpad is back, so restart the clock even if the
+    // relink below fails transiently: winding down 1s after an unarchive push
+    // because the grace happened to be nearly spent is the exact mis-click
+    // recovery this window exists for. Same `pending` object, so every
+    // post-await identity check still holds.
+    clearTimeout(pending.deadline)
+    pending.deadline = setTimeout(() => void this.windDown(pending), this.graceMs)
     await this.attemptReattach(pending)
   }
 

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -7,6 +7,7 @@ export {
   type AllowedTmuxKey,
   type TmuxKeyFailureCode,
 } from "./tmux-key"
+export { ArchiveGraceController, type ArchiveGraceHooks, type ArchiveGraceOptions } from "./archive-grace"
 export {
   ARCHIVE_RESTORE_GRACE_MS,
   ARCHIVE_RESTORE_PROBE_MS,


### PR DESCRIPTION
Stacked on #1561.

## Problem

Both harness runtimes implement the same archive → grace → wind-down machine, and they had drifted. Of the four CRITICAL findings on #1561's adversarial review, **three were in Pi's copy and none were in `RemoteSession`** — same logic, one copy hardened by review, the other written fresh. Every one of those bugs had the identical shape: state read before an `await` and acted on after it, once the deadline had already fired or a second caller had won.

## Solution

`ArchiveGraceController` in `@threa/bot-runtime-client` — the package both runtimes already depend on. It owns the parts that keep getting this wrong: the pending state, the deadline, the probe-inflight guard, and the post-await identity re-checks. The `pending` object is the identity token; every resumption re-checks `this.pending !== pending` and bails, which is what makes the wind-down terminal.

Runtime-specific effects go through hooks, chosen so neither runtime gains a request it wasn't already making: `isArchived` drives the attached direction (Claude's `getStreamArchivedAt`, Pi's stream GET), `reattach` drives the detached one (both a session-create that fails while still archived).

Two behaviors that were only in one copy are now in both by construction:

- **A restore push restarts the grace.** Previously an unarchive at t=4:59 whose relink failed transiently still wound the worktree down a second later — the exact mis-click recovery the window exists for.
- **`generation` for in-flight callers.** A session-create issued before the archive can resolve after it; committing that link resurrects a link to an archived scratchpad and hides the detach from the next probe. Callers snapshot the counter and drop the result if it moved.

No consumers in this layer — the two migrations are the layers above. It ships with its own tests rather than waiting for them.

## Test plan

- [x] `bun test ./extensions/bot-runtime-client/` — 91 pass, including wind-down-is-terminal, restore-restarts-grace, inconclusive-probe-never-detaches, and no-overlapping-probes
- [x] `typecheck` clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
