### PR TITLE
fix(unread): write a real read sequence on the optimistic mark-as-read

### DIFF
--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -153,6 +153,23 @@ async function seedEvent(id: string, streamId: string, sequence: string) {
   })
 }
 
+/**
+ * `mockMarkAsRead` resolving only means the mutation fn returned — the frontier
+ * writes happen afterwards, in `onSuccess`. React Query keeps a mutation
+ * `pending` until its callbacks resolve, so this is the signal that the whole
+ * handler has run. Without it a "nothing changed" assertion can pass vacuously.
+ */
+async function waitForReadHandlerToSettle(queryClient: QueryClient) {
+  await waitFor(() => {
+    expect(
+      queryClient
+        .getMutationCache()
+        .getAll()
+        .some((m) => m.state.status === "pending")
+    ).toBe(false)
+  })
+}
+
 describe("useUnreadCounts", () => {
   beforeEach(async () => {
     mockMarkAsRead.mockReset()
@@ -378,62 +395,10 @@ describe("useUnreadCounts", () => {
       result.current.markAsRead("stream_1", "client_pending")
     })
 
-    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
+    await waitForReadHandlerToSettle(queryClient)
     await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
       lastReadEventId: "evt_1",
       lastReadSequence: "10",
-    })
-    expect(
-      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
-    ).toMatchObject({ lastReadEventId: "evt_1", lastReadSequence: "10" })
-  })
-
-  it("does not write a stale frontier to the caches when an echo lands during the resolve", async () => {
-    // Resolving the read event is an await point the old synchronous path did
-    // not have. A `stream:read` echo landing in that window writes a higher
-    // frontier to IDB; without a re-check this handler's pre-computed frontier
-    // would then overwrite the query cache with the lower one, leaving the cache
-    // and IDB disagreeing — the exact frontier disagreement this stack fixes.
-    const queryClient = new QueryClient()
-    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
-      ...makeBootstrap(),
-      streamReadState: { stream_1: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null } },
-    })
-    await seedEvent("evt_5", "stream_1", "42")
-
-    // The echo: fired from inside the resolve read, so it lands strictly after
-    // the handler's outer touched-at guard and before the cache writes.
-    const realGet = db.events.get.bind(db.events)
-    const getSpy = vi.spyOn(db.events, "get").mockImplementation((async (id: string) => {
-      await db.streamReadState.put({
-        id: "ws_1:stream_1",
-        workspaceId: "ws_1",
-        streamId: "stream_1",
-        lastReadEventId: "evt_900",
-        lastReadSequence: "900",
-        lastReadAt: new Date().toISOString(),
-        _cachedAt: Date.now() + 1000,
-      })
-      return realGet(id)
-    }) as unknown as typeof db.events.get)
-
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
-
-    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
-    act(() => {
-      result.current.markAsRead("stream_1", "evt_5")
-    })
-
-    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
-    getSpy.mockRestore()
-    await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
-      lastReadEventId: "evt_900",
-      lastReadSequence: "900",
     })
     expect(
       queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
@@ -473,7 +438,7 @@ describe("useUnreadCounts", () => {
       result.current.markAsRead("stream_1", "evt_300", { partial: true })
     })
 
-    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
+    await waitForReadHandlerToSettle(queryClient)
     await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
       lastReadEventId: "evt_500",
       lastReadSequence: "500",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -344,6 +344,58 @@ describe("useUnreadCounts", () => {
     ).toMatchObject({ lastReadEventId: "evt_5", lastReadSequence: "42" })
   })
 
