### PR TITLE
perf(conversations): move the boundary rules into the cached prompt prefix

### DIFF
--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -21,27 +21,16 @@ export const BOUNDARY_EXTRACTION_TEMPERATURE = 0.2
 export const NEW_MESSAGE_ATTACHMENT_CHARS = 2000
 export const RECENT_ATTACHMENT_CHARS = 400
 
-export const BOUNDARY_EXTRACTION_SYSTEM_PROMPT = `You are a conversation boundary classifier. You analyze messages and output ONLY valid JSON matching the required schema. No explanations, no markdown, no prose - just the JSON object.`
+export const BOUNDARY_EXTRACTION_SYSTEM_PROMPT = `You are a conversation boundary classifier. You analyze messages and output ONLY valid JSON matching the required schema. No explanations, no markdown, no prose - just the JSON object.
 
-export const BOUNDARY_EXTRACTION_PROMPT = `Analyze this new message and decide which conversation(s) it belongs to. You may also move recent messages that were placed in the wrong conversation, now that this new message clarifies what was happening.
+Analyze this new message and decide which conversation(s) it belongs to. You may also move recent messages that were placed in the wrong conversation, now that this new message clarifies what was happening.
 
-## Active Conversations
-{{CONVERSATIONS}}
+The message to classify, the active conversations, the recent messages, and any explicit reply arrive in the next message, under those four headings.
 
-## Recent Messages
-{{RECENT_MESSAGES}}
-
-## New Message
-From: {{AUTHOR}}
-Content: {{CONTENT}}
-
-## Explicit reply
-{{REPLY_CONTEXT}}
-
-When the new message explicitly quote-replies an earlier message, that is a deliberate user action and the STRONGEST available signal of continuity — it OVERRIDES every other signal, including recency and whatever exchange is currently live. When this section lists a quoted conversation, assign the new message (as primary) to that conversation, even if a different conversation owns all the most recent messages. Override this only when the new message's own words explicitly open a different subject while quoting ("unrelated, but…"). A reply that merely reacts, agrees, asks a follow-up, or builds on the quoted message ("samma här", "kör på det", "sounds good") ALWAYS stays in the quoted message's conversation — brevity is not a reason to leave it in the live exchange. The quoted message's conversation is listed in Active Conversations above, so you can always assign to it.
+When the new message explicitly quote-replies an earlier message, that is a deliberate user action and the STRONGEST available signal of continuity — it OVERRIDES every other signal, including recency and whatever exchange is currently live. When this section lists a quoted conversation, assign the new message (as primary) to that conversation, even if a different conversation owns all the most recent messages. Override this only when the new message's own words explicitly open a different subject while quoting ("unrelated, but…"). A reply that merely reacts, agrees, asks a follow-up, or builds on the quoted message ("samma här", "kör på det", "sounds good") ALWAYS stays in the quoted message's conversation — brevity is not a reason to leave it in the live exchange. The quoted message's conversation is listed in the Active Conversations section below, so you can always assign to it.
 
 ## Attachments
-Some messages above may include an indented \`[attachment <filename> (<kind>)]:\` block beneath them. That block is the extracted text of the attachment — the transcript for audio/video, OCR text for an image, the parsed body for a PDF/Word/Excel, etc. Treat that extracted text as **part of the message's content** when judging topic continuity: a voice memo whose transcript is about onboarding is an onboarding message even if its written content is empty. Pay particular attention to the new message's attachments, since a short or empty written body is often a wrapper around the real payload that lives in the attachment.
+Some messages in the sections below may include an indented \`[attachment <filename> (<kind>)]:\` block beneath them. That block is the extracted text of the attachment — the transcript for audio/video, OCR text for an image, the parsed body for a PDF/Word/Excel, etc. Treat that extracted text as **part of the message's content** when judging topic continuity: a voice memo whose transcript is about onboarding is an onboarding message even if its written content is empty. Pay particular attention to the new message's attachments, since a short or empty written body is often a wrapper around the real payload that lives in the attachment.
 
 ## Time
 Messages carry an age like "(5m ago)" or "(2d ago)" and conversations carry "last active …", all relative to the new message ("just now" = within the last minute). Treat time as first-class evidence. Chat happens in sessions: turns minutes apart are one live exchange; a gap of several hours — an afternoon, overnight, a weekend — usually means the participants came back for a NEW conversation, even in the same stream between the same people.
@@ -105,6 +94,19 @@ When you set newConversationTopic, write a short title of 2-5 words that names t
 - Keep names, products, technical terms, and other proper nouns exactly as they appear in the conversation. Never translate, localize, or re-spell them — carry the participants' own words into the title verbatim.
 
 Respond with ONLY the JSON object. No explanation, no markdown code blocks.`
