### PR TITLE
fix(timeline): clear the scroller gesture stamp in render on stream switch

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1392,6 +1392,18 @@ export function StreamContent({
   // the bottom only stops auto-follow when the *user* did it — content growth
   // (new message, link preview, virtua measuring) must not disarm follow.
   const userInteractedAtRef = useRef(0)
+  // Clear the stamp in RENDER on a stream switch, not in the stream-reset effect
+  // below. StreamContent stays mounted across streams, and the open-at-marker
+  // decision is a layout effect — which runs before passive effects in the same
+  // commit — so a passive reset let it read the PREVIOUS stream's stamp and
+  // consume the once-per-stream decision as "the user already scrolled". Any
+  // pointerdown on the old timeline (clicking a message) then silently disabled
+  // open-at-marker for the next stream opened.
+  const gestureStampStreamRef = useRef(streamId)
+  if (gestureStampStreamRef.current !== streamId) {
+    gestureStampStreamRef.current = streamId
+    userInteractedAtRef.current = 0
+  }
 
   const {
     listRef,
@@ -1924,7 +1936,6 @@ export function StreamContent({
     pendingScrollTarget.current = null
     setDeepLinkGaveUp(false)
     setDeepLinkHoldExpired(false)
-    userInteractedAtRef.current = 0
     exitJumpMode()
     setIsSearchOpen(false)
     clearSearch()


### PR DESCRIPTION
## Why

`Settings → Opening unread streams → At the first unread message` silently did nothing much of the time. Reported as "felt like it didn't work at all, then I couldn't repro it" — a clean reload followed by a sidebar click works, which is exactly the case that hides this.

## What was wrong

`StreamContent` stays mounted across stream switches. The once-per-stream open-at-marker decision (`resolveUnreadMarkerOpen`) runs in a `useLayoutEffect`, and checks `userInteractedAt > 0` — "the user already chose a position, don't move them" — *before* the loading/settle gates, so it can decide on the very first commit of the new stream.

The stamp it reads was zeroed in the passive stream-reset effect. React runs layout effects before passive effects in the same commit, so on a stream switch the decision read the **previous** stream's stamp, returned `"skip"`, and set `decided = true` — permanently, since nothing re-opens a consumed decision.

The stamp is set by `wheel`/`touch`/`keydown`/**`pointerdown`** on the timeline scroller, so merely clicking a message in the stream you were reading disabled open-at-marker for the next stream you opened.

## Change

Zero the stamp in render on `streamId` change, matching the other stream-scoped latches in this component (`deepLinkLatchRef`, `unreadMarkerOpenRef`, and `useUnreadDivider`'s own latch). Strictly earlier than the old reset, so every other reader (`useTimelineScroll`, edge pagination, the `scrollToMessage` refine loop) sees the same value it did before or a fresher one.

## Verification

`bunx tsc --noEmit`, eslint, and the full frontend vitest suite (5052/5053; the one failure is `billing-timezone-section` timing out under parallel load — unrelated, passes in isolation).

## Residual risk

Not unit-tested: the defect is React effect ordering inside a 3000-line component with no mount harness, and a test of the ordering itself would test React. The stack's second PR covers the other half of the bug and does carry tests.

Second, independent cause of the same symptom is #1578. A third (read pointer outside the tail-anchored 50-event bootstrap window) needs a backend change and is not in this stack.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
