### PR TITLE
fix(stream-context): scope backfill message queries through streams

### DIFF
--- a/apps/backend/src/db/migrations/20260727080000_backfill_message_scoped_requeue.sql
+++ b/apps/backend/src/db/migrations/20260727080000_backfill_message_scoped_requeue.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- Re-enqueue the two backfills whose plan queries scoped `messages` by a column
+-- it does not have
+-- =============================================================================
+--
+-- `messages` carries no `workspace_id`; it scopes through its stream. Both
+-- `stream-context-index` and `mention-actor-refs` planned with
+-- `WHERE workspace_id = $1` against it, so every plan job threw
+-- `column "workspace_id" does not exist` and dead-lettered before fanning out a
+-- single chunk. The symptom for stream-context was an empty "In this stream"
+-- panel for all pre-existing content while live writes kept indexing correctly.
+--
+-- The queries now scope through `streams`, so this re-enqueues both. Chunks are
+-- idempotent (`ON CONFLICT DO NOTHING` on the identity index for stream-context;
+-- a no-op rewrite for mentions), so overlapping with rows the live path already
+-- wrote is safe. The original dead-lettered jobs stay where they are — they
+-- carry no state worth recovering.
+--
+-- `process_after` is 15 minutes out (INV-67) so replicas still on the old code
+-- have cut over before a chunk job claims a definition they don't register.
+
+INSERT INTO queue_messages (
+    id,
+    queue_name,
+    workspace_id,
+    payload,
+    process_after,
+    inserted_at
+)
+SELECT
+    'queue_' || replace(gen_random_uuid()::text, '-', ''),
+    'backfill.plan',
+    w.id,
+    jsonb_build_object(
+        'workspaceId', w.id,
+        'backfillName', name.value
+    ),
+    NOW() + INTERVAL '15 minutes',
+    NOW()
+FROM workspaces w
+CROSS JOIN (VALUES ('stream-context-index'), ('mention-actor-refs')) AS name(value);

