### PR TITLE
feat(agents): tier agent tools by how much a wrong call costs

### DIFF
--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,4 +1,4 @@
-export { defineAgentTool, toVercelToolDefs, buildToolPromptSections } from "./runtime/agent-tool"
+export { defineAgentTool, tierOfBuiltTool, toVercelToolDefs, buildToolPromptSections } from "./runtime/agent-tool"
 export type { AgentTool, AgentToolConfig, AgentToolResult, ExecutionPhase } from "./runtime/agent-tool"
 export {
   negotiateCapabilities,

--- a/packages/agent-runtime/src/runtime/agent-tool.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { z } from "zod"
-import { AgentStepTypes } from "@threa/types"
-import { buildToolPromptSections, defineAgentTool, type AgentTool } from "./agent-tool"
+import { AgentStepTypes, AgentToolNames, ToolTiers } from "@threa/types"
+import { buildToolPromptSections, defineAgentTool, tierOfBuiltTool, type AgentTool } from "./agent-tool"
 
 function makeTool(name: string, promptBlock?: string): AgentTool {
   return defineAgentTool({
@@ -32,5 +32,35 @@ describe("buildToolPromptSections", () => {
   test("returns an empty string when no tool carries prose", () => {
     expect(buildToolPromptSections([makeTool("silent")])).toBe("")
     expect(buildToolPromptSections([])).toBe("")
+  })
+})
+
+describe("tier resolution", () => {
+  test("a registered tool takes its tier from the table, not its definition site", () => {
+    expect(tierOfBuiltTool(makeTool(AgentToolNames.DELEGATE_TASK))).toBe(ToolTiers.GUARDED)
+    expect(tierOfBuiltTool(makeTool(AgentToolNames.WEB_SEARCH))).toBe(ToolTiers.UNCHECKED)
+  })
+
+  test("an unregistered host-local tool is tier 1", () => {
+    expect(tierOfBuiltTool(makeTool("enclave_local_reader"))).toBe(ToolTiers.UNCHECKED)
+  })
+
+  // The point of resolving centrally: a definition site cannot claim a tier the
+  // table disagrees with. Declaring one at all is the mistake, so it throws
+  // rather than being quietly overwritten — a silently ignored `tier: 1` on a
+  // guarded tool would read, in review, exactly like a tool that skips the
+  // guardian.
+  test("declaring a tier at the definition site throws", () => {
+    expect(() =>
+      defineAgentTool({
+        name: AgentToolNames.WEB_SEARCH,
+        description: "d",
+        categories: ["web"],
+        tier: ToolTiers.UNCHECKED,
+        inputSchema: z.object({}),
+        execute: async () => ({ output: "ok" }),
+        trace: { stepType: AgentStepTypes.WEB_SEARCH, formatContent: () => "" },
+      })
+    ).toThrow(/TOOL_TIERS_BY_NAME/)
   })
 })

--- a/packages/agent-runtime/src/runtime/agent-tool.ts
+++ b/packages/agent-runtime/src/runtime/agent-tool.ts
@@ -1,6 +1,14 @@
 import type { Tool } from "ai"
 import { z } from "zod"
-import type { AgentStepType, ToolPrivacyCategory, TraceSource, SourceItem } from "@threa/types"
+import {
+  ToolTiers,
+  tierOfTool,
+  type AgentStepType,
+  type ToolPrivacyCategory,
+  type ToolTier,
+  type TraceSource,
+  type SourceItem,
+} from "@threa/types"
 
 export interface AgentToolResult {
   /** What the LLM sees as the tool result */
@@ -39,6 +47,22 @@ export interface AgentToolConfig<TSchema extends z.ZodTypeAny = z.ZodTypeAny> {
    * sees) that no policy ever gates.
    */
   categories: readonly ToolPrivacyCategory[]
+  /**
+   * How much this call can cost the user if the model is wrong about wanting
+   * it. Tier 2+ is reviewed by the host's guardian before it executes; tier 1
+   * runs straight through.
+   *
+   * NOT written at definition sites — `defineAgentTool` resolves it from
+   * `TOOL_TIERS_BY_NAME`, so a registered tool cannot be given a tier that
+   * disagrees with the table. `categories` is passed per-site for historical
+   * reasons; deriving the tier centrally is the stronger arrangement, because
+   * the only way to change a tool's tier is to edit the table every reviewer
+   * already watches.
+   *
+   * Unregistered host-local tools (the enclave's in-process readers) resolve to
+   * tier 1: they read what the model already sees and write nothing.
+   */
+  tier?: ToolTier
   /**
    * System-prompt prose advertising this tool: a complete `## Section` block
    * (no leading/trailing blank lines). Hosts assemble the prompt's tool
@@ -90,7 +114,17 @@ export interface AgentTool {
 }
 
 export function defineAgentTool<TSchema extends z.ZodTypeAny>(config: AgentToolConfig<TSchema>): AgentTool {
-  return { name: config.name, config: config as AgentToolConfig }
+  if (config.tier !== undefined) {
+    throw new Error(
+      `Tool "${config.name}" sets \`tier\` at its definition site. The tier comes from TOOL_TIERS_BY_NAME; remove it.`
+    )
+  }
+  return { name: config.name, config: { ...config, tier: tierOfTool(config.name) } as AgentToolConfig }
+}
+
+/** The tier a built tool executes at, resolved when it was defined. */
+export function tierOfBuiltTool(tool: AgentTool): ToolTier {
+  return tool.config.tier ?? ToolTiers.UNCHECKED
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -473,6 +473,16 @@ export {
 } from "./tool-privacy"
 export type { ToolPrivacyCategory, ToolPrivacyPolicy } from "./tool-privacy"
 
+export {
+  TOOL_TIERS,
+  ToolTiers,
+  TOOL_TIERS_BY_NAME,
+  GUARDED_TOOL_NAMES,
+  tierOfTool,
+  requiresGuardianReview,
+} from "./tool-tiers"
+export type { ToolTier } from "./tool-tiers"
+
 // API types
 export type {
   // Streams

--- a/packages/types/src/tool-tiers.test.ts
+++ b/packages/types/src/tool-tiers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { AGENT_TOOL_NAMES, AgentToolNames } from "./constants"
+import {
+  GUARDED_TOOL_NAMES,
+  TOOL_TIERS,
+  TOOL_TIERS_BY_NAME,
+  ToolTiers,
+  isAgentToolName,
+  requiresGuardianReview,
+  tierOfTool,
+} from "./tool-tiers"
+
+describe("TOOL_TIERS_BY_NAME", () => {
+  test("every registered tool has a valid tier", () => {
+    for (const name of AGENT_TOOL_NAMES) {
+      expect(TOOL_TIERS).toContain(TOOL_TIERS_BY_NAME[name])
+    }
+  })
+
+  test("the guarded set is exactly the tools at tier 2 or above", () => {
+    const expected = AGENT_TOOL_NAMES.filter((name) => TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED)
+
+    expect([...GUARDED_TOOL_NAMES]).toEqual([...expected])
+  })
+
+  // The one tool that carries the user's own authority: delegate_task compiles
+  // a brief and hands it to the user's local agent, which executes with their
+  // credentials on their machine. If a future edit drops it back to tier 1 the
+  // guardian silently stops running on the highest-authority action in the
+  // product, with no other signal — so it is asserted by name, not derived.
+  test("delegate_task is guarded", () => {
+    expect(TOOL_TIERS_BY_NAME[AgentToolNames.DELEGATE_TASK]).toBe(ToolTiers.GUARDED)
+  })
+
+  test("reads and in-stream participation stay unchecked", () => {
+    const unchecked = [
+      AgentToolNames.SEND_MESSAGE,
+      AgentToolNames.WEB_SEARCH,
+      AgentToolNames.SEARCH_MESSAGES,
+      AgentToolNames.READ_ATTACHMENT,
+      AgentToolNames.REACT_TO_MESSAGE,
+      AgentToolNames.UPDATE_STREAM_BRIEF,
+      AgentToolNames.SAVE_MEMO,
+    ] as const
+
+    for (const name of unchecked) {
+      expect(TOOL_TIERS_BY_NAME[name]).toBe(ToolTiers.UNCHECKED)
+    }
+  })
+})
+
+describe("tierOfTool", () => {
+  test("resolves a registered tool from the table", () => {
+    expect(tierOfTool(AgentToolNames.DELEGATE_TASK)).toBe(ToolTiers.GUARDED)
+    expect(tierOfTool(AgentToolNames.WEB_SEARCH)).toBe(ToolTiers.UNCHECKED)
+  })
+
+  // Host-local tools (the enclave's in-process readers) are not in the registry.
+  // They read what the model already sees, so unchecked is correct — but the
+  // fallback must be tier 1 by decision, not by an undefined leaking through.
+  test("an unregistered name resolves to tier 1, not undefined", () => {
+    expect(isAgentToolName("enclave_local_reader")).toBe(false)
+    expect(tierOfTool("enclave_local_reader")).toBe(ToolTiers.UNCHECKED)
+  })
+})
+
+describe("requiresGuardianReview", () => {
+  test("gates at tier 2 and above", () => {
+    expect(requiresGuardianReview(ToolTiers.UNCHECKED)).toBe(false)
+    expect(requiresGuardianReview(ToolTiers.GUARDED)).toBe(true)
+    expect(requiresGuardianReview(ToolTiers.CONFIRMED)).toBe(true)
+  })
+})

--- a/packages/types/src/tool-tiers.ts
+++ b/packages/types/src/tool-tiers.ts
@@ -1,0 +1,113 @@
+import { AGENT_TOOL_NAMES, type AgentToolName } from "./constants"
+
+/**
+ * How much a tool call can cost the user if the model is wrong about wanting it.
+ *
+ * The tier decides what has to happen BEFORE the call executes, not whether the
+ * caller is allowed to hold the tool at all — that stays with the per-stream
+ * privacy policy (`TOOL_CATEGORIES_BY_NAME`) and with which dependencies the
+ * host constructs. A tier is about intent; a category is about exposure.
+ */
+export const TOOL_TIERS = [1, 2, 3] as const
+export type ToolTier = (typeof TOOL_TIERS)[number]
+
+export const ToolTiers = {
+  /**
+   * Reads, and participation inside the stream the turn is already running in.
+   * Executes with no extra check: the worst case is a wasted call whose result
+   * the user can see and ignore.
+   */
+  UNCHECKED: 1,
+  /**
+   * Writes durable state OUTSIDE the stream, or acts with the user's own
+   * authority. A guardian reviews the conversation for evidence the user asked
+   * for this before the call runs.
+   */
+  GUARDED: 2,
+  /**
+   * Reserved for explicit human-in-the-loop confirmation. Nothing is tier 3 yet
+   * and no mechanism exists — a tool placed here would be reviewed like tier 2
+   * and nothing more, so do not use it as if the stronger check existed.
+   */
+  CONFIRMED: 3,
+} as const satisfies Record<string, ToolTier>
+
+/**
+ * Every agent tool's tier.
+ *
+ * Exhaustive via `satisfies` over `AgentToolName`: a newly added tool fails to
+ * compile here until it is tiered, exactly like `TOOL_CATEGORIES_BY_NAME`.
+ *
+ * What that does NOT catch is a tool tiered WRONG — the build passes and every
+ * table-driven test passes, because the table is also what the tests believe.
+ * The rule that decides it, checkable by reading one line of a diff: **if the
+ * call writes something the user would still see after closing this stream, or
+ * acts with their authority somewhere else, it is not tier 1.** Reading, and
+ * writing into the conversation the agent is already part of, are tier 1.
+ */
+export const TOOL_TIERS_BY_NAME = {
+  // Participation in the running stream: the user sees every one of these land
+  // in the conversation they are already looking at, and can undo it there.
+  send_message: 1,
+  react_to_message: 1,
+  schedule_follow_up: 1,
+  list_follow_ups: 1,
+  cancel_follow_up: 1,
+  update_follow_up: 1,
+  update_stream_brief: 1,
+
+  // Reads — no durable effect at all.
+  web_search: 1,
+  read_url: 1,
+  general_research: 1,
+  search_messages: 1,
+  search_streams: 1,
+  search_users: 1,
+  get_stream_messages: 1,
+  search_attachments: 1,
+  read_attachment: 1,
+  describe_memo: 1,
+  github_repos: 1,
+  github_commits: 1,
+  github_pulls: 1,
+  github_content: 1,
+  github_workflows: 1,
+  github_releases: 1,
+  github_issues: 1,
+  linear_list_issues: 1,
+  linear_get_issue: 1,
+  linear_list_projects: 1,
+  linear_get_project: 1,
+
+  // A memo outlives the stream, but it is inert: knowledge the user can read
+  // and delete, with no authority attached and nothing acting on it.
+  save_memo: 1,
+
+  // Hands a compiled brief to the user's own local agent, which then executes
+  // with the user's credentials on the user's machine. The highest-authority
+  // action in the product — more than any setting — so it is guarded despite
+  // predating the tier system.
+  delegate_task: 2,
+} as const satisfies Record<AgentToolName, ToolTier>
+
+export function isAgentToolName(name: string): name is AgentToolName {
+  return name in TOOL_TIERS_BY_NAME
+}
+
+/**
+ * The tier of a tool by name. Registered names come from the table; anything
+ * else is a host-local tool (the enclave's in-process readers), which is
+ * conversation-local by construction and therefore tier 1.
+ */
+export function tierOfTool(name: string): ToolTier {
+  return isAgentToolName(name) ? TOOL_TIERS_BY_NAME[name] : ToolTiers.UNCHECKED
+}
+
+/** Tools a guardian must review before they execute. */
+export const GUARDED_TOOL_NAMES: readonly AgentToolName[] = AGENT_TOOL_NAMES.filter(
+  (name) => TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED
+)
+
+export function requiresGuardianReview(tier: ToolTier): boolean {
+  return tier >= ToolTiers.GUARDED
+}


### PR DESCRIPTION
Adds `TOOL_TIERS_BY_NAME` — exhaustive over `AgentToolName` like
`TOOL_CATEGORIES_BY_NAME`, so a new tool cannot compile until it is tiered.
Tier 1 executes unchecked; tier 2 will be reviewed by the guardian before it
runs (next layer). No behavior change here.

`delegate_task` is the only existing tool at tier 2. It compiles a brief and
hands it to the user's local agent, which executes with the user's credentials
on the user's machine — more authority than anything else in the toolset, and
currently unguarded.

`defineAgentTool` resolves the tier from the table rather than each of the 29
definition sites passing it (as `categories` does), and throws if a site
declares one: a silently-overwritten `tier: 1` on a guarded tool would read in
review exactly like a tool that skips the guardian.

The table catches an unclassified tool, never a misclassified one — the failure
mode that just cost a night on the prompt-cache split. The rule that decides it
is on the table, and `delegate_task`'s tier is asserted by name so a future edit
back to 1 fails rather than silently disabling the guardian. Verified by
mistiering it on purpose: 3 tests fail.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787733633&installation_model_id=20758&pr_number=1588&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1588&signature=f8fac8a704cc86c98ae57752562559c2a8043ffa26cf2d09e88a5ef51adea276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->