### PR TITLE
fix(stream-context): keep chip counts stable across a category change

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -82,12 +82,28 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const debounced = useSearchState(debouncedQuery, users)
   const unsupported = live.parsed.filters.filter((f) => !isSupported(f))
 
+  // Counts are whole-scope and CATEGORY-INDEPENDENT server-side (`service.list`
+  // strips the category before counting), but they ride the feed's first page,
+  // and that query is keyed on the category. Selecting a chip therefore starts a
+  // fresh query with no counts yet, so anything reading `feed.counts` directly
+  // would drop to the local tally — hundreds → tens → hundreds as the page lands.
+  // Hold the last server counts and keep using them while the category changes;
+  // key them by the filters that DO narrow them so a new search can't show stale
+  // numbers.
+  const countsKey = [
+    streamId,
+    debounced.parsed.text ?? "",
+    debounced.authorId ?? "",
+    debounced.before ?? "",
+    debounced.after ?? "",
+  ].join("|")
+  const [heldCounts, setHeldCounts] = useState<{ key: string; counts: Record<ContextCategory, number> } | null>(null)
+  const serverCounts = heldCounts?.key === countsKey ? heldCounts.counts : null
+
   // A `?context=<category>` deep link (or a chip whose category later empties
   // out) must not strand the panel on a filter the scope has nothing for — fall
   // back to "all" once the server-owned counts say so, for the query and the
-  // chip row alike. Counts are whole-scope and category-independent server-side,
-  // so the fallback converges in one render rather than oscillating.
-  const [serverCounts, setServerCounts] = useState<Record<ContextCategory, number> | null>(null)
+  // chip row alike.
   const effectiveFilter: Filter = filter !== "all" && serverCounts?.[filter] === 0 ? "all" : filter
 
   const category: ContextCategory | undefined = effectiveFilter === "all" ? undefined : effectiveFilter
@@ -132,11 +148,11 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       ),
     [rows, searchTerms, authorId, before, after]
   )
-  const counts = feed.counts ?? localCounts
+  const counts = feed.counts ?? serverCounts ?? localCounts
   const feedCounts = feed.counts
   useEffect(() => {
-    if (feedCounts) setServerCounts(feedCounts)
-  }, [feedCounts])
+    if (feedCounts) setHeldCounts({ key: countsKey, counts: feedCounts })
+  }, [feedCounts, countsKey])
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0)
 
   const sentinelRef = useRef<HTMLDivElement | null>(null)

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -222,6 +222,40 @@ describe("StreamContextPanel — flag on", () => {
     await userEvent.click(screen.getByRole("button", { name: /^Memories/ }))
     expect(await screen.findByText("Retention decision")).toBeInTheDocument()
     expect(screen.queryByText("Alpha")).not.toBeInTheDocument()
+
+    // Counts are category-independent server-side, but they ride the feed's
+    // first page and that query is keyed on the category — so selecting a chip
+    // must not drop the chips back to the local IDB tally while the new page
+    // loads. Without the held counts this reads "1" (the cached row) mid-flight.
+    expect(screen.getByRole("button", { name: /^Links/ })).toHaveTextContent("9")
+    expect(screen.getByRole("button", { name: /^Memories/ })).toHaveTextContent("4")
+  })
+
+  it("keeps server counts across a chip change while the new page is in flight", async () => {
+    await db.streamContextItems.bulkPut([
+      cachedRow(serverItem({ category: "link", refId: "https://a.example", detail: { url: "https://a.example" } })),
+    ])
+    let resolveSecond: (value: ListStreamContextResponse) => void = () => {}
+    vi.spyOn(streamContextApi, "list")
+      .mockResolvedValueOnce(listResponse({ counts: { ...EMPTY_COUNTS, link: 240, memo: 37 } }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<ListStreamContextResponse>((resolve) => {
+            resolveSecond = resolve
+          })
+      )
+
+    renderPanel()
+    expect(await screen.findByRole("button", { name: /^Links/ })).toHaveTextContent("240")
+
+    // The second page never resolves, so this pins what the chips read while a
+    // category query is still in flight — the moment the flip-flop happened.
+    await userEvent.click(screen.getByRole("button", { name: /^Memories/ }))
+    await waitFor(() => expect(streamContextApi.list).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole("button", { name: /^Links/ })).toHaveTextContent("240")
+    expect(screen.getByRole("button", { name: /^Memories/ })).toHaveTextContent("37")
+
+    resolveSecond(listResponse({ counts: { ...EMPTY_COUNTS, link: 240, memo: 37 } }))
   })
 
   it("filters locally as you type, before the debounced server phase runs", async () => {


### PR DESCRIPTION
Selecting a type chip in "In this stream" made the counts jump — hundreds, then tens, then hundreds again. Reported from prod with a video.

Counts are whole-scope and **category-independent** server-side: `StreamContextService.list` deliberately calls `countsByCategory` with `category: undefined`, so tapping "Links" still reports how many Files and Memories exist. But those counts ride the feed's first page, and the feed query is keyed on the category. Selecting a chip started a fresh query whose first page had not landed, `feed.counts` was null, and the panel fell back to the local IDB tally — a few dozen cached rows against a stream with hundreds indexed. When the page arrived, the real numbers returned.

The last server counts are now held and reused across a category change, keyed by the filters that genuinely narrow them — stream, free text, author, date bounds — so a new search still recomputes rather than showing stale numbers. The local tally goes back to being only what it was built for: the offline and first-paint fallback.

The regression test pins the exact moment the flip-flop happened: it leaves the second (category) request unresolved and asserts the chips still read the server's numbers. It fails on the pre-fix code.

Not changed, and worth knowing: the *list* still fills in progressively — the panel renders matching cached rows immediately, then the page widens the set. That is the offline-first design working, and unlike the counts it is not showing a wrong number, just fewer rows for a moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787757180&installation_model_id=20758&pr_number=1599&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1599&signature=2d9a66d2764512e06e3ec8081d63e9fd5b78c9d663f81340b34db7a6980cfa27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->