### PR TITLE
fix(sidebar): show the unsent-draft hint on scratchpad rows

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it, beforeEach, vi } from "vitest"
 import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom"
 import { fireEvent, render, screen, waitFor } from "@/test"
-import { StreamTypes, Visibilities } from "@threa/types"
+import { LabelableResourceTypes, StreamTypes, Visibilities } from "@threa/types"
 import { ScratchpadItem } from "./scratchpad-item"
+import { SidebarLabelsProvider } from "./sidebar-labels"
 import type { StreamItemData } from "./types"
 import type { SidebarBoardMode } from "./board-sidebar-mode"
 import * as contextsModule from "@/contexts"
@@ -12,6 +13,7 @@ import * as streamSettingsModule from "@/components/stream-settings/use-stream-s
 import * as urgencyTrackingModule from "./use-urgency-tracking"
 import * as itemDrawerModule from "./use-sidebar-item-drawer"
 import * as sidebarActionsModule from "./sidebar-actions"
+import * as workspaceStoreModule from "@/stores/workspace-store"
 
 const collapseOnMobile = vi.fn()
 const archiveStream = vi.fn(async () => {})
@@ -435,6 +437,46 @@ describe("ScratchpadItem", () => {
       />
     )
     expect(screen.getByRole("link", { name: /Notes/i })).toHaveAttribute("href", "/w/workspace_1/s/stream_scratchpad_1")
+  })
+
+  it("shows the unsent-draft hint alongside the label dots, however many labels", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceLabels").mockReturnValue([
+      { id: "label_1", name: "Hardware", color: "#3b82f6", emoji: "💻", archivedAt: null },
+      { id: "label_2", name: "Urgent", color: "#ef4444", emoji: null, archivedAt: null },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceLabels>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceLabelAssignments").mockReturnValue([
+      { labelId: "label_1", resourceType: LabelableResourceTypes.STREAM, resourceId: "stream_scratchpad_1" },
+      { labelId: "label_2", resourceType: LabelableResourceTypes.STREAM, resourceId: "stream_scratchpad_1" },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceLabelAssignments>)
+
+    renderWithRouter(
+      <SidebarLabelsProvider workspaceId="workspace_1">
+        <ScratchpadItem
+          workspaceId="workspace_1"
+          stream={createScratchpad({ hasLoadedDraft: true })}
+          isActive={false}
+          unreadCount={0}
+          mentionCount={0}
+        />
+      </SidebarLabelsProvider>
+    )
+
+    expect(screen.getByRole("img", { name: "2 labels" })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "Unsent draft" })).toBeInTheDocument()
+  })
+
+  it("hides the unsent-draft hint on the active scratchpad (its composer already shows the draft)", () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({ hasLoadedDraft: true })}
+        isActive
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    expect(screen.queryByRole("img", { name: "Unsent draft" })).not.toBeInTheDocument()
   })
 
   it("chats mode: no board verbs on the scratchpad", () => {

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -20,6 +20,7 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { SectionPicker } from "./section-picker"
 import { MentionIndicator } from "@/components/mention-indicator"
+import { DraftIndicator } from "@/components/draft-indicator"
 import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useInputMode } from "@/hooks/use-input-mode"
@@ -348,6 +349,8 @@ export function ScratchpadItem({
                   )}
                   <div className="ml-auto flex items-center gap-1.5">
                     <StreamLabelDots streamId={streamWithPreview.id} />
+                    {/* Suppressed on the active stream — its composer already shows the draft. */}
+                    {streamWithPreview.hasLoadedDraft && !isActive && <DraftIndicator />}
                     <MentionIndicator count={mentionCount} />
                   </div>
                 </div>


### PR DESCRIPTION
## Why

A scratchpad you step away from with an unsent composer draft showed no pencil in the sidebar. Reported as "streams with labels do not show the draft icon" — the observed row was a labeled scratchpad, so labels looked like the cause. They are not: on channel/DM rows the label dots and the pencil share the same trailing slot and coexist at any label count (verified live with 1 and 3 labels, below). `ScratchpadItem` simply never rendered `DraftIndicator`.

#1056 excluded scratchpads deliberately — "a scratchpad is itself a draft". That reasoning covers virtual `draft_` scratchpads, which `useDraftSummary` already skips (`hasLoadedDraft` stays false), but not persisted ones: their composer draft is the same situation as a channel's.

## Change

`ScratchpadItem` renders `DraftIndicator` on `hasLoadedDraft && !isActive`, in the same trailing slot after `StreamLabelDots`, matching `StreamItem`. No change to the summary derivation or to any other row.

## Verification

Two new `scratchpad-item.test.tsx` cases: the hint renders next to a two-label `StreamLabelDots` (`2 labels` + `Unsent draft`), and is suppressed on the active row. Neutralising the guard fails the first one; frontend typecheck clean. Live in `bun run dev:test` + Playwright across five rows (plain/labeled scratchpad, plain/1-label/3-label channel):

| Before | After |
| --- | --- |
| ![before](https://seer.build/ws_vbyzjvdg6g/i/img_gahjncyp77/draft-icon-before.webp) | ![after](https://seer.build/ws_vbyzjvdg6g/i/img_yxh1qx5dyb/draft-icon-after.webp) |

## Residual risk

The pencil now appears on scratchpad rows that previously had none — intended, and identical to the channel behaviour. Virtual `draft_` scratchpad rows are unaffected (already excluded upstream).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787732506&installation_model_id=20758&pr_number=1587&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1587&signature=fb2a5cfc8c6ae0391271165219881b6952c5b1e6f58e74a0ba6032c6f59421a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->