### PR TITLE
fix(ai): correct the model price table and take haiku out of every default

### DIFF
--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -95,7 +95,7 @@ Keep responses short and direct. Default to a few sentences unless the user asks
     avatarEmoji: null,
     avatarUrl: null,
     systemPrompt: "You are a minimal Threa agent. Follow system instructions and do not use tools.",
-    model: "openrouter:anthropic/claude-haiku-4.5",
+    model: "openrouter:openai/gpt-5.4-mini",
     escalationModel: null,
     temperature: 0,
     maxTokens: null,

--- a/apps/backend/src/features/agents/companion/config.ts
+++ b/apps/backend/src/features/agents/companion/config.ts
@@ -10,8 +10,12 @@ if (ariadneTemperature == null) {
 }
 export const COMPANION_TEMPERATURE = ariadneTemperature
 
-// Model for rolling long-context summaries of dropped history
-export const COMPANION_SUMMARY_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
+// Model for rolling long-context summaries of dropped history. Same tier as the
+// episode summary below and for the same reason — this is structured
+// condensation, and mini is both more capable and genuinely cheaper than
+// haiku-4.5 ($0.75/$4.50 against $1.00/$5.00; the $0.25/$1.25 that once made
+// haiku look like the cost-effective tier was a documentation error).
+export const COMPANION_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 // Lower temperature for deterministic summary updates
 export const COMPANION_SUMMARY_TEMPERATURE = 0.1
@@ -19,8 +23,7 @@ export const COMPANION_SUMMARY_TEMPERATURE = 0.1
 // Episode summaries (roadmap 3.1): a cheap post-completion condensation of what
 // the persona did and concluded in a session, stored on the session row and
 // replayed into later turns as "Previous sessions". Same small model the memo
-// classifier/memorizer runs (`MEMO_CLASSIFIER_MODEL_ID`) — more capable and
-// cheaper than haiku for this structured-condensation shape.
+// classifier/memorizer runs (`MEMO_CLASSIFIER_MODEL_ID`).
 export const EPISODE_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 export const EPISODE_SUMMARY_TEMPERATURE = 0.1
 export const EPISODE_SUMMARY_MAX_TOKENS = 256

--- a/apps/backend/src/features/agents/config.ts
+++ b/apps/backend/src/features/agents/config.ts
@@ -4,7 +4,7 @@ import { AgentToolNames, type AgentToolName } from "@threa/types"
  * Persona agent supersede rerun response validation config (INV-44).
  * Shared between production code and any future evals.
  */
-export const SUPERSEDE_RESPONSE_VALIDATOR_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
+export const SUPERSEDE_RESPONSE_VALIDATOR_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 export const SUPERSEDE_RESPONSE_VALIDATOR_MAX_TOKENS = 180
 export const SUPERSEDE_RESPONSE_VALIDATOR_TEMPERATURE = 0
 
@@ -14,7 +14,7 @@ export const SUPERSEDE_RESPONSE_VALIDATOR_TEMPERATURE = 0
  * the shared component (`@threa/agent-runtime` turn-digest). The enclave uses
  * its own pinned turn model instead — it has exactly one egress-approved model.
  */
-export const TURN_DIGEST_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
+export const TURN_DIGEST_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 /**
  * Follow-up scheduling bounds (`schedule_follow_up` tool, roadmap 1.1).

--- a/apps/backend/src/features/agents/researcher/config.ts
+++ b/apps/backend/src/features/agents/researcher/config.ts
@@ -9,9 +9,15 @@
  * Model for workspace agent retrieval planning / evaluation.
  *
  * Chosen for fast, predictable tail latency (single reliable provider path) and
- * solid structured-output compliance; the cost-effective Anthropic tier.
+ * solid structured-output compliance. Was `claude-haiku-4.5`, on the reasoning
+ * that it was "the cost-effective Anthropic tier" — haiku bills $1.00/$5.00, not
+ * the $0.25/$1.25 `docs/model-reference.md` claimed, which made it the dearest
+ * small model in the stack. Mini is cheaper on both axes and shares the single
+ * reliable provider path that motivated the original choice; it already carries
+ * the highest-volume component we run (boundary extraction, ~1k calls/month) at
+ * ~2s per call.
  */
