### PR TITLE
feat(ai-usage): record how many prompt tokens the provider cached

### DIFF
--- a/apps/backend/src/db/migrations/20260727183842_ai_usage_cached_prompt_tokens.sql
+++ b/apps/backend/src/db/migrations/20260727183842_ai_usage_cached_prompt_tokens.sql
@@ -1,0 +1,11 @@
+-- Record how many prompt tokens the provider served from its cache.
+-- OpenRouter already reports this per call (promptTokensDetails.cachedTokens);
+-- without a column the value is discarded, so cache effectiveness is invisible
+-- and has to be inferred by reconstructing each bill from list prices.
+--
+-- Backfill is deliberately absent: the value is unknowable for existing rows,
+-- and 0 is the truthful reading for them (no call before this column landed
+-- placed a cacheable prefix on any background component).
+
+ALTER TABLE ai_usage_records
+ADD COLUMN IF NOT EXISTS cached_prompt_tokens INTEGER NOT NULL DEFAULT 0;

--- a/apps/backend/src/features/ai-usage/cost-service.ts
+++ b/apps/backend/src/features/ai-usage/cost-service.ts
@@ -63,6 +63,7 @@ export class AICostService implements AICostServiceLike {
         model: params.model,
         provider: params.provider,
         promptTokens: params.usage.promptTokens ?? 0,
+        cachedPromptTokens: params.usage.cachedPromptTokens ?? 0,
         completionTokens: params.usage.completionTokens ?? 0,
         totalTokens: params.usage.totalTokens ?? 0,
         costUsd: cost,
@@ -215,10 +216,24 @@ export function createNoOpCostService(): AICostServiceLike {
       // No-op
     },
     async getWorkspaceUsage() {
-      return { totalCostUsd: 0, totalTokens: 0, promptTokens: 0, completionTokens: 0, recordCount: 0 }
+      return {
+        totalCostUsd: 0,
+        totalTokens: 0,
+        promptTokens: 0,
+        cachedPromptTokens: 0,
+        completionTokens: 0,
+        recordCount: 0,
+      }
     },
     async getCurrentMonthUsage() {
-      return { totalCostUsd: 0, totalTokens: 0, promptTokens: 0, completionTokens: 0, recordCount: 0 }
+      return {
+        totalCostUsd: 0,
+        totalTokens: 0,
+        promptTokens: 0,
+        cachedPromptTokens: 0,
+        completionTokens: 0,
+        recordCount: 0,
+      }
     },
   }
 }

