### PR TITLE
fix(composer): let attachment chips be copied and pasted

### DIFF
--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import { DOMParser as PMDOMParser, DOMSerializer, type Slice } from "@tiptap/pm/model"
+import { NodeSelection } from "@tiptap/pm/state"
+import { createEditorExtensions } from "./editor-extensions"
+import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
+
+const CHIP_ATTRS: AttachmentReferenceAttrs = {
+  id: "att_01ABC",
+  filename: "notes.txt",
+  mimeType: "text/plain",
+  sizeBytes: 12,
+  status: "uploaded",
+  imageIndex: null,
+  error: null,
+}
+
+function createEditorWithChip() {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "before " },
+            { type: "attachmentReference", attrs: CHIP_ATTRS },
+            { type: "text", text: " after" },
+          ],
+        },
+      ],
+    },
+  })
+}
+
+function chipPos(editor: Editor): number {
+  let pos = -1
+  editor.state.doc.descendants((node, at) => {
+    if (node.type.name === "attachmentReference") pos = at
+    return true
+  })
+  if (pos < 0) throw new Error("Chip not found")
+  return pos
+}
+
+/**
+ * The clipboard's `text/html` flavour, the one an in-app paste restores the
+ * document from. ProseMirror builds it with the schema's `renderHTML`.
+ */
+function clipboardHtml(editor: Editor, slice: Slice): string {
+  const dom = DOMSerializer.fromSchema(editor.schema).serializeFragment(slice.content)
+  const wrapper = document.createElement("div")
+  wrapper.appendChild(dom)
+  return wrapper.innerHTML
+}
+
+function pasteHtml(editor: Editor, html: string): Slice {
+  const wrapper = document.createElement("div")
+  wrapper.innerHTML = html
+  return PMDOMParser.fromSchema(editor.schema).parseSlice(wrapper)
+}
+
+describe("attachment reference clipboard roundtrip", () => {
+  it("serializes a chip selected on its own and parses it back with its attributes", () => {
+    const editor = createEditorWithChip()
+    editor.view.dispatch(editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, chipPos(editor))))
+
+    const parsed = pasteHtml(editor, clipboardHtml(editor, editor.state.selection.content()))
+
+    expect(parsed.content.firstChild?.attrs).toEqual(CHIP_ATTRS)
+  })
+
+  it("serializes a text range that contains a chip", () => {
+    const editor = createEditorWithChip()
+    editor.commands.selectAll()
+
+    const parsed = pasteHtml(editor, clipboardHtml(editor, editor.state.selection.content()))
+
+    expect(parsed.content.toJSON()).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "before " },
+          { type: "attachmentReference", attrs: CHIP_ATTRS },
+          { type: "text", text: " after" },
+        ],
+      },
+    ])
+  })
+})

--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { Editor } from "@tiptap/core"
 import { DOMParser as PMDOMParser, DOMSerializer, type Slice } from "@tiptap/pm/model"
 import { NodeSelection } from "@tiptap/pm/state"
@@ -15,8 +15,21 @@ const CHIP_ATTRS: AttachmentReferenceAttrs = {
   error: null,
 }
 
