### PR TITLE
fix(attachments): bound the text preview by characters, not only by lines

### DIFF
--- a/apps/backend/src/features/attachments/text/parsers/code-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/code-parser.ts
@@ -1,6 +1,7 @@
 import type { TextSection, CodeStructure } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
 import { EXTENSION_LANGUAGE_MAP, getFileExtension } from "../config"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 100
 const LINES_PER_SECTION = 50
@@ -42,7 +43,7 @@ export const codeParser: TextParser = {
       format: "code",
       sections,
       structure,
-      previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+      previewContent: buildPreview(lines, PREVIEW_LINES),
       totalLines,
     }
   },

--- a/apps/backend/src/features/attachments/text/parsers/csv-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/csv-parser.ts
@@ -1,5 +1,6 @@
 import type { TextSection, CsvStructure } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 50
 const SAMPLE_ROWS = 5
@@ -58,7 +59,7 @@ export const csvParser: TextParser = {
       format: "csv",
       sections,
       structure,
-      previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+      previewContent: buildPreview(lines, PREVIEW_LINES),
       totalLines,
     }
   },

--- a/apps/backend/src/features/attachments/text/parsers/json-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/json-parser.ts
@@ -1,5 +1,6 @@
 import type { TextSection, JsonStructure } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 50
 const MAX_KEYS_TO_SHOW = 20
@@ -18,7 +19,7 @@ export const jsonParser: TextParser = {
         format: "json",
         sections: [],
         structure: null,
-        previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+        previewContent: buildPreview(lines, PREVIEW_LINES),
         totalLines,
       }
     }
@@ -77,7 +78,7 @@ export const jsonParser: TextParser = {
       format: "json",
       sections,
       structure,
-      previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+      previewContent: buildPreview(lines, PREVIEW_LINES),
       totalLines,
     }
   },

--- a/apps/backend/src/features/attachments/text/parsers/markdown-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/markdown-parser.ts
@@ -1,5 +1,6 @@
 import type { TextSection, MarkdownStructure } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 100
 
@@ -72,7 +73,7 @@ export const markdownParser: TextParser = {
       })
     }
 
-    const previewContent = lines.slice(0, PREVIEW_LINES).join("\n")
+    const previewContent = buildPreview(lines, PREVIEW_LINES)
 
     const structure: MarkdownStructure = {
       toc,

--- a/apps/backend/src/features/attachments/text/parsers/parsers.test.ts
+++ b/apps/backend/src/features/attachments/text/parsers/parsers.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { getParser } from "./index"
+import { PREVIEW_MAX_CHARS } from "./preview"
 
 describe("plainTextParser", () => {
   const parser = getParser("plain")
@@ -246,5 +247,42 @@ func Main() {
       expect(result.structure.imports).toContain("fmt")
       expect(result.structure.exports).toContain("Main")
     }
+  })
+})
+
+describe("preview bounds", () => {
+  // A line budget alone bounds nothing: minified HTML/JSON and single-line log
+  // dumps put a whole file on one line. Production sent 278,480 prompt tokens
+  // for one such HTML file before the character cap existed.
+  const oneLongLine = "x".repeat(500_000)
+
+  test("caps a single enormous line at the character ceiling", () => {
+    const result = getParser("plain").parse(oneLongLine, "minified.html")
+
+    expect(result.previewContent.length).toBeLessThanOrEqual(PREVIEW_MAX_CHARS + 32)
+    expect(result.previewContent.endsWith("…[preview truncated]")).toBe(true)
+  })
+
+  test("caps every format, not just the one that was reported", () => {
+    const cases: Array<[Parameters<typeof getParser>[0], string]> = [
+      ["plain", "minified.html"],
+      ["json", "logs.json"],
+      ["csv", "rows.csv"],
+      ["yaml", "config.yaml"],
+      ["markdown", "notes.md"],
+      ["code", "bundle.js"],
+    ]
+
+    for (const [format, filename] of cases) {
+      const result = getParser(format).parse(oneLongLine, filename)
+      expect({ format, over: result.previewContent.length > PREVIEW_MAX_CHARS + 32 }).toEqual({ format, over: false })
+    }
+  })
+
+  test("leaves a preview that fits untouched", () => {
+    const content = "Line 1\nLine 2\nLine 3"
+    const result = getParser("plain").parse(content, "file.txt")
+
+    expect(result.previewContent).toBe(content)
   })
 })

