### PR TITLE
feat(stream-context): serve the collapsed feed and occurrence pages

### DIFF
--- a/apps/backend/src/features/access-log/operations.ts
+++ b/apps/backend/src/features/access-log/operations.ts
@@ -203,6 +203,7 @@ export const ACCESS_LOG_OPERATIONS = [
   "scheduled_messages.send_now",
   // Agent follow-ups / delegations / bot-access
   "agent_follow_ups.cancel",
+  "stream_context.list",
   "delegations.list",
   "delegations.get",
   "delegations.cancel",

--- a/apps/backend/src/features/access-log/operations.ts
+++ b/apps/backend/src/features/access-log/operations.ts
@@ -77,6 +77,8 @@ export const ACCESS_LOG_OPERATIONS = [
   "user_e2e_keys.revoke",
   "enclave.list_active_keys",
   // Streams
+  "stream_context.list",
+  "stream_context.occurrences",
   "streams.list",
   "streams.create",
   "streams.read_all",
@@ -203,7 +205,6 @@ export const ACCESS_LOG_OPERATIONS = [
   "scheduled_messages.send_now",
   // Agent follow-ups / delegations / bot-access
   "agent_follow_ups.cancel",
-  "stream_context.list",
   "delegations.list",
   "delegations.get",
   "delegations.cancel",

--- a/apps/backend/src/features/link-previews/repository.ts
+++ b/apps/backend/src/features/link-previews/repository.ts
@@ -10,7 +10,6 @@ import {
 } from "@threa/types"
 
 /** Union of all rich provider preview types persisted in `link_previews.preview_type`. */
-export type RichPreviewType = RichLinkPreviewType
 /** Union of all rich provider preview payloads stored in `link_previews.preview_data`. */
 export type RichPreview = GitHubPreview | LinearPreview | VideoPreview
 
@@ -26,7 +25,7 @@ export interface LinkPreview {
   siteName: string | null
   contentType: LinkPreviewContentType
   status: LinkPreviewStatus
-  previewType: RichPreviewType | null
+  previewType: RichLinkPreviewType | null
   previewData: RichPreview | null
   targetWorkspaceId: string | null
   targetStreamId: string | null
@@ -75,7 +74,7 @@ export interface UpdateLinkPreviewParams {
   faviconUrl?: string | null
   siteName?: string | null
   contentType?: LinkPreviewContentType
-  previewType?: RichPreviewType | null
+  previewType?: RichLinkPreviewType | null
   previewData?: RichPreview | null
   status: LinkPreviewStatus
   expiresAt?: Date | null
@@ -102,7 +101,7 @@ function mapRow(row: Record<string, unknown>): LinkPreview {
     siteName: row.site_name as string | null,
     contentType: row.content_type as LinkPreviewContentType,
     status: row.status as LinkPreviewStatus,
-    previewType: (row.preview_type as RichPreviewType | null) ?? null,
+    previewType: (row.preview_type as RichLinkPreviewType | null) ?? null,
     previewData: (row.preview_data as RichPreview | null) ?? null,
     targetWorkspaceId: (row.target_workspace_id as string | null) ?? null,
     targetStreamId: (row.target_stream_id as string | null) ?? null,

--- a/apps/backend/src/features/link-previews/repository.ts
+++ b/apps/backend/src/features/link-previews/repository.ts
@@ -1,18 +1,16 @@
 import { sql, type Querier } from "@threa/backend-common"
 import {
   type GitHubPreview,
-  type GitHubPreviewType,
   type LinearPreview,
-  type LinearPreviewType,
   type VideoPreview,
-  type VideoPreviewType,
+  type RichLinkPreviewType,
   type LinkPreviewContentType,
   type LinkPreviewStatus,
   isInAppLinkContentType,
 } from "@threa/types"
 
 /** Union of all rich provider preview types persisted in `link_previews.preview_type`. */
-export type RichPreviewType = GitHubPreviewType | LinearPreviewType | VideoPreviewType
+export type RichPreviewType = RichLinkPreviewType
 /** Union of all rich provider preview payloads stored in `link_previews.preview_data`. */
 export type RichPreview = GitHubPreview | LinearPreview | VideoPreview
 

--- a/apps/backend/src/features/stream-context/cursor.test.ts
+++ b/apps/backend/src/features/stream-context/cursor.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test"
+import { decodeContextCursor, encodeContextCursor } from "./cursor"
+
+describe("context cursor", () => {
+  it("round-trips the keyset position", () => {
+    const cursor = { occurredAt: new Date("2026-07-20T10:00:00.123Z"), id: "sctx_1" }
+    expect(decodeContextCursor(encodeContextCursor(cursor))).toEqual(cursor)
+  })
+
+  it("passes an absent cursor through as absent", () => {
+    expect(decodeContextCursor(undefined)).toBeUndefined()
+  })
+
+  it.each([
+    ["no separator", Buffer.from("2026-07-20T10:00:00.000Z", "utf8").toString("base64url")],
+    ["empty id", Buffer.from("2026-07-20T10:00:00.000Z|", "utf8").toString("base64url")],
+    ["unparseable timestamp", Buffer.from("yesterday|sctx_1", "utf8").toString("base64url")],
+    ["not base64 at all", "!!!!"],
+  ])("rejects a malformed cursor (%s) with a 400", (_label, raw) => {
+    expect(() => decodeContextCursor(raw)).toThrow(
+      expect.objectContaining({ status: 400, code: "INVALID_CURSOR" }) as unknown as Error
+    )
+  })
+})

--- a/apps/backend/src/features/stream-context/cursor.ts
+++ b/apps/backend/src/features/stream-context/cursor.ts
@@ -1,0 +1,22 @@
+import { HttpError } from "../../lib/errors"
+import type { StreamContextCursor } from "./read-repository"
+
+/**
+ * Opaque keyset cursor. The only encoder/decoder — a malformed cursor is a 400
+ * (INV-32), never a silent reset to the unfiltered first page.
+ */
+export function encodeContextCursor(cursor: StreamContextCursor): string {
+  return Buffer.from(`${cursor.occurredAt.toISOString()}|${cursor.id}`, "utf8").toString("base64url")
+}
+
+export function decodeContextCursor(raw: string | undefined): StreamContextCursor | undefined {
+  if (raw === undefined) return undefined
+  const decoded = Buffer.from(raw, "base64url").toString("utf8")
+  const separator = decoded.indexOf("|")
+  const occurredAt = new Date(decoded.slice(0, separator))
+  const id = decoded.slice(separator + 1)
+  if (separator === -1 || id.length === 0 || Number.isNaN(occurredAt.getTime())) {
+    throw new HttpError("Invalid cursor", { status: 400, code: "INVALID_CURSOR" })
+  }
+  return { occurredAt, id }
+}

--- a/apps/backend/src/features/stream-context/extract.ts
+++ b/apps/backend/src/features/stream-context/extract.ts
@@ -2,7 +2,7 @@ import { collectGiphyEmbeds } from "@threa/prosemirror"
 import { categoryFromMime, stripMarkdownToInline, type AttachmentSummary, type JSONContent } from "@threa/types"
 import { streamContextItemId } from "../../lib/id"
 import { extractUrls, normalizeUrl, getAppOrigins } from "../link-previews"
-import type { ContextCategory, ContextRefKind, NewStreamContextItem } from "./types"
+import type { ContextCategory, StreamContextRefKind, NewStreamContextItem } from "./types"
 
 /** btree index bound — a longer href cannot be indexed, so it is not projected. */
 const MAX_URL_LENGTH = 2000
@@ -39,7 +39,7 @@ export function contextRowsForMessage(params: ContextRowsForMessageParams): NewS
 
   const push = (
     category: ContextCategory,
-    refKind: ContextRefKind,
+    refKind: StreamContextRefKind,
     refId: string,
     groupKey: string,
     detail: Record<string, unknown>

--- a/apps/backend/src/features/stream-context/handlers.test.ts
+++ b/apps/backend/src/features/stream-context/handlers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { Request, Response } from "express"
+import { createStreamContextHandlers } from "./handlers"
+import type { StreamContextService } from "./service"
+
+function harness(response: unknown = { items: [], counts: null, nextCursor: null, mode: "index" }) {
+  const list = mock(async (_params: unknown) => response as never)
+  const listOccurrences = mock(async (_params: unknown) => response as never)
+  const handlers = createStreamContextHandlers({
+    streamContextService: { list, listOccurrences } as unknown as StreamContextService,
+  })
+  const json = mock((_body: unknown) => undefined)
+  return { handlers, list, listOccurrences, res: { json } as unknown as Response, json }
+}
+
+function request(query: Record<string, unknown>): Request {
+  return {
+    query,
+    params: { streamId: "stream_1" },
+    user: { id: "usr_1" },
+    workspaceId: "ws_1",
+  } as unknown as Request
+}
+
+describe("stream context handlers", () => {
+  it("defaults scope to tree and limit to 40, and forwards the parsed filters", async () => {
+    const { handlers, list, res, json } = harness()
+
+    await handlers.list(
+      request({ category: "media", q: "budget", from: "usr_7", before: "2026-07-01T00:00:00.000Z" }),
+      res
+    )
+
+    expect(list.mock.calls[0]![0]).toEqual({
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_1",
+      scope: "tree",
+      category: "media",
+      queryText: "budget",
+      authorId: "usr_7",
+      before: new Date("2026-07-01T00:00:00.000Z"),
+      after: undefined,
+      cursor: undefined,
+      limit: 40,
+    })
+    expect(json.mock.calls[0]![0]).toEqual({ items: [], counts: null, nextCursor: null, mode: "index" })
+  })
+
+  it("rejects an out-of-range limit, an unknown scope, and an unknown category", async () => {
+    const { handlers, list, res } = harness()
+
+    for (const query of [{ limit: "101" }, { scope: "workspace" }, { category: "invoice" }]) {
+      await expect(handlers.list(request(query), res)).rejects.toMatchObject({
+        status: 400,
+        code: "VALIDATION_ERROR",
+      })
+    }
+    expect(list).not.toHaveBeenCalled()
+  })
+
+  it("requires category and groupKey on the occurrences route", async () => {
+    const { handlers, listOccurrences, res } = harness({ items: [], nextCursor: null })
+
+    await expect(handlers.listOccurrences(request({ category: "link" }), res)).rejects.toMatchObject({
+      status: 400,
+      code: "VALIDATION_ERROR",
+    })
+    expect(listOccurrences).not.toHaveBeenCalled()
+
+    await handlers.listOccurrences(
+      request({ category: "link", groupKey: "https://example.com/a", scope: "stream", limit: "5" }),
+      res
+    )
+
+    expect(listOccurrences.mock.calls[0]![0]).toEqual({
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_1",
+      scope: "stream",
+      category: "link",
+      groupKey: "https://example.com/a",
+      cursor: undefined,
+      limit: 5,
+    })
+  })
+})

--- a/apps/backend/src/features/stream-context/handlers.ts
+++ b/apps/backend/src/features/stream-context/handlers.ts
@@ -1,0 +1,69 @@
+import type { Request, Response } from "express"
+import { z } from "zod"
+import { CONTEXT_CATEGORIES, STREAM_CONTEXT_SCOPES } from "@threa/types"
+import { validateRequest } from "../../lib/validation"
+import type { StreamContextService } from "./service"
+
+const DEFAULT_LIMIT = 40
+const MAX_LIMIT = 100
+
+const baseQuerySchema = z.object({
+  scope: z.enum(STREAM_CONTEXT_SCOPES).default("tree"),
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(MAX_LIMIT).default(DEFAULT_LIMIT),
+})
+
+const listQuerySchema = baseQuerySchema.extend({
+  category: z.enum(CONTEXT_CATEGORIES).optional(),
+  q: z.string().min(1).max(500).optional(),
+  /** Author id — the panel resolves `from:@slug` to an id before calling. */
+  from: z.string().min(1).optional(),
+  before: z.string().datetime().optional(),
+  after: z.string().datetime().optional(),
+})
+
+const occurrencesQuerySchema = baseQuerySchema.extend({
+  category: z.enum(CONTEXT_CATEGORIES),
+  groupKey: z.string().min(1),
+})
+
+interface Dependencies {
+  streamContextService: StreamContextService
+}
+
+export function createStreamContextHandlers({ streamContextService }: Dependencies) {
+  return {
+    async list(req: Request, res: Response) {
+      const query = validateRequest(listQuerySchema, req.query)
+      const response = await streamContextService.list({
+        workspaceId: req.workspaceId!,
+        userId: req.user!.id,
+        streamId: req.params.streamId!,
+        scope: query.scope,
+        category: query.category,
+        queryText: query.q,
+        authorId: query.from,
+        before: query.before ? new Date(query.before) : undefined,
+        after: query.after ? new Date(query.after) : undefined,
+        cursor: query.cursor,
+        limit: query.limit,
+      })
+      res.json(response)
+    },
+
+    async listOccurrences(req: Request, res: Response) {
+      const query = validateRequest(occurrencesQuerySchema, req.query)
+      const response = await streamContextService.listOccurrences({
+        workspaceId: req.workspaceId!,
+        userId: req.user!.id,
+        streamId: req.params.streamId!,
+        scope: query.scope,
+        category: query.category,
+        groupKey: query.groupKey,
+        cursor: query.cursor,
+        limit: query.limit,
+      })
+      res.json(response)
+    },
+  }
+}

--- a/apps/backend/src/features/stream-context/handlers.ts
+++ b/apps/backend/src/features/stream-context/handlers.ts
@@ -13,8 +13,10 @@ const baseQuerySchema = z.object({
   limit: z.coerce.number().int().positive().max(MAX_LIMIT).default(DEFAULT_LIMIT),
 })
 
-const listQuerySchema = baseQuerySchema.extend({
-  category: z.enum(CONTEXT_CATEGORIES).optional(),
+/** The narrowing filters, shared by both routes: `occurrenceCount` is counted
+ *  over the filtered set, so an expansion that dropped them would return more
+ *  rows than the number the user clicked. */
+const filterQuerySchema = z.object({
   q: z.string().min(1).max(500).optional(),
   /** Author id — the panel resolves `from:@slug` to an id before calling. */
   from: z.string().min(1).optional(),
@@ -22,7 +24,11 @@ const listQuerySchema = baseQuerySchema.extend({
   after: z.string().datetime().optional(),
 })
 
-const occurrencesQuerySchema = baseQuerySchema.extend({
+const listQuerySchema = baseQuerySchema.merge(filterQuerySchema).extend({
+  category: z.enum(CONTEXT_CATEGORIES).optional(),
+})
+
+const occurrencesQuerySchema = baseQuerySchema.merge(filterQuerySchema).extend({
   category: z.enum(CONTEXT_CATEGORIES),
   groupKey: z.string().min(1),
 })
@@ -60,6 +66,10 @@ export function createStreamContextHandlers({ streamContextService }: Dependenci
         scope: query.scope,
         category: query.category,
         groupKey: query.groupKey,
+        queryText: query.q,
+        authorId: query.from,
+        before: query.before ? new Date(query.before) : undefined,
+        after: query.after ? new Date(query.after) : undefined,
         cursor: query.cursor,
         limit: query.limit,
       })

--- a/apps/backend/src/features/stream-context/index.ts
+++ b/apps/backend/src/features/stream-context/index.ts
@@ -1,6 +1,17 @@
 export { StreamContextRepository } from "./repository"
+export { StreamContextReadRepository } from "./read-repository"
+export type {
+  ListFeedParams,
+  ListOccurrencesParams,
+  StreamContextCursor,
+  StreamContextFeedFilters,
+  StreamContextFeedRow,
+} from "./read-repository"
+export { encodeContextCursor, decodeContextCursor } from "./cursor"
+export { createStreamContextService, type StreamContextService } from "./service"
+export { createStreamContextHandlers } from "./handlers"
 export { contextRowsForMessage, contextSnippet } from "./extract"
 export type { ContextRowsForMessageParams } from "./extract"
-export { CONTEXT_CATEGORIES, CONTEXT_REF_KINDS } from "./types"
-export type { ContextCategory, ContextRefKind, NewStreamContextItem } from "./types"
+export { CONTEXT_CATEGORIES, STREAM_CONTEXT_REF_KINDS } from "./types"
+export type { ContextCategory, StreamContextRefKind, NewStreamContextItem } from "./types"
 export { registerStreamContextBackfill, STREAM_CONTEXT_BACKFILL_NAME } from "./backfill"

--- a/apps/backend/src/features/stream-context/read-repository.test.ts
+++ b/apps/backend/src/features/stream-context/read-repository.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "bun:test"
+import { StreamContextReadRepository, type StreamContextFeedFilters } from "./read-repository"
+
+// SQL-shape tests, matching `repository.test.ts`: the fake Querier never reaches
+// Postgres, so what is pinned here is the clause ORDER (filters inside `scoped`,
+// collapse over the filtered set, keyset last) and the mapping of a returned row.
+function fakeDb(rows: unknown[] = []) {
+  const queries: Array<{ text: string; values: unknown[] }> = []
+  const db = {
+    async query(textOrConfig: any, values?: unknown[]) {
+      const text = typeof textOrConfig === "string" ? textOrConfig : textOrConfig.text
+      const vals = typeof textOrConfig === "string" ? (values ?? []) : (textOrConfig.values ?? [])
+      queries.push({ text, values: vals })
+      return { rows, rowCount: rows.length }
+    },
+  }
+  return { db: db as any, queries }
+}
+
+const filters: StreamContextFeedFilters = {
+  workspaceId: "ws_1",
+  rootStreamId: "stream_root",
+  streamId: "stream_thread",
+  scope: "tree",
+}
+
+function dbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sctx_1",
+    stream_id: "stream_thread",
+    category: "link",
+    ref_kind: "url",
+    ref_id: "https://example.com/a?utm_source=x",
+    group_key: "https://example.com/a",
+    source_message_id: "msg_1",
+    author_id: "usr_1",
+    occurred_at: new Date("2026-07-20T10:00:00.000Z"),
+    sequence: "42",
+    snippet: "look at this",
+    detail: { url: "https://example.com/a?utm_source=x" },
+    occurrence_count: 3,
+    link_url: "https://example.com/a",
+    link_title: "Example",
+    link_description: "A page",
+    link_site_name: "example.com",
+    link_favicon_url: "https://example.com/f.ico",
+    link_image_url: "https://example.com/i.png",
+    link_preview_type: "github_pr",
+    link_content_type: "website",
+    link_status: "completed",
+    attachment_id: null,
+    attachment_filename: null,
+    attachment_mime_type: null,
+    attachment_size_bytes: null,
+    attachment_width: null,
+    attachment_height: null,
+    memo_title: null,
+    memo_knowledge_type: null,
+    task_title: null,
+    task_status: null,
+    task_claimed_by_label: null,
+    task_status_note: null,
+    task_result_message_id: null,
+    thread_name: null,
+    thread_reply_count: null,
+    thread_last_reply_at: null,
+    thread_anchor_event_id: null,
+    ...overrides,
+  }
+}
+
+describe("StreamContextReadRepository.listFeed", () => {
+  it("filters inside the scoped CTE, collapses per (category, group_key), then applies the keyset", async () => {
+    const { db, queries } = fakeDb()
+
+    await StreamContextReadRepository.listFeed(db, {
+      ...filters,
+      category: "link",
+      cursor: { occurredAt: new Date("2026-07-19T00:00:00.000Z"), id: "sctx_9" },
+      limit: 41,
+    })
+
+    const text = queries[0]!.text
+    const scopedEnd = text.indexOf("grouped AS")
+    const collapse = text.indexOf(
+      "ROW_NUMBER() OVER (PARTITION BY category, group_key ORDER BY occurred_at DESC, id DESC)"
+    )
+    const keyset = text.indexOf("(occurred_at, id) <")
+    expect(text.indexOf("sci.category =")).toBeLessThan(scopedEnd)
+    expect(scopedEnd).toBeLessThan(collapse)
+    expect(collapse).toBeLessThan(keyset)
+    expect(text).toContain("COUNT(*) OVER (PARTITION BY category, group_key)")
+    expect(text).toContain("WHERE rn = 1")
+    expect(text).toContain("ORDER BY occurred_at DESC, id DESC")
+    expect(queries[0]!.values).toContain("link")
+    expect(queries[0]!.values).toContain("sctx_9")
+    expect(queries[0]!.values).toContain(41)
+  })
+
+  it("joins link_previews on normalized_url, not through the per-message junction", async () => {
+    const { db, queries } = fakeDb()
+
+    await StreamContextReadRepository.listFeed(db, { ...filters, limit: 10 })
+
+    const { text } = queries[0]!
+    // message_link_previews caps at 5 previews per message, while the index
+    // projects every url — joining through it would strip display data the
+    // unique (workspace_id, normalized_url) index demonstrably holds.
+    expect(text).not.toContain("message_link_previews")
+    expect(text).toContain("LEFT JOIN link_previews lp")
+    expect(text).toContain("lp.normalized_url = sci.group_key")
+    expect(text).toContain("lp.preview_type AS link_preview_type")
+    expect(text).toContain("lp.content_type AS link_content_type")
+  })
+
+  it("scopes tree reads on root_stream_id and stream reads on stream_id", async () => {
+    const tree = fakeDb()
+    await StreamContextReadRepository.listFeed(tree.db, { ...filters, scope: "tree", limit: 10 })
+    const stream = fakeDb()
+    await StreamContextReadRepository.listFeed(stream.db, { ...filters, scope: "stream", limit: 10 })
+
+    const scopeValues = (q: { values: unknown[] }) => q.values.slice(0, 4)
+    expect(tree.queries[0]!.text).toContain("sci.root_stream_id =")
+    expect(tree.queries[0]!.text).toContain("sci.stream_id =")
+    expect(scopeValues(tree.queries[0]!)).toEqual(["ws_1", true, "stream_root", false])
+    expect(scopeValues(stream.queries[0]!)).toEqual(["ws_1", false, "stream_root", true])
+  })
+
+  it("narrows on free text, author, and both date bounds", async () => {
+    const { db, queries } = fakeDb()
+
+    await StreamContextReadRepository.listFeed(db, {
+      ...filters,
+      queryText: "budget",
+      authorId: "usr_7",
+      before: new Date("2026-07-01T00:00:00.000Z"),
+      after: new Date("2026-06-01T00:00:00.000Z"),
+      limit: 10,
+    })
+
+    const { text, values } = queries[0]!
+    expect(text).toContain("sci.author_id =")
+    expect(text).toContain("sci.occurred_at <")
+    expect(text).toContain("sci.occurred_at >=")
+    expect(text).toContain("lp.title ILIKE")
+    expect(text).toContain("att.filename ILIKE")
+    expect(text).toContain("mem.title ILIKE")
+    expect(text).toContain("dt.title ILIKE")
+    expect(text).toContain("sci.snippet ILIKE")
+    expect(values).toContain("usr_7")
+    expect(values).toContain("%budget%")
+    const dates = values.filter((v) => v instanceof Date).map((v) => (v as Date).toISOString())
+    expect(dates.slice(0, 2)).toEqual(["2026-07-01T00:00:00.000Z", "2026-06-01T00:00:00.000Z"])
+  })
+
+  it("maps a collapsed link row to the wire item, joining display data live", async () => {
+    const { db } = fakeDb([dbRow()])
+
+    const [item] = await StreamContextReadRepository.listFeed(db, { ...filters, limit: 10 })
+
+    expect(item).toEqual({
+      key: "link:https://example.com/a?utm_source=x:msg_1",
+      category: "link",
+      refKind: "url",
+      refId: "https://example.com/a?utm_source=x",
+      groupKey: "https://example.com/a",
+      streamId: "stream_thread",
+      sourceMessageId: "msg_1",
+      authorId: "usr_1",
+      occurredAt: "2026-07-20T10:00:00.000Z",
+      sequence: "42",
+      snippet: "look at this",
+      occurrenceCount: 3,
+      detail: {
+        url: "https://example.com/a",
+        title: "Example",
+        description: "A page",
+        siteName: "example.com",
+        faviconUrl: "https://example.com/f.ico",
+        imageUrl: "https://example.com/i.png",
+        previewType: "github_pr",
+        contentType: "website",
+        previewStatus: "completed",
+      },
+      cursorOccurredAt: new Date("2026-07-20T10:00:00.000Z"),
+      id: "sctx_1",
+    })
+  })
+
+  it("maps a giphy media row from the stored detail when no attachment row exists", async () => {
+    const { db } = fakeDb([
+      dbRow({
+        category: "media",
+        ref_kind: "giphy",
+        ref_id: "https://media.giphy.com/x.gif",
+        group_key: "https://media.giphy.com/x.gif",
+        detail: { giphyUrl: "https://media.giphy.com/x.gif", title: "dancing", width: 200, height: 100 },
+        link_url: null,
+        link_title: null,
+        link_description: null,
+        link_site_name: null,
+        link_favicon_url: null,
+        link_image_url: null,
+        link_preview_type: null,
+        link_content_type: null,
+        link_status: null,
+      }),
+    ])
+
+    const [item] = await StreamContextReadRepository.listFeed(db, { ...filters, limit: 10 })
+
+    expect(item!.detail).toEqual({
+      attachmentId: null,
+      filename: null,
+      mimeType: null,
+      sizeBytes: null,
+      width: 200,
+      height: 100,
+      mediaKind: "gif",
+      giphyUrl: "https://media.giphy.com/x.gif",
+      giphyTitle: "dancing",
+    })
+  })
+})
+
+describe("StreamContextReadRepository.countsByCategory", () => {
+  it("counts distinct artifacts over the whole filtered scope, unpaged", async () => {
+    const { db, queries } = fakeDb([
+      { category: "link", count: 4 },
+      { category: "media", count: 2 },
+      { category: "not_a_category", count: 9 },
+    ])
+
+    const counts = await StreamContextReadRepository.countsByCategory(db, { ...filters, queryText: "budget" })
+
+    expect(queries[0]!.text).toContain("COUNT(DISTINCT group_key)")
+    expect(queries[0]!.text).not.toContain("ORDER BY")
+    expect(queries[0]!.text).toContain("GROUP BY category")
+    expect(queries[0]!.values).toContain("%budget%")
+    expect(counts).toEqual({ link: 4, media: 2, file: 0, memo: 0, delegation: 0, thread: 0 })
+  })
+})
+
+describe("StreamContextReadRepository.listOccurrences", () => {
+  it("returns the uncollapsed rows for one group_key with the same keyset ordering", async () => {
+    const { db, queries } = fakeDb([dbRow({ occurrence_count: 1 })])
+
+    const [item] = await StreamContextReadRepository.listOccurrences(db, {
+      workspaceId: "ws_1",
+      rootStreamId: "stream_root",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: "link",
+      groupKey: "https://example.com/a",
+      cursor: { occurredAt: new Date("2026-07-19T00:00:00.000Z"), id: "sctx_9" },
+      limit: 11,
+    })
+
+    const { text, values } = queries[0]!
+    expect(text).toContain("sci.group_key =")
+    expect(text).not.toContain("ROW_NUMBER()")
+    expect(text).toContain("(occurred_at, id) <")
+    expect(text).toContain("ORDER BY occurred_at DESC, id DESC")
+    expect(values).toContain("https://example.com/a")
+    expect(item!.occurrenceCount).toBe(1)
+  })
+})

--- a/apps/backend/src/features/stream-context/read-repository.ts
+++ b/apps/backend/src/features/stream-context/read-repository.ts
@@ -35,11 +35,7 @@ export interface ListFeedParams extends StreamContextFeedFilters {
   limit: number
 }
 
-export interface ListOccurrencesParams {
-  workspaceId: string
-  rootStreamId: string
-  streamId: string
-  scope: StreamContextScope
+export interface ListOccurrencesParams extends StreamContextFeedFilters {
   category: ContextCategory
   groupKey: string
   cursor?: StreamContextCursor
@@ -221,7 +217,7 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
       dt.claimed_by_label AS task_claimed_by_label,
       dt.status_note AS task_status_note,
       dt.result_message_id AS task_result_message_id,
-      th.name AS thread_name,
+      th.display_name AS thread_name,
       th.reply_count AS thread_reply_count,
       th.last_reply_at AS thread_last_reply_at,
       th.parent_anchor_id AS thread_anchor_event_id
@@ -265,7 +261,7 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
         OR att.filename ILIKE ${likePattern}
         OR mem.title ILIKE ${likePattern}
         OR dt.title ILIKE ${likePattern}
-        OR th.name ILIKE ${likePattern}
+        OR th.display_name ILIKE ${likePattern}
       )
   `
 }
@@ -322,16 +318,10 @@ export const StreamContextReadRepository = {
 
   /** The uncollapsed occurrences of one artifact, same ordering and same live joins. */
   async listOccurrences(db: Querier, params: ListOccurrencesParams): Promise<StreamContextFeedRow[]> {
-    const scoped = scopedSql(
-      {
-        workspaceId: params.workspaceId,
-        rootStreamId: params.rootStreamId,
-        streamId: params.streamId,
-        scope: params.scope,
-        category: params.category,
-      },
-      { groupKey: params.groupKey }
-    )
+    // Same filters as the feed: `occurrenceCount` is counted over the filtered
+    // set, so an expansion that ignored them would return more rows than the
+    // number the user clicked.
+    const scoped = scopedSql({ ...params, category: params.category }, { groupKey: params.groupKey })
     const cursor = params.cursor
     const result = await db.query<DbRow>(composeSql`
       WITH scoped AS (${scoped})

--- a/apps/backend/src/features/stream-context/read-repository.ts
+++ b/apps/backend/src/features/stream-context/read-repository.ts
@@ -1,0 +1,349 @@
+import type {
+  LinkPreviewContentType,
+  LinkPreviewStatus,
+  RichLinkPreviewType,
+  ContextCategory,
+  StreamContextRefKind,
+  StreamContextItem,
+  StreamContextItemDetail,
+  StreamContextScope,
+} from "@threa/types"
+import { CONTEXT_CATEGORIES, streamContextItemKey } from "@threa/types"
+import { composeSql, sql, type Querier } from "../../db"
+
+export interface StreamContextFeedFilters {
+  workspaceId: string
+  rootStreamId: string
+  streamId: string
+  scope: StreamContextScope
+  category?: ContextCategory
+  queryText?: string
+  authorId?: string
+  /** Exclusive upper bound on `occurred_at`. */
+  before?: Date
+  /** Inclusive lower bound on `occurred_at`. */
+  after?: Date
+}
+
+export interface StreamContextCursor {
+  occurredAt: Date
+  id: string
+}
+
+export interface ListFeedParams extends StreamContextFeedFilters {
+  cursor?: StreamContextCursor
+  limit: number
+}
+
+export interface ListOccurrencesParams {
+  workspaceId: string
+  rootStreamId: string
+  streamId: string
+  scope: StreamContextScope
+  category: ContextCategory
+  groupKey: string
+  cursor?: StreamContextCursor
+  limit: number
+}
+
+export interface StreamContextFeedRow extends StreamContextItem {
+  /** Keyset position — the cursor is built from this, never from `occurredAt`'s string form. */
+  cursorOccurredAt: Date
+  id: string
+}
+
+interface DbRow {
+  id: string
+  stream_id: string
+  category: string
+  ref_kind: string
+  ref_id: string
+  group_key: string
+  source_message_id: string | null
+  author_id: string | null
+  occurred_at: Date
+  sequence: string | null
+  snippet: string
+  detail: Record<string, unknown>
+  occurrence_count: number
+  link_url: string | null
+  link_title: string | null
+  link_description: string | null
+  link_site_name: string | null
+  link_favicon_url: string | null
+  link_image_url: string | null
+  link_preview_type: RichLinkPreviewType | null
+  link_content_type: LinkPreviewContentType | null
+  link_status: LinkPreviewStatus | null
+  attachment_id: string | null
+  attachment_filename: string | null
+  attachment_mime_type: string | null
+  attachment_size_bytes: string | null
+  attachment_width: number | null
+  attachment_height: number | null
+  memo_title: string | null
+  memo_knowledge_type: string | null
+  task_title: string | null
+  task_status: string | null
+  task_claimed_by_label: string | null
+  task_status_note: string | null
+  task_result_message_id: string | null
+  thread_name: string | null
+  thread_reply_count: number | null
+  thread_last_reply_at: Date | null
+  thread_anchor_event_id: string | null
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" ? value : null
+}
+
+function detailFor(row: DbRow): StreamContextItemDetail {
+  switch (row.category as ContextCategory) {
+    case "link":
+      return {
+        url: row.link_url ?? stringOrNull(row.detail.url) ?? row.ref_id,
+        title: row.link_title,
+        description: row.link_description,
+        siteName: row.link_site_name,
+        faviconUrl: row.link_favicon_url,
+        imageUrl: row.link_image_url,
+        previewType: row.link_preview_type,
+        contentType: row.link_content_type,
+        previewStatus: row.link_status,
+      }
+    case "media":
+    case "file":
+      return {
+        attachmentId: row.attachment_id,
+        filename: row.attachment_filename,
+        mimeType: row.attachment_mime_type,
+        sizeBytes: row.attachment_size_bytes === null ? null : Number(row.attachment_size_bytes),
+        width: row.attachment_width ?? numberOrNull(row.detail.width),
+        height: row.attachment_height ?? numberOrNull(row.detail.height),
+        mediaKind: stringOrNull(row.detail.mediaKind) ?? (row.ref_kind === "giphy" ? "gif" : null),
+        giphyUrl: stringOrNull(row.detail.giphyUrl),
+        giphyTitle: stringOrNull(row.detail.title),
+      }
+    case "memo":
+      return { title: row.memo_title, knowledgeType: row.memo_knowledge_type }
+    case "delegation":
+      return {
+        title: row.task_title,
+        status: row.task_status,
+        claimedByLabel: row.task_claimed_by_label,
+        statusNote: row.task_status_note,
+        resultMessageId: row.task_result_message_id,
+      }
+    case "thread":
+      return {
+        name: row.thread_name,
+        replyCount: row.thread_reply_count ?? 0,
+        lastReplyAt: row.thread_last_reply_at?.toISOString() ?? null,
+        anchorEventId: row.thread_anchor_event_id,
+      }
+  }
+}
+
+function mapRow(row: DbRow): StreamContextFeedRow {
+  const category = row.category as ContextCategory
+  return {
+    key: streamContextItemKey({ category, refId: row.ref_id, sourceMessageId: row.source_message_id }),
+    category,
+    refKind: row.ref_kind as StreamContextRefKind,
+    refId: row.ref_id,
+    groupKey: row.group_key,
+    streamId: row.stream_id,
+    sourceMessageId: row.source_message_id,
+    authorId: row.author_id,
+    occurredAt: row.occurred_at.toISOString(),
+    sequence: row.sequence === null ? null : String(row.sequence),
+    snippet: row.snippet,
+    occurrenceCount: row.occurrence_count,
+    detail: detailFor(row),
+    cursorOccurredAt: row.occurred_at,
+    id: row.id,
+  }
+}
+
+const EPOCH = new Date(0)
+
+/**
+ * Scope + filters + the live display joins, as one fragment. Every read path
+ * (feed, counts, occurrences) starts from this so a filter can never apply on
+ * one and silently not on another — the free-text predicate reaches into the
+ * joined columns, so the joins have to precede the filters, and the collapse
+ * has to follow both.
+ */
+function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: string }) {
+  const isTree = filters.scope === "tree"
+  const queryText = filters.queryText?.trim()
+  const hasQuery = Boolean(queryText)
+  const likePattern = `%${(queryText ?? "").replace(/[\\%_]/g, "\\$&")}%`
+
+  return sql`
+    SELECT
+      sci.id,
+      sci.stream_id,
+      sci.category,
+      sci.ref_kind,
+      sci.ref_id,
+      sci.group_key,
+      sci.source_message_id,
+      sci.author_id,
+      sci.occurred_at,
+      sci.sequence,
+      sci.snippet,
+      sci.detail,
+      lp.url AS link_url,
+      lp.title AS link_title,
+      lp.description AS link_description,
+      lp.site_name AS link_site_name,
+      lp.favicon_url AS link_favicon_url,
+      lp.image_url AS link_image_url,
+      lp.preview_type AS link_preview_type,
+      lp.content_type AS link_content_type,
+      lp.status AS link_status,
+      att.id AS attachment_id,
+      att.filename AS attachment_filename,
+      att.mime_type AS attachment_mime_type,
+      att.size_bytes AS attachment_size_bytes,
+      att.width AS attachment_width,
+      att.height AS attachment_height,
+      mem.title AS memo_title,
+      mem.knowledge_type AS memo_knowledge_type,
+      dt.title AS task_title,
+      dt.status AS task_status,
+      dt.claimed_by_label AS task_claimed_by_label,
+      dt.status_note AS task_status_note,
+      dt.result_message_id AS task_result_message_id,
+      th.name AS thread_name,
+      th.reply_count AS thread_reply_count,
+      th.last_reply_at AS thread_last_reply_at,
+      th.parent_anchor_id AS thread_anchor_event_id
+    FROM stream_context_items sci
+    LEFT JOIN link_previews lp
+      ON sci.category = 'link'
+     AND lp.workspace_id = sci.workspace_id
+     AND lp.normalized_url = sci.group_key
+    LEFT JOIN attachments att
+      ON sci.ref_kind = 'attachment'
+     AND att.workspace_id = sci.workspace_id
+     AND att.id = sci.ref_id
+    LEFT JOIN memos mem
+      ON sci.category = 'memo'
+     AND mem.workspace_id = sci.workspace_id
+     AND mem.id = sci.ref_id
+    LEFT JOIN delegated_tasks dt
+      ON sci.category = 'delegation'
+     AND dt.workspace_id = sci.workspace_id
+     AND dt.id = sci.ref_id
+    LEFT JOIN streams th
+      ON sci.category = 'thread'
+     AND th.workspace_id = sci.workspace_id
+     AND th.id = sci.ref_id
+    WHERE sci.workspace_id = ${filters.workspaceId}
+      AND (
+        (${isTree} AND sci.root_stream_id = ${filters.rootStreamId})
+        OR (${!isTree} AND sci.stream_id = ${filters.streamId})
+      )
+      AND (${filters.category === undefined} OR sci.category = ${filters.category ?? ""})
+      AND (${extra?.groupKey === undefined} OR sci.group_key = ${extra?.groupKey ?? ""})
+      AND (${filters.authorId === undefined} OR sci.author_id = ${filters.authorId ?? ""})
+      AND (${filters.before === undefined} OR sci.occurred_at < ${filters.before ?? EPOCH}::timestamptz)
+      AND (${filters.after === undefined} OR sci.occurred_at >= ${filters.after ?? EPOCH}::timestamptz)
+      AND (
+        ${!hasQuery}
+        OR sci.snippet ILIKE ${likePattern}
+        OR lp.title ILIKE ${likePattern}
+        OR lp.site_name ILIKE ${likePattern}
+        OR lp.url ILIKE ${likePattern}
+        OR att.filename ILIKE ${likePattern}
+        OR mem.title ILIKE ${likePattern}
+        OR dt.title ILIKE ${likePattern}
+        OR th.name ILIKE ${likePattern}
+      )
+  `
+}
+
+export const StreamContextReadRepository = {
+  /**
+   * Collapsed feed: one row per (category, group_key), the newest occurrence,
+   * carrying how many occurrences it stands for. Filters run inside `scoped`,
+   * before the collapse and before the keyset, so a cursor is only ever valid
+   * for the filter set that produced it.
+   */
+  async listFeed(db: Querier, params: ListFeedParams): Promise<StreamContextFeedRow[]> {
+    const scoped = scopedSql(params)
+    const cursor = params.cursor
+    const result = await db.query<DbRow>(composeSql`
+      WITH scoped AS (${scoped}),
+      grouped AS (
+        SELECT
+          scoped.*,
+          ROW_NUMBER() OVER (PARTITION BY category, group_key ORDER BY occurred_at DESC, id DESC) AS rn,
+          COUNT(*) OVER (PARTITION BY category, group_key)::int AS occurrence_count
+        FROM scoped
+      )
+      SELECT * FROM grouped
+      WHERE rn = 1
+        AND (
+          ${cursor === undefined}
+          OR (occurred_at, id) < (${cursor?.occurredAt ?? EPOCH}::timestamptz, ${cursor?.id ?? ""}::text)
+        )
+      ORDER BY occurred_at DESC, id DESC
+      LIMIT ${params.limit}
+    `)
+    return result.rows.map(mapRow)
+  },
+
+  /** Whole-scope counts over the collapsed set — distinct artifacts, not occurrences. */
+  async countsByCategory(db: Querier, filters: StreamContextFeedFilters): Promise<Record<ContextCategory, number>> {
+    const scoped = scopedSql(filters)
+    const result = await db.query<{ category: string; count: number }>(composeSql`
+      WITH scoped AS (${scoped})
+      SELECT category, COUNT(DISTINCT group_key)::int AS count
+      FROM scoped
+      GROUP BY category
+    `)
+
+    const counts = Object.fromEntries(CONTEXT_CATEGORIES.map((c) => [c, 0])) as Record<ContextCategory, number>
+    for (const row of result.rows) {
+      if ((CONTEXT_CATEGORIES as readonly string[]).includes(row.category)) {
+        counts[row.category as ContextCategory] = row.count
+      }
+    }
+    return counts
+  },
+
+  /** The uncollapsed occurrences of one artifact, same ordering and same live joins. */
+  async listOccurrences(db: Querier, params: ListOccurrencesParams): Promise<StreamContextFeedRow[]> {
+    const scoped = scopedSql(
+      {
+        workspaceId: params.workspaceId,
+        rootStreamId: params.rootStreamId,
+        streamId: params.streamId,
+        scope: params.scope,
+        category: params.category,
+      },
+      { groupKey: params.groupKey }
+    )
+    const cursor = params.cursor
+    const result = await db.query<DbRow>(composeSql`
+      WITH scoped AS (${scoped})
+      SELECT scoped.*, 1 AS occurrence_count
+      FROM scoped
+      WHERE (
+        ${cursor === undefined}
+        OR (occurred_at, id) < (${cursor?.occurredAt ?? EPOCH}::timestamptz, ${cursor?.id ?? ""}::text)
+      )
+      ORDER BY occurred_at DESC, id DESC
+      LIMIT ${params.limit}
+    `)
+    return result.rows.map(mapRow)
+  },
+}

--- a/apps/backend/src/features/stream-context/service.test.ts
+++ b/apps/backend/src/features/stream-context/service.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import type { Stream } from "../streams"
+import * as streamsBarrel from "../streams"
+import { E2eStreamsRepository } from "../e2e-streams"
+import { decodeContextCursor } from "./cursor"
+import { StreamContextReadRepository, type StreamContextFeedRow } from "./read-repository"
+import { createStreamContextService } from "./service"
+
+const pool = {} as Pool
+const service = createStreamContextService({ pool })
+
+function stream(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_thread",
+    workspaceId: "ws_1",
+    type: "thread",
+    rootStreamId: "stream_channel",
+    parentStreamId: "stream_channel",
+    ...overrides,
+  } as Stream
+}
+
+function feedRow(overrides: Partial<StreamContextFeedRow> = {}): StreamContextFeedRow {
+  return {
+    key: "link:https://example.com/a:msg_1",
+    category: "link",
+    refKind: "url",
+    refId: "https://example.com/a",
+    groupKey: "https://example.com/a",
+    streamId: "stream_thread",
+    sourceMessageId: "msg_1",
+    authorId: "usr_1",
+    occurredAt: "2026-07-20T10:00:00.000Z",
+    sequence: "42",
+    snippet: "look",
+    occurrenceCount: 2,
+    detail: {
+      url: "https://example.com/a",
+      title: null,
+      description: null,
+      siteName: null,
+      faviconUrl: null,
+      imageUrl: null,
+      previewType: null,
+      contentType: null,
+      previewStatus: null,
+    },
+    cursorOccurredAt: new Date("2026-07-20T10:00:00.000Z"),
+    id: "sctx_1",
+    ...overrides,
+  }
+}
+
+function grantAccess(result: Stream | null = stream()) {
+  return spyOn(streamsBarrel, "checkStreamAccess").mockResolvedValue(result)
+}
+
+function sealed(value: boolean) {
+  return spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(value)
+}
+
+const listParams = {
+  workspaceId: "ws_1",
+  userId: "usr_1",
+  streamId: "stream_thread",
+  scope: "tree" as const,
+  limit: 2,
+}
+
+afterEach(() => {
+  spyOn(streamsBarrel, "checkStreamAccess").mockRestore()
+  spyOn(E2eStreamsRepository, "isE2eStream").mockRestore()
+  spyOn(StreamContextReadRepository, "listFeed").mockRestore()
+  spyOn(StreamContextReadRepository, "countsByCategory").mockRestore()
+  spyOn(StreamContextReadRepository, "listOccurrences").mockRestore()
+})
+
+describe("StreamContextService.list", () => {
+  it("queries the resolved root under scope=tree, so a non-member thread inside a member channel is included", async () => {
+    grantAccess(stream())
+    sealed(false)
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([
+      feedRow({ streamId: "stream_thread" }),
+    ])
+    spyOn(StreamContextReadRepository, "countsByCategory").mockResolvedValue({
+      link: 1,
+      media: 0,
+      file: 0,
+      memo: 0,
+      delegation: 0,
+      thread: 0,
+    })
+
+    const response = await service.list(listParams)
+
+    expect(listFeed.mock.calls[0]![1]).toEqual({
+      workspaceId: "ws_1",
+      rootStreamId: "stream_channel",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: undefined,
+      queryText: undefined,
+      authorId: undefined,
+      before: undefined,
+      after: undefined,
+      cursor: undefined,
+      limit: 3,
+    })
+    expect(response).toEqual({
+      items: [
+        {
+          key: "link:https://example.com/a:msg_1",
+          category: "link",
+          refKind: "url",
+          refId: "https://example.com/a",
+          groupKey: "https://example.com/a",
+          streamId: "stream_thread",
+          sourceMessageId: "msg_1",
+          authorId: "usr_1",
+          occurredAt: "2026-07-20T10:00:00.000Z",
+          sequence: "42",
+          snippet: "look",
+          occurrenceCount: 2,
+          detail: {
+            url: "https://example.com/a",
+            title: null,
+            description: null,
+            siteName: null,
+            faviconUrl: null,
+            imageUrl: null,
+            previewType: null,
+            contentType: null,
+            previewStatus: null,
+          },
+        },
+      ],
+      counts: { link: 1, media: 0, file: 0, memo: 0, delegation: 0, thread: 0 },
+      nextCursor: null,
+      mode: "index",
+    })
+  })
+
+  it("pages by keyset: the extra row is withheld and its predecessor becomes the cursor", async () => {
+    grantAccess(stream())
+    sealed(false)
+    spyOn(StreamContextReadRepository, "countsByCategory").mockResolvedValue({
+      link: 3,
+      media: 0,
+      file: 0,
+      memo: 0,
+      delegation: 0,
+      thread: 0,
+    })
+    spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([
+      feedRow({ key: "a", id: "sctx_3", cursorOccurredAt: new Date("2026-07-20T12:00:00.000Z") }),
+      feedRow({ key: "b", id: "sctx_2", cursorOccurredAt: new Date("2026-07-20T11:00:00.000Z") }),
+      feedRow({ key: "c", id: "sctx_1", cursorOccurredAt: new Date("2026-07-20T10:00:00.000Z") }),
+    ])
+
+    const first = await service.list(listParams)
+
+    expect(first.items.map((item) => item.key)).toEqual(["a", "b"])
+    expect(decodeContextCursor(first.nextCursor!)).toEqual({
+      occurredAt: new Date("2026-07-20T11:00:00.000Z"),
+      id: "sctx_2",
+    })
+
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([feedRow({ key: "c" })])
+    listFeed.mockClear()
+    const counts = spyOn(StreamContextReadRepository, "countsByCategory")
+    counts.mockClear()
+
+    const second = await service.list({ ...listParams, cursor: first.nextCursor! })
+
+    expect(listFeed.mock.calls[0]![1]!.cursor).toEqual({
+      occurredAt: new Date("2026-07-20T11:00:00.000Z"),
+      id: "sctx_2",
+    })
+    expect(second.items.map((item) => item.key)).toEqual(["c"])
+    // Counts are whole-scope and first-page only — later pages omit them.
+    expect(second.counts).toBeNull()
+    expect(counts).not.toHaveBeenCalled()
+  })
+
+  it("passes every filter through untouched", async () => {
+    grantAccess(stream())
+    sealed(false)
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([])
+    spyOn(StreamContextReadRepository, "countsByCategory").mockResolvedValue({
+      link: 0,
+      media: 0,
+      file: 0,
+      memo: 0,
+      delegation: 0,
+      thread: 0,
+    })
+
+    await service.list({
+      ...listParams,
+      scope: "stream",
+      category: "media",
+      queryText: "budget",
+      authorId: "usr_7",
+      before: new Date("2026-07-01T00:00:00.000Z"),
+      after: new Date("2026-06-01T00:00:00.000Z"),
+    })
+
+    expect(listFeed.mock.calls[0]![1]).toEqual({
+      workspaceId: "ws_1",
+      rootStreamId: "stream_channel",
+      streamId: "stream_thread",
+      scope: "stream",
+      category: "media",
+      queryText: "budget",
+      authorId: "usr_7",
+      before: new Date("2026-07-01T00:00:00.000Z"),
+      after: new Date("2026-06-01T00:00:00.000Z"),
+      cursor: undefined,
+      limit: 3,
+    })
+  })
+
+  it("counts the whole scope with the category selector stripped, keeping the other filters", async () => {
+    grantAccess(stream())
+    sealed(false)
+    spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([])
+    const counts = spyOn(StreamContextReadRepository, "countsByCategory").mockResolvedValue({
+      link: 4,
+      media: 2,
+      file: 0,
+      memo: 1,
+      delegation: 0,
+      thread: 0,
+    })
+
+    await service.list({ ...listParams, category: "link", queryText: "budget" })
+
+    expect(counts.mock.calls[0]![1]).toEqual({
+      workspaceId: "ws_1",
+      rootStreamId: "stream_channel",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: undefined,
+      queryText: "budget",
+      authorId: undefined,
+      before: undefined,
+      after: undefined,
+    })
+  })
+
+  it("404s a caller without stream access", async () => {
+    grantAccess(null)
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([])
+
+    await expect(service.list(listParams)).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    expect(listFeed).not.toHaveBeenCalled()
+  })
+
+  it("rejects a malformed cursor instead of returning the unfiltered first page", async () => {
+    grantAccess(stream())
+    sealed(false)
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([])
+
+    await expect(service.list({ ...listParams, cursor: "not-a-cursor" })).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_CURSOR",
+    })
+    expect(listFeed).not.toHaveBeenCalled()
+  })
+
+  it("hands a sealed stream back to the client path without touching the index", async () => {
+    grantAccess(stream({ id: "stream_channel", rootStreamId: null }))
+    sealed(true)
+    const listFeed = spyOn(StreamContextReadRepository, "listFeed").mockResolvedValue([])
+
+    const response = await service.list(listParams)
+
+    expect(response).toEqual({
+      items: [],
+      counts: { link: 0, media: 0, file: 0, memo: 0, delegation: 0, thread: 0 },
+      nextCursor: null,
+      mode: "client",
+    })
+    expect(listFeed).not.toHaveBeenCalled()
+  })
+})
+
+describe("StreamContextService.listOccurrences", () => {
+  it("queries one artifact's rows against the resolved root", async () => {
+    grantAccess(stream())
+    sealed(false)
+    const listOccurrences = spyOn(StreamContextReadRepository, "listOccurrences").mockResolvedValue([
+      feedRow({ key: "a", occurrenceCount: 1 }),
+    ])
+
+    const response = await service.listOccurrences({
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: "link",
+      groupKey: "https://example.com/a",
+      limit: 2,
+    })
+
+    expect(listOccurrences.mock.calls[0]![1]).toEqual({
+      workspaceId: "ws_1",
+      rootStreamId: "stream_channel",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: "link",
+      groupKey: "https://example.com/a",
+      cursor: undefined,
+      limit: 3,
+    })
+    expect(response.items.map((item) => item.key)).toEqual(["a"])
+    expect(response.nextCursor).toBeNull()
+  })
+
+  it("returns nothing for a sealed stream", async () => {
+    grantAccess(stream())
+    sealed(true)
+    const listOccurrences = spyOn(StreamContextReadRepository, "listOccurrences").mockResolvedValue([])
+
+    const response = await service.listOccurrences({
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_thread",
+      scope: "tree",
+      category: "link",
+      groupKey: "https://example.com/a",
+      limit: 2,
+    })
+
+    expect(response).toEqual({ items: [], nextCursor: null })
+    expect(listOccurrences).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/stream-context/service.ts
+++ b/apps/backend/src/features/stream-context/service.ts
@@ -38,6 +38,10 @@ export interface ListStreamContextOccurrencesParams {
   scope: StreamContextScope
   category: ContextCategory
   groupKey: string
+  queryText?: string
+  authorId?: string
+  before?: Date
+  after?: Date
   cursor?: string
   limit: number
 }
@@ -124,6 +128,10 @@ export function createStreamContextService({ pool }: Dependencies) {
         scope: params.scope,
         category: params.category,
         groupKey: params.groupKey,
+        queryText: params.queryText,
+        authorId: params.authorId,
+        before: params.before,
+        after: params.after,
         cursor,
         limit: params.limit + 1,
       })

--- a/apps/backend/src/features/stream-context/service.ts
+++ b/apps/backend/src/features/stream-context/service.ts
@@ -1,0 +1,135 @@
+import type { Pool } from "pg"
+import {
+  CONTEXT_CATEGORIES,
+  type ContextCategory,
+  type ListStreamContextOccurrencesResponse,
+  type ListStreamContextResponse,
+  type StreamContextItem,
+  type StreamContextScope,
+} from "@threa/types"
+import { HttpError } from "../../lib/errors"
+import { E2eStreamsRepository } from "../e2e-streams"
+import { checkStreamAccess } from "../streams"
+import { encodeContextCursor, decodeContextCursor } from "./cursor"
+import { StreamContextReadRepository, type StreamContextFeedRow } from "./read-repository"
+
+interface Dependencies {
+  pool: Pool
+}
+
+export interface ListStreamContextParams {
+  workspaceId: string
+  userId: string
+  streamId: string
+  scope: StreamContextScope
+  category?: ContextCategory
+  queryText?: string
+  authorId?: string
+  before?: Date
+  after?: Date
+  cursor?: string
+  limit: number
+}
+
+export interface ListStreamContextOccurrencesParams {
+  workspaceId: string
+  userId: string
+  streamId: string
+  scope: StreamContextScope
+  category: ContextCategory
+  groupKey: string
+  cursor?: string
+  limit: number
+}
+
+const ZERO_COUNTS = (): Record<ContextCategory, number> =>
+  Object.fromEntries(CONTEXT_CATEGORIES.map((c) => [c, 0])) as Record<ContextCategory, number>
+
+function toItem(row: StreamContextFeedRow): StreamContextItem {
+  const { cursorOccurredAt: _cursorOccurredAt, id: _id, ...item } = row
+  return item
+}
+
+function page(rows: StreamContextFeedRow[], limit: number): { items: StreamContextItem[]; nextCursor: string | null } {
+  const hasMore = rows.length > limit
+  const visible = hasMore ? rows.slice(0, limit) : rows
+  const last = visible[visible.length - 1]
+  return {
+    items: visible.map(toItem),
+    nextCursor: hasMore && last ? encodeContextCursor({ occurredAt: last.cursorOccurredAt, id: last.id }) : null,
+  }
+}
+
+/**
+ * Read side of the "in this stream" index. Access is resolved once per request
+ * through {@link checkStreamAccess} and the query then runs against the root it
+ * resolved (INV-62) — never against `stream_members`, so a thread the caller is
+ * not a member of still shows up under its readable root.
+ */
+export function createStreamContextService({ pool }: Dependencies) {
+  async function resolveScope(params: { workspaceId: string; userId: string; streamId: string }) {
+    const stream = await checkStreamAccess(pool, params.streamId, params.workspaceId, params.userId)
+    if (!stream) {
+      throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+    }
+    const rootStreamId = stream.rootStreamId ?? stream.id
+    const sealed = await E2eStreamsRepository.isE2eStream(pool, params.workspaceId, rootStreamId)
+    return { rootStreamId, sealed }
+  }
+
+  return {
+    async list(params: ListStreamContextParams): Promise<ListStreamContextResponse> {
+      const { rootStreamId, sealed } = await resolveScope(params)
+      const cursor = decodeContextCursor(params.cursor)
+
+      // A sealed stream holds only ciphertext, so the index is empty by
+      // construction — the panel derives locally instead of paging nothing.
+      if (sealed) {
+        return { items: [], counts: ZERO_COUNTS(), nextCursor: null, mode: "client" }
+      }
+
+      const filters = {
+        workspaceId: params.workspaceId,
+        rootStreamId,
+        streamId: params.streamId,
+        scope: params.scope,
+        category: params.category,
+        queryText: params.queryText,
+        authorId: params.authorId,
+        before: params.before,
+        after: params.after,
+      }
+
+      const rows = await StreamContextReadRepository.listFeed(pool, { ...filters, cursor, limit: params.limit + 1 })
+      // Counts are per-chip totals for the whole scope, so the category
+      // selector must not narrow them — every other chip would read 0.
+      const counts = cursor
+        ? null
+        : await StreamContextReadRepository.countsByCategory(pool, { ...filters, category: undefined })
+      return { ...page(rows, params.limit), counts, mode: "index" }
+    },
+
+    async listOccurrences(params: ListStreamContextOccurrencesParams): Promise<ListStreamContextOccurrencesResponse> {
+      const { rootStreamId, sealed } = await resolveScope(params)
+      const cursor = decodeContextCursor(params.cursor)
+
+      if (sealed) {
+        return { items: [], nextCursor: null }
+      }
+
+      const rows = await StreamContextReadRepository.listOccurrences(pool, {
+        workspaceId: params.workspaceId,
+        rootStreamId,
+        streamId: params.streamId,
+        scope: params.scope,
+        category: params.category,
+        groupKey: params.groupKey,
+        cursor,
+        limit: params.limit + 1,
+      })
+      return page(rows, params.limit)
+    },
+  }
+}
+
+export type StreamContextService = ReturnType<typeof createStreamContextService>

--- a/apps/backend/src/features/stream-context/types.ts
+++ b/apps/backend/src/features/stream-context/types.ts
@@ -1,5 +1,4 @@
-export const CONTEXT_CATEGORIES = ["link", "media", "file", "memo", "delegation", "thread"] as const
-export type ContextCategory = (typeof CONTEXT_CATEGORIES)[number]
+import type { ContextCategory, StreamContextRefKind } from "@threa/types"
 
 /**
  * Categories a message body owns, i.e. exactly what `contextRowsForMessage`
@@ -9,8 +8,8 @@ export type ContextCategory = (typeof CONTEXT_CATEGORIES)[number]
  */
 export const MESSAGE_BODY_CONTEXT_CATEGORIES = ["link", "media", "file"] as const
 
-export const CONTEXT_REF_KINDS = ["url", "attachment", "giphy", "memo", "delegation", "thread"] as const
-export type ContextRefKind = (typeof CONTEXT_REF_KINDS)[number]
+export { CONTEXT_CATEGORIES, STREAM_CONTEXT_REF_KINDS } from "@threa/types"
+export type { ContextCategory, StreamContextRefKind } from "@threa/types"
 
 export interface NewStreamContextItem {
   id: string
@@ -18,7 +17,7 @@ export interface NewStreamContextItem {
   streamId: string
   rootStreamId: string
   category: ContextCategory
-  refKind: ContextRefKind
+  refKind: StreamContextRefKind
   refId: string
   groupKey: string
   sourceMessageId: string | null

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -98,6 +98,7 @@ import type { SavedSuggestionsService } from "./features/saved-suggestions"
 import type { ScheduledMessagesService } from "./features/scheduled-messages"
 import type { AgentFollowUpService, PersonaConfigService } from "./features/agents"
 import { createDelegationHandlers, type DelegationService } from "./features/delegations"
+import { createStreamContextHandlers, createStreamContextService } from "./features/stream-context"
 import { BotAccessRequestService, createBotAccessRequestHandlers } from "./features/bot-access-requests"
 import type { DraftsService } from "./features/drafts"
 import type { LabelService, LabelAssignmentService, LabelMessageService } from "./features/labels"
@@ -353,6 +354,9 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const agentSession = createAgentSessionHandlers({ pool })
   const agentFollowUps = createAgentFollowUpHandlers({ pool, agentFollowUpService })
   const delegations = createDelegationHandlers({ pool, delegationService })
+  const streamContext = createStreamContextHandlers({
+    streamContextService: createStreamContextService({ pool }),
+  })
   const botAccessRequestService = new BotAccessRequestService({ pool, streamService })
   const botAccessRequests = createBotAccessRequestHandlers({ botAccessRequestService, streamService })
   const contextBag = createContextBagHandlers({ pool, ai })
@@ -694,6 +698,18 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     audit("streams.update", "write"),
     stream.update
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/context",
+    ...authed,
+    audit("stream_context.list", "read"),
+    streamContext.list
+  )
+  app.get(
+    "/api/workspaces/:workspaceId/streams/:streamId/context/occurrences",
+    ...authed,
+    audit("stream_context.list", "read"),
+    streamContext.listOccurrences
   )
   app.get(
     "/api/workspaces/:workspaceId/streams/:streamId/bootstrap",

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -708,7 +708,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get(
     "/api/workspaces/:workspaceId/streams/:streamId/context/occurrences",
     ...authed,
-    audit("stream_context.list", "read"),
+    audit("stream_context.occurrences", "read"),
     streamContext.listOccurrences
   )
   app.get(

--- a/apps/backend/tests/integration/stream-context-read.test.ts
+++ b/apps/backend/tests/integration/stream-context-read.test.ts
@@ -1,0 +1,179 @@
+/**
+ * "In this stream" read path, against a real schema.
+ *
+ * The unit suites assert query SHAPE against a fake Querier, which cannot catch
+ * a scope predicate that still names both columns or a join that quietly starts
+ * filtering on membership. These run the generated SQL.
+ *
+ * The case that matters is INV-62: a thread the viewer is not a member of, under
+ * a channel they can read, must appear in the tree-scoped feed — membership is
+ * not access, and filtering on `stream_members` silently drops thread content.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService } from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { createStreamContextService } from "../../src/features/stream-context"
+import { userId, workspaceId } from "../../src/lib/id"
+import { StreamTypes, Visibilities } from "@threa/types"
+
+describe("stream context read path", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let eventService: EventService
+  let service: ReturnType<typeof createStreamContextService>
+
+  const wsId = workspaceId()
+  const memberId = userId()
+  const outsiderId = userId()
+  let channelId: string
+  let threadId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    eventService = new EventService(pool)
+    service = createStreamContextService({ pool })
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Context WS",
+        slug: `context-ws-${wsId}`,
+        createdBy: memberId,
+      })
+      await addTestMember(client, wsId, memberId)
+      await addTestMember(client, wsId, outsiderId)
+    })
+
+    const channel = await streamService.create({
+      workspaceId: wsId,
+      type: StreamTypes.CHANNEL,
+      name: "context-channel",
+      slug: `context-channel-${wsId.slice(-8)}`,
+      visibility: Visibilities.PUBLIC,
+      createdBy: memberId,
+    })
+    channelId = channel.id
+
+    const anchor = await eventService.createMessage({
+      workspaceId: wsId,
+      streamId: channelId,
+      authorId: memberId,
+      authorType: "user",
+      ...testMessageContent("channel link https://example.com/channel-doc"),
+    })
+
+    // The thread is created by the OUTSIDER, so the member holds no membership
+    // row on it — the case a `stream_members` filter would drop.
+    const thread = await streamService.create({
+      workspaceId: wsId,
+      type: StreamTypes.THREAD,
+      parentStreamId: channelId,
+      parentAnchorId: anchor.id,
+      createdBy: outsiderId,
+    })
+    threadId = thread.id
+
+    await eventService.createMessage({
+      workspaceId: wsId,
+      streamId: threadId,
+      authorId: outsiderId,
+      authorType: "user",
+      ...testMessageContent("thread link https://example.com/thread-doc"),
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("scope=tree returns a link shared in a thread the viewer never joined", async () => {
+    const response = await service.list({
+      workspaceId: wsId,
+      userId: memberId,
+      streamId: channelId,
+      scope: "tree",
+      limit: 40,
+    })
+
+    expect({
+      mode: response.mode,
+      urls: response.items
+        .filter((item) => item.category === "link")
+        .map((item) => item.refId)
+        .sort(),
+      linkCount: response.counts?.link,
+    }).toEqual({
+      mode: "index",
+      urls: ["https://example.com/channel-doc", "https://example.com/thread-doc"],
+      linkCount: 2,
+    })
+  })
+
+  test("scope=stream returns the channel's own rows and the thread it spawned", async () => {
+    const response = await service.list({
+      workspaceId: wsId,
+      userId: memberId,
+      streamId: channelId,
+      scope: "stream",
+      limit: 40,
+    })
+
+    const rows = response.items
+      .map((item) => ({ category: item.category, refId: item.refId }))
+      .sort((a, b) => a.category.localeCompare(b.category))
+    expect(rows).toEqual([
+      { category: "link", refId: "https://example.com/channel-doc" },
+      { category: "thread", refId: threadId },
+    ])
+  })
+
+  test("the thread's own feed carries its link", async () => {
+    const response = await service.list({
+      workspaceId: wsId,
+      userId: memberId,
+      streamId: threadId,
+      scope: "stream",
+      limit: 40,
+    })
+
+    expect(response.items.map((item) => item.refId)).toEqual(["https://example.com/thread-doc"])
+  })
+
+  test("a filtered feed pages by the filter's own cursor", async () => {
+    const first = await service.list({
+      workspaceId: wsId,
+      userId: memberId,
+      streamId: channelId,
+      scope: "tree",
+      category: "link",
+      limit: 1,
+    })
+    expect(first.items).toHaveLength(1)
+    expect(first.nextCursor).not.toBeNull()
+
+    const second = await service.list({
+      workspaceId: wsId,
+      userId: memberId,
+      streamId: channelId,
+      scope: "tree",
+      category: "link",
+      cursor: first.nextCursor!,
+      limit: 1,
+    })
+
+    expect({
+      secondRefIds: second.items.map((item) => item.refId),
+      overlapsFirstPage: second.items.some((item) => item.key === first.items[0]!.key),
+      countsOnlyOnFirstPage: second.counts,
+    }).toEqual({
+      secondRefIds: ["https://example.com/channel-doc"],
+      overlapsFirstPage: false,
+      countsOnlyOnFirstPage: null,
+    })
+  })
+})

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1079,6 +1079,9 @@ export const VideoPreviewTypes = {
   VIDEO: "video",
 } as const satisfies Record<string, VideoPreviewType>
 
+/** Every value `link_previews.preview_type` can hold — the closed set of rich provider cards. */
+export type RichLinkPreviewType = GitHubPreviewType | LinearPreviewType | VideoPreviewType
+
 export const SHARE_FLAVORS = ["pointer", "quote"] as const
 export type ShareFlavor = (typeof SHARE_FLAVORS)[number]
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -55,6 +55,7 @@ export function defineFlag<
  */
 export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
+  streamContextIndex: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -242,6 +242,7 @@ export {
   VIDEO_PREVIEW_TYPES,
   type VideoPreviewType,
   VideoPreviewTypes,
+  type RichLinkPreviewType,
   // Share flavors
   SHARE_FLAVORS,
   type ShareFlavor,
@@ -1051,3 +1052,23 @@ export {
   type AgentActivityStartedPayload,
   type AgentActivityEndedPayload,
 } from "./agent-trace"
+
+// "In this stream" context index
+export {
+  CONTEXT_CATEGORIES,
+  STREAM_CONTEXT_REF_KINDS,
+  STREAM_CONTEXT_SCOPES,
+  streamContextItemKey,
+  type ContextCategory,
+  type StreamContextRefKind,
+  type StreamContextScope,
+  type StreamContextItem,
+  type StreamContextItemDetail,
+  type StreamContextLinkDetail,
+  type StreamContextAttachmentDetail,
+  type StreamContextMemoDetail,
+  type StreamContextDelegationDetail,
+  type StreamContextThreadDetail,
+  type ListStreamContextResponse,
+  type ListStreamContextOccurrencesResponse,
+} from "./stream-context"

--- a/packages/types/src/stream-context.ts
+++ b/packages/types/src/stream-context.ts
@@ -1,0 +1,114 @@
+// "In this stream" wire contract. The backend serves rows out of the
+// `stream_context_items` projection; the client derives the same rows locally
+// for sealed streams and reconciles the two sets by `key`, so the literals and
+// the key derivation live here rather than in either app (INV-33).
+
+import type { LinkPreviewContentType, LinkPreviewStatus, RichLinkPreviewType } from "./constants"
+
+export const CONTEXT_CATEGORIES = ["link", "media", "file", "memo", "delegation", "thread"] as const
+export type ContextCategory = (typeof CONTEXT_CATEGORIES)[number]
+
+export const STREAM_CONTEXT_REF_KINDS = ["url", "attachment", "giphy", "memo", "delegation", "thread"] as const
+export type StreamContextRefKind = (typeof STREAM_CONTEXT_REF_KINDS)[number]
+
+export const STREAM_CONTEXT_SCOPES = ["stream", "tree"] as const
+export type StreamContextScope = (typeof STREAM_CONTEXT_SCOPES)[number]
+
+/** Row identity, computed identically on both sides of the wire. */
+export function streamContextItemKey(input: {
+  category: ContextCategory
+  refId: string
+  sourceMessageId: string | null
+}): string {
+  return `${input.category}:${input.refId}:${input.sourceMessageId ?? ""}`
+}
+
+/** Joined live from `link_previews`; every field is null until the preview lands. */
+export interface StreamContextLinkDetail {
+  url: string
+  title: string | null
+  description: string | null
+  siteName: string | null
+  faviconUrl: string | null
+  imageUrl: string | null
+  /** `link_previews.preview_type` — the rich provider card, null for a plain page. */
+  previewType: RichLinkPreviewType | null
+  /** `link_previews.content_type` — website | pdf | image | in_app_*. */
+  contentType: LinkPreviewContentType | null
+  previewStatus: LinkPreviewStatus | null
+}
+
+/** Shared by `media` and `file`. Giphy rows carry no attachment, only the stored detail. */
+export interface StreamContextAttachmentDetail {
+  attachmentId: string | null
+  filename: string | null
+  mimeType: string | null
+  sizeBytes: number | null
+  width: number | null
+  height: number | null
+  mediaKind: string | null
+  giphyUrl: string | null
+  giphyTitle: string | null
+}
+
+export interface StreamContextMemoDetail {
+  title: string | null
+  knowledgeType: string | null
+}
+
+export interface StreamContextDelegationDetail {
+  title: string | null
+  status: string | null
+  claimedByLabel: string | null
+  statusNote: string | null
+  resultMessageId: string | null
+}
+
+export interface StreamContextThreadDetail {
+  name: string | null
+  replyCount: number
+  lastReplyAt: string | null
+  anchorEventId: string | null
+}
+
+export type StreamContextItemDetail =
+  | StreamContextLinkDetail
+  | StreamContextAttachmentDetail
+  | StreamContextMemoDetail
+  | StreamContextDelegationDetail
+  | StreamContextThreadDetail
+
+export interface StreamContextItem {
+  /** `${category}:${refId}:${sourceMessageId ?? ""}` — see {@link streamContextItemKey}. */
+  key: string
+  category: ContextCategory
+  refKind: StreamContextRefKind
+  refId: string
+  groupKey: string
+  /** The stream the artifact lives in — a thread of the root under `scope=tree`. */
+  streamId: string
+  sourceMessageId: string | null
+  authorId: string | null
+  /** ISO — the source message's `created_at`. */
+  occurredAt: string
+  /** bigint as string. */
+  sequence: string | null
+  snippet: string
+  /** Occurrences this collapsed row stands for; 1 in the occurrences endpoint. */
+  occurrenceCount: number
+  detail: StreamContextItemDetail
+}
+
+export interface ListStreamContextResponse {
+  items: StreamContextItem[]
+  /** Whole-scope counts; only the first page carries them. */
+  counts: Record<ContextCategory, number> | null
+  nextCursor: string | null
+  /** `client` = sealed stream, the panel derives locally instead. */
+  mode: "index" | "client"
+}
+
+export interface ListStreamContextOccurrencesResponse {
+  items: StreamContextItem[]
+  nextCursor: string | null
+}


### PR DESCRIPTION
Layer 3 of 5. Layers 1 and 2 fill `stream_context_items`; this serves it.

Two endpoints:

- `GET /streams/:streamId/context` — the collapsed feed. Category, free text, author, and date bounds apply **before** the collapse and before the keyset, so a cursor is only ever valid for the filter set that produced it — the filtered-cursor requirement that a one-shot capped search cannot satisfy. Collapse keeps the newest occurrence per `(category, group_key)` and reports how many occurrences it stands for.
- `GET /streams/:streamId/context/occurrences` — every occurrence of one artifact, same ordering, so the panel can expand "shared 4 times" into four separate jumps.

Display data joins live — link previews, attachments, memos, delegated tasks, thread rows — so the index never serves a stale title or delegation status. Access is a single `checkStreamAccess`, after which the query filters on the root that check resolved rather than on raw `stream_members` (INV-62); `scope=tree` (the default) covers a stream and its threads, which is what makes a file shared inside a thread findable from the channel. Sealed streams short-circuit to `mode: "client"` without touching the index.

Also adds the `streamContextIndex` flag (default off, unread until layer 5) and moves the category/ref-kind literals into `packages/types` so client and server share one definition.

Adversarial review found three defects, all fixed here:

- `detail.previewType` was populated from `link_previews.content_type`, while everywhere else in the codebase `previewType` means `preview_type`. A GitHub PR link would have reported `"website"` and rendered as a generic card forever, with no type error — both columns are now selected and typed off their source-of-truth unions.
- The link join went through `message_link_previews`, which caps at 5 previews per message, while the projection indexes every URL. Links 6+ in a roundup would have had no title or favicon and been unmatchable by search, even with a completed preview row sitting in the table. It now joins `link_previews` directly on `normalized_url = group_key`, which the unique index makes single-valued.
- `countsByCategory` inherited the request's `category`, so tapping the Links chip reported 0 for every other category — precisely the chip-count bug this endpoint exists to fix.

Verification: 53 stream-context tests plus the monorepo typecheck, lint, and migration checks. The reviewer additionally loaded the real DDL into a scratch Postgres and executed the generated SQL against seeded rows — collapse, keyset paging, both scopes, date bounds, author filter, and the ILIKE escaping were checked against real results, not just query shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
