### PR TITLE
fix(composer): copy block/mark styling only when the selection includes its boundary

### DIFF
--- a/apps/frontend/src/components/editor/clipboard-copy.test.ts
+++ b/apps/frontend/src/components/editor/clipboard-copy.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@tiptap/react"
+import { NodeSelection } from "@tiptap/pm/state"
+import { createEditorExtensions } from "./editor-extensions"
+import { parseMarkdown } from "./editor-markdown"
+import { serializeClipboardSlice } from "./clipboard-copy"
+
+function createTestEditor(content: string | JSONContent) {
+  const extensions = createEditorExtensions({
+    placeholder: "Type a message...",
+    mentionSuggestion: {
+      items: () => [],
+      render: () => ({ onStart: () => {}, onUpdate: () => {}, onExit: () => {}, onKeyDown: () => false }),
+    },
+  })
+
+  return new Editor({
+    element: document.createElement("div"),
+    extensions,
+    content:
+      typeof content === "string"
+        ? parseMarkdown(
+            content,
+            () => "user",
+            () => null
+          )
+        : content,
+  })
+}
+
+/** Absolute positions of a literal run of text inside the document. */
+function findText(editor: Editor, needle: string): { from: number; to: number } {
+  let found: { from: number; to: number } | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found) return false
+    if (!node.isText) return true
+    const index = (node.text ?? "").indexOf(needle)
+    if (index === -1) return true
+    found = { from: pos + index, to: pos + index + needle.length }
+    return false
+  })
+  if (!found) throw new Error(`Text not found in editor: ${needle}`)
+  return found
+}
+
+/** What the editor writes to `text/plain` when the given run is copied. */
+function copySelection(editor: Editor, needle: string): string {
+  editor.commands.setTextSelection(findText(editor, needle))
+  return serializeClipboardSlice(editor.state.selection.content(), editor.view)
+}
+
+function copyEverything(editor: Editor): string {
+  editor.commands.selectAll()
+  return serializeClipboardSlice(editor.state.selection.content(), editor.view)
+}
+
+describe("serializeClipboardSlice", () => {
+  describe("block styling only when the selection contains a boundary", () => {
+    it("copies text taken from inside a code block bare", () => {
+      const editor = createTestEditor("```ts\nconst apiKey = 1\n```")
+
+      expect(copySelection(editor, "apiKey")).toBe("apiKey")
+    })
+
+    it("copies multiple lines taken from inside a code block bare", () => {
+      const editor = createTestEditor("```ts\nconst a = 1\nconst b = 2\n```")
+
+      expect(copySelection(editor, "const a = 1\nconst b = 2")).toBe("const a = 1\nconst b = 2")
+    })
+
+    it("leaves markdown inside a code block untouched", () => {
+      const editor = createTestEditor("```plaintext\n> Hi there\n```")
+
+      expect(copySelection(editor, "there")).toBe("there")
+    })
+
+    it("keeps the fence when the whole block is selected across its boundaries", () => {
+      const editor = createTestEditor("```ts\nconst apiKey = 1\n```")
+
+      expect(copyEverything(editor)).toBe("```ts\nconst apiKey = 1\n```")
+    })
+
+    it("copies text taken from inside a blockquote without the quote marker", () => {
+      const editor = createTestEditor("> quoted line")
+
+      expect(copySelection(editor, "quoted")).toBe("quoted")
+    })
+
+    it("keeps quote markers when the whole quote is selected across its boundaries", () => {
+      const editor = createTestEditor("> quoted line")
+
+      expect(copyEverything(editor)).toBe("> quoted line")
+    })
+
+    it("drops the quote wrapper but keeps paragraph structure across a multi-paragraph quote", () => {
+      const editor = createTestEditor({
+        type: "doc",
+        content: [
+          {
+            type: "blockquote",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "first line" }] },
+              { type: "paragraph", content: [{ type: "text", text: "second line" }] },
+            ],
+          },
+        ],
+      })
+
+      editor.commands.setTextSelection({
+        from: findText(editor, "first").from,
+        to: findText(editor, "second").to,
+      })
+
+      expect(serializeClipboardSlice(editor.state.selection.content(), editor.view)).toBe("first line\n\nsecond")
+    })
+
+    it("copies text taken from inside a heading without the hashes", () => {
+      const editor = createTestEditor("## A heading")
+
+      expect(copySelection(editor, "heading")).toBe("heading")
+    })
+
+    it("copies text taken from inside a list item without the bullet", () => {
+      const editor = createTestEditor("- first item\n- second item")
+
+      expect(copySelection(editor, "first")).toBe("first")
+    })
+
+    it("keeps bullets when the list is selected across its boundaries", () => {
+      const editor = createTestEditor("- first item\n- second item")
+
+      expect(copyEverything(editor)).toBe("- first item\n- second item")
+    })
+
+    it("keeps block styling when the selection crosses into a sibling block", () => {
+      const editor = createTestEditor("```ts\nconst a = 1\n```\n\ntail paragraph")
+
+      editor.commands.setTextSelection({
+        from: findText(editor, "const a").from,
+        to: findText(editor, "tail").to,
+      })
+
+      expect(serializeClipboardSlice(editor.state.selection.content(), editor.view)).toBe(
+        "```ts\nconst a = 1\n```\n\ntail"
+      )
+    })
+  })
+
+  describe("inline marks only when the selection contains the run's boundaries", () => {
+    it("copies part of a bold run without the bold markers", () => {
+      const editor = createTestEditor("**bold words** tail")
+
+      expect(copySelection(editor, "words")).toBe("words")
+    })
+
+    it("copies a whole bold run with the bold markers", () => {
+      const editor = createTestEditor("**bold words** tail")
+
+      expect(copySelection(editor, "bold words")).toBe("**bold words**")
+    })
+
+    it("copies part of an italic run without the italic markers", () => {
+      const editor = createTestEditor("*Example a* tail")
+
+      expect(copySelection(editor, "a")).toBe("a")
+    })
+
+    it("keeps marks on runs that sit entirely inside the selection", () => {
+      const editor = createTestEditor("lead **bold** trail")
+
+      editor.commands.setTextSelection({
+        from: findText(editor, "ead").from,
+        to: findText(editor, "trai").to,
+      })
+
+      expect(serializeClipboardSlice(editor.state.selection.content(), editor.view)).toBe("ead **bold** trai")
+    })
+
+    it("trims only the mark that straddles the edge", () => {
+      const editor = createTestEditor("**bold `code` words** tail")
+
+      expect(copySelection(editor, "words")).toBe("words")
+      expect(copySelection(editor, "code")).toBe("`code`")
+    })
+  })
+
+  describe("chips", () => {
+    it("serializes an inline atom selected on its own", () => {
+      const editor = createTestEditor("[@alice](user:usr_01ABC) said hi")
+      let mentionPos = -1
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === "mention") mentionPos = pos
+        return true
+      })
+      expect(mentionPos).toBeGreaterThanOrEqual(0)
+
+      editor.view.dispatch(editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, mentionPos)))
+
+      expect(serializeClipboardSlice(editor.state.selection.content(), editor.view)).toBe("[@alice](user:usr_01ABC)")
+    })
+
+    it("keeps chips when the whole message is copied", () => {
+      const editor = createTestEditor("[@alice](user:usr_01ABC) said hi")
+
+      expect(copyEverything(editor)).toBe("[@alice](user:usr_01ABC) said hi")
+    })
+  })
+})

