### PR TITLE
fix(unread): resolve the unread divider frontier by sequence, not window position

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -535,6 +535,12 @@ describe("resolveUnreadMarkerOpen", () => {
     expect(resolveUnreadMarkerOpen({ ...base, readStateResolved: false })).toBe("wait")
   })
 
+  it("waits rather than skips on an unresolved read position even with a divider latched", () => {
+    // An unresolvable frontier is not "never read": consuming the once-per-stream
+    // decision here is the recurring bug — the stream opens at the tail forever.
+    expect(resolveUnreadMarkerOpen({ ...base, readStateResolved: false, dividerEventId: "event_5" })).toBe("wait")
+  })
+
   it("skips in latest mode — the default open-at-bottom behaviour is untouched", () => {
     expect(resolveUnreadMarkerOpen({ ...base, unreadOpenPosition: "latest" })).toBe("skip")
   })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -44,7 +44,7 @@ import {
   useWorkspaceStreamMemberships,
   useWorkspaceStreamReadStates,
 } from "@/stores/workspace-store"
-import { resolveFrontierEventId } from "@/lib/read-frontier"
+import { resolveFrontierEventId, resolveFrontierSequence } from "@/lib/read-frontier"
 import { useUser } from "@/auth"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
@@ -283,10 +283,10 @@ export function canActOnDeepLinkNavigation<T extends string>(args: {
  * yet", an equivalent read position since suppressed events aren't readable
  * content). A fresh thread member's watermark is seeded on their member_added
  * event by the backend, but threads hide membership events from the rendered
- * window — so consumers that resolve the watermark against `displayEvents`
- * (the read frontier, the unread divider) would see an unresolvable pointer
- * and give up: no divider renders and auto-read never fires, leaving the
- * thread permanently unread (the ghost-unread-thread bug). A watermark outside
+ * window — so the auto-read frontier (`useLastSeenEvent`), which resolves the
+ * watermark's index in `displayEvents`, would see an unresolvable pointer and
+ * give up: auto-read never fires, leaving the thread permanently unread (the
+ * ghost-unread-thread bug). A watermark outside
  * the loaded window entirely is returned as-is: read progress is unknowable
  * there, and the consumers' existing suppression semantics must keep applying.
  */
@@ -636,10 +636,11 @@ export function StreamContent({
   const bootstrapReadState = useMemo(() => {
     const rs = bootstrap?.readState
     if (rs) return rs
-    if (rs === null) return { lastReadEventId: null }
+    if (rs === null) return { lastReadEventId: null, lastReadSequence: null, lastReadAt: null }
     return undefined
   }, [bootstrap?.readState])
   const lastReadEventId = resolveFrontierEventId(idbReadState ?? bootstrapReadState)
+  const frontierSequence = resolveFrontierSequence(idbReadState ?? bootstrapReadState)
 
   const stream = streamFromProps ?? idbStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
@@ -898,8 +899,8 @@ export function StreamContent({
   }, [events, isThread])
 
   // See remapSuppressedWatermark: a fresh thread member's watermark sits on a
-  // membership event that threads hide from the rendered window; the read
-  // frontier and the unread divider need it remapped to a rendered position.
+  // membership event that threads hide from the rendered window; the auto-read
+  // frontier (useLastSeenEvent) needs it remapped to a rendered position.
   const frontierLastReadEventId = useMemo(
     () => (isThread ? remapSuppressedWatermark(lastReadEventId, events, displayEvents) : lastReadEventId),
     [isThread, lastReadEventId, events, displayEvents]
@@ -2010,7 +2011,7 @@ export function StreamContent({
   // the divider via the "N new" jump button or by scrolling up.
   const { dividerEventId, dismiss: dismissUnreadDivider } = useUnreadDivider({
     events: displayEvents,
-    lastReadEventId: frontierLastReadEventId,
+    lastReadSequence: frontierSequence ?? null,
     currentUserId: currentWorkspaceUserId ?? undefined,
     streamId,
     isLoading,
@@ -2020,13 +2021,12 @@ export function StreamContent({
     // scrolls via the virtua-aware scrollToFirstUnread instead of the hook's
     // querySelector path (off-screen rows aren't in the DOM when virtualized).
     scrollToUnread: false,
-    // `lastReadEventId` is `string | null` once resolved; it is only `undefined`
-    // while the read sources (stream row / membership) are still hydrating. Gate
-    // on that so a not-yet-known read position can't be read as "all unread" and
-    // latch a divider on the first message (which would then stick for the
-    // session). `idbStream` alone isn't enough — its denormalized copy can be a
-    // stale null while the authoritative membership value is still loading.
-    readStateResolved: frontierLastReadEventId !== undefined,
+    // `frontierSequence` is `bigint | null` once resolved; it is `undefined`
+    // while the read sources are still hydrating OR when the watermark carries
+    // no sequence. Gate on that so an unknown read position can't be read as
+    // "all unread" and latch a divider on the first message (which would then
+    // stick for the session).
+    readStateResolved: frontierSequence !== undefined,
     // Skip overlay-read events so the divider anchors on the first *effectively*
     // unread row, not one already read from a conversation surface.
     overlayReadIds: readOverlay,
@@ -2043,8 +2043,8 @@ export function StreamContent({
   // once the read pointer has passed it (read through, or "Mark as read") — a
   // pure read-state signal, not a time-based fade.
   const isDividerDimmed = useMemo(
-    () => isDividerReadPast(events, dividerEventId, lastReadEventId),
-    [events, dividerEventId, lastReadEventId]
+    () => isDividerReadPast(events, dividerEventId, frontierSequence ?? null),
+    [events, dividerEventId, frontierSequence]
   )
 
   // Read the last loaded event from a ref so the Escape listener below doesn't
@@ -2215,9 +2215,7 @@ export function StreamContent({
       alreadyDecided: unreadMarkerOpenRef.current.decided,
       isLoading,
       isSettling: useVirtualized && virtualIsInitialSettling,
-      // `lastReadEventId` is only undefined while the read sources are still
-      // hydrating (same gate as readStateResolved on useUnreadDivider above).
-      readStateResolved: lastReadEventId !== undefined,
+      readStateResolved: frontierSequence !== undefined,
       isJumpMode,
       // The per-stream deep-link latch, not the transient ?m= param — a stream
       // entered via deep-link must never marker-scroll, even after ?m= clears.

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2242,7 +2242,7 @@ export function StreamContent({
     isLoading,
     useVirtualized,
     virtualIsInitialSettling,
-    lastReadEventId,
+    frontierSequence,
     isJumpMode,
     skipInitialScroll,
     dividerEventId,

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -15,11 +15,12 @@ function anchorsOf(events: readonly { id: string }[]): Set<string> {
   return new Set(events.map((event) => event.id))
 }
 
-function makeMessageEvent(id: string, actorId: string) {
+/** Sequence is derived from the id's numeric suffix (`event_3` → `"3"`). */
+function makeMessageEvent(id: string, actorId: string, sequence = id.replace(/^\D+/, "")) {
   return {
     id,
     streamId: "stream_1",
-    sequence: id,
+    sequence,
     eventType: "message_created",
     payload: { messageId: `msg_${id}` },
     actorId,
@@ -35,23 +36,23 @@ describe("useUnreadDivider", () => {
     // the session; the divider must wait until readStateResolved flips true.
     const events = [makeMessageEvent("event_1", "other")]
     const { result, rerender } = renderHook(
-      ({ readStateResolved, lastReadEventId }: { readStateResolved: boolean; lastReadEventId: string | null }) =>
+      ({ readStateResolved, lastReadSequence }: { readStateResolved: boolean; lastReadSequence: bigint | null }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved,
         }),
-      { initialProps: { readStateResolved: false, lastReadEventId: null as string | null } }
+      { initialProps: { readStateResolved: false, lastReadSequence: null as bigint | null } }
     )
 
     expect(result.current.firstUnreadEventId).toBeUndefined()
     expect(result.current.dividerEventId).toBeUndefined()
 
     // Read position resolves and the message is already read → still no divider.
-    rerender({ readStateResolved: true, lastReadEventId: "event_1" })
+    rerender({ readStateResolved: true, lastReadSequence: 1n })
     expect(result.current.dividerEventId).toBeUndefined()
   })
 
@@ -59,26 +60,26 @@ describe("useUnreadDivider", () => {
     const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
 
     const { result, rerender } = renderHook(
-      ({ lastReadEventId }: { lastReadEventId: string | null | undefined }) =>
+      ({ lastReadSequence }: { lastReadSequence: bigint | null }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
       {
-        initialProps: { lastReadEventId: null as string | null | undefined },
+        initialProps: { lastReadSequence: null as bigint | null },
       }
     )
 
-    rerender({ lastReadEventId: null })
+    rerender({ lastReadSequence: null })
     expect(result.current.dividerEventId).toBe("event_1")
 
     // Auto-mark-as-read clears the live unread, but the divider stays latched
     // at its position for the rest of the reading session.
-    rerender({ lastReadEventId: "event_2" })
+    rerender({ lastReadSequence: 2n })
     expect(result.current.firstUnreadEventId).toBeUndefined()
     expect(result.current.dividerEventId).toBe("event_1")
   })
@@ -91,16 +92,16 @@ describe("useUnreadDivider", () => {
       makeMessageEvent("event_4", "other"),
     ]
     const { result, rerender } = renderHook(
-      ({ lastReadEventId }: { lastReadEventId: string | null }) =>
+      ({ lastReadSequence }: { lastReadSequence: bigint | null }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
-      { initialProps: { lastReadEventId: "event_3" as string | null } }
+      { initialProps: { lastReadSequence: 3n as bigint | null } }
     )
 
     // Read through event_3 → divider latched at event_4.
@@ -108,7 +109,7 @@ describe("useUnreadDivider", () => {
 
     // Mark event_2 unread → the read pointer moves back to event_1, so the first
     // unread is now event_2. The divider must follow it UP, not stay at event_4.
-    rerender({ lastReadEventId: "event_1" })
+    rerender({ lastReadSequence: 1n })
     expect(result.current.dividerEventId).toBe("event_2")
   })
 
@@ -120,16 +121,16 @@ describe("useUnreadDivider", () => {
       makeMessageEvent("event_4", "other"),
     ]
     const { result, rerender } = renderHook(
-      ({ lastReadEventId }: { lastReadEventId: string | null }) =>
+      ({ lastReadSequence }: { lastReadSequence: bigint | null }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
           readStateResolved: true,
         }),
-      { initialProps: { lastReadEventId: "event_3" as string | null } }
+      { initialProps: { lastReadSequence: 3n as bigint | null } }
     )
 
     expect(result.current.dividerEventId).toBe("event_4")
@@ -138,7 +139,7 @@ describe("useUnreadDivider", () => {
 
     // Marking an earlier message unread re-positions the divider, so the prior
     // dismissal (keyed to event_4) no longer applies.
-    rerender({ lastReadEventId: "event_1" })
+    rerender({ lastReadSequence: 1n })
     expect(result.current.dividerEventId).toBe("event_2")
   })
 
@@ -149,7 +150,7 @@ describe("useUnreadDivider", () => {
       ({ streamId, events }: { streamId: string; events: ReturnType<typeof makeMessageEvent>[] }) =>
         useUnreadDivider({
           events,
-          lastReadEventId: null,
+          lastReadSequence: null,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId,
@@ -169,7 +170,7 @@ describe("useUnreadDivider", () => {
       ({ streamId, events }: { streamId: string; events: ReturnType<typeof makeMessageEvent>[] }) =>
         useUnreadDivider({
           events,
-          lastReadEventId: null,
+          lastReadSequence: null,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId,
@@ -195,15 +196,15 @@ describe("useUnreadDivider", () => {
       ({
         streamId,
         events,
-        lastReadEventId,
+        lastReadSequence,
       }: {
         streamId: string
         events: ReturnType<typeof makeMessageEvent>[]
-        lastReadEventId: string | null
+        lastReadSequence: bigint | null
       }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId,
@@ -213,7 +214,7 @@ describe("useUnreadDivider", () => {
         initialProps: {
           streamId: "stream_1",
           events: [makeMessageEvent("event_1", "other")],
-          lastReadEventId: null as string | null,
+          lastReadSequence: null as bigint | null,
         },
       }
     )
@@ -223,7 +224,7 @@ describe("useUnreadDivider", () => {
     rerender({
       streamId: "stream_2",
       events: [makeMessageEvent("event_9", "other")],
-      lastReadEventId: "event_9",
+      lastReadSequence: 9n,
     })
     expect(result.current.dividerEventId).toBeUndefined()
   })
@@ -244,7 +245,7 @@ describe("useUnreadDivider", () => {
       ({ highlightMessageId, streamId }: { highlightMessageId: string | null; streamId: string }) =>
         useUnreadDivider({
           events,
-          lastReadEventId: null,
+          lastReadSequence: null,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId,
@@ -279,7 +280,7 @@ describe("useUnreadDivider", () => {
     renderHook(() =>
       useUnreadDivider({
         events,
-        lastReadEventId: null,
+        lastReadSequence: null,
         currentUserId: "me",
         anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
@@ -296,7 +297,7 @@ describe("useUnreadDivider", () => {
     const { result } = renderHook(() =>
       useUnreadDivider({
         events,
-        lastReadEventId: null,
+        lastReadSequence: null,
         currentUserId: "me",
         anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
@@ -318,16 +319,16 @@ describe("useUnreadDivider", () => {
     const { result, rerender } = renderHook(
       ({
         events,
-        lastReadEventId,
+        lastReadSequence,
         isAttentive,
       }: {
         events: ReturnType<typeof makeMessageEvent>[]
-        lastReadEventId: string | null
+        lastReadSequence: bigint | null
         isAttentive: boolean
       }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
@@ -337,7 +338,7 @@ describe("useUnreadDivider", () => {
       {
         initialProps: {
           events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
-          lastReadEventId: null as string | null,
+          lastReadSequence: null as bigint | null,
           isAttentive: true,
         },
       }
@@ -347,7 +348,7 @@ describe("useUnreadDivider", () => {
     expect(result.current.dividerEventId).toBe("event_1")
     rerender({
       events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
-      lastReadEventId: "event_2",
+      lastReadSequence: 2n,
       isAttentive: true,
     })
     expect(result.current.dividerEventId).toBe("event_1")
@@ -358,22 +359,18 @@ describe("useUnreadDivider", () => {
       makeMessageEvent("event_2", "other"),
       makeMessageEvent("event_3", "other"),
     ]
-    rerender({ events: withBlurredArrival, lastReadEventId: "event_2", isAttentive: false })
+    rerender({ events: withBlurredArrival, lastReadSequence: 2n, isAttentive: false })
     expect(result.current.dividerEventId).toBe("event_3")
-
-    // isDividerReadPast compares numeric bigint sequences; the helper's
-    // sequence is its id string, so remap for the red→grey assertions.
-    const sequenced = withBlurredArrival.map((e, i) => ({ ...e, sequence: String(i + 1) })) as typeof withBlurredArrival
 
     // Refocus: the divider stays on the away block while it is still unread…
-    rerender({ events: withBlurredArrival, lastReadEventId: "event_2", isAttentive: true })
+    rerender({ events: withBlurredArrival, lastReadSequence: 2n, isAttentive: true })
     expect(result.current.dividerEventId).toBe("event_3")
-    expect(isDividerReadPast(sequenced, "event_3", "event_2")).toBe(false)
+    expect(isDividerReadPast(withBlurredArrival, "event_3", 2n)).toBe(false)
 
     // …and holds position (dimming to grey) once auto-read passes it.
-    rerender({ events: withBlurredArrival, lastReadEventId: "event_3", isAttentive: true })
+    rerender({ events: withBlurredArrival, lastReadSequence: 3n, isAttentive: true })
     expect(result.current.dividerEventId).toBe("event_3")
-    expect(isDividerReadPast(sequenced, "event_3", "event_3")).toBe(true)
+    expect(isDividerReadPast(withBlurredArrival, "event_3", 3n)).toBe(true)
   })
 
   it("does NOT move the divider forward while the viewer is attentive", () => {
@@ -382,14 +379,14 @@ describe("useUnreadDivider", () => {
     const { result, rerender } = renderHook(
       ({
         events,
-        lastReadEventId,
+        lastReadSequence,
       }: {
         events: ReturnType<typeof makeMessageEvent>[]
-        lastReadEventId: string | null
+        lastReadSequence: bigint | null
       }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
@@ -399,18 +396,18 @@ describe("useUnreadDivider", () => {
       {
         initialProps: {
           events: [makeMessageEvent("event_1", "other")],
-          lastReadEventId: null as string | null,
+          lastReadSequence: null as bigint | null,
         },
       }
     )
 
     expect(result.current.dividerEventId).toBe("event_1")
-    rerender({ events: [makeMessageEvent("event_1", "other")], lastReadEventId: "event_1" })
+    rerender({ events: [makeMessageEvent("event_1", "other")], lastReadSequence: 1n })
 
     // A focused live arrival: first unread is now event_2, but the latch holds.
     rerender({
       events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
-      lastReadEventId: "event_1",
+      lastReadSequence: 1n,
     })
     expect(result.current.dividerEventId).toBe("event_1")
   })
@@ -421,7 +418,7 @@ describe("useUnreadDivider", () => {
       ({ events, isAttentive }: { events: ReturnType<typeof makeMessageEvent>[]; isAttentive: boolean }) =>
         useUnreadDivider({
           events,
-          lastReadEventId: "event_1",
+          lastReadSequence: 1n,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
@@ -448,7 +445,7 @@ describe("useUnreadDivider", () => {
       ({ events, isAttentive }: { events: ReturnType<typeof makeMessageEvent>[]; isAttentive: boolean }) =>
         useUnreadDivider({
           events,
-          lastReadEventId: "event_1",
+          lastReadSequence: 1n,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
@@ -468,16 +465,16 @@ describe("useUnreadDivider", () => {
     const { result, rerender } = renderHook(
       ({
         events,
-        lastReadEventId,
+        lastReadSequence,
         isAttentive,
       }: {
         events: ReturnType<typeof makeMessageEvent>[]
-        lastReadEventId: string | null
+        lastReadSequence: bigint | null
         isAttentive: boolean
       }) =>
         useUnreadDivider({
           events,
-          lastReadEventId,
+          lastReadSequence,
           currentUserId: "me",
           anchorableEventIds: anchorsOf(events),
           streamId: "stream_1",
@@ -487,7 +484,7 @@ describe("useUnreadDivider", () => {
       {
         initialProps: {
           events: [makeMessageEvent("event_1", "other")],
-          lastReadEventId: null as string | null,
+          lastReadSequence: null as bigint | null,
           isAttentive: true,
         },
       }
@@ -499,7 +496,7 @@ describe("useUnreadDivider", () => {
 
     rerender({
       events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
-      lastReadEventId: "event_1",
+      lastReadSequence: 1n,
       isAttentive: false,
     })
     expect(result.current.dividerEventId).toBe("event_2")
@@ -517,7 +514,7 @@ describe("useUnreadDivider", () => {
     const { result } = renderHook(() =>
       useUnreadDivider({
         events,
-        lastReadEventId: null,
+        lastReadSequence: null,
         currentUserId: "me",
         anchorableEventIds: new Set(["event_2"]),
         streamId: "stream_1",
@@ -533,7 +530,7 @@ describe("useUnreadDivider", () => {
     const { result } = renderHook(() =>
       useUnreadDivider({
         events,
-        lastReadEventId: null,
+        lastReadSequence: null,
         currentUserId: "me",
         anchorableEventIds: new Set<string>(),
         streamId: "stream_1",
@@ -549,12 +546,114 @@ describe("useUnreadDivider", () => {
     const { result } = renderHook(() =>
       useUnreadDivider({
         events,
-        lastReadEventId: null,
+        lastReadSequence: null,
         currentUserId: "me",
         anchorableEventIds: anchorsOf(events),
         streamId: "stream_1",
         readStateResolved: true,
         overlayReadIds: new Set(["msg_event_1", "msg_event_2"]),
+      })
+    )
+
+    expect(result.current.dividerEventId).toBeUndefined()
+  })
+
+  it("anchors the divider when the frontier sits far below the loaded window", () => {
+    // THE DEFECT: the watermark event (sequence 5) is nowhere in the tail-anchored
+    // window, so the old position lookup returned undefined and no line rendered.
+    const events = [makeMessageEvent("event_a", "other", "100"), makeMessageEvent("event_b", "other", "150")]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadSequence: 5n,
+        currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
+        streamId: "stream_1",
+        readStateResolved: true,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBe("event_a")
+  })
+
+  it("places the divider on the first event past a frontier whose own event is not loaded", () => {
+    const events = [
+      makeMessageEvent("event_a", "other", "100"),
+      makeMessageEvent("event_b", "other", "130"),
+      makeMessageEvent("event_c", "other", "150"),
+    ]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadSequence: 120n,
+        currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
+        streamId: "stream_1",
+        readStateResolved: true,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBe("event_b")
+  })
+
+  it("treats a null frontier as never-read and anchors on the first loaded row", () => {
+    const events = [makeMessageEvent("event_a", "other", "100"), makeMessageEvent("event_b", "other", "150")]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadSequence: null,
+        currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
+        streamId: "stream_1",
+        readStateResolved: true,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBe("event_a")
+  })
+
+  it("never latches or scrolls while the frontier is unresolved", () => {
+    // The input that makes resolveUnreadMarkerOpen return "wait": no divider and
+    // no scroll, so the once-per-stream marker decision stays unconsumed.
+    const events = [makeMessageEvent("event_1", "other")]
+    const enabledCalls: (boolean | undefined)[] = []
+    vi.spyOn(useScrollToElementModule, "useScrollToElement").mockImplementation(((
+      options: { enabled?: boolean } = {}
+    ) => {
+      enabledCalls.push(options.enabled)
+      return undefined
+    }) as unknown as typeof useScrollToElementModule.useScrollToElement)
+
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadSequence: null,
+        currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
+        streamId: "stream_1",
+        readStateResolved: false,
+      })
+    )
+
+    expect(result.current.dividerEventId).toBeUndefined()
+    expect(enabledCalls[enabledCalls.length - 1]).toBe(false)
+  })
+
+  it("does not anchor on the viewer's own pending event with a placeholder sequence", () => {
+    // Optimistic sends carry a Date.now()-scale sequence far above the window
+    // (lib/optimistic-sequence.ts) — own rows are never unread regardless.
+    const events = [
+      makeMessageEvent("event_a", "other", "100"),
+      makeMessageEvent("event_pending", "me", String(Date.now())),
+    ]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadSequence: 100n,
+        currentUserId: "me",
+        anchorableEventIds: anchorsOf(events),
+        streamId: "stream_1",
+        readStateResolved: true,
       })
     )
 
@@ -572,16 +671,22 @@ describe("isDividerReadPast", () => {
 
   it("is red (not read past) while the read pointer sits before the divider", () => {
     // Divider at event_2, pointer at event_1 (unread still at/after the line).
-    expect(isDividerReadPast(events, "event_2", "event_1")).toBe(false)
+    expect(isDividerReadPast(events, "event_2", 1n)).toBe(false)
   })
 
   it("is grey (read past) once the pointer reaches or passes the divider", () => {
-    expect(isDividerReadPast(events, "event_2", "event_2")).toBe(true)
-    expect(isDividerReadPast(events, "event_2", "event_3")).toBe(true)
+    expect(isDividerReadPast(events, "event_2", 2n)).toBe(true)
+    expect(isDividerReadPast(events, "event_2", 3n)).toBe(true)
+  })
+
+  it("is grey when the frontier is past the divider but the watermark event is not loaded", () => {
+    // The second half of the defect: an out-of-window watermark used to pin the
+    // line red forever, since the pointer row could not be found in `events`.
+    expect(isDividerReadPast(events, "event_2", 999n)).toBe(true)
   })
 
   it("is red when nothing is read yet (null pointer) or the divider is hidden", () => {
     expect(isDividerReadPast(events, "event_2", null)).toBe(false)
-    expect(isDividerReadPast(events, undefined, "event_3")).toBe(false)
+    expect(isDividerReadPast(events, undefined, 3n)).toBe(false)
   })
 })

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -4,7 +4,8 @@ import { useScrollToElement } from "./use-scroll-to-element"
 
 interface UseUnreadDividerOptions {
   events: StreamEvent[]
-  lastReadEventId: string | null | undefined
+  /** The read frontier as a per-stream sequence; `null` = explicit never-read. */
+  lastReadSequence: bigint | null
   currentUserId: string | undefined
   streamId: string
   /** Whether to scroll to first unread on initial load */
@@ -15,7 +16,7 @@ interface UseUnreadDividerOptions {
   isLoading?: boolean
   /**
    * Whether the viewer's read position is known yet. While false (membership /
-   * stream row still hydrating) `lastReadEventId` is not authoritative, so we
+   * stream row still hydrating) `lastReadSequence` is not authoritative, so we
    * must not treat the first message as unread — doing so would latch a divider
    * that then sticks for the session (the divider persists; there is no
    * clear-on-read to undo a bad guess). Defaults to false: a caller must
@@ -68,17 +69,19 @@ interface UseUnreadDividerResult {
  * pointer reaches or passes its position (the viewer read through it, or marked
  * it read). The divider renders red while this is false (unread still sits at or
  * after the line) and muted-gray once true — a pure read-state signal, no timer.
+ * The divider row is located in `events` (a rendered anchor by construction);
+ * the pointer side is a sequence compare, so a frontier outside the loaded
+ * window no longer pins the line red forever.
  */
 export function isDividerReadPast(
   events: StreamEvent[],
   dividerEventId: string | undefined,
-  lastReadEventId: string | null | undefined
+  lastReadSequence: bigint | null
 ): boolean {
-  if (!dividerEventId || lastReadEventId == null) return false
+  if (!dividerEventId || lastReadSequence === null) return false
   const divider = events.find((e) => e.id === dividerEventId)
-  const pointer = events.find((e) => e.id === lastReadEventId)
-  if (!divider || !pointer) return false
-  return BigInt(pointer.sequence) >= BigInt(divider.sequence)
+  if (!divider) return false
+  return lastReadSequence >= BigInt(divider.sequence)
 }
 
 /**
@@ -93,7 +96,7 @@ export function isDividerReadPast(
  */
 export function useUnreadDivider({
   events,
-  lastReadEventId,
+  lastReadSequence,
   currentUserId,
   streamId,
   scrollToUnread = true,
@@ -107,27 +110,22 @@ export function useUnreadDivider({
   const firstUnreadEventId = useMemo(() => {
     if (events.length === 0 || !readStateResolved) return undefined
 
-    const startIndex = lastReadEventId ? events.findIndex((e) => e.id === lastReadEventId) + 1 : 0
-
-    if (startIndex <= 0 && lastReadEventId) {
-      // lastReadEventId not found in events - can't determine first unread
-      return undefined
-    }
-
-    // Find the first *effectively* unread visible event from another user after
-    // the last read position. Skip events that render no row of their own and
-    // rows already in the overlay (individually read from a conversation
-    // surface).
-    for (let i = startIndex; i < events.length; i++) {
+    // Find the first *effectively* unread visible event from another user past
+    // the read frontier. Compared by sequence, not by the watermark event's
+    // position, so a frontier outside the loaded window still resolves. Skip
+    // events that render no row of their own and rows already in the overlay
+    // (individually read from a conversation surface).
+    for (let i = 0; i < events.length; i++) {
       const event = events[i]
       if (event.actorId === currentUserId || !anchorableEventIds.has(event.id)) continue
+      if (lastReadSequence !== null && BigInt(event.sequence) <= lastReadSequence) continue
       const messageId = (event.payload as { messageId?: string } | null)?.messageId
       if (messageId && overlayReadIds?.has(messageId)) continue
       return event.id
     }
 
     return undefined
-  }, [events, lastReadEventId, currentUserId, readStateResolved, overlayReadIds, anchorableEventIds])
+  }, [events, lastReadSequence, currentUserId, readStateResolved, overlayReadIds, anchorableEventIds])
 
   // Latch the first unread position for this stream and hold it for the whole
   // reading session. Done in render (not an effect) so it's immune to effect

--- a/apps/frontend/src/lib/read-frontier.test.ts
+++ b/apps/frontend/src/lib/read-frontier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { resolveFrontierEventId } from "./read-frontier"
+import { resolveFrontierEventId, resolveFrontierSequence } from "./read-frontier"
 
 describe("resolveFrontierEventId", () => {
   it("a present row with a watermark resolves to it", () => {
@@ -12,5 +12,23 @@ describe("resolveFrontierEventId", () => {
 
   it("stays undefined (hydrating) while the row is absent", () => {
     expect(resolveFrontierEventId(undefined)).toBeUndefined()
+  })
+})
+
+describe("resolveFrontierSequence", () => {
+  it("stays undefined (hydrating) while the row is absent", () => {
+    expect(resolveFrontierSequence(undefined)).toBeUndefined()
+  })
+
+  it("a present never-read row resolves to null", () => {
+    expect(resolveFrontierSequence({ lastReadEventId: null, lastReadSequence: null })).toBeNull()
+  })
+
+  it("a present row with a sequence resolves to it", () => {
+    expect(resolveFrontierSequence({ lastReadEventId: "evt_rs", lastReadSequence: "7" })).toBe(7n)
+  })
+
+  it("a watermark with no sequence is unresolvable, never guessed as never-read", () => {
+    expect(resolveFrontierSequence({ lastReadEventId: "evt_rs", lastReadSequence: null })).toBeUndefined()
   })
 })

--- a/apps/frontend/src/lib/read-frontier.ts
+++ b/apps/frontend/src/lib/read-frontier.ts
@@ -10,3 +10,18 @@ export function resolveFrontierEventId(
 ): string | null | undefined {
   return readState?.lastReadEventId
 }
+
+/**
+ * The frontier as a per-stream sequence, for consumers that must compare a read
+ * position against events that may not be loaded (the unread divider). `null` is
+ * the explicit never-read frontier; `undefined` means unresolvable — an absent
+ * row (hydrating) or a watermark id whose sequence is missing (a legacy row).
+ * An unresolvable frontier is never guessed as never-read: consumers must wait.
+ */
+export function resolveFrontierSequence(
+  readState: { lastReadEventId: string | null; lastReadSequence: string | null } | undefined
+): bigint | null | undefined {
+  if (!readState) return undefined
+  if (readState.lastReadSequence !== null) return BigInt(readState.lastReadSequence)
+  return readState.lastReadEventId === null ? null : undefined
+}


### PR DESCRIPTION
## Why

Third and last cause of "Settings → Opening unread streams → **At the first unread message**" not working reliably (first two: #1577, #1578). This is the one that matches the report that it fails more often on streams not visited in the session.

`useUnreadDivider` found the first unread by locating `lastReadEventId`'s **position** in the loaded events array, and returned `undefined` when the id was not in it. The per-stream bootstrap window is tail-anchored at 50 events and is never anchored on the read frontier, so a viewer more than ~50 events behind — or whose watermark event was deleted, moved, or is hidden in this view — got no divider at all. `resolveUnreadMarkerOpen` then returned `"skip"`, consumed the once-per-stream decision, and the stream opened at the tail with no "New" line.

`isDividerReadPast` had the same weakness on the pointer side: with the watermark out of window it returned `false` forever, so the line would also have stayed red.

## Change

`resolveFrontierSequence` resolves the frontier to a `bigint`, keeping three states distinct:

| state | value | meaning |
| --- | --- | --- |
| present row, null watermark | `null` | explicit never-read |
| present row, sequence set | `bigint` | resolved |
| absent row, **or** id set with a null sequence (legacy) | `undefined` | unresolvable |

Unresolvable feeds `readStateResolved: false`, so the marker-open decision returns `"wait"` and stays **unconsumed** — never a guessed frontier. That is the binding rule this whole stack is built around: all three causes were the decision consuming itself on a path that could not act.

The scan then compares `BigInt(event.sequence)` against the frontier. When the frontier sits below the whole loaded window, every loaded event is genuinely unread, so the divider lands on the first rendered row and existing scroll-up pagination converges it. **No fetching is added** — no window widening, no anchor chasing, no backend change.

`remapSuppressedWatermark` is **retained**. The divider no longer consumes it, but `useLastSeenEvent` still resolves the auto-read pointer by index, and a thread member's watermark sits on a `member_added` event that threads strip from the rendered window — deleting it would resurrect the ghost-unread-thread bug. Only its comments change.

## Verification

`tsc --noEmit` clean; **full frontend suite 5073/5073**. 18 enumerated tests: the defect itself (frontier far below the window now yields a divider), a frontier inside the range whose event is not loaded, explicit never-read, unresolvable-never-latches, the viewer's own pending event with a `Date.now()`-scale optimistic sequence not anchoring, `isDividerReadPast` grey with an out-of-window watermark, and the `resolveUnreadMarkerOpen` "wait"-not-"skip" case at the exact input this PR changes. Every pre-existing divider test was retargeted to bigint frontiers with its assertion intent intact.

## Known issues

**Thread display order can disagree with sequence order.** `displayEvents` re-sorts threads by `createdAt`, and the move statements in `StreamEventRepository` rewrite `stream_id`/`sequence` but not `created_at` — so a message moved into a thread carries an old `createdAt` with a new high sequence. With a frontier falling between an inverted pair, an already-read row can render below the "New" line.

Not fixed here, deliberately: once display order and read order disagree, *some* read row renders below the line whatever the divider anchors on — it is a property of sorting threads by `createdAt` while read state is sequence-based, not of the anchor rule. The new behaviour is also better than the old one in that case, which placed the line after the moved row's array index and rendered a genuinely unread row above it, looking read.

**Legacy IDB rows** (id set, sequence null) resolve to `undefined` → `"wait"` → open at the tail with the decision unconsumed, until the next bootstrap or socket echo rewrites the row. Both happen on every stream open, so it self-heals, and the visible outcome until then is what ships today.

## Deferred from the plan

Chasing the true first unread outside the loaded window by fetching around the watermark. The existing load-around machinery sets `isJumpMode`, which both makes `resolveUnreadMarkerOpen` return `"skip"` and disables auto-read (`autoMarkEnabled` gates on `!isJumpMode`) — trading a missing line for a stuck badge. Full reasoning in the plan.