--- a/apps/backend/src/features/ai-usage/usage-repository.ts
+++ b/apps/backend/src/features/ai-usage/usage-repository.ts
@@ -11,6 +11,7 @@ interface AIUsageRecordRow {
   model: string
   provider: string
   prompt_tokens: number
+  cached_prompt_tokens: number
   completion_tokens: number
   total_tokens: number
   cost_usd: string // NUMERIC comes as string from pg
@@ -28,6 +29,8 @@ export interface AIUsageRecord {
   model: string
   provider: string
   promptTokens: number
+  /** Prompt tokens the provider served from its cache — a subset of promptTokens. */
+  cachedPromptTokens: number
   completionTokens: number
   totalTokens: number
   costUsd: number
@@ -45,6 +48,7 @@ export interface InsertAIUsageRecordParams {
   model: string
   provider: string
   promptTokens: number
+  cachedPromptTokens: number
   completionTokens: number
   totalTokens: number
   costUsd: number
@@ -56,6 +60,7 @@ export interface UsageSummary {
   totalCostUsd: number
   totalTokens: number
   promptTokens: number
+  cachedPromptTokens: number
   completionTokens: number
   recordCount: number
 }
@@ -64,6 +69,8 @@ export interface ModelBreakdown {
   model: string
   totalCostUsd: number
   totalTokens: number
+  promptTokens: number
+  cachedPromptTokens: number
   recordCount: number
 }
 
@@ -71,6 +78,8 @@ export interface FunctionBreakdown {
   functionId: string
   totalCostUsd: number
   totalTokens: number
+  promptTokens: number
+  cachedPromptTokens: number
   recordCount: number
 }
 
@@ -106,6 +115,7 @@ function mapRowToRecord(row: AIUsageRecordRow): AIUsageRecord {
     model: row.model,
     provider: row.provider,
     promptTokens: row.prompt_tokens,
+    cachedPromptTokens: row.cached_prompt_tokens,
     completionTokens: row.completion_tokens,
     totalTokens: row.total_tokens,
     costUsd: parseFloat(row.cost_usd),
@@ -117,7 +127,7 @@ function mapRowToRecord(row: AIUsageRecordRow): AIUsageRecord {
 
 const SELECT_FIELDS = `
   id, workspace_id, user_id, session_id, function_id,
-  model, provider, prompt_tokens, completion_tokens,
+  model, provider, prompt_tokens, cached_prompt_tokens, completion_tokens,
   total_tokens, cost_usd, origin, metadata, created_at
 `
 
@@ -126,7 +136,7 @@ export const AIUsageRepository = {
     const result = await db.query<AIUsageRecordRow>(sql`
       INSERT INTO ai_usage_records (
         id, workspace_id, user_id, session_id, function_id,
-        model, provider, prompt_tokens, completion_tokens,
+        model, provider, prompt_tokens, cached_prompt_tokens, completion_tokens,
         total_tokens, cost_usd, origin, metadata
       )
       VALUES (
@@ -138,6 +148,7 @@ export const AIUsageRepository = {
         ${params.model},
         ${params.provider},
         ${params.promptTokens},
+        ${params.cachedPromptTokens},
         ${params.completionTokens},
         ${params.totalTokens},
         ${params.costUsd},
@@ -163,6 +174,7 @@ export const AIUsageRepository = {
       total_cost_usd: string | null
       total_tokens: string | null
       prompt_tokens: string | null
+      cached_prompt_tokens: string | null
       completion_tokens: string | null
       record_count: string
     }>(sql`
@@ -170,6 +182,7 @@ export const AIUsageRepository = {
         COALESCE(SUM(cost_usd), 0) as total_cost_usd,
         COALESCE(SUM(total_tokens), 0) as total_tokens,
         COALESCE(SUM(prompt_tokens), 0) as prompt_tokens,
+        COALESCE(SUM(cached_prompt_tokens), 0) as cached_prompt_tokens,
         COALESCE(SUM(completion_tokens), 0) as completion_tokens,
         COUNT(*) as record_count
       FROM ai_usage_records
@@ -183,6 +196,7 @@ export const AIUsageRepository = {
       totalCostUsd: parseFloat(row.total_cost_usd ?? "0"),
       totalTokens: parseInt(row.total_tokens ?? "0", 10),
       promptTokens: parseInt(row.prompt_tokens ?? "0", 10),
+      cachedPromptTokens: parseInt(row.cached_prompt_tokens ?? "0", 10),
       completionTokens: parseInt(row.completion_tokens ?? "0", 10),
       recordCount: parseInt(row.record_count, 10),
     }
@@ -199,6 +213,7 @@ export const AIUsageRepository = {
       total_cost_usd: string | null
       total_tokens: string | null
       prompt_tokens: string | null
+      cached_prompt_tokens: string | null
       completion_tokens: string | null
       record_count: string
     }>(sql`
@@ -206,6 +221,7 @@ export const AIUsageRepository = {
         COALESCE(SUM(cost_usd), 0) as total_cost_usd,
         COALESCE(SUM(total_tokens), 0) as total_tokens,
         COALESCE(SUM(prompt_tokens), 0) as prompt_tokens,
+        COALESCE(SUM(cached_prompt_tokens), 0) as cached_prompt_tokens,
         COALESCE(SUM(completion_tokens), 0) as completion_tokens,
         COUNT(*) as record_count
       FROM ai_usage_records
@@ -220,6 +236,7 @@ export const AIUsageRepository = {
       totalCostUsd: parseFloat(row.total_cost_usd ?? "0"),
       totalTokens: parseInt(row.total_tokens ?? "0", 10),
       promptTokens: parseInt(row.prompt_tokens ?? "0", 10),
+      cachedPromptTokens: parseInt(row.cached_prompt_tokens ?? "0", 10),
       completionTokens: parseInt(row.completion_tokens ?? "0", 10),
       recordCount: parseInt(row.record_count, 10),
     }
@@ -235,12 +252,16 @@ export const AIUsageRepository = {
       model: string
       total_cost_usd: string
       total_tokens: string
+      prompt_tokens: string
+      cached_prompt_tokens: string
       record_count: string
     }>(sql`
       SELECT
         model,
         SUM(cost_usd) as total_cost_usd,
         SUM(total_tokens) as total_tokens,
+        SUM(prompt_tokens) as prompt_tokens,
+        SUM(cached_prompt_tokens) as cached_prompt_tokens,
         COUNT(*) as record_count
       FROM ai_usage_records
       WHERE workspace_id = ${workspaceId}
@@ -254,6 +275,8 @@ export const AIUsageRepository = {
       model: row.model,
       totalCostUsd: parseFloat(row.total_cost_usd),
       totalTokens: parseInt(row.total_tokens, 10),
+      promptTokens: parseInt(row.prompt_tokens, 10),
+      cachedPromptTokens: parseInt(row.cached_prompt_tokens, 10),
       recordCount: parseInt(row.record_count, 10),
     }))
   },
@@ -268,12 +291,16 @@ export const AIUsageRepository = {
       function_id: string
       total_cost_usd: string
       total_tokens: string
+      prompt_tokens: string
+      cached_prompt_tokens: string
       record_count: string
     }>(sql`
       SELECT
         function_id,
         SUM(cost_usd) as total_cost_usd,
         SUM(total_tokens) as total_tokens,
+        SUM(prompt_tokens) as prompt_tokens,
+        SUM(cached_prompt_tokens) as cached_prompt_tokens,
         COUNT(*) as record_count
       FROM ai_usage_records
       WHERE workspace_id = ${workspaceId}
@@ -287,6 +314,8 @@ export const AIUsageRepository = {
       functionId: row.function_id,
       totalCostUsd: parseFloat(row.total_cost_usd),
       totalTokens: parseInt(row.total_tokens, 10),
+      promptTokens: parseInt(row.prompt_tokens, 10),
+      cachedPromptTokens: parseInt(row.cached_prompt_tokens, 10),
       recordCount: parseInt(row.record_count, 10),
     }))
   },

--- a/apps/backend/tests/e2e/ai-usage-cached-tokens.test.ts
+++ b/apps/backend/tests/e2e/ai-usage-cached-tokens.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { AIUsageRepository } from "../../src/features/ai-usage"
+import { aiUsageId } from "../../src/lib/id"
+import { createTestPool } from "../integration/setup"
+
+const workspaceId = `ws_cachedtok_${Math.random().toString(36).slice(2)}`
+const periodStart = new Date("2026-01-01T00:00:00Z")
+const periodEnd = new Date("2027-01-01T00:00:00Z")
+
+function record(overrides: {
+  functionId: string
+  model: string
+  promptTokens: number
+  cachedPromptTokens: number
+  completionTokens: number
+  costUsd: number
+}) {
+  return {
+    id: aiUsageId(),
+    workspaceId,
+    functionId: overrides.functionId,
+    model: overrides.model,
+    provider: "openrouter",
+    promptTokens: overrides.promptTokens,
+    cachedPromptTokens: overrides.cachedPromptTokens,
+    completionTokens: overrides.completionTokens,
+    totalTokens: overrides.promptTokens + overrides.completionTokens,
+    costUsd: overrides.costUsd,
+    origin: "system" as const,
+  }
+}
+
+describe("ai_usage_records.cached_prompt_tokens", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = createTestPool()
+    await AIUsageRepository.insert(
+      pool,
+      record({
+        functionId: "boundary-extraction",
+        model: "openai/gpt-5.4-mini",
+        promptTokens: 4000,
+        cachedPromptTokens: 2816,
+        completionTokens: 240,
+        costUsd: 0.000713,
+      })
+    )
+    await AIUsageRepository.insert(
+      pool,
+      record({
+        functionId: "boundary-extraction",
+        model: "openai/gpt-5.4-mini",
+        promptTokens: 4000,
+        cachedPromptTokens: 0,
+        completionTokens: 240,
+        costUsd: 0.002576,
+      })
+    )
+    await AIUsageRepository.insert(
+      pool,
+      record({
+        functionId: "image-caption",
+        model: "google/gemini-2.5-flash",
+        promptTokens: 2400,
+        cachedPromptTokens: 0,
+        completionTokens: 350,
+        costUsd: 0.0016,
+      })
+    )
+  })
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM ai_usage_records WHERE workspace_id = $1", [workspaceId])
+    await pool.end()
+  })
+
+  test("survives the insert/read round-trip through the repository", async () => {
+    const inserted = await AIUsageRepository.insert(
+      pool,
+      record({
+        functionId: "memo-classify-conversation",
+        model: "openai/gpt-5.4-mini",
+        promptTokens: 3000,
+        cachedPromptTokens: 1024,
+        completionTokens: 40,
+        costUsd: 0.001,
+      })
+    )
+
+    const readBack = await AIUsageRepository.findById(pool, inserted.id)
+
+    expect(inserted.cachedPromptTokens).toBe(1024)
+    expect(readBack?.cachedPromptTokens).toBe(1024)
+  })
+
+  test("sums into the workspace summary alongside prompt tokens", async () => {
+    const summary = await AIUsageRepository.getWorkspaceUsage(pool, workspaceId, periodStart, periodEnd)
+
+    expect({
+      promptTokens: summary.promptTokens,
+      cachedPromptTokens: summary.cachedPromptTokens,
+      recordCount: summary.recordCount,
+    }).toEqual({ promptTokens: 13400, cachedPromptTokens: 3840, recordCount: 4 })
+  })
+
+  test("sums per function, so a component's cache hit rate is computable", async () => {
+    const byFunction = await AIUsageRepository.getUsageByFunction(pool, workspaceId, periodStart, periodEnd)
+    const boundary = byFunction.find((row) => row.functionId === "boundary-extraction")
+
+    expect({ promptTokens: boundary?.promptTokens, cachedPromptTokens: boundary?.cachedPromptTokens }).toEqual({
+      promptTokens: 8000,
+      cachedPromptTokens: 2816,
+    })
+  })
+
+  test("sums per model, and reports zero for a model that cached nothing", async () => {
+    const byModel = await AIUsageRepository.getUsageByModel(pool, workspaceId, periodStart, periodEnd)
+    const gemini = byModel.find((row) => row.model === "google/gemini-2.5-flash")
+
+    expect({ promptTokens: gemini?.promptTokens, cachedPromptTokens: gemini?.cachedPromptTokens }).toEqual({
+      promptTokens: 2400,
+      cachedPromptTokens: 0,
+    })
+  })
+})

--- a/apps/frontend/src/components/ai-usage/capability-breakdown.test.tsx
+++ b/apps/frontend/src/components/ai-usage/capability-breakdown.test.tsx
@@ -4,14 +4,52 @@ import type { AIUsageByFunction, AIUsageByModel } from "@threa/types"
 import { CapabilityBreakdown } from "./capability-breakdown"
 
 const byFunction: AIUsageByFunction[] = [
-  { functionId: "message-embedding", category: "memory", totalCostUsd: 0.1, totalTokens: 1000, recordCount: 40 },
-  { functionId: "memo-embedding", category: "memory", totalCostUsd: 0.05, totalTokens: 500, recordCount: 10 },
-  { functionId: "agent-loop", category: "agents", totalCostUsd: 0.3, totalTokens: 9000, recordCount: 12 },
+  {
+    functionId: "message-embedding",
+    category: "memory",
+    totalCostUsd: 0.1,
+    totalTokens: 1000,
+    promptTokens: 800,
+    cachedPromptTokens: 600,
+    recordCount: 40,
+  },
+  {
+    functionId: "memo-embedding",
+    category: "memory",
+    totalCostUsd: 0.05,
+    totalTokens: 500,
+    promptTokens: 400,
+    cachedPromptTokens: 0,
+    recordCount: 10,
+  },
+  {
+    functionId: "agent-loop",
+    category: "agents",
+    totalCostUsd: 0.3,
+    totalTokens: 9000,
+    promptTokens: 8000,
+    cachedPromptTokens: 2000,
+    recordCount: 12,
+  },
 ]
 
 const byModel: AIUsageByModel[] = [
-  { model: "provider/big", totalCostUsd: 0.3, totalTokens: 9000, recordCount: 12 },
-  { model: "provider/embed", totalCostUsd: 0.15, totalTokens: 1500, recordCount: 50 },
+  {
+    model: "provider/big",
+    totalCostUsd: 0.3,
+    totalTokens: 9000,
+    promptTokens: 8000,
+    cachedPromptTokens: 2000,
+    recordCount: 12,
+  },
+  {
+    model: "provider/embed",
+    totalCostUsd: 0.15,
+    totalTokens: 1500,
+    promptTokens: 1200,
+    cachedPromptTokens: 0,
+    recordCount: 50,
+  },
 ]
 
 const totalCost = 0.45
@@ -37,6 +75,25 @@ describe("CapabilityBreakdown", () => {
     expect(screen.getByText("message-embedding")).toBeInTheDocument()
     expect(screen.getByText("memo-embedding")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Memory \(GAM\)/ })).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("shows the cache hit rate per model, and nothing where no tokens were cached", () => {
+    render(<CapabilityBreakdown byFunction={byFunction} byModel={byModel} totalCost={totalCost} isLoading={false} />)
+
+    // provider/big: 2000 of 8000 prompt tokens read from cache.
+    expect(screen.getByText("25% cached")).toBeInTheDocument()
+    // provider/embed cached nothing — no label rather than a "0%" that reads as a fault.
+    expect(screen.queryByText("0% cached")).not.toBeInTheDocument()
+  })
+
+  it("shows the cache hit rate on expanded per-function rows", async () => {
+    const user = userEvent.setup()
+    render(<CapabilityBreakdown byFunction={byFunction} byModel={byModel} totalCost={totalCost} isLoading={false} />)
+
+    await user.click(screen.getByRole("button", { name: /Memory \(GAM\)/ }))
+
+    // message-embedding: 600 of 800 prompt tokens read from cache.
+    expect(screen.getByText("75% cached")).toBeInTheDocument()
   })
 
   it("renders the empty state when there is no function usage", () => {

--- a/apps/frontend/src/components/ai-usage/capability-breakdown.tsx
+++ b/apps/frontend/src/components/ai-usage/capability-breakdown.tsx
@@ -16,6 +16,28 @@ interface CategoryGroup {
   functions: AIUsageByFunction[]
 }
 
+/**
+ * Share of prompt tokens the provider served from its cache. Rendered only
+ * above zero: a fresh column of "0%" on every row would read as a fault rather
+ * than as "this component has no cacheable prefix", which is the common and
+ * unremarkable case.
+ */
+function cacheHitPct(promptTokens: number, cachedPromptTokens: number): number | null {
+  if (promptTokens <= 0 || cachedPromptTokens <= 0) return null
+  return (cachedPromptTokens / promptTokens) * 100
+}
+
+function CacheHitLabel({ promptTokens, cachedPromptTokens }: { promptTokens: number; cachedPromptTokens: number }) {
+  const pct = cacheHitPct(promptTokens, cachedPromptTokens)
+  // Fixed width whether or not the label renders, so expanding a category can't
+  // shift the columns beside it (INV-21).
+  return (
+    <span className="w-16 text-right text-[11px] tabular-nums text-muted-foreground">
+      {pct === null ? "" : `${pct.toFixed(0)}% cached`}
+    </span>
+  )
+}
+
 function CategoryRow({
   group,
   isExpanded,
@@ -60,6 +82,7 @@ function CategoryRow({
             <li key={fn.functionId} className="flex items-baseline gap-2 text-[11px]">
               <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground">{fn.functionId}</span>
               <span className="tabular-nums text-foreground">{formatCurrency(fn.totalCostUsd)}</span>
+              <CacheHitLabel promptTokens={fn.promptTokens} cachedPromptTokens={fn.cachedPromptTokens} />
               <span className="w-16 text-right tabular-nums text-muted-foreground">
                 {fn.recordCount.toLocaleString()} calls
               </span>
@@ -184,6 +207,7 @@ export function CapabilityBreakdown({
                         {model.model}
                       </span>
                       <span className="tabular-nums">{formatCurrency(model.totalCostUsd)}</span>
+                      <CacheHitLabel promptTokens={model.promptTokens} cachedPromptTokens={model.cachedPromptTokens} />
                       <span className="w-24 text-right text-[11px] tabular-nums text-muted-foreground">
                         {model.totalTokens.toLocaleString()} tok
                       </span>

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1975,8 +1975,10 @@ export interface CommandFailedPayload {
 
 export interface AIUsageSummary {
   totalCostUsd: number
-  totalPromptTokens: number
-  totalCompletionTokens: number
+  promptTokens: number
+  /** Prompt tokens the provider served from its cache — a subset of promptTokens. */
+  cachedPromptTokens: number
+  completionTokens: number
   totalTokens: number
   recordCount: number
 }
@@ -2006,6 +2008,8 @@ export interface AIUsageByFunction {
   category: AIUsageCategory
   totalCostUsd: number
   totalTokens: number
+  promptTokens: number
+  cachedPromptTokens: number
   recordCount: number
 }
 
@@ -2013,6 +2017,8 @@ export interface AIUsageByModel {
   model: string
   totalCostUsd: number
   totalTokens: number
+  promptTokens: number
+  cachedPromptTokens: number
   recordCount: number
 }
 


### PR DESCRIPTION
OpenRouter reports cached prompt tokens on every call and `extractUsageWithCost`
already lifts them into `UsageWithCost.cachedPromptTokens`, but the table had no
column, so the value was dropped on insert. Cache effectiveness was therefore
only observable by reconstructing each bill from list prices by hand — which is
how a month of `gpt-5.6-luna` calls paying a 25% cache-write premium for zero
reads went unnoticed.

Adds the column, threads it through insert/read and the workspace, per-function
and per-model aggregates, and surfaces a hit-rate label on the usage panel where
the per-component and per-model rows already live.

`AIUsageSummary` claimed `totalPromptTokens`/`totalCompletionTokens`; the handler
has always spread the repository shape straight onto the wire, so those two names
never arrived and nothing read them. Corrected to the fields actually sent while
adding the new one.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