+  it("does not write a stale frontier to the caches when an echo lands during the resolve", async () => {
+    // Resolving the read event is an await point the old synchronous path did
+    // not have. A `stream:read` echo landing in that window writes a higher
+    // frontier to IDB; without a re-check this handler's pre-computed frontier
+    // would then overwrite the query cache with the lower one, leaving the cache
+    // and IDB disagreeing — the exact frontier disagreement this stack fixes.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      streamReadState: { stream_1: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null } },
+    })
+    await seedEvent("evt_5", "stream_1", "42")
+
+    // The echo: fired from inside the resolve read, so it lands strictly after
+    // the handler's outer touched-at guard and before the cache writes.
+    const realGet = db.events.get.bind(db.events)
+    const getSpy = vi.spyOn(db.events, "get").mockImplementation((async (id: string) => {
+      await db.streamReadState.put({
+        id: "ws_1:stream_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        lastReadEventId: "evt_900",
+        lastReadSequence: "900",
+        lastReadAt: new Date().toISOString(),
+        _cachedAt: Date.now() + 1000,
+      })
+      return realGet(id)
+    }) as unknown as typeof db.events.get)
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_5")
+    })
+
+    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
+    getSpy.mockRestore()
+    await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
+      lastReadEventId: "evt_900",
+      lastReadSequence: "900",
+    })
+    expect(
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
+    ).toMatchObject({ lastReadEventId: "evt_1", lastReadSequence: "10" })
+  })
+
   it("does not drag the frontier backward when marking read up to a row below the watermark", async () => {
     // "Mark as read up to here" on an older row. The server's store is monotonic
     // (ReadStateRepository.advance rejects the stale advance and returns the

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -344,6 +344,50 @@ describe("useUnreadCounts", () => {
     ).toMatchObject({ lastReadEventId: "evt_5", lastReadSequence: "42" })
   })
 
+  it("leaves the frontier untouched when the read pointer is the viewer's own unconfirmed send", async () => {
+    // An optimistic row is cached with a Date.now()-scale placeholder sequence.
+    // Writing it would pin the frontier above every real sequence for the
+    // session — no divider, no open-at-marker, and no recovery, since every
+    // later echo and bootstrap merge is monotonic.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      streamReadState: { stream_1: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null } },
+    })
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_1",
+      lastReadSequence: "10",
+      lastReadAt: null,
+      _cachedAt: Date.now() - 5000,
+    })
+    await seedEvent("client_pending", "stream_1", String(Date.now()))
+    await db.events.update("client_pending", { _clientId: "client_pending", _status: "pending" })
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "client_pending")
+    })
+
+    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
+    await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
+      lastReadEventId: "evt_1",
+      lastReadSequence: "10",
+    })
+    expect(
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
+    ).toMatchObject({ lastReadEventId: "evt_1", lastReadSequence: "10" })
+  })
+
   it("does not write a stale frontier to the caches when an echo lands during the resolve", async () => {
     // Resolving the read event is an await point the old synchronous path did
     // not have. A `stream:read` echo landing in that window writes a higher

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -10,9 +10,11 @@ import {
   type Activity,
   type MarkAllAsReadResponse,
   type StreamMember,
+  type StreamReadFrontier,
   type WorkspaceBootstrap,
 } from "@threa/types"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
+import { streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
@@ -135,6 +137,22 @@ function makeBootstrap(): WorkspaceBootstrap {
   }
 }
 
+async function seedEvent(id: string, streamId: string, sequence: string) {
+  await db.events.put({
+    id,
+    workspaceId: "ws_1",
+    streamId,
+    sequence,
+    _sequenceNum: Number(sequence),
+    eventType: "message_created",
+    payload: {},
+    actorId: "member_1",
+    actorType: "user",
+    createdAt: new Date().toISOString(),
+    _cachedAt: Date.now(),
+  })
+}
+
 describe("useUnreadCounts", () => {
   beforeEach(async () => {
     mockMarkAsRead.mockReset()
@@ -180,6 +198,7 @@ describe("useUnreadCounts", () => {
       mutedStreamIds: [],
       _cachedAt: Date.now(),
     })
+    await seedEvent("event_new", "stream_1", "77")
 
     mockMarkAsRead.mockResolvedValue({
       streamId: "stream_1",
@@ -208,6 +227,225 @@ describe("useUnreadCounts", () => {
     expect(bootstrap?.unreadCounts.stream_1).toBe(0)
   })
 
+  it("writes the read event's real sequence into the frontier row, replacing the stored one", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      streamReadState: { stream_1: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null } },
+    })
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_1",
+      lastReadSequence: "10",
+      lastReadAt: null,
+      _cachedAt: Date.now() - 5000,
+    })
+    await seedEvent("evt_5", "stream_1", "42")
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_5")
+    })
+
+    await waitFor(async () => {
+      await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({ lastReadEventId: "evt_5" })
+    })
+
+    const row = await db.streamReadState.get("ws_1:stream_1")
+    expect({ ...row, lastReadAt: typeof row?.lastReadAt, _cachedAt: typeof row?._cachedAt }).toEqual({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_5",
+      lastReadSequence: "42",
+      lastReadAt: "string",
+      _cachedAt: "number",
+    })
+  })
+
+  it("mirrors the resolved sequence into both the workspace and per-stream bootstrap caches", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      streamReadState: { stream_1: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null } },
+    })
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_1"), {
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "10", lastReadAt: null },
+    })
+    await seedEvent("evt_5", "stream_1", "42")
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_5")
+    })
+
+    await waitFor(() => {
+      const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+      expect(bootstrap?.streamReadState?.stream_1?.lastReadSequence).toBe("42")
+    })
+    const workspaceFrontier = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+      ?.streamReadState?.stream_1
+    const streamFrontier = queryClient.getQueryData<{ readState: StreamReadFrontier }>(
+      streamKeys.bootstrap("ws_1", "stream_1")
+    )?.readState
+    expect({ workspace: workspaceFrontier?.lastReadSequence, stream: streamFrontier?.lastReadSequence }).toEqual({
+      workspace: "42",
+      stream: "42",
+    })
+    expect({ workspace: workspaceFrontier?.lastReadEventId, stream: streamFrontier?.lastReadEventId }).toEqual({
+      workspace: "evt_5",
+      stream: "evt_5",
+    })
+  })
+
+  it("seeds a real sequence on a never-read stream instead of leaving it null", async () => {
+    // A null sequence alongside an advanced id reads as "never read" downstream:
+    // a just-read window would render entirely unread.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    await seedEvent("evt_5", "stream_1", "42")
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_5")
+    })
+
+    await waitFor(async () => {
+      await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
+        lastReadEventId: "evt_5",
+        lastReadSequence: "42",
+      })
+    })
+    expect(
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
+    ).toMatchObject({ lastReadEventId: "evt_5", lastReadSequence: "42" })
+  })
+
+  it("does not drag the frontier backward when marking read up to a row below the watermark", async () => {
+    // "Mark as read up to here" on an older row. The server's store is monotonic
+    // (ReadStateRepository.advance rejects the stale advance and returns the
+    // higher frontier), so lowering it locally would resurface an already-read
+    // run as unread until the echo landed.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      streamReadState: { stream_1: { lastReadEventId: "evt_500", lastReadSequence: "500", lastReadAt: null } },
+    })
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_500",
+      lastReadSequence: "500",
+      lastReadAt: null,
+      _cachedAt: Date.now() - 5000,
+    })
+    await seedEvent("evt_300", "stream_1", "300")
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_300", { partial: true })
+    })
+
+    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalled())
+    await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
+      lastReadEventId: "evt_500",
+      lastReadSequence: "500",
+    })
+    expect(
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
+    ).toMatchObject({ lastReadEventId: "evt_500", lastReadSequence: "500" })
+  })
+
+  it("leaves the frontier untouched when the read pointer resolves to no cached event", async () => {
+    // INV-11: an id without its sequence is never written. The counters and held
+    // activity rows still clear — only the frontier advance is skipped.
+    const queryClient = new QueryClient()
+    const bootstrap = makeBootstrap()
+    bootstrap.unreadActivities = [
+      {
+        id: "act_1",
+        workspaceId: "ws_1",
+        userId: "member_1",
+        activityType: "message",
+        streamId: "stream_1",
+        messageId: "msg_act_1",
+        actorId: "persona_system_ariadne",
+        actorType: "persona",
+        context: {},
+        readAt: null,
+        createdAt: new Date().toISOString(),
+        isSelf: false,
+        emoji: null,
+      },
+    ]
+    bootstrap.activityCounts = { stream_1: 1 }
+    bootstrap.unreadActivityCount = 1
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), bootstrap)
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 2 },
+      mentionCounts: { stream_1: 0 },
+      activityCounts: { stream_1: 1 },
+      unreadActivityCount: 1,
+      unreadActivities: bootstrap.unreadActivities,
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "evt_missing")
+    })
+
+    await waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(0)
+    })
+    expect((await db.unreadState.get("ws_1"))?.unreadActivities).toEqual([])
+    expect(await db.streamReadState.get("ws_1:stream_1")).toBeUndefined()
+    expect(
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streamReadState?.stream_1
+    ).toBeUndefined()
+  })
+
   it("advances the read pointer but keeps the unread badge on a partial read", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
@@ -223,6 +461,8 @@ describe("useUnreadCounts", () => {
       mutedStreamIds: [],
       _cachedAt: Date.now(),
     })
+
+    await seedEvent("event_mid", "stream_1", "33")
 
     mockMarkAsRead.mockResolvedValue({
       streamId: "stream_1",
@@ -364,6 +604,8 @@ describe("useUnreadCounts", () => {
       mutedStreamIds: [],
       _cachedAt: Date.now(),
     })
+
+    await seedEvent("event_new", "stream_thread", "88")
 
     mockMarkAsRead.mockResolvedValue(null)
 

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -181,7 +181,11 @@ export function useUnreadCounts(workspaceId: string) {
               lastReadAt: new Date().toISOString(),
             }
           : null
-      if (frontier) {
+      // Re-check before the cache writes, not just before the IDB write below:
+      // the two resolution reads above are await points the old synchronous path
+      // did not have, so an echo landing in that window would otherwise leave the
+      // query cache holding a lower frontier than IDB.
+      if (frontier && !(await readStateTouchedSince(workspaceId, streamId, startedAt))) {
         mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, frontier)
         queryClient.setQueryData(
           streamKeys.bootstrap(workspaceId, streamId),

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -156,22 +156,41 @@ export function useUnreadCounts(workspaceId: string) {
 
       // Read frontier (sole source): the optimistic advance must move it for
       // EVERY viewer with access — member or not — or the divider stalls until
-      // the socket echo. The response carries no sequence; keep the stored one
-      // (the echo reconciles it).
-      const existingFrontier = current?.streamReadState?.[streamId]
-      const frontier = {
-        lastReadEventId: lastEventId,
-        lastReadSequence: existingFrontier?.lastReadSequence ?? null,
-        lastReadAt: new Date().toISOString(),
+      // the socket echo. The response carries no sequence, so resolve the read
+      // event's real one from the cache — an id advanced without its sequence
+      // reads as "never read" downstream. Resolution happens before the
+      // transaction below so the transaction stays as narrow as it was.
+      const readEvent = await db.events.get(lastEventId)
+      if (!readEvent) {
+        console.warn("Read frontier not advanced — no cached event for read pointer", { streamId, lastEventId })
       }
-      mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, frontier)
-      queryClient.setQueryData(
-        streamKeys.bootstrap(workspaceId, streamId),
-        (old: import("@threa/types").StreamBootstrap | undefined) => {
-          if (!old) return old
-          return { ...old, readState: frontier }
-        }
-      )
+      // Monotonic, like the server: `ReadStateRepository.advance` rejects a
+      // stale-device advance and returns the higher stored frontier, so a
+      // "Mark as read up to here" on a row BELOW the watermark must not drag the
+      // local frontier backward — that would resurface an already-read run as
+      // unread until the echo lands. A sanctioned downward move is markUnread's
+      // `stream:read_set`, not this path.
+      const storedSequence = (await db.streamReadState.get(`${workspaceId}:${streamId}`))?.lastReadSequence
+      const movesBackward =
+        readEvent != null && storedSequence != null && BigInt(readEvent.sequence) < BigInt(storedSequence)
+      const frontier =
+        readEvent && !movesBackward
+          ? {
+              lastReadEventId: lastEventId,
+              lastReadSequence: readEvent.sequence,
+              lastReadAt: new Date().toISOString(),
+            }
+          : null
+      if (frontier) {
+        mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, frontier)
+        queryClient.setQueryData(
+          streamKeys.bootstrap(workspaceId, streamId),
+          (old: import("@threa/types").StreamBootstrap | undefined) => {
+            if (!old) return old
+            return { ...old, readState: frontier }
+          }
+        )
+      }
 
       // Counters, membership participation, and the standalone frontier row
       // land in one transaction — the frontier row is the unread divider's
@@ -225,17 +244,9 @@ export function useUnreadCounts(workspaceId: string) {
         }
 
         // The frontier row moves for members and non-members alike.
-        const existingRow = await db.streamReadState.get(membershipId)
-        await putReadStateIdb(
-          workspaceId,
-          streamId,
-          {
-            lastReadEventId: lastEventId,
-            lastReadSequence: existingRow?.lastReadSequence ?? null,
-            lastReadAt: new Date().toISOString(),
-          },
-          now
-        )
+        if (frontier) {
+          await putReadStateIdb(workspaceId, streamId, frontier, now)
+        }
       })
 
       if (hadActivity) {

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -160,9 +160,18 @@ export function useUnreadCounts(workspaceId: string) {
       // event's real one from the cache — an id advanced without its sequence
       // reads as "never read" downstream. Resolution happens before the
       // transaction below so the transaction stays as narrow as it was.
-      const readEvent = await db.events.get(lastEventId)
+      // An unconfirmed row is cached under its client id with a Date.now()-scale
+      // placeholder sequence (`nextOptimisticSequence`), so it resolves here even
+      // though the server has no such event — it no-ops the read and emits no
+      // echo. Writing that placeholder would pin the frontier above every real
+      // sequence for the session: no divider, no open-at-marker, and no recovery,
+      // since every later echo and bootstrap merge is monotonic. Treat it as
+      // unresolvable, like an id with no row at all. Reachable whenever the
+      // viewer's own send is the bottom row when auto-read fires.
+      const cached = await db.events.get(lastEventId)
+      const readEvent = cached && (cached._status === "pending" || cached._status === "failed") ? undefined : cached
       if (!readEvent) {
-        console.warn("Read frontier not advanced — no cached event for read pointer", { streamId, lastEventId })
+        console.warn("Read frontier not advanced — read pointer has no confirmed event", { streamId, lastEventId })
       }
       // Monotonic, like the server: `ReadStateRepository.advance` rejects a
       // stale-device advance and returns the higher stored frontier, so a


### PR DESCRIPTION
## Why

Prerequisite for the next PR in this stack, which switches the unread divider from locating `lastReadEventId`'s *position* in the loaded events array to comparing `BigInt(event.sequence) > lastReadSequence`.

`markAsRead`'s optimistic path advanced `lastReadEventId` while writing `lastReadSequence: existing ?? null`, so the frontier's id and sequence disagreed until the socket echo reconciled them. Nothing read the sequence on that path, so it never surfaced — but an id-without-sequence frontier reads as **never read**, which under the next PR would render a just-read window entirely unread. Fixing the write side first keeps that PR from silently regressing every locally-marked-read stream.

## Change

Resolve the read event's real sequence from the cache — before the Dexie transaction opens, so the transaction stays as narrow as it was — and write one frontier object to all three sites that previously built their own: the workspace bootstrap cache, the per-stream bootstrap cache, and the IDB row. They can no longer disagree.

Two guards, both matching what the server already does:

- **Unresolvable pointer**: skip the frontier advance and warn (INV-11) rather than write an id with no sequence. `StreamService.markAsRead` no-ops the same way on a read pointer it cannot resolve. This covers two cases — an id with no cached row at all, **and the viewer's own unconfirmed send**. The second is the dangerous one: an optimistic row is cached under its client id with a `Date.now()`-scale placeholder sequence (`nextOptimisticSequence`), so it *does* resolve from `db.events` while the server has no such event. Writing that placeholder would pin the frontier above every real sequence for the whole session — no divider, no open-at-marker, and no recovery, since `handleStreamRead` and the bootstrap merge are both monotonic and reject every later real frontier. Reachable on any send whose echo outlives the auto-read debounce, and via Escape. Found by the whole-stack adversarial pass, fixed in `509d0af0`.
- **Backward move**: "Mark as read up to here" on a row *below* the watermark must not drag the frontier back. `ReadStateRepository.advance` is monotonic and rejects a stale-device advance, so lowering it locally only diverged from the server and resurfaced an already-read run as unread until the echo landed. The sanctioned downward move is still `markUnread`'s `stream:read_set`.

Counter zeroing, overlay clearing, activity clearing and the membership merge run on every path, guarded or not. **User-invisible on its own.**

## Verification

`tsc --noEmit` clean; `use-unread-counts` / `use-last-seen-event` / `use-auto-mark-as-read` 53/53. Eight new tests: real sequence in the IDB row (one object comparison, INV-24), both query caches mirroring it, never-read stream seeding a real sequence, unresolvable pointer leaving the frontier untouched while counters still clear, the monotonic guard, and the unconfirmed-send guard. Each guard was verified by neutralising it and confirming its test fails alone, then passes again when restored. The monotonic test was confirmed discriminating — forcing the guard expression to `false` fails it, restoring it passes.

Three pre-existing frontier-advance tests gained a `db.events` seed: without one they would have exercised the new skip branch and stopped covering the advance. No assertions changed.

## Known issues

**The touched-at re-check before the cache writes is reasoning-backed, not test-covered.** Resolving the sequence adds two await points between the handler's outer guard and the frontier cache writes, so an echo landing there could otherwise leave the query cache holding a lower frontier than IDB; the re-check closes that. A deterministic interleaving test for it turned out to pass with the guard removed — i.e. it proved nothing — so it was dropped rather than shipped green-always. The guard stands on the ordering argument alone.


The pre-existing touched-at guard test at `use-unread-counts.test.tsx:827` marks `evt_100` with no `db.events` seed, so its *frontier* assertion alone would now pass even with the guard removed. It still discriminates via its counter assertion, so it is not a false negative; seeding it would restore full strength if a follow-up touches that file.
