### PR TITLE
feat(stream-context): jump the panel's list to a date from its day markers

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react"
+import type { VirtualizerHandle } from "virtua"
 import { useSearchParams } from "react-router-dom"
 import { PanelRight, Sparkles } from "lucide-react"
 import { SidePanelClose, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { DateJumpMenu } from "@/components/timeline/date-jump-menu"
 import { StreamContextList } from "./stream-context-list"
 import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { CONTEXT_CATEGORIES, type ContextCategory, type ContextItem } from "@/lib/stream-context/types"
@@ -171,6 +175,38 @@ export function TimelineDayMarker({ label }: { label: string }) {
 }
 
 /**
+ * The day marker as a jump affordance: tapping a date opens the same menu the
+ * timeline's date pill uses, and picking moves this list rather than the
+ * messages. Mirrors how dates work in the stream view, which is where the
+ * gesture is learned.
+ */
+function DayMarkerJump({ label, day, onJumpToDate }: { label: string; day: Date; onJumpToDate: (date: Date) => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Jump to a date — showing ${label}`}
+          className="w-full rounded-md text-left transition-colors hover:bg-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <TimelineDayMarker label={label} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-0">
+        <DateJumpMenu
+          defaultMonth={day}
+          onPick={(date) => {
+            onJumpToDate(date)
+            setOpen(false)
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
  * The day-grouped timeline body. `renderItem` lets a caller decorate a row
  * (the index panel wraps multi-occurrence rows in an expander) without the row
  * component knowing about either path.
@@ -180,12 +216,18 @@ export function ContextTimeline({
   renderItem,
   footer,
   scrollRef,
+  listRef,
+  onJumpToDate,
 }: {
   items: ContextItem[]
   renderItem: (item: ContextItem) => React.ReactNode
   footer?: React.ReactNode
   /** The panel's scroller. Given one, rows are windowed; without one they all mount. */
   scrollRef?: React.RefObject<HTMLDivElement | null>
+  /** virtua's handle, so the panel can scroll to an unmounted row on a date jump. */
+  listRef?: React.RefObject<VirtualizerHandle | null>
+  /** Given one, day markers become jump-to-date triggers. */
+  onJumpToDate?: (date: Date) => void
 }) {
   // Flattened, not nested per day: virtua windows a flat child list, so a day
   // marker is a row of its own rather than a wrapper around its group. Keyed on
@@ -197,7 +239,11 @@ export function ContextTimeline({
   // feed carries the same `row.first` flag for the same reason.
   const rows = groupItemsByDay(items, new Date()).flatMap((group, index) => [
     <div key={`day:${group.items[0].key}`} className={index === 0 ? "pt-0" : "pt-3"}>
-      <TimelineDayMarker label={group.label} />
+      {onJumpToDate ? (
+        <DayMarkerJump label={group.label} day={new Date(group.items[0].createdAt)} onJumpToDate={onJumpToDate} />
+      ) : (
+        <TimelineDayMarker label={group.label} />
+      )}
     </div>,
     ...group.items.map((item) => <div key={item.key}>{renderItem(item)}</div>),
   ])
@@ -211,7 +257,13 @@ export function ContextTimeline({
         aria-hidden
         className="absolute bottom-3 left-6 top-3 w-px bg-gradient-to-b from-primary/40 via-border to-border"
       />
-      {scrollRef ? <StreamContextList scrollRef={scrollRef}>{rows}</StreamContextList> : rows}
+      {scrollRef ? (
+        <StreamContextList scrollRef={scrollRef} listRef={listRef}>
+          {rows}
+        </StreamContextList>
+      ) : (
+        rows
+      )}
       {footer}
     </div>
   )

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { useSearchParams } from "react-router-dom"
-import { PanelRight, Sparkles } from "lucide-react"
+import { ChevronDown, PanelRight, Sparkles } from "lucide-react"
 import { SidePanelClose, SidePanelHeader, SidePanelTitle } from "@/components/ui/side-panel"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -185,12 +185,18 @@ function DayMarkerJump({ label, day, onJumpToDate }: { label: string; day: Date;
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
+        {/* Carries the chevron the timeline's date pill uses, because that is
+            what makes a date read as a control — on touch there is no hover to
+            reveal it. `py-2` lifts the tap target off the 11px label to a
+            thumb-sized row; the visual rhythm is unchanged because the marker
+            keeps its own `py-1`. */}
         <button
           type="button"
           aria-label={`Jump to a date — showing ${label}`}
-          className="w-full rounded-md text-left transition-colors hover:bg-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="group flex w-full items-center rounded-md py-2 text-left transition-colors hover:bg-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <TimelineDayMarker label={label} />
+          <ChevronDown className="ml-1 size-3 shrink-0 text-muted-foreground opacity-60" aria-hidden />
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-64 p-0">

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from "react"
 import type { VirtualizerHandle } from "virtua"
+import { toast } from "sonner"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
 import { localStartOfDayMs } from "@/lib/dates"
@@ -79,10 +80,14 @@ export function StreamContextDerivedPanel({
       for (const group of groupItemsByDay(visible, new Date())) {
         if (Date.parse(group.items[0].createdAt) < endOfDayMs) {
           listRef.current?.scrollToIndex(flatIndex, { align: "start" })
+          scrollerRef.current?.focus({ preventScroll: true })
           return
         }
         flatIndex += 1 + group.items.length
       }
+      // This path holds only the loaded window, so an older date has nothing to
+      // land on — say so rather than silently doing nothing.
+      toast.info("Nothing indexed on or before that date")
     },
     [visible]
   )
@@ -123,6 +128,10 @@ export function StreamContextDerivedPanel({
       {note && <p className="shrink-0 border-b px-3 py-1.5 text-[11px] text-muted-foreground">{note}</p>}
       <div
         ref={scrollerRef}
+        // Focusable so a date jump can park focus here when the marker that
+        // opened the menu is windowed out (Radix would otherwise return focus to
+        // a removed node and drop it to <body>).
+        tabIndex={-1}
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
       >
         {body}

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
 import { localStartOfDayMs } from "@/lib/dates"
-import { groupItemsByDay } from "@/lib/stream-context/grouping"
+import { markerIndexForDate } from "@/lib/stream-context/grouping"
 import { deriveStreamContext } from "@/lib/stream-context/derive"
 import { delegationContextItems, withDelegations } from "@/lib/stream-context/delegations"
 import { StreamContextRow } from "./stream-context-row"
@@ -75,19 +75,15 @@ export function StreamContextDerivedPanel({
   // and the jump is a no-op rather than a fetch.
   const jumpToDate = useCallback(
     (date: Date) => {
-      const endOfDayMs = localStartOfDayMs(date) + DAY_MS
-      let flatIndex = 0
-      for (const group of groupItemsByDay(visible, new Date())) {
-        if (Date.parse(group.items[0].createdAt) < endOfDayMs) {
-          listRef.current?.scrollToIndex(flatIndex, { align: "start" })
-          scrollerRef.current?.focus({ preventScroll: true })
-          return
-        }
-        flatIndex += 1 + group.items.length
+      const index = markerIndexForDate(visible, localStartOfDayMs(date) + DAY_MS, new Date())
+      if (index === -1) {
+        // This path holds only the loaded window, so an older date has nothing
+        // to land on — say so rather than silently doing nothing.
+        toast.info("Nothing indexed on or before that date")
+        return
       }
-      // This path holds only the loaded window, so an older date has nothing to
-      // land on — say so rather than silently doing nothing.
-      toast.info("Nothing indexed on or before that date")
+      listRef.current?.scrollToIndex(index, { align: "start" })
+      scrollerRef.current?.focus({ preventScroll: true })
     },
     [visible]
   )

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -1,6 +1,9 @@
-import { useMemo, useRef } from "react"
+import { useCallback, useMemo, useRef } from "react"
+import type { VirtualizerHandle } from "virtua"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
+import { localStartOfDayMs } from "@/lib/dates"
+import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { deriveStreamContext } from "@/lib/stream-context/derive"
 import { delegationContextItems, withDelegations } from "@/lib/stream-context/delegations"
 import { StreamContextRow } from "./stream-context-row"
@@ -21,6 +24,8 @@ import {
  * Still the path for sealed streams (the server holds ciphertext, never an
  * index) and for workspaces with `streamContextIndex` off.
  */
+const DAY_MS = 24 * 60 * 60 * 1000
+
 export function StreamContextDerivedPanel({
   workspaceId,
   streamId,
@@ -62,6 +67,25 @@ export function StreamContextDerivedPanel({
   const isLoading = events === undefined || (delegationsPending && visible.length === 0)
 
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const listRef = useRef<VirtualizerHandle | null>(null)
+
+  // Same jump affordance as the indexed panel, minus the paging: this path
+  // renders the loaded window only, so a date beyond it has nothing to land on
+  // and the jump is a no-op rather than a fetch.
+  const jumpToDate = useCallback(
+    (date: Date) => {
+      const endOfDayMs = localStartOfDayMs(date) + DAY_MS
+      let flatIndex = 0
+      for (const group of groupItemsByDay(visible, new Date())) {
+        if (Date.parse(group.items[0].createdAt) < endOfDayMs) {
+          listRef.current?.scrollToIndex(flatIndex, { align: "start" })
+          return
+        }
+        flatIndex += 1 + group.items.length
+      }
+    },
+    [visible]
+  )
 
   let body: React.ReactNode
   if (isLoading) {
@@ -72,6 +96,8 @@ export function StreamContextDerivedPanel({
     body = (
       <ContextTimeline
         scrollRef={scrollerRef}
+        listRef={listRef}
+        onJumpToDate={jumpToDate}
         items={visible}
         renderItem={(item) => (
           <StreamContextRow

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, Search, WifiOff, X } from "lucide-react"
 import { streamContextApi } from "@/api"
 import { useIsOnline } from "@/components/layout/connection-status"
@@ -13,11 +14,14 @@ import { parseSearchQuery, type ParsedFilter } from "@/lib/search-query-parser"
 import { contextItemFromCached } from "@/lib/stream-context/from-cached"
 import { collapseContextRows, countByCategory, filterContextRows } from "@/lib/stream-context/filter"
 import type { ContextCategory, ContextItem } from "@/lib/stream-context/types"
+import { localStartOfDayMs } from "@/lib/dates"
+import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { cn } from "@/lib/utils"
 import {
   contextGroupRef,
   seedStreamContextItems,
   useStreamContextOccurrences,
+  readStreamContextRows,
   useStreamContextRows,
   type CachedStreamContextItem,
 } from "@/stores/stream-context-store"
@@ -60,6 +64,12 @@ const NEXT_PAGE_PREFETCH_MARGIN = "300px"
  * {@link useStreamContextFeed}'s paged seeds. Sealed streams get `mode: "client"`
  * back from the endpoint and fall through to the derive path.
  */
+const DAY_MS = 24 * 60 * 60 * 1000
+// A jump into unloaded history pages until it reaches the day. Bounded so a date
+// older than the whole stream settles instead of paging forever; at 40 rows a
+// page this reaches ~400 artifacts back, and the user can keep scrolling.
+const MAX_JUMP_PAGES = 10
+
 export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const { workspaceId, streamId, onClose, onJumpToMessage, onOpenThread, onOpenMemo, onOpenGallery } = props
   const stream = useStreamFromStore(streamId)
@@ -156,7 +166,57 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0)
 
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const listRef = useRef<VirtualizerHandle | null>(null)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  // Jump the LIST to a date — navigation, not filtering: the feed stays one
+  // continuous list and the view moves. Rows are newest-first, so the first
+  // group at or before the day's end is the nearest-earlier landing spot (dates
+  // here are sparse; most days hold nothing).
+  //
+  // The index is into the FLAT child list the timeline renders — it interleaves
+  // a day marker before each group — not into the rows. Landing on the marker
+  // also reads better: the header states which day you are now at. The target is
+  // usually not mounted, hence virtua's `scrollToIndex` over a DOM scroll.
+  const items = visibleRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
+
+  const markerIndexFor = useCallback((candidates: ContextItem[], endOfDayMs: number): number => {
+    let flatIndex = 0
+    for (const group of groupItemsByDay(candidates, new Date())) {
+      if (Date.parse(group.items[0].createdAt) < endOfDayMs) return flatIndex
+      flatIndex += 1 + group.items.length
+    }
+    return -1
+  }, [])
+
+  const jumpToDate = useCallback(
+    async (date: Date) => {
+      const endOfDayMs = localStartOfDayMs(date) + DAY_MS
+      let index = markerIndexFor(items, endOfDayMs)
+      // Not loaded that far back yet: page until it is, bounded so a date older
+      // than the whole stream can't spin. Each page widens the IDB-backed list.
+      for (let page = 0; index === -1 && page < MAX_JUMP_PAGES && feed.hasNextPage; page += 1) {
+        await feed.fetchNextPage()
+        const fresh = await readStreamContextRows(workspaceId, streamId, rootStreamId, "tree")
+        const rebuilt = collapseContextRows(
+          filterContextRows(fresh, {
+            category,
+            terms: searchTerms,
+            authorId: authorId ?? undefined,
+            before,
+            after,
+          })
+        )
+        index = markerIndexFor(
+          rebuilt.map(contextItemFromCached).filter((item): item is ContextItem => item !== null),
+          endOfDayMs
+        )
+      }
+      if (index === -1) return
+      listRef.current?.scrollToIndex(index, { align: "start" })
+    },
+    [items, markerIndexFor, feed, workspaceId, streamId, rootStreamId, category, searchTerms, authorId, before, after]
+  )
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = feed
   useEffect(() => {
     const node = sentinelRef.current
@@ -184,7 +244,6 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   }
 
   const isLoading = rows === undefined || (feed.isLoading && visibleRows.length === 0)
-  const items = visibleRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
   const itemsByKey = new Map(visibleRows.map((row) => [row.key, row]))
 
   // The cached window ends here and the next page can't be fetched — say so
@@ -217,6 +276,8 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
     body = (
       <ContextTimeline
         scrollRef={scrollerRef}
+        listRef={listRef}
+        onJumpToDate={jumpToDate}
         items={items}
         renderItem={(item) => (
           <ContextRowWithOccurrences

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, Search, WifiOff, X } from "lucide-react"
+import { toast } from "sonner"
 import { streamContextApi } from "@/api"
 import { useIsOnline } from "@/components/layout/connection-status"
 import { extractSearchTerms } from "@/components/search/highlight"
@@ -189,10 +190,15 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
     return -1
   }, [])
 
+  const [jumping, setJumping] = useState(false)
   const jumpToDate = useCallback(
     async (date: Date) => {
       const endOfDayMs = localStartOfDayMs(date) + DAY_MS
       let index = markerIndexFor(items, endOfDayMs)
+      // Paging to an unloaded date is several round trips; without this the
+      // panel just sits there. Only set it when a fetch is actually needed, so
+      // the common in-window jump stays instant and flicker-free.
+      if (index === -1 && feed.hasNextPage) setJumping(true)
       // Not loaded that far back yet: page until it is, bounded so a date older
       // than the whole stream can't spin. Each page widens the IDB-backed list.
       for (let page = 0; index === -1 && page < MAX_JUMP_PAGES && feed.hasNextPage; page += 1) {
@@ -212,8 +218,20 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
           endOfDayMs
         )
       }
-      if (index === -1) return
+      setJumping(false)
+      if (index === -1) {
+        // Same wording the timeline's date jump uses for the same dead end, so
+        // the two surfaces fail identically (INV-63: this needs attention and
+        // has no on-screen anchor of its own).
+        toast.info("Nothing indexed on or before that date")
+        return
+      }
       listRef.current?.scrollToIndex(index, { align: "start" })
+      // The marker that opened the menu is usually windowed out by the jump, so
+      // Radix's focus-return lands on a removed node and focus falls to <body>.
+      // Park it on the scroller instead: the user stays inside the panel and can
+      // keep tabbing from where they landed.
+      scrollerRef.current?.focus({ preventScroll: true })
     },
     [items, markerIndexFor, feed, workspaceId, streamId, rootStreamId, category, searchTerms, authorId, before, after]
   )
@@ -302,7 +320,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
         footer={
           <>
             <div ref={sentinelRef} aria-hidden className="h-px" />
-            {isFetchingNextPage && <ContextSkeleton />}
+            {(isFetchingNextPage || jumping) && <ContextSkeleton />}
             {boundaryNode}
           </>
         }
@@ -361,6 +379,10 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
 
       <div
         ref={scrollerRef}
+        // Focusable so a date jump can park focus here when the marker that
+        // opened the menu is windowed out (Radix would otherwise return focus to
+        // a removed node and drop it to <body>).
+        tabIndex={-1}
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
       >
         {body}

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -16,7 +16,7 @@ import { contextItemFromCached } from "@/lib/stream-context/from-cached"
 import { collapseContextRows, countByCategory, filterContextRows } from "@/lib/stream-context/filter"
 import type { ContextCategory, ContextItem } from "@/lib/stream-context/types"
 import { localStartOfDayMs } from "@/lib/dates"
-import { groupItemsByDay } from "@/lib/stream-context/grouping"
+import { markerIndexForDate } from "@/lib/stream-context/grouping"
 import { cn } from "@/lib/utils"
 import {
   contextGroupRef,
@@ -171,38 +171,27 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
 
   // Jump the LIST to a date — navigation, not filtering: the feed stays one
-  // continuous list and the view moves. Rows are newest-first, so the first
-  // group at or before the day's end is the nearest-earlier landing spot (dates
-  // here are sparse; most days hold nothing).
-  //
-  // The index is into the FLAT child list the timeline renders — it interleaves
-  // a day marker before each group — not into the rows. Landing on the marker
-  // also reads better: the header states which day you are now at. The target is
-  // usually not mounted, hence virtua's `scrollToIndex` over a DOM scroll.
+  // continuous list and the view moves. The target is usually not mounted,
+  // hence virtua's `scrollToIndex` over a DOM scroll.
   const items = visibleRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
-
-  const markerIndexFor = useCallback((candidates: ContextItem[], endOfDayMs: number): number => {
-    let flatIndex = 0
-    for (const group of groupItemsByDay(candidates, new Date())) {
-      if (Date.parse(group.items[0].createdAt) < endOfDayMs) return flatIndex
-      flatIndex += 1 + group.items.length
-    }
-    return -1
-  }, [])
 
   const [jumping, setJumping] = useState(false)
   const jumpToDate = useCallback(
     async (date: Date) => {
       const endOfDayMs = localStartOfDayMs(date) + DAY_MS
-      let index = markerIndexFor(items, endOfDayMs)
+      let index = markerIndexForDate(items, endOfDayMs, new Date())
       // Paging to an unloaded date is several round trips; without this the
       // panel just sits there. Only set it when a fetch is actually needed, so
       // the common in-window jump stays instant and flicker-free.
       if (index === -1 && feed.hasNextPage) setJumping(true)
       // Not loaded that far back yet: page until it is, bounded so a date older
       // than the whole stream can't spin. Each page widens the IDB-backed list.
-      for (let page = 0; index === -1 && page < MAX_JUMP_PAGES && feed.hasNextPage; page += 1) {
-        await feed.fetchNextPage()
+      // `more` tracks the FETCH's own result — `feed.hasNextPage` is captured at
+      // render and stays true here, so it would keep re-reading IDB for every
+      // remaining iteration after history runs out.
+      let more = feed.hasNextPage
+      for (let page = 0; index === -1 && page < MAX_JUMP_PAGES && more; page += 1) {
+        more = (await feed.fetchNextPage()).hasNextPage
         const fresh = await readStreamContextRows(workspaceId, streamId, rootStreamId, "tree")
         const rebuilt = collapseContextRows(
           filterContextRows(fresh, {
@@ -213,9 +202,10 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
             after,
           })
         )
-        index = markerIndexFor(
+        index = markerIndexForDate(
           rebuilt.map(contextItemFromCached).filter((item): item is ContextItem => item !== null),
-          endOfDayMs
+          endOfDayMs,
+          new Date()
         )
       }
       setJumping(false)
@@ -233,7 +223,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       // keep tabbing from where they landed.
       scrollerRef.current?.focus({ preventScroll: true })
     },
-    [items, markerIndexFor, feed, workspaceId, streamId, rootStreamId, category, searchTerms, authorId, before, after]
+    [items, feed, workspaceId, streamId, rootStreamId, category, searchTerms, authorId, before, after]
   )
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = feed
   useEffect(() => {

--- a/apps/frontend/src/components/stream-context/stream-context-list.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-list.tsx
@@ -1,4 +1,4 @@
-import { Virtualizer } from "virtua"
+import { Virtualizer, type VirtualizerHandle } from "virtua"
 import type { ReactNode, RefObject } from "react"
 
 /**
@@ -16,6 +16,9 @@ import type { ReactNode, RefObject } from "react"
 export interface StreamContextListProps {
   /** The scroller the panel owns; virtua reads native scroll metrics off it. */
   scrollRef: RefObject<HTMLDivElement | null>
+  /** virtua's imperative handle, so a date jump can `scrollToIndex` a row that
+   *  is not mounted — the whole point of windowing is that it usually isn't. */
+  listRef?: RefObject<VirtualizerHandle | null>
   children: ReactNode
 }
 
@@ -24,9 +27,9 @@ export interface StreamContextListProps {
 // be generous.
 const BUFFER_SIZE_PX = 600
 
-export function StreamContextList({ scrollRef, children }: StreamContextListProps) {
+export function StreamContextList({ scrollRef, listRef, children }: StreamContextListProps) {
   return (
-    <Virtualizer scrollRef={scrollRef} bufferSize={BUFFER_SIZE_PX}>
+    <Virtualizer ref={listRef} scrollRef={scrollRef} bufferSize={BUFFER_SIZE_PX}>
       {children}
     </Virtualizer>
   )

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { toast } from "sonner"
 import { createElement, Fragment } from "react"
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -13,6 +14,7 @@ import * as connectionStatus from "@/components/layout/connection-status"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import * as streamContextListModule from "@/components/stream-context/stream-context-list"
+import * as storeModule from "@/stores/stream-context-store"
 import { streamContextItemKey, type ListStreamContextResponse, type StreamContextItem } from "@threa/types"
 import { StreamContextPanel } from "./stream-context-panel"
 
@@ -553,6 +555,40 @@ describe("StreamContextPanel — flag on", () => {
     releasePage(listResponse({ items: [older], counts: null }))
 
     await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
+  })
+
+  it("stops paging for an unreachable date as soon as the server says history is exhausted", async () => {
+    vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
+      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex: vi.fn() }
+      return createElement(Fragment, null, children)
+    })
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({ category: "link", refId: "https://newest.example", occurredAt: "2026-07-20T10:00:00.000Z" })
+      )
+    )
+    // One page of history, then the end. `hasNextPage` on the render-time
+    // snapshot stays true for the whole loop, so only the fetch's own result
+    // can stop it before it burns all MAX_JUMP_PAGES iterations.
+    const readRows = vi.spyOn(storeModule, "readStreamContextRows")
+    const toastInfo = vi.spyOn(toast, "info").mockReturnValue("" as ReturnType<typeof toast.info>)
+    vi.spyOn(streamContextApi, "list")
+      .mockResolvedValueOnce(listResponse({ counts: null, nextCursor: "c1" }))
+      .mockResolvedValue(listResponse({ counts: null }))
+
+    renderPanel()
+    await screen.findAllByRole("button", { name: /Jump to a date/ })
+    readRows.mockClear()
+
+    await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
+    await userEvent.click(await screen.findByText("Jump to a specific date…"))
+    await userEvent.click(await screen.findByText("2"))
+
+    await waitFor(() => expect(toastInfo).toHaveBeenCalledWith("Nothing indexed on or before that date"))
+    // One page fetched, one re-read. The bound is MAX_JUMP_PAGES (10), so a
+    // loop trusting the stale snapshot re-reads ten times to reach the same
+    // dead end.
+    expect(readRows).toHaveBeenCalledTimes(1)
   })
 
   it("does not offer expansion on a locally derived row (no server groupKey yet)", async () => {

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -511,6 +511,50 @@ describe("StreamContextPanel — flag on", () => {
     expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" })
   })
 
+  it("pages into unloaded history to reach a jump target, then lands on it", async () => {
+    const scrollToIndex = vi.fn()
+    vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
+      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex }
+      return createElement(Fragment, null, children)
+    })
+    // Only the newest day is cached; the 12th arrives with the jump's page.
+    const older = serverItem({
+      category: "link",
+      refId: "https://older.example",
+      occurredAt: "2026-07-12T10:00:00.000Z",
+    })
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({ category: "link", refId: "https://newest.example", occurredAt: "2026-07-20T10:00:00.000Z" })
+      )
+    )
+    // The jump's page is held open, so the assertions below can distinguish
+    // "waited for the page" from "read IDB before it landed".
+    let releasePage: (value: ListStreamContextResponse) => void = () => {}
+    vi.spyOn(streamContextApi, "list")
+      .mockResolvedValueOnce(listResponse({ counts: null, nextCursor: "c1" }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<ListStreamContextResponse>((resolve) => {
+            releasePage = resolve
+          })
+      )
+
+    renderPanel()
+    await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
+    await userEvent.click(await screen.findByText("Jump to a specific date…"))
+    await userEvent.click(await screen.findByText("12"))
+
+    // Still in flight: nothing to land on yet. If `fetchNextPage` resolved
+    // before the page landed, the loop would have burned its budget against
+    // stale IDB and given up here instead of waiting.
+    expect(scrollToIndex).not.toHaveBeenCalled()
+
+    releasePage(listResponse({ items: [older], counts: null }))
+
+    await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
+  })
+
   it("does not offer expansion on a locally derived row (no server groupKey yet)", async () => {
     await db.streamContextItems.put(
       cachedRow(

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -481,6 +481,36 @@ describe("StreamContextPanel — flag on", () => {
     expect(onJumpToMessage).toHaveBeenCalledWith("event_delegation_1")
   })
 
+  it("jumps the list to a picked date, landing on the nearest earlier day", async () => {
+    const scrollToIndex = vi.fn()
+    vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
+      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex }
+      return createElement(Fragment, null, children)
+    })
+    // Newest-first: [marker 20th, row, marker 12th, row, marker 2nd, row].
+    await db.streamContextItems.bulkPut([
+      cachedRow(
+        serverItem({ category: "link", refId: "https://newest.example", occurredAt: "2026-07-20T10:00:00.000Z" })
+      ),
+      cachedRow(
+        serverItem({ category: "link", refId: "https://target.example", occurredAt: "2026-07-12T10:00:00.000Z" })
+      ),
+      cachedRow(
+        serverItem({ category: "link", refId: "https://oldest.example", occurredAt: "2026-07-02T10:00:00.000Z" })
+      ),
+    ])
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(listResponse({ counts: null }))
+
+    renderPanel()
+    await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
+    await userEvent.click(await screen.findByText("Jump to a specific date…"))
+    await userEvent.click(await screen.findByText("12"))
+
+    // The 12th's marker sits at flat index 2 — past the 20th's marker and its
+    // one row. Landing on the marker, not the row, so the header reads the day.
+    expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" })
+  })
+
   it("does not offer expansion on a locally derived row (no server groupKey yet)", async () => {
     await db.streamContextItems.put(
       cachedRow(

--- a/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
@@ -28,8 +28,10 @@ export interface StreamContextFeed {
   mode: ListStreamContextResponse["mode"] | null
   hasNextPage: boolean
   /** Resolves when the page has landed and been seeded — a date jump pages in a
-   *  loop and must not re-read IDB before the rows are there. */
-  fetchNextPage: () => Promise<unknown>
+   *  loop and must not re-read IDB before the rows are there. Its `hasNextPage`
+   *  is the post-fetch truth; the field above is a render-time snapshot and
+   *  stays stale inside such a loop. */
+  fetchNextPage: () => Promise<{ hasNextPage: boolean }>
   isFetchingNextPage: boolean
   isLoading: boolean
   isError: boolean
@@ -84,7 +86,18 @@ export function useStreamContextFeed(
     counts: firstPage?.counts ?? null,
     mode: firstPage?.mode ?? null,
     hasNextPage: query.hasNextPage,
-    fetchNextPage: () => query.fetchNextPage(),
+    // Seed before resolving. The effect above also seeds, but it runs a render
+    // later — a caller that awaits this and then reads IDB (the date jump) would
+    // race it and see the page missing.
+    fetchNextPage: async () => {
+      const result = await query.fetchNextPage()
+      await seedStreamContextItems(
+        workspaceId,
+        rootStreamId,
+        (result.data?.pages ?? []).flatMap((page) => page.items)
+      )
+      return { hasNextPage: result.hasNextPage }
+    },
     isFetchingNextPage: query.isFetchingNextPage,
     isLoading: query.isLoading,
     isError: query.isError,

--- a/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
@@ -27,7 +27,9 @@ export interface StreamContextFeed {
   /** `client` = sealed stream; the panel derives locally instead. */
   mode: ListStreamContextResponse["mode"] | null
   hasNextPage: boolean
-  fetchNextPage: () => void
+  /** Resolves when the page has landed and been seeded — a date jump pages in a
+   *  loop and must not re-read IDB before the rows are there. */
+  fetchNextPage: () => Promise<unknown>
   isFetchingNextPage: boolean
   isLoading: boolean
   isError: boolean
@@ -82,7 +84,7 @@ export function useStreamContextFeed(
     counts: firstPage?.counts ?? null,
     mode: firstPage?.mode ?? null,
     hasNextPage: query.hasNextPage,
-    fetchNextPage: () => void query.fetchNextPage(),
+    fetchNextPage: () => query.fetchNextPage(),
     isFetchingNextPage: query.isFetchingNextPage,
     isLoading: query.isLoading,
     isError: query.isError,

--- a/apps/frontend/src/components/timeline/date-jump-menu.tsx
+++ b/apps/frontend/src/components/timeline/date-jump-menu.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react"
+import { CalendarDays, ChevronLeft } from "lucide-react"
+import { Calendar } from "@/components/ui/calendar"
+import { getPastDatePresets } from "@/lib/dates"
+
+/**
+ * The body of a jump-to-date popover: quick presets, then a calendar behind a
+ * "specific date" step. Shared by the timeline's floating date pill and the
+ * "In this stream" panel's day markers so the two jumps offer the same choices
+ * and read the same way — the panel's jump moves its own list, the timeline's
+ * moves the messages, but the menu is one implementation (INV-35).
+ *
+ * Owns only its preset/calendar step state; the caller owns the popover and
+ * closes it from `onPick`.
+ */
+export function DateJumpMenu({ defaultMonth, onPick }: { defaultMonth: Date; onPick: (date: Date) => void }) {
+  const [showCalendar, setShowCalendar] = useState(false)
+
+  if (showCalendar) {
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowCalendar(false)}
+          className="flex w-full items-center gap-1.5 border-b px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
+          Back
+        </button>
+        <Calendar
+          mode="single"
+          defaultMonth={defaultMonth}
+          onSelect={(date) => date && onPick(date)}
+          disabled={{ after: new Date() }}
+          className="p-2"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col py-1">
+      {getPastDatePresets().map((preset) => (
+        <button
+          key={preset.id}
+          type="button"
+          onClick={() => onPick(preset.date)}
+          className="px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+        >
+          {preset.label}
+        </button>
+      ))}
+      <div className="my-1 border-t" />
+      <button
+        type="button"
+        onClick={() => setShowCalendar(true)}
+        className="flex items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+      >
+        <CalendarDays className="h-4 w-4 text-muted-foreground" aria-hidden />
+        Jump to a specific date…
+      </button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/timeline/stream-date-header.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react"
-import { CalendarDays, ChevronDown, ChevronLeft } from "lucide-react"
+import { ChevronDown } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Calendar } from "@/components/ui/calendar"
-import { formatDayDivider, getPastDatePresets } from "@/lib/dates"
+import { formatDayDivider } from "@/lib/dates"
+import { DateJumpMenu } from "./date-jump-menu"
 import { useForwardScroll } from "@/hooks/use-forward-scroll"
 import { cn } from "@/lib/utils"
 
@@ -30,7 +30,6 @@ interface StreamDateHeaderProps {
  */
 export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRef }: StreamDateHeaderProps) {
   const [open, setOpen] = useState(false)
-  const [showCalendar, setShowCalendar] = useState(false)
   // Forward a wheel/touch scroll begun on the pill to the timeline scroller —
   // gated off while the jump popover is open so it scrolls its own list.
   const forwardScroll = useForwardScroll(scrollerRef, !open)
@@ -41,7 +40,6 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
   const jump = (date: Date) => {
     onJumpToDate(date)
     setOpen(false)
-    setShowCalendar(false)
   }
 
   return (
@@ -51,13 +49,7 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
         visible ? "opacity-100" : "opacity-0"
       )}
     >
-      <Popover
-        open={open}
-        onOpenChange={(next) => {
-          setOpen(next)
-          if (!next) setShowCalendar(false)
-        }}
-      >
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button
             type="button"
@@ -84,47 +76,7 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
           </button>
         </PopoverTrigger>
         <PopoverContent align="center" className="w-64 p-0">
-          {showCalendar ? (
-            <div>
-              <button
-                type="button"
-                onClick={() => setShowCalendar(false)}
-                className="flex w-full items-center gap-1.5 border-b px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground"
-              >
-                <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
-                Back
-              </button>
-              <Calendar
-                mode="single"
-                defaultMonth={new Date(dayStartMs)}
-                onSelect={(date) => date && jump(date)}
-                disabled={{ after: new Date() }}
-                className="p-2"
-              />
-            </div>
-          ) : (
-            <div className="flex flex-col py-1">
-              {getPastDatePresets().map((preset) => (
-                <button
-                  key={preset.id}
-                  type="button"
-                  onClick={() => jump(preset.date)}
-                  className="px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                >
-                  {preset.label}
-                </button>
-              ))}
-              <div className="my-1 border-t" />
-              <button
-                type="button"
-                onClick={() => setShowCalendar(true)}
-                className="flex items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-              >
-                <CalendarDays className="h-4 w-4 text-muted-foreground" aria-hidden />
-                Jump to a specific date…
-              </button>
-            </div>
-          )}
+          <DateJumpMenu defaultMonth={new Date(dayStartMs)} onPick={jump} />
         </PopoverContent>
       </Popover>
     </div>

--- a/apps/frontend/src/lib/stream-context/grouping.ts
+++ b/apps/frontend/src/lib/stream-context/grouping.ts
@@ -44,3 +44,23 @@ export function groupItemsByDay(items: ContextItem[], now: Date): TimelineGroup[
   }
   return groups
 }
+
+/**
+ * Index of the day marker to land on when jumping to a date, into the FLAT
+ * child list the timeline renders — which interleaves a marker before each
+ * group, so a row index lands a row or two off. `-1` when nothing is early
+ * enough.
+ *
+ * Rows are newest-first, so the first group at or before the day's end is the
+ * nearest-earlier landing spot; dates here are sparse and most days hold
+ * nothing. Lives beside the grouping it indexes so the paged and non-paged jump
+ * paths can't drift apart (INV-35).
+ */
+export function markerIndexForDate(items: ContextItem[], endOfDayMs: number, now: Date): number {
+  let flatIndex = 0
+  for (const group of groupItemsByDay(items, now)) {
+    if (Date.parse(group.items[0].createdAt) < endOfDayMs) return flatIndex
+    flatIndex += 1 + group.items.length
+  }
+  return -1
+}

--- a/apps/frontend/src/stores/stream-context-store.ts
+++ b/apps/frontend/src/stores/stream-context-store.ts
@@ -29,6 +29,29 @@ function toCached(workspaceId: string, rootStreamId: string, item: StreamContext
  * `scope: "tree"` reads the root's whole thread tree (INV-62 — a thread's
  * content belongs to its root's context); `"stream"` reads just this stream.
  */
+/**
+ * One-shot read of the same rows {@link useStreamContextRows} subscribes to.
+ * The live query drives render; a date jump needs the CURRENT rows mid-loop,
+ * after each page lands and before React has re-rendered, so it reads directly.
+ */
+export async function readStreamContextRows(
+  workspaceId: string,
+  streamId: string,
+  rootStreamId: string,
+  scope: StreamContextScope
+): Promise<CachedStreamContextItem[]> {
+  const [index, anchor] =
+    scope === "tree"
+      ? (["[rootStreamId+occurredAt]", rootStreamId] as const)
+      : (["[streamId+occurredAt]", streamId] as const)
+  const rows = await db.streamContextItems
+    .where(index)
+    .between([anchor, Dexie.minKey], [anchor, Dexie.maxKey])
+    .reverse()
+    .toArray()
+  return rows.filter((row) => row.workspaceId === workspaceId)
+}
+
 export function useStreamContextRows(
   workspaceId: string,
   streamId: string,

--- a/tests/browser/global-setup.ts
+++ b/tests/browser/global-setup.ts
@@ -8,7 +8,7 @@
  * Local: Uses docker-compose.test.yml (ports 5455/9002) to avoid dev conflicts
  * CI: Uses GitHub Actions services (ports 5454/9000)
  */
-import { execSync, spawnSync } from "child_process"
+import { execFileSync, execSync, spawnSync } from "child_process"
 import * as path from "path"
 
 const isCI = !!process.env.CI
@@ -38,7 +38,7 @@ function findContainer(pattern: string): string | null {
  * In CI, uses the container names from GitHub Actions workflow.
  * Locally, finds containers by the service name pattern from docker-compose.test.yml.
  */
-export function getContainerNames(): { postgres: string; minio: string } {
+function getContainerNames(): { postgres: string; minio: string } {
   if (isCI) {
     return { postgres: "postgres", minio: "minio" }
   }
@@ -54,6 +54,30 @@ export function getContainerNames(): { postgres: string; minio: string } {
   }
 
   return { postgres, minio }
+}
+
+/**
+ * Run SQL against the browser-test database from a spec.
+ *
+ * The two environments are reached differently and there is no name that works
+ * in both: CI's postgres is a GitHub Actions *service* container, addressable
+ * over TCP on the runner but carrying a generated docker name, while the local
+ * one is a compose container on a port the dev stack doesn't use.
+ */
+export function runTestSql(sql: string): void {
+  const db = deriveTestDatabaseName()
+  // argv, never a shell string: multi-line SQL through a shell reaches psql
+  // with its newlines still escaped, and psql reads `\n` as a meta-command.
+  const psql = ["psql", "-U", "threa", "-d", db, "-v", "ON_ERROR_STOP=1", "-c", sql]
+  const [command, args, env] = isCI
+    ? ([
+        psql[0]!,
+        ["-h", "localhost", "-p", String(DB_PORT), ...psql.slice(1)],
+        { ...process.env, PGPASSWORD: "threa" },
+      ] as const)
+    : (["docker", ["exec", getContainerNames().postgres, ...psql], process.env] as const)
+
+  execFileSync(command, args, { encoding: "utf-8", env })
 }
 
 /**

--- a/tests/browser/global-setup.ts
+++ b/tests/browser/global-setup.ts
@@ -38,7 +38,7 @@ function findContainer(pattern: string): string | null {
  * In CI, uses the container names from GitHub Actions workflow.
  * Locally, finds containers by the service name pattern from docker-compose.test.yml.
  */
-function getContainerNames(): { postgres: string; minio: string } {
+export function getContainerNames(): { postgres: string; minio: string } {
   if (isCI) {
     return { postgres: "postgres", minio: "minio" }
   }

--- a/tests/browser/stream-context-panel.spec.ts
+++ b/tests/browser/stream-context-panel.spec.ts
@@ -1,7 +1,5 @@
-import { execFileSync } from "child_process"
-import * as path from "path"
 import { test, expect, type Page } from "@playwright/test"
-import { getContainerNames } from "./global-setup"
+import { runTestSql } from "./global-setup"
 import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
 
 /**
@@ -43,46 +41,21 @@ async function seedLinkMessages(page: Page, workspaceId: string, streamId: strin
   }
 }
 
-/** Same derivation global-setup and playwright.config use. */
-function testDatabaseName(): string {
-  const explicit = process.env.PLAYWRIGHT_TEST_DB_NAME?.trim()
-  if (explicit) return explicit
-  const sanitized = path
-    .basename(process.cwd())
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_|_$/g, "")
-  return `${sanitized || "threa"}_browser_test`
-}
-
 /**
  * Backdate half the stream's events so the panel renders more than one day
  * group. Without this every seeded row lands today, and "jump to today" is
  * indistinguishable from the browser restoring focus to the trigger at the top —
  * a jump that moves DOWN to an older day is the assertion focus cannot fake.
- * `docker exec psql` mirrors what global-setup already does for DB work.
+ *
+ * 10 days back, so the "Last week" preset (7 days) lands on it under the
+ * nearest-earlier rule.
  */
 function backdateOlderHalf(streamId: string): void {
-  const sql = `UPDATE stream_events SET created_at = NOW() - INTERVAL '10 days'
-     WHERE stream_id = '${streamId}'
-       AND id IN (SELECT id FROM stream_events WHERE stream_id = '${streamId}' ORDER BY sequence LIMIT ${MESSAGE_COUNT / 2})`
-  // 10 days back, so the "Last week" preset (7 days) lands on it under the
-  // nearest-earlier rule.
-  // Resolved the same way global-setup does — "postgres" in CI, the
-  // compose container locally. A hardcoded name passes locally (any worktree's
-  // container reaches the same instance) and fails in CI.
-  execFileSync("docker", [
-    "exec",
-    getContainerNames().postgres,
-    "psql",
-    "-U",
-    "threa",
-    "-d",
-    testDatabaseName(),
-    "-c",
-    sql,
-  ])
+  runTestSql(
+    `UPDATE stream_events SET created_at = NOW() - INTERVAL '10 days'
+       WHERE stream_id = '${streamId}'
+         AND id IN (SELECT id FROM stream_events WHERE stream_id = '${streamId}' ORDER BY sequence LIMIT ${MESSAGE_COUNT / 2})`
+  )
 }
 
 function panelScroller(page: Page) {

--- a/tests/browser/stream-context-panel.spec.ts
+++ b/tests/browser/stream-context-panel.spec.ts
@@ -1,0 +1,138 @@
+import { execFileSync } from "child_process"
+import * as path from "path"
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * The "In this stream" panel's two behaviours that only exist in a real browser:
+ * windowing, and the date jump.
+ *
+ * Both are invisible to the component tests by construction — `virtua` renders
+ * nothing under jsdom's zero-height, no-op-ResizeObserver layout, so every
+ * component test swaps the virtualization seam for a passthrough. That leaves
+ * "are rows actually windowed" and "does `scrollToIndex` actually move the list"
+ * unverified everywhere else.
+ *
+ * Runs on the derive path (the `streamContextIndex` flag is off by default), which
+ * shares `ContextTimeline`, the virtualizer seam and the day-marker jump with the
+ * indexed path — so it exercises the same rendering and scrolling code.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+/** Enough link-bearing messages that windowing has something to leave unmounted. */
+const MESSAGE_COUNT = 60
+
+async function seedLinkMessages(page: Page, workspaceId: string, streamId: string): Promise<void> {
+  const BATCH_SIZE = 6
+  for (let start = 1; start <= MESSAGE_COUNT; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE - 1, MESSAGE_COUNT)
+    const batch: Promise<void>[] = []
+    for (let i = start; i <= end; i++) {
+      const n = String(i).padStart(3, "0")
+      batch.push(
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `artifact ${n} https://example.com/artifact-${n}` },
+          })
+          .then((r) => expectApiOk(r, `Send message ${i}`))
+      )
+    }
+    await Promise.all(batch)
+  }
+}
+
+/** Same derivation global-setup and playwright.config use. */
+function testDatabaseName(): string {
+  const explicit = process.env.PLAYWRIGHT_TEST_DB_NAME?.trim()
+  if (explicit) return explicit
+  const sanitized = path
+    .basename(process.cwd())
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+  return `${sanitized || "threa"}_browser_test`
+}
+
+/**
+ * Backdate half the stream's events so the panel renders more than one day
+ * group. Without this every seeded row lands today, and "jump to today" is
+ * indistinguishable from the browser restoring focus to the trigger at the top —
+ * a jump that moves DOWN to an older day is the assertion focus cannot fake.
+ * `docker exec psql` mirrors what global-setup already does for DB work.
+ */
+function backdateOlderHalf(streamId: string): void {
+  const sql = `UPDATE stream_events SET created_at = NOW() - INTERVAL '10 days'
+     WHERE stream_id = '${streamId}'
+       AND id IN (SELECT id FROM stream_events WHERE stream_id = '${streamId}' ORDER BY sequence LIMIT ${MESSAGE_COUNT / 2})`
+  // 10 days back, so the "Last week" preset (7 days) lands on it under the
+  // nearest-earlier rule.
+  execFileSync("docker", [
+    "exec",
+    process.env.PLAYWRIGHT_PG_CONTAINER ?? "threapersons-editor-postgres-test-1",
+    "psql",
+    "-U",
+    "threa",
+    "-d",
+    testDatabaseName(),
+    "-c",
+    sql,
+  ])
+}
+
+function panelScroller(page: Page) {
+  // The panel's own scroller — the element the virtualizer reads metrics from.
+  return page.locator('[role="dialog"] .overflow-y-auto').first()
+}
+
+test("windows its rows and jumps to a date from a day marker", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "context-panel")
+  await createChannel(page, `context-${Date.now().toString(36)}`)
+
+  // Both ids come from the URL after the channel is open — the workspace id the
+  // creation call returns is not yet routable while provisioning settles.
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  await seedLinkMessages(page, workspaceId!, streamId!)
+  backdateOlderHalf(streamId!)
+  await page.reload()
+
+  await page.getByRole("button", { name: "In this stream" }).click()
+  const scroller = panelScroller(page)
+  await expect(scroller).toBeVisible()
+  // Link rows carry the host as their title; wait for the feed to render.
+  await expect(page.locator('[role="dialog"]').getByText("example.com").first()).toBeVisible()
+
+  // ── Windowing: the scroller reserves the full list height, but only a slice
+  // of the rows is mounted. Without virtua every row would be in the DOM.
+  const metrics = await scroller.evaluate((el) => ({
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+    mountedRows: el.querySelectorAll('a[href*="example.com"]').length,
+  }))
+  expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight * 2)
+  expect(metrics.mountedRows).toBeGreaterThan(0)
+  expect(metrics.mountedRows).toBeLessThan(MESSAGE_COUNT / 2)
+
+  // ── Date jump: scroll away, then jump back via a day marker. Every seeded
+  // message lands today, so "Today" is the day to return to — what is being
+  // verified is that picking a date actually moves the list, which is exactly
+  // what jsdom cannot show.
+  // Start at the top, then jump to the backdated half — a successful jump moves
+  // DOWN the list. Restoring focus to the trigger (which sits at the top) can
+  // only scroll up, so this cannot pass unless `scrollToIndex` actually ran.
+  await scroller.evaluate((el) => el.scrollTo({ top: 0 }))
+  await expect.poll(async () => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50)
+
+  await page
+    .getByRole("button", { name: /Jump to a date/ })
+    .first()
+    .click()
+  await page.getByRole("button", { name: "Last week", exact: true }).click()
+
+  await expect.poll(async () => scroller.evaluate((el) => el.scrollTop), { timeout: 10_000 }).toBeGreaterThan(300)
+})

