### PR TITLE
feat(harnessd): reap worktrees archived while nothing was running

### DIFF
--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -12,6 +12,7 @@ Usage:
   threa-harnessd list
   threa-harnessd up [--tmux <session>] [--dry-run] [--recreate-worktree]
   threa-harnessd resume-active                (alias of up; also revive-unarchived, restore-active)
+  threa-harnessd reap [--dry-run]             (clean up worktrees whose scratchpad was archived while nothing was running)
   threa-harnessd watch-unarchived [--tmux <session>] [--dry-run]
   threa-harnessd boot-resume [--tmux <session>] [--dry-run]
   threa-harnessd install-watch [--tmux <session>]

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -42,6 +42,7 @@ import {
 } from "./resume"
 import { attachedTmuxSession, ensureTmuxSession, sendKeys } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
+import { defaultReapDeps, reapArchivedWorktrees } from "./reap"
 import { restorableWorktreeSource, restoreManagedWorktree } from "./worktree"
 import { runWatchLoop, unavailableBackoffMs, uniqueSupervisorTargets, watchIntervalMs } from "./watch"
 
@@ -121,6 +122,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
 }
 
 export async function watchUnarchived(options: ResumeOptions): Promise<void> {
+  const watchStartedAtMs = Date.now()
   const session = options.tmux ?? "threa-agents"
   const reconnectIntervalMs = watchIntervalMs()
   const claudeConfig = readThreaChannelConfig()
@@ -147,6 +149,13 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
           { ...options, tmux: session, recreateWorktree: true, respectProbeBackoff: true },
           target
         )
+        // Reap on the untargeted sweep only: a restore event means a specific
+        // scratchpad just came BACK, which is the opposite of reapable.
+        if (!target && !options.dryRun) {
+          await reapArchived({ observingSinceMs: watchStartedAtMs }).catch((error) =>
+            console.warn(`harnessd: reap pass failed: ${error instanceof Error ? error.message : String(error)}`)
+          )
+        }
         if (!unavailable) {
           // A targeted restore event must not cancel an outstanding full
           // reconnect catch-up: another dormant runtime may still need it.
@@ -191,6 +200,48 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
       console.error(`harnessd: supervisor connect failed: ${error instanceof Error ? error.message : String(error)}`)
     },
   })