+/**
+ * Editors are torn down after each test: a live view keeps a DOMObserver
+ * timeout that fires after the test environment is gone, which vitest reports
+ * as an uncaught `document is not defined` and fails the run.
+ */
+const openEditors: Editor[] = []
+
+afterEach(() => {
+  while (openEditors.length > 0) {
+    openEditors.pop()?.destroy()
+  }
+})
+
 function createEditorWithChip() {
-  return new Editor({
+  const editor = new Editor({
     element: document.createElement("div"),
     extensions: createEditorExtensions({ placeholder: "Type a message..." }),
     content: {
@@ -33,6 +46,8 @@ function createEditorWithChip() {
       ],
     },
   })
+  openEditors.push(editor)
+  return editor
 }
 
 function chipPos(editor: Editor): number {

--- a/apps/frontend/src/components/editor/attachment-reference-extension.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.ts
@@ -97,8 +97,11 @@ export const AttachmentReferenceExtension = Node.create({
     return [{ tag: 'span[data-type="attachment-reference"]' }]
   },
 
+  // No content hole: the node is an atom, and ProseMirror's DOMSerializer
+  // throws on one ("Content hole not allowed in a leaf node spec"), taking
+  // down every copy of a selection that holds a chip.
   renderHTML({ HTMLAttributes }) {
-    return ["span", mergeAttributes(HTMLAttributes, { "data-type": "attachment-reference" }), 0]
+    return ["span", mergeAttributes(HTMLAttributes, { "data-type": "attachment-reference" })]
   },
 
   // Plain text rendering for copy/paste out of editor

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -276,4 +276,72 @@ test.describe("Inline File Uploads", () => {
     // After unhover: pill should NOT be highlighted anymore
     await expect(attachmentPill).not.toHaveAttribute("data-highlighted", "true", { timeout: 1000 })
   })
+
+  /**
+   * The chip is an atom whose `renderHTML` used to carry a content hole, so
+   * ProseMirror's clipboard serializer threw ("Content hole not allowed in a
+   * leaf node spec") on any selection holding one — nothing reached the
+   * clipboard and the chip could not be moved.
+   */
+  test("should copy and paste an attachment chip", async ({ page }) => {
+    const editor = page.locator("[contenteditable='true']")
+    await editor.click()
+
+    await page.evaluate(async () => {
+      const target = document.querySelector("[contenteditable='true']")
+      if (!target) throw new Error("Editor not found")
+      const file = new File([new Blob(["Hello, world!"], { type: "text/plain" })], "document.txt", {
+        type: "text/plain",
+      })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(file)
+      target.dispatchEvent(
+        new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: dataTransfer })
+      )
+    })
+
+    await expect(editor.locator("span[data-type='attachment-reference']")).toHaveCount(1, { timeout: 10000 })
+
+    // Copy the composer's content (chip included), then paste the same
+    // flavours back — the real in-app clipboard path, which restores the
+    // document from the `data-pm-slice` HTML. Retried until the upload has
+    // settled, since a chip still reserving carries a temp id.
+    let copied = { html: "", text: "" }
+    await expect(async () => {
+      await editor.click()
+      await page.keyboard.press("Control+a")
+      copied = await page.evaluate(() => {
+        const target = document.querySelector("[contenteditable='true']")
+        if (!target) throw new Error("Editor not found")
+        const clipboardData = new DataTransfer()
+        target.dispatchEvent(new ClipboardEvent("copy", { bubbles: true, cancelable: true, clipboardData }))
+        return { html: clipboardData.getData("text/html"), text: clipboardData.getData("text/plain") }
+      })
+      expect(copied.html).toContain('data-status="uploaded"')
+    }).toPass({ timeout: 15000 })
+    expect(copied.html).toContain("data-pm-slice")
+    expect(copied.html).toContain("attachment-reference")
+
+    // Collapse the select-all before pasting — pasting while it still stands
+    // replaces the document instead of duplicating the chip.
+    await page.keyboard.press("ArrowRight")
+    await page.waitForFunction(() => window.getSelection()?.isCollapsed === true)
+
+    await page.evaluate((flavours) => {
+      const target = document.querySelector("[contenteditable='true']")
+      if (!target) throw new Error("Editor not found")
+      const clipboardData = new DataTransfer()
+      clipboardData.setData("text/html", flavours.html)
+      clipboardData.setData("text/plain", flavours.text)
+      target.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData }))
+    }, copied)
+
+    await expect(editor.locator("span[data-type='attachment-reference']")).toHaveCount(2, { timeout: 5000 })
+
+    // Both chips point at the same attachment, so the message carries two
+    // references and one attachment.
+    await page.getByRole("button", { name: "Send" }).click()
+    await expect(page.locator(".markdown-content button:has-text('document.txt')")).toHaveCount(2, { timeout: 10000 })
+    await expect(page.getByRole("button", { name: /document\.txt 13 B/ })).toHaveCount(1, { timeout: 10000 })
+  })
 })


### PR DESCRIPTION
Stacked on #1617.

## Problem

Inline attachment chips could not be copied or pasted at all. `attachmentReference` is the only atom in the editor whose `renderHTML` returned a content hole — `["span", attrs, 0]` — and ProseMirror's `DOMSerializer` throws `RangeError: Content hole not allowed in a leaf node spec` on one. That happens while building the clipboard's `text/html`, so **any** copy of a selection holding a chip failed: no `data-pm-slice` payload reached the clipboard, and the chip could not be moved.

Every sibling atom (`mention`, `memoEmbed`, `giphyEmbed`, `quoteReply`, `sharedMessage`) already omits the hole; this one was the outlier.

## Solution

Drop the `0`. The chip's attributes ride the span's `data-*` attributes, which `parseHTML` already reads back, so a pasted chip restores with its id, filename, mimeType, sizeBytes and status.

Two chips pointing at one attachment send correctly: `extractUploadedAttachments` (`message-input.tsx`) keys by attachment id, so the message carries two inline references and one attachment — asserted end to end in the browser test.

Drag-and-drop of chips is not in scope; Kris asked for copy-paste "at least".

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/attachment-reference-extension.ts` | content hole removed |
| `apps/frontend/src/components/editor/attachment-reference-extension.test.ts` | **new** — clipboard HTML → parse roundtrip, chip alone and inside a range |
| `tests/browser/inline-file-upload.spec.ts` | copy → paste → send a duplicated chip |

## Test plan

- [x] `vitest src/components/editor` — 407 pass (29 files)
- [x] `playwright tests/browser/inline-file-upload.spec.ts` — 6 pass
- [x] Reverted the fix and re-ran: 2 unit failures (`Content hole not allowed in a leaf node spec`) and the browser test fails — the tests can fail
- [x] `bun run lint`, monorepo typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787781171&installation_model_id=20758&pr_number=1619&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1619&signature=dec8e9ffa41ea4a0c0a9a25ebc5b1d4f684c28f0bc2d4d70e672054cab673647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->