### PR TITLE
feat(stream-context): make the panel's data offline-first on the sync engine

### DIFF
--- a/apps/backend/src/features/link-previews/url-utils.ts
+++ b/apps/backend/src/features/link-previews/url-utils.ts
@@ -1,5 +1,11 @@
 import { collectLinkUrls } from "@threa/prosemirror"
-import type { JSONContent, LinkPreviewContentType } from "@threa/types"
+import {
+  BLOCKED_HOSTNAMES,
+  BLOCKED_IP_PATTERNS,
+  TRACKING_PARAMS,
+  type JSONContent,
+  type LinkPreviewContentType,
+} from "@threa/types"
 
 /**
  * A parsed reference to an in-app resource linked from a message.
@@ -127,39 +133,6 @@ export function parseInAppLink(url: string, appOrigins: string[]): InAppLinkRef 
   }
 }
 
-/** Tracking parameters to strip during normalization */
-const TRACKING_PARAMS = new Set([
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_term",
-  "utm_content",
-  "fbclid",
-  "gclid",
-  "ref",
-  "source",
-])
-
-/**
- * Private/reserved IP ranges that must not be fetched (SSRF protection).
- * Includes loopback, link-local, private networks, and cloud metadata endpoints.
- */
-const BLOCKED_IP_PATTERNS = [
-  /^127\./, // loopback
-  /^10\./, // private class A
-  /^172\.(1[6-9]|2\d|3[01])\./, // private class B
-  /^192\.168\./, // private class C
-  /^169\.254\./, // link-local
-  /^0\./, // current network
-  /^\[?::1\]?$/, // IPv6 loopback
-  /^\[?fe80:/i, // IPv6 link-local
-  /^\[?fc00:/i, // IPv6 unique local
-  /^\[?fd/i, // IPv6 unique local
-]
-
-/** Hostnames that must not be fetched (cloud metadata endpoints) */
-const BLOCKED_HOSTNAMES = new Set(["metadata.google.internal", "metadata.google.com"])
-
 /**
  * Check if a URL targets a private/internal address (SSRF protection).
  * Returns true if the URL should be blocked.
@@ -170,7 +143,6 @@ export function isBlockedUrl(url: string): boolean {
     const hostname = parsed.hostname.toLowerCase()
 
     if (BLOCKED_HOSTNAMES.has(hostname)) return true
-    if (hostname === "localhost") return true
 
     for (const pattern of BLOCKED_IP_PATTERNS) {
       if (pattern.test(hostname)) return true

--- a/apps/backend/src/features/stream-context/types.ts
+++ b/apps/backend/src/features/stream-context/types.ts
@@ -1,14 +1,6 @@
 import type { ContextCategory, StreamContextRefKind } from "@threa/types"
 
-/**
- * Categories a message body owns, i.e. exactly what `contextRowsForMessage`
- * rebuilds. An edit refresh must not touch the other categories — memo and
- * thread landmarks are anchored on a message but written by other paths and
- * nothing re-creates them.
- */
-export const MESSAGE_BODY_CONTEXT_CATEGORIES = ["link", "media", "file"] as const
-
-export { CONTEXT_CATEGORIES, STREAM_CONTEXT_REF_KINDS } from "@threa/types"
+export { CONTEXT_CATEGORIES, MESSAGE_BODY_CONTEXT_CATEGORIES, STREAM_CONTEXT_REF_KINDS } from "@threa/types"
 export type { ContextCategory, StreamContextRefKind } from "@threa/types"
 
 export interface NewStreamContextItem {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1502,7 +1502,7 @@ export class ThreaDatabase extends Dexie {
     // and converges from the sync appliers and the read endpoint.
     this.version(45).stores({
       streamContextItems:
-        "key, workspaceId, streamId, rootStreamId, [rootStreamId+occurredAt], [streamId+occurredAt], [groupRef+occurredAt]",
+        "key, workspaceId, streamId, rootStreamId, [workspaceId+sourceMessageId], [rootStreamId+occurredAt], [streamId+occurredAt], [groupRef+occurredAt]",
     })
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -13,6 +13,7 @@ import type {
   SidebarConfig,
   Slot,
   StreamContextBagPayload,
+  StreamContextItem,
   StreamPurpose,
   StreamType,
   ThreaDocument,
@@ -966,6 +967,33 @@ export interface CachedBoardMutedStream {
   _cachedAt: number
 }
 /**
+ * One "In this stream" context row — the client's copy of a
+ * `stream_context_items` projection row (link, media, file, memo, delegation,
+ * thread), and the panel's read authority once C5 cuts it over.
+ *
+ * Keyed by the wire `key` (`${category}:${refId}:${sourceMessageId}` — see
+ * `streamContextItemKey`), never the server's ULID: the same key is derivable
+ * locally from a timeline event, so a locally-derived row and the server row it
+ * anticipates collapse to one row on `bulkPut` instead of double-rendering.
+ *
+ * `groupRef` is the compound-index carrier for occurrence lookups
+ * (`${category}:${groupKey}`). `groupKey` is server-computed (the GitHub/Linear-
+ * aware URL normalizer stays backend-only), so a locally-derived row leaves it
+ * equal to `refId` and groups by the raw href until the server row overwrites
+ * it under the same `key`.
+ */
+export interface CachedStreamContextItem extends StreamContextItem {
+  workspaceId: string
+  /** The stream's effective root — the scope the tree feed reads. */
+  rootStreamId: string
+  /** `${category}:${groupKey}`, indexed with `occurredAt` for occurrences. */
+  groupRef: string
+  _cachedAt: number
+  /** Locally derived, not yet reconciled against a server row. */
+  _status?: "pending"
+}
+
+/**
  * One hydrated slot value persisted for offline/cold-start pointer rendering
  * (Amendment A). Slots live here — NOT in the TanStack bootstrap cache: the
  * sync layer is the single write boundary, and render reads canonical rows via
@@ -1014,6 +1042,7 @@ export class ThreaDatabase extends Dexie {
   boardMutedStreams!: EntityTable<CachedBoardMutedStream, "id">
   uploadJobs!: EntityTable<CachedUploadJob, "attachmentId">
   slots!: Table<CachedSlot, [string, string]>
+  streamContextItems!: EntityTable<CachedStreamContextItem, "key">
 
   constructor(name: string) {
     super(name)
@@ -1463,6 +1492,19 @@ export class ThreaDatabase extends Dexie {
     // as-is — readers ignore the stale properties (Dexie can't drop them).
     this.version(44).stores({})
 
+    // v45: "In this stream" context rows get their own store so the panel reads
+    // from IDB like the timeline does, instead of re-deriving the whole view
+    // from the loaded event window. Primary key is the wire `key` so a locally
+    // derived row and its server counterpart reconcile in place. The three
+    // compound indexes are the three reads: the tree feed, the single-stream
+    // feed, and a group's occurrences — all ordered by `occurredAt` (ISO
+    // timestamps sort lexically, so no numeric mirror is needed). Starts empty
+    // and converges from the sync appliers and the read endpoint.
+    this.version(45).stores({
+      streamContextItems:
+        "key, workspaceId, streamId, rootStreamId, [rootStreamId+occurredAt], [streamId+occurredAt], [groupRef+occurredAt]",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -1541,6 +1583,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.labelAssignments.clear(),
       db.sidebarConfigs.clear(),
       db.conversations.clear(),
+      db.streamContextItems.clear(),
       db.slots.clear(),
       // The persisted device key seals this identity's private key for
       // auto-resume — sign-out must drop it so the next account can't resume

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -38,5 +38,6 @@ export type {
   CachedBoardPost,
   CachedUploadJob,
   CachedSlot,
+  CachedStreamContextItem,
 } from "./database"
 export type { EventType } from "@threa/types"

--- a/apps/frontend/src/lib/stream-context/rows.test.ts
+++ b/apps/frontend/src/lib/stream-context/rows.test.ts
@@ -201,10 +201,19 @@ describe("contextItemsFromEvent", () => {
               memoId: "memo_1",
               title: "Decision",
               knowledgeType: "decision",
-              sourceMessageIds: ["msg_9", "msg_10", "msg_11"],
+              sourceMessageIds: ["msg_10", "msg_11"],
             },
             // No resolvable source — the server skips it, so must we.
             { memoId: "memo_2", title: "Fact", knowledgeType: "fact", sourceMessageIds: [] },
+            // PARTIALLY resolvable: the server resolves sources workspace-wide,
+            // this sees only a window, so anchoring on the resolvable subset
+            // would key the row differently and never reconcile. Skip it.
+            {
+              memoId: "memo_3",
+              title: "Partial",
+              knowledgeType: "context",
+              sourceMessageIds: ["msg_9", "msg_10"],
+            },
           ],
         },
       },

--- a/apps/frontend/src/lib/stream-context/rows.test.ts
+++ b/apps/frontend/src/lib/stream-context/rows.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest"
+import type { AttachmentSummary, JSONContent } from "@threa/types"
+import type { CachedEvent } from "@/db"
+import { contextItemsFromEvent } from "./rows"
+
+const CTX = { workspaceId: "ws_1", streamId: "stream_thread", rootStreamId: "stream_root" }
+
+function attachment(overrides: Partial<AttachmentSummary> & { id: string; mimeType: string }): AttachmentSummary {
+  return { filename: "f", sizeBytes: 10, ...overrides }
+}
+
+function messageEvent(payload: Record<string, unknown>, createdAt = "2026-07-01T10:00:00.000Z"): CachedEvent {
+  return {
+    id: "event_1",
+    workspaceId: "ws_1",
+    streamId: "stream_thread",
+    sequence: "42",
+    _sequenceNum: 42,
+    eventType: "message_created",
+    payload,
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt,
+    _cachedAt: 0,
+  }
+}
+
+function doc(...content: JSONContent[]): JSONContent {
+  return { type: "doc", content: [{ type: "paragraph", content }] }
+}
+
+describe("contextItemsFromEvent", () => {
+  it("emits one row per artifact with the message's own timestamp and identity keys", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "# Heading\nlook at [this](https://example.com/a)",
+        contentJson: doc({
+          type: "text",
+          text: "this",
+          marks: [{ type: "link", attrs: { href: "https://example.com/a" } }],
+        }),
+        attachments: [
+          attachment({ id: "att_img", mimeType: "image/png" }),
+          attachment({ id: "att_file", mimeType: "application/pdf" }),
+        ],
+      }),
+      CTX
+    )
+
+    expect(rows.map((r) => r.key)).toEqual([
+      "link:https://example.com/a:msg_1",
+      "media:att_img:msg_1",
+      "file:att_file:msg_1",
+    ])
+    expect(rows.map((r) => [r.category, r.refKind, r.refId])).toEqual([
+      ["link", "url", "https://example.com/a"],
+      ["media", "attachment", "att_img"],
+      ["file", "attachment", "att_file"],
+    ])
+    expect(rows.every((r) => r.occurredAt === "2026-07-01T10:00:00.000Z")).toBe(true)
+    expect(rows.every((r) => r.streamId === "stream_thread" && r.rootStreamId === "stream_root")).toBe(true)
+    expect(rows.every((r) => r.sourceMessageId === "msg_1" && r.authorId === "usr_1")).toBe(true)
+    // Snippet is the stripped first line (INV-60), not the raw markdown.
+    expect(rows[0].snippet).toBe("Heading")
+  })
+
+  it("leaves groupKey equal to refId — the collapse key is server-computed", () => {
+    const [row] = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "x",
+        contentJson: doc({
+          type: "text",
+          text: "x",
+          // A trailing slash + fragment the server's normalizer would strip.
+          marks: [{ type: "link", attrs: { href: "https://Example.com/a/#frag" } }],
+        }),
+      }),
+      CTX
+    )
+    expect(row.refId).toBe("https://Example.com/a/#frag")
+    expect(row.groupKey).toBe("https://Example.com/a/#frag")
+    expect(row.groupRef).toBe("link:https://Example.com/a/#frag")
+  })
+
+  it("splits media/file and mediaKind the way the server does", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        attachments: [
+          attachment({ id: "a_gif", mimeType: "image/gif" }),
+          attachment({ id: "a_gif_param", mimeType: "image/gif; charset=binary" }),
+          attachment({ id: "a_png", mimeType: "image/png" }),
+          attachment({ id: "a_mp4", mimeType: "video/mp4" }),
+          attachment({ id: "a_zip", mimeType: "application/zip" }),
+        ],
+      }),
+      CTX
+    )
+    expect(rows.map((r) => [r.refId, r.category, (r.detail as { mediaKind: string | null }).mediaKind])).toEqual([
+      ["a_gif", "media", "gif"],
+      // Parameterised mime is NOT a gif — equality, matching extract.ts.
+      ["a_gif_param", "media", "image"],
+      ["a_png", "media", "image"],
+      ["a_mp4", "media", "video"],
+      ["a_zip", "file", null],
+    ])
+  })
+
+  it("emits a media row per inline Giphy embed", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "giphyEmbed",
+              attrs: { giphyUrl: "https://media.giphy.com/x.gif", title: "cat", width: 200, height: 100 },
+            },
+          ],
+        },
+      }),
+      CTX
+    )
+    expect(rows.map((r) => r.key)).toEqual(["media:https://media.giphy.com/x.gif:msg_1"])
+    expect(rows[0].refKind).toBe("giphy")
+    expect(rows[0].detail).toMatchObject({
+      mediaKind: "gif",
+      giphyUrl: "https://media.giphy.com/x.gif",
+      giphyTitle: "cat",
+      attachmentId: null,
+    })
+  })
+
+  it("dedupes repeated refs within one message", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: doc(
+          { type: "text", text: "a", marks: [{ type: "link", attrs: { href: "https://example.com/a" } }] },
+          { type: "text", text: " " },
+          { type: "text", text: "b", marks: [{ type: "link", attrs: { href: "https://example.com/a" } }] }
+        ),
+      }),
+      CTX
+    )
+    expect(rows).toHaveLength(1)
+  })
+
+  it("skips non-http hrefs and over-long urls the server never projects", () => {
+    const long = `https://example.com/${"x".repeat(2100)}`
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: doc(
+          { type: "text", text: "a", marks: [{ type: "link", attrs: { href: "mailto:a@b.com" } }] },
+          { type: "text", text: "b", marks: [{ type: "link", attrs: { href: long } }] }
+        ),
+      }),
+      CTX
+    )
+    expect(rows).toEqual([])
+  })
+
+  it("anchors memo rows on the first surviving source and the latest source's timestamp", () => {
+    // msg_9 is cited first but deleted (absent from the window); msg_10 and
+    // msg_11 survive, msg_11 being the later of the two.
+    const sources = new Map<string, CachedEvent>([
+      [
+        "msg_10",
+        {
+          ...messageEvent({ messageId: "msg_10" }, "2026-06-01T09:00:00.000Z"),
+          id: "e10",
+          actorId: "usr_2",
+          sequence: "50",
+        },
+      ],
+      [
+        "msg_11",
+        {
+          ...messageEvent({ messageId: "msg_11" }, "2026-06-01T09:30:00.000Z"),
+          id: "e11",
+          actorId: "usr_3",
+          sequence: "51",
+        },
+      ],
+    ])
+    const rows = contextItemsFromEvent(
+      {
+        ...messageEvent({}, "2026-07-01T10:00:00.000Z"),
+        eventType: "memos:captured",
+        payload: {
+          memos: [
+            {
+              memoId: "memo_1",
+              title: "Decision",
+              knowledgeType: "decision",
+              sourceMessageIds: ["msg_9", "msg_10", "msg_11"],
+            },
+            // No resolvable source — the server skips it, so must we.
+            { memoId: "memo_2", title: "Fact", knowledgeType: "fact", sourceMessageIds: [] },
+          ],
+        },
+      },
+      CTX,
+      sources
+    )
+    expect(rows.map((r) => [r.key, r.sourceMessageId, r.occurredAt, r.authorId, r.sequence])).toEqual([
+      ["memo:memo_1:msg_10", "msg_10", "2026-06-01T09:30:00.000Z", "usr_3", "51"],
+    ])
+    expect(rows[0].detail).toEqual({ title: "Decision", knowledgeType: "decision" })
+    expect(rows[0].snippet).toBe("Decision")
+  })
+
+  it("collapses hrefs the server dedupes into one row (fragment / tracking params)", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: doc(
+          { type: "text", text: "a", marks: [{ type: "link", attrs: { href: "https://docs.example.com/guide" } }] },
+          {
+            type: "text",
+            text: "b",
+            marks: [{ type: "link", attrs: { href: "https://docs.example.com/guide#install" } }],
+          },
+          {
+            type: "text",
+            text: "c",
+            marks: [{ type: "link", attrs: { href: "https://docs.example.com/guide?utm_source=x" } }],
+          },
+          { type: "text", text: "d", marks: [{ type: "link", attrs: { href: "https://DOCS.example.com/guide/" } }] }
+        ),
+      }),
+      CTX
+    )
+    // One row, keyed on the FIRST raw href — the same one the server projects.
+    expect(rows.map((r) => r.key)).toEqual(["link:https://docs.example.com/guide:msg_1"])
+  })
+
+  it("ignores events that carry no context artifacts", () => {
+    expect(contextItemsFromEvent({ ...messageEvent({}), eventType: "thread_created" }, CTX)).toEqual([])
+    // A message event without a messageId can't be keyed.
+    expect(contextItemsFromEvent(messageEvent({ contentMarkdown: "hi" }), CTX)).toEqual([])
+  })
+
+  /**
+   * Parity seam: these are the exact keys `contextRowsForMessage`
+   * (apps/backend/src/features/stream-context/extract.ts) produces for the same
+   * message. Pinned as literals — the frontend test setup can't import backend
+   * code, and the whole reconcile collapses if the two spellings drift.
+   */
+  it("produces the same keys the backend projection writes for the same message", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_parity",
+        contentMarkdown: "see [docs](https://example.com/docs)",
+        contentJson: doc({
+          type: "text",
+          text: "docs",
+          marks: [{ type: "link", attrs: { href: "https://example.com/docs" } }],
+        }),
+        attachments: [
+          attachment({ id: "att_1", mimeType: "image/gif" }),
+          attachment({ id: "att_2", mimeType: "text/csv" }),
+        ],
+      }),
+      CTX
+    )
+    expect(new Set(rows.map((r) => r.key))).toEqual(
+      new Set(["link:https://example.com/docs:msg_parity", "media:att_1:msg_parity", "file:att_2:msg_parity"])
+    )
+  })
+})