+}
+
+/**
+ * Clean up worktrees whose scratchpad was archived while nothing was running to
+ * notice. The live-runtime wind-down cannot cover that case; harnessd outlives
+ * reboots, so the backstop lives here.
+ */
+export async function reapArchived(options: { dryRun?: boolean; observingSinceMs?: number } = {}): Promise<void> {
+  const claudeConfig = readThreaChannelConfig()
+  const piConfig = readPiRemoteConfig()
+  const targetFor = (config: { baseUrl?: string; workspaceId?: string; apiKey?: string }) => {
+    const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+    const apiKey = process.env.THREA_API_KEY || config.apiKey
+    if (!workspaceId || !apiKey) return undefined
+    return { baseUrl: configuredThreaBaseUrl(config), workspaceId, apiKey }
+  }
+  const [target] = uniqueSupervisorTargets([targetFor(claudeConfig), targetFor(piConfig)])
+  if (!target) throw new Error("harnessd: no Threa credentials found for the reap pass")
+
+  // Same lock as resumeActive: a revive can be recreating the very worktree
+  // this pass would force-remove, and they race the server independently.
+  const deps = defaultReapDeps(target)
+  if (options.observingSinceMs !== undefined) deps.observingSinceMs = options.observingSinceMs
+  const release = options.dryRun
+    ? () => {}
+    : await acquireProcessLock(join(dirname(inventoryPath()), "resume-active.lock"))
+  let outcomes
+  try {
+    outcomes = await reapArchivedWorktrees(deps, options.dryRun ?? false)
+  } finally {
+    release()
+  }
+  if (outcomes.length === 0) {
+    console.log("No recorded harness links.")
+    return
+  }
+  const counts = new Map<string, number>()
+  for (const outcome of outcomes) {
+    console.log(`${outcome.status}\t${outcome.worktree}${outcome.detail ? `\t${outcome.detail}` : ""}`)
+    counts.set(outcome.status, (counts.get(outcome.status) ?? 0) + 1)
+  }
+  console.log(`harnessd: ${[...counts].map(([status, count]) => `${count} ${status}`).join(", ")}`)
 }
 
 export async function bootResume(options: ResumeOptions): Promise<void> {

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -15,6 +15,7 @@ import {
   spawnAgent,
   steerAgent,
   stopAgent,
+  reapArchived,
   watchUnarchived,
 } from "./commands"
 import { die } from "./errors"
@@ -35,6 +36,7 @@ async function main(): Promise<void> {
     await resumeActive(parseResume(args))
     return
   }
+  if (command === "reap") return reapArchived({ dryRun: args.includes("--dry-run") })
   if (command === "watch-unarchived") return watchUnarchived(parseResume(args))
   if (command === "boot-resume") return bootResume(parseResume(args))
   if (command === "install-watch" || command === "install-boot-resume") {

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test"
+import type { HarnessLink } from "@threa/bot-runtime-client"
+import { OBSERVER_WARMUP_MS, REAP_AFTER_MS, reapArchivedWorktrees, type ReapDeps } from "./reap"
+import type { LocalTmuxPane } from "./discovery"
+
+const NOW = Date.parse("2026-07-27T12:00:00.000Z")
+const WORKTREE = "/repo/threa.feature"
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: "ccs-abc",
+    instanceId: "cc-abc",
+    rootStreamId: "stream_root",
+    worktree: WORKTREE,
+    pid: 4242,
+    updatedAt: "2026-07-27T10:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "threa-agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 4242,
+    cwd: WORKTREE,
+    // A launch the resolver can tie back to the record's runtime session.
+    startCommand:
+      "env THREA_RUNTIME_SESSION_ID=ccs-abc claude --dangerously-load-development-channels server:threa-channel",
+    ...overrides,
+  }
+}
+
+interface Recorded {
+  woundDown: string[]
+  killed: string[]
+  forgotten: string[]
+}
+
+function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded: Recorded } {
+  const recorded: Recorded = { woundDown: [], killed: [], forgotten: [] }
+  const deps: ReapDeps = {
+    links: () => [link()],
+    panes: () => [pane()],
+    scratchpadStatus: async () => "archived",
+    // Long enough ago that the owning runtime has had its full chance.
+    archivedAt: async () => new Date(NOW - REAP_AFTER_MS - 60_000).toISOString(),
+    pathExists: () => true,
+    windDown: (cwd) => {
+      recorded.woundDown.push(cwd)
+      return { pushed: true }
+    },
+    killWindow: (windowId) => void recorded.killed.push(windowId),
+    forgetLink: (id) => void recorded.forgotten.push(id),
+    now: () => NOW,
+    log: () => {},
+    ...overrides,
+  }
+  return { deps, recorded }
+}
+
+describe("reapArchivedWorktrees", () => {
+  test("reaps a worktree whose scratchpad was archived past the margin", async () => {
+    const { deps, recorded } = makeDeps()
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome).toMatchObject({ status: "reaped", worktree: WORKTREE })
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"] })
+  })
+
+  test("leaves the owning runtime its full detection window plus grace", async () => {
+    // The runtime can take a socket-backstop poll to notice, then holds its own
+    // grace. Reaping inside that would steal an unarchive from a live runtime.
+    const { deps, recorded } = makeDeps({
+      archivedAt: async () => new Date(NOW - REAP_AFTER_MS + 60_000).toISOString(),
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped grace")
+    expect(recorded.woundDown).toEqual([])
+  })
+
+  test("never touches an active scratchpad", async () => {
+    const { deps, recorded } = makeDeps({ scratchpadStatus: async () => "active" })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped active")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("an unreadable scratchpad is never grounds to delete", async () => {
+    // 403/404 is indistinguishable from a missing API-key scope.
+    for (const status of ["inaccessible", "unavailable"] as const) {
+      const { deps, recorded } = makeDeps({ scratchpadStatus: async () => status })
+
+      const [outcome] = await reapArchivedWorktrees(deps)
+
+      expect(outcome.status).toBe(`skipped ${status}`)
+      expect(recorded.woundDown).toEqual([])
+    }
+  })
+
+  test("refuses to guess when two panes share the worktree", async () => {
+    const { deps, recorded } = makeDeps({
+      panes: () => [pane(), pane({ windowId: "@9", paneId: "%10" })],
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(["skipped ambiguous", "skipped occupied"]).toContain(outcome.status)
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("refuses a worktree now occupied by a session the record does not own", async () => {
+    // Worktree paths are stable per feature name and get reused. A record left
+    // behind by a crashed runtime names a directory a different, LIVE session
+    // now occupies; reaping on it would push and delete that session's work
+    // under the label "scratchpad archived", and kill its window.
+    const { deps, recorded } = makeDeps({
+      panes: () => [
+        pane({
+          startCommand:
+            "env THREA_RUNTIME_SESSION_ID=ccs-somebody-else claude --dangerously-load-development-channels server:threa-channel",
+        }),
+      ],
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped occupied")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("a freshly woken daemon gives runtimes their own detection window first", async () => {
+    // archivedAt keeps accruing while the machine sleeps, but the runtime that
+    // owns the worktree was asleep too and only starts its detection+grace on
+    // wake. Reaping in that instant races a live runtime that never got a
+    // chance.
+    const { deps, recorded } = makeDeps({ observingSinceMs: NOW - OBSERVER_WARMUP_MS + 60_000 })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped observer too young")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("an explicit run has no warmup gate — a human asking is the signal", async () => {
+    const { deps, recorded } = makeDeps({ observingSinceMs: undefined })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("reaped")
+    expect(recorded.woundDown).toEqual([WORKTREE])
+  })
+
+  test("a worktree already gone just drops the record", async () => {
+    const { deps, recorded } = makeDeps({ pathExists: () => false })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped worktree missing")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: ["ccs-abc"] })
+  })
+
+  test("a link with no live pane is still reaped — that is the offline case", async () => {
+    // Archived while the machine slept and the runtime never came back: no
+    // window to kill, but the worktree is exactly what needs cleaning up.
+    const { deps, recorded } = makeDeps({ panes: () => [] })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("reaped")
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: [], forgotten: ["ccs-abc"] })
+  })
+
+  test("the window closes even when the cleanup refuses, and the worktree is left behind", async () => {
+    const { deps, recorded } = makeDeps({
+      windDown: (cwd) => {
+        recorded.woundDown.push(cwd)
+        return { pushed: false, reason: "branch 'HEAD' is protected or detached — leaving everything as is" }
+      },
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("reaped")
+    expect(outcome.detail).toContain("pushed=false")
+    expect(recorded.killed).toEqual(["@7"])
+  })
+
+  test("dry run decides without touching anything", async () => {
+    const { deps, recorded } = makeDeps()
+
+    const [outcome] = await reapArchivedWorktrees(deps, true)
+
+    expect(outcome.status).toBe("would reap")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("one failing link does not abort the sweep", async () => {
+    const { deps, recorded } = makeDeps({
+      links: () => [link({ runtimeSessionId: "boom", rootStreamId: "stream_boom" }), link({ runtimeSessionId: "ok" })],
+      panes: () => [],
+      archivedAt: async (streamId) => {
+        if (streamId === "stream_boom") throw new Error("threa unreachable")
+        return new Date(NOW - REAP_AFTER_MS - 60_000).toISOString()
+      },
+    })
+
+    const outcomes = await reapArchivedWorktrees(deps)
+
+    expect(outcomes.map((o) => o.status)).toEqual(["skipped unavailable", "reaped"])
+    expect(recorded.woundDown).toEqual([WORKTREE])
+  })
+
+  test("the margin outlasts a runtime's own detection plus grace", () => {
+    // 15-min socket backstop + 2x the 5-min grace.
+    expect(REAP_AFTER_MS).toBe(25 * 60 * 1000)
+  })
+})

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -1,0 +1,221 @@
+import {
+  ARCHIVE_RESTORE_GRACE_MS,
+  WS_BACKSTOP_POLL_MS,
+  clearHarnessLink,
+  pushBranchAndScheduleRemoval,
+  readHarnessLinks,
+  type HarnessLink,
+} from "@threa/bot-runtime-client"
+import { existsSync } from "node:fs"
+import { listLocalTmuxPanes, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
+import { output } from "./shell"
+import { fetchScratchpadArchivedAt, fetchScratchpadStatus, type ScratchpadStatus } from "./resume"
+
+/**
+ * The reaper: clean up worktrees whose scratchpad was archived while nothing
+ * was around to notice.
+ *
+ * A live runtime winds itself down when its scratchpad is archived. That
+ * covers the common case and nothing here should interfere with it. What it
+ * cannot cover is an archive that lands when the owning runtime is dead or
+ * absent — the machine was asleep, it rebooted, the process was killed — and
+ * a cold start does not help either: Claude's cold start replaces an archived
+ * scratchpad with a fresh one rather than winding down, so the worktree and
+ * its tmux window survive indefinitely.
+ *
+ * harnessd is the only component that outlives all of that, so the backstop
+ * belongs here.
+ */
+
+/**
+ * How long after `archivedAt` the reaper may act.
+ *
+ * A live runtime can take a full socket-backstop poll to notice the archive,
+ * and then holds its own grace window before winding down. Acting sooner would
+ * steal an unarchive from a runtime that was about to reattach, so wait out
+ * both and add the same margin again.
+ */
+export const REAP_AFTER_MS = WS_BACKSTOP_POLL_MS + ARCHIVE_RESTORE_GRACE_MS * 2
+
+export type ReapStatus =
+  | "reaped"
+  | "would reap"
+  | "skipped active"
+  | "skipped grace"
+  | "skipped worktree missing"
+  | "skipped ambiguous"
+  | "skipped occupied"
+  | "skipped observer too young"
+  | "skipped inaccessible"
+  | "skipped unavailable"
+
+export interface ReapOutcome {
+  runtimeSessionId: string
+  worktree: string
+  status: ReapStatus
+  detail?: string
+}
+
+export interface ReapDeps {
+  /** Undefined for an explicit CLI run; set by the daemon so a just-woken pass waits out {@link OBSERVER_WARMUP_MS}. */
+  observingSinceMs?: number
+  links: () => HarnessLink[]
+  panes: () => LocalTmuxPane[]
+  scratchpadStatus: (streamId: string) => Promise<ScratchpadStatus>
+  archivedAt: (streamId: string) => Promise<string | undefined>
+  pathExists: (path: string) => boolean
+  windDown: (cwd: string, log: (message: string) => void) => { pushed: boolean; reason?: string }
+  killWindow: (windowId: string) => void
+  forgetLink: (runtimeSessionId: string) => void
+  now: () => number
+  log: (message: string) => void
+}
+
+export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; apiKey: string }): ReapDeps {
+  return {
+    links: readHarnessLinks,
+    panes: listLocalTmuxPanes,
+    scratchpadStatus: (streamId) => fetchScratchpadStatus({ ...target, streamId }),
+    archivedAt: (streamId) => fetchScratchpadArchivedAt({ ...target, streamId }),
+    pathExists: existsSync,
+    windDown: pushBranchAndScheduleRemoval,
+    killWindow: (windowId) => {
+      output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+    },
+    forgetLink: clearHarnessLink,
+    now: Date.now,
+    log: (message) => console.log(`reap\t${message}`),
+  }
+}
+
+type WindowDecision =
+  | { kind: "none" }
+  | { kind: "kill"; pane: LocalTmuxPane }
+  | { kind: "refuse"; status: ReapStatus; reason: string }
+
+/**
+ * Which window, if any, this record may kill.
+ *
+ * Matching on cwd alone is not enough. Worktree paths are stable per feature
+ * name and get reused, so a record left behind by a crashed runtime can name a
+ * directory a different, live session now occupies — reaping on that record
+ * would push and delete the live session's work under the label "scratchpad
+ * archived". Identity comes from `resolveManagedAgentPane`, the resolver built
+ * for exactly this failure; occupancy is then the veto.
+ */
+function decideWindow(link: HarnessLink, panes: LocalTmuxPane[]): WindowDecision {
+  const occupants = panes.filter((pane) => pane.cwd === link.worktree)
+  // Nobody is in the worktree: the offline case this reaper exists for.
+  if (occupants.length === 0) return { kind: "none" }
+
+  const resolved = resolveManagedAgentPane(
+    {
+      runtime: link.runtimeKind === "pi-local" ? "pi" : "claude",
+      runtimeSessionId: link.runtimeSessionId,
+      worktree: link.worktree,
+    },
+    panes
+  )
+  if (resolved.status === "found" && occupants.length === 1 && resolved.pane.paneId === occupants[0]!.paneId) {
+    return { kind: "kill", pane: resolved.pane }
+  }
+  return {
+    kind: "refuse",
+    status: resolved.status === "ambiguous" ? "skipped ambiguous" : "skipped occupied",
+    reason:
+      resolved.status === "ambiguous"
+        ? resolved.reason
+        : `${link.worktree} is occupied by a session this record does not identify as its own`,
+  }
+}
+
+/** One recorded link's decision, and (outside dry-run) its cleanup. */
+export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolean): Promise<ReapOutcome> {
+  const base = { runtimeSessionId: link.runtimeSessionId, worktree: link.worktree }
+  const status = await deps.scratchpadStatus(link.rootStreamId)
+  if (status === "unavailable") return { ...base, status: "skipped unavailable" }
+  if (status === "active") return { ...base, status: "skipped active" }
+  if (status === "inaccessible") {
+    // 403/404 is indistinguishable from a missing scope, so it is never
+    // grounds to delete anything.
+    return { ...base, status: "skipped inaccessible", detail: "cannot read the scratchpad; leaving it alone" }
+  }
+
+  const archivedAt = await deps.archivedAt(link.rootStreamId)
+  const archivedMs = archivedAt ? Date.parse(archivedAt) : Number.NaN
+  if (!Number.isFinite(archivedMs)) {
+    return { ...base, status: "skipped unavailable", detail: "archived but no readable archivedAt" }
+  }
+  const age = deps.now() - archivedMs
+  if (age < REAP_AFTER_MS) {
+    return {
+      ...base,
+      status: "skipped grace",
+      detail: `archived ${Math.round(age / 60_000)}m ago; the owning runtime gets until ${Math.round(REAP_AFTER_MS / 60_000)}m`,
+    }
+  }
+
+  const window = decideWindow(link, deps.panes())
+  if (window.kind === "refuse") return { ...base, status: window.status, detail: window.reason }
+
+  if (!deps.pathExists(link.worktree)) {
+    // Already gone — the record is the only leftover.
+    if (!dryRun) deps.forgetLink(link.runtimeSessionId)
+    return { ...base, status: "skipped worktree missing" }
+  }
+
+  if (dryRun) {
+    return { ...base, status: "would reap", detail: `archived ${Math.round(age / 60_000)}m ago` }
+  }
+
+  const report = deps.windDown(link.worktree, (message) => deps.log(`${link.worktree}: ${message}`))
+  // The window goes either way: the scratchpad is archived, so the session is
+  // over even when the cleanup refused (detached HEAD, unpushable branch). A
+  // refusal leaves the worktree on disk for a human — nothing is lost.
+  if (window.kind === "kill") deps.killWindow(window.pane.windowId)
+  deps.forgetLink(link.runtimeSessionId)
+  return {
+    ...base,
+    status: "reaped",
+    detail: `pushed=${report.pushed}${report.reason ? ` (${report.reason})` : ""}${window.kind === "kill" ? ` window=${window.pane.windowId}` : ""}`,
+  }
+}
+
+/**
+ * How long this process must have been watching before its automatic pass may
+ * reap.
+ *
+ * `archivedAt` keeps accruing while the machine sleeps, so on wake the margin
+ * can already be spent — but the runtime that owns the worktree was asleep
+ * too, and its detection-plus-grace clock only restarts now. Reaping in that
+ * instant races a live runtime that never got its chance. An explicitly
+ * invoked `reap` skips this: a human asking is the signal.
+ */
+export const OBSERVER_WARMUP_MS = WS_BACKSTOP_POLL_MS + ARCHIVE_RESTORE_GRACE_MS
+
+export async function reapArchivedWorktrees(deps: ReapDeps, dryRun = false): Promise<ReapOutcome[]> {
+  const links = deps.links()
+  if (links.length === 0) return []
+  if (deps.observingSinceMs !== undefined && deps.now() - deps.observingSinceMs < OBSERVER_WARMUP_MS) {
+    return links.map((link) => ({
+      runtimeSessionId: link.runtimeSessionId,
+      worktree: link.worktree,
+      status: "skipped observer too young" as const,
+      detail: "watching since less than one detection window; runtimes get first refusal",
+    }))
+  }
+  const outcomes: ReapOutcome[] = []
+  for (const link of links) {
+    try {
+      outcomes.push(await reapLink(link, deps, dryRun))
+    } catch (error) {
+      outcomes.push({
+        runtimeSessionId: link.runtimeSessionId,
+        worktree: link.worktree,
+        status: "skipped unavailable",
+        detail: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  return outcomes
+}

--- a/extensions/harness-daemon/src/resume.ts
+++ b/extensions/harness-daemon/src/resume.ts
@@ -65,6 +65,17 @@ export function withoutProbeBackoff(agent: ManagedAgent, nowMs: number): Managed
 
 export type ScratchpadStatus = "active" | "archived" | "inaccessible" | "unavailable"
 
+/** When the scratchpad was archived, for callers that must wait out a grace before acting. */
+export async function fetchScratchpadArchivedAt(params: {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+  streamId: string
+}): Promise<string | undefined> {
+  const detail = await fetchScratchpadStatusOnce(params)
+  return typeof detail === "string" ? undefined : detail.archivedAt
+}
+
 export async function fetchScratchpadStatus(
   params: {
     baseUrl: string
@@ -77,10 +88,11 @@ export async function fetchScratchpadStatus(
   // A full `up` pass probes every inventory row; retrying through 429s keeps
   // one rate-limit blip from aborting the whole sweep as "unavailable".
   for (let attempt = 0; ; attempt += 1) {
-    const status = await fetchScratchpadStatusOnce(params)
-    if (typeof status === "string") return status
+    const result = await fetchScratchpadStatusOnce(params)
+    if (typeof result === "string") return result
+    if (result.status) return result.status
     if (attempt >= 2) return "unavailable"
-    await sleep(status.rateLimitedForMs || 2_000 * (attempt + 1))
+    await sleep(result.rateLimitedForMs || 2_000 * (attempt + 1))
   }
 }
 
@@ -89,7 +101,7 @@ async function fetchScratchpadStatusOnce(params: {
   workspaceId: string
   apiKey: string
   streamId: string
-}): Promise<ScratchpadStatus | { rateLimitedForMs: number }> {
+}): Promise<ScratchpadStatus | { rateLimitedForMs?: number; status?: ScratchpadStatus; archivedAt?: string }> {
   try {
     const response = await fetch(
       `${params.baseUrl.replace(/\/$/, "")}/api/v1/workspaces/${params.workspaceId}/streams/${params.streamId}`,
@@ -105,7 +117,7 @@ async function fetchScratchpadStatusOnce(params: {
     if (!response.ok) return response.status >= 500 ? "unavailable" : "inaccessible"
     const json = (await response.json()) as { data?: { archivedAt?: string | null } }
     if (!json.data || typeof json.data !== "object") return "inaccessible"
-    return json.data.archivedAt ? "archived" : "active"
+    return json.data.archivedAt ? { status: "archived", archivedAt: json.data.archivedAt } : "active"
   } catch {
     return "unavailable"
   }


### PR DESCRIPTION
Stacked on #1593.

## Problem

The wind-down shipped in #1561 handles an archive that lands **while a current-code runtime is running**. Two holes survive it, and both open exactly when you're offline:

1. **Runtime dead, window alive.** Machine sleeps or reboots, the pad is archived meanwhile. Nothing reaps: `reviveAgent` returns `already running` when a window exists and `skipped archived` when it doesn't, so the worktree and window sit there indefinitely.
2. **Cold start against an archived pad.** Claude's cold start uses `ifArchived: "replace"` — restarting into an archived pad silently **mints a fresh scratchpad** and the old worktree lives on. Steady-state behavior, not a migration artifact.

Observed concretely: 17 stale windows on a real machine needed a hand-written script to clear, because nothing in the system could do it.

harnessd is the only component that outlives sleep, reboots and runtime crashes (LaunchAgent, `RunAtLoad` + `KeepAlive`), so the backstop belongs here. It was too dangerous to write before #1561 gave it an identity-safe pane resolver.

## Solution

`threa-harnessd reap [--dry-run]`, also run on each untargeted reconciliation pass — not on restore events, since a restore means a pad just came *back*. It reads the link registry from #1593, checks each scratchpad against the server, and runs the same `pushBranchAndScheduleRemoval` a runtime would.

**The margin is the load-bearing decision.** A runtime can take a full socket-backstop poll (15 min) to notice an archive it was never pushed, then holds its own 5-min grace before winding down. Reaping sooner would steal an unarchive from a runtime that was about to reattach. `REAP_AFTER_MS` waits out both and adds the grace again — 25 minutes, derived from the shared constants rather than picked.

It refuses rather than guesses, on the grounds that this deletes worktrees:

| Situation | Behavior |
| --- | --- |
| Scratchpad active | untouched |
| Archived, inside the margin | left to the owning runtime |
| `inaccessible` (403/404) | never reaped — indistinguishable from a missing key scope |
| Two panes share the worktree | reported, nothing killed |
| Worktree already gone | drops the stale record only |
| No live pane at all | reaped — this *is* the offline case |
| Cleanup refuses (detached HEAD) | window closes, worktree left on disk for a human |

A failing link logs and the sweep continues.

Also isolates `THREA_HARNESS_LINKS_DIR` in the two runtime test suites — without it a test run wrote real records into the developer's home, which this reaper would then read. Caught by dry-running against a real machine, not by a test.

## Test plan

- [x] `bun test ./extensions/` — 598 pass; 11 new reaper tests, one per refusal above
- [x] `typecheck` clean across all four extension packages
- [x] Dry-run against a real machine: ran end to end, correctly refused three garbage records as `inaccessible`
- [x] Verified a full test run leaves the real links dir empty

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