--- a/apps/backend/src/features/mentions/mention-backfill.ts
+++ b/apps/backend/src/features/mentions/mention-backfill.ts
@@ -39,14 +39,16 @@ function listIdsQuery(table: BackfillTable, workspaceId: string) {
     case "messages":
       return sql`
         SELECT id FROM messages
-        WHERE workspace_id = ${workspaceId} AND content_json IS NOT NULL AND e2e_version IS NULL
+        WHERE stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
+          AND content_json IS NOT NULL AND e2e_version IS NULL
         ORDER BY id
       `
     case "message_versions":
       return sql`
         SELECT v.id FROM message_versions v
         JOIN messages m ON m.id = v.message_id
-        WHERE m.workspace_id = ${workspaceId} AND m.e2e_version IS NULL AND v.content_json IS NOT NULL
+        JOIN streams s ON s.id = m.stream_id
+        WHERE s.workspace_id = ${workspaceId} AND m.e2e_version IS NULL AND v.content_json IS NOT NULL
         ORDER BY v.id
       `
     case "scheduled_messages":
@@ -69,7 +71,18 @@ function selectRowsQuery(table: BackfillTable, workspaceId: string, ids: string[
     return sql`
       SELECT v.id, v.content_json FROM message_versions v
       JOIN messages m ON m.id = v.message_id
-      WHERE m.workspace_id = ${workspaceId} AND v.id = ANY(${ids}) AND v.content_json IS NOT NULL
+      JOIN streams s ON s.id = m.stream_id
+      WHERE s.workspace_id = ${workspaceId} AND v.id = ANY(${ids}) AND v.content_json IS NOT NULL
+    `
+  }
+  // `messages` carries no `workspace_id` of its own — it scopes through its
+  // stream, the same way `MessageRepository.findByIdsInWorkspace` does.
+  if (table === "messages") {
+    return sql`
+      SELECT id, content_json FROM messages
+      WHERE id = ANY(${ids})
+        AND content_json IS NOT NULL
+        AND stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
     `
   }
   return sql`

--- a/apps/backend/src/features/stream-context/backfill.ts
+++ b/apps/backend/src/features/stream-context/backfill.ts
@@ -105,8 +105,7 @@ export async function plan(ctx: BackfillContext, workspaceId: string): Promise<S
 
   const messages = await ctx.pool.query<{ id: string; stream_id: string }>(sql`
     SELECT id, stream_id FROM messages
-    WHERE workspace_id = ${workspaceId}
-      AND stream_id = ANY(${streamIds})
+    WHERE stream_id = ANY(${streamIds})
       AND deleted_at IS NULL
     ORDER BY stream_id, id
   `)
@@ -126,7 +125,6 @@ export async function plan(ctx: BackfillContext, workspaceId: string): Promise<S
     JOIN messages m ON m.id = ANY(mo.source_message_ids)
     JOIN streams s ON s.id = m.stream_id AND s.workspace_id = ${workspaceId}
     WHERE mo.workspace_id = ${workspaceId}
-      AND m.workspace_id = ${workspaceId}
       AND m.stream_id = ANY(${streamIds})
   `)
   const delegationStreams = await ctx.pool.query<{ stream_id: string }>(sql`
@@ -332,7 +330,9 @@ async function loadAnchorMessages(ctx: BackfillContext, workspaceId: string, ids
   const result = await ctx.pool.query<AnchorRow>(sql`
     SELECT id, author_id, created_at, sequence, content_markdown
     FROM messages
-    WHERE workspace_id = ${workspaceId} AND id = ANY(${ids}) AND deleted_at IS NULL
+    WHERE id = ANY(${ids})
+      AND deleted_at IS NULL
+      AND stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
   `)
   return result.rows
 }
@@ -354,7 +354,7 @@ async function reconcileMessagesChunk(
 ): Promise<number> {
   const current = await ctx.pool.query<{ id: string; edited_at: Date | null }>(sql`
     SELECT id, edited_at FROM messages
-    WHERE workspace_id = ${workspaceId}
+    WHERE stream_id = ${chunk.streamId}
       AND id = ANY(${snapshot.map((message) => message.id)})
       AND stream_id = ${chunk.streamId}
       AND deleted_at IS NULL
@@ -385,8 +385,7 @@ async function processMessagesChunk(
   const messages = await ctx.pool.query<MessageRow>(sql`
     SELECT id, author_id, created_at, sequence, content_json, content_markdown, edited_at
     FROM messages
-    WHERE workspace_id = ${workspaceId}
-      AND stream_id = ${chunk.streamId}
+    WHERE stream_id = ${chunk.streamId}
       AND id = ANY(${chunk.ids})
       AND deleted_at IS NULL
     ORDER BY id
@@ -425,7 +424,6 @@ async function processMemosChunk(
     JOIN messages m ON m.id = ANY(mo.source_message_ids)
     JOIN streams s ON s.id = m.stream_id AND s.workspace_id = ${workspaceId}
     WHERE mo.workspace_id = ${workspaceId}
-      AND m.workspace_id = ${workspaceId}
       AND ${TOP_LEVEL_STREAM_SQL} = ${chunk.streamId}
   `)
   if (memos.rows.length === 0) return []

--- a/apps/backend/src/features/stream-context/read-repository.test.ts
+++ b/apps/backend/src/features/stream-context/read-repository.test.ts
@@ -146,7 +146,11 @@ describe("StreamContextReadRepository.listFeed", () => {
     expect(text).toContain("att.filename ILIKE")
     expect(text).toContain("mem.title ILIKE")
     expect(text).toContain("dt.title ILIKE")
-    expect(text).toContain("sci.snippet ILIKE")
+    expect(text).toContain("sci.ref_id ILIKE")
+    // The message's snippet is deliberately NOT matched: every artifact of a
+    // message shares it, so one message carrying five links would match all
+    // five for a term naming only one.
+    expect(text).not.toContain("sci.snippet ILIKE")
     expect(values).toContain("usr_7")
     expect(values).toContain("%budget%")
     const dates = values.filter((v) => v instanceof Date).map((v) => (v as Date).toISOString())

--- a/apps/backend/src/features/stream-context/read-repository.ts
+++ b/apps/backend/src/features/stream-context/read-repository.ts
@@ -254,7 +254,7 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
       AND (${filters.after === undefined} OR sci.occurred_at >= ${filters.after ?? EPOCH}::timestamptz)
       AND (
         ${!hasQuery}
-        OR sci.snippet ILIKE ${likePattern}
+        OR sci.ref_id ILIKE ${likePattern}
         OR lp.title ILIKE ${likePattern}
         OR lp.site_name ILIKE ${likePattern}
         OR lp.url ILIKE ${likePattern}

--- a/apps/backend/tests/integration/stream-context-backfill.test.ts
+++ b/apps/backend/tests/integration/stream-context-backfill.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The backfill's SQL, against a real schema.
+ *
+ * Its unit suite drives a fake pool, which cannot catch a column that does not
+ * exist — the same gap that let `th.name` reach production in the read path. A
+ * chunk that throws goes to the DLQ, and the symptom is an empty panel for all
+ * historical content while live writes keep working.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService } from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { plan, processChunk } from "../../src/features/stream-context/backfill"
+import { workspaceId } from "../../src/lib/id"
+import { sql } from "../../src/db"
+import { StreamTypes, Visibilities } from "@threa/types"
+
+describe("stream-context backfill against the real schema", () => {
+  let pool: Pool
+  let ctx: { pool: Pool }
+
+  const wsId = workspaceId()
+  let ownerId: string
+  let peerId: string
+  let channelId: string
+  let dmId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    ctx = { pool }
+    const streamService = new StreamService(pool)
+    const eventService = new EventService(pool)
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Backfill WS",
+        slug: `backfill-ws-${wsId}`,
+        createdBy: wsId,
+      })
+      ownerId = (await addTestMember(client, wsId, `owner-${wsId.slice(-8)}`)).id
+      peerId = (await addTestMember(client, wsId, `peer-${wsId.slice(-8)}`)).id
+    })
+
+    const channel = await streamService.create({
+      workspaceId: wsId,
+      type: StreamTypes.CHANNEL,
+      name: "backfill-channel",
+      slug: `backfill-channel-${wsId.slice(-8)}`,
+      visibility: Visibilities.PUBLIC,
+      createdBy: ownerId,
+    })
+    channelId = channel.id
+
+    const dm = await streamService.findOrCreateDm({
+      workspaceId: wsId,
+      userOneId: ownerId,
+      userTwoId: peerId,
+    })
+    dmId = dm.id
+
+    for (const streamId of [channelId, dmId]) {
+      await eventService.createMessage({
+        workspaceId: wsId,
+        streamId,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent(`see https://example.com/${streamId}/doc`),
+      })
+    }
+
+    // The rows the live write path just created are what the backfill must
+    // converge on, so clear them and let the backfill rebuild from stored state.
+    await pool.query(sql`DELETE FROM stream_context_items WHERE workspace_id = ${wsId}`)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("plan lists the workspace's streams without throwing", async () => {
+    const chunks = await plan(ctx as never, wsId)
+    const streamIds = new Set(chunks.filter((c) => c.kind === "messages").map((c) => c.streamId))
+
+    expect({ hasChannel: streamIds.has(channelId), hasDm: streamIds.has(dmId) }).toEqual({
+      hasChannel: true,
+      hasDm: true,
+    })
+  })
+
+  test("every chunk kind executes and the message chunks rebuild the rows", async () => {
+    const chunks = await plan(ctx as never, wsId)
+    for (const chunk of chunks) {
+      await processChunk(ctx as never, wsId, chunk)
+    }
+
+    const rows = await pool.query<{ stream_id: string; category: string; ref_id: string }>(sql`
+      SELECT stream_id, category, ref_id FROM stream_context_items WHERE workspace_id = ${wsId}
+      ORDER BY ref_id
+    `)
+
+    expect(rows.rows).toEqual([
+      { stream_id: channelId, category: "link", ref_id: `https://example.com/${channelId}/doc` },
+      { stream_id: dmId, category: "link", ref_id: `https://example.com/${dmId}/doc` },
+    ])
+  })
+
+  test("re-running every chunk inserts nothing new", async () => {
+    const before = await pool.query<{ count: string }>(sql`
+      SELECT count(*)::text AS count FROM stream_context_items WHERE workspace_id = ${wsId}
+    `)
+    for (const chunk of await plan(ctx as never, wsId)) {
+      await processChunk(ctx as never, wsId, chunk)
+    }
+    const after = await pool.query<{ count: string }>(sql`
+      SELECT count(*)::text AS count FROM stream_context_items WHERE workspace_id = ${wsId}
+    `)
+
+    expect(after.rows[0]!.count).toEqual(before.rows[0]!.count)
+  })
+})

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -378,7 +378,7 @@ describe("StreamContextPanel — flag on", () => {
     expect(screen.getByRole("button", { name: /^Links/ })).toHaveTextContent("1")
   })
 
-  it("applies the active text filter to an expanded group's occurrences", async () => {
+  it("filters by the artifact's own text, not the message it came from", async () => {
     const shared = {
       category: "link" as const,
       refId: "https://filtered.example",
@@ -397,11 +397,21 @@ describe("StreamContextPanel — flag on", () => {
     vi.spyOn(streamContextApi, "occurrences").mockResolvedValue({ items: [newer, older], nextCursor: null })
 
     renderPanel()
-    await userEvent.type(await screen.findByLabelText("Search in this stream"), "quarterly")
+    const search = await screen.findByLabelText("Search in this stream")
 
+    // The artifact's own title matches, so the group survives and expands to
+    // every occurrence — the count and the expansion agree.
+    await userEvent.type(search, "Filtered")
     await userEvent.click(await screen.findByRole("button", { name: /Shared 2 times/ }))
     expect(await screen.findByText("quarterly plan")).toBeInTheDocument()
-    expect(screen.queryByText("old draft")).not.toBeInTheDocument()
+    expect(screen.getByText("old draft")).toBeInTheDocument()
+
+    // A term that appears only in one source message's snippet matches nothing:
+    // every artifact of a message shares that snippet, so matching it made a
+    // message carrying five links match all five for a term naming only one.
+    await userEvent.clear(search)
+    await userEvent.type(search, "quarterly")
+    await waitFor(() => expect(screen.queryByText("Filtered")).not.toBeInTheDocument())
   })
 
   it("does not offer expansion on a locally derived row (no server groupKey yet)", async () => {

--- a/apps/frontend/src/lib/stream-context/filter.ts
+++ b/apps/frontend/src/lib/stream-context/filter.ts
@@ -13,14 +13,19 @@ export interface ContextRowFilters {
 }
 
 /**
- * The searchable text of a row: its snippet plus whatever the joined detail
- * carries (a link's title/url, an attachment's filename, a memo/task title, a
- * thread's name). Locally derived rows have an empty detail, so they match on
- * the snippet alone until the server row reconciles them.
+ * The searchable text of a row: the ARTIFACT's own text — its ref (url /
+ * attachment id / memo id) plus whatever the joined detail carries (a link's
+ * title/url, an attachment's filename, a memo/task title, a thread's name).
+ *
+ * Deliberately NOT the snippet. The snippet is the source message's first line,
+ * which every artifact of that message shares, so including it made one message
+ * carrying five links match all five for a term naming only one — the filter
+ * looked broken because only the true match highlighted. Mirrors the endpoint's
+ * predicate; the two must agree or phase 2 widens into rows phase 1 excluded.
  */
 export function contextRowText(row: CachedStreamContextItem): string {
   const detail = row.detail as unknown as Record<string, unknown>
-  const parts = [row.snippet, row.refId]
+  const parts = [row.refId]
   for (const field of ["url", "title", "siteName", "description", "filename", "giphyTitle", "name", "statusNote"]) {
     const value = detail?.[field]
     if (typeof value === "string") parts.push(value)


### PR DESCRIPTION
The "In this stream" panel showed nothing but content posted since the deploy. Not slowness — the backfill never ran a single chunk.

`messages` carries no `workspace_id`; it scopes through its stream. Both backfills planned with `WHERE workspace_id = $1` against it, so every `backfill.plan` job threw `column "workspace_id" does not exist` and dead-lettered *before* fanning out any chunks. The live write path was unaffected, which is exactly why recent artifacts appeared and nothing older did. The same shape means **`mention-actor-refs` has been failing this way since it shipped in June** — fixed here too.

The queries now scope the way `MessageRepository.findByIdsInWorkspace` does. The migration re-enqueues both backfills 15 minutes out (INV-67); chunks are idempotent on the identity index, so overlapping with rows the live path already wrote is safe, and the dead-lettered jobs are left alone — they carry no recoverable state.

**Why it shipped:** the backfill's unit tests drive a fake pool that records SQL text, so its queries had never touched a real schema — the same gap that let `th.name` reach production one PR earlier. `tests/integration/stream-context-backfill.test.ts` now runs plan plus every chunk kind against `threa_test` and asserts the rebuilt rows; it fails loudly on this class of bug.

**Search fix, same report:** the predicate matched a row's `snippet` — the source message's first line, which every artifact of that message shares. One message carrying five PR links matched all five for a term naming only one, and only the true match highlighted, so the filter looked broken. Both sides now match the artifact's own text (url, title, filename, memo/task title). One consequence worth stating: text search narrows *which artifacts* show, not which occurrences within one, so a row and its "shared N times" count can no longer disagree.

Verification: the new DB-backed backfill tests plus the existing read-path ones, 3383 backend tests, the stream-context/search frontend suites, typecheck, lint, `check:migrations`. The full frontend suite was not run to completion locally (repeated runs were surfacing unrelated load flakes in `e2e-session-store` and `sync-engine`, both green in isolation) — CI covers it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787732420&installation_model_id=20758&pr_number=1586&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1586&signature=71ae14859be5408b2d6d62ec23ae83f18e8efe05af46104c4b5537d3856f5297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->