### PR TITLE
feat(composer): let the send button sit on the left

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -178,3 +178,24 @@ describe("updatePreferencesSchema message collapse settings", () => {
     expect(parsed.messageCollapseToHeight).toBeUndefined()
   })
 })
+
+describe("updatePreferencesSchema accessibility.composerActionSide", () => {
+  it("accepts both sides", () => {
+    expect(updatePreferencesSchema.parse({ accessibility: { composerActionSide: "left" } }).accessibility).toEqual({
+      composerActionSide: "left",
+    })
+    expect(updatePreferencesSchema.parse({ accessibility: { composerActionSide: "right" } }).accessibility).toEqual({
+      composerActionSide: "right",
+    })
+  })
+
+  it("rejects an unknown side", () => {
+    expect(updatePreferencesSchema.safeParse({ accessibility: { composerActionSide: "top" } }).success).toBe(false)
+  })
+
+  it("is omitted when not supplied, so a partial accessibility update leaves it alone", () => {
+    expect(updatePreferencesSchema.parse({ accessibility: { reducedMotion: true } }).accessibility).toEqual({
+      reducedMotion: true,
+    })
+  })
+})

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -10,6 +10,7 @@ import {
   FONT_SIZE_OPTIONS,
   FONT_FAMILY_OPTIONS,
   MESSAGE_SEND_MODE_OPTIONS,
+  COMPOSER_ACTION_SIDE_OPTIONS,
   LINK_PREVIEW_DEFAULT_OPTIONS,
   LABEL_REMOVE_ON_MOVE_OPTIONS,
   UNREAD_OPEN_POSITION_OPTIONS,
@@ -133,6 +134,7 @@ const updatePreferencesSchema = z.object({
       highContrast: z.boolean().optional(),
       fontSize: z.enum(FONT_SIZE_OPTIONS).optional(),
       fontFamily: z.enum(FONT_FAMILY_OPTIONS).optional(),
+      composerActionSide: z.enum(COMPOSER_ACTION_SIDE_OPTIONS).optional(),
     })
     .optional(),
 })

--- a/apps/frontend/src/components/composer/composer-action-bar.test.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import * as elementWidthModule from "@/hooks/use-element-width"
 import { ComposerActionBar, planActionOverflow, planTriggerVisibility } from "./composer-action-bar"
@@ -133,5 +134,47 @@ describe("squeezed trigger mounting", () => {
     const trigger = screen.getByTestId("stash-trigger")
     expect(trigger).toBeInTheDocument()
     expect(trigger).not.toBeVisible()
+  })
+})
+
+describe("action side", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function renderBar(side?: "left" | "right") {
+    render(
+      <TooltipProvider>
+        <ComposerActionBar
+          formatOpen={false}
+          onToggleFormat={() => {}}
+          onInsertEmoji={() => {}}
+          onInsertMention={() => {}}
+          onInsertCommand={() => {}}
+          onAttachClick={() => {}}
+          side={side}
+          sendButton={<button type="button">Send</button>}
+        />
+      </TooltipProvider>
+    )
+    // The mirror is a flex-direction flip, so the class on the row is the only
+    // signal jsdom can see — it has no layout to measure.
+    return screen.getByRole("button", { name: "Formatting" }).parentElement
+  }
+
+  it("keeps the row in source order by default", () => {
+    expect(renderBar()).not.toHaveClass("flex-row-reverse")
+  })
+
+  it("mirrors the row so Send lands on the left", () => {
+    expect(renderBar("left")).toHaveClass("flex-row-reverse")
+  })
+
+  it("anchors the overflow menu to the edge the '+' trigger moved to", async () => {
+    // 170px folds every collapsible action, so the "+" trigger renders.
+    vi.spyOn(elementWidthModule, "useElementWidth").mockReturnValue(170)
+    renderBar("left")
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }))
+    expect(screen.getByRole("menu")).toHaveAttribute("data-align", "end")
   })
 })

--- a/apps/frontend/src/components/composer/composer-action-bar.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.tsx
@@ -5,6 +5,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useElementWidth } from "@/hooks/use-element-width"
 import { cn } from "@/lib/utils"
