### PR TITLE
fix(timeline): anchor the unread divider on a row the timeline renders

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -7,6 +7,7 @@ import {
   collectDelegationStatusPatches,
   collectBotAccessStatusPatches,
   collectCallEndedPatches,
+  collectDividerAnchorIds,
   filterVisibleItems,
   findFirstMessageId,
   findMessageItemIndex,
@@ -652,6 +653,46 @@ describe("findEventItemIndex", () => {
 
   it("returns -1 when the event is not in the window so the cold-load scroll falls back to the bottom", () => {
     expect(findEventItemIndex([eventItem("evt_1")], "evt_gone")).toBe(-1)
+  })
+})
+
+describe("collectDividerAnchorIds", () => {
+  it("collects exactly the ids findEventItemIndex can resolve", () => {
+    const items: TimelineItem[] = [
+      { type: "event", event: createEvent({ id: "evt_1", sequence: "1", eventType: "message_created", payload: {} }) },
+      {
+        type: "session_group",
+        sessionId: "sess_1",
+        sessionVersion: 1,
+        events: [
+          createSessionStartedEvent("evt_2", "2", "sess_1", "msg_1"),
+          createSessionCompletedEvent("evt_3", "3", "sess_1"),
+        ],
+      },
+      {
+        type: "command_group",
+        commandId: "cmd_1",
+        events: [createEvent({ id: "evt_4", sequence: "4", eventType: "command_dispatched", payload: {} })],
+      },
+      { type: "day_divider", dayStartMs: 0 },
+    ]
+
+    // Groups anchor on their FIRST event only — evt_3 is inside the session card
+    // but is not a row of its own, so it can never carry the divider.
+    expect(collectDividerAnchorIds(items)).toEqual(new Set(["evt_1", "evt_2", "evt_4"]))
+    for (const id of ["evt_1", "evt_2", "evt_4"]) expect(findEventItemIndex(items, id)).toBeGreaterThanOrEqual(0)
+    expect(findEventItemIndex(items, "evt_3")).toBe(-1)
+  })
+
+  it("drops zero-height event rows the thread list renders as null", () => {
+    // The non-virtualized (thread) list skips filterVisibleItems, so the
+    // zero-height rule has to be re-applied here or the divider anchors on a
+    // reaction and renders nothing.
+    const items: TimelineItem[] = [
+      { type: "event", event: createEvent({ id: "evt_1", sequence: "1", eventType: "reaction_added", payload: {} }) },
+      { type: "event", event: createEvent({ id: "evt_2", sequence: "2", eventType: "message_created", payload: {} }) },
+    ]
+    expect(collectDividerAnchorIds(items)).toEqual(new Set(["evt_2"]))
   })
 })
 

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -353,6 +353,31 @@ const ZERO_HEIGHT_EVENT_TYPES = new Set([
 ])
 
 /**
+ * Ids the unread divider may anchor on — exactly what `isFirstUnread` matches
+ * and `findEventItemIndex` resolves, computed from the rows the timeline is
+ * actually rendering. A row that never reaches the list (a zero-height event
+ * type, another user's command events, a session card hidden in a channel)
+ * contributes nothing, so a divider anchored off this set can never point at a
+ * row that does not exist — which rendered no "New" line and made both scroll
+ * paths no-op silently. The zero-height re-check covers the non-virtualized
+ * (thread) list, which does not run `filterVisibleItems` but still renders
+ * those events as null.
+ */
+export function collectDividerAnchorIds(items: TimelineItem[]): Set<string> {
+  const ids = new Set<string>()
+  for (const item of items) {
+    if (item.type === "event") {
+      if (ZERO_HEIGHT_EVENT_TYPES.has(item.event.eventType)) continue
+      ids.add(item.event.id)
+    } else if (item.type === "command_group" || item.type === "session_group") {
+      const firstEventId = item.events[0]?.id
+      if (firstEventId) ids.add(firstEventId)
+    }
+  }
+  return ids
+}
+
+/**
  * Filters out timeline items that would render as zero-height elements.
  * Must be applied before computing virtualizer count/keys to prevent overlap.
  */

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -95,6 +95,7 @@ import {
   findTimelineTargetIndex,
   getTimelineItemKey,
   filterVisibleItems,
+  collectDividerAnchorIds,
   OLDER_SKELETON_ITEMS,
   type TimelineItem,
   type TimelineItemRenderContext,
@@ -1365,6 +1366,8 @@ export function StreamContent({
   // face on the virtualized path (roadmap 1.4).
   const callEndedPatches = useMemo(() => collectCallEndedPatches(timelineItems), [timelineItems])
 
+  const dividerAnchorIds = useMemo(() => collectDividerAnchorIds(visibleItems), [visibleItems])
+
   // Mirror of `visibleItems` for the long-lived scrollToMessage retry loop:
   // its closure is created once per scroll but runs for up to ~1.2s, during
   // which the event window can shift. Reading the ref keeps each retry tick
@@ -2027,6 +2030,9 @@ export function StreamContent({
     // Skip overlay-read events so the divider anchors on the first *effectively*
     // unread row, not one already read from a conversation surface.
     overlayReadIds: readOverlay,
+    // Keep the anchor on a row the list is actually rendering — see
+    // collectDividerAnchorIds.
+    anchorableEventIds: dividerAnchorIds,
     // Same signal that gates auto-read: while the viewer is away the divider may
     // re-latch forward at the first away-arrival (messages that came in while
     // blurred get the persistent red→grey strip, as if the stream were re-opened).

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -10,6 +10,11 @@ beforeEach(() => {
   )
 })
 
+/** Every event renders a row of its own — the ordinary all-messages timeline. */
+function anchorsOf(events: readonly { id: string }[]): Set<string> {
+  return new Set(events.map((event) => event.id))
+}
+
 function makeMessageEvent(id: string, actorId: string) {
   return {
     id,
@@ -35,6 +40,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved,
         }),
@@ -58,6 +64,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
@@ -89,6 +96,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
@@ -117,6 +125,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
@@ -142,6 +151,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId: null,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId,
           readStateResolved: true,
         }),
@@ -157,7 +167,14 @@ describe("useUnreadDivider", () => {
   it("hides the latched divider once dismissed, and re-shows it on a fresh stream", () => {
     const { result, rerender } = renderHook(
       ({ streamId, events }: { streamId: string; events: ReturnType<typeof makeMessageEvent>[] }) =>
-        useUnreadDivider({ events, lastReadEventId: null, currentUserId: "me", streamId, readStateResolved: true }),
+        useUnreadDivider({
+          events,
+          lastReadEventId: null,
+          currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
+          streamId,
+          readStateResolved: true,
+        }),
       { initialProps: { streamId: "stream_1", events: [makeMessageEvent("event_1", "other")] } }
     )
 
@@ -183,7 +200,15 @@ describe("useUnreadDivider", () => {
         streamId: string
         events: ReturnType<typeof makeMessageEvent>[]
         lastReadEventId: string | null
-      }) => useUnreadDivider({ events, lastReadEventId, currentUserId: "me", streamId, readStateResolved: true }),
+      }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId,
+          currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
+          streamId,
+          readStateResolved: true,
+        }),
       {
         initialProps: {
           streamId: "stream_1",
@@ -221,6 +246,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId: null,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId,
           highlightMessageId,
           readStateResolved: true,
@@ -255,6 +281,7 @@ describe("useUnreadDivider", () => {
         events,
         lastReadEventId: null,
         currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
         highlightMessageId: null,
         readStateResolved: true,
@@ -271,6 +298,7 @@ describe("useUnreadDivider", () => {
         events,
         lastReadEventId: null,
         currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
         readStateResolved: true,
         // event_1 was read individually above the watermark (a conversation-
@@ -301,6 +329,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
           isAttentive,
@@ -362,6 +391,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
           isAttentive: true,
@@ -393,6 +423,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId: "event_1",
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
           isAttentive,
@@ -419,6 +450,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId: "event_1",
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
           isAttentive,
@@ -447,6 +479,7 @@ describe("useUnreadDivider", () => {
           events,
           lastReadEventId,
           currentUserId: "me",
+          anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
           isAttentive,
@@ -472,6 +505,45 @@ describe("useUnreadDivider", () => {
     expect(result.current.dividerEventId).toBe("event_2")
   })
 
+  it("skips an unread event that renders no row and anchors on the next one that does", () => {
+    // A first unread the timeline drops (a zero-height event type, another
+    // user's command events, a session card hidden in a channel) used to latch
+    // the divider on a row that does not exist: no "New" line rendered and both
+    // scroll paths resolved no index, so open-at-marker silently no-opped.
+    const events = [
+      { ...makeMessageEvent("event_1", "other"), eventType: "command_dispatched" as const },
+      makeMessageEvent("event_2", "other"),
+    ]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadEventId: null,
+        currentUserId: "me",
+        anchorableEventIds: new Set(["event_2"]),
+        streamId: "stream_1",
+        readStateResolved: true,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBe("event_2")
+  })
+
+  it("shows no divider when no unread event renders a row", () => {
+    const events = [{ ...makeMessageEvent("event_1", "other"), eventType: "reaction_added" as const }]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadEventId: null,
+        currentUserId: "me",
+        anchorableEventIds: new Set<string>(),
+        streamId: "stream_1",
+        readStateResolved: true,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBeUndefined()
+  })
+
   it("shows no divider when every candidate unread row is overlay-read", () => {
     const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
     const { result } = renderHook(() =>
@@ -479,6 +551,7 @@ describe("useUnreadDivider", () => {
         events,
         lastReadEventId: null,
         currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
         readStateResolved: true,
         overlayReadIds: new Set(["msg_event_1", "msg_event_2"]),

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -2,13 +2,6 @@ import { useState, useRef, useMemo, useCallback } from "react"
 import type { StreamEvent } from "@threa/types"
 import { useScrollToElement } from "./use-scroll-to-element"
 
-/**
- * Event types that don't render as visible timeline items.
- * Reactions update existing messages in place and return null from EventItem,
- * so they should not trigger the unread divider.
- */
-const INVISIBLE_EVENT_TYPES = new Set(["reaction_added", "reaction_removed"])
-
 interface UseUnreadDividerOptions {
   events: StreamEvent[]
   lastReadEventId: string | null | undefined
@@ -36,6 +29,16 @@ interface UseUnreadDividerOptions {
    * surface is skipped. See docs/sparse-read-overlay-design.md.
    */
   overlayReadIds?: ReadonlySet<string>
+  /**
+   * Ids the rendered timeline can actually anchor a divider on
+   * (`collectDividerAnchorIds` over the list's items). An unread event outside
+   * this set renders no row — a zero-height event type, another user's command
+   * events, a session card hidden in a channel — so anchoring there produced an
+   * invisible divider and a scroll target neither `scrollToMessage` nor
+   * `scrollToFirstUnread` could resolve. Skipping them lands the divider on the
+   * first unread row the viewer can actually see.
+   */
+  anchorableEventIds: ReadonlySet<string>
   /**
    * Whether the viewer's attention is plausibly on this page — the same signal
    * that gates auto-read (`useAutoReadAttention`). While false, the read pointer
@@ -98,6 +101,7 @@ export function useUnreadDivider({
   isLoading = false,
   readStateResolved = false,
   overlayReadIds,
+  anchorableEventIds,
   isAttentive = true,
 }: UseUnreadDividerOptions): UseUnreadDividerResult {
   const firstUnreadEventId = useMemo(() => {
@@ -111,19 +115,19 @@ export function useUnreadDivider({
     }
 
     // Find the first *effectively* unread visible event from another user after
-    // the last read position. Skip event types that don't render as timeline
-    // items (e.g. reactions) and rows already in the overlay (individually read
-    // from a conversation surface).
+    // the last read position. Skip events that render no row of their own and
+    // rows already in the overlay (individually read from a conversation
+    // surface).
     for (let i = startIndex; i < events.length; i++) {
       const event = events[i]
-      if (event.actorId === currentUserId || INVISIBLE_EVENT_TYPES.has(event.eventType)) continue
+      if (event.actorId === currentUserId || !anchorableEventIds.has(event.id)) continue
       const messageId = (event.payload as { messageId?: string } | null)?.messageId
       if (messageId && overlayReadIds?.has(messageId)) continue
       return event.id
     }
 
     return undefined
-  }, [events, lastReadEventId, currentUserId, readStateResolved, overlayReadIds])
+  }, [events, lastReadEventId, currentUserId, readStateResolved, overlayReadIds, anchorableEventIds])
 
   // Latch the first unread position for this stream and hold it for the whole
   // reading session. Done in render (not an effect) so it's immune to effect


### PR DESCRIPTION
## Why

Second independent cause of "open at the first unread message doesn't reliably work" (first is #1577). This one also makes the red "New" divider itself disappear, and it is data-dependent, so it reads as random.

## What was wrong

`useUnreadDivider` picked the first unread event that was not a reaction. The rendered list is far narrower than that:

- `filterVisibleItems` drops all of `ZERO_HEIGHT_EVENT_TYPES` — command and agent-session lifecycle events, `agent:follow_up_cancelled`, `delegation:status_changed`, `bot_access:status_changed`, `call_ended`;
- `groupTimelineItems` drops another user's command events entirely;
- session cards are hidden in channels (`hideSessionCards`);
- a group row anchors on its **first** event only, so a later event inside a session card is not addressable.

When the unread boundary landed on one of those, the divider anchored on a row that does not exist: `isFirstUnread` matched nothing so no "New" line rendered, and both `scrollToMessage` and `scrollToFirstUnread` resolved index `-1` and no-opped — while `resolveUnreadMarkerOpen` had already marked the decision consumed, so nothing retried. Same failure hits the "N new" jump button.

## Change

`collectDividerAnchorIds(items)` derives the anchorable ids from the items the timeline is actually rendering, mirroring `isFirstUnread`/`findEventItemIndex` (including the group-anchors-on-its-first-event rule). It re-applies the zero-height rule itself because the non-virtualized thread list skips `filterVisibleItems` but still renders those events as `null` — that path previously relied on the reaction-only set, so dropping the set without this would have regressed it.

`useUnreadDivider` takes the set as a required option (single call site) and skips any unread event outside it, so the divider lands on the first unread row the viewer can actually see. `INVISIBLE_EVENT_TYPES` is deleted — the anchor set subsumes it.

## Verification

Regression tests for both halves: `collectDividerAnchorIds` (group anchoring + the thread-path zero-height re-check) and the hook skipping a non-rendering unread event. `bunx tsc --noEmit`, eslint, and the full frontend vitest suite green (one unrelated flake, see #1577).

## Residual risk

Behaviour change: if the first unread is a session card in a channel, the divider now sits *below* it, on the next visible row, instead of nowhere. Slightly late is the intended trade against invisible.