+
+export const BOUNDARY_EXTRACTION_PROMPT = `## Active Conversations
+{{CONVERSATIONS}}
+
+## Recent Messages
+{{RECENT_MESSAGES}}
+
+## New Message
+From: {{AUTHOR}}
+Content: {{CONTENT}}
+
+## Explicit reply
+{{REPLY_CONTEXT}}`
 
 // --- On-demand conversation split (agent-proposed) -------------------------
 // Re-cluster the messages of ONE existing conversation into ≥1 topic group, in

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -6,6 +6,7 @@ import type { AI } from "@threa/agent-runtime"
 import type { ConfigResolver, ComponentConfig } from "../../../lib/ai/config-resolver"
 
 import { NoObjectGeneratedError } from "ai"
+import { BOUNDARY_EXTRACTION_PROMPT, BOUNDARY_EXTRACTION_SYSTEM_PROMPT } from "./config"
 
 const mockGenerateObject = mock(
   async (): Promise<{ value: any; response: any; usage: any }> => ({
@@ -795,6 +796,60 @@ describe("LLMBoundaryExtractor", () => {
       const userPrompt = call.messages.find((m) => m.role === "user")?.content ?? ""
       expect(userPrompt).toContain("[msg_stale] (26h ago)")
       expect(userPrompt).toContain("last active 26h ago")
+    })
+  })
+
+  // The rules block is ~3k tokens and identical on every call across every
+  // workspace, so it is worth caching — but a provider only caches the span
+  // before the first difference. Any per-call value that leaks into the system
+  // message truncates that span to nothing and silently restores full price on
+  // ~1k calls a month.
+  describe("cacheable prefix", () => {
+    test("keeps every per-call value out of the system message", async () => {
+      const context = createMockContext({ streamType: "dm" })
+      mockGenerateObject.mockResolvedValueOnce({
+        value: { assignments: [{ conversationId: null, isPrimary: true }], newConversationTopic: "T", confidence: 0.9 },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const messages = calls[0]?.[0]?.messages ?? []
+      const systemPrompt = messages.find((m) => m.role === "system")?.content ?? ""
+      const userPrompt = messages.find((m) => m.role === "user")?.content ?? ""
+
+      // Nothing from this call's data may appear in the cached half.
+      expect(systemPrompt).not.toContain(context.newMessage.contentMarkdown)
+      expect(systemPrompt).not.toContain(context.newMessage.id)
+      for (const conversation of context.activeConversations) {
+        expect(systemPrompt).not.toContain(conversation.id)
+      }
+      // …and it all has to be in the half that follows.
+      expect(userPrompt).toContain(context.newMessage.contentMarkdown)
+
+      // (Length and placeholder checks run against the real constants below —
+      // this resolver is a stub, so its systemPrompt says nothing about prod.)
+      expect(systemPrompt).toBeTruthy()
+    })
+
+    test("ships the whole rules block as a fixed system prompt, with the data slots in the user template", () => {
+      // Every per-call value lives in the user template; none in the system half.
+      expect(BOUNDARY_EXTRACTION_SYSTEM_PROMPT).not.toMatch(/\{\{[A-Z_]+\}\}/)
+      expect(BOUNDARY_EXTRACTION_PROMPT.match(/\{\{[A-Z_]+\}\}/g)).toEqual([
+        "{{CONVERSATIONS}}",
+        "{{RECENT_MESSAGES}}",
+        "{{AUTHOR}}",
+        "{{CONTENT}}",
+        "{{REPLY_CONTEXT}}",
+      ])
+
+      // Under OpenAI's 1024-token floor nothing caches at all. ~4.7 chars per
+      // token on this prose, so 8000 characters is a comfortable margin.
+      expect(BOUNDARY_EXTRACTION_SYSTEM_PROMPT.length).toBeGreaterThan(8000)
     })
   })
 })


### PR DESCRIPTION
`BOUNDARY_EXTRACTION_PROMPT` interpolated the active conversations and recent
messages at the top and then followed with ~3,000 tokens of fixed classification
rules. A provider caches only the span before the first difference, so with a
32-token system prompt the cacheable prefix was 61 tokens — under OpenAI's
1024-token floor. Every one of ~1,015 monthly calls paid full price for the same
rules.

The rules now ship as the system prompt (3,021 tokens, no interpolation) and the
four data sections as the user message. Measured on the real prompt shape with
different content each call:

  call #1  prompt=3153  cached=0     $0.002437   <- cache write, free on mini
  call #2  prompt=3153  cached=2816  $0.000536
  call #3  prompt=3153  cached=2816  $0.000536

78% off per call. 86.4% of production calls arrive within 10 minutes of the
previous one and a probe confirmed hits survive that gap, so the expected saving
is ~$1.67/mo against this component's $4.17.

This is a behavioural change, not a reformat — the rules used to sit *after* the
data, and recency-last is a real technique for rule adherence. Gated on the
94-case suite at 3 runs per case:

  before  122/123 case-runs, confidence 0.967
  after   121/123 and 123/123 on two samples, confidence 0.962

Both arms fail only in the same borderline live-pivot family, and the baseline
itself moved between 39/41 and 40/41 across single runs, so the difference is
inside the suite's own variance. Two directional references were rewritten,
since "listed in Active Conversations above" is false once the data is below.

Adds a guard that fails if any `{{...}}` slot reappears in the system half or
the block drops under the token floor — the two ways this silently reverts to
full price.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