--- a/apps/frontend/src/components/editor/clipboard-copy.test.ts
+++ b/apps/frontend/src/components/editor/clipboard-copy.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { Editor } from "@tiptap/core"
 import type { JSONContent } from "@tiptap/react"
 import { NodeSelection } from "@tiptap/pm/state"
 import { createEditorExtensions } from "./editor-extensions"
 import { parseMarkdown } from "./editor-markdown"
 import { serializeClipboardSlice } from "./clipboard-copy"
+
+/**
+ * Editors are torn down after each test: a live view keeps a DOMObserver
+ * timeout that fires after the test environment is gone, which vitest reports
+ * as an uncaught `document is not defined` and fails the run.
+ */
+const openEditors: Editor[] = []
+
+afterEach(() => {
+  while (openEditors.length > 0) {
+    openEditors.pop()?.destroy()
+  }
+})
 
 function createTestEditor(content: string | JSONContent) {
   const extensions = createEditorExtensions({
@@ -15,7 +28,7 @@ function createTestEditor(content: string | JSONContent) {
     },
   })
 
-  return new Editor({
+  const editor = new Editor({
     element: document.createElement("div"),
     extensions,
     content:
@@ -27,6 +40,8 @@ function createTestEditor(content: string | JSONContent) {
           )
         : content,
   })
+  openEditors.push(editor)
+  return editor
 }
 
 /** Absolute positions of a literal run of text inside the document. */

--- a/apps/frontend/src/components/editor/clipboard-copy.ts
+++ b/apps/frontend/src/components/editor/clipboard-copy.ts
@@ -1,0 +1,129 @@
+/**
+ * Clipboard `text/plain` serializer for editor copy/cut.
+ *
+ * ProseMirror's default text serialization is bare `textContent` — code
+ * fences, quote markers, list bullets, and chip references (mentions, quote
+ * replies, shared messages) all vanish, so pasting back can never restore
+ * them. Markdown is the editor's canonical text form and the paste path
+ * parses it, closing the copy → paste roundtrip.
+ *
+ * Styling is written only when the selection actually contains the boundary
+ * that produces it: text taken from inside a code block, quote, list item or
+ * heading copies bare, and a mark run the selection cuts into copies
+ * unmarked. Selecting a whole block (or across its edges) still copies the
+ * block form. An in-app paste is unaffected either way — it restores the
+ * exact document from the `data-pm-slice` HTML flavour — so this only
+ * governs plain-text targets: another app, a code block (ProseMirror pastes
+ * text into `code` blocks), and paste-without-formatting.
+ */
+import { Fragment, type Mark, type Node as PMNode, type Slice } from "@tiptap/pm/model"
+import { TextSelection } from "@tiptap/pm/state"
+import type { EditorView } from "@tiptap/pm/view"
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+
+export function serializeClipboardSlice(slice: Slice, view?: EditorView): string {
+  if (slice.content.size === 0) return ""
+
+  // A NodeSelection of an inline atom (a chip) yields a slice whose top level
+  // is inline content; the serializer expects blocks, so wrap it.
+  if (slice.content.firstChild?.isInline) {
+    return serializeBlocks([{ type: "paragraph", content: slice.content.toJSON() as JSONContent[] }])
+  }
+
+  const unwrapped = dropUnselectedBlocks(slice)
+  if (typeof unwrapped === "string") return unwrapped
+
+  return serializeBlocks(dropMarkRunsCutBySelection(unwrapped, view).toJSON() as JSONContent[] | null)
+}
+
+function serializeBlocks(content: JSONContent[] | null): string {
+  if (!content || content.length === 0) return ""
+  return serializeToMarkdown({ type: "doc", content })
+}
+
+/**
+ * Peel the wrappers the selection never entered. A slice open at both ends
+ * sits strictly inside its outermost block, so that block's markdown (fence,
+ * `>`, bullet, `#`) belongs to text the user did not copy. Returns a string
+ * when the innermost wrapper is a code block: its text carries no inline
+ * markup, so it is the copy verbatim, escaping included.
+ */
+function dropUnselectedBlocks(slice: Slice): Fragment | string {
+  let content = slice.content
+  let open = Math.min(slice.openStart, slice.openEnd)
+
+  while (open > 0 && content.childCount === 1 && content.firstChild) {
+    const only = content.firstChild
+    if (only.isTextblock) {
+      if (only.type.spec.code) return only.textContent
+      return Fragment.from(only.type.schema.nodes.paragraph.create(null, only.content))
+    }
+    content = only.content
+    open -= 1
+  }
+
+  return content
+}
+
+/**
+ * Drop marks whose run continues past the selection edge — the `**` the user
+ * left behind is not theirs to copy. A run fully inside the selection keeps
+ * its marks; only the leading and trailing runs are trimmed, and only for the
+ * marks that actually straddle the edge.
+ */
+function dropMarkRunsCutBySelection(content: Fragment, view?: EditorView): Fragment {
+  const selection = view?.state.selection
+  if (!(selection instanceof TextSelection)) return content
+
+  const before = selection.$from.nodeBefore
+  const after = selection.$to.nodeAfter
+  const cutAtStart = before?.isText ? before.marks : []
+  const cutAtEnd = after?.isText ? after.marks : []
+  if (cutAtStart.length === 0 && cutAtEnd.length === 0) return content
+
+  return dropEdgeMarks(content, cutAtStart, cutAtEnd, true, true)
+}
+
+function dropEdgeMarks(
+  fragment: Fragment,
+  cutAtStart: readonly Mark[],
+  cutAtEnd: readonly Mark[],
+  atStart: boolean,
+  atEnd: boolean
+): Fragment {
+  const children: PMNode[] = []
+  fragment.forEach((child, _offset, index) => {
+    const isFirst = atStart && index === 0
+    const isLast = atEnd && index === fragment.childCount - 1
+
+    if (child.isTextblock) {
+      children.push(child.copy(dropInlineEdgeMarks(child.content, isFirst ? cutAtStart : [], isLast ? cutAtEnd : [])))
+      return
+    }
+    if (child.isLeaf) {
+      children.push(child)
+      return
+    }
+    children.push(child.copy(dropEdgeMarks(child.content, cutAtStart, cutAtEnd, isFirst, isLast)))
+  })
+  return Fragment.fromArray(children)
+}
+
+function dropInlineEdgeMarks(content: Fragment, cutAtStart: readonly Mark[], cutAtEnd: readonly Mark[]): Fragment {
+  const nodes: PMNode[] = []
+  content.forEach((node) => nodes.push(node))
+
+  for (const mark of cutAtStart) {
+    for (let index = 0; index < nodes.length && mark.isInSet(nodes[index].marks); index++) {
+      nodes[index] = nodes[index].mark(mark.type.removeFromSet(nodes[index].marks))
+    }
+  }
+  for (const mark of cutAtEnd) {
+    for (let index = nodes.length - 1; index >= 0 && mark.isInSet(nodes[index].marks); index--) {
+      nodes[index] = nodes[index].mark(mark.type.removeFromSet(nodes[index].marks))
+    }
+  }
+
+  return Fragment.fromArray(nodes)
+}

--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -30,10 +30,10 @@ import { EditorBehaviors, handleLinkToolbarAction, isSuggestionActive } from "./
 import {
   serializeToMarkdown,
   parseMarkdown,
-  serializeClipboardSlice,
   isProseMirrorClipboardEvent,
   type MentionTypeLookup,
 } from "./editor-markdown"
+import { serializeClipboardSlice } from "./clipboard-copy"
 import { useMentionSuggestion, useChannelSuggestion, useEmojiSuggestion } from "./triggers"
 import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -9,9 +9,8 @@
  * dispatching a slash command). The parsers stay unified so the two sides
  * can't drift.
  */
-import { parseMarkdown, serializeToMarkdown } from "@threa/prosemirror"
+import { parseMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
-import type { Slice } from "@tiptap/pm/model"
 
 export {
   serializeToMarkdown,
@@ -29,23 +28,6 @@ export {
  * carry no reference and must not resolve to slugs, so every interactive parse
  * flag is off. Shared by every prompt-authoring editor so they can't drift.
  */
-/**
- * Clipboard `text/plain` serializer for editor copy/cut. The default
- * ProseMirror text serialization is bare `textContent` — code fences, quote
- * markers, list bullets, and chip references (mentions, quote replies, shared
- * messages) all vanish, so pasting back can never restore them. Markdown is
- * the editor's canonical text form and the paste path parses it, closing the
- * copy → paste roundtrip.
- */
-export function serializeClipboardSlice(slice: Slice): string {
-  const content = slice.content.toJSON() as JSONContent[] | null
-  if (!content) return ""
-  // A NodeSelection of an inline atom (a chip) yields a slice whose top level
-  // is inline content; the serializer expects blocks, so wrap it.
-  const blocks = slice.content.firstChild?.isInline ? [{ type: "paragraph", content }] : content
-  return serializeToMarkdown({ type: "doc", content: blocks })
-}
-
 /**
  * Content copied from a ProseMirror editor carries a `data-pm-slice` HTML
  * payload that restores the exact document, chips included. Paste handlers

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -12,10 +12,10 @@ import { EditorToolbar } from "./editor-toolbar"
 import {
   serializeToMarkdown,
   parseMarkdown,
-  serializeClipboardSlice,
   isProseMirrorClipboardEvent,
   type MentionTypeLookup,
 } from "./editor-markdown"
+import { serializeClipboardSlice } from "./clipboard-copy"
 import {
   useMentionSuggestion,
   useChannelSuggestion,

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -70,6 +70,17 @@ async function pastePlainText(page: Page, text: string): Promise<void> {
   }, text)
 }
 
+/** Paste into the composer at wherever the caret already is, without clicking it first. */
+async function pasteAtCaret(page: Page, text: string): Promise<void> {
+  await page.evaluate((value) => {
+    const editor = document.querySelector("main [contenteditable='true']")
+    if (!editor) throw new Error("Editor not found")
+    const clipboardData = new DataTransfer()
+    clipboardData.setData("text/plain", value)
+    editor.dispatchEvent(new ClipboardEvent("paste", { clipboardData, bubbles: true, cancelable: true }))
+  }, text)
+}
+
 /**
  * Fire a synthetic copy/cut on the editor selection and return what the
  * editor wrote to `text/plain` — i.e. the output of the composer's
@@ -257,5 +268,66 @@ test.describe("Composer copy/paste roundtrip", () => {
     // Paste the cut markdown back — the full document must come back.
     await pastePlainText(page, cut)
     await expectEditorHasAllStyles(page)
+  })
+
+  /**
+   * Copying from strictly inside a block must not carry that block's own
+   * markdown: the fence/quote marker/bullet belongs to text the selection
+   * never touched, and pasting it back into the block wrote it out literally.
+   */
+  test("copying from inside a code block copies bare and pastes back without a fence", async ({ page }) => {
+    await pastePlainText(page, "```plaintext\n> Hi there\n```")
+    const editor = composerEditor(page)
+    await expect(editor.locator("pre code")).toHaveText("> Hi there")
+
+    let copied = ""
+    await expect(async () => {
+      await selectEditorText(page, "there")
+      copied = await captureEditorClipboard(page, "copy")
+      expect(copied).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(copied).toBe("there")
+
+    // Collapse to the end of the copied run — still inside the code block —
+    // and paste there, the move the fence used to break.
+    await page.keyboard.press("ArrowRight")
+    await pasteAtCaret(page, copied)
+
+    await expect(editor.locator("pre code")).toHaveText("> Hi therethere")
+    await expect(editor.locator("pre")).toHaveCount(1)
+  })
+
+  test("copying from inside a quote copies bare", async ({ page }) => {
+    await pastePlainText(page, "> quoted line")
+    await expect(composerEditor(page).locator("blockquote")).toContainText("quoted line")
+
+    let copied = ""
+    await expect(async () => {
+      await selectEditorText(page, "quoted")
+      copied = await captureEditorClipboard(page, "copy")
+      expect(copied).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(copied).toBe("quoted")
+  })
+
+  test("copying part of a mark run drops the mark, the whole run keeps it", async ({ page }) => {
+    await pastePlainText(page, "**bold words** tail")
+    await expect(composerEditor(page).locator("strong")).toHaveText("bold words")
+
+    let partial = ""
+    await expect(async () => {
+      await selectEditorText(page, "words")
+      partial = await captureEditorClipboard(page, "copy")
+      expect(partial).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(partial).toBe("words")
+
+    let whole = ""
+    await expect(async () => {
+      await selectEditorText(page, "bold words")
+      whole = await captureEditorClipboard(page, "copy")
+      expect(whole).not.toBe("")
+    }).toPass({ timeout: 10000 })
+    expect(whole).toBe("**bold words**")
   })
 })

--- a/tests/browser/composer-copy-paste-roundtrip.spec.ts
+++ b/tests/browser/composer-copy-paste-roundtrip.spec.ts
@@ -119,6 +119,17 @@ async function selectEditorText(page: Page, text: string): Promise<void> {
   }, text)
 }
 
+/**
+ * Collapse the selection to its end and wait for it to take. Pasting while a
+ * selection still stands replaces it, so a test that means to paste *after* the
+ * copied run has to land the caret first — `ArrowRight` races the DOM-range
+ * selection ProseMirror is still reading.
+ */
+async function collapseSelectionToEnd(page: Page): Promise<void> {
+  await page.evaluate(() => window.getSelection()?.collapseToEnd())
+  await page.waitForFunction(() => window.getSelection()?.isCollapsed === true)
+}
+
 /** Every style from {@link buildCanonicalMarkdown}, asserted against the live editor DOM. */
 async function expectEditorHasAllStyles(page: Page): Promise<void> {
   const editor = composerEditor(page)
@@ -288,9 +299,9 @@ test.describe("Composer copy/paste roundtrip", () => {
     }).toPass({ timeout: 10000 })
     expect(copied).toBe("there")
 
-    // Collapse to the end of the copied run — still inside the code block —
-    // and paste there, the move the fence used to break.
-    await page.keyboard.press("ArrowRight")
+    // Paste at the end of the copied run — still inside the code block — the
+    // move the fence used to break.
+    await collapseSelectionToEnd(page)
     await pasteAtCaret(page, copied)
 
     await expect(editor.locator("pre code")).toHaveText("> Hi therethere")


### PR DESCRIPTION
## Problem

Copying anything from strictly inside a multi-line block carried that block's own markdown. `serializeClipboardSlice` (`editor-markdown.ts`) serialized the raw slice, and a selection made inside a block arrives wrapped in it — `doc.slice` returns the code block / blockquote / list item with `openStart = openEnd > 0`. So copying `there` out of a code block put ```` ```plaintext\nthere\n``` ```` on `text/plain`, and pasting it one line down inside the same block wrote the fence out literally: ProseMirror ignores the HTML flavour and inserts `text/plain` when the caret is in a `code` node. Same shape for `>` quote markers, `-` bullets and `#` hashes.

The same eagerness applied to marks: copying `a` out of an italic `Example a` produced `*a*`, which is what paste-without-formatting (cmd+shift+v) then inserted verbatim — it takes `text/plain` and does not parse markdown.

## Solution

Styling is written only when the selection contains the boundary that produces it — Kris's rule: "only copy the style if it includes the boundary".

- `dropUnselectedBlocks` peels wrappers while `min(openStart, openEnd) > 0` and the level has a single child, so a selection strictly inside a block copies bare. A code block short-circuits to `node.textContent` — verbatim, no markdown escaping.
- `dropMarkRunsCutBySelection` drops marks that continue past the selection edge (`$from.nodeBefore` / `$to.nodeAfter` carry them), trimming only the leading/trailing run. A run entirely inside the selection keeps its marks.
- Unchanged: select-all, a whole-block selection (triple-click makes a `NodeSelection`, `openStart = 0`), and any selection crossing a block edge — those include a boundary, so they keep the block form. In-app paste is unaffected either way; it restores the exact document from the `data-pm-slice` HTML flavour, chips included.
- New file over growing `editor-markdown.ts` — that file is a thin re-export shim for `@threa/prosemirror`, and this is ~90 lines of selection logic with its own test surface.

Residual, deliberate: copying a *whole* bold word and pasting with cmd+shift+v still yields `**bold**`. The boundary is in the selection, so the rule says keep it.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/clipboard-copy.ts` | **new** — boundary-aware `clipboardTextSerializer` |
| `apps/frontend/src/components/editor/clipboard-copy.test.ts` | **new** — 18 tests driving a real editor + view |
| `apps/frontend/src/components/editor/editor-markdown.ts` | `serializeClipboardSlice` moved out |
| `apps/frontend/src/components/editor/rich-editor.tsx` | import moved |
| `apps/frontend/src/components/editor/document-editor-modal.tsx` | import moved |
| `tests/browser/composer-copy-paste-roundtrip.spec.ts` | 3 browser tests incl. the reported repro |

## Test plan

- [x] `vitest src/components/editor` — 405 pass (28 files)
- [x] `playwright tests/browser/composer-copy-paste-roundtrip.spec.ts` — 5 pass, including the 2 pre-existing roundtrip tests
- [x] Both guards neutralised and re-run: 7 + 3 unit failures, 3 browser failures — the tests can fail
- [x] `bun run lint`, monorepo typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787780503&installation_model_id=20758&pr_number=1617&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1617&signature=b86f357e5fa2ab45476263b03b6abdc725b8f062e7d0ecedc430ccd368a8afc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->