### PR TITLE
perf(conversations): drop the boundary `reasoning` field nobody reads

### DIFF
--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -227,8 +227,12 @@ export const extractionResponseSchema = z.object({
     )
     .nullable()
     .describe("Updates to completeness/status/summary for affected conversations, or null if none"),
+  // No `reasoning` field here on purpose. Structured output is generated in
+  // schema order, so a rationale declared after the decisions is emitted after
+  // them and cannot inform them — it was pure output cost (21.6% of completion
+  // tokens, measured) and nothing ever read it. The split schema's `reasoning`
+  // IS consumed and surfaces in the user-facing proposal; that one stays.
   confidence: z.number().min(0).max(1).describe("Overall confidence in this classification (0.0 to 1.0)"),
-  reasoning: z.string().nullable().describe("Brief explanation of the classification decision"),
 })
 
 export type ExtractionResponse = z.infer<typeof extractionResponseSchema>


### PR DESCRIPTION
`extractionResponseSchema` asked the model for `reasoning: "Brief explanation of
the classification decision"` on every call. `validateResult` never touched it,
`ExtractionResult` has no such field, and the prompt's own Output Requirements
section never documented it — only the zod `.describe()` did. Removing it
produces no type errors anywhere, which is the tell.

A rationale field usually earns its keep by making a model articulate before it
commits. It cannot here: it was declared last in the object, after `confidence`,
and structured output is generated in schema order, so the explanation was
emitted after every decision it might have informed.

Measured on the production prompt and model across three cases: **458 → 359
completion tokens, 21.6% less output**, ~$0.24/mo against this component's $1.10
output spend.

Gated on the 94-case suite at 3 runs per case: 121/123, confidence 0.96, against
a 122/123 baseline — the dips are single runs in the same borderline live-pivot
family that moves on the baseline too. Kept separate from the prefix hoist so an
eval movement stays attributable to one change.

`conversationSplitResponseSchema.reasoning` is untouched — that one is consumed
and rendered in the split proposal.



---

Part of stack #1610 — background AI cost reduction. Measured baseline and the adversarial pass behind these changes: https://seer.build/ws_vbyzjvdg6g/b/bg-ai-cost-b48fd4/
