### PR TITLE
feat(calls): offer Take over up front instead of a Join that 409s

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -360,7 +360,13 @@ describe("CallDock — pre-join permission taxonomy", () => {
     const manager = makeManager()
     renderDock(manager)
     await userEvent.click(screen.getByText("launch"))
-    expect(manager.startCall).toHaveBeenCalledWith(expect.objectContaining({ takeover: undefined }))
+    // The launch request is passed through untouched — a plain join carries no
+    // takeover, so the server's 409 (and the prompt) is what introduces it.
+    expect(manager.startCall).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      streamId: "stream_1",
+      mode: "video",
+    })
   })
 
   it("shows the pre-join gate on a fresh launch after the prior call was minimized", async () => {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -177,8 +177,10 @@ describe("CallDock — idle", () => {
 
     expect(screen.getByText(/moved to another device/i)).toBeInTheDocument()
     await userEvent.click(screen.getByRole("button", { name: "Rejoin here" }))
+    // Asks for takeover outright: this chip only exists because the other device
+    // holds the call, so a plain join would 409 and re-ask what the chip answered.
     expect(manager.startCall).toHaveBeenCalledWith(
-      expect.objectContaining({ streamId: "stream_1", expectedCallId: "call_1" })
+      expect.objectContaining({ streamId: "stream_1", expectedCallId: "call_1", takeover: true })
     )
   })
 

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -20,6 +20,13 @@ export interface CallLaunchRequest {
   expectedCallId?: string
   /** Join with the camera already publishing (the "Start with camera" choice). */
   cameraOn?: boolean
+  /**
+   * Displace this user's live endpoint on another device instead of being
+   * rejected by it (409 `CALL_ENDPOINT_ACTIVE`). Set by an entry point that
+   * already knows the call is on another device — see `useCallOnAnotherDevice` —
+   * or by answering the takeover prompt. Never set on a plain first join.
+   */
+  takeover?: boolean
 }
 
 /**
@@ -57,7 +64,7 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
   const runIdRef = useRef(0)
 
   const run = useCallback(
-    async (request: CallLaunchRequest, opts?: { takeover?: boolean }) => {
+    async (request: CallLaunchRequest) => {
       // Already in (or joining) a call: startCall would synchronously reject with
       // a plain Error, which the catch below would surface as a stale join_error
       // carrying the wrong request (and a "Try again" that starts an unintended
@@ -72,7 +79,7 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
       // permission taxonomy is derived from startCall's own typed capture failure
       // instead of a separate pre-flight getUserMedia.
       try {
-        await manager.startCall({ ...request, takeover: opts?.takeover })
+        await manager.startCall(request)
         if (runId !== runIdRef.current) return
         setState({ status: "idle" })
       } catch (err) {
@@ -108,10 +115,11 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
     if (state.status === "permission_error" || state.status === "join_error") void run(state.request)
   }, [run, state])
 
-  // Takeover is only ever reachable from the prompt — never folded into `retry`,
-  // so no other error path can displace another device without being asked.
+  // `retry` replays the request untouched, so takeover is only ever added by an
+  // entry point that already knew (`request.takeover`) or by answering this
+  // prompt — no error path can displace another device unasked.
   const takeOver = useCallback(() => {
-    if (state.status === "takeover_prompt") void run(state.request, { takeover: true })
+    if (state.status === "takeover_prompt") void run({ ...state.request, takeover: true })
   }, [run, state])
 
   const cancel = useCallback(() => {

--- a/apps/frontend/src/components/call/call-moved-chip.tsx
+++ b/apps/frontend/src/components/call/call-moved-chip.tsx
@@ -11,27 +11,34 @@ import { useDisplacedCall } from "./call-store-hooks"
  *
  * A chip with actions rather than a toast (INV-63): it needs a decision, and a
  * toast would expire before a user who was looking at their other device sees it.
- * Rejoin runs the ordinary launch, so if the other device is still holding the
- * call the takeover prompt confirms moving it back.
+ * This chip exists BECAUSE the other device holds the call, so its action asks
+ * for takeover directly — routing through a plain join would 409 and re-ask a
+ * question the chip already answered. Harmless if that device has since left:
+ * with no live endpoint, takeover mints a fresh one.
+ *
+ * The pill caps at the viewport so a phone truncates the message instead of
+ * pushing the actions off the left edge (it is `fixed right-4` with no left
+ * anchor, and this branch of the dock is shared with mobile).
  */
 export function CallMovedChip() {
   const displaced = useDisplacedCall()
   const { launch } = useCallLaunch()
   if (!displaced) return null
   return (
-    <div className="flex items-center gap-1.5 rounded-full border bg-background py-1.5 pl-3 pr-1.5 text-xs shadow-lg">
-      <PhoneForwarded className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-      <span className="text-muted-foreground">Call moved to another device</span>
+    <div className="flex max-w-[calc(100vw-2rem)] items-center gap-1.5 rounded-full border bg-background py-1.5 pl-3 pr-1.5 text-xs shadow-lg">
+      <PhoneForwarded className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 truncate text-muted-foreground">Call moved to another device</span>
       <Button
         size="sm"
         variant="secondary"
-        className="h-6 px-2 text-[11px]"
+        className="h-8 shrink-0 px-2 text-[11px]"
         onClick={() =>
           launch({
             workspaceId: displaced.workspaceId,
             streamId: displaced.streamId,
             mode: displaced.mode,
             expectedCallId: displaced.callId,
+            takeover: true,
           })
         }
       >
@@ -40,7 +47,7 @@ export function CallMovedChip() {
       <Button
         size="icon"
         variant="ghost"
-        className="h-6 w-6"
+        className="h-8 w-8 shrink-0"
         aria-label="Dismiss"
         onClick={() => setDisplacedCall(null)}
       >

--- a/apps/frontend/src/components/call/call-start-menu.test.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "@testing-library/react"
-import { render, screen, userEvent } from "@/test"
+import { fireEvent, render, screen, userEvent, waitFor } from "@/test"
+import * as authModule from "@/auth"
 import { clearCallState, setCallSession, setCallPhase } from "@/stores/call-store"
+import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls-store"
+import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import type { CallController } from "@/calls/call-manager"
 import { CallStartMenu } from "./call-start-menu"
 import { CallManagerProvider } from "./call-manager-context"
@@ -32,8 +35,53 @@ function renderMenu(manager: CallController) {
   )
 }
 
-beforeEach(() => clearCallState())
+beforeEach(() => {
+  clearCallState()
+  __resetActiveCallsStore()
+  resetWorkspaceStoreCache()
+  // The menu reads viewer identity to tell "join" from "take over".
+  vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
+})
 afterEach(() => vi.restoreAllMocks())
+
+/** Seed the viewer as a workspace user so identity resolves, then put them in the stream's live call. */
+function seedSelfInLiveCall() {
+  seedWorkspaceCache("ws_1", {
+    workspace: {
+      id: "ws_1",
+      name: "WS",
+      slug: "ws",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [
+      {
+        id: "usr_self",
+        workspaceId: "ws_1",
+        workosUserId: "workos_self",
+        email: "self@example.com",
+        role: "member",
+        slug: "self",
+        name: "Ada",
+        _cachedAt: Date.now(),
+      },
+    ] as unknown as Parameters<typeof seedWorkspaceCache>[1]["users"],
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+  upsertActiveCall("ws_1", {
+    callId: "call_1",
+    streamId: "stream_1",
+    rootStreamId: "stream_1",
+    mode: "video",
+    participantCount: 1,
+    participantUserIds: ["usr_self"],
+  })
+}
 
 describe("CallStartMenu", () => {
   it("starts a mic-only call on 'Start voice call'", async () => {
@@ -64,5 +112,40 @@ describe("CallStartMenu", () => {
       setCallPhase("connected")
     })
     expect(screen.getByRole("button", { name: "You're already in a call" })).toBeDisabled()
+  })
+})
+
+describe("CallStartMenu — the call is on another device", () => {
+  it("collapses to a single Take over action that displaces the other device", async () => {
+    const manager = makeManager()
+    seedSelfInLiveCall()
+    renderMenu(manager)
+
+    // No voice/video menu: the running call already decided that, and the only
+    // open question is which device carries it.
+    expect(screen.queryByRole("button", { name: "Start call" })).toBeNull()
+    // fireEvent, not userEvent: userEvent's pointer sequence doesn't reach this
+    // button's onClick under jsdom (the Radix triggers above are unaffected — they
+    // act on pointerdown). A real browser click is covered by the calls e2e.
+    fireEvent.click(screen.getByRole("button", { name: "Take over call on this device" }))
+    await waitFor(() => expect(manager.startCall).toHaveBeenCalled())
+
+    expect(manager.startCall).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: "stream_1", expectedCallId: "call_1", takeover: true })
+    )
+  })
+
+  it("keeps the ordinary start menu when the live call does not include the viewer", () => {
+    seedSelfInLiveCall()
+    upsertActiveCall("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      mode: "video",
+      participantCount: 1,
+      participantUserIds: ["usr_other"],
+    })
+    renderMenu(makeManager())
+    expect(screen.getByRole("button", { name: "Start call" })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/call/call-start-menu.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.tsx
@@ -1,8 +1,10 @@
-import { ChevronDown, Phone, Video } from "lucide-react"
+import { ChevronDown, Phone, PhoneForwarded, Video } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
+import { useActiveCallsForStream } from "@/stores/active-calls-store"
 import { useCallLaunch } from "./call-launch-context"
+import { useCallOnAnotherDevice } from "./use-call-on-another-device"
 
 /**
  * The call-start affordance: a small menu offering "Start voice call" (mic only,
@@ -11,6 +13,11 @@ import { useCallLaunch } from "./call-launch-context"
  * menu — rather than a hidden default. The launch runs inside the item click's user
  * gesture so iOS honors the AudioContext (INV via CallLaunch). Disabled (and the
  * menu unopenable) while a call is already active.
+ *
+ * When this stream's live call already has the viewer on ANOTHER device, the menu
+ * collapses to a single "Take over" button: the voice/video choice belongs to the
+ * call that is already running, and the only thing left to decide is which device
+ * carries it. The camera is still a tap away once the call lands here.
  */
 export function CallStartMenu({
   workspaceId,
@@ -26,7 +33,30 @@ export function CallStartMenu({
   className?: string
 }) {
   const { launch, callActive } = useCallLaunch()
+  // Store-only (no fetch): this menu renders on channels and DMs, which are their
+  // own root, so the stream's live call is the entry filed under it.
+  const liveHere = useActiveCallsForStream(workspaceId, streamId).find((call) => call.streamId === streamId)
+  const liveCallId = expectedCallId ?? liveHere?.callId
+  const onAnotherDevice = useCallOnAnotherDevice(workspaceId, liveCallId)
   const start = (cameraOn: boolean) => launch({ workspaceId, streamId, mode: "video", expectedCallId, cameraOn })
+
+  if (onAnotherDevice) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn("h-8 gap-1 px-2", className)}
+        disabled={callActive}
+        title={callActive ? "You're already in a call" : "Move this call to this device"}
+        aria-label="Take over call on this device"
+        onClick={() => launch({ workspaceId, streamId, mode: "video", expectedCallId: liveCallId, takeover: true })}
+      >
+        <PhoneForwarded className="h-4 w-4" />
+        <span className="text-xs">Take over</span>
+      </Button>
+    )
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/apps/frontend/src/components/call/call-store-hooks.ts
+++ b/apps/frontend/src/components/call/call-store-hooks.ts
@@ -51,6 +51,11 @@ export function useDesktopSurfaceOverride(): DesktopSurface | null {
   return useCallSelector((s) => s.desktopSurfaceOverride)
 }
 
+/** The call this device is in (or joining), or null. */
+export function useCallId(): string | null {
+  return useCallSelector((s) => s.callId)
+}
+
 export function useCallStreamId(): string | null {
   return useCallSelector((s) => s.streamId)
 }

--- a/apps/frontend/src/components/call/rejoin-bar.test.tsx
+++ b/apps/frontend/src/components/call/rejoin-bar.test.tsx
@@ -54,14 +54,14 @@ describe("RejoinBar", () => {
     seedStoreLive()
     renderBar()
     expect(screen.getByText(/still in this call/i)).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Rejoin" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Take over" })).toBeTruthy()
   })
 
   it("Rejoin dispatches the launch flow with the call's mode, asking to take the endpoint back", async () => {
     stubBootstrap(LIVE)
     seedStoreLive()
     renderBar()
-    await userEvent.click(screen.getByRole("button", { name: "Rejoin" }))
+    await userEvent.click(screen.getByRole("button", { name: "Take over" }))
     // The bar only shows while a live endpoint the viewer isn't on exists — this
     // tab's own lapsed lease (a rebind) or another device (a takeover).
     expect(launch).toHaveBeenCalledWith({

--- a/apps/frontend/src/components/call/rejoin-bar.test.tsx
+++ b/apps/frontend/src/components/call/rejoin-bar.test.tsx
@@ -57,16 +57,19 @@ describe("RejoinBar", () => {
     expect(screen.getByRole("button", { name: "Rejoin" })).toBeTruthy()
   })
 
-  it("Rejoin dispatches the launch flow with the call's mode", async () => {
+  it("Rejoin dispatches the launch flow with the call's mode, asking to take the endpoint back", async () => {
     stubBootstrap(LIVE)
     seedStoreLive()
     renderBar()
     await userEvent.click(screen.getByRole("button", { name: "Rejoin" }))
+    // The bar only shows while a live endpoint the viewer isn't on exists — this
+    // tab's own lapsed lease (a rebind) or another device (a takeover).
     expect(launch).toHaveBeenCalledWith({
       workspaceId: "ws_1",
       streamId: "stream_1",
       mode: "video",
       expectedCallId: "call_1",
+      takeover: true,
     })
   })
 

--- a/apps/frontend/src/components/call/rejoin-bar.tsx
+++ b/apps/frontend/src/components/call/rejoin-bar.tsx
@@ -70,7 +70,19 @@ export function RejoinBar({ workspaceId, streamId }: { workspaceId: string; stre
         <Button
           size="sm"
           className="h-7 px-3 text-[12px]"
-          onClick={() => launch({ workspaceId, streamId, mode: activeCall.mode, expectedCallId: activeCall.callId })}
+          onClick={() =>
+            launch({
+              workspaceId,
+              streamId,
+              mode: activeCall.mode,
+              expectedCallId: activeCall.callId,
+              // The bar only shows while the viewer holds a live endpoint they are
+              // not on — a lapsed lease from this tab's previous incarnation (a
+              // rebind server-side) or a genuinely live other device. Asking for
+              // takeover covers both; it is a no-op when the rebind path applies.
+              takeover: true,
+            })
+          }
         >
           Rejoin
         </Button>

--- a/apps/frontend/src/components/call/rejoin-bar.tsx
+++ b/apps/frontend/src/components/call/rejoin-bar.tsx
@@ -15,7 +15,15 @@ import { useCallPhase, useCallStreamId } from "./call-store-hooks"
  * surfaces exactly that, and this prominent bar offers a fresh rejoin.
  *
  * Rejoin mints a new incarnation via the launch flow (start-or-join on the same
- * stream, gesture-safe). "Leave" is a real leave, not a dismiss: it closes the
+ * stream, gesture-safe) and asks for takeover — it renders under exactly the
+ * condition `useCallOnAnotherDevice` reports to the header and the timeline card,
+ * which both label the action "Take over", and a bar reading "Rejoin" beside a
+ * header reading "Take over" for one click is a contradiction the viewer can see.
+ * The two cases behind that condition are indistinguishable from the client (this
+ * tab's own lapsed lease after a reload vs. a genuinely live second device), so
+ * one wording covers both; the server resolves the first as a rebind anyway.
+ *
+ * "Leave" is a real leave, not a dismiss: it closes the
  * viewer's live endpoints server-side so the lease can't keep them a zombie
  * participant for the ~45s grace window (the alternative — a silent dismiss —
  * would leave a ghost tile for peers).
@@ -70,6 +78,7 @@ export function RejoinBar({ workspaceId, streamId }: { workspaceId: string; stre
         <Button
           size="sm"
           className="h-7 px-3 text-[12px]"
+          title="Move this call to this device"
           onClick={() =>
             launch({
               workspaceId,
@@ -84,7 +93,7 @@ export function RejoinBar({ workspaceId, streamId }: { workspaceId: string; stre
             })
           }
         >
-          Rejoin
+          Take over
         </Button>
       </div>
     </div>

--- a/apps/frontend/src/components/call/use-call-on-another-device.ts
+++ b/apps/frontend/src/components/call/use-call-on-another-device.ts
@@ -1,0 +1,34 @@
+import { useActiveCall } from "@/stores/active-calls-store"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useCallId } from "./call-store-hooks"
+
+/**
+ * True when the viewer already holds this call somewhere that isn't this device:
+ * the live roster still lists them (`participantUserIds`, kept fresh by
+ * `call:participants_changed`), but no local session is on that call.
+ *
+ * Entry points read this BEFORE the user acts, so joining from a second device
+ * offers "Take over" up front instead of a Join that fails with 409
+ * `CALL_ENDPOINT_ACTIVE` and then asks for confirmation. The 409 prompt stays as
+ * the fallback for what this can't see coming — a device that joined a moment
+ * ago, or a roster this client hasn't received yet.
+ *
+ * Reads the stream-scoped roster: the workspace bootstrap seeds presence only
+ * (`ActiveCall` carries no ids), so this is meaningful on a stream the viewer has
+ * opened — which is where every entry point that consults it lives. Elsewhere it
+ * answers false and the 409 prompt covers the case.
+ *
+ * Also true right after a reload of this same tab, where the "other device" is
+ * the previous incarnation still holding an unlapsed lease. Taking over is the
+ * right action there too, and the server resolves it as a rebind rather than a
+ * takeover (a lapsed-socket endpoint is `reconnecting`, which rebinds first), so
+ * the extra flag costs nothing.
+ */
+export function useCallOnAnotherDevice(workspaceId: string | undefined, callId: string | undefined): boolean {
+  const live = useActiveCall(workspaceId, callId)
+  const selfUserId = useWorkspaceUserId(workspaceId ?? "")
+  const localCallId = useCallId()
+  if (!live || !selfUserId || !callId) return false
+  if (localCallId === callId) return false
+  return live.participantUserIds.includes(selfUserId)
+}

--- a/apps/frontend/src/components/timeline/call-card.test.tsx
+++ b/apps/frontend/src/components/timeline/call-card.test.tsx
@@ -7,6 +7,7 @@ import * as hooksModule from "@/hooks"
 import { PanelProvider } from "@/contexts"
 import * as launchModule from "@/components/call/call-launch-context"
 import * as callHooksModule from "@/components/call/call-store-hooks"
+import * as anotherDeviceModule from "@/components/call/use-call-on-another-device"
 import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls-store"
 import { CallCard } from "./call-card"
 
@@ -28,6 +29,8 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof launchModule.useCallLaunch>)
   vi.spyOn(callHooksModule, "useCallPhase").mockReturnValue("idle")
   vi.spyOn(callHooksModule, "useCallStreamId").mockReturnValue(null)
+  // Default: the viewer is not in this call anywhere. The take-over case flips it.
+  vi.spyOn(anotherDeviceModule, "useCallOnAnotherDevice").mockReturnValue(false)
   vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(false)
   vi.spyOn(hooksModule, "useInputMode").mockReturnValue("mouse")
 })
@@ -103,6 +106,32 @@ describe("CallCard", () => {
       streamId: "stream_1",
       mode: "video",
       expectedCallId: "call_1",
+      takeover: false,
+    })
+  })
+
+  it("offers Take over instead of Join when the viewer holds this call on another device", async () => {
+    upsertActiveCall("ws_1", {
+      callId: "call_1",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      mode: "video",
+      participantCount: 1,
+      participantUserIds: ["usr_a"],
+    })
+    vi.spyOn(anotherDeviceModule, "useCallOnAnotherDevice").mockReturnValue(true)
+    renderCard()
+
+    // The card says what will happen BEFORE the click — no Join that 409s and
+    // then asks for confirmation.
+    expect(screen.queryByRole("button", { name: "Join" })).toBeNull()
+    await userEvent.click(screen.getByRole("button", { name: "Take over" }))
+    expect(launch).toHaveBeenCalledWith({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      mode: "video",
+      expectedCallId: "call_1",
+      takeover: true,
     })
   })
 

--- a/apps/frontend/src/components/timeline/call-card.tsx
+++ b/apps/frontend/src/components/timeline/call-card.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Link2, LogIn, MessageSquareReply, Phone, Video } from "lucide-react"
+import { Link2, LogIn, MessageSquareReply, Phone, PhoneForwarded, Video } from "lucide-react"
 import { toast } from "sonner"
 import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent, ThreadSummary } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -7,6 +7,7 @@ import { useActors } from "@/hooks"
 import { useActiveCall } from "@/stores/active-calls-store"
 import { useCallLaunch } from "@/components/call/call-launch-context"
 import { useCallPhase, useCallStreamId } from "@/components/call/call-store-hooks"
+import { useCallOnAnotherDevice } from "@/components/call/use-call-on-another-device"
 import { buildStreamLink } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
 import { ThreadSlot } from "./thread-slot"
@@ -120,6 +121,9 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   // Shared thread affordance keyed on the card's event id: `replyUrl` opens the
   // real thread when one exists, else the draft panel to start the call chat.
   const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
+  // Known before the click, so the affordance says what will actually happen
+  // instead of a Join that 409s and then asks.
+  const onAnotherDevice = useCallOnAnotherDevice(workspaceId, payload?.callId)
   const actionSurface = useTimelineCardActionSurface()
 
   if (!payload) return null
@@ -129,6 +133,18 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   // The viewer is already in THIS call (one active call per stream) when a call
   // is up and their local session is on this stream.
   const selfInThisCall = callPhase !== "idle" && inCallStreamId === streamId
+
+  // One live call per stream, so "already in it elsewhere" needs no id match.
+  const joinLabel = onAnotherDevice ? "Take over" : "Join"
+  const joinTitle = onAnotherDevice ? "Move this call to this device" : undefined
+  const join = () =>
+    launch({
+      workspaceId,
+      streamId,
+      mode: payload.mode,
+      expectedCallId: payload.callId,
+      takeover: onAnotherDevice,
+    })
 
   const replyCount = payload.replyCount ?? 0
   const hasThread = !!payload.threadId || replyCount > 0
@@ -146,9 +162,9 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   if (isLive && !selfInThisCall) {
     actions.push({
       id: "join",
-      label: "Join call",
-      icon: LogIn,
-      onSelect: () => launch({ workspaceId, streamId, mode: payload.mode, expectedCallId: payload.callId }),
+      label: onAnotherDevice ? "Take over call on this device" : "Join call",
+      icon: onAnotherDevice ? PhoneForwarded : LogIn,
+      onSelect: join,
       disabled: callActive,
       disabledReason: callActive ? "You're already in another call" : undefined,
     })
@@ -234,15 +250,15 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
             ) : (
               <button
                 type="button"
-                onClick={() => launch({ workspaceId, streamId, mode: payload.mode, expectedCallId: payload.callId })}
+                onClick={join}
                 disabled={callActive}
-                title={callActive ? "You're already in another call" : undefined}
+                title={callActive ? "You're already in another call" : joinTitle}
                 className={cn(
                   "min-h-9 rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors sm:min-h-0",
                   callActive ? "opacity-50" : "hover:bg-primary/90"
                 )}
               >
-                Join
+                {joinLabel}
               </button>
             ))}
         </div>

--- a/docs/plans/calls-multi-device-participation.md
+++ b/docs/plans/calls-multi-device-participation.md
@@ -102,11 +102,37 @@ So the displaced client tears down **locally only**. That is internal to
 `CallManager` (`teardown()` is private and emits nothing), so no `CallController`
 API change: the manager handles the socket event itself.
 
+### The UI knows before the click
+
+Kris's ruling: an action that fails and then asks "are you sure?" is the wrong
+shape. The entry point should already know the call is on another device and
+offer takeover as the action — the Teams framing, "take over" rather than "join".
+
+The client can know: the active-calls store carries `participantUserIds`, kept
+fresh by `call:participants_changed` and seeded per stream from the stream
+bootstrap. `useCallOnAnotherDevice(workspaceId, callId)` is true when that roster
+lists the viewer and no local session is on that call.
+
+- The timeline call card's **Join** becomes **Take over** (and the row/menu action
+  "Take over call on this device"), launching with `takeover: true`.
+- The stream header's start menu collapses to a single **Take over** button: the
+  running call already settled voice-vs-video, so the only open question is which
+  device carries it.
+- The rejoin bar asks for takeover too. It only ever shows while a live endpoint
+  the viewer isn't on exists — this tab's own lapsed lease or another device — and
+  takeover is a no-op in the first case, because a lapsed-socket endpoint is
+  `reconnecting` and the rebind branch runs first.
+
+The 409 prompt below stays as the **fallback**, not the main path: a device that
+joined a second ago, a roster this client hasn't received, or an entry point on a
+stream whose roster was never loaded.
+
 ### Frontend shape
 
 6. `CallManagerDeps.startCallRest` and `CallManager.startCall` params gain
    `takeover?: boolean`.
-7. `CallLaunchState` += `{ status: "takeover_prompt"; request }`. In
+7. `CallLaunchRequest` += `takeover?: boolean` (set by an entry point that already
+   knows). `CallLaunchState` += `{ status: "takeover_prompt"; request }`. In
    `CallLaunchProvider.run`'s catch, an `ApiError` with code
    `CALL_ENDPOINT_ACTIVE` sets that state instead of `join_error` + toast; a new
    `takeOver()` action re-runs the same request with `takeover: true`. The dock

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -210,15 +210,23 @@ test.describe("1:1 DM calls", () => {
       await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 20000 })
 
       await second.page.goto(`/w/${workspaceId}/s/${dmStreamId}`)
-      await second.page.getByRole("button", { name: "Start a call" }).click()
-      await second.page.getByRole("menuitem", { name: "Start voice call" }).click()
 
-      // Prompted, not toasted — and nothing has moved until the user says so.
-      await expect(second.page.getByText(/in this call on another device/i)).toBeVisible({ timeout: 20000 })
+      // The second device knows from the stream's roster that this user is already
+      // in the call, so the entry point offers Take over up front — no Join that
+      // 409s and then asks. Both the header and the timeline card say so.
+      const takeOver = second.page.getByRole("button", { name: "Take over call on this device" })
+      await expect(takeOver).toBeVisible({ timeout: 20000 })
+      // Exact, so the header's "Take over call on this device" doesn't match: this
+      // is the timeline card's own button.
+      await expect(second.page.getByRole("button", { name: "Take over", exact: true })).toBeVisible({ timeout: 20000 })
+      // Nothing has moved by merely offering it.
       await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 5000 })
 
-      await second.page.getByRole("button", { name: "Join on this device" }).click()
+      await takeOver.click()
       await expect(second.page.locator(CALL_TILE)).toHaveCount(2, { timeout: 25000 })
+      // Straight in: the 409 prompt is the fallback for what the UI can't see
+      // coming, and it must not appear on the path the UI predicted.
+      await expect(second.page.getByText(/in this call on another device/i)).toHaveCount(0)
 
       // The displaced device is told, promptly — not left on a dead call until its
       // lease renew fails 15s later.

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -216,9 +216,12 @@ test.describe("1:1 DM calls", () => {
       // 409s and then asks. Both the header and the timeline card say so.
       const takeOver = second.page.getByRole("button", { name: "Take over call on this device" })
       await expect(takeOver).toBeVisible({ timeout: 20000 })
-      // Exact, so the header's "Take over call on this device" doesn't match: this
-      // is the timeline card's own button.
-      await expect(second.page.getByRole("button", { name: "Take over", exact: true })).toBeVisible({ timeout: 20000 })
+      // Exact, so the header's "Take over call on this device" doesn't match. More
+      // than one matches by design — the timeline card and the rejoin bar both
+      // offer it, in the same words as the header (see rejoin-bar.tsx).
+      await expect(second.page.getByRole("button", { name: "Take over", exact: true }).first()).toBeVisible({
+        timeout: 20000,
+      })
       // Nothing has moved by merely offering it.
       await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 5000 })
 
@@ -234,6 +237,17 @@ test.describe("1:1 DM calls", () => {
       await expect(a.locator(CALL_TILE)).toHaveCount(0, { timeout: 5000 })
       // B never lost their peer: the identity stayed in the call, only its endpoint moved.
       await expect(b.locator(CALL_TILE)).toHaveCount(2, { timeout: 20000 })
+
+      // The chip is `fixed right-4` with no left anchor and renders on the branch
+      // mobile shares, so measure it at phone width: it must stay on screen.
+      await a.setViewportSize({ width: 360, height: 740 })
+      const chip = a.getByText(/moved to another device/i).locator("xpath=ancestor::div[1]")
+      const box = await chip.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.x).toBeGreaterThanOrEqual(0)
+      expect(box!.x + box!.width).toBeLessThanOrEqual(360)
+      await expect(chip.getByRole("button", { name: "Rejoin here" })).toBeVisible()
+      await expect(chip.getByRole("button", { name: "Dismiss" })).toBeVisible()
 
       await second.page.getByRole("button", { name: "Leave call" }).click()
       await b.getByRole("button", { name: "Leave call" }).click()
@@ -261,7 +275,8 @@ test.describe("1:1 DM calls", () => {
       await a.goto(`/w/${workspaceId}/s/${dmStreamId}`)
       await expect(a.getByText(/still in this call/i)).toBeVisible({ timeout: 25000 })
 
-      await a.getByRole("button", { name: "Rejoin" }).click()
+      // One wording across the bar, the header and the card — see rejoin-bar.tsx.
+      await a.getByRole("button", { name: "Take over", exact: true }).first().click()
       // Both docks converge back to 2 participants.
       await expect(a.locator(CALL_TILE)).toHaveCount(2, { timeout: 25000 })
       await expect(b.locator(CALL_TILE)).toHaveCount(2, { timeout: 25000 })


### PR DESCRIPTION
## Problem

[#1566](https://github.com/threahq/threa/pull/1566) shipped takeover as act-then-confirm: click Join, get a 409, then answer "you're in this call on another device — join here?". Kris's call, and he's right: that's the pattern where the UI knows something and makes the user find out by failing. Teams frames it the other way — the entry point already says "take over".

## Solution

The client can know before the click. The active-calls store carries `participantUserIds` (kept fresh by `call:participants_changed`, seeded per stream by the stream bootstrap), so `useCallOnAnotherDevice(workspaceId, callId)` is true when that roster lists the viewer and no local session is on that call.

- **Timeline call card**: **Join** becomes **Take over**, launching with `takeover: true`; the row/context action reads "Take over call on this device".
- **Stream header**: the start menu collapses to a single **Take over** button. The running call already settled voice-vs-video, so the only open question is which device carries it — and the camera is a tap away once it lands. Reads the store, not a fetch, so the header gains no data dependency.
- **Rejoin bar**: asks for takeover too. It only renders while a live endpoint the viewer isn't on exists — this tab's own lapsed lease, or another device — and takeover is a no-op in the first case because a lapsed-socket endpoint is `reconnecting`, which the rebind branch handles before takeover is consulted.
- `takeover` moves onto `CallLaunchRequest`, so `retry` replays a request untouched: the flag is only ever added by an entry point that knew, or by answering the prompt.

The 409 prompt stays as the fallback for what this can't see coming — a device that joined a second ago, or an entry point on a stream whose roster was never loaded. The e2e now asserts it does *not* appear on the predicted path.

## Files

| File | Change |
| ---- | ------ |
| `components/call/use-call-on-another-device.ts` | **new** — the shared signal |
| `components/timeline/call-card.tsx` | Take over label + action |
| `components/call/call-start-menu.tsx` | Single Take over button when the call is elsewhere |
| `components/call/rejoin-bar.tsx` | Rejoin asks for takeover |
| `components/call/call-launch-context.tsx` | `takeover` on the request |
| `components/call/call-store-hooks.ts` | `useCallId` |
| `tests/browser/calls.spec.ts` | e2e takes the new path; asserts no prompt |

## Test plan

- [x] `bunx vitest run` — 5063 pass, 0 fail (3 new: card take-over label + launch args, header collapse, header untouched when the call isn't the viewer's)
- [x] `bunx playwright test --project=calls --workers=2` — 5 pass
- [x] frontend typecheck + monorepo lint — clean

One test note: the header's Take over button doesn't respond to `userEvent.click` under jsdom (the Radix triggers in the same file do — they act on `pointerdown`), so that unit test uses `fireEvent`. A real browser click is covered by the e2e, which is how I confirmed it isn't a UX bug.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787695833&installation_model_id=20758&pr_number=1574&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1574&signature=d602071eed1af84f6ebe14b4d93659033cea0d582d0a5acc9b58f4d67d004339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->