### PR TITLE
fix(calls): sit the idle call chips above the real composer on a phone

### DIFF
--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -73,15 +73,71 @@ function Harness({
   )
 }
 
+/** Manual ResizeObserver that can fire for one specific observed element. */
+function installTargetedResizeObserver(): {
+  fireFor: (target: Element, blockSize: number) => void
+  restore: () => void
+} {
+  const original = global.ResizeObserver
+  const callbacks = new Map<Element, ResizeCallback>()
+  class TargetedResizeObserver {
+    constructor(private readonly cb: ResizeCallback) {}
+    observe(target: Element) {
+      callbacks.set(target, this.cb)
+    }
+    unobserve(target: Element) {
+      callbacks.delete(target)
+    }
+    disconnect() {
+      for (const [target, cb] of callbacks) if (cb === this.cb) callbacks.delete(target)
+    }
+  }
+  global.ResizeObserver = TargetedResizeObserver as unknown as typeof ResizeObserver
+  return {
+    fireFor: (target, blockSize) =>
+      callbacks.get(target)?.(
+        [{ borderBoxSize: [{ blockSize, inlineSize: 0 }] }] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver
+      ),
+    restore: () => {
+      global.ResizeObserver = original
+    },
+  }
+}
+
+/** Main timeline + thread panel, the two editor zones that can coexist. */
+function TwoZones({ showPanel }: { showPanel: boolean }) {
+  const mainRef = useComposerHeightPublish()
+  const panelRef = useComposerHeightPublish()
+  return (
+    <>
+      <div data-editor-zone="main">
+        <div data-testid="main-composer" ref={mainRef} />
+      </div>
+      {showPanel && (
+        <div data-editor-zone="panel">
+          <div data-testid="panel-composer" ref={panelRef} />
+        </div>
+      )}
+    </>
+  )
+}
+
+function rootHeight(): string {
+  return document.documentElement.style.getPropertyValue("--composer-height")
+}
+
 describe("useComposerHeightPublish", () => {
   let restoreRect: () => void
 
   beforeEach(() => {
     restoreRect = pinInitialHeight(80)
+    document.documentElement.style.removeProperty("--composer-height")
   })
 
   afterEach(() => {
     restoreRect()
+    document.documentElement.style.removeProperty("--composer-height")
   })
 
   it("publishes the measured height as --composer-height on the editor zone", () => {
@@ -225,6 +281,48 @@ describe("useComposerHeightPublish", () => {
       ro.fire(160)
       expect(onHeightChange).toHaveBeenCalledTimes(2)
       expect(onHeightChange).toHaveBeenLastCalledWith(160, { initial: false })
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("mirrors the live height onto :root, replacing the boot approximation", () => {
+    const ro = installManualResizeObserver()
+    try {
+      // What `applyPersistedComposerHeight` leaves at boot: a previous session's
+      // long draft. Surfaces outside every editor zone (the call dock's chips,
+      // the incoming ring) read this, so it must not survive the first measure.
+      document.documentElement.style.setProperty("--composer-height", "350px")
+      render(<Harness onHeightChange={() => {}} />)
+      expect(rootHeight()).toBe("80px")
+
+      ro.fire(132)
+      expect(rootHeight()).toBe("132px")
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("gives :root to the most recently measured zone, and to the survivor when it unmounts", () => {
+    const ro = installTargetedResizeObserver()
+    try {
+      const { getByTestId, rerender } = render(<TwoZones showPanel />)
+      const main = getByTestId("main-composer")
+      const panel = getByTestId("panel-composer")
+
+      ro.fireFor(panel, 240)
+      expect(rootHeight()).toBe("240px")
+
+      ro.fireFor(main, 96)
+      expect(rootHeight()).toBe("96px")
+
+      ro.fireFor(panel, 240)
+      expect(rootHeight()).toBe("240px")
+
+      // Panel closes: fall back to the main composer's real height, not the
+      // panel's last measurement and not the boot value.
+      rerender(<TwoZones showPanel={false} />)
+      expect(rootHeight()).toBe("96px")
     } finally {
       ro.restore()
     }

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -1,5 +1,9 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react"
-import { persistComposerHeight } from "@/lib/composer-height-storage"
+import {
+  persistComposerHeight,
+  publishComposerHeightToRoot,
+  unpublishComposerHeightFromRoot,
+} from "@/lib/composer-height-storage"
 
 interface UseComposerHeightPublishOptions {
   active?: boolean
@@ -33,7 +37,10 @@ interface UseComposerHeightPublishOptions {
  * preserving its parent component and hooks. Scrollable
  * siblings inside the same editor zone can consume the variable (e.g.
  * plain-scroll `padding-bottom`) to reserve space for the floating composer
- * pill.
+ * pill. The same measurement is mirrored to `:root` via
+ * `publishComposerHeightToRoot` for surfaces that sit outside every editor zone
+ * (the call dock's bottom-anchored chips and ring) — see that function for the
+ * multiple-zone rule.
  *
  * The first measurement runs in a layout effect (before paint) so the variable
  * and the timeline's bottom anchor can be corrected in the same frame the list
@@ -94,6 +101,7 @@ export function useComposerHeightPublish({
         return
       }
       zone.style.setProperty("--composer-height", `${px}px`)
+      publishComposerHeightToRoot(el, px)
       persistComposerHeight(px)
       // Notify on any change from the height the footer was last sized for —
       // including the initial measure when it differs from first paint (see the
@@ -120,6 +128,7 @@ export function useComposerHeightPublish({
     return () => {
       cancelAnimationFrame(retryRafId)
       ro.disconnect()
+      unpublishComposerHeightFromRoot(el)
       // Intentionally leave --composer-height set so stream navigation
       // starts with a reasonable approximation instead of falling back to 0px.
     }

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -97,6 +97,44 @@ export function applyPersistedComposerHeight(): void {
 }
 
 /**
+ * Live publishers of the global variable, in write order (a `Map` re-keyed on
+ * every write, so the last entry is the most recently measured composer).
+ */
+const rootPublishers = new Map<HTMLElement, number>()
+
+/**
+ * Mirrors a live composer measurement onto `:root`.
+ *
+ * `useComposerHeightPublish` scopes the variable to the nearest
+ * `[data-editor-zone]`, which is right for the timeline spacer but leaves the
+ * app-level fixed surfaces (the call dock's idle chips, the incoming-call ring)
+ * out of reach — they mount as siblings of the shell, so on a phone they read
+ * the boot approximation applied above for the whole session. A previous
+ * session's long draft persists ~350px and the chip then floats mid-screen.
+ *
+ * Most recent writer wins. Several editor zones can be mounted (main timeline +
+ * thread panel), but only the one the user last touched is under the dock on a
+ * phone, and it is the one that last measured. Dropping a publisher falls back
+ * to the newest survivor rather than the boot value, so closing the panel
+ * re-reveals the main composer's real height instead of a stale one.
+ */
+export function publishComposerHeightToRoot(el: HTMLElement, heightPx: number): void {
+  if (typeof document === "undefined") return
+  rootPublishers.delete(el)
+  rootPublishers.set(el, heightPx)
+  document.documentElement.style.setProperty(CSS_VAR, `${heightPx}px`)
+}
+
+export function unpublishComposerHeightFromRoot(el: HTMLElement): void {
+  if (typeof document === "undefined") return
+  if (!rootPublishers.delete(el)) return
+  let survivor: number | null = null
+  for (const px of rootPublishers.values()) survivor = px
+  if (survivor === null) return
+  document.documentElement.style.setProperty(CSS_VAR, `${survivor}px`)
+}
+
+/**
  * Persists a freshly-measured composer height for the next page load, keyed by
  * the current viewport so mobile and desktop never seed each other's fallback.
  * No-op when the value is outside the sanity window so corrupt measurements

--- a/tests/browser/calls.spec.ts
+++ b/tests/browser/calls.spec.ts
@@ -239,13 +239,38 @@ test.describe("1:1 DM calls", () => {
       await expect(b.locator(CALL_TILE)).toHaveCount(2, { timeout: 20000 })
 
       // The chip is `fixed right-4` with no left anchor and renders on the branch
-      // mobile shares, so measure it at phone width: it must stay on screen.
+      // mobile shares, so measure it at phone width: it must stay on screen, and
+      // sit just above the composer rather than floating over the timeline.
+      //
+      // Seeding `:root` reproduces the reported bug's precondition: that is where
+      // `applyPersistedComposerHeight` writes a previous session's composer height
+      // at boot, and the chip mounts outside every `[data-editor-zone]`, so it
+      // reads that value and nothing else. Seed before the resize, which makes the
+      // live composer re-measure — the correction under test.
+      await a.evaluate(() => document.documentElement.style.setProperty("--composer-height", "350px"))
       await a.setViewportSize({ width: 360, height: 740 })
       const chip = a.getByText(/moved to another device/i).locator("xpath=ancestor::div[1]")
       const box = await chip.boundingBox()
       expect(box).not.toBeNull()
       expect(box!.x).toBeGreaterThanOrEqual(0)
       expect(box!.x + box!.width).toBeLessThanOrEqual(360)
+
+      // DOCK_BOTTOM's `+ 1rem` above the real composer, measured against the
+      // composer's own box so no persisted approximation can satisfy it. Asserted
+      // as a distance from 16px so an overlap fails as loudly as a float.
+      const composer = a.locator("[data-message-composer-root]").first()
+      await expect
+        .poll(
+          async () => {
+            const chipBox = await chip.boundingBox()
+            const composerBox = await composer.boundingBox()
+            if (!chipBox || !composerBox) return Number.POSITIVE_INFINITY
+            return Math.abs(composerBox.y - (chipBox.y + chipBox.height) - 16)
+          },
+          { timeout: 5000 }
+        )
+        .toBeLessThanOrEqual(4)
+
       await expect(chip.getByRole("button", { name: "Rejoin here" })).toBeVisible()
       await expect(chip.getByRole("button", { name: "Dismiss" })).toBeVisible()
 


### PR DESCRIPTION
## Problem

Reported from an Android PWA: the "Call moved to another device" chip floated in the lower middle of the screen, over timeline content, ~370px above the bottom, instead of sitting above the composer.

`DOCK_BOTTOM` (`call-dock.tsx:26`) offsets by `var(--composer-height)` below `sm:`, but `useComposerHeightPublish` writes that variable only onto the nearest `[data-editor-zone]`. `CallDock` mounts as a sibling of `AppShell` (`workspace-layout.tsx:528`), outside every zone, so it reads the `:root` copy — written once at boot by `applyPersistedComposerHeight()` from `localStorage` and never corrected for the rest of the session. A previous session that ended with a long draft or attachment chips persists up to 400px, and the chip inherits it. `ActiveElsewhereChip` and the incoming-call ring (`RING_ABOVE_DOCK_BOTTOM`) share the constants and had the same defect.

Measured pre-fix in a real browser at 360×740 with `:root` seeded to 350px: the chip's bottom edge sat 290px above the composer's actual top (composer measured 76px). Post-fix: 16px, `DOCK_BOTTOM`'s own `+ 1rem`.

## Solution

Mirror every live measurement onto `:root`, alongside the existing zone-scoped write.

- `publishComposerHeightToRoot` / `unpublishComposerHeightFromRoot` in `composer-height-storage.ts` — the module that already owns `:root --composer-height`, so the variable keeps one writer.
- Multiple zones (main timeline + thread panel) are resolved by a write-ordered `Map<HTMLElement, number>`: most recent measurement wins. On a phone only one zone is on screen, and the one under the dock is the one the user last touched. Unpublishing falls back to the newest surviving publisher, not the boot value — closing the panel re-reveals the main composer's real height rather than the panel's last one. `active: false` (expand-to-fullscreen) already runs the cleanup, so a hidden composer drops out on its own.
- Zone-scoped consumers are unaffected: an inline style on the zone still beats the inherited `:root` value. Desktop is untouched — `MOBILE_BREAKPOINT` is 640, so `DOCK_BOTTOM`'s `sm:` branch covers exactly the non-mobile case and never reads the variable.
- Rejected: publishing from a single designated zone (wrong one is visible when the mobile thread panel is open) and measuring the composer inside the dock (a second observer, and restructuring the dock was out of scope).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/composer-height-storage.ts` | `publishComposerHeightToRoot` / `unpublishComposerHeightFromRoot` + the write-ordered publisher map |
| `apps/frontend/src/hooks/use-composer-height-publish.ts` | Mirror each measurement to `:root`; unpublish on cleanup |
| `apps/frontend/src/hooks/use-composer-height-publish.test.tsx` | Boot-value replacement + two-zone precedence/fallback |
| `tests/browser/calls.spec.ts` | Chip's gap measured against the composer's own box, with `:root` seeded stale |

## Test plan

- [x] `apps/frontend` vitest full suite — 5162 pass, 0 fail
- [x] Both new unit tests verified to fail with the `:root` mirror removed (350px stale value survives; two-zone fallback empty)
- [x] `playwright --project=calls --workers=2` — 5 pass; the takeover test fails pre-fix (290px gap vs the 16px bound) and passes post-fix
- [x] `playwright --project=chromium` composer-bottom-spacing, infinite-scroll, nested-thread-navigation, conversation-overlay — 10 pass (the other `--composer-height` consumers)
- [x] `bun run typecheck`, `bun run lint`
- [ ] Not verified on a physical Android PWA — the reproduction is the seeded `:root` value in a 360px Chromium viewport

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787780807&installation_model_id=20758&pr_number=1618&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1618&signature=b30b46ae6691c1f7e172b13270966a0a0abb6543154c6f306a7bdd122a154656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->