### PR TITLE
fix(composer): mirror the collapsed row and the desktop format hint

### DIFF
--- a/apps/frontend/src/components/composer/composer-action-bar.test.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.test.tsx
@@ -170,6 +170,18 @@ describe("action side", () => {
     expect(renderBar("left")).toHaveClass("flex-row-reverse")
   })
 
+  it("aligns the format hint to the mirrored far edge", () => {
+    // The hint span is `flex-1`, so it spans the free width; without an
+    // alignment flip its text hugs Send instead of the opposite edge.
+    renderBar("left")
+    expect(screen.getByText("Select text to format")).toHaveClass("text-right")
+  })
+
+  it("leaves the format hint at the leading edge by default", () => {
+    renderBar()
+    expect(screen.getByText("Select text to format")).not.toHaveClass("text-right")
+  })
+
   it("anchors the overflow menu to the edge the '+' trigger moved to", async () => {
     // 170px folds every collapsible action, so the "+" trigger renders.
     vi.spyOn(elementWidthModule, "useElementWidth").mockReturnValue(170)

--- a/apps/frontend/src/components/composer/composer-action-bar.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.tsx
@@ -256,8 +256,14 @@ export function ComposerActionBar({
         </>
       ) : (
         // truncate, never wrap: a second line grows the bar and shifts the
-        // composer (INV-21).
-        <span className="text-[11px] text-muted-foreground flex-1 truncate select-none pointer-events-none">
+        // composer (INV-21). The span spans the free width, so its text needs
+        // aligning to the far edge or the mirror leaves it hugging Send.
+        <span
+          className={cn(
+            "text-[11px] text-muted-foreground flex-1 truncate select-none pointer-events-none",
+            mirrored && "text-right"
+          )}
+        >
           Select text to format
         </span>
       )}

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -9,6 +9,7 @@ import type { CachedDraft } from "@/hooks"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import type { JSONContent } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
+import * as contextsModule from "@/contexts"
 import * as editorModule from "@/components/editor"
 import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
@@ -367,6 +368,29 @@ describe("MessageComposer", () => {
       render(<MessageComposer {...defaultProps} pendingAttachments={[]} />)
 
       expect(screen.queryByText(/\.txt$/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe("collapsed composer action side", () => {
+    // The collapsed row renders its own Send button rather than going through
+    // EditorActionBar (which this suite mocks), so it needs mirroring of its
+    // own — it was the one surface the original change missed.
+    function collapsedRow(side: "left" | "right") {
+      isMobileMockValue = true
+      vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
+        preferences: { accessibility: { composerActionSide: side } },
+      } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+
+      render(<MessageComposer {...defaultProps} placeholder="Write a reply..." />)
+      return screen.getByText("Write a reply...").parentElement
+    }
+
+    it("keeps Send trailing the preview by default", () => {
+      expect(collapsedRow("right")).not.toHaveClass("flex-row-reverse")
+    })
+
+    it("mirrors so Send leads the preview", () => {
+      expect(collapsedRow("left")).toHaveClass("flex-row-reverse")
     })
   })
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -1234,7 +1234,13 @@ export function MessageComposer({
               }}
             >
               {isMobile && !mobileChromeOpen && (
-                <div className={cn(COLLAPSED_COMPOSER_ROW, "text-sm select-none pointer-events-none")}>
+                <div
+                  className={cn(
+                    COLLAPSED_COMPOSER_ROW,
+                    "text-sm select-none pointer-events-none",
+                    mirrored && "flex-row-reverse"
+                  )}
+                >
                   <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
                   <div className="pointer-events-auto">{sendButton}</div>
                 </div>


### PR DESCRIPTION
## Problem

Two composer surfaces #1614 left unmirrored, both reported by Kris against the shipped feature:

1. The mobile **collapsed/unfocused** composer row keeps Send on the right until the composer opens. That row renders its own Send button rather than going through `EditorActionBar`, so the mirror never reached it — and it is the state a left-handed user actually taps first.
2. On desktop the `Select text to format` hint sits next to Send instead of the far edge, so the mirrored bar is not a true mirror. The hint is a `flex-1` span: reversing the row moves the span, but `flex-row-reverse` does not flip text alignment inside it, so the text stays flush against the span's leading edge — which after the reverse is the edge next to Send.

## Solution

- `message-composer.tsx` — the collapsed row takes `flex-row-reverse` when mirrored, so Send leads the preview.
- `composer-action-bar.tsx` — the hint span takes `text-right` when mirrored.

The collapsed row's **preview text stays left-aligned deliberately.** It is `truncate`d, and `text-overflow: ellipsis` only renders at the line's end edge — right-aligning it would push the overflow off the start and clip the text with no ellipsis, trading a cosmetic asymmetry for a real truncation bug. The short, non-overflowing format hint has no such constraint, which is why only it gets `text-right`.

Also swept every remaining sidedness token across the nine composer/editor files. Two asymmetries were found and deliberately left: `CollapsedComposerBar` (the board/thread resting affordance — it has no Send button, so there is nothing to bring into reach, and it renders on desktop board surfaces too) and the mobile table hint's `self-start` (which if anything lands better mirrored, since it now sits over the `Aa` button it refers to). Everything else is either already conditional or reversed by its container.

## Test plan

- [x] Frontend composer/editor/settings suites — 530 pass
- [x] `bun run typecheck` — all 15 workspaces clean; `bun run lint` clean via pre-commit
- [x] Both new tests verified non-vacuous — neutralizing each fix fails its own test and nothing else
- [x] Live on `dev:test` with the preference set to `left`: [mobile collapsed](https://seer.build/ws_vbyzjvdg6g/i/img_5tyj1xq6q7/leftie-10-mobile-collapsed-left.webp) (Send now leads the draft preview), [desktop hint](https://seer.build/ws_vbyzjvdg6g/i/img_vs1y757dc5/leftie-11-desktop-hint-left.webp) (hint now flush to the far edge)

Follows #1614.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787778860&installation_model_id=20758&pr_number=1615&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1615&signature=9d6507dac0f1804aff0cb7279e8a504a6ea677377132c8d13a1e909d507a9ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->