### PR TITLE
fix(ai-usage): never render a real cache hit as "0% cached"

### DIFF
--- a/apps/frontend/src/components/ai-usage/capability-breakdown.test.tsx
+++ b/apps/frontend/src/components/ai-usage/capability-breakdown.test.tsx
@@ -96,6 +96,29 @@ describe("CapabilityBreakdown", () => {
     expect(screen.getByText("75% cached")).toBeInTheDocument()
   })
 
+  it("never rounds a real cache hit down to 0%", () => {
+    // The panel window is month-to-date, so the first hits after a prompt is
+    // made cacheable sit against everything billed at full price before them.
+    // "0% cached" there would read as broken when it means "just started".
+    const barelyCached: AIUsageByModel[] = [
+      {
+        model: "provider/big",
+        totalCostUsd: 0.3,
+        totalTokens: 9000,
+        promptTokens: 4_000_000,
+        cachedPromptTokens: 2816,
+        recordCount: 12,
+      },
+    ]
+    // The by-model list only renders alongside at least one capability row.
+    render(
+      <CapabilityBreakdown byFunction={byFunction} byModel={barelyCached} totalCost={totalCost} isLoading={false} />
+    )
+
+    expect(screen.getByText("<1% cached")).toBeInTheDocument()
+    expect(screen.queryByText("0% cached")).not.toBeInTheDocument()
+  })
+
   it("renders the empty state when there is no function usage", () => {
     render(<CapabilityBreakdown byFunction={[]} byModel={[]} totalCost={0} isLoading={false} />)
     expect(screen.getByText(/No AI usage recorded yet this cycle/i)).toBeInTheDocument()

--- a/apps/frontend/src/components/ai-usage/capability-breakdown.tsx
+++ b/apps/frontend/src/components/ai-usage/capability-breakdown.tsx
@@ -27,13 +27,26 @@ function cacheHitPct(promptTokens: number, cachedPromptTokens: number): number |
   return (cachedPromptTokens / promptTokens) * 100
 }
 
+/**
+ * A non-zero share must never render as "0% cached" — that reads as "caching is
+ * broken" when it means "caching started partway through the billing period".
+ * The window is month-to-date, so the first cached call after a prompt is made
+ * cacheable lands against a denominator of everything billed at full price
+ * before it: one 2,816-token hit against boundary extraction's ~4M tokens for
+ * the month is 0.07%, which rounds to zero and inverts the signal.
+ */
+function formatCacheHit(pct: number): string {
+  if (pct < 1) return "<1% cached"
+  return `${pct.toFixed(0)}% cached`
+}
+
 function CacheHitLabel({ promptTokens, cachedPromptTokens }: { promptTokens: number; cachedPromptTokens: number }) {
   const pct = cacheHitPct(promptTokens, cachedPromptTokens)
   // Fixed width whether or not the label renders, so expanding a category can't
   // shift the columns beside it (INV-21).
   return (
     <span className="w-16 text-right text-[11px] tabular-nums text-muted-foreground">
-      {pct === null ? "" : `${pct.toFixed(0)}% cached`}
+      {pct === null ? "" : formatCacheHit(pct)}
     </span>
   )
 }


### PR DESCRIPTION
The panel window is month-to-date, so the first hits after a prompt is made cacheable land against a denominator of everything billed at full price before them. Boundary extraction has 4,009,582 prompt tokens so far this month, all uncached; the first cached call contributes 2,816 — 0.07%, which rounds to "0% cached".

That is the exact opposite of the true signal, shown at precisely the moment someone is checking whether stack #1610 worked. Sub-1% shares now render `<1% cached`, which distinguishes "just started" from the "no cacheable prefix" case that renders nothing at all.

Verification: frontend suite 5,150 green; the new guard was confirmed to fail with the branch removed.

Follow-up to stack #1610.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787770731&installation_model_id=20758&pr_number=1613&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1613&signature=ff505d241e9382367ff50f8042f62bc1dffe390523d3b6cac05b749c821dd9b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->