### PR TITLE
perf(memos): skip re-classification when nothing the classifier sees has changed

### DIFF
--- a/apps/backend/src/db/migrations/20260727190022_memo_pending_classified_fingerprint.sql
+++ b/apps/backend/src/db/migrations/20260727190022_memo_pending_classified_fingerprint.sql
@@ -1,0 +1,13 @@
+-- Remember what the memo classifier was last shown for a conversation, so a
+-- re-queue that carries no new content can skip the AI call.
+--
+-- Boundary extraction emits `conversation:updated` for completeness and summary
+-- changes, not only for new messages, and the accumulator queues on every one.
+-- In production that produced 37 of 602 classify calls where the conversation
+-- had not changed at all since the previous pass.
+--
+-- NULL means "never classified" and always classifies — existing rows keep
+-- their current behaviour rather than being assumed unchanged.
+
+ALTER TABLE memo_pending_items
+ADD COLUMN IF NOT EXISTS classified_fingerprint TEXT;

--- a/apps/backend/src/features/memos/classification-fingerprint.test.ts
+++ b/apps/backend/src/features/memos/classification-fingerprint.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test"
+import { classificationFingerprint } from "./classification-fingerprint"
+import type { Message } from "../messaging"
+import type { Memo } from "./repository"
+
+function message(overrides: Partial<Message> & { id: string }): Message {
+  return {
+    streamId: "stream_1",
+    sequence: 1n,
+    authorId: "usr_1",
+    authorType: "user",
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "hello",
+    replyCount: 0,
+    clientMessageId: null,
+    sentVia: null,
+    reactions: {},
+    metadata: {},
+    conversationIntent: null,
+    editedAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-07-01T10:00:00Z"),
+    ciphertext: null,
+    envelope: null,
+    e2eVersion: null,
+    ...overrides,
+  } as Message
+}
+
+function memo(overrides: Partial<Memo> & { id: string }): Memo {
+  return {
+    workspaceId: "ws_1",
+    memoType: "conversation",
+    sourceMessageId: null,
+    sourceConversationId: "conv_1",
+    title: "Cache ordering",
+    abstract: "Static block goes first.",
+    keyPoints: [],
+    sourceMessageIds: [],
+    participantIds: [],
+    knowledgeType: "decision",
+    tags: [],
+    parentMemoId: null,
+    status: "active",
+    version: 1,
+    revisionReason: null,
+    authoredByKind: "agent",
+    sourceSessionId: null,
+    scope: "workspace",
+    scopeUserId: null,
+    createdAt: new Date("2026-07-01T10:00:00Z"),
+    updatedAt: new Date("2026-07-01T10:00:00Z"),
+    archivedAt: null,
+    ...overrides,
+  } as Memo
+}
+
+const conversation = {
+  status: "resolved" as const,
+  topicSummary: "Cache-prefix ordering",
+  participantIds: ["usr_1", "usr_2"],
+  messageIds: ["msg_1", "msg_2"],
+}
+const messages = [message({ id: "msg_1" }), message({ id: "msg_2" })]
+const memos = [memo({ id: "memo_1" })]
+
+const baseline = classificationFingerprint(conversation, messages, memos)
+
+describe("classificationFingerprint", () => {
+  test("is stable across passes when nothing has moved", () => {
+    // Re-derived from freshly built inputs, as a later batch would do.
+    const again = classificationFingerprint(
+      { ...conversation, participantIds: ["usr_2", "usr_1"] },
+      [message({ id: "msg_1" }), message({ id: "msg_2" })],
+      [memo({ id: "memo_1" })]
+    )
+
+    expect(again).toBe(baseline)
+  })
+
+  test("changes when a message is added", () => {
+    const changed = classificationFingerprint(
+      { ...conversation, messageIds: ["msg_1", "msg_2", "msg_3"] },
+      [...messages, message({ id: "msg_3" })],
+      memos
+    )
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when a message is edited, though the id list is identical", () => {
+    const changed = classificationFingerprint(
+      conversation,
+      [message({ id: "msg_1", editedAt: new Date("2026-07-02T09:00:00Z") }), message({ id: "msg_2" })],
+      memos
+    )
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when a message is deleted", () => {
+    const changed = classificationFingerprint(
+      conversation,
+      [message({ id: "msg_1", deletedAt: new Date("2026-07-02T09:00:00Z") }), message({ id: "msg_2" })],
+      memos
+    )
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when the conversation is reopened", () => {
+    const changed = classificationFingerprint({ ...conversation, status: "active" }, messages, memos)
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when the topic summary is rewritten", () => {
+    const changed = classificationFingerprint({ ...conversation, topicSummary: "Something else" }, messages, memos)
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when a participant joins", () => {
+    const changed = classificationFingerprint(
+      { ...conversation, participantIds: ["usr_1", "usr_2", "usr_3"] },
+      messages,
+      memos
+    )
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  // The classifier is asked `shouldReviseExisting` against these memos, so a
+  // memo edited or superseded elsewhere changes the correct answer even though
+  // the conversation itself has stood still.
+  test("changes when an existing memo is revised", () => {
+    const changed = classificationFingerprint(conversation, messages, [memo({ id: "memo_1", version: 2 })])
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("changes when a memo is added to the conversation", () => {
+    const changed = classificationFingerprint(conversation, messages, [...memos, memo({ id: "memo_2" })])
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  test("ignores the ordering of memos and participants", () => {
+    const reordered = classificationFingerprint({ ...conversation, participantIds: ["usr_2", "usr_1"] }, messages, [
+      memo({ id: "memo_2" }),
+      memo({ id: "memo_1" }),
+    ])
+    const forward = classificationFingerprint(conversation, messages, [memo({ id: "memo_1" }), memo({ id: "memo_2" })])
+
+    expect(reordered).toBe(forward)
+  })
+
+  test("distinguishes a message the batch could not load from one it could", () => {
+    const changed = classificationFingerprint(conversation, [message({ id: "msg_1" })], memos)
+
+    expect(changed).not.toBe(baseline)
+  })
+})

--- a/apps/backend/src/features/memos/classification-fingerprint.ts
+++ b/apps/backend/src/features/memos/classification-fingerprint.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto"
+import type { Message } from "../messaging"
+import type { Conversation } from "../conversations"
+import type { Memo } from "./repository"
+
+/**
+ * A digest of everything the memo classifier is shown for a conversation.
+ *
+ * Two passes with the same fingerprint would put an identical question to the
+ * model, so the second can be skipped. The accumulator re-queues a conversation
+ * on every `conversation:updated` — including completeness and summary changes
+ * that carry no new content — so a share of classify calls re-ask a question
+ * already answered.
+ *
+ * It hashes the *inputs* that determine the prompt, never the rendered prompt.
+ * The transcript is rendered with relative ages against `new Date()` at batch
+ * time, so its text differs on every pass even when nothing happened; hashing
+ * it would mean the fingerprint never matches and the gate never fires.
+ *
+ * Deliberately included, each because it can flip the classifier's answer
+ * without any message changing:
+ * - `status` — a resolve or reopen changes whether the conversation reads as
+ *   settled knowledge.
+ * - `topicSummary` and `participantIds` — both are rendered into the prompt.
+ * - each message's `editedAt` / `deletedAt` — an edit rewrites the transcript
+ *   while leaving the id list identical.
+ * - each existing memo's `version` — the classifier is asked
+ *   `shouldReviseExisting` against these; a memo edited or superseded elsewhere
+ *   changes the correct answer even though the conversation stands still.
+ */
+export function classificationFingerprint(
+  conversation: Pick<Conversation, "status" | "topicSummary" | "participantIds" | "messageIds">,
+  messages: Message[],
+  existingMemos: Memo[]
+): string {
+  const messageById = new Map(messages.map((m) => [m.id, m]))
+
+  const parts = [
+    `status:${conversation.status}`,
+    `topic:${conversation.topicSummary ?? ""}`,
+    `participants:${[...conversation.participantIds].sort().join(",")}`,
+    ...conversation.messageIds.map((id) => {
+      const message = messageById.get(id)
+      // A message the batch could not load is still a change of input if it
+      // later appears, so it hashes distinctly from a loaded one.
+      if (!message) return `m:${id}:missing`
+      return `m:${id}:${message.editedAt?.getTime() ?? 0}:${message.deletedAt?.getTime() ?? 0}`
+    }),
+    ...[...existingMemos].map((memo) => `memo:${memo.id}:${memo.version}`).sort(),
+  ]
+
+  return createHash("sha256").update(parts.join("\n")).digest("hex")
+}

--- a/apps/backend/src/features/memos/pending-item-repository.ts
+++ b/apps/backend/src/features/memos/pending-item-repository.ts
@@ -10,6 +10,7 @@ interface PendingItemRow {
   item_id: string
   queued_at: Date
   processed_at: Date | null
+  classified_fingerprint: string | null
 }
 
 export interface PendingMemoItem {
@@ -20,6 +21,8 @@ export interface PendingMemoItem {
   itemId: string
   queuedAt: Date
   processedAt: Date | null
+  /** Digest of the classifier inputs at the last pass; null = never classified. */
+  classifiedFingerprint: string | null
 }
 
 export interface QueuePendingItemParams {
@@ -39,10 +42,11 @@ function mapRowToPendingItem(row: PendingItemRow): PendingMemoItem {
     itemId: row.item_id,
     queuedAt: row.queued_at,
     processedAt: row.processed_at,
+    classifiedFingerprint: row.classified_fingerprint,
   }
 }
 
-const SELECT_FIELDS = `id, workspace_id, stream_id, item_type, item_id, queued_at, processed_at`
+const SELECT_FIELDS = `id, workspace_id, stream_id, item_type, item_id, queued_at, processed_at, classified_fingerprint`
 
 export const PendingItemRepository = {
   async queue(client: PoolClient, items: QueuePendingItemParams[]): Promise<PendingMemoItem[]> {
@@ -92,6 +96,29 @@ export const PendingItemRepository = {
       UPDATE memo_pending_items
       SET processed_at = NOW()
       WHERE id = ANY(${ids})
+    `)
+  },
+
+  /**
+   * Store what the classifier was shown, so the next pass over the same
+   * conversation can tell whether the question has changed. Written only for
+   * items that actually reached the model — a skipped item's stored digest is
+   * still the right one, and a deferred item was never asked.
+   */
+  async recordClassifiedFingerprints(
+    client: PoolClient,
+    entries: Array<{ id: string; fingerprint: string }>
+  ): Promise<void> {
+    if (entries.length === 0) return
+
+    await client.query(sql`
+      UPDATE memo_pending_items AS p
+      SET classified_fingerprint = v.fingerprint
+      FROM UNNEST(
+        ${entries.map((e) => e.id)}::text[],
+        ${entries.map((e) => e.fingerprint)}::text[]
+      ) AS v(id, fingerprint)
+      WHERE p.id = v.id
     `)
   },
 

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -6,6 +6,7 @@ import { MemoService } from "./service"
 import { MEMO_REFLECTIVE_MAX_MEMOS } from "./config"
 import { MemoRepository } from "./repository"
 import { PendingItemRepository, type PendingMemoItem } from "./pending-item-repository"
+import { classificationFingerprint } from "./classification-fingerprint"
 import type { MemoContent } from "./memorizer"
 import type { ConversationClassification } from "./classifier"
 import { OutboxRepository } from "../../lib/outbox"
@@ -23,7 +24,7 @@ const WORKSPACE_ID = "ws_1"
 const STREAM_ID = "stream_1"
 const CONVERSATION_ID = "conv_1"
 
-function fakePendingItem(): PendingMemoItem {
+function fakePendingItem(overrides: Partial<PendingMemoItem> = {}): PendingMemoItem {
   return {
     id: "pend_1",
     workspaceId: WORKSPACE_ID,
@@ -32,6 +33,8 @@ function fakePendingItem(): PendingMemoItem {
     itemId: CONVERSATION_ID,
     queuedAt: new Date(),
     processedAt: null,
+    classifiedFingerprint: null,
+    ...overrides,
   }
 }
 
@@ -108,7 +111,7 @@ const classification: ConversationClassification = {
   containsActionItems: false,
 }
 
-function setupService(options: { memoContents: MemoContent[] }) {
+function setupService(options: { memoContents: MemoContent[]; pendingItem?: Partial<PendingMemoItem> }) {
   const clientQuery = mock(async () => ({ rows: [] }))
   const fakeClient = { query: clientQuery } as unknown as PoolClient
   spyOn(dbModule, "withClient").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
@@ -116,8 +119,11 @@ function setupService(options: { memoContents: MemoContent[] }) {
   spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
     fn(fakeClient)) as typeof dbModule.withTransaction)
 
-  spyOn(PendingItemRepository, "findUnprocessed").mockResolvedValue([fakePendingItem()])
+  spyOn(PendingItemRepository, "findUnprocessed").mockResolvedValue([fakePendingItem(options.pendingItem)])
   spyOn(PendingItemRepository, "markProcessed").mockResolvedValue(undefined as never)
+  const recordFingerprints = spyOn(PendingItemRepository, "recordClassifiedFingerprints").mockResolvedValue(
+    undefined as never
+  )
   spyOn(MemoRepository, "findByStream").mockResolvedValue([])
   spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
   spyOn(MemoRepository, "getAllTags").mockResolvedValue([])
@@ -151,9 +157,11 @@ function setupService(options: { memoContents: MemoContent[] }) {
   const streamEventInsertMany = spyOn(StreamEventRepository, "insertMany").mockResolvedValue([insertedStreamEvent])
   const contextInsertMany = spyOn(StreamContextRepository, "insertMany").mockResolvedValue(0)
 
+  const classifyConversation = mock(async () => classification)
+
   const service = new MemoService({
     pool: {} as never,
-    classifier: { classifyConversation: async () => classification } as never,
+    classifier: { classifyConversation } as never,
     memorizer: {
       memorizeConversation: async () => options.memoContents,
       reviseMemo: async () => [],
@@ -173,6 +181,8 @@ function setupService(options: { memoContents: MemoContent[] }) {
     clientQuery,
     contextInsertMany,
     findSourceMessages,
+    classifyConversation,
+    recordFingerprints,
   }
 }
 
@@ -1140,5 +1150,61 @@ describe("MemoService — stream-context projection privacy + scoping", () => {
         sourceMessageId: "msg_trigger",
       }),
     ])
+  })
+})
+
+describe("MemoService.processBatch — re-classification change gate", () => {
+  afterEach(() => mock.restore())
+
+  it("classifies a conversation it has never seen and records what it was shown", async () => {
+    const { service, classifyConversation, recordFingerprints } = setupService({ memoContents: [memoContent] })
+
+    await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(classifyConversation).toHaveBeenCalledTimes(1)
+    expect(recordFingerprints.mock.calls[0]?.[1]).toEqual([
+      { id: "pend_1", fingerprint: expect.any(String) as unknown as string },
+    ])
+  })
+
+  it("skips the AI call when the conversation is unchanged since that pass", async () => {
+    // The digest the previous pass would have stored, derived from the same
+    // fakes this batch will load.
+    const stored = classificationFingerprint(fakeConversation(), [...fakeMessages().values()], [])
+    const { service, classifyConversation, recordFingerprints } = setupService({
+      memoContents: [memoContent],
+      pendingItem: { classifiedFingerprint: stored },
+    })
+
+    const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(classifyConversation).not.toHaveBeenCalled()
+    expect(result.memosCreated).toBe(0)
+    // Nothing new was asked, so nothing new is recorded — the stored digest still stands.
+    expect(recordFingerprints.mock.calls[0]?.[1]).toEqual([])
+  })
+
+  it("still marks a skipped item processed, so it does not re-queue forever", async () => {
+    const stored = classificationFingerprint(fakeConversation(), [...fakeMessages().values()], [])
+    const { service } = setupService({
+      memoContents: [memoContent],
+      pendingItem: { classifiedFingerprint: stored },
+    })
+    const markProcessed = PendingItemRepository.markProcessed as unknown as ReturnType<typeof mock>
+
+    await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(markProcessed.mock.calls[0]?.[1]).toEqual(["pend_1"])
+  })
+
+  it("classifies again when the stored digest is stale", async () => {
+    const { service, classifyConversation } = setupService({
+      memoContents: [memoContent],
+      pendingItem: { classifiedFingerprint: "digest-from-before-the-last-two-messages" },
+    })
+
+    await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(classifyConversation).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -10,6 +10,7 @@ import { WorkspaceSettingsRepository } from "../workspace-settings"
 import { StreamContextRepository, contextSnippet, type NewStreamContextItem } from "../stream-context"
 import { MemoRepository, type Memo } from "./repository"
 import { PendingItemRepository, type PendingMemoItem } from "./pending-item-repository"
+import { classificationFingerprint } from "./classification-fingerprint"
 import { MemoClassifier } from "./classifier"
 import { Memorizer } from "./memorizer"
 import { MessageFormatter } from "../../lib/ai/message-formatter"
@@ -394,6 +395,7 @@ export class MemoService implements MemoServiceLike {
     const memoryContext = fetchedData.existingMemos.map((m) => m.abstract)
     const memosToCreate: MemoToCreate[] = []
     const deferredItemIds = new Set<string>()
+    const classifiedFingerprints: Array<{ id: string; fingerprint: string }> = []
     let memosCreated = 0
     let memosDeduped = 0
     let itemsFailed = 0
@@ -462,12 +464,27 @@ export class MemoService implements MemoServiceLike {
 
         const existingMemos = fetchedData.existingConversationMemos.get(item.itemId) ?? []
 
+        // Nothing the classifier is shown has moved since the last pass, so it
+        // would be asked an identical question. The accumulator re-queues on
+        // every `conversation:updated`, including completeness and summary
+        // changes that carry no new content.
+        const fingerprint = classificationFingerprint(conversation, messagesArray, existingMemos)
+        if (item.classifiedFingerprint === fingerprint) {
+          logger.debug(
+            { conversationId: conversation.id },
+            "Conversation unchanged since last classification — skipping"
+          )
+          continue
+        }
+
         // First user message author's timezone, used to anchor relative dates in
         // memos and to render existing-memo timestamps for the classifier.
         const firstUserMsg = messagesArray.find((m) => m.authorType === "user")
         const authorTimezone = firstUserMsg
           ? (fetchedData.authorTimezones.get(firstUserMsg.authorId) ?? undefined)
           : undefined
+
+        classifiedFingerprints.push({ id: item.id, fingerprint })
 
         // AI call (no connection held)
         const classification = await this.classifier.classifyConversation(
@@ -792,6 +809,10 @@ export class MemoService implements MemoServiceLike {
       // Deferred items stay unprocessed and are retried on the next batch check
       // cycle (~30s quiet interval, not 5-min cap) since last_activity_at is
       // already older than the quiet threshold.
+      // Written before markProcessed so a conversation that reached the model
+      // this pass can be recognised as unchanged on the next one.
+      await PendingItemRepository.recordClassifiedFingerprints(client, classifiedFingerprints)
+
       const itemsToMark = fetchedData.pending.filter((p) => !deferredItemIds.has(p.id))
       if (itemsToMark.length > 0) {
         await PendingItemRepository.markProcessed(


### PR DESCRIPTION
The accumulator queues a conversation on every `conversation:updated`, and
boundary extraction emits that for completeness and summary changes as well as
for new messages. Production, 30 days: 602 classify calls over 302
conversations, of which 37 re-asked an identical question — same messages, same
status, same memos — for $0.099.

Stores a digest of the classifier's inputs on the pending item and skips the
call when it matches. The digest covers what can flip the answer without a
message arriving: conversation status (a reopen), topic summary, participants,
each message's `editedAt`/`deletedAt` (an edit rewrites the transcript while
leaving the id list identical), and each existing memo's `version` — the
classifier is asked `shouldReviseExisting` against those, so a memo revised
elsewhere changes the correct answer while the conversation stands still.

It hashes inputs, never the rendered prompt: the transcript carries relative
ages computed against `new Date()` at batch time, so its text differs on every
pass and hashing it would mean the gate never fires.

A skipped item is still marked processed, so it does not re-queue forever. NULL
means never-classified and always classifies, so existing rows keep their
current behaviour.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