--- a/tests/browser/stream-context-panel.spec.ts
+++ b/tests/browser/stream-context-panel.spec.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "child_process"
 import * as path from "path"
 import { test, expect, type Page } from "@playwright/test"
+import { getContainerNames } from "./global-setup"
 import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
 
 /**
@@ -68,9 +69,12 @@ function backdateOlderHalf(streamId: string): void {
        AND id IN (SELECT id FROM stream_events WHERE stream_id = '${streamId}' ORDER BY sequence LIMIT ${MESSAGE_COUNT / 2})`
   // 10 days back, so the "Last week" preset (7 days) lands on it under the
   // nearest-earlier rule.
+  // Resolved the same way global-setup does — "postgres" in CI, the
+  // compose container locally. A hardcoded name passes locally (any worktree's
+  // container reaches the same instance) and fails in CI.
   execFileSync("docker", [
     "exec",
-    process.env.PLAYWRIGHT_PG_CONTAINER ?? "threapersons-editor-postgres-test-1",
+    getContainerNames().postgres,
     "psql",
     "-U",
     "threa",


### PR DESCRIPTION
Finding an artifact you remember by *when* — "that image was around the 12th" — meant scrolling the panel back through weeks of rows. Tapping a day marker now opens the same jump menu the timeline's date pill uses, and picking a date moves this list to it.

**Navigation, not filtering**, and the distinction is the point. The panel already accepts `before:`/`after:` in search, but those hide everything outside the range — you lose the surrounding context and can't scroll naturally past it. A jump keeps one continuous list and just repositions you, so you can keep going in both directions from where you land.

Reuses rather than parallels: the popover body (presets + calendar) is extracted out of the timeline's date pill into `DateJumpMenu` and shared, so both surfaces offer the same choices and the gesture is learned once (INV-35). The pill is refactored onto it in the same commit. Markers were chosen over a header control because it matches how dates already work in the stream view.

Two rules worth stating because they're judgement calls, both confirmed with Kris:

- **Nearest-earlier landing.** Dates here are sparse — most days hold no artifacts at all — so requiring an exact match would mostly fail. Picking the 12th lands on the 12th if it has anything, otherwise the closest day before it.
- **Filters survive the jump.** Jumping while "Media" is selected keeps you in Media.

The scroll target is the day **marker**, not the group's first row. `virtua` indexes the flat child list, which interleaves a marker before each group, so a row index would land a row or two off — silently. The test pins the exact index and fails when the marker offset is dropped (verified by breaking it deliberately).

A date past the loaded window pages until it is reached, bounded at 10 pages so a date older than the whole stream settles instead of spinning. The derive path (flag off, sealed streams) gets the same affordance without the paging, since it only ever holds the loaded window.

Verification: 638 frontend tests across the touched areas, typecheck, lint. Not verified in a real browser — the jump itself is `scrollToIndex` on a live virtualizer, which jsdom cannot exercise; the index computation and wiring are what the tests pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787765802&installation_model_id=20758&pr_number=1601&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1601&signature=6d5f5d987b70a165dbc39c5838bab7f98526f953948a1d5acfe98d3bba7a888c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->