--- a/apps/backend/src/features/attachments/text/parsers/plain-text-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/plain-text-parser.ts
@@ -7,6 +7,7 @@
 
 import type { TextSection } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 100
 const SECTION_SIZE = 100 // Lines per section for large files
@@ -33,7 +34,7 @@ export const plainTextParser: TextParser = {
       }
     }
 
-    const previewContent = lines.slice(0, PREVIEW_LINES).join("\n")
+    const previewContent = buildPreview(lines, PREVIEW_LINES)
 
     return {
       format: "plain",

--- a/apps/backend/src/features/attachments/text/parsers/preview.ts
+++ b/apps/backend/src/features/attachments/text/parsers/preview.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared construction of the `previewContent` every parser hands to the
+ * `text-summary` model.
+ *
+ * Each parser picks its own line budget — 50 for the structured formats where a
+ * few rows already show the shape, 100 for prose and code — but a line budget
+ * alone does not bound anything. Minified HTML, minified JSON, and single-line
+ * log dumps put an entire file on one line, so "the first 100 lines" is "the
+ * whole file". Production had four such calls: one 5 MB HTML file produced a
+ * 278,480-token prompt, and the four together were $0.249 of that component's
+ * $0.253 for the month.
+ *
+ * The character cap is the real bound; the line budget stays because it is the
+ * better shape when lines are lines.
+ */
+
+/**
+ * Hard ceiling on preview characters, whatever the line budget admits.
+ *
+ * ~24k characters is roughly 6k tokens: ample for a model asked to write a
+ * one-paragraph summary and a section list, and it holds the worst single call
+ * to a fraction of a cent instead of eight. Large files store no full text
+ * anyway (`fullTextToStore` is null above the LARGE threshold) and expose a
+ * `read_attachment` tool for agents that need the body, so the summary is a
+ * signpost rather than the payload — truncating it costs very little.
+ */
+export const PREVIEW_MAX_CHARS = 24_000
+
+const TRUNCATION_MARKER = "\n…[preview truncated]"
+
+/**
+ * Take the first `maxLines` lines, then clamp to {@link PREVIEW_MAX_CHARS}.
+ * The marker tells the model the text it is summarizing is partial, so it does
+ * not report a truncated file as complete.
+ */
+export function buildPreview(lines: string[], maxLines: number): string {
+  const preview = lines.slice(0, maxLines).join("\n")
+  if (preview.length <= PREVIEW_MAX_CHARS) return preview
+  return preview.slice(0, PREVIEW_MAX_CHARS) + TRUNCATION_MARKER
+}

--- a/apps/backend/src/features/attachments/text/parsers/yaml-parser.ts
+++ b/apps/backend/src/features/attachments/text/parsers/yaml-parser.ts
@@ -2,6 +2,7 @@
 import yaml from "js-yaml"
 import type { TextSection, JsonStructure } from "@threa/types"
 import type { ParseResult, TextParser } from "./types"
+import { buildPreview } from "./preview"
 
 const PREVIEW_LINES = 50
 const MAX_KEYS_TO_SHOW = 20
@@ -20,7 +21,7 @@ export const yamlParser: TextParser = {
         format: "yaml",
         sections: [],
         structure: null,
-        previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+        previewContent: buildPreview(lines, PREVIEW_LINES),
         totalLines,
       }
     }
@@ -82,7 +83,7 @@ export const yamlParser: TextParser = {
       format: "yaml",
       sections,
       structure,
-      previewContent: lines.slice(0, PREVIEW_LINES).join("\n"),
+      previewContent: buildPreview(lines, PREVIEW_LINES),
       totalLines,
     }
   },


### PR DESCRIPTION
Every text parser capped `previewContent` at 50 or 100 lines and at nothing
else. A line budget bounds nothing when a file has no line breaks: minified
HTML, minified JSON and single-line log dumps put the whole file on line one,
so "the first 100 lines" is the entire file.

Production, last 30 days: four `text-summary` calls at 129,001–278,480 prompt
tokens, together $0.249 of that component's $0.253. There was no ceiling at all
above them — a large enough minified file would have exceeded the context
window of any model with less than a 1M window and hard-failed rather than
merely cost money.

Adds a shared `buildPreview` that keeps each parser's own line budget (50 for
structured formats, 100 for prose and code) and clamps the result to 24k
characters (~6k tokens) with a marker so the model knows the text is partial.
Large files store no full text anyway and expose `read_attachment` for agents
that need the body, so the summary is a signpost, not the payload.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