-export const WORKSPACE_AGENT_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
+export const WORKSPACE_AGENT_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 /** Lower temperature to reduce decision variance in retrieval planning */
 export const WORKSPACE_AGENT_TEMPERATURE = 0.1
 

--- a/apps/backend/src/features/ai-usage/budget-service.test.ts
+++ b/apps/backend/src/features/ai-usage/budget-service.test.ts
@@ -126,7 +126,7 @@ describe("AIBudgetService.checkBudget enforcement window", () => {
       reason: "soft_limit",
       currentUsageUsd: 60,
       budgetUsd: 50,
-      recommendedModel: "openrouter:anthropic/claude-haiku-4.5",
+      recommendedModel: "openrouter:openai/gpt-5.4-mini",
     })
     expect(captured.usagePeriod).toEqual(monthRangeInTimezone("Asia/Tokyo"))
   })

--- a/apps/backend/src/features/ai-usage/budget-service.ts
+++ b/apps/backend/src/features/ai-usage/budget-service.ts
@@ -10,17 +10,31 @@ const DEFAULT_MONTHLY_BUDGET_USD = 50.0
 
 const SOFT_LIMIT_THRESHOLD = 0.8 // 80% - start degrading models
 
-/** Full model IDs with provider prefix to match the format used in AI calls. */
+/**
+ * Where an over-budget workspace's model requests land. Full model IDs with
+ * provider prefix to match the format used in AI calls.
+ *
+ * Every target is `gpt-5.4-mini` — the cheapest current-generation model that
+ * still holds up on the agentic tool use a degraded persona turn has to keep
+ * doing. The previous targets were picked against the price table in
+ * `docs/model-reference.md`, which listed `claude-haiku-4.5` at $0.25/$1.25;
+ * it bills $1.00/$5.00, so the valve that fires when a workspace has just blown
+ * its budget was switching to a model 33% dearer per input token than mini. The
+ * OpenAI targets were worse: `gpt-4o-mini` and `gpt-5-mini` are both deprecated
+ * (INV-16).
+ */
 const MODEL_DEGRADATION_MAP: Record<string, string> = {
-  "openrouter:anthropic/claude-sonnet-5": "openrouter:anthropic/claude-haiku-4.5",
-  "openrouter:anthropic/claude-sonnet-4.6": "openrouter:anthropic/claude-haiku-4.5",
-  "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:anthropic/claude-haiku-4.5",
-  "openrouter:anthropic/claude-sonnet-4.5": "openrouter:anthropic/claude-haiku-4.5",
-  "openrouter:anthropic/claude-sonnet-4": "openrouter:anthropic/claude-haiku-4.5",
+  "openrouter:anthropic/claude-opus-4.8": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-sonnet-5": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-sonnet-4.6": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-sonnet-4.5": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-sonnet-4": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-haiku-4.5": "openrouter:openai/gpt-5.4-mini",
 
-  "openrouter:openai/gpt-4o": "openrouter:openai/gpt-4o-mini",
-  "openrouter:openai/gpt-5": "openrouter:openai/gpt-5-mini",
-  "openrouter:openai/gpt-5-turbo": "openrouter:openai/gpt-5-mini",
+  "openrouter:openai/gpt-4o": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:openai/gpt-5": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:openai/gpt-5-turbo": "openrouter:openai/gpt-5.4-mini",
 }
 
 export interface BudgetStatus {

--- a/apps/backend/src/lib/ai/config-resolver.test.ts
+++ b/apps/backend/src/lib/ai/config-resolver.test.ts
@@ -28,7 +28,7 @@ describe("StaticConfigResolver", () => {
     expect(companionConfig.temperature).toBe(0.7)
 
     const researcherConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_RESEARCHER)
-    expect(researcherConfig.modelId).toBe("openrouter:anthropic/claude-haiku-4.5")
+    expect(researcherConfig.modelId).toBe("openrouter:openai/gpt-5.4-mini")
     expect(researcherConfig.temperature).toBe(0.1)
 
     const embeddingConfig = await resolver.resolve(COMPONENT_PATHS.EMBEDDING)

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -1,8 +1,38 @@
 # AI Model Reference
 
-**Last updated:** 2026-07-11
+**Last updated:** 2026-07-27
 
 This document provides a comprehensive reference for AI models including capabilities, pricing, and usage guidelines. Always verify against this file when working with AI integration.
+
+## Price table
+
+All figures per 1M tokens, verified against the live OpenRouter models endpoint on 2026-07-27. **Verify before making a model-choice argument** — this table was wrong about `claude-haiku-4.5` by 4× for months, and five components were pinned to it on the strength of that number:
+
+```bash
+curl -s https://openrouter.ai/api/v1/models -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+ | jq -r '.data[] | select(.id|test("MODEL")) | [.id,(.pricing.prompt|tonumber*1e6),(.pricing.completion|tonumber*1e6),(.pricing.input_cache_read//"-"),(.pricing.input_cache_write//"-")] | @tsv'
+```
+
+| Model                           | Input | Output | Cache read | Cache write |
+| ------------------------------- | ----- | ------ | ---------- | ----------- |
+| `openai/gpt-5.4-nano`           | $0.20 | $1.25  | $0.02      | free        |
+| `openai/gpt-5.4-mini`           | $0.75 | $4.50  | $0.075     | free        |
+| `openai/gpt-5.6-luna`           | $1.00 | $6.00  | $0.107     | **$1.25**   |
+| `anthropic/claude-haiku-4.5`    | $1.00 | $5.00  | $0.10      | $1.25       |
+| `anthropic/claude-sonnet-5`     | $2.00 | $10.00 | $0.20      | $2.50       |
+| `anthropic/claude-sonnet-4.6`   | $3.00 | $15.00 | $0.30      | $3.75       |
+| `anthropic/claude-opus-4.8`     | $5.00 | $25.00 | $0.50      | $6.25       |
+| `google/gemini-2.5-flash`       | $0.30 | $2.50  | $0.03      | $0.083      |
+| `google/gemini-2.5-flash-lite`  | $0.10 | $0.40  | $0.01      | $0.083      |
+| `google/gemini-2.5-pro`         | $1.25 | $10.00 | $0.125     | $0.375      |
+| `openai/text-embedding-3-small` | $0.02 | —      | —          | —           |
+
+**Cache columns are not a footnote — they change which model is cheapest.**
+
+- **Free writes (OpenAI family).** Caching is automatic and costs nothing to attempt, so a stable ≥1024-token prefix is pure upside. A cache miss bills the normal input rate.
+- **Paid writes (Anthropic, Google, and `gpt-5.6-luna`).** A miss on a cacheable-size prompt bills the **write** rate, not the input rate. This is a bet that the prefix will be read back; below roughly 1.4 reads per write it loses money. `gpt-5.6-luna`'s listed $1.00 input is therefore the rate that never applies — in production it bills $1.25 on a miss or $0.107 on a hit.
+- **Anthropic and Google need an explicit breakpoint** (`applyCacheBreakpoints`, `packages/agent-runtime/src/ai/ai.ts`); the OpenAI family needs only prefix stability.
+- **A prefix only caches if it is genuinely a prefix.** Interpolating a date, a language rule, or a message list _above_ the static block truncates the cacheable span to whatever precedes the first variable — commonly a few dozen tokens, under the 1024-token floor, so nothing caches at all.
 
 ## Model Capabilities Registry
 
@@ -38,7 +68,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Anthropic's Claude 5-generation Sonnet (July 2026). Near-Opus quality on agentic and coding work at Sonnet cost. Adaptive thinking on by default; new tokenizer produces ~30% more tokens for the same text vs Sonnet 4.6 (per-token price is lower, so equivalent-request cost is roughly a wash during intro pricing). 1M context window.
 
-**Typical cost:** ~$2.00 per 1M input tokens, ~$10.00 per 1M output tokens (introductory pricing through 2026-08-31; $3.00/$15.00 after)
+**Typical cost:** ~$2.00 per 1M input tokens, ~$10.00 per 1M output tokens (introductory pricing through 2026-08-31; $3.00/$15.00 after). Cache read $0.20, cache write $2.50.
 
 **When to use:**
 
@@ -56,7 +86,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Latest high-quality reasoning model from Anthropic's Claude 4.6 generation. Successor to Claude Sonnet 4.5 with improved capabilities.
 
-**Typical cost:** ~$3.00 per 1M input tokens, ~$15.00 per 1M output tokens
+**Typical cost:** ~$3.00 per 1M input tokens, ~$15.00 per 1M output tokens (cache read $0.30, cache write $3.75)
 
 **When to use:**
 
@@ -75,7 +105,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Anthropic's most capable generally available model (Opus family). Text, image, and file inputs with reasoning support and a 1M-token context window. Same per-token price as Opus 4.5/4.6/4.7 (~1.7x Sonnet input, ~1.7x output).
 
-**Typical cost:** ~$5.00 per 1M input tokens, ~$25.00 per 1M output tokens
+**Typical cost:** ~$5.00 per 1M input tokens, ~$25.00 per 1M output tokens (cache read $0.50, cache write $6.25)
 
 **When to use:**
 
@@ -91,19 +121,46 @@ All models use `provider:modelPath` format:
 
 **Name:** Claude Haiku 4.5
 
-**Description:** Fast, cost-effective model from Anthropic's Claude 4.5 generation. Good balance of speed, cost, and accuracy for structured tasks.
+**Description:** Fast model from Anthropic's Claude 4.5 generation. Despite the name, **not the cheap tier** — it is the most expensive small model available to us, above `gpt-5.4-mini` on input and output and 5× `gpt-5.4-nano` on input.
 
-**Typical cost:** ~$0.25 per 1M input tokens, ~$1.25 per 1M output tokens
+**Typical cost:** ~$1.00 per 1M input tokens, ~$5.00 per 1M output tokens (cache read $0.10, cache **write** $1.25)
+
+**When to use:** nothing, currently. No production component selects it.
+
+This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On the strength of that number five components were pinned to haiku "for cost" (companion summary, workspace-agent plan/eval, turn digest, supersede validator, the Empty Agent shell) and the over-budget degradation map in `ai-usage/budget-service.ts` degraded Sonnet _to_ it, buying 2× where `gpt-5.4-mini` buys 2.7× and `gpt-5.4-nano` buys 10×. All six now target mini. Left in `models.yaml` so personas a user deliberately pinned to it keep resolving.
+
+**Use instead:** `gpt-5.4-mini` for structured condensation and extraction, `gpt-5.4-nano` for classification and ranking.
+
+---
+
+### openrouter:google/gemini-2.5-flash
+
+**Name:** Gemini 2.5 Flash
+
+**Description:** Fast multimodal model with a 1M-token context window. Vision quality is the reason it is here — it reads screenshots, charts, and scanned documents well enough to drive downstream extraction.
+
+**Typical cost:** ~$0.30 per 1M input tokens, ~$2.50 per 1M output tokens (cache read $0.03, cache write $0.083)
 
 **When to use:**
 
-- Classification and extraction (structured output)
-- Simple reasoning tasks
-- General chat and conversations
-- High-volume batch operations where quality bar is met
-- Stream naming, memo classification
+- Image captioning and OCR (`image-caption`) — production choice
+- Large-attachment summarization where the 1M window matters (`text-summary`)
 
-**Use instead of:** `claude-3-haiku`, `claude-3.5-haiku`, or any Claude 3.x series models
+**Note:** for image work, output is typically the larger half of the bill — the structured extraction schema (headings, labels, body, chart/table/diagram data) is verbose. Shape the schema before reaching for a cheaper model.
+
+---
+
+### openrouter:google/gemini-2.5-flash-lite
+
+**Name:** Gemini 2.5 Flash Lite
+
+**Description:** Smaller, cheaper sibling of 2.5 Flash — 3× cheaper input, 6× cheaper output.
+
+**Typical cost:** ~$0.10 per 1M input tokens, ~$0.40 per 1M output tokens (cache read $0.01, cache write $0.083)
+
+**When to use:**
+
+- Not yet in production. It is the obvious swap target for `image-caption`, but there is **no eval suite for that component** (`evals/suites/multimodal-vision` drives `PersonaAgent.run()`, not the captioner), and captions feed boundary extraction, memo extraction, and agent context — a quality regression there is silent. Build the suite before swapping.
 
 ---
 
@@ -113,7 +170,7 @@ All models use `provider:modelPath` format:
 
 **Description:** High-quality reasoning model from Anthropic's Claude 4 generation. Best for complex tasks requiring nuanced understanding and generation.
 
-**Typical cost:** ~$3.00 per 1M input tokens, ~$15.00 per 1M output tokens
+**Typical cost:** ~$3.00 per 1M input tokens, ~$15.00 per 1M output tokens (cache read $0.30, cache write $3.75)
 
 **When to use:**
 
@@ -133,7 +190,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Cost-effective model from OpenAI's GPT-5 generation. Good balance of performance and cost for general tasks.
 
-**Typical cost:** ~$0.40 per 1M input tokens, ~$1.60 per 1M output tokens
+**Typical cost:** ~$0.25 per 1M input tokens, ~$2.00 per 1M output tokens
 
 **When to use:**
 
@@ -153,7 +210,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Ultra-fast, cost-effective model from OpenAI's GPT-5 generation. Optimized for high-throughput tasks.
 
-**Typical cost:** ~$0.10 per 1M input tokens, ~$0.40 per 1M output tokens
+**Typical cost:** ~$0.05 per 1M input tokens, ~$0.40 per 1M output tokens
 
 **When to use:**
 
@@ -173,7 +230,7 @@ All models use `provider:modelPath` format:
 
 **Description:** High-capability small model from OpenAI's GPT-5.4 generation (March 2026). Significantly improves over GPT-5 Mini across coding, reasoning, multimodal understanding, and tool use while running 2x faster. Supports configurable reasoning effort levels. 400K context window.
 
-**Typical cost:** ~$0.75 per 1M input tokens, ~$4.50 per 1M output tokens
+**Typical cost:** ~$0.75 per 1M input tokens, ~$4.50 per 1M output tokens (cache read $0.075, writes free)
 
 **When to use:**
 
@@ -193,7 +250,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Fast, cost-efficient model in OpenAI's GPT-5.6 series (July 2026). Positioned for high-volume, latency-sensitive tasks — chat, classification, lightweight agentic workflows. 1M context window. Available EU-pinned. A `gpt-5.6-luna-pro` variant (same price) serves the same weights with `reasoning.mode: pro` for harder tasks at higher latency.
 
-**Typical cost:** ~$1.00 per 1M input tokens, ~$6.00 per 1M output tokens
+**Typical cost:** ~$1.25 per 1M input tokens on a cache miss, ~$6.00 per 1M output tokens; $0.107 per 1M on a cache hit. The $1.00 headline rate applies only below the 1024-token cache floor — see the write-premium note in the price table.
 
 **When to use:**
 
@@ -213,7 +270,7 @@ All models use `provider:modelPath` format:
 
 **Description:** Smallest, cheapest model in OpenAI's GPT-5.4 generation (March 2026). Optimized for low-latency, high-volume tasks. Outperforms GPT-5 Mini on benchmarks despite lower cost. Supports configurable reasoning effort levels. 400K context window.
 
-**Typical cost:** ~$0.20 per 1M input tokens, ~$1.25 per 1M output tokens
+**Typical cost:** ~$0.20 per 1M input tokens, ~$1.25 per 1M output tokens (cache read $0.02, writes free)
 
 **When to use:**
 


### PR DESCRIPTION
`docs/model-reference.md` listed `claude-haiku-4.5` at $0.25/$1.25 per 1M. It
bills $1.00/$5.00 — 4x under, confirmed by reconstructing `summary-update` and
`ws-eval` from production usage rows to the cent. That made haiku the most
expensive small model available to us while reading as the cheap tier, and five
components were pinned to it on that basis, one of them commented "the
cost-effective Anthropic tier".

Worse, `MODEL_DEGRADATION_MAP` sent Sonnet to haiku when a workspace exceeded
its budget: the valve that fires on overspend switched to a model dearer per
input token than mini. Its OpenAI targets were `gpt-4o-mini` and `gpt-5-mini`,
both deprecated (INV-16).

Every default now targets `gpt-5.4-mini` — cheaper than haiku on both axes, no
cache-write premium, and already the tier trusted for structured condensation
(episode summaries) and the highest-volume component we run. Moved: companion
summary, workspace-agent plan/eval, turn digest, supersede validator, the Empty
Agent shell, and the whole degradation map. haiku stays in `models.yaml` so
personas a user deliberately pinned to it keep resolving.

The doc gains a verified price table with **cache-read and cache-write columns**,
which it never had — the omission is also why `gpt-5.6-luna`'s 25% write premium
went unnoticed for a month. Prices for `gpt-5-mini` and `gpt-5-nano` were wrong
too, and `gemini-2.5-flash` was in production but absent from the doc entirely.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