+import type { ComposerActionSide } from "@threa/types"
 
 /**
  * Approximate rendered width of one 28px icon button plus its 4px flex gap.
@@ -34,10 +35,10 @@ interface CollapsibleAction {
  * without a real ResizeObserver (jsdom stubs it to a no-op).
  *
  * Actions keep their incoming array order in both result lists (that's the
- * left-to-right display order); only `collapsePriority` decides *which* ones
- * fold. A constant slot is reserved for the always-present left affordance
- * (the format hint, or the "+" trigger) so the count doesn't oscillate as the
- * menu appears and disappears.
+ * display order); only `collapsePriority` decides *which* ones fold. A constant
+ * slot is reserved for the always-present leading affordance (the format hint,
+ * or the "+" trigger) so the count doesn't oscillate as the menu appears and
+ * disappears.
  */
 export function planActionOverflow<T extends { key: string; collapsePriority: number }>(
   actions: T[],
@@ -102,12 +103,14 @@ export interface ComposerActionBarProps {
   /** Scheduled-messages picker trigger; inline (its popover needs an anchor), dropped first under extreme squeeze. */
   scheduledMessagesTrigger?: ReactNode
   sendButton: ReactNode
+  /** Which edge Send hugs; "left" mirrors the whole row. */
+  side?: ComposerActionSide
 }
 
 /**
  * The desktop composer's bottom action row. Folds its secondary insert actions
- * (emoji, mention, command, attach, expand) into a left-anchored "+" menu as
- * the composer narrows — so the bar stays on one clean line in a side panel or
+ * (emoji, mention, command, attach, expand) into a "+" menu anchored opposite
+ * Send as the composer narrows — so the bar stays on one clean line in a side panel or
  * small window instead of overflowing. Formatting and Send are always inline;
  * the un-foldable triggers (dictation, stash, schedule) drop from the tail only
  * if the bar is squeezed past the all-folded minimum (`+` Aa Send), so the row
@@ -129,7 +132,9 @@ export function ComposerActionBar({
   stashedDraftsTrigger,
   scheduledMessagesTrigger,
   sendButton,
+  side = "right",
 }: ComposerActionBarProps) {
+  const mirrored = side === "left"
   const barRef = useRef<HTMLDivElement>(null)
   const width = useElementWidth(barRef)
 
@@ -207,11 +212,11 @@ export function ComposerActionBar({
   const mainInlineActions = inlineActions.filter((a) => a.key !== "expand")
 
   return (
-    <div ref={barRef} className="flex items-center gap-1">
+    <div ref={barRef} className={cn("flex items-center gap-1", mirrored && "flex-row-reverse")}>
       {overflowActions.length > 0 ? (
         <>
-          {/* Left-anchored overflow menu. Bordered so it reads as "more
-              options" rather than just another flat ghost action. */}
+          {/* Overflow menu, anchored to the edge opposite Send. Bordered so it
+              reads as "more options" rather than just another flat ghost action. */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -230,13 +235,15 @@ export function ComposerActionBar({
                 emoji/mention suggestion popups still anchor at the caret. */}
             <DropdownMenuContent
               side="top"
-              align="start"
+              align={mirrored ? "end" : "start"}
               className="min-w-[168px]"
               onCloseAutoFocus={(e) => e.preventDefault()}
             >
-              {/* Render collapsed actions bottom-up so the leftmost toolbar item
-                  sits closest to the "+" trigger and the rightmost item is
-                  farthest away — matching the spatial order of the bar. */}
+              {/* Render collapsed actions bottom-up so the toolbar item nearest
+                  the "+" trigger sits closest to it in the menu and the farthest
+                  one is farthest away. Unaffected by `mirrored`: row-reverse
+                  flips the whole row, so "+" and its neighbours mirror together
+                  and their relative order is preserved. */}
               {[...overflowActions].reverse().map((action) => (
                 <DropdownMenuItem key={action.key} className="gap-2 cursor-pointer" onSelect={action.onSelect}>
                   <span className="flex h-4 w-4 items-center justify-center text-muted-foreground">{action.icon}</span>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -14,6 +14,7 @@ import { flushSync } from "react-dom"
 import { ArrowUp, X, Plus, AtSign, Slash, Paperclip } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { useComposerActionSide } from "@/hooks/use-composer-action-side"
 import { usePreferencesOptional } from "@/contexts"
 import { getEffectiveKeyBinding, matchesKeyBinding } from "@/lib/keyboard-shortcuts"
 import { RichEditor, EditorToolbar, EditorActionBar } from "@/components/editor"
@@ -376,6 +377,8 @@ export function MessageComposer({
   // isn't torn down mid-take.
   const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobile()
+  const actionSide = useComposerActionSide()
+  const mirrored = actionSide === "left"
   // Selection toolbar is a hover/mouse affordance, so it keys off the active
   // input mode (a finger suppresses it) rather than viewport width — a mouse on
   // a touchscreen laptop still gets it.
@@ -971,7 +974,12 @@ export function MessageComposer({
               <div className="h-[50vh]" />
             </div>
 
-            <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-10 flex items-center gap-1.5">
+            <div
+              className={cn(
+                "absolute bottom-[max(1rem,env(safe-area-inset-bottom))] z-10 flex items-center gap-1.5",
+                mirrored ? "left-4 flex-row-reverse" : "right-4"
+              )}
+            >
               {/* Action drawer — always visible on desktop; on touch (no hover) it
                 stays behind the + button and opens on tap. `inert` while
                 collapsed on mobile so its buttons drop out of tab order instead
@@ -980,6 +988,7 @@ export function MessageComposer({
                 inert={isMobile && !fabActionsOpen}
                 className={cn(
                   "flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out",
+                  mirrored && "flex-row-reverse",
                   isMobile ? "max-w-0 opacity-0" : "max-w-[240px] opacity-100",
                   fabActionsOpen && "max-w-[240px] opacity-100"
                 )}
@@ -1125,7 +1134,7 @@ export function MessageComposer({
                       <ArrowUp className="h-4 w-4" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent side="left" className="text-xs">
+                  <TooltipContent side={mirrored ? "right" : "left"} className="text-xs">
                     {sendHint}
                   </TooltipContent>
                 </Tooltip>
@@ -1289,9 +1298,12 @@ export function MessageComposer({
                       onMobileExpandedChange={setMobileExpanded}
                       showAttach
                       onAttachClick={handleAttachClick}
+                      side={actionSide}
                       trailingContent={
                         micButton || stashedDraftsTrigger || scheduledMessagesTrigger ? (
-                          <div className="flex items-center gap-1">
+                          // Mirrored too, so Send stays the outermost control
+                          // rather than sitting behind the triggers.
+                          <div className={cn("flex items-center gap-1", mirrored && "flex-row-reverse")}>
                             {micButton}
                             {stashedDraftsTrigger}
                             {scheduledMessagesTrigger}
@@ -1304,6 +1316,7 @@ export function MessageComposer({
                     />
                   ) : (
                     <ComposerActionBar
+                      side={actionSide}
                       disabled={controlsDisabled}
                       formatOpen={formatOpen}
                       onToggleFormat={() => setFormatOpen((v) => !v)}
@@ -1336,7 +1349,7 @@ export function MessageComposer({
             </div>
           </div>
 
-          <div className="flex justify-end px-1 pt-1">
+          <div className={cn("flex px-1 pt-1", mirrored ? "justify-start" : "justify-end")}>
             <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
               {sendHint}
             </span>

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -11,6 +11,7 @@ import { stripMarkdownToInline } from "@/lib/markdown"
 import { formatFutureTime, formatSendCountdown } from "@/lib/dates"
 import { useScheduledList, useCancelScheduled, useSendScheduledNow } from "@/hooks"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { composerPopoverAlign, useComposerActionSide } from "@/hooks/use-composer-action-side"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { useLongPress } from "@/hooks/use-long-press"
 import { usePreferencesOptional } from "@/contexts"
@@ -94,6 +95,7 @@ export function ScheduledMessagesPicker({
   // Virtual-keyboard guard keys off the ACTIVE input — a soft keyboard is only
   // up when the user is actually typing with a finger.
   const isTouchInput = useInputMode() === "touch"
+  const actionSide = useComposerActionSide()
   // Browser-local timezone is the default everywhere in the UI — native
   // pickers operate in device-local, so we keep the custom-time path on
   // device-local to avoid silent drift. The user's saved profile timezone
@@ -233,7 +235,7 @@ export function ScheduledMessagesPicker({
         </Tooltip>
 
         <PopoverContent
-          align="end"
+          align={composerPopoverAlign(actionSide)}
           side="top"
           sideOffset={8}
           className="w-80 p-0"

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -8,6 +8,7 @@ import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryptio
 import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { composerPopoverAlign, useComposerActionSide } from "@/hooks/use-composer-action-side"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
 import { usePreferencesOptional } from "@/contexts"
 import { formatKeyBinding, getEffectiveKeyBinding } from "@/lib/keyboard-shortcuts"
@@ -97,6 +98,7 @@ export function StashedDraftsPicker({
   // Active input drives the virtual-keyboard guard and the "Tap"/"Press" +
   // keyboard-shortcut copy — a hardware keyboard is present only with a mouse.
   const isTouch = useInputMode() === "touch"
+  const actionSide = useComposerActionSide()
   const count = drafts.length
   const now = useMemo(() => new Date(), [open])
 
@@ -198,7 +200,7 @@ export function StashedDraftsPicker({
 
         <PopoverContent
           ref={contentRef}
-          align="end"
+          align={composerPopoverAlign(actionSide)}
           side="top"
           sideOffset={8}
           className="w-80 p-0"

--- a/apps/frontend/src/components/editor/editor-action-bar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.test.tsx
@@ -88,3 +88,19 @@ describe("EditorActionBar", () => {
     expect(onDesktopExpandClick).toHaveBeenCalled()
   })
 })
+
+describe("action side", () => {
+  // The mirror is a flex-direction flip, so the class on the row is the only
+  // signal jsdom can see — it has no layout to measure.
+  const row = () => screen.getByRole("button", { name: "Formatting" }).parentElement
+
+  it("keeps the row in source order by default", () => {
+    renderBar()
+    expect(row()).not.toHaveClass("flex-row-reverse")
+  })
+
+  it("mirrors the row so Send lands on the left", () => {
+    renderBar({ side: "left" })
+    expect(row()).toHaveClass("flex-row-reverse")
+  })
+})

--- a/apps/frontend/src/components/editor/editor-action-bar.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.tsx
@@ -3,6 +3,7 @@ import { AtSign, Slash, Paperclip, Maximize2, Minimize2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
+import type { ComposerActionSide } from "@threa/types"
 import type { RichEditorHandle } from "./rich-editor"
 
 function handlePointerAction(action: () => void) {
@@ -38,6 +39,12 @@ export interface EditorActionBarProps {
   onDesktopExpandClick?: () => void
   // Trailing slot: Send button (composer) or Cancel+Save (edit form)
   trailingContent: ReactNode
+  /**
+   * Which edge the row's controls hug. "left" mirrors the row so `trailingContent`
+   * (which carries Send) lands under a left thumb rather than in the opposite
+   * corner from it.
+   */
+  side?: ComposerActionSide
 }
 
 export function EditorActionBar({
@@ -56,10 +63,11 @@ export function EditorActionBar({
   showDesktopExpand = false,
   onDesktopExpandClick,
   trailingContent,
+  side = "right",
 }: EditorActionBarProps) {
   return (
-    <div className="flex items-center gap-1">
-      {/* Spacer — pushes buttons to the right */}
+    <div className={cn("flex items-center gap-1", side === "left" && "flex-row-reverse")}>
+      {/* Spacer — pushes buttons to whichever edge `side` names */}
       <span className="flex-1" />
 
       {/* Expand/collapse toggle — mobile inline expansion */}

--- a/apps/frontend/src/components/settings/accessibility-settings.test.tsx
+++ b/apps/frontend/src/components/settings/accessibility-settings.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AccessibilitySettings } from "./accessibility-settings"
+import * as contextsModule from "@/contexts"
+
+const updateAccessibility = vi.fn()
+
+function mountWith(accessibility: unknown) {
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { accessibility },
+    updateAccessibility,
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  render(<AccessibilitySettings />)
+}
+
+describe("AccessibilitySettings composer action side", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    updateAccessibility.mockReset()
+  })
+
+  it("writes the chosen side", async () => {
+    mountWith({
+      reducedMotion: false,
+      highContrast: false,
+      fontSize: "medium",
+      fontFamily: "system",
+      composerActionSide: "right",
+    })
+
+    await userEvent.click(screen.getByLabelText("Left"))
+
+    expect(updateAccessibility).toHaveBeenCalledWith({ composerActionSide: "left" })
+  })
+
+  it("shows the default when a cached preferences blob predates the field", () => {
+    // Preferences are read from the IDB cache, so a client that cached before
+    // this field shipped has an accessibility object without it. The control
+    // must still render its default rather than nothing.
+    mountWith({ reducedMotion: false, highContrast: false, fontSize: "medium", fontFamily: "system" })
+
+    expect(screen.getByRole("radio", { name: "Right" })).toBeChecked()
+    expect(screen.getByRole("radio", { name: "Left" })).not.toBeChecked()
+  })
+})

--- a/apps/frontend/src/components/settings/accessibility-settings.tsx
+++ b/apps/frontend/src/components/settings/accessibility-settings.tsx
@@ -44,7 +44,10 @@ const FONT_FAMILY_DESCRIPTIONS: Record<FontFamily, string> = {
 export function AccessibilitySettings() {
   const { preferences, updateAccessibility } = usePreferences()
 
-  const accessibility = preferences?.accessibility ?? DEFAULT_ACCESSIBILITY
+  // Spread over the defaults rather than replacing them: preferences come from
+  // the IDB cache, so a blob written before a field existed carries an
+  // `accessibility` object missing it, and the control would render unset.
+  const accessibility = { ...DEFAULT_ACCESSIBILITY, ...preferences?.accessibility }
 
   return (
     <div className="space-y-6">

--- a/apps/frontend/src/components/settings/accessibility-settings.tsx
+++ b/apps/frontend/src/components/settings/accessibility-settings.tsx
@@ -3,7 +3,15 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import { usePreferences } from "@/contexts"
-import { FONT_SIZE_OPTIONS, FONT_FAMILY_OPTIONS, type FontSize, type FontFamily } from "@threa/types"
+import {
+  FONT_SIZE_OPTIONS,
+  FONT_FAMILY_OPTIONS,
+  COMPOSER_ACTION_SIDE_OPTIONS,
+  DEFAULT_ACCESSIBILITY,
+  type FontSize,
+  type FontFamily,
+  type ComposerActionSide,
+} from "@threa/types"
 
 const FONT_SIZE_LABELS: Record<FontSize, string> = {
   small: "Small (14px)",
@@ -17,6 +25,16 @@ const FONT_FAMILY_LABELS: Record<FontFamily, string> = {
   dyslexic: "OpenDyslexic",
 }
 
+const COMPOSER_ACTION_SIDE_LABELS: Record<ComposerActionSide, string> = {
+  right: "Right",
+  left: "Left",
+}
+
+const COMPOSER_ACTION_SIDE_DESCRIPTIONS: Record<ComposerActionSide, string> = {
+  right: "Send sits at the right end of the composer, after the other controls",
+  left: "Mirrors the row so Send sits at the left end, within reach of a left thumb",
+}
+
 const FONT_FAMILY_DESCRIPTIONS: Record<FontFamily, string> = {
   system: "Clean, readable font for everyday use",
   monospace: "Fixed-width font for code-like appearance",
@@ -26,12 +44,7 @@ const FONT_FAMILY_DESCRIPTIONS: Record<FontFamily, string> = {
 export function AccessibilitySettings() {
   const { preferences, updateAccessibility } = usePreferences()
 
-  const accessibility = preferences?.accessibility ?? {
-    reducedMotion: false,
-    highContrast: false,
-    fontSize: "medium" as const,
-    fontFamily: "system" as const,
-  }
+  const accessibility = preferences?.accessibility ?? DEFAULT_ACCESSIBILITY
 
   return (
     <div className="space-y-6">
@@ -71,6 +84,32 @@ export function AccessibilitySettings() {
             onCheckedChange={(checked) => updateAccessibility({ highContrast: checked })}
           />
         </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Composer actions</h3>
+          <p className="text-sm text-muted-foreground">Which end of the composer holds the Send button</p>
+        </div>
+        <RadioGroup
+          value={accessibility.composerActionSide}
+          onValueChange={(value) => updateAccessibility({ composerActionSide: value as ComposerActionSide })}
+          className="space-y-4"
+        >
+          {COMPOSER_ACTION_SIDE_OPTIONS.map((option) => (
+            <div key={option} className="flex items-start space-x-3">
+              <RadioGroupItem value={option} id={`composer-action-side-${option}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`composer-action-side-${option}`} className="cursor-pointer">
+                  {COMPOSER_ACTION_SIDE_LABELS[option]}
+                </Label>
+                <p className="text-sm text-muted-foreground">{COMPOSER_ACTION_SIDE_DESCRIPTIONS[option]}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
       </section>
 
       <Separator />

--- a/apps/frontend/src/components/settings/tab-config.ts
+++ b/apps/frontend/src/components/settings/tab-config.ts
@@ -60,7 +60,7 @@ export const SETTINGS_TAB_CONFIG: Record<SettingsTab, SettingsTabConfig> = {
   },
   accessibility: {
     label: "Accessibility",
-    description: "Motion, contrast, and fonts",
-    keywords: ["font", "contrast", "motion", "a11y", "dyslexic"],
+    description: "Motion, contrast, fonts, and composer layout",
+    keywords: ["font", "contrast", "motion", "a11y", "dyslexic", "left-handed", "handedness", "reach", "send"],
   },
 }

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -260,3 +260,5 @@ export {
   type CachedLabel,
   type CachedLabelAssignment,
 } from "./use-labels"
+
+export { useComposerActionSide, composerPopoverAlign } from "./use-composer-action-side"

--- a/apps/frontend/src/hooks/use-composer-action-side.ts
+++ b/apps/frontend/src/hooks/use-composer-action-side.ts
@@ -1,5 +1,5 @@
 import { usePreferencesOptional } from "@/contexts"
-import { type ComposerActionSide } from "@threa/types"
+import { DEFAULT_ACCESSIBILITY, type ComposerActionSide } from "@threa/types"
 
 /**
  * Which end of the composer's action row holds Send.
@@ -9,10 +9,13 @@ import { type ComposerActionSide } from "@threa/types"
  * timeline, board — and handed to the bar as opaque nodes, so the bar cannot
  * reach their popover alignment. They read it here instead of adding the prop
  * to three hosts. Falls back to the default outside a provider (markdown
- * previews, component tests).
+ * previews, component tests) and for a cached preferences blob written before
+ * this field existed.
  */
 export function useComposerActionSide(): ComposerActionSide {
-  return usePreferencesOptional()?.preferences?.accessibility?.composerActionSide ?? "right"
+  return (
+    usePreferencesOptional()?.preferences?.accessibility?.composerActionSide ?? DEFAULT_ACCESSIBILITY.composerActionSide
+  )
 }
 
 /**

--- a/apps/frontend/src/hooks/use-composer-action-side.ts
+++ b/apps/frontend/src/hooks/use-composer-action-side.ts
@@ -1,0 +1,24 @@
+import { usePreferencesOptional } from "@/contexts"
+import { type ComposerActionSide } from "@threa/types"
+
+/**
+ * Which end of the composer's action row holds Send.
+ *
+ * The action bars take this as a prop (they stay pure and width-testable), but
+ * the drafts/schedule pickers are constructed by the hosts — stream panel,
+ * timeline, board — and handed to the bar as opaque nodes, so the bar cannot
+ * reach their popover alignment. They read it here instead of adding the prop
+ * to three hosts. Falls back to the default outside a provider (markdown
+ * previews, component tests).
+ */
+export function useComposerActionSide(): ComposerActionSide {
+  return usePreferencesOptional()?.preferences?.accessibility?.composerActionSide ?? "right"
+}
+
+/**
+ * Alignment for a popover anchored to the composer card by a trigger sitting at
+ * `side` — the popover hugs the same edge its trigger does.
+ */
+export function composerPopoverAlign(side: ComposerActionSide): "start" | "end" {
+  return side === "left" ? "start" : "end"
+}

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -98,6 +98,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
         fontFamily: "system",
         reducedMotion: false,
         highContrast: false,
+        composerActionSide: "right",
       },
       keyboardShortcuts: {},
       createdAt: new Date().toISOString(),

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -122,6 +122,7 @@ function makeBootstrap(): WorkspaceBootstrap {
         fontFamily: "system",
         reducedMotion: false,
         highContrast: false,
+        composerActionSide: "right",
       },
       keyboardShortcuts: {},
       createdAt: new Date().toISOString(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -771,6 +771,10 @@ export {
   MESSAGE_SEND_MODE_OPTIONS,
   type MessageSendMode,
   MessageSendModes,
+  // Composer action side
+  COMPOSER_ACTION_SIDE_OPTIONS,
+  type ComposerActionSide,
+  ComposerActionSides,
   // Link preview default
   LINK_PREVIEW_DEFAULT_OPTIONS,
   type LinkPreviewDefault,

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -85,6 +85,17 @@ export const MessageSendModes = {
   CMD_ENTER: "cmdEnter",
 } as const satisfies Record<string, MessageSendMode>
 
+// Which end of the composer's action row holds Send and its neighboring
+// controls. "right" is the conventional layout; "left" mirrors the row so Send
+// falls inside a left thumb's arc instead of the opposite corner.
+export const COMPOSER_ACTION_SIDE_OPTIONS = ["right", "left"] as const
+export type ComposerActionSide = (typeof COMPOSER_ACTION_SIDE_OPTIONS)[number]
+
+export const ComposerActionSides = {
+  RIGHT: "right",
+  LEFT: "left",
+} as const satisfies Record<string, ComposerActionSide>
+
 // Where a stream opens when there are unread messages. "latest" (default)
 // lands at the newest message with an "N new messages" affordance pointing up
 // at the unread marker; "marker" (Discord-style) lands on the first unread
@@ -241,6 +252,7 @@ export interface AccessibilityPreferences {
   highContrast: boolean
   fontSize: FontSize
   fontFamily: FontFamily
+  composerActionSide: ComposerActionSide
 }
 
 /**
@@ -251,6 +263,7 @@ export const DEFAULT_ACCESSIBILITY: AccessibilityPreferences = {
   highContrast: false,
   fontSize: "medium",
   fontFamily: "system",
+  composerActionSide: "right",
 }
 
 /**


### PR DESCRIPTION
## Problem

`EditorActionBar` right-aligns every control behind a `flex-1` spacer, so on mobile Send sits in the bottom-right corner with the left half of the row empty. Using a large phone left-handed, that corner is the single furthest point from the thumb's pivot — roughly 1120px of arc on a 6.7" screen, against ~650px to the keyboard's own return key. Kris hit this holding his phone in his left hand.

## Solution

A user preference, `accessibility.composerActionSide` (`"right"` default | `"left"`), that mirrors the composer's action row so Send hugs the left edge.

- Mirroring is `flex-row-reverse` on the row. The desktop bar's overflow math (`planActionOverflow`, `planTriggerVisibility`) is already direction-agnostic, so no algorithm changed — only the flex direction, the `+` menu's `align`, and the send-hint's `justify`.
- Four surfaces move together, or the mirror reads as half-applied: the mobile bar (`editor-action-bar.tsx`), the desktop bar (`composer-action-bar.tsx`), the fullscreen editor's FAB cluster (`message-composer.tsx:977`, `right-4` → `left-4` plus a reversed drawer so it still expands away from the edge), and the send hint.
- The drafts/schedule pickers read the preference themselves via `useComposerActionSide()` rather than taking a prop — they are built by the hosts (stream panel, timeline, board) and handed to the bar as opaque nodes, so the bar cannot reach their `PopoverContent align`. A hook over threading a prop through three hosts.
- Nested under `accessibility` over a top-level key: `flattenUpdates` already walks that sub-object generically, so it skips the `simpleKeys` array in `service.ts` — the list that silently drops a key when you forget it. Storage is the existing `user_preference_overrides` JSONB table, so **no migration and no column**.
- Account-scoped, not device-scoped, and honored on desktop as well as mobile. Handedness is a property of the person, not the screen; a device-scoped copy (the `call-prefs-store.ts` pattern) would make a left-handed user set it twice, and a mobile-only toggle would visibly do nothing in the settings dialog on the device most likely to be opening it. Kris's call.

**Deliberately not mirrored.** The preference reaches the message composer only. `EditorActionBar`'s seven other mounts (message edit forms, scheduled edit, persona editor, stream description, AI settings) keep the default `side="right"`, as do the other right-anchored mobile surfaces — sidebar swipe direction, swipe-to-quote, toast corner, call dock. The sidebar one in particular collides with the OS back-gesture zone (`use-sidebar-swipe.ts:4`) and wants its own decision, not this PR's.

## Files

| File | Change |
| ---- | ---- |
| `packages/types/src/preferences.ts` | `COMPOSER_ACTION_SIDE_OPTIONS`, field on `AccessibilityPreferences`, `"right"` default |
| `apps/backend/.../user-preferences/handlers.ts` | `composerActionSide` in the accessibility Zod object (INV-55) |
| `apps/frontend/src/hooks/use-composer-action-side.ts` | **new** — `useComposerActionSide()` + `composerPopoverAlign()` |
| `.../editor/editor-action-bar.tsx` | `side` prop; mirrors the row |
| `.../composer/composer-action-bar.tsx` | `side` prop; mirrors the row, flips the `+` menu `align` |
| `.../composer/message-composer.tsx` | Reads the preference; mirrors the trailing cluster, FAB cluster, send hint |
| `.../composer/{stashed-drafts,scheduled-messages}-picker.tsx` | Popover `align` follows the trigger's edge |
| `.../settings/accessibility-settings.tsx` | "Composer actions" radio section; hand-inlined defaults replaced with `DEFAULT_ACCESSIBILITY` (INV-33) |
| `.../settings/tab-config.ts` | Tab description + `left-handed`/`handedness`/`reach` keywords for the palette |

## Test plan

- [x] `bun run test` — backend 3735 unit + 371 e2e pass
- [x] Frontend composer/editor/settings suites — 524 pass, post-rebase
- [x] `bun run typecheck` — all 15 workspaces clean
- [x] `bun run lint` — clean
- [x] New tests verified non-vacuous: neutralizing the mirror fails the `flex-row-reverse` assertions, hardcoding `align="start"` fails the overflow-menu test
- [x] Live on `dev:test` at 390px and 1280px — `PATCH …/preferences` round-trips `composerActionSide: "left"`, and all four surfaces mirror ([mobile](https://seer.build/ws_vbyzjvdg6g/i/img_e9mbk70gvq/leftie-03-composer-left.webp), [desktop](https://seer.build/ws_vbyzjvdg6g/i/img_z1y21hmgzz/leftie-04-desktop-left.webp), [fullscreen FAB](https://seer.build/ws_vbyzjvdg6g/i/img_ykc0azqaed/leftie-07-fullscreen-fab-left.webp), [settings](https://seer.build/ws_vbyzjvdg6g/i/img_y6vq4b0885/leftie-05-settings-accessibility.webp); [before](https://seer.build/ws_vbyzjvdg6g/i/img_2h5ayapvq9/leftie-02-composer-right.webp))
- [ ] Full frontend suite (5154 tests) — 3 timeouts under parallel load in `persona-editor` / `sidebar-editor`, all passing in isolation. A clean `origin/main` tree fails 2 the same way, with the failing set differing per run, so this is pre-existing load flake and not from this branch.

One trade-off worth a reviewer's eye: `flex-row-reverse` reverses visual order without reversing DOM order, so tab order runs right-to-left through the mirrored row. Each control stays individually reachable and the row is a set of independent icon buttons with no meaningful reading sequence, which is why this is the same mechanism RTL layouts use — but if you'd rather reverse the JSX, say so and I'll swap it.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775483&installation_model_id=20758&pr_number=1614&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1614&signature=22f07161750334037947f36fef8788caf66b1b0f0aefbb0e0e83fd7bc304e9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->