--- a/apps/frontend/src/lib/stream-context/rows.test.ts
+++ b/apps/frontend/src/lib/stream-context/rows.test.ts
@@ -168,6 +168,45 @@ describe("contextItemsFromEvent", () => {
     expect(rows).toEqual([])
   })
 
+  it("blocks the same hosts the server's isBlockedUrl blocks (shared lists)", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: doc(
+          { type: "text", text: "a", marks: [{ type: "link", attrs: { href: "http://0.10.0.1/x" } }] },
+          { type: "text", text: "b", marks: [{ type: "link", attrs: { href: "http://[fd00::1]/x" } }] },
+          {
+            type: "text",
+            text: "c",
+            marks: [{ type: "link", attrs: { href: "https://metadata.google.internal/x" } }],
+          }
+        ),
+      }),
+      CTX
+    )
+    expect(rows).toEqual([])
+  })
+
+  it("collapses a ?ref= duplicate the way the server's TRACKING_PARAMS do", () => {
+    const rows = contextItemsFromEvent(
+      messageEvent({
+        messageId: "msg_1",
+        contentMarkdown: "",
+        contentJson: doc(
+          { type: "text", text: "a", marks: [{ type: "link", attrs: { href: "https://example.com/post" } }] },
+          {
+            type: "text",
+            text: "b",
+            marks: [{ type: "link", attrs: { href: "https://example.com/post?ref=threa" } }],
+          }
+        ),
+      }),
+      CTX
+    )
+    expect(rows.map((r) => r.key)).toEqual(["link:https://example.com/post:msg_1"])
+  })
+
   it("anchors memo rows on the first surviving source and the latest source's timestamp", () => {
     // msg_9 is cited first but deleted (absent from the window); msg_10 and
     // msg_11 survive, msg_11 being the later of the two.

--- a/apps/frontend/src/lib/stream-context/rows.ts
+++ b/apps/frontend/src/lib/stream-context/rows.ts
@@ -113,6 +113,10 @@ export function contextItemsFromEvent(
     for (const url of collectLinkUrls(contentJson)) {
       if (url.length > MAX_URL_LENGTH) continue
       if (!/^https?:\/\//i.test(url)) continue
+      // The server drops non-public hosts (`isBlockedUrl` inside
+      // `filterAndDeduplicateUrls`), so projecting one here would leave a local
+      // row no server page can ever reconcile.
+      if (isLocalBlockedHost(url)) continue
       // The server emits only the FIRST raw href of each normalized group
       // (`filterAndDeduplicateUrls`), so two hrefs differing only by fragment or
       // tracking params yield ONE server row. Dedupe the same way or the extra
@@ -197,7 +201,11 @@ function memoRows(
     const resolved = memo.sourceMessageIds
       .map((id) => sourceMessages?.get(id))
       .filter((source): source is CachedEvent => source !== undefined)
-    if (resolved.length === 0) continue
+    // ALL cited sources must resolve, not merely one: the server resolves them
+    // workspace-wide while this sees a bounded event window, so a partial
+    // resolution anchors the row on a different message than the server does and
+    // the two keys never reconcile. No row is better than a permanent duplicate.
+    if (resolved.length !== memo.sourceMessageIds.length || resolved.length === 0) continue
     const latest = resolved.reduce((a, b) => (b.createdAt > a.createdAt ? b : a))
     const firstMessageId = (resolved[0].payload as { messageId?: string })?.messageId ?? null
     rows.push(
@@ -215,6 +223,24 @@ function memoRows(
     )
   }
   return rows
+}
+
+/**
+ * The server's `isBlockedUrl` rejects private/internal hosts before projecting a
+ * link. This is the host half of that rule — enough to stop a permanently
+ * unreconcilable local row; the server stays authoritative for the rest.
+ */
+function isLocalBlockedHost(raw: string): boolean {
+  try {
+    const host = new URL(raw).hostname.toLowerCase()
+    if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return true
+    if (host === "0.0.0.0" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return true
+    if (/^10\./.test(host) || /^192\.168\./.test(host) || /^169\.254\./.test(host)) return true
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true
+    return false
+  } catch {
+    return true
+  }
 }
 
 /** Tracking params `normalizeUrl` strips server-side. */

--- a/apps/frontend/src/lib/stream-context/rows.ts
+++ b/apps/frontend/src/lib/stream-context/rows.ts
@@ -1,0 +1,298 @@
+import { collectGiphyEmbeds, collectLinkUrls } from "@threa/prosemirror"
+import {
+  categoryFromMime,
+  streamContextItemKey,
+  type AttachmentSummary,
+  type CapturedMemoSummary,
+  type ContextCategory,
+  type JSONContent,
+  type StreamContextItemDetail,
+  type StreamContextRefKind,
+} from "@threa/types"
+import { stripMarkdownToInline } from "@/lib/markdown"
+import type { CachedEvent, CachedStreamContextItem } from "@/db"
+
+/**
+ * btree index bound on the server — a longer href is never projected, so a
+ * local row for it would never reconcile. Mirrors `stream-context/extract.ts`.
+ */
+const MAX_URL_LENGTH = 2000
+const SNIPPET_MAX = 120
+
+/** The slice of a `message_created` payload a context row is derived from. */
+interface MessageEventPayload {
+  messageId?: string
+  contentMarkdown?: string
+  contentJson?: JSONContent
+  attachments?: AttachmentSummary[]
+}
+
+interface MemosCapturedPayload {
+  memos?: CapturedMemoSummary[]
+}
+
+export interface ContextRowsContext {
+  workspaceId: string
+  /** The stream the artifact lives in — a thread id for thread content. */
+  streamId: string
+  /** The stream's effective root; equals `streamId` for a non-thread. */
+  rootStreamId: string
+}
+
+function snippetOf(markdown: string | undefined): string {
+  if (!markdown) return ""
+  const firstLine = markdown.split("\n").find((line) => line.trim().length > 0) ?? ""
+  const inline = stripMarkdownToInline(firstLine).trim()
+  return inline.length > SNIPPET_MAX ? `${inline.slice(0, SNIPPET_MAX)}…` : inline
+}
+
+/**
+ * Locally derive the context rows a timeline event contributes — the same rows
+ * the backend's `contextRowsForMessage` writes for the same message, one row per
+ * (message × artifact), so the two sets reconcile by `key`.
+ *
+ * Two deliberate divergences from the server, both self-healing on reconcile:
+ *
+ * - `groupKey` is left equal to `refId`. The collapse key is server-computed
+ *   (the GitHub/Linear-aware URL normalizer stays backend-only), so a local link
+ *   row groups by its raw href until the server row overwrites it under the same
+ *   `key`.
+ * - `detail` carries only what the event itself knows. The server joins live
+ *   display data (link previews, attachment metadata, memo titles) onto its rows.
+ *
+ * Rows are deduped within the message by `(category, refId)`, matching the
+ * server's per-message dedup; occurrences across messages stay separate rows.
+ */
+export function contextItemsFromEvent(
+  event: CachedEvent,
+  ctx: ContextRowsContext,
+  /** The `message_created` events a `memos:captured` payload cites, by message id. */
+  sourceMessages?: ReadonlyMap<string, CachedEvent>
+): CachedStreamContextItem[] {
+  if (event.eventType === "memos:captured") return memoRows(event, ctx, sourceMessages)
+  if (event.eventType !== "message_created") return []
+
+  const payload = event.payload as MessageEventPayload
+  const messageId = payload.messageId
+  if (!messageId) return []
+
+  const rows: CachedStreamContextItem[] = []
+  const seen = new Set<string>()
+  const snippet = snippetOf(payload.contentMarkdown)
+
+  const push = (
+    category: ContextCategory,
+    refKind: StreamContextRefKind,
+    refId: string,
+    detail: StreamContextItemDetail
+  ): void => {
+    const dedupe = `${category}:${refId}`
+    if (seen.has(dedupe)) return
+    seen.add(dedupe)
+    rows.push(
+      buildRow(ctx, {
+        category,
+        refKind,
+        refId,
+        sourceMessageId: messageId,
+        authorId: event.actorId,
+        occurredAt: event.createdAt,
+        sequence: event.sequence,
+        snippet,
+        detail,
+      })
+    )
+  }
+
+  // Body links read from the structured document (INV-58), never serialized
+  // markdown — the same source `extractUrls` prefers on the server. The raw href
+  // is the ref id; normalization is the server's job.
+  const contentJson = payload.contentJson
+  if (contentJson) {
+    const seenNormalized = new Set<string>()
+    for (const url of collectLinkUrls(contentJson)) {
+      if (url.length > MAX_URL_LENGTH) continue
+      if (!/^https?:\/\//i.test(url)) continue
+      // The server emits only the FIRST raw href of each normalized group
+      // (`filterAndDeduplicateUrls`), so two hrefs differing only by fragment or
+      // tracking params yield ONE server row. Dedupe the same way or the extra
+      // local row never reconciles and the panel double-renders the link.
+      const normalized = localNormalizedUrl(url)
+      if (seenNormalized.has(normalized)) continue
+      seenNormalized.add(normalized)
+      push("link", "url", url, emptyLinkDetail(url))
+    }
+  }
+
+  for (const attachment of payload.attachments ?? []) {
+    const mimeCategory = categoryFromMime(attachment.mimeType)
+    if (mimeCategory === "image" || mimeCategory === "video") {
+      // Equality, not a prefix match — a parameterised mime must classify the
+      // same on both sides or the two rows carry different `mediaKind`s.
+      const imageKind = attachment.mimeType.toLowerCase() === "image/gif" ? "gif" : "image"
+      const mediaKind = mimeCategory === "video" ? "video" : imageKind
+      push("media", "attachment", attachment.id, {
+        attachmentId: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        width: attachment.width ?? null,
+        height: attachment.height ?? null,
+        mediaKind,
+        giphyUrl: null,
+        giphyTitle: null,
+      })
+    } else {
+      push("file", "attachment", attachment.id, {
+        attachmentId: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        width: null,
+        height: null,
+        mediaKind: null,
+        giphyUrl: null,
+        giphyTitle: null,
+      })
+    }
+  }
+
+  for (const embed of contentJson ? collectGiphyEmbeds(contentJson) : []) {
+    push("media", "giphy", embed.giphyUrl, {
+      attachmentId: null,
+      filename: null,
+      mimeType: null,
+      sizeBytes: null,
+      width: embed.width ?? null,
+      height: embed.height ?? null,
+      mediaKind: "gif",
+      giphyUrl: embed.giphyUrl,
+      giphyTitle: embed.title ?? null,
+    })
+  }
+
+  return rows
+}
+
+/**
+ * Memo rows from a `memos:captured` broadcast (INV-62): one per captured memo,
+ * anchored on its source messages exactly as `indexCapturedMemos` anchors the
+ * server's row — the LATEST resolvable source's timestamp (capture time lands
+ * minutes late; extraction is debounced) and the FIRST resolvable source as the
+ * "jump to origin" target. A memo whose sources all resolve to nothing is
+ * skipped, matching the server, so no orphan row is written that the server
+ * never reconciles and no delete can ever reach.
+ */
+function memoRows(
+  event: CachedEvent,
+  ctx: ContextRowsContext,
+  sourceMessages?: ReadonlyMap<string, CachedEvent>
+): CachedStreamContextItem[] {
+  const payload = event.payload as MemosCapturedPayload
+  const seen = new Set<string>()
+  const rows: CachedStreamContextItem[] = []
+  for (const memo of payload?.memos ?? []) {
+    if (seen.has(memo.memoId)) continue
+    seen.add(memo.memoId)
+    const resolved = memo.sourceMessageIds
+      .map((id) => sourceMessages?.get(id))
+      .filter((source): source is CachedEvent => source !== undefined)
+    if (resolved.length === 0) continue
+    const latest = resolved.reduce((a, b) => (b.createdAt > a.createdAt ? b : a))
+    const firstMessageId = (resolved[0].payload as { messageId?: string })?.messageId ?? null
+    rows.push(
+      buildRow(ctx, {
+        category: "memo",
+        refKind: "memo",
+        refId: memo.memoId,
+        sourceMessageId: firstMessageId,
+        authorId: latest.actorId,
+        occurredAt: latest.createdAt,
+        sequence: latest.sequence,
+        snippet: snippetOf(memo.title),
+        detail: { title: memo.title, knowledgeType: memo.knowledgeType },
+      })
+    )
+  }
+  return rows
+}
+
+/** Tracking params `normalizeUrl` strips server-side. */
+const TRACKING_PARAMS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]
+
+/**
+ * The host/fragment/tracking-param rules the server's `normalizeUrl` applies,
+ * used ONLY to decide which hrefs collapse into one local row. The server's
+ * GitHub/Linear-aware hash retention stays backend-only: this can therefore
+ * collapse a pair the server keeps apart, which self-heals when the seed lands
+ * the missing row — the reverse (an extra local row) would never reconcile.
+ */
+function localNormalizedUrl(raw: string): string {
+  try {
+    const url = new URL(raw)
+    url.hostname = url.hostname.toLowerCase()
+    for (const param of TRACKING_PARAMS) url.searchParams.delete(param)
+    url.searchParams.sort()
+    if (url.pathname.length > 1 && url.pathname.endsWith("/")) url.pathname = url.pathname.slice(0, -1)
+    if ((url.protocol === "https:" && url.port === "443") || (url.protocol === "http:" && url.port === "80")) {
+      url.port = ""
+    }
+    url.hash = ""
+    return url.toString()
+  } catch {
+    return raw.toLowerCase()
+  }
+}
+
+function emptyLinkDetail(url: string): StreamContextItemDetail {
+  return {
+    url,
+    title: null,
+    description: null,
+    siteName: null,
+    faviconUrl: null,
+    imageUrl: null,
+    previewType: null,
+    contentType: null,
+    previewStatus: null,
+  }
+}
+
+function buildRow(
+  ctx: ContextRowsContext,
+  input: {
+    category: ContextCategory
+    refKind: StreamContextRefKind
+    refId: string
+    sourceMessageId: string | null
+    authorId: string | null
+    occurredAt: string
+    sequence: string | null
+    snippet: string
+    detail: StreamContextItemDetail
+  }
+): CachedStreamContextItem {
+  return {
+    key: streamContextItemKey({
+      category: input.category,
+      refId: input.refId,
+      sourceMessageId: input.sourceMessageId,
+    }),
+    category: input.category,
+    refKind: input.refKind,
+    refId: input.refId,
+    groupKey: input.refId,
+    groupRef: `${input.category}:${input.refId}`,
+    streamId: ctx.streamId,
+    rootStreamId: ctx.rootStreamId,
+    workspaceId: ctx.workspaceId,
+    sourceMessageId: input.sourceMessageId,
+    authorId: input.authorId,
+    occurredAt: input.occurredAt,
+    sequence: input.sequence,
+    snippet: input.snippet,
+    occurrenceCount: 1,
+    detail: input.detail,
+    _cachedAt: Date.now(),
+  }
+}

--- a/apps/frontend/src/lib/stream-context/rows.ts
+++ b/apps/frontend/src/lib/stream-context/rows.ts
@@ -1,7 +1,10 @@
 import { collectGiphyEmbeds, collectLinkUrls } from "@threa/prosemirror"
 import {
+  BLOCKED_HOSTNAMES,
+  BLOCKED_IP_PATTERNS,
   categoryFromMime,
   streamContextItemKey,
+  TRACKING_PARAMS,
   type AttachmentSummary,
   type CapturedMemoSummary,
   type ContextCategory,
@@ -227,24 +230,20 @@ function memoRows(
 
 /**
  * The server's `isBlockedUrl` rejects private/internal hosts before projecting a
- * link. This is the host half of that rule — enough to stop a permanently
- * unreconcilable local row; the server stays authoritative for the rest.
+ * link, so projecting one here would leave a permanently unreconcilable row.
+ * Matches against the shared lists (INV-33) so the two sides cannot drift; the
+ * extra suffix rules only block MORE, which self-heals when the seed lands.
  */
 function isLocalBlockedHost(raw: string): boolean {
   try {
     const host = new URL(raw).hostname.toLowerCase()
-    if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return true
-    if (host === "0.0.0.0" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return true
-    if (/^10\./.test(host) || /^192\.168\./.test(host) || /^169\.254\./.test(host)) return true
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true
-    return false
+    if (BLOCKED_HOSTNAMES.has(host)) return true
+    if (host.endsWith(".localhost") || host.endsWith(".local")) return true
+    return BLOCKED_IP_PATTERNS.some((pattern) => pattern.test(host))
   } catch {
     return true
   }
 }
-
-/** Tracking params `normalizeUrl` strips server-side. */
-const TRACKING_PARAMS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]
 
 /**
  * The host/fragment/tracking-param rules the server's `normalizeUrl` applies,

--- a/apps/frontend/src/stores/stream-context-store.test.tsx
+++ b/apps/frontend/src/stores/stream-context-store.test.tsx
@@ -190,9 +190,40 @@ describe("stream-context-store", () => {
       serverItem({ key: "link:z:msg_3", refId: "z", groupKey: "z", sourceMessageId: "msg_3" }),
     ])
 
-    const { result } = renderHook(() => useStreamContextOccurrences("link:https://example.com/a"))
+    const { result } = renderHook(() => useStreamContextOccurrences(WORKSPACE_ID, ROOT, "link:https://example.com/a"))
     await waitFor(() => expect(result.current).toBeDefined())
     expect(result.current?.map((r) => r.key)).toEqual(["link:a:msg_2", "link:a:msg_1"])
+  })
+
+  it("scopes occurrences to the current workspace and root", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [serverItem({ key: "link:a:msg_1" })])
+    await seedStreamContextItems("ws_other", ROOT, [serverItem({ key: "link:a:msg_other" })])
+    await seedStreamContextItems(WORKSPACE_ID, "stream_other_root", [
+      serverItem({ key: "link:a:msg_root2", streamId: "stream_other_root" }),
+    ])
+
+    const { result } = renderHook(() => useStreamContextOccurrences(WORKSPACE_ID, ROOT, "link:https://example.com/a"))
+    await waitFor(() => expect(result.current).toBeDefined())
+    expect(result.current?.map((r) => r.key)).toEqual(["link:a:msg_1"])
+  })
+
+  it("keeps a thread landmark anchored on an edited message", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({ key: "link:https://example.com/a:msg_1" }),
+      serverItem({
+        key: "thread:stream_t1:msg_1",
+        category: "thread",
+        refKind: "thread",
+        refId: "stream_t1",
+        groupKey: "stream_t1",
+        detail: { name: "Thread", replyCount: 2, lastReplyAt: null, anchorEventId: null },
+      }),
+    ])
+
+    // Edited to drop the link entirely.
+    await replaceContextRowsForMessage(WORKSPACE_ID, "msg_1", [])
+
+    expect((await db.streamContextItems.toArray()).map((r) => r.key)).toEqual(["thread:stream_t1:msg_1"])
   })
 
   it("deletes every row a message contributed", async () => {

--- a/apps/frontend/src/stores/stream-context-store.test.tsx
+++ b/apps/frontend/src/stores/stream-context-store.test.tsx
@@ -8,6 +8,7 @@ import {
   deleteContextRowsForMessage,
   putLocalContextRows,
   reparentContextRows,
+  replaceContextRowsForMessage,
   seedStreamContextItems,
   useStreamContextOccurrences,
   useStreamContextRows,
@@ -152,6 +153,34 @@ describe("stream-context-store", () => {
     const row = await db.streamContextItems.get(local[0].key)
     expect(row).toMatchObject({ groupKey: "https://example.com/a", detail: { title: "Example" } })
     expect(row?._status).toBeUndefined()
+  })
+
+  it("keeps reconciled fields across an edit's replace, and drops only what the edit removed", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({
+        key: "link:https://example.com/a:msg_1",
+        groupKey: "https://example.com/a",
+        detail: { title: "Example", url: "https://example.com/a" } as StreamContextItem["detail"],
+      }),
+      serverItem({
+        key: "link:https://example.com/gone:msg_1",
+        refId: "https://example.com/gone",
+        groupKey: "https://example.com/gone",
+      }),
+    ])
+
+    // The edit keeps the first link and adds a new one; the second is gone.
+    const rebuilt = contextItemsFromEvent(messageEvent("msg_1", "https://example.com/a", "2026-07-01T10:00:00.000Z"), {
+      workspaceId: WORKSPACE_ID,
+      streamId: ROOT,
+      rootStreamId: ROOT,
+    })
+    await replaceContextRowsForMessage(WORKSPACE_ID, "msg_1", rebuilt)
+
+    const rows = await db.streamContextItems.toArray()
+    expect(
+      rows.map((r) => ({ key: r.key, groupKey: r.groupKey, title: (r.detail as { title?: string }).title }))
+    ).toEqual([{ key: "link:https://example.com/a:msg_1", groupKey: "https://example.com/a", title: "Example" }])
   })
 
   it("lists every occurrence of a group, newest first", async () => {

--- a/apps/frontend/src/stores/stream-context-store.test.tsx
+++ b/apps/frontend/src/stores/stream-context-store.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { db } from "@/db"
+import type { StreamContextItem } from "@threa/types"
+import { contextItemsFromEvent } from "@/lib/stream-context/rows"
+import type { CachedEvent } from "@/db"
+import {
+  deleteContextRowsForMessage,
+  putLocalContextRows,
+  reparentContextRows,
+  seedStreamContextItems,
+  useStreamContextOccurrences,
+  useStreamContextRows,
+} from "./stream-context-store"
+
+const WORKSPACE_ID = "ws_1"
+const ROOT = "stream_root"
+
+function serverItem(overrides: Partial<StreamContextItem> & { key: string }): StreamContextItem {
+  return {
+    category: "link",
+    refKind: "url",
+    refId: "https://example.com/a",
+    groupKey: "https://example.com/a",
+    streamId: ROOT,
+    sourceMessageId: "msg_1",
+    authorId: "usr_1",
+    occurredAt: "2026-07-01T10:00:00.000Z",
+    sequence: "1",
+    snippet: "hi",
+    occurrenceCount: 1,
+    detail: {
+      url: "https://example.com/a",
+      title: null,
+      description: null,
+      siteName: null,
+      faviconUrl: null,
+      imageUrl: null,
+      previewType: null,
+      contentType: null,
+      previewStatus: null,
+    },
+    ...overrides,
+  }
+}
+
+function messageEvent(messageId: string, href: string, createdAt: string, streamId = ROOT): CachedEvent {
+  return {
+    id: `event_${messageId}`,
+    workspaceId: WORKSPACE_ID,
+    streamId,
+    sequence: "1",
+    _sequenceNum: 1,
+    eventType: "message_created",
+    payload: {
+      messageId,
+      contentMarkdown: "hi",
+      contentJson: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "x", marks: [{ type: "link", attrs: { href } }] }] },
+        ],
+      },
+    },
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt,
+    _cachedAt: 0,
+  }
+}
+
+describe("stream-context-store", () => {
+  beforeEach(async () => {
+    await db.streamContextItems.clear()
+  })
+
+  it("live-reads seeded rows newest first, scoped to the root's tree", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({ key: "link:a:msg_1", refId: "a", groupKey: "a", occurredAt: "2026-07-01T10:00:00.000Z" }),
+      serverItem({
+        key: "link:b:msg_2",
+        refId: "b",
+        groupKey: "b",
+        occurredAt: "2026-07-02T10:00:00.000Z",
+        streamId: "stream_thread",
+      }),
+    ])
+
+    const { result } = renderHook(() => useStreamContextRows(WORKSPACE_ID, ROOT, ROOT, "tree"))
+    await waitFor(() => expect(result.current).toBeDefined())
+    expect(result.current?.map((r) => r.key)).toEqual(["link:b:msg_2", "link:a:msg_1"])
+
+    // `stream` scope sees only the rows filed on that stream.
+    const streamScope = renderHook(() => useStreamContextRows(WORKSPACE_ID, ROOT, ROOT, "stream"))
+    await waitFor(() => expect(streamScope.result.current).toBeDefined())
+    expect(streamScope.result.current?.map((r) => r.key)).toEqual(["link:a:msg_1"])
+  })
+
+  it("resolves to [] for an empty store rather than staying in loading", async () => {
+    const { result } = renderHook(() => useStreamContextRows(WORKSPACE_ID, ROOT, ROOT, "tree"))
+    await waitFor(() => expect(result.current).toEqual([]))
+  })
+
+  it("collapses a local row and the server's row for the same key, keeping the server's groupKey", async () => {
+    const local = contextItemsFromEvent(messageEvent("msg_1", "https://Example.com/a/", "2026-07-01T10:00:00.000Z"), {
+      workspaceId: WORKSPACE_ID,
+      streamId: ROOT,
+      rootStreamId: ROOT,
+    })
+    await putLocalContextRows(local)
+    expect(await db.streamContextItems.get(local[0].key)).toMatchObject({
+      _status: "pending",
+      groupKey: "https://Example.com/a/",
+    })
+
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({
+        key: local[0].key,
+        refId: "https://Example.com/a/",
+        groupKey: "https://example.com/a",
+        detail: { title: "Example", url: "https://Example.com/a/" } as StreamContextItem["detail"],
+      }),
+    ])
+
+    const rows = await db.streamContextItems.toArray()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      groupKey: "https://example.com/a",
+      groupRef: "link:https://example.com/a",
+    })
+    expect(rows[0]._status).toBeUndefined()
+  })
+
+  it("does not let a re-derived local row overwrite the reconciled server row", async () => {
+    const local = contextItemsFromEvent(messageEvent("msg_1", "https://Example.com/a/", "2026-07-01T10:00:00.000Z"), {
+      workspaceId: WORKSPACE_ID,
+      streamId: ROOT,
+      rootStreamId: ROOT,
+    })
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({
+        key: local[0].key,
+        refId: "https://Example.com/a/",
+        groupKey: "https://example.com/a",
+        detail: { title: "Example", url: "https://Example.com/a/" } as StreamContextItem["detail"],
+      }),
+    ])
+
+    // Event replay (catch-up, gate resume) re-derives the same local row.
+    await putLocalContextRows(local)
+
+    const row = await db.streamContextItems.get(local[0].key)
+    expect(row).toMatchObject({ groupKey: "https://example.com/a", detail: { title: "Example" } })
+    expect(row?._status).toBeUndefined()
+  })
+
+  it("lists every occurrence of a group, newest first", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({ key: "link:a:msg_1", occurredAt: "2026-07-01T10:00:00.000Z" }),
+      serverItem({ key: "link:a:msg_2", sourceMessageId: "msg_2", occurredAt: "2026-07-03T10:00:00.000Z" }),
+      serverItem({ key: "link:z:msg_3", refId: "z", groupKey: "z", sourceMessageId: "msg_3" }),
+    ])
+
+    const { result } = renderHook(() => useStreamContextOccurrences("link:https://example.com/a"))
+    await waitFor(() => expect(result.current).toBeDefined())
+    expect(result.current?.map((r) => r.key)).toEqual(["link:a:msg_2", "link:a:msg_1"])
+  })
+
+  it("deletes every row a message contributed", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({ key: "link:a:msg_1" }),
+      serverItem({ key: "media:b:msg_1", category: "media", refKind: "attachment", refId: "b", groupKey: "b" }),
+      serverItem({ key: "link:a:msg_2", sourceMessageId: "msg_2" }),
+    ])
+    await deleteContextRowsForMessage(WORKSPACE_ID, "msg_1")
+    expect((await db.streamContextItems.toArray()).map((r) => r.key)).toEqual(["link:a:msg_2"])
+  })
+
+  it("re-homes moved messages' rows onto the destination thread", async () => {
+    await seedStreamContextItems(WORKSPACE_ID, ROOT, [
+      serverItem({ key: "link:a:msg_1" }),
+      serverItem({ key: "link:a:msg_2", sourceMessageId: "msg_2" }),
+    ])
+    await reparentContextRows(WORKSPACE_ID, ["msg_1"], "stream_thread", ROOT)
+
+    expect(await db.streamContextItems.get("link:a:msg_1")).toMatchObject({
+      streamId: "stream_thread",
+      rootStreamId: ROOT,
+    })
+    expect(await db.streamContextItems.get("link:a:msg_2")).toMatchObject({ streamId: ROOT })
+  })
+})

--- a/apps/frontend/src/stores/stream-context-store.ts
+++ b/apps/frontend/src/stores/stream-context-store.ts
@@ -1,0 +1,135 @@
+import Dexie from "dexie"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db, type CachedStreamContextItem } from "@/db"
+import type { StreamContextItem, StreamContextScope } from "@threa/types"
+
+/** The compound-index carrier for occurrence lookups — see {@link CachedStreamContextItem}. */
+export function contextGroupRef(item: Pick<StreamContextItem, "category" | "groupKey">): string {
+  return `${item.category}:${item.groupKey}`
+}
+
+function toCached(workspaceId: string, rootStreamId: string, item: StreamContextItem): CachedStreamContextItem {
+  return {
+    ...item,
+    workspaceId,
+    rootStreamId,
+    groupRef: contextGroupRef(item),
+    _cachedAt: Date.now(),
+  }
+}
+
+/**
+ * Reactive "In this stream" feed, newest first — the panel's read authority,
+ * mirroring how the timeline reads `events` from IDB. A live sync applier or a
+ * page seed re-sorts the feed in place without a refetch. Returns `undefined`
+ * until the first IDB read resolves (loading), `[]` when genuinely empty.
+ *
+ * `scope: "tree"` reads the root's whole thread tree (INV-62 — a thread's
+ * content belongs to its root's context); `"stream"` reads just this stream.
+ */
+export function useStreamContextRows(
+  workspaceId: string,
+  streamId: string,
+  rootStreamId: string,
+  scope: StreamContextScope
+): CachedStreamContextItem[] | undefined {
+  return useLiveQuery(async () => {
+    const [index, anchor] =
+      scope === "tree"
+        ? (["[rootStreamId+occurredAt]", rootStreamId] as const)
+        : (["[streamId+occurredAt]", streamId] as const)
+    const rows = await db.streamContextItems
+      .where(index)
+      .between([anchor, Dexie.minKey], [anchor, Dexie.maxKey])
+      .reverse()
+      .toArray()
+    // Cross-workspace ids never collide, but the filter keeps a stale row from a
+    // previous account's database out of the feed if one is ever left behind.
+    return rows.filter((row) => row.workspaceId === workspaceId)
+  }, [workspaceId, streamId, rootStreamId, scope])
+}
+
+/**
+ * Every occurrence of one collapsed group ("shared 4 times"), newest first.
+ * Locally derived rows group by their raw `refId` until the server's normalized
+ * `groupKey` lands, so an expanded group can gain members on reconcile.
+ */
+export function useStreamContextOccurrences(groupRef: string | null): CachedStreamContextItem[] | undefined {
+  return useLiveQuery(async () => {
+    if (!groupRef) return []
+    return db.streamContextItems
+      .where("[groupRef+occurredAt]")
+      .between([groupRef, Dexie.minKey], [groupRef, Dexie.maxKey])
+      .reverse()
+      .toArray()
+  }, [groupRef])
+}
+
+/**
+ * Seed the store from a fetched page (subscribe-then-fetch, INV-53). `bulkPut`
+ * upserts the fetched rows without touching rows the page didn't return, so a
+ * locally derived row the server hasn't projected yet survives, and a row the
+ * server does return reconciles over its local copy under the same `key` —
+ * gaining the real `groupKey`/`detail` and losing `_status`.
+ */
+export async function seedStreamContextItems(
+  workspaceId: string,
+  rootStreamId: string,
+  items: StreamContextItem[]
+): Promise<void> {
+  if (items.length === 0) return
+  await db.streamContextItems.bulkPut(items.map((item) => toCached(workspaceId, rootStreamId, item)))
+}
+
+/**
+ * Write locally derived rows (`contextItemsFromEvent`) so the panel shows an
+ * artifact the instant its message lands, offline included. Marked
+ * `_status: "pending"`: the server row that reconciles them shares the `key`,
+ * so there is no insert-then-swap and no duplicate.
+ */
+export async function putLocalContextRows(rows: CachedStreamContextItem[]): Promise<void> {
+  if (rows.length === 0) return
+  await db.transaction("rw", db.streamContextItems, async () => {
+    // Never downgrade a reconciled row. Event re-delivery is routine (catch-up
+    // replays every sync-log entry through these handlers, and the gate's resume
+    // splice re-applies buffered live events), so a blind `bulkPut` would stomp
+    // the server's `groupKey`/`detail` back to a bare local row on every
+    // reconnect. Only absent or still-`pending` keys are written.
+    const existing = await db.streamContextItems.bulkGet(rows.map((row) => row.key))
+    const reconciled = new Set(existing.filter((row) => row && row._status !== "pending").map((row) => row!.key))
+    const writable = rows.filter((row) => !reconciled.has(row.key))
+    if (writable.length === 0) return
+    await db.streamContextItems.bulkPut(writable.map((row) => ({ ...row, _status: "pending" as const })))
+  })
+}
+
+/** Drop every row a message contributed — its delete, or the first half of an
+ *  edit's replace (the server does the same with `replaceForMessage`). */
+export async function deleteContextRowsForMessage(workspaceId: string, messageId: string): Promise<void> {
+  await db.streamContextItems
+    .where("workspaceId")
+    .equals(workspaceId)
+    .filter((row) => row.sourceMessageId === messageId)
+    .delete()
+}
+
+/**
+ * Re-home the rows of moved messages onto the thread they now live in. The
+ * artifacts keep their identity (`key` is message-scoped, not stream-scoped), so
+ * this is a patch, never a delete-and-rebuild — mirrors the server's
+ * `reparentMessages`.
+ */
+export async function reparentContextRows(
+  workspaceId: string,
+  messageIds: string[],
+  streamId: string,
+  rootStreamId: string
+): Promise<void> {
+  if (messageIds.length === 0) return
+  const moved = new Set(messageIds)
+  await db.streamContextItems
+    .where("workspaceId")
+    .equals(workspaceId)
+    .filter((row) => row.sourceMessageId !== null && moved.has(row.sourceMessageId))
+    .modify({ streamId, rootStreamId })
+}

--- a/apps/frontend/src/stores/stream-context-store.ts
+++ b/apps/frontend/src/stores/stream-context-store.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedStreamContextItem } from "@/db"
-import type { StreamContextItem, StreamContextScope } from "@threa/types"
+import { MESSAGE_BODY_CONTEXT_CATEGORIES, type StreamContextItem, type StreamContextScope } from "@threa/types"
 
 /** The compound-index carrier for occurrence lookups — see {@link CachedStreamContextItem}. */
 export function contextGroupRef(item: Pick<StreamContextItem, "category" | "groupKey">): string {
@@ -54,15 +54,25 @@ export function useStreamContextRows(
  * Locally derived rows group by their raw `refId` until the server's normalized
  * `groupKey` lands, so an expanded group can gain members on reconcile.
  */
-export function useStreamContextOccurrences(groupRef: string | null): CachedStreamContextItem[] | undefined {
+export function useStreamContextOccurrences(
+  workspaceId: string,
+  rootStreamId: string,
+  groupRef: string | null
+): CachedStreamContextItem[] | undefined {
   return useLiveQuery(async () => {
     if (!groupRef) return []
-    return db.streamContextItems
+    const rows = await db.streamContextItems
       .where("[groupRef+occurredAt]")
       .between([groupRef, Dexie.minKey], [groupRef, Dexie.maxKey])
       .reverse()
       .toArray()
-  }, [groupRef])
+    // One IDB database backs every workspace of the account and a groupRef is
+    // only `category:groupKey`, so the same link shared in another workspace or
+    // another root lands under the same key. The server's `listOccurrences`
+    // filters workspace + root; an unfiltered read would list more occurrences
+    // than the row was labelled with and jump into a foreign stream.
+    return rows.filter((row) => row.workspaceId === workspaceId && row.rootStreamId === rootStreamId)
+  }, [workspaceId, rootStreamId, groupRef])
 }
 
 /**
@@ -132,7 +142,15 @@ export async function replaceContextRowsForMessage(
     const existingByKey = new Map(existing.map((row) => [row.key, row]))
     const nextKeys = new Set(rows.map((row) => row.key))
 
-    const removed = existing.filter((row) => !nextKeys.has(row.key)).map((row) => row.key)
+    // Only the categories the body owns are replaceable — a memo or thread
+    // landmark carries the same `sourceMessageId` but is written by another path
+    // that never re-creates it (mirrors the server's `replaceForMessage`, which
+    // deletes `MESSAGE_BODY_CONTEXT_CATEGORIES` only).
+    const removed = existing
+      .filter(
+        (row) => (MESSAGE_BODY_CONTEXT_CATEGORIES as readonly string[]).includes(row.category) && !nextKeys.has(row.key)
+      )
+      .map((row) => row.key)
     if (removed.length > 0) await db.streamContextItems.bulkDelete(removed)
 
     const merged = rows.map((row) => {

--- a/apps/frontend/src/stores/stream-context-store.ts
+++ b/apps/frontend/src/stores/stream-context-store.ts
@@ -103,14 +103,52 @@ export async function putLocalContextRows(rows: CachedStreamContextItem[]): Prom
   })
 }
 
-/** Drop every row a message contributed — its delete, or the first half of an
- *  edit's replace (the server does the same with `replaceForMessage`). */
+/** Drop every row a message contributed — its delete (the server does the same
+ *  with `deleteByMessageId`). */
 export async function deleteContextRowsForMessage(workspaceId: string, messageId: string): Promise<void> {
-  await db.streamContextItems
-    .where("workspaceId")
-    .equals(workspaceId)
-    .filter((row) => row.sourceMessageId === messageId)
-    .delete()
+  await db.streamContextItems.where("[workspaceId+sourceMessageId]").equals([workspaceId, messageId]).delete()
+}
+
+/**
+ * Rebuild a message's rows after an edit, preserving what only the server knows.
+ *
+ * A delete-then-put would drop the reconciled `groupKey`/`detail` of rows the
+ * edit did not touch — `putLocalContextRows`' never-downgrade guard cannot see a
+ * row that was just deleted, so a typo fix would strip a link's title and
+ * regress its collapse key to the raw href. Surviving keys keep their reconciled
+ * fields and take only the re-derived ones; keys the edit removed are deleted;
+ * genuinely new keys land as pending.
+ */
+export async function replaceContextRowsForMessage(
+  workspaceId: string,
+  messageId: string,
+  rows: CachedStreamContextItem[]
+): Promise<void> {
+  await db.transaction("rw", db.streamContextItems, async () => {
+    const existing = await db.streamContextItems
+      .where("[workspaceId+sourceMessageId]")
+      .equals([workspaceId, messageId])
+      .toArray()
+    const existingByKey = new Map(existing.map((row) => [row.key, row]))
+    const nextKeys = new Set(rows.map((row) => row.key))
+
+    const removed = existing.filter((row) => !nextKeys.has(row.key)).map((row) => row.key)
+    if (removed.length > 0) await db.streamContextItems.bulkDelete(removed)
+
+    const merged = rows.map((row) => {
+      const prior = existingByKey.get(row.key)
+      if (!prior || prior._status === "pending") return { ...row, _status: "pending" as const }
+      return {
+        ...prior,
+        snippet: row.snippet,
+        occurredAt: row.occurredAt,
+        streamId: row.streamId,
+        rootStreamId: row.rootStreamId,
+        _cachedAt: row._cachedAt,
+      }
+    })
+    await db.streamContextItems.bulkPut(merged)
+  })
 }
 
 /**
@@ -126,10 +164,8 @@ export async function reparentContextRows(
   rootStreamId: string
 ): Promise<void> {
   if (messageIds.length === 0) return
-  const moved = new Set(messageIds)
   await db.streamContextItems
-    .where("workspaceId")
-    .equals(workspaceId)
-    .filter((row) => row.sourceMessageId !== null && moved.has(row.sourceMessageId))
+    .where("[workspaceId+sourceMessageId]")
+    .anyOf(messageIds.map((messageId) => [workspaceId, messageId]))
     .modify({ streamId, rootStreamId })
 }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest"
 import { QueryClient } from "@tanstack/react-query"
 import type { Socket } from "socket.io-client"
 import { db, type CachedEvent } from "@/db"
@@ -19,8 +19,10 @@ import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 import { sharedMessageSlotKey } from "@threa/types"
 import type {
+  AttachmentSummary,
   BotRuntimePresenceSummary,
   LinkPreviewSummary,
+  Stream,
   SharedMessageSlot,
   SlotMap,
   StreamBootstrap,
@@ -3457,5 +3459,363 @@ describe("applyStreamBootstrap standalone frontier persistence (non-member unloc
   it("leaves the store untouched when the field is absent (payload cached before it shipped)", async () => {
     await applyStreamBootstrap("ws_1", streamId, makeBootstrap([], streamId))
     expect(await db.streamReadState.get(`ws_1:${streamId}`)).toBeUndefined()
+  })
+})
+
+describe("registerStreamSocketHandlers — stream context rows", () => {
+  const STREAM_ID = "stream_ctx"
+  const THREAD_ID = "stream_ctx_thread"
+
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => unknown>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => unknown) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => unknown) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all([...(handlers.get(event) ?? [])].map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function messageEvent(
+    messageId: string,
+    body: { href?: string; attachments?: AttachmentSummary[] },
+    sequence = "10"
+  ): StreamEvent {
+    return {
+      id: `event_${messageId}`,
+      streamId: STREAM_ID,
+      sequence,
+      eventType: "message_created",
+      payload: {
+        messageId,
+        contentMarkdown: "hello",
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: body.href
+                ? [{ type: "text", text: "x", marks: [{ type: "link", attrs: { href: body.href } }] }]
+                : [{ type: "text", text: "x" }],
+            },
+          ],
+        },
+        attachments: body.attachments ?? [],
+      },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: "2026-07-01T10:00:00.000Z",
+    }
+  }
+
+  let harness: ReturnType<typeof createTestSocket>
+  let unregister: () => void
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.streamContextItems.clear()
+    await db.streams.put({
+      id: STREAM_ID,
+      workspaceId: "ws_1",
+      type: "channel",
+      displayName: "ctx",
+      slug: "ctx",
+      description: null,
+      visibility: "public",
+      parentStreamId: null,
+      rootStreamId: null,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "usr_1",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      archivedAt: null,
+      _cachedAt: Date.now(),
+    } as never)
+    harness = createTestSocket()
+    unregister = registerStreamSocketHandlers(harness.socket, "ws_1", STREAM_ID, new QueryClient())
+  })
+
+  afterEach(() => unregister())
+
+  it("writes a pending row per artifact when a message lands", async () => {
+    await harness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: messageEvent("msg_1", {
+        href: "https://example.com/a",
+        attachments: [{ id: "att_1", filename: "p.png", mimeType: "image/png", sizeBytes: 5 }],
+      }),
+    })
+
+    const rows = await db.streamContextItems.toArray()
+    expect(rows.map((r) => [r.key, r.streamId, r.rootStreamId, r._status]).sort()).toEqual([
+      ["link:https://example.com/a:msg_1", STREAM_ID, STREAM_ID, "pending"],
+      ["media:att_1:msg_1", STREAM_ID, STREAM_ID, "pending"],
+    ])
+    expect(rows.every((r) => r.occurredAt === "2026-07-01T10:00:00.000Z")).toBe(true)
+  })
+
+  it("files a thread's rows under its root so the tree feed sees them", async () => {
+    await db.streams.put({
+      id: THREAD_ID,
+      workspaceId: "ws_1",
+      type: "thread",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: STREAM_ID,
+      rootStreamId: STREAM_ID,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "usr_1",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      archivedAt: null,
+      _cachedAt: Date.now(),
+    } as never)
+    const threadHarness = createTestSocket()
+    const off = registerStreamSocketHandlers(threadHarness.socket, "ws_1", THREAD_ID, new QueryClient())
+
+    await threadHarness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: THREAD_ID,
+      event: { ...messageEvent("msg_t", { href: "https://example.com/t" }), streamId: THREAD_ID },
+    })
+    off()
+
+    expect(await db.streamContextItems.get("link:https://example.com/t:msg_t")).toMatchObject({
+      streamId: THREAD_ID,
+      rootStreamId: STREAM_ID,
+    })
+  })
+
+  it("rebuilds a message's rows on edit, dropping a link the edit removed", async () => {
+    await harness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: messageEvent("msg_1", {
+        href: "https://example.com/gone",
+        attachments: [{ id: "att_1", filename: "p.png", mimeType: "image/png", sizeBytes: 5 }],
+      }),
+    })
+
+    await harness.emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: {
+        id: "event_edit",
+        streamId: STREAM_ID,
+        sequence: "11",
+        eventType: "message_edited",
+        payload: {
+          messageId: "msg_1",
+          contentMarkdown: "hello",
+          contentJson: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "x", marks: [{ type: "link", attrs: { href: "https://example.com/new" } }] },
+                ],
+              },
+            ],
+          },
+        },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: "2026-07-01T11:00:00.000Z",
+      },
+    })
+
+    const keys = (await db.streamContextItems.toArray()).map((r) => r.key).sort()
+    // The attachment row survives (the edit payload doesn't carry attachments);
+    // the removed link is gone and the new one is there.
+    expect(keys).toEqual(["link:https://example.com/new:msg_1", "media:att_1:msg_1"])
+  })
+
+  it("drops a deleted message's rows", async () => {
+    await harness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: messageEvent("msg_1", { href: "https://example.com/a" }),
+    })
+    await harness.emit("message:deleted", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      messageId: "msg_1",
+      deletedAt: "2026-07-01T12:00:00.000Z",
+    })
+    expect(await db.streamContextItems.toArray()).toEqual([])
+  })
+
+  it("writes memo rows from a memos:captured broadcast, anchored on the source message", async () => {
+    await harness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: { ...messageEvent("msg_9", {}, "5"), createdAt: "2026-07-01T09:00:00.000Z" },
+    })
+
+    await harness.emit("stream:memos_captured", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: {
+        id: "event_memos",
+        streamId: STREAM_ID,
+        sequence: "20",
+        eventType: "memos:captured",
+        payload: {
+          memos: [{ memoId: "memo_1", title: "Decision", knowledgeType: "decision", sourceMessageIds: ["msg_9"] }],
+        },
+        actorId: null,
+        actorType: null,
+        createdAt: "2026-07-01T13:00:00.000Z",
+      },
+    })
+
+    // Anchored on the source message's own time, not the debounced capture time.
+    expect(await db.streamContextItems.get("memo:memo_1:msg_9")).toMatchObject({
+      category: "memo",
+      sourceMessageId: "msg_9",
+      streamId: STREAM_ID,
+      occurredAt: "2026-07-01T09:00:00.000Z",
+    })
+  })
+
+  it("re-homes moved messages' rows onto the destination thread", async () => {
+    await harness.emit("message:created", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: messageEvent("msg_1", { href: "https://example.com/a" }),
+    })
+
+    const thread = {
+      id: THREAD_ID,
+      workspaceId: "ws_1",
+      type: "thread",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: STREAM_ID,
+      rootStreamId: STREAM_ID,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "usr_1",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      archivedAt: null,
+    } as unknown as Stream
+
+    // Emitted on the SOURCE stream's handler only: the destination is a
+    // brand-new thread with no subscription at move time, so the destination leg
+    // does not exist in the real fan-out.
+    await harness.emit("messages:moved", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      sourceStreamId: STREAM_ID,
+      destinationStreamId: THREAD_ID,
+      targetMessageId: "msg_target",
+      movedMessageIds: ["msg_1"],
+      thread,
+      events: [],
+      removedEventIds: [],
+      sourceTombstoneEvent: {
+        id: "event_tomb",
+        streamId: STREAM_ID,
+        sequence: "30",
+        eventType: "messages_moved",
+        payload: {},
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: "2026-07-01T14:00:00.000Z",
+      },
+      parentReplyCount: 1,
+      parentThreadSummary: null,
+    })
+
+    expect(await db.streamContextItems.get("link:https://example.com/a:msg_1")).toMatchObject({
+      streamId: THREAD_ID,
+      rootStreamId: STREAM_ID,
+    })
+  })
+
+  it("leaves a reconciled server row untouched when its event is replayed", async () => {
+    const event = messageEvent("msg_1", { href: "https://example.com/a" })
+    await harness.emit("message:created", { workspaceId: "ws_1", streamId: STREAM_ID, event })
+
+    // The read endpoint seeds the server's copy over the same key.
+    const seeded = await db.streamContextItems.get("link:https://example.com/a:msg_1")
+    await db.streamContextItems.put({
+      ...seeded!,
+      groupKey: "https://example.com/a",
+      groupRef: "link:https://example.com/a",
+      detail: { ...seeded!.detail, title: "Example" },
+      _status: undefined,
+    })
+
+    // Catch-up replays the same event through the same handler.
+    await harness.emit("message:created", { workspaceId: "ws_1", streamId: STREAM_ID, event })
+
+    expect(await db.streamContextItems.get("link:https://example.com/a:msg_1")).toMatchObject({
+      detail: expect.objectContaining({ title: "Example" }),
+      _status: undefined,
+    })
+  })
+
+  it("keeps a message's rows on edit when its created event is outside the cached window", async () => {
+    // A seeded server row whose message_created event this session never cached.
+    await db.streamContextItems.put({
+      key: "link:https://example.com/old:msg_old",
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      rootStreamId: STREAM_ID,
+      category: "link",
+      refKind: "url",
+      refId: "https://example.com/old",
+      groupKey: "https://example.com/old",
+      groupRef: "link:https://example.com/old",
+      sourceMessageId: "msg_old",
+      authorId: "usr_1",
+      occurredAt: "2026-06-01T10:00:00.000Z",
+      sequence: "1",
+      snippet: "old",
+      occurrenceCount: 1,
+      detail: { url: "https://example.com/old", title: "Old" },
+      _cachedAt: Date.now(),
+    } as never)
+
+    await harness.emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId: STREAM_ID,
+      event: {
+        id: "event_edit_old",
+        streamId: STREAM_ID,
+        sequence: "99",
+        eventType: "message_edited",
+        payload: { messageId: "msg_old", contentMarkdown: "typo fixed", contentJson: { type: "doc", content: [] } },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: "2026-07-01T15:00:00.000Z",
+      },
+    })
+
+    expect(await db.streamContextItems.get("link:https://example.com/old:msg_old")).toBeDefined()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -33,6 +33,8 @@ import {
   rehomeActivities,
 } from "./unread-counters"
 import { upsertActiveCall, updateCallParticipants } from "@/stores/active-calls-store"
+import { contextItemsFromEvent, type ContextRowsContext } from "@/lib/stream-context/rows"
+import { deleteContextRowsForMessage, putLocalContextRows, reparentContextRows } from "@/stores/stream-context-store"
 
 // ============================================================================
 // Bootstrap application — writes stream bootstrap data to IndexedDB
@@ -1035,6 +1037,59 @@ function isEncryptedPayload(payload: unknown): boolean {
   return !!p && typeof p.ciphertext === "string" && !!p.envelope
 }
 
+/**
+ * The scope a stream's context rows are filed under: the stream itself plus its
+ * effective root, so a thread's artifacts still surface in the root's tree feed
+ * (INV-62). Falls back to the stream as its own root when its row isn't cached.
+ */
+async function resolveContextScope(workspaceId: string, streamId: string): Promise<ContextRowsContext> {
+  const stream = await db.streams.get(streamId)
+  return { workspaceId, streamId, rootStreamId: stream?.rootStreamId ?? streamId }
+}
+
+/**
+ * Maintain the local "In this stream" rows for an event the client just applied.
+ * Derived rows are `_status: "pending"` until the read endpoint seeds the
+ * server's copy over the same `key`, so the panel shows an artifact the instant
+ * its message lands — offline included — without a duplicate on reconcile.
+ *
+ * E2E events are skipped: their payload is ciphertext at rest, the server
+ * projects no rows for a sealed stream, and the panel derives that view from
+ * decrypted content instead.
+ */
+async function applyContextRowsForEvent(workspaceId: string, streamId: string, event: CachedEvent): Promise<void> {
+  if (isEncryptedPayload(event.payload)) return
+  const rows = contextItemsFromEvent(
+    event,
+    await resolveContextScope(workspaceId, streamId),
+    await resolveMemoSourceEvents(streamId, event)
+  )
+  await putLocalContextRows(rows)
+}
+
+/**
+ * The `message_created` events a `memos:captured` payload cites, by message id.
+ * A memo row is anchored on its source messages, not on the capture broadcast
+ * (extraction is debounced, so capture time lands minutes after the landmark) —
+ * `indexCapturedMemos` resolves the same way, and the two must agree or they
+ * write different identity keys. Empty for every other event type.
+ */
+async function resolveMemoSourceEvents(streamId: string, event: CachedEvent): Promise<Map<string, CachedEvent>> {
+  const resolved = new Map<string, CachedEvent>()
+  if (event.eventType !== "memos:captured") return resolved
+  const payload = event.payload as { memos?: { sourceMessageIds?: string[] }[] } | undefined
+  const wanted = new Set((payload?.memos ?? []).flatMap((memo) => memo.sourceMessageIds ?? []))
+  if (wanted.size === 0) return resolved
+  await db.events
+    .where("[streamId+eventType]")
+    .equals([streamId, "message_created"])
+    .each((candidate) => {
+      const messageId = (candidate.payload as { messageId?: string })?.messageId
+      if (messageId && wanted.has(messageId)) resolved.set(messageId, candidate)
+    })
+  return resolved
+}
+
 export interface StreamSocketHandlerOptions {
   /**
    * Called after a live event was written whose sequence leaves a hole behind
@@ -1176,6 +1231,13 @@ export function registerStreamSocketHandlers(
       onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
     }
 
+    await applyContextRowsForEvent(workspaceId, streamId, {
+      ...newEvent,
+      workspaceId,
+      _sequenceNum: sequenceToNum(newEvent.sequence),
+      _cachedAt: now,
+    })
+
     // Seed the decrypt cache so the encrypted server event renders its content
     // immediately. Only meaningful for E2E events (the wire payload carries a
     // ciphertext); for plaintext sends the render path ignores the cache.
@@ -1238,6 +1300,22 @@ export function registerStreamSocketHandlers(
       await writeSlotCarrier({ database: db, workspaceId, streamId, carrier: payload, mode: "merge", cachedAt: now })
     })
 
+    // Replace, not patch: an edit can drop a link the message used to carry, so
+    // the message's rows are rebuilt from the now-updated event (which still
+    // holds the attachments the edit payload doesn't carry). Only when a rebuild
+    // source exists — `db.events` holds a window, not the whole history, and
+    // deleting without rebuilding would drop the seeded server rows of an older
+    // message with nothing to write back.
+    const editedEvent = await db.events
+      .where("[streamId+eventType]")
+      .equals([streamId, "message_created"])
+      .filter((e) => (e.payload as { messageId?: string })?.messageId === editPayload.messageId)
+      .first()
+    if (editedEvent) {
+      await deleteContextRowsForMessage(workspaceId, editPayload.messageId)
+      await applyContextRowsForEvent(workspaceId, streamId, editedEvent)
+    }
+
     if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(editPayload.contentJson)) {
       // Deploy-skew fallback — see handleMessageCreated.
       await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
@@ -1251,6 +1329,10 @@ export function registerStreamSocketHandlers(
       ...p,
       deletedAt: payload.deletedAt,
     }))
+
+    // A deleted message holds no context rows — the server drops them in the
+    // delete transaction with no separate event.
+    await deleteContextRowsForMessage(workspaceId, payload.messageId)
 
     // Fix A2: the delete transaction marks the message's activity rows read
     // server-side with no counter event, so drop the held rows here to match.
@@ -1313,6 +1395,19 @@ export function registerStreamSocketHandlers(
         await db.streams.put(streamUpdate)
       }
     })
+
+    // Re-home the moved messages' context rows onto the thread. Gated on the
+    // SOURCE (like the activity rehome below): the destination of a move is
+    // usually a freshly created thread with no subscription and therefore no
+    // registered handlers, so a destination gate would never fire.
+    if (payload.sourceStreamId === streamId) {
+      await reparentContextRows(
+        workspaceId,
+        payload.movedMessageIds,
+        payload.destinationStreamId,
+        payload.thread.rootStreamId ?? payload.thread.id
+      )
+    }
 
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
@@ -1489,6 +1584,17 @@ export function registerStreamSocketHandlers(
     })
     if (gapAfterSequence !== null) {
       onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+    }
+
+    // `memos:captured` is the only appended row that carries context artifacts
+    // (INV-62 — the capture broadcast names each memo and its source messages).
+    if (payload.event.eventType === "memos:captured") {
+      await applyContextRowsForEvent(workspaceId, streamId, {
+        ...payload.event,
+        workspaceId,
+        _sequenceNum: sequenceToNum(payload.event.sequence),
+        _cachedAt: now,
+      })
     }
   }
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -34,7 +34,12 @@ import {
 } from "./unread-counters"
 import { upsertActiveCall, updateCallParticipants } from "@/stores/active-calls-store"
 import { contextItemsFromEvent, type ContextRowsContext } from "@/lib/stream-context/rows"
-import { deleteContextRowsForMessage, putLocalContextRows, reparentContextRows } from "@/stores/stream-context-store"
+import {
+  deleteContextRowsForMessage,
+  putLocalContextRows,
+  reparentContextRows,
+  replaceContextRowsForMessage,
+} from "@/stores/stream-context-store"
 
 // ============================================================================
 // Bootstrap application — writes stream bootstrap data to IndexedDB
@@ -1057,13 +1062,22 @@ async function resolveContextScope(workspaceId: string, streamId: string): Promi
  * projects no rows for a sealed stream, and the panel derives that view from
  * decrypted content instead.
  */
-async function applyContextRowsForEvent(workspaceId: string, streamId: string, event: CachedEvent): Promise<void> {
+async function applyContextRowsForEvent(
+  workspaceId: string,
+  streamId: string,
+  event: CachedEvent,
+  opts?: { replaceMessageId?: string }
+): Promise<void> {
   if (isEncryptedPayload(event.payload)) return
   const rows = contextItemsFromEvent(
     event,
     await resolveContextScope(workspaceId, streamId),
     await resolveMemoSourceEvents(streamId, event)
   )
+  if (opts?.replaceMessageId) {
+    await replaceContextRowsForMessage(workspaceId, opts.replaceMessageId, rows)
+    return
+  }
   await putLocalContextRows(rows)
 }
 
@@ -1312,8 +1326,7 @@ export function registerStreamSocketHandlers(
       .filter((e) => (e.payload as { messageId?: string })?.messageId === editPayload.messageId)
       .first()
     if (editedEvent) {
-      await deleteContextRowsForMessage(workspaceId, editPayload.messageId)
-      await applyContextRowsForEvent(workspaceId, streamId, editedEvent)
+      await applyContextRowsForEvent(workspaceId, streamId, editedEvent, { replaceMessageId: editPayload.messageId })
     }
 
     if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(editPayload.contentJson)) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -456,6 +456,9 @@ export {
   threaFetchUserAgent,
 } from "./outbound-fetch"
 
+// URL filtering/dedup values shared by the backend link filter and the client projection
+export { BLOCKED_HOSTNAMES, BLOCKED_IP_PATTERNS, TRACKING_PARAMS } from "./url-normalization"
+
 // Attachment categories (mime → category mapping for the attachment explorer)
 export { ATTACHMENT_CATEGORIES, categoryFromMime, mimePrefixesForCategory } from "./attachment-categories"
 export type { AttachmentCategory } from "./attachment-categories"
@@ -1057,6 +1060,7 @@ export {
 export {
   CONTEXT_CATEGORIES,
   STREAM_CONTEXT_REF_KINDS,
+  MESSAGE_BODY_CONTEXT_CATEGORIES,
   STREAM_CONTEXT_SCOPES,
   streamContextItemKey,
   type ContextCategory,

--- a/packages/types/src/stream-context.ts
+++ b/packages/types/src/stream-context.ts
@@ -8,6 +8,14 @@ import type { LinkPreviewContentType, LinkPreviewStatus, RichLinkPreviewType } f
 export const CONTEXT_CATEGORIES = ["link", "media", "file", "memo", "delegation", "thread"] as const
 export type ContextCategory = (typeof CONTEXT_CATEGORIES)[number]
 
+/**
+ * Categories a message body owns, i.e. exactly what a message's context-row
+ * derivation rebuilds. An edit refresh must not touch the other categories —
+ * memo, delegation and thread landmarks are anchored on a message but written by
+ * other paths and nothing re-creates them.
+ */
+export const MESSAGE_BODY_CONTEXT_CATEGORIES = ["link", "media", "file"] as const
+
 export const STREAM_CONTEXT_REF_KINDS = ["url", "attachment", "giphy", "memo", "delegation", "thread"] as const
 export type StreamContextRefKind = (typeof STREAM_CONTEXT_REF_KINDS)[number]
 

--- a/packages/types/src/url-normalization.ts
+++ b/packages/types/src/url-normalization.ts
@@ -1,0 +1,42 @@
+/**
+ * The VALUES behind link filtering and dedup, shared so the backend's
+ * `link-previews/url-utils.ts` and the frontend's local context-row projection
+ * agree on which links exist and which collapse into one (INV-33). Each side
+ * keeps its own matching code; only these lists are the source of truth. A
+ * client list that drifts narrower projects local rows the server never writes,
+ * which can never reconcile.
+ */
+
+/** Private/reserved IP ranges that must not be fetched (SSRF protection). */
+export const BLOCKED_IP_PATTERNS: readonly RegExp[] = [
+  /^127\./, // loopback
+  /^10\./, // private class A
+  /^172\.(1[6-9]|2\d|3[01])\./, // private class B
+  /^192\.168\./, // private class C
+  /^169\.254\./, // link-local
+  /^0\./, // current network
+  /^\[?::1\]?$/, // IPv6 loopback
+  /^\[?fe80:/i, // IPv6 link-local
+  /^\[?fc00:/i, // IPv6 unique local
+  /^\[?fd/i, // IPv6 unique local
+]
+
+/** Hostnames that must not be fetched (cloud metadata endpoints). */
+export const BLOCKED_HOSTNAMES: ReadonlySet<string> = new Set([
+  "localhost",
+  "metadata.google.internal",
+  "metadata.google.com",
+])
+
+/** Tracking parameters stripped during URL normalization. */
+export const TRACKING_PARAMS: readonly string[] = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "fbclid",
+  "gclid",
+  "ref",
+  "source",
+]


### PR DESCRIPTION
Layer 4 of 5. Layers 1-3 give the panel a server-side index; this gives the client somewhere to keep it.

`streamContextItems` is a new Dexie store holding one row per (message × artifact), keyed by the same `${category}:${refId}:${sourceMessageId}` the server computes — so a locally derived row and the server's row for the same artifact are literally the same row, and reconciliation is a `bulkPut`, not a merge. This is the board's `conversations` cutover (IDB v36) applied to the context feed: IDB becomes the read authority, the fetch layer becomes a seeding engine.

Rows arrive from two places: sync-engine appliers for message create/edit/delete/move and `memos:captured`, and seeded server pages (layer 5). Delegation and thread rows, and rows for a send that has not yet echoed, come with the seed rather than being derived locally — a deliberate limit, since those categories carry no locally derivable identity. `groupKey` is left equal to `refId` locally — the normalized collapse key is deliberately server-only, so the client never has to reimplement the GitHub/Linear-aware URL normalizer — and is filled in when the server row lands.

No panel change yet; `derive.ts` still drives the UI. Layer 5 cuts it over.

Adversarial review found five defects, all in the reconcile seam, all fixed here:

- **Replay stomped reconciled rows.** The local write sat outside `handleMessageCreated`'s dedupe guard and did a whole-record `bulkPut`. Catch-up replays every sync-log entry through these handlers, so a reconnect would have reset every row to a bare local one — link cards silently losing their titles and images, and the collapse key regressing to the raw href. Local writes now never downgrade a reconciled row.
- **The move reparent never ran.** It was gated on the destination stream, but the dominant case creates a fresh thread, which has no subscription and no registered handlers at move time. Gated on the source now, matching the activity rehome directly below it.
- **Link rows double-rendered.** Locally they deduped by raw href; the server dedupes by normalized URL, so `?utm_source=` and `#fragment` variants produced a local row that no server page would ever reconcile.
- **An edit could delete rows it could not rebuild** when the message's event was outside the cached window.
- **Memo rows sorted wrong.** They used the debounced `memos:captured` broadcast time and the first *cited* source, where the server uses the latest *resolvable* source message — minutes of drift, and a non-reconciling key whenever the first citation had been deleted.

Verification: 508 frontend tests across the touched areas, monorepo typecheck, lint.

Follow-up commit, from post-PR review: the edit path deleted a message's rows and rebuilt them, which walked straight back into the downgrade above — the never-downgrade guard cannot see a row that was just deleted. Replacing now preserves reconciled fields on surviving keys. Also indexed `[workspaceId+sourceMessageId]` (v45 is unreleased) so per-message delete and reparent stop scanning the workspace, mirrored the server's blocked-host rule locally, and made memo anchoring all-or-nothing rather than resolving against whatever happens to be in the cached window.
