### PR TITLE
perf(stream-context): window the "In this stream" timeline with virtua

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
@@ -56,6 +56,22 @@ describe("ContextTimeline virtualization wiring", () => {
     expect(screen.getByText("b")).toBeInTheDocument()
   })
 
+  it("spaces day markers by an explicit flag, not `:first-child`", () => {
+    // virtua wraps every child in its own item element, so a `first:pt-0` class
+    // would match EVERY marker and collapse the gap between all day groups —
+    // invisible to jsdom (no CSS) and to the passthrough swap. Pin the classes.
+    const seam = vi
+      .spyOn(streamContextListModule, "StreamContextList")
+      .mockImplementation(({ children }) => createElement(Fragment, null, children))
+
+    render(<ContextTimeline items={items} renderItem={renderItem} scrollRef={createRef<HTMLDivElement>()} />)
+
+    const markers = (seam.mock.calls[0]![0].children as { props: { className?: string } }[]).filter(
+      (child) => typeof child.props.className === "string"
+    )
+    expect(markers.map((m) => m.props.className)).toEqual(["pt-0", "pt-3"])
+  })
+
   it("renders every row unwindowed when no scroller is supplied", () => {
     const seam = vi.spyOn(streamContextListModule, "StreamContextList")
 

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createElement, Fragment, createRef } from "react"
+import { render, screen } from "@testing-library/react"
+import * as streamContextListModule from "./stream-context-list"
+import { ContextTimeline } from "./stream-context-chrome"
+import type { ContextItem } from "@/lib/stream-context/types"
+
+/**
+ * The windowing itself only works in a real browser (jsdom has zero-height
+ * layout and a no-op ResizeObserver), so what these pin is the WIRING: given a
+ * scroller the timeline must hand its rows to the virtualization seam, and
+ * without one it must still render them. A regression here silently un-windows
+ * the panel — hundreds of rows mounting at once — with every other test green,
+ * because they all swap the seam for a passthrough.
+ */
+function item(key: string, occurredAt: string): ContextItem {
+  return {
+    key,
+    category: "link",
+    createdAt: occurredAt,
+    sourceMessageId: `msg_${key}`,
+    snippet: "",
+    url: `https://example.com/${key}`,
+    title: key,
+    siteName: null,
+    faviconUrl: null,
+    imageUrl: null,
+    previewKind: "generic",
+    badge: null,
+    refCount: 1,
+  } as ContextItem
+}
+
+describe("ContextTimeline virtualization wiring", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const items = [item("a", "2026-07-20T10:00:00.000Z"), item("b", "2026-07-19T10:00:00.000Z")]
+  const renderItem = (i: ContextItem) => <span key={i.key}>{i.key}</span>
+
+  it("hands its rows to the virtualization seam when the panel supplies a scroller", () => {
+    const seam = vi
+      .spyOn(streamContextListModule, "StreamContextList")
+      .mockImplementation(({ children }) => createElement(Fragment, null, children))
+    const scrollRef = createRef<HTMLDivElement>()
+
+    render(<ContextTimeline items={items} renderItem={renderItem} scrollRef={scrollRef} />)
+
+    expect(seam).toHaveBeenCalled()
+    expect(seam.mock.calls[0]![0].scrollRef).toBe(scrollRef)
+    // The day markers ride the same flat child list as the rows — virtua windows
+    // a flat list, so a marker must not wrap its group.
+    expect(seam.mock.calls[0]![0].children).toHaveLength(4)
+    expect(screen.getByText("a")).toBeInTheDocument()
+    expect(screen.getByText("b")).toBeInTheDocument()
+  })
+
+  it("renders every row unwindowed when no scroller is supplied", () => {
+    const seam = vi.spyOn(streamContextListModule, "StreamContextList")
+
+    render(<ContextTimeline items={items} renderItem={renderItem} />)
+
+    expect(seam).not.toHaveBeenCalled()
+    expect(screen.getByText("a")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -190,8 +190,13 @@ export function ContextTimeline({
   // Flattened, not nested per day: virtua windows a flat child list, so a day
   // marker is a row of its own rather than a wrapper around its group. Keyed on
   // a stable item id — date labels repeat across years and would collide.
-  const rows = groupItemsByDay(items, new Date()).flatMap((group) => [
-    <div key={`day:${group.items[0].key}`} className="pt-3 first:pt-0">
+  //
+  // The first group's lack of top padding is an explicit flag, NOT `first:pt-0`:
+  // virtua wraps every child in its own item element, so `:first-child` would
+  // match every marker and collapse the gap between all day groups. The board's
+  // feed carries the same `row.first` flag for the same reason.
+  const rows = groupItemsByDay(items, new Date()).flatMap((group, index) => [
+    <div key={`day:${group.items[0].key}`} className={index === 0 ? "pt-0" : "pt-3"}>
       <TimelineDayMarker label={group.label} />
     </div>,
     ...group.items.map((item) => <div key={item.key}>{renderItem(item)}</div>),

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from "react-router-dom"
 import { PanelRight, Sparkles } from "lucide-react"
 import { SidePanelClose, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
 import { Skeleton } from "@/components/ui/skeleton"
+import { StreamContextList } from "./stream-context-list"
 import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { CONTEXT_CATEGORIES, type ContextCategory, type ContextItem } from "@/lib/stream-context/types"
 import { cn } from "@/lib/utils"
@@ -178,28 +179,34 @@ export function ContextTimeline({
   items,
   renderItem,
   footer,
+  scrollRef,
 }: {
   items: ContextItem[]
   renderItem: (item: ContextItem) => React.ReactNode
   footer?: React.ReactNode
+  /** The panel's scroller. Given one, rows are windowed; without one they all mount. */
+  scrollRef?: React.RefObject<HTMLDivElement | null>
 }) {
-  const groups = groupItemsByDay(items, new Date())
+  // Flattened, not nested per day: virtua windows a flat child list, so a day
+  // marker is a row of its own rather than a wrapper around its group. Keyed on
+  // a stable item id — date labels repeat across years and would collide.
+  const rows = groupItemsByDay(items, new Date()).flatMap((group) => [
+    <div key={`day:${group.items[0].key}`} className="pt-3 first:pt-0">
+      <TimelineDayMarker label={group.label} />
+    </div>,
+    ...group.items.map((item) => <div key={item.key}>{renderItem(item)}</div>),
+  ])
+
   return (
     <div className="relative pb-2">
       {/* the spine — one continuous line behind every node; a hint of gold at
-          its origin (the golden thread) fading down. */}
+          its origin (the golden thread) fading down. Outside the virtualizer:
+          it spans the whole list, not any one windowed row. */}
       <div
         aria-hidden
         className="absolute bottom-3 left-6 top-3 w-px bg-gradient-to-b from-primary/40 via-border to-border"
       />
-      {groups.map((group) => (
-        // Key on a stable item id, not the display label (date labels can
-        // repeat across years and would collide).
-        <div key={group.items[0].key} className="pt-3 first:pt-0">
-          <TimelineDayMarker label={group.label} />
-          {group.items.map((item) => renderItem(item))}
-        </div>
-      ))}
+      {scrollRef ? <StreamContextList scrollRef={scrollRef}>{rows}</StreamContextList> : rows}
       {footer}
     </div>
   )

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useMemo, useRef } from "react"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
 import { deriveStreamContext } from "@/lib/stream-context/derive"
@@ -61,6 +61,8 @@ export function StreamContextDerivedPanel({
   const visible = effectiveFilter === "all" ? items : items.filter((i) => i.category === effectiveFilter)
   const isLoading = events === undefined || (delegationsPending && visible.length === 0)
 
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+
   let body: React.ReactNode
   if (isLoading) {
     body = <ContextSkeleton />
@@ -69,6 +71,7 @@ export function StreamContextDerivedPanel({
   } else {
     body = (
       <ContextTimeline
+        scrollRef={scrollerRef}
         items={visible}
         renderItem={(item) => (
           <StreamContextRow
@@ -92,7 +95,10 @@ export function StreamContextDerivedPanel({
         <ContextChipRow chips={chipsFromCounts(counts, total)} active={effectiveFilter} onSelect={setFilter} />
       )}
       {note && <p className="shrink-0 border-b px-3 py-1.5 text-[11px] text-muted-foreground">{note}</p>}
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+      <div
+        ref={scrollerRef}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
+      >
         {body}
       </div>
     </div>

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -155,6 +155,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   }, [feedCounts, countsKey])
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0)
 
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = feed
   useEffect(() => {
@@ -215,6 +216,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   } else {
     body = (
       <ContextTimeline
+        scrollRef={scrollerRef}
         items={items}
         renderItem={(item) => (
           <ContextRowWithOccurrences
@@ -296,7 +298,10 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
         <ContextChipRow chips={chipsFromCounts(counts, total)} active={effectiveFilter} onSelect={setFilter} />
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+      <div
+        ref={scrollerRef}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
+      >
         {body}
       </div>
     </div>

--- a/apps/frontend/src/components/stream-context/stream-context-list.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-list.tsx
@@ -1,0 +1,33 @@
+import { Virtualizer } from "virtua"
+import type { ReactNode, RefObject } from "react"
+
+/**
+ * The "In this stream" timeline's virtualization boundary, mirroring
+ * `BoardFeedList`. Wraps `virtua`'s `Virtualizer` over the scroller the panel
+ * owns so only on-screen rows mount — a busy stream indexes hundreds of
+ * artifacts and the panel pages further on scroll, so the row count grows
+ * without bound.
+ *
+ * A plain function component on purpose: it is the single seam tests replace
+ * with a passthrough via namespace `spyOn` (INV-48), since `virtua` renders
+ * nothing under jsdom's zero-height, no-op-ResizeObserver layout. Keep this
+ * module free of panel logic so that swap stays a pure render passthrough.
+ */
+export interface StreamContextListProps {
+  /** The scroller the panel owns; virtua reads native scroll metrics off it. */
+  scrollRef: RefObject<HTMLDivElement | null>
+  children: ReactNode
+}
+
+// Off-screen px kept mounted so a fling doesn't outrun mount+measure and flash
+// blank rows. Context rows are short and cheap next to board cards, so this can
+// be generous.
+const BUFFER_SIZE_PX = 600
+
+export function StreamContextList({ scrollRef, children }: StreamContextListProps) {
+  return (
+    <Virtualizer scrollRef={scrollRef} bufferSize={BUFFER_SIZE_PX}>
+      {children}
+    </Virtualizer>
+  )
+}

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createElement, Fragment } from "react"
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
@@ -11,6 +12,7 @@ import * as hooks from "@/hooks"
 import * as connectionStatus from "@/components/layout/connection-status"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
+import * as streamContextListModule from "@/components/stream-context/stream-context-list"
 import { streamContextItemKey, type ListStreamContextResponse, type StreamContextItem } from "@threa/types"
 import { StreamContextPanel } from "./stream-context-panel"
 
@@ -94,6 +96,13 @@ function renderPanel(options: { flag?: "on" | "off"; entry?: string } = {}) {
 
 beforeEach(async () => {
   vi.restoreAllMocks()
+  // `virtua` renders zero rows under jsdom's zero-height, no-op-ResizeObserver
+  // layout, so swap the panel's virtualization seam for a passthrough that
+  // renders every child — these tests exercise the real rows; the windowing
+  // itself is verified in a browser. Same swap board.test.tsx makes (INV-48).
+  vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children }) =>
+    createElement(Fragment, null, children)
+  )
   observerCallbacks = []
   vi.stubGlobal(
     "IntersectionObserver",


### PR DESCRIPTION
The "In this stream" panel mounted every loaded row. It pages on scroll and a busy stream indexes hundreds of artifacts — 830 on the stream that surfaced this — so the DOM grew without bound as you scrolled.

Reuses the board's pattern rather than inventing one. `StreamContextList` is the same thin `virtua` seam as `BoardFeedList`: it wraps `Virtualizer` over the scroller the panel owns and stays free of panel logic, so tests can swap it for a passthrough (virtua renders nothing under jsdom's zero-height, no-op-ResizeObserver layout).

`ContextTimeline` now flattens its day groups into a single child list — virtua windows a flat list, so a day marker becomes a row of its own rather than a wrapper around its group. The spine stays outside the virtualizer: it spans the whole list, not any one windowed row. Both panels get this, since the index path and the flag-off/sealed derive path share the timeline.

**On verification, honestly:** the passthrough swap means no existing test observes the windowing — that is the board's precedent too, where it says "the windowing itself is verified in a browser". So the new chrome test pins the *wiring* instead: given a scroller the timeline must hand its rows to the seam, and without one it must still render them all. Without that, a regression could silently un-window the panel while every other test stayed green, because they all replace the seam. The windowing behaviour itself has not been exercised locally in a real browser — the panel sits behind a control-plane feature flag that the local dev stack does not serve.

Separately, and not addressed here: this panel is not the only thing this workstream added. Rows are also maintained by sync-engine appliers that run regardless of the flag — an extra IDB transaction per incoming message in every subscribed stream, replayed for every entry on catch-up. If the app still feels heavy with the panel closed, that is where to look next, and it wants measurement rather than more guessing.

Verification: 2670 frontend tests across components/lib/pages, typecheck, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787761722&installation_model_id=20758&pr_number=1600&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1600&signature=5f69f72a7130ac4b72e258c361da16a841208f1e86e2a9dd7960b064b8ae4e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->