### PR TITLE
feat(calls): record call page-lifecycle events so a locked phone can be diagnosed

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -17,6 +17,7 @@ import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
 import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
 import { resetCallStoreCache } from "@/stores/call-store"
+import { clearCallLifecycleLog } from "@/calls/lifecycle-log"
 import { resetIncomingCallStoreCache } from "@/stores/incoming-call-store"
 import { resetFloatingSurfaceGeometryStoreCache } from "@/stores/floating-surface-geometry-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
@@ -84,6 +85,7 @@ function flushModuleStoreCaches(): void {
   // the transport, and stops tracks (the CallManager's registered hangup) so an
   // account switch with a live call never leaves the prior account's mic hot.
   resetCallStoreCache()
+  clearCallLifecycleLog()
   resetIncomingCallStoreCache()
   resetFloatingSurfaceGeometryStoreCache()
   resetRevealGate()

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -11,6 +11,7 @@ import { AUDIO_CAPTURE_CONSTRAINTS, VIDEO_CAPTURE_CONSTRAINTS } from "./config"
 import { ApiError } from "@/api/client"
 import { getCallState, clearCallState, resetCallStoreCache, type CallRosterParticipant } from "@/stores/call-store"
 import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
+import { clearCallLifecycleLog, getCallLifecycleEvents } from "./lifecycle-log"
 
 // Shared teardown-order log: the mic track, socket, and transport push into it so
 // the ordered-hangup test can pin emit-leave → close-transport → stop-tracks.
@@ -84,6 +85,8 @@ interface FakeSocket extends CallSocket {
   pendingJoinAck: ((result: unknown) => void) | null
   /** When true, `call:join` acks with a failure so the join promise rejects. */
   failJoin: boolean
+  /** The ack `call:lease:renew` replies with. */
+  leaseRenewAck: unknown
   fire(event: string, ...args: unknown[]): void
 }
 
@@ -98,6 +101,7 @@ function makeSocket(): FakeSocket {
     deferJoin: false,
     pendingJoinAck: null,
     failJoin: false,
+    leaseRenewAck: { ok: true, data: { leaseExpiresAt: new Date().toISOString() } },
     emit(event, payload, ack) {
       emitted.push({ event, payload })
       if (event === "call:leave") order.push("leave")
@@ -106,7 +110,7 @@ function makeSocket(): FakeSocket {
         else if (socket.deferJoin) socket.pendingJoinAck = ack ?? null
         else ack?.({ ok: true, data: socket.joinAck })
       } else if (event === "call:leave") ack?.({ ok: true })
-      else if (event === "call:lease:renew") ack?.({ ok: true, data: { leaseExpiresAt: new Date().toISOString() } })
+      else if (event === "call:lease:renew") ack?.(socket.leaseRenewAck)
     },
     on(event, handler) {
       handlers.set(event, handler)
@@ -165,21 +169,35 @@ function participant(overrides: Partial<CallRosterParticipant>): CallRosterParti
   }
 }
 
+// Every manager built by a test, so the afterEach can hang up the ones a test
+// left connected. A live session keeps its document/window lifecycle listeners
+// attached, and those write into the shared lifecycle log from later tests.
+const managers: CallManager[] = []
+
+function newManager(deps: CallManagerDeps, audioContainer: HTMLElement | null): CallManager {
+  const manager = new CallManager(deps, audioContainer)
+  managers.push(manager)
+  return manager
+}
+
 describe("CallManager", () => {
   beforeEach(() => {
     order = []
     clearCallState()
     setDictationExternalHold(false)
   })
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers()
+    for (const manager of managers.splice(0)) {
+      if (manager.isActive()) await manager.leaveCall()
+    }
   })
 
   it("join happy path: REST → socket join → connect → publish mic → connected", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
@@ -195,7 +213,7 @@ describe("CallManager", () => {
   it("join defaults to mic-on / camera-off even in video mode; camera publishes only on setCameraOn", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
     // Plan §In-call features: join is mic-on, camera-off — no camera capture yet.
     expect(transport._events).toContain("publish:mic")
@@ -210,7 +228,7 @@ describe("CallManager", () => {
   it("joins with the camera publishing when cameraOn is requested (Start with camera)", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video", cameraOn: true })
     // Camera is up at join, not deferred to a setCameraOn tap.
     expect(transport._events).toContain("publish:mic")
@@ -233,7 +251,7 @@ describe("CallManager", () => {
       rosterVersion: 0,
       roster: [],
     })
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
 
@@ -246,7 +264,7 @@ describe("CallManager", () => {
   it("audio_only mode ignores setCameraOn", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     await manager.setCameraOn(true)
     expect(transport._events).not.toContain("publish:camera")
@@ -255,7 +273,7 @@ describe("CallManager", () => {
   it("drops a stale/duplicate roster version, applies a newer one", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     // Newer version applies.
@@ -272,7 +290,7 @@ describe("CallManager", () => {
   it("track-registry diff drives pull then stopPull", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     socket.fire("call:roster", {
@@ -297,7 +315,7 @@ describe("CallManager", () => {
   it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     socket.fire("call:roster", {
@@ -314,7 +332,7 @@ describe("CallManager", () => {
     vi.useFakeTimers()
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     socket.emitted.length = 0
@@ -381,7 +399,7 @@ describe("CallManager", () => {
   it("mute gates track.enabled and emits call:state", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     const micTrack = getMicTrack(transport)
@@ -394,7 +412,7 @@ describe("CallManager", () => {
   it("ordered teardown: emit leave → close transport → stop tracks", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     order = []
 
@@ -411,7 +429,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     expect(deps.mintIncarnation).toHaveBeenCalledTimes(1)
 
@@ -431,7 +449,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     await manager.leaveCall()
 
@@ -452,7 +470,7 @@ describe("CallManager", () => {
   it("double startCall throws synchronously while the first is joining (in-flight guard)", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
 
     // The first start suspends at its first await with the `starting` sentinel set.
     const first = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
@@ -470,7 +488,7 @@ describe("CallManager", () => {
   it("a stale reconnect-join continuation no-ops after teardown", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     // A socket reconnect fires a rejoin whose ack we hold in flight.
@@ -505,7 +523,7 @@ describe("CallManager", () => {
           releaseWake = () => resolve(null)
         })
     )
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     const start = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     // Drain all microtasks so runStart reaches the parked wake-lock request.
@@ -541,7 +559,7 @@ describe("CallManager", () => {
       if (c.video) kinds.push("video")
       return makeStream(kinds)
     })
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     // Fire two switches without awaiting the first — the chain must serialize them.
@@ -561,7 +579,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
     await manager.setCameraOn(true)
 
@@ -584,7 +602,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     // Join defaults to camera-off, so the switch only records the preference.
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
 
@@ -606,7 +624,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
     // Seed an explicit device pref, then turn the camera on with it.
     await manager.switchCameraDevice("cam-1")
@@ -645,7 +663,7 @@ describe("CallManager", () => {
       if (c.video) kinds.push("video")
       return makeStream(kinds)
     })
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     const err = await manager.switchInputDevice("dev-x").catch((e) => e)
@@ -662,7 +680,7 @@ describe("CallManager", () => {
   it("a roster event dispatched before hangupSync no-ops after the flush", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     // Capture the handler as if a roster broadcast were already dispatched into the loop.
@@ -689,7 +707,7 @@ describe("CallManager", () => {
     socket.failJoin = true
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     await expect(manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })).rejects.toThrow()
 
@@ -713,7 +731,7 @@ describe("CallManager", () => {
           releaseWake = () => resolve(null)
         })
     )
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     const start = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     await new Promise((r) => setTimeout(r, 0))
@@ -732,7 +750,7 @@ describe("CallManager", () => {
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
     ;(deps.startCallRest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network down"))
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     await expect(manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })).rejects.toThrow(
       /network down/
@@ -749,7 +767,7 @@ describe("CallManager", () => {
     socket.deferJoin = true
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     const start = manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     // Park at the socket join — `starting` is true with no session yet.
@@ -775,7 +793,7 @@ describe("CallManager", () => {
   it("F3: a reconnect returning a NEW endpoint id tears down instead of staying connected", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
-    const manager = new CallManager(makeDeps(socket, transport), null)
+    const manager = newManager(makeDeps(socket, transport), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
     expect(getCallState().phase).toBe("connected")
 
@@ -813,7 +831,7 @@ describe("CallManager", () => {
       if (kind === "camera") throw new Error("camera publish rejected")
       transport._events.push(`publish:${kind}`)
     })
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
 
     const err = await manager.setCameraOn(true).catch((e) => e)
@@ -835,7 +853,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video", expectedCallId: "call_ring" })
 
@@ -854,7 +872,7 @@ describe("CallManager", () => {
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
     ;(deps.startCallRest as ReturnType<typeof vi.fn>).mockRejectedValue(new ApiError(409, "CALL_ENDED", "Call ended"))
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
 
     const err = await manager
       .startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video", expectedCallId: "call_gone" })
@@ -866,6 +884,131 @@ describe("CallManager", () => {
     expect(getCallState().phase).toBe("idle")
     // The bound start 409'd before admitting us — there is nothing to self-leave.
     expect(deps.leaveCallRest).not.toHaveBeenCalled()
+  })
+
+  // ── lifecycle log (diagnostic only — no behavior reads it) ─────────────────
+
+  describe("lifecycle log", () => {
+    function kinds(): string[] {
+      return getCallLifecycleEvents().map((e) => e.kind)
+    }
+
+    async function startedManager(socket: FakeSocket, transport: MediaTransport) {
+      const manager = newManager(makeDeps(socket, transport), null)
+      await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+      clearCallLifecycleLog()
+      return manager
+    }
+
+    function setVisibility(value: DocumentVisibilityState): void {
+      Object.defineProperty(document, "visibilityState", { configurable: true, get: () => value })
+    }
+
+    beforeEach(() => {
+      clearCallLifecycleLog()
+    })
+    afterEach(() => {
+      Object.defineProperty(document, "visibilityState", { configurable: true, get: () => "visible" })
+      clearCallLifecycleLog()
+    })
+
+    it("records page-lifecycle events from document and window", async () => {
+      await startedManager(makeSocket(), makeTransport())
+
+      setVisibility("hidden")
+      document.dispatchEvent(new Event("visibilitychange"))
+      setVisibility("visible")
+      document.dispatchEvent(new Event("visibilitychange"))
+      document.dispatchEvent(new Event("freeze"))
+      document.dispatchEvent(new Event("resume"))
+      window.dispatchEvent(new Event("pagehide"))
+
+      expect(kinds()).toEqual(["hidden", "visible", "freeze", "resume", "pagehide"])
+    })
+
+    it("records a socket drop and a rejoin onto the same endpoint", async () => {
+      const socket = makeSocket()
+      await startedManager(socket, makeTransport())
+
+      socket.fire("disconnect")
+      socket.fire("connect")
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(kinds()).toEqual(["socket_disconnect", "socket_connect", "rejoin_same_endpoint"])
+    })
+
+    it("records a rejoin that returns a different endpoint id", async () => {
+      const socket = makeSocket()
+      await startedManager(socket, makeTransport())
+
+      socket.joinAck = { ...socket.joinAck, endpointId: "ep_2" }
+      socket.fire("disconnect")
+      socket.fire("connect")
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(getCallLifecycleEvents().map((e) => ({ kind: e.kind, detail: e.detail }))).toEqual([
+        { kind: "socket_disconnect", detail: undefined },
+        { kind: "socket_connect", detail: undefined },
+        { kind: "rejoin_new_endpoint", detail: "ep_2" },
+        { kind: "teardown", detail: undefined },
+      ])
+    })
+
+    it("records a failed rejoin", async () => {
+      const socket = makeSocket()
+      await startedManager(socket, makeTransport())
+
+      socket.failJoin = true
+      socket.fire("disconnect")
+      socket.fire("connect")
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(kinds()).toEqual(["socket_disconnect", "socket_connect", "rejoin_failed", "teardown"])
+    })
+
+    it("records lease renews, with the ack code as the failure detail", async () => {
+      vi.useFakeTimers()
+      const socket = makeSocket()
+      await startedManager(socket, makeTransport())
+
+      vi.advanceTimersByTime(15_000)
+      expect(kinds()).toEqual(["lease_renew_ok"])
+
+      socket.leaseRenewAck = { ok: false, code: "CALL_LEASE_SUPERSEDED" }
+      vi.advanceTimersByTime(15_000)
+      expect(getCallLifecycleEvents().at(1)).toMatchObject({
+        kind: "lease_renew_failed",
+        detail: "CALL_LEASE_SUPERSEDED",
+      })
+    })
+
+    it("leak guard: every lifecycle listener is detached on leaveCall", async () => {
+      const docAdd = vi.spyOn(document, "addEventListener")
+      const docRemove = vi.spyOn(document, "removeEventListener")
+      const winAdd = vi.spyOn(window, "addEventListener")
+      const winRemove = vi.spyOn(window, "removeEventListener")
+      const manager = await startedManager(makeSocket(), makeTransport())
+
+      const lifecycleEvents = new Set(["visibilitychange", "freeze", "resume", "pagehide", "pageshow"])
+      const attached = [...docAdd.mock.calls, ...winAdd.mock.calls].filter(([event]) =>
+        lifecycleEvents.has(event as string)
+      )
+      expect(attached.map(([event]) => event)).toEqual(["visibilitychange", "freeze", "resume", "pagehide", "pageshow"])
+
+      await manager.leaveCall()
+
+      // Same handler identity, not just the same event name — a listener left on
+      // `document` retains the session closure and stacks per call.
+      const detached = [...docRemove.mock.calls, ...winRemove.mock.calls]
+      for (const binding of attached) expect(detached).toContainEqual(binding)
+
+      clearCallLifecycleLog()
+      document.dispatchEvent(new Event("freeze"))
+      window.dispatchEvent(new Event("pagehide"))
+      expect(getCallLifecycleEvents()).toEqual([])
+
+      for (const spy of [docAdd, docRemove, winAdd, winRemove]) spy.mockRestore()
+    })
   })
 })
 

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -347,7 +347,7 @@ describe("CallManager", () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const deps = makeDeps(socket, transport)
-    const manager = new CallManager(deps, null)
+    const manager = newManager(deps, null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
 
     socket.fire("call:endpoint:closed", { callId: "call_1", endpointId: "ep_1", reason: "taken_over" })
@@ -370,7 +370,7 @@ describe("CallManager", () => {
 
   it("ignores an endpoint-closed event for another call or another endpoint", async () => {
     const socket = makeSocket()
-    const manager = new CallManager(makeDeps(socket, makeTransport()), null)
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     socket.fire("call:endpoint:closed", { callId: "call_other", endpointId: "ep_1" })
@@ -383,7 +383,7 @@ describe("CallManager", () => {
   it("lands on the same displaced state when only the lease renew reports the takeover", async () => {
     vi.useFakeTimers()
     const socket = makeSocket()
-    const manager = new CallManager(makeDeps(socket, makeTransport()), null)
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
     await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
 
     // The backstop for a device that lost the socket push.

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -922,8 +922,9 @@ describe("CallManager", () => {
       document.dispatchEvent(new Event("freeze"))
       document.dispatchEvent(new Event("resume"))
       window.dispatchEvent(new Event("pagehide"))
+      window.dispatchEvent(new Event("pageshow"))
 
-      expect(kinds()).toEqual(["hidden", "visible", "freeze", "resume", "pagehide"])
+      expect(kinds()).toEqual(["hidden", "visible", "freeze", "resume", "pagehide", "pageshow"])
     })
 
     it("records a socket drop and a rejoin onto the same endpoint", async () => {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -22,6 +22,7 @@ import {
   type CallRosterParticipant,
   type CallDeviceState,
 } from "@/stores/call-store"
+import { recordCallLifecycleEvent, type CallLifecycleKind } from "./lifecycle-log"
 import {
   CloudflareSfuTransport,
   type MediaTransport,
@@ -204,7 +205,8 @@ interface CallSession {
   meterRaf: number | null
   wakeLock: WakeLockLike | null
   releaseLock: (() => void) | null
-  onVisibility: (() => void) | null
+  /** Detaches every page-lifecycle listener installed for this session. */
+  onLifecycle: (() => void) | null
   onDeviceChange: (() => void) | null
 }
 
@@ -403,7 +405,7 @@ export class CallManager implements CallController {
         meterRaf: null,
         wakeLock: null,
         releaseLock,
-        onVisibility: null,
+        onLifecycle: null,
         onDeviceChange: null,
       }
       this.session = session
@@ -740,10 +742,12 @@ export class CallManager implements CallController {
       // A socket drop is NOT a call end (the lease holds the slot). Demote to
       // reconnecting; the CF media session survives brief socket loss.
       if (!this.sessionForGen(gen)) return
+      recordCallLifecycleEvent({ kind: "socket_disconnect" })
       setCallPhase("reconnecting")
     })
     session.socket.on("connect", () => {
       if (!this.sessionForGen(gen)) return
+      recordCallLifecycleEvent({ kind: "socket_connect" })
       // Transient reconnect: rejoin with the SAME incarnation (rebinds the same
       // endpoint + epoch). A new incarnation is only minted by a fresh page load.
       this.joinOverSocket(session.socket, {
@@ -765,17 +769,20 @@ export class CallManager implements CallController {
           // the user re-enters via the stream's live-call card / rejoin surfaces
           // (a fresh incarnation on the fresh endpoint).
           if (join.endpointId !== s.endpointId) {
+            recordCallLifecycleEvent({ kind: "rejoin_new_endpoint", detail: join.endpointId })
             void this.teardown()
             return
           }
+          recordCallLifecycleEvent({ kind: "rejoin_same_endpoint" })
           s.endpointId = join.endpointId
           this.applyRoster(s, join.rosterVersion, join.roster)
           setCallPhase("connected")
         })
-        .catch(() => {
+        .catch((err: unknown) => {
           // Same recheck: a stale failed rejoin for the OLD call must not tear
           // down whatever `this.session` now is (possibly a newly started call).
           if (!this.sessionForGen(gen)) return
+          recordCallLifecycleEvent({ kind: "rejoin_failed", detail: err instanceof Error ? err.message : undefined })
           void this.teardown()
         })
     })
@@ -1185,6 +1192,8 @@ export class CallManager implements CallController {
         // stale ack never tears down a newer call.
         if (!this.sessionForGen(gen)) return
         const ack = result as Ack<{ leaseExpiresAt: string }>
+        if (ack?.ok) recordCallLifecycleEvent({ kind: "lease_renew_ok" })
+        else recordCallLifecycleEvent({ kind: "lease_renew_failed", detail: ack?.code })
         // A superseded lease means our endpoint was taken over — the call is lost
         // on this incarnation. The socket push above normally gets here first;
         // this is the backstop for a device that lost the socket, and it lands on
@@ -1256,23 +1265,46 @@ export class CallManager implements CallController {
 
   // ── wake lock + devices ─────────────────────────────────────────────────
 
+  /**
+   * One listener set for the page-lifecycle signals: visibility carries both the
+   * log entry and the wake-lock re-acquire (one listener, two jobs), `freeze`/
+   * `resume` are `document` events, `pagehide`/`pageshow` are `window` events.
+   * The returned detach closure is stored on the session — a listener left
+   * attached retains the whole session closure and stacks per call.
+   */
+  private installLifecycleListeners(session: CallSession): void {
+    if (typeof document === "undefined") return
+    const onVisibility = () => {
+      if (this.session !== session) return
+      const visible = document.visibilityState === "visible"
+      recordCallLifecycleEvent({ kind: visible ? "visible" : "hidden" })
+      if (visible && (!session.wakeLock || session.wakeLock.released)) {
+        void this.deps.requestWakeLock().then((lock) => {
+          if (this.session === session) session.wakeLock = lock
+        })
+      }
+    }
+    const recorder = (kind: CallLifecycleKind) => () => {
+      if (this.session !== session) return
+      recordCallLifecycleEvent({ kind })
+    }
+    const bindings: Array<[EventTarget, string, () => void]> = [
+      [document, "visibilitychange", onVisibility],
+      [document, "freeze", recorder("freeze")],
+      [document, "resume", recorder("resume")],
+    ]
+    if (typeof window !== "undefined") {
+      bindings.push([window, "pagehide", recorder("pagehide")], [window, "pageshow", recorder("pageshow")])
+    }
+    for (const [target, event, handler] of bindings) target.addEventListener(event, handler)
+    session.onLifecycle = () => {
+      for (const [target, event, handler] of bindings) target.removeEventListener(event, handler)
+    }
+  }
+
   private async acquireWakeLock(session: CallSession): Promise<void> {
     session.wakeLock = await this.deps.requestWakeLock().catch(() => null)
-    if (typeof document !== "undefined") {
-      const onVisibility = () => {
-        if (this.session !== session) return
-        if (document.visibilityState === "visible" && (!session.wakeLock || session.wakeLock.released)) {
-          void this.deps.requestWakeLock().then((lock) => {
-            if (this.session === session) session.wakeLock = lock
-          })
-        }
-      }
-      document.addEventListener("visibilitychange", onVisibility)
-      // Store the bound handler so teardown can detach it — a listener left on
-      // `document` retains the whole session closure and leaks it (and stacks
-      // per call).
-      session.onVisibility = onVisibility
-    }
+    this.installLifecycleListeners(session)
     // Auto-refresh the device list on hot-plug/unplug for the call's life.
     if (typeof navigator !== "undefined" && navigator.mediaDevices) {
       const onDeviceChange = () => {
@@ -1409,6 +1441,7 @@ export class CallManager implements CallController {
   private async teardown(): Promise<void> {
     const session = this.session
     if (!session) return
+    recordCallLifecycleEvent({ kind: "teardown" })
     this.session = null
     this.clearTimers(session)
     this.removeSocketHandlers(session)
@@ -1452,13 +1485,11 @@ export class CallManager implements CallController {
   }
 
   private removeSessionListeners(session: CallSession): void {
-    if (session.onVisibility && typeof document !== "undefined") {
-      document.removeEventListener("visibilitychange", session.onVisibility)
-    }
+    session.onLifecycle?.()
     if (session.onDeviceChange && typeof navigator !== "undefined" && navigator.mediaDevices) {
       navigator.mediaDevices.removeEventListener("devicechange", session.onDeviceChange)
     }
-    session.onVisibility = null
+    session.onLifecycle = null
     session.onDeviceChange = null
   }
 

--- a/apps/frontend/src/calls/lifecycle-log.test.ts
+++ b/apps/frontend/src/calls/lifecycle-log.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  CALL_LIFECYCLE_LOG_MAX,
+  clearCallLifecycleLog,
+  getCallLifecycleEvents,
+  recordCallLifecycleEvent,
+  subscribeCallLifecycle,
+} from "./lifecycle-log"
+
+describe("call lifecycle log", () => {
+  beforeEach(() => {
+    clearCallLifecycleLog()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-01T10:00:00.000Z"))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    clearCallLifecycleLog()
+  })
+
+  it("keeps the newest MAX entries and drops the oldest", () => {
+    for (let i = 0; i < CALL_LIFECYCLE_LOG_MAX + 5; i++) {
+      recordCallLifecycleEvent({ kind: "freeze", detail: String(i) })
+    }
+
+    const events = getCallLifecycleEvents()
+    // The surviving window is entries 5..MAX+4 — the first five fell off.
+    expect(events.map((e) => e.detail)).toEqual(Array.from({ length: CALL_LIFECYCLE_LOG_MAX }, (_, i) => String(i + 5)))
+  })
+
+  it("stamps `at` and carries kind + detail", () => {
+    recordCallLifecycleEvent({ kind: "lease_renew_failed", detail: "CALL_LEASE_SUPERSEDED" })
+
+    expect(getCallLifecycleEvents()).toEqual([
+      { at: Date.parse("2026-07-01T10:00:00.000Z"), kind: "lease_renew_failed", detail: "CALL_LEASE_SUPERSEDED" },
+    ])
+  })
+
+  it("notifies subscribers on record and stops after unsubscribe", () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeCallLifecycle(listener)
+
+    recordCallLifecycleEvent({ kind: "visible" })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    recordCallLifecycleEvent({ kind: "hidden" })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("clearCallLifecycleLog empties the ring", () => {
+    recordCallLifecycleEvent({ kind: "teardown" })
+    clearCallLifecycleLog()
+    expect(getCallLifecycleEvents()).toEqual([])
+  })
+})

--- a/apps/frontend/src/calls/lifecycle-log.ts
+++ b/apps/frontend/src/calls/lifecycle-log.ts
@@ -1,0 +1,71 @@
+import { useSyncExternalStore } from "react"
+
+// Bounded in-memory ring of call page-lifecycle events (module store +
+// useSyncExternalStore, like call-store). Diagnostic only — nothing reads it to
+// make a decision. NOT cleared on teardown or on the next call's start: it exists
+// to explain a call that already died, so clearing it there would erase the
+// evidence. Bounded instead, and dropped only by the account flush.
+
+export const CALL_LIFECYCLE_KINDS = [
+  "visible",
+  "hidden",
+  "freeze",
+  "resume",
+  "pagehide",
+  "pageshow",
+  "socket_connect",
+  "socket_disconnect",
+  "lease_renew_ok",
+  "lease_renew_failed",
+  "rejoin_same_endpoint",
+  "rejoin_new_endpoint",
+  "rejoin_failed",
+  "teardown",
+] as const
+
+export type CallLifecycleKind = (typeof CALL_LIFECYCLE_KINDS)[number]
+
+export const CALL_LIFECYCLE_LOG_MAX = 200
+
+export interface CallLifecycleEntry {
+  at: number
+  kind: CallLifecycleKind
+  detail?: string
+}
+
+let entries: CallLifecycleEntry[] = []
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+/** Append an event, stamping `at`; oldest entries fall off at the cap. */
+export function recordCallLifecycleEvent(entry: { kind: CallLifecycleKind; detail?: string }): void {
+  const next = entries.concat({ at: Date.now(), ...entry })
+  entries = next.length > CALL_LIFECYCLE_LOG_MAX ? next.slice(next.length - CALL_LIFECYCLE_LOG_MAX) : next
+  emit()
+}
+
+/** Oldest first. */
+export function getCallLifecycleEvents(): CallLifecycleEntry[] {
+  return entries
+}
+
+export function subscribeCallLifecycle(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Flush entry point (account switch / logout), beside `resetCallStoreCache`. */
+export function clearCallLifecycleLog(): void {
+  if (entries.length === 0) return
+  entries = []
+  emit()
+}
+
+export function useCallLifecycleEvents(): CallLifecycleEntry[] {
+  return useSyncExternalStore(subscribeCallLifecycle, getCallLifecycleEvents, getCallLifecycleEvents)
+}

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -5,6 +5,8 @@ import { fireEvent, render, screen, userEvent } from "@/test"
 import { StreamTypes } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
 import * as workspaceStore from "@/stores/workspace-store"
+import * as sonner from "sonner"
+import { clearCallLifecycleLog, recordCallLifecycleEvent } from "@/calls/lifecycle-log"
 import {
   clearCallState,
   getCallState,
@@ -308,6 +310,52 @@ describe("CallControls — mobile flip", () => {
     enterVideoCall({ cameras: [device("c1", "Front", "videoinput")] })
 
     expect(screen.queryByLabelText("Flip camera")).toBeNull()
+  })
+})
+
+describe("ConnectionDiagnostics — lifecycle log", () => {
+  beforeEach(() => {
+    clearCallLifecycleLog()
+  })
+  afterEach(() => {
+    clearCallLifecycleLog()
+  })
+
+  async function openDiagnostics() {
+    renderControls(makeManager())
+    enterVideoCall()
+    await userEvent.click(screen.getByLabelText("Connection diagnostics"))
+  }
+
+  it("renders the recorded entries newest-first", async () => {
+    act(() => {
+      recordCallLifecycleEvent({ kind: "freeze" })
+      recordCallLifecycleEvent({ kind: "lease_renew_failed", detail: "CALL_LEASE_SUPERSEDED" })
+    })
+    await openDiagnostics()
+
+    const rows = (await screen.findByRole("list")).querySelectorAll("li")
+    expect([...rows].map((li) => li.textContent?.replace(/^\d\d:\d\d:\d\d\.\d\d\d/, ""))).toEqual([
+      "lease_renew_failed CALL_LEASE_SUPERSEDED",
+      "freeze",
+    ])
+  })
+
+  it("copies the log and confirms in place, with no toast", async () => {
+    const writeText = vi.fn(async () => {})
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+    const toastSuccess = vi.spyOn(sonner.toast, "success")
+    act(() => {
+      recordCallLifecycleEvent({ kind: "pagehide" })
+    })
+    await openDiagnostics()
+
+    await userEvent.click(screen.getByLabelText("Copy lifecycle log"))
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("pagehide"))
+    // In-place confirmation in the same footprint — never a success toast (INV-63).
+    expect(await screen.findByLabelText("Copied")).toBeInTheDocument()
+    expect(toastSuccess).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -1,5 +1,6 @@
+import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
-import { Settings, Signal } from "lucide-react"
+import { Check, Copy, Settings, Signal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -18,6 +19,7 @@ import { CALL_SURFACE_PROTECTED_ATTR } from "./call-surface-geometry"
 import { useCallManager } from "./call-manager-context"
 import { CameraButton, ChatButton, FlipButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { useCallDevices, useCallDiagnostics } from "./call-store-hooks"
+import { useCallLifecycleEvents, type CallLifecycleEntry } from "@/calls/lifecycle-log"
 
 // setSinkId (output device selection) is unsupported on Safari/Firefox; hide the
 // speaker picker where the API is absent rather than showing a dead control.
@@ -146,6 +148,71 @@ function formatLimitation(limitation: CallDiagnostics["qualityLimitation"]): str
   }
 }
 
+/** Device-local wall clock with milliseconds — a lifecycle log is read by ordering. */
+function formatLifecycleTime(at: number): string {
+  const d = new Date(at)
+  const pad = (n: number, width = 2) => String(n).padStart(width, "0")
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+}
+
+function lifecycleLogText(entries: CallLifecycleEntry[]): string {
+  return entries.map((e) => [formatLifecycleTime(e.at), e.kind, e.detail].filter(Boolean).join(" ")).join("\n")
+}
+
+/**
+ * Page-lifecycle / socket / lease trace for the current and previous calls. It
+ * survives teardown by design — a call that already died is exactly what it has
+ * to explain.
+ */
+function LifecycleLogSection() {
+  const events = useCallLifecycleEvents()
+  const [copied, setCopied] = useState(false)
+  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => void (resetRef.current && clearTimeout(resetRef.current)), [])
+
+  const newestFirst = [...events].reverse()
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(lifecycleLogText(newestFirst))
+    } catch {
+      return
+    }
+    setCopied(true)
+    if (resetRef.current) clearTimeout(resetRef.current)
+    resetRef.current = setTimeout(() => setCopied(false), 1200)
+  }, [newestFirst])
+
+  return (
+    <div className="mt-3 border-t pt-2">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="font-medium">Lifecycle</p>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label={copied ? "Copied" : "Copy lifecycle log"}
+          disabled={newestFirst.length === 0}
+          onClick={() => void copy()}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </Button>
+      </div>
+      {newestFirst.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No events yet</p>
+      ) : (
+        <ul className="max-h-40 space-y-0.5 overflow-y-auto text-xs">
+          {newestFirst.map((e, i) => (
+            <li key={`${e.at}:${e.kind}:${i}`} className="flex justify-between gap-2">
+              <span className="text-muted-foreground tabular-nums">{formatLifecycleTime(e.at)}</span>
+              <span className="truncate">{e.detail ? `${e.kind} ${e.detail}` : e.kind}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 export function ConnectionDiagnostics({ diagnostics }: { diagnostics: CallDiagnostics }) {
   return (
     <Popover>
@@ -170,6 +237,7 @@ export function ConnectionDiagnostics({ diagnostics }: { diagnostics: CallDiagno
             <dd>{formatLimitation(diagnostics.qualityLimitation)}</dd>
           </div>
         </dl>
+        <LifecycleLogSection />
       </PopoverContent>
     </Popover>
   )

--- a/apps/frontend/src/components/call/call-controls.tsx
+++ b/apps/frontend/src/components/call/call-controls.tsx
@@ -203,8 +203,8 @@ function LifecycleLogSection() {
         <ul className="max-h-40 space-y-0.5 overflow-y-auto text-xs">
           {newestFirst.map((e, i) => (
             <li key={`${e.at}:${e.kind}:${i}`} className="flex justify-between gap-2">
-              <span className="text-muted-foreground tabular-nums">{formatLifecycleTime(e.at)}</span>
-              <span className="truncate">{e.detail ? `${e.kind} ${e.detail}` : e.kind}</span>
+              <span className="text-muted-foreground shrink-0 tabular-nums">{formatLifecycleTime(e.at)}</span>
+              <span className="min-w-0 truncate">{e.detail ? `${e.kind} ${e.detail}` : e.kind}</span>
             </li>
           ))}
         </ul>

--- a/docs/plans/calls-background-mobile.md
+++ b/docs/plans/calls-background-mobile.md
@@ -1,0 +1,404 @@
+# Calls in the background on a phone
+
+Status: **Planned, not built.** Nothing here is measured on real hardware yet.
+Every code claim below was checked against the source at `b6760411`; the
+`Verified` / `Unverified` notes say which is which.
+
+## The ceiling, stated up front
+
+Slack and Teams get the system call overlay because they are native apps. Every
+mechanism behind that overlay is a native API with no web equivalent:
+
+| What Slack/Teams do                                                      | The API                                                          | Available to a PWA                     |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------- |
+| System in-call UI, status-bar call chip, call log, Bluetooth hook-switch | Android `ConnectionService` / telecom                            | No                                     |
+| Ring over the lock screen                                                | Full-screen intent (`USE_FULL_SCREEN_INTENT`, Android 14+ gated) | No                                     |
+| Floating call bubble over other apps                                     | `SYSTEM_ALERT_WINDOW`                                            | No                                     |
+| Survive backgrounding indefinitely                                       | Foreground service, `microphone` type                            | No                                     |
+| iPhone parity                                                            | CallKit + PushKit VoIP push                                      | No — Apple restricts PushKit to native |
+
+So: we cannot build our own call overlay, and we cannot join the system one,
+without a native shell. The cheap native path is a **TWA** (Trusted Web
+Activity): the same web app inside an Android app shell that can own a
+foreground service, a `ConnectionService`, and a full-screen intent, talking to
+the page over a message channel. That is a real project with a Play Store
+listing attached — a separate decision, not a patch.
+
+Everything below is the web ceiling, which on Android is higher than it looks.
+
+## What the code actually does today
+
+Verified against `apps/frontend/src/calls/call-manager.ts` (1560 lines, one
+`CallManager` class owning session, socket, transport, capture, lease):
+
+- **No Media Session anywhere.** `grep mediaSession apps/ packages/ tests/` is
+  empty. Nothing sets metadata, action handlers, or playback state.
+- **Remote audio is per-track.** `attachRemoteAudio` (`call-manager.ts:1109`)
+  creates one `<audio>` per pulled remote track and removes it on
+  `stopPull`/track-end (`detachRemoteAudio`, `:1127`). Before the first peer
+  track arrives — ringing out, or a solo call — no audio element exists at all.
+  So the Media Session precondition ("actually playing audio") is not met for
+  the part of the call where a lock-screen control would matter most.
+- **Two silent-teardown branches, not one.** The socket `connect` handler
+  (`:745`) re-joins with the same incarnation, then:
+  - `:767` — a _different_ endpoint id means the lease was reaped and the server
+    minted a fresh endpoint; the transport is bound to the old one, so it
+    `teardown()`s. No state, no explanation. This is the locked-phone case.
+  - `:775` — the re-join itself rejecting also `teardown()`s, equally silently.
+    The design doc named only the first; both need the same landing state.
+- **The lease-renew branch is NOT silent — it has the wrong copy.** A renew
+  whose ack is `CALL_LEASE_SUPERSEDED` (`:1192`) routes to `handleTakenOver`
+  (`:797`), which tears down and writes `DisplacedCall`, rendering
+  `CallMovedChip` — "Call moved to another device". Server-side,
+  `CallEndpointRepository.renewLease` returns null for a superseded epoch **and**
+  for a swept (`status = 'closed'`) endpoint (`repository.ts:1086`), so a
+  lease reaped while the phone was locked lands on takeover copy. That is a
+  correction to the design doc's "the user unlocks to no call and no reason":
+  depending on which signal wins the race, they get nothing, or they get told
+  their call moved to a device they never touched.
+- **Lease constants confirmed.** `ENDPOINT_LEASE_TTL_MS = 45_000` (both
+  `apps/frontend/src/calls/config.ts:17` and
+  `apps/backend/src/features/calls/config.ts:83`), renew at TTL/3 = 15s
+  (`LEASE_RENEW_FRACTION`), sweep 15s (`CALL_SWEEP_INTERVAL_MS`). **Read only —
+  no chunk here changes them.**
+- **The manager already owns a `visibilitychange` listener** (`acquireWakeLock`,
+  `:1259-1285`) plus a `devicechange` one, both detached in
+  `removeSessionListeners` (`:1454`) precisely because a stray listener retains
+  the session closure. Lifecycle instrumentation extends that set; it does not
+  add a parallel listener rig.
+- **Deps are fully injected.** `CallManagerDeps` (`:121`) carries every browser
+  API the manager touches (`requestWakeLock`, `acquireUserMedia`, `locks`,
+  `createAudioContext`, …) and every test builds a `CallManager` with fakes.
+  Media Session gets the same treatment — no global monkey-patching, and jsdom's
+  missing `navigator.mediaSession` never has to be faked.
+
+Unverified, taken from the user's own measurement: Chrome 150 accepts
+`hangup` / `togglemicrophone` / `togglecamera` action handlers and exposes
+`setMicrophoneActive` / `setCameraActive`. Nothing in this repo proves it, and
+jsdom cannot.
+
+## PR stack
+
+Three chunks, bottom to top. All three edit `call-manager.ts`, so they stack
+rather than run in parallel; the ordering is otherwise driven by §3 feeding §2
+(the freeze flag below) and by putting the chunk whose copy is most likely to
+churn on top, where a rewrite rebases nothing.
+
+```
+main
+ └── feat/calls-lifecycle-log          (§3)
+      └── feat/calls-media-session     (§1)
+           └── feat/calls-ended-while-away  (§2 + §4)
+```
+
+---
+
+### 1. `feat/calls-lifecycle-log` — base `main`
+
+The design's own first step: one locked-phone test should answer what Android
+does, with timestamps, before anyone argues about a TTL.
+
+**Deliverables**
+
+- `apps/frontend/src/calls/lifecycle-log.ts` — a bounded module ring, shaped
+  like `call-store.ts` (module state + `useSyncExternalStore` subscribe; the
+  sanctioned non-React store pattern here, not a new hidden singleton):
+  `recordCallLifecycleEvent(entry)`, `getCallLifecycleEvents()`,
+  `subscribeCallLifecycle(fn)`, `clearCallLifecycleLog()`, cap `CALL_LIFECYCLE_LOG_MAX = 200`.
+  Entry: `{ at: number; kind: CallLifecycleKind; detail?: string }` with
+  `CALL_LIFECYCLE_KINDS` as the const-array source of truth (INV-31/33):
+  `visible | hidden | freeze | resume | pagehide | pageshow | socket_connect |
+socket_disconnect | lease_renew_ok | lease_renew_failed | rejoin_same_endpoint |
+rejoin_new_endpoint | rejoin_failed | teardown`.
+  **Not cleared on teardown or on the next call's start** — the log exists to
+  explain a call that already died; clearing it at teardown would erase exactly
+  the evidence. Bounded instead. Cleared only by `clearCallLifecycleLog`, wired
+  into the account flush next to `resetCallStoreCache`.
+- `call-manager.ts`: fold the existing `visibilitychange` handler and new
+  `freeze` / `resume` / `pagehide` / `pageshow` listeners into one
+  `installLifecycleListeners(session)` stored on `session.onLifecycle`, detached
+  in `removeSessionListeners`. `freeze`/`resume` are `document` events,
+  `pagehide`/`pageshow` are `window` events. The wake-lock re-acquire keeps
+  riding the same visibility handler (INV-35 — one listener, two jobs, not two
+  listeners).
+- `call-manager.ts`: record `socket_connect` / `socket_disconnect` in the
+  existing socket handlers, the three re-join outcomes in the `connect`
+  continuation, `lease_renew_ok` / `lease_renew_failed` (with the ack `code` as
+  `detail`) in `startLeaseTimer`, and `teardown`.
+- `apps/frontend/src/components/call/call-controls.tsx`: a scrollable log
+  section inside the existing `ConnectionDiagnostics` popover (`:149`), under
+  the RTT/loss/quality list, plus a Copy control. The popover is reachable on a
+  phone — `CallControls` renders in `TinyGalleryView` and `FullscreenView` of
+  the mobile drawer. Copy confirms in place with an icon swap in the same
+  footprint, never a `toast.success` (INV-63, INV-21); the popover is a fixed
+  `max-h` with `overflow-y-auto` so a growing log never resizes it.
+
+**Tests**
+
+- `apps/frontend/src/calls/lifecycle-log.test.ts` — pushing `MAX + 5` entries
+  keeps the newest `MAX` and drops the oldest (assert the surviving list, not a
+  count, INV-23); `subscribeCallLifecycle` fires on record and unsubscribes;
+  `clearCallLifecycleLog` empties it. `vi.setSystemTime` for deterministic `at`.
+- `apps/frontend/src/calls/call-manager.test.ts` (extend) —
+  - after `startCall`, dispatching `visibilitychange` (hidden/visible), `freeze`,
+    `resume` on `document` and `pagehide` on `window` appends the matching
+    entries in order;
+  - `socket.fire("disconnect")` then `"connect"` appends
+    `socket_disconnect`, `socket_connect`, `rejoin_same_endpoint`;
+  - with `socket.joinAck.endpointId` changed, the same sequence appends
+    `rejoin_new_endpoint`; with `socket.failJoin = true`, `rejoin_failed`;
+  - the lease renew records `lease_renew_ok`, and a `CALL_LEASE_SUPERSEDED` ack
+    records `lease_renew_failed` with that code as `detail`;
+  - **leak guard:** after `leaveCall()`, dispatching `freeze` appends nothing
+    (the listeners are detached — the same failure `removeSessionListeners`
+    exists to prevent).
+- `apps/frontend/src/components/call/call-controls.test.tsx` (extend) — seed the
+  log, open the diagnostics popover, assert the entries render newest-first with
+  their kind; click Copy and assert the clipboard payload plus the in-place
+  confirmation (no toast).
+
+**Excluded**
+
+- Any change to `ENDPOINT_LEASE_TTL_MS`, `LEASE_RENEW_FRACTION`, or
+  `CALL_SWEEP_INTERVAL_MS`. That is the decision this chunk exists to inform.
+- A settings-page or standalone diagnostics surface. The log survives teardown
+  and the next call's start, so starting any call and opening the existing
+  popover reads the previous call's tail — a new permanent surface for raw event
+  rows would be product clutter (INV-36).
+- Sending the log anywhere (telemetry, backend). Copy-to-clipboard is the whole
+  export story.
+
+**Why this boundary:** a reviewer sees one bounded ring, one listener-lifecycle
+change inside a method that already manages listeners, and one popover section.
+No behavior changes: nothing reads the log to make a decision yet.
+
+---
+
+### 2. `feat/calls-media-session` — base `feat/calls-lifecycle-log`
+
+The closest thing to a call overlay the web gives us: on Android a media
+notification with the call's title, a mute toggle and a hang-up button, reachable
+from the lock screen — and a signal to the OS that this page is doing something
+worth keeping alive.
+
+**Deliverables**
+
+- `apps/frontend/src/calls/media-session.ts` — `createCallMediaSession()`
+  returning a `CallMediaSession`:
+  `activate({ title, subtitle })`, `setTitle(title)`,
+  `setHandlers({ hangup, toggleMicrophone, toggleCamera })`,
+  `setMicrophoneActive(active)`, `setCameraActive(active)`, `release()`.
+  It owns **one long-lived `<audio>`** for the session's life: a self-contained
+  silent-WAV `data:` URI (no network, CSP-safe), `loop = true`, not muted,
+  started inside the start gesture. Every `navigator.mediaSession.setActionHandler`
+  call is individually `try`/`catch`ed — an unsupported action throws
+  `TypeError` and must not take the supported ones down with it. `release()`
+  pauses and removes the element, clears each handler, nulls `metadata`, and sets
+  `playbackState = "none"`.
+- `call-manager.ts`: `CallManagerDeps.createMediaSession(): CallMediaSession | null`
+  (production wires `createCallMediaSession()` when `navigator.mediaSession`
+  exists, else null — INV-12/13, constructed once, injected, so no test touches a
+  real Media Session). `CallSession.mediaSession` holds the handle.
+  - `runStart` activates it **before** the transport connect and before the first
+    capture, so a call that is only ringing out already owns a session.
+  - Handlers: `hangup → void this.leaveCall()`,
+    `toggleMicrophone → this.setMuted(!muted)`,
+    `toggleCamera → void this.setCameraOn(!cameraOn)` — the existing controller
+    methods, no parallel path (INV-35).
+  - `setMuted` / `setCameraOn` mirror into `setMicrophoneActive` /
+    `setCameraActive` so the notification's toggles match the app.
+  - `teardown` and `hangupSync` both `release()`, in the same block that releases
+    the wake lock.
+- `CallController.setCallTitle(title: string)` — thin pass-through to
+  `mediaSession.setTitle`. The manager holds a `streamId`, not a name, and stream
+  names resolve out of the workspace caches through
+  `apps/frontend/src/hooks/use-stream-name.ts` (frontend `CLAUDE.md`: one
+  resolver, no hand-rolled lookups), which is a hook. So the resolved label is
+  pushed in, not pulled.
+- `apps/frontend/src/components/call/use-call-media-session-title.ts` — a hook
+  calling `useStreamName(workspaceId, streamId, "generic")` and pushing the
+  result through `useCallManager().setCallTitle` in an effect. Called once from
+  `CallDock`; `streamIdForLabel` moves above `CallDock`'s early return (it is
+  pure) so the hook is unconditional. One more consumer of the existing resolver,
+  not a fifth copy of the lookup.
+
+**Tests**
+
+- `apps/frontend/src/calls/media-session.test.ts` — drive `createCallMediaSession`
+  with an injected fake `navigator.mediaSession`-shaped object and a fake audio
+  element factory: `activate` plays the element and sets metadata;
+  a `setActionHandler` that throws `TypeError` for `hangup` still leaves
+  `togglemicrophone` registered; `release()` pauses + removes the element,
+  clears every handler and nulls the metadata.
+- `apps/frontend/src/calls/call-manager.test.ts` (extend, fake
+  `createMediaSession` dep) —
+  - `activate` is called during `startCall` before `transport.connect`
+    (assert against the transport's `_events` ordering log), i.e. a ringing-out
+    call has a session;
+  - the registered `hangup` handler triggers a real leave (assert the emitted
+    `call:leave`);
+  - `setMuted(true)` calls `setMicrophoneActive(false)`; `setCameraOn(true)`
+    calls `setCameraActive(true)`;
+  - `leaveCall()` and the store-flush `hangupSync` path each call `release()`
+    exactly once;
+  - a null `createMediaSession` (unsupported platform) leaves the whole start
+    path working — no throw, phase still `connected`.
+- `apps/frontend/src/components/call/call-dock.test.tsx` (extend) — seed a named
+  stream in the workspace cache, mount `CallDock` in a connected call with a fake
+  `CallController`, assert `setCallTitle` received the resolved stream name (and
+  that a DM resolves to the peer's name, the case a hand-rolled lookup gets
+  wrong).
+
+**Excluded**
+
+- Consolidating remote audio into one element. `attachRemoteAudio`'s
+  per-track elements exist for the AEC reference and `setSinkId`; the silent
+  element is additive and does not replace them.
+- A service-worker notification (§5 — see _Not building_ below).
+- Any lock-screen artwork. `MediaMetadata.artwork` needs a same-origin image
+  pipeline for avatars; title + subtitle is the honest v1.
+
+**Why this boundary:** a reviewer sees one new collaborator with its own test, an
+injected dep, and mirror calls at three existing sites. Nothing about session
+lifetime or teardown ordering changes. If Chrome refuses a session for a silent
+element (the one real risk — flagged, unverified), this chunk is the only one to
+revisit.
+
+---
+
+### 3. `feat/calls-ended-while-away` — base `feat/calls-media-session`
+
+Never disappear silently, and never claim the call "moved to another device"
+when the truth is "your phone was locked and the lease lapsed".
+
+**Deliverables**
+
+- `apps/frontend/src/stores/call-store.ts`: `DisplacedCall` gains
+  `reason: "taken_over" | "ended_while_away"`. The interface name stays —
+  renaming it (and `CallMovedChip`, `useDisplacedCall`, the dock branch, the e2e
+  selector) is churn with no behavior in it.
+- `call-manager.ts`: `CallSession.suspendedSinceRenew: boolean`, set by the
+  chunk-1 `freeze` and `pagehide` handlers, cleared on every successful lease
+  renew. `freeze`/`pagehide` only — a plain desktop tab switch fires
+  `visibilitychange` and must not be read as "the phone was locked".
+- Reason selection, by signal:
+  - `call:endpoint:closed` push (`:732`) → `"taken_over"`, unconditionally. The
+    server addressed it to this endpoint under the call-row lock; it is the one
+    unambiguous takeover signal. Existing copy and the e2e assertion at
+    `tests/browser/calls.spec.ts:236` are unchanged by design.
+  - re-join returning a different endpoint id (`:767`), a failed re-join
+    (`:775`), and a `CALL_LEASE_SUPERSEDED` renew (`:1192`) →
+    `suspendedSinceRenew ? "ended_while_away" : "taken_over"`. All three are
+    ambiguous from the client (a reaped lease and a superseded one are the same
+    null from `renewLease`); the freeze/pagehide evidence is the only thing that
+    tells them apart, which is why this chunk sits on top of the instrumentation.
+  - The two `teardown()`-only branches now write the notice **after** teardown,
+    the ordering `handleTakenOver` already uses (teardown clears the store, so a
+    notice written before it would be wiped).
+- `apps/frontend/src/components/call/call-moved-chip.tsx`: copy switches on
+  `reason` — `"taken_over"` keeps "Call moved to another device" / "Rejoin
+  here"; `"ended_while_away"` reads "Call ended while your phone was locked" with
+  the same one-tap action. The action stays a `takeover: true` launch bound to
+  `expectedCallId`: the user's own stale endpoint may still hold a lease, so a
+  plain join would 409 and re-ask a question the chip already answered.
+  **No auto-rejoin** — it would re-open the mic with no gesture.
+- `apps/frontend/src/lib/platform.ts` — `isIosWebKit()` (UA `iPhone|iPad|iPod`,
+  plus `MacIntel` + `maxTouchPoints > 1` for iPadOS).
+- `apps/frontend/src/components/call/ios-lock-notice.tsx` — a one-line banner
+  shaped exactly like `CaptureErrorBanner` (INV-35), rendered by
+  `MobileCallDrawer` at the same place (`mobile-call-drawer.tsx:302`, so
+  `contentMode !== "min"`), only when `isIosWebKit()`: locking the phone ends the
+  call. Static from mount, fixed row — no layout shift (INV-21), no toast, no
+  dismissal state.
+
+**Tests**
+
+- `apps/frontend/src/calls/call-manager.test.ts` —
+  - **rewrite the existing F3 test** (`call-manager.test.ts:775`, currently
+    asserting `phase: "idle"` and nothing else): a re-join with a new endpoint id still tears down **and**
+    now writes `displacedCall` with `reason: "taken_over"` when the page never
+    froze, and `reason: "ended_while_away"` after a dispatched `freeze` (and
+    again after a `pagehide`);
+  - a failed re-join (`socket.failJoin = true`) writes the same notice rather
+    than vanishing;
+  - a successful lease renew clears `suspendedSinceRenew`, so a freeze followed
+    by a good renew followed by a takeover still reads `"taken_over"`;
+  - the `call:endpoint:closed` push keeps `reason: "taken_over"` even after a
+    freeze (the existing takeover tests at `:328` and `:365` extended, not
+    replaced).
+- `apps/frontend/src/components/call/call-dock.test.tsx` (extend) — seeding each
+  reason renders its own copy, and both keep the Rejoin + Dismiss actions.
+- `apps/frontend/src/components/call/mobile-call-drawer.test.tsx` (extend) — with
+  a stubbed iOS `navigator`, the notice renders in the drawer's non-`min` modes
+  and is absent otherwise; on a non-iOS UA it never renders.
+- `tests/browser/calls.spec.ts` — unchanged. The takeover flow still asserts
+  "moved to another device" because the push branch is untouched; that it still
+  passes is the regression signal. Run with
+  `bunx playwright test --project=calls --workers=2`.
+
+**Excluded**
+
+- Auto-rejoin. Explicitly not wanted.
+- `CALL_ACCESS_REVOKED`. `startLeaseTimer` acts only on `CALL_LEASE_SUPERSEDED`,
+  so a user removed from the host stream mid-call keeps a "connected" UI over a
+  socket the server has already unbound (`signaling-gateway.ts:316-321`) — a real
+  adjacent bug, found while reading this path. It needs its own copy and an
+  action-less chip (Rejoin is wrong when access is gone), so it belongs with
+  stream-access work, not here. Recorded so it is not lost.
+- Touching `detectSingleActiveCapture` (`call-manager.ts:1491`) or
+  `use-visual-viewport.ts`'s private `isIOS`. Both are iOS probes with slightly
+  different predicates; unifying them changes load-bearing capture behavior and a
+  545-line viewport suite from a chunk about copy. Three probes remain, one of
+  them new and shared — stated, not hidden.
+- Lease tuning. Still gated on the §3 data.
+
+**Why this boundary:** a reviewer sees one store field, one derived reason, three
+call sites that already tore down now saying why, and one banner. It is also the
+chunk whose wording Kris is most likely to rewrite, which is why it sits on top.
+
+---
+
+## Not building
+
+**§5, the service-worker ongoing-call notification.** On Android it duplicates
+what the Media Session notification already gives (lock-screen presence, a
+hang-up affordance), and it does not buy the thing that would actually matter —
+survival. Only a foreground service keeps a page alive, and a service worker
+cannot own one. Its click handler can focus the PWA, but it cannot resume a
+frozen page's media. So it adds a notification-permission dependency and a second
+notification surface for no new capability. Revisit only if the §3 data shows the
+Media Session notification is unreliable on Android.
+
+## Verification — real hardware, both platforms, §3 log on
+
+1. Lock 30s, unlock — call still up? Read the log for what fired while locked.
+2. Lock 2 min, unlock — call still up, or the §2 "ended while your phone was
+   locked" chip (never the takeover copy)?
+3. Switch to another app for 2 min.
+4. Take a real phone call mid-Threa-call.
+5. Lock screen shows the call (title = the stream/DM name), the mute toggle
+   tracks the app, and hang-up from the lock screen actually ends the call.
+6. iOS: the notice is visible in the drawer, and locking lands on the same
+   explicit ended state rather than a silent vanish.
+
+Then, and only then, revisit the 45s / 15s / 15s lease numbers. Raising the TTL
+trades directly against ghost endpoints — a dead device holds a participant slot
+for the whole TTL.
+
+## Assumptions that could not be verified from source
+
+- Chrome's call-specific Media Session actions and `setMicrophoneActive` /
+  `setCameraActive` (user-measured in Chrome 150; jsdom cannot test them, which
+  is why they sit behind an injected collaborator).
+- That Chrome grants a media session to a **silent** looping audio element. This
+  is the standard trick and the reason §1 is shaped this way, but if Android
+  refuses it, chunk 2's silent element is the piece to revisit — routing remote
+  audio through one long-lived element instead would work but costs the
+  per-track AEC/`setSinkId` shape.
+- What Android actually does to a frozen PWA holding a WebRTC session. That is
+  the whole point of chunk 1.
+- Whether the freeze path can be driven from Playwright. Chromium exposes
+  `Page.setWebLifecycleState` over CDP (`context.newCDPSession(page)`), which
+  would make §2's re-join branches e2e-testable; it may refuse on a page holding
+  a live peer connection. Worth one spike, but no chunk's completion depends on
+  it — the unit tests dispatch `freeze`/`pagehide` directly.


### PR DESCRIPTION
## Problem

Nobody has measured what happens to a call when the phone locks. The behaviour is decided by signals we don't record: whether the page is frozen, whether the socket drops, and whether the 15s lease renew keeps landing against the 45s TTL (`ENDPOINT_LEASE_TTL_MS`, mirrored in `apps/frontend/src/calls/config.ts` and `apps/backend/src/features/calls/config.ts`). Three `call-manager.ts` branches can end a call from those signals — a re-join returning a different endpoint id (`:767`), a failed re-join (`:775`), and a `CALL_LEASE_SUPERSEDED` renew (`:1192`) — and after the fact there is no way to tell which fired, or when.

Tuning the lease against a guess is the wrong move: raising the TTL trades directly against ghost endpoints, since a dead device holds a participant slot for the whole TTL.

## Solution

Record the signals, change nothing. This chunk is inert by design — nothing reads the log to make a decision, and no lease constant is touched.

- `apps/frontend/src/calls/lifecycle-log.ts` — a bounded module ring shaped like `call-store.ts` (module state + `subscribe` + `useSyncExternalStore`), `CALL_LIFECYCLE_KINDS` as the const source of truth for the type (INV-31/33), capped at `CALL_LIFECYCLE_LOG_MAX = 200`. Fourteen kinds: `visible`/`hidden`, `freeze`/`resume`, `pagehide`/`pageshow`, `socket_connect`/`socket_disconnect`, `lease_renew_ok`/`lease_renew_failed` (ack `code` as detail), the three re-join outcomes, and `teardown`.
- **Not cleared on teardown or on the next call's start.** The log exists to explain a call that already died; clearing it there would erase exactly the evidence. Bounded instead, and dropped only by the account flush, next to `resetCallStoreCache`.
- `call-manager.ts` — the existing `visibilitychange` handler and the new `freeze`/`resume` (`document`) and `pagehide`/`pageshow` (`window`) listeners fold into one `installLifecycleListeners`, with a single detach closure on `session.onLifecycle` replacing `session.onVisibility`. One listener doing two jobs over two listeners (INV-35): the wake-lock re-acquire still rides the visibility handler, with its guard unchanged.
- `ConnectionDiagnostics` (`call-controls.tsx:149`) gains a scrollable newest-first log section with a Copy control. That popover is what a phone can actually reach — `CallControls` renders in the mobile drawer's `TinyGalleryView` and `FullscreenView`. Copy confirms by swapping its icon in the same `h-7 w-7` footprint (INV-63, INV-21); no toast.
- No standalone diagnostics page — the log survives teardown, so starting any call and opening the existing popover reads the dead call's tail. A permanent surface for raw event rows would be clutter (INV-36).
- Copy-to-clipboard is the whole export story. Nothing is sent to telemetry or the backend.

Known limitation, deliberate: the listeners are session-scoped, so the trace stops at `teardown`. If the call dies while the phone is locked you see the `freeze` that preceded it but not the `resume`/`pageshow` on unlock. App-level lifecycle listeners would close that gap and are not worth it — the tester knows when they unlocked, and the question this chunk asks (did the page freeze, and did the renews stop) is answered without it.

Deliberate deviation, so nobody "fixes" it: `formatLifecycleTime` is a local `HH:mm:ss.SSS` formatter rather than `lib/dates.ts` (INV-42). A lifecycle trace is read by ordering, and `dates.ts` has no millisecond entry point — `formatTime24h` stops at minutes. It still renders device-local, which is what INV-42 is protecting.

Also included: `docs/plans/calls-background-mobile.md`, rewritten as the three-chunk stack plan. It carries one correction verified against source — a lease reaped while the phone is locked is **not** always a silent teardown. `CallEndpointRepository.renewLease` (`repository.ts:1086`) returns the same null for a swept endpoint as for a superseded one, so that path already lands on `CallMovedChip`, telling a locked phone its call moved to a device the user never touched. The top chunk of the stack fixes the copy; this one gives it the freeze evidence to tell the two apart.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/calls/lifecycle-log.ts` | **new** — bounded ring, kinds, subscribe/clear, `useCallLifecycleEvents` |
| `apps/frontend/src/calls/lifecycle-log.test.ts` | **new** — cap, entry shape, subscribe/unsubscribe, clear |
| `apps/frontend/src/calls/call-manager.ts` | `installLifecycleListeners` + one detach closure; record sites at socket, re-join, lease renew, teardown |
| `apps/frontend/src/calls/call-manager.test.ts` | lifecycle cases + leak guard; all managers now tracked and hung up in `afterEach` |
| `apps/frontend/src/components/call/call-controls.tsx` | `LifecycleLogSection` inside `ConnectionDiagnostics` |
| `apps/frontend/src/components/call/call-controls.test.tsx` | newest-first render, copy payload, in-place confirmation |
| `apps/frontend/src/auth/account-scope.tsx` | `clearCallLifecycleLog()` in `flushModuleStoreCaches` |
| `docs/plans/calls-background-mobile.md` | **new** — the three-chunk plan |

A test-hygiene change worth flagging: ~21 existing `CallManager` tests left a live session, and a live session now keeps `document`/`window` listeners attached that write into the shared log from later tests. Every `new CallManager(` in that file goes through a tracked `newManager(...)`, and `afterEach` hangs up anything still active. Without it the lifecycle tests fail on cross-test bleed.

## Test plan

- [x] `vitest src/calls/ src/components/call/ src/lib/no-happy-path-success-toast.test.ts` — 21 files, 230 tests pass
- [x] `tsc --noEmit` (`apps/frontend`) — clean
- [x] eslint on the touched files — clean
- [x] Falsifiability: neutralising `session.onLifecycle?.()` reds the leak guard; dropping `.reverse()` reds the newest-first test; dropping the cap slice reds the ring test. The first check also exposed the original leak guard as vacuous (the handler's own `this.session !== session` gate already suppressed the entry) — it now asserts the exact add/remove handler pairs
- [x] Adversarial review pass — empty finding set; `/code-review` found one (a long lifecycle row overflowed the `w-56` popover horizontally instead of ellipsizing), fixed in `65549852`. No test for it: jsdom cannot measure layout and asserting the class would only restate the fix
- [ ] Real hardware. That is the point of this chunk and it cannot be run in CI: lock the phone 30s and 2min, switch apps, take a real phone call mid-call, then read the log

<details>
<summary>📋 Full implementation plan</summary>

`docs/plans/calls-background-mobile.md`, added in this PR. Chunk 1 of three:

```
main
 └── feat/calls-lifecycle-log          (instrumentation — this PR)
      └── feat/calls-media-session     (Media Session + one long-lived silent audio element)
           └── feat/calls-ended-while-away  (DisplacedCall.reason + the iOS notice)
```

The doc also states what is deliberately **not** being built: the service-worker ongoing-call notification (duplicates the Media Session notification on Android and buys no survival — only a foreground service does that, and a SW cannot own one), lease tuning (gated on this chunk's data), and any native/TWA shell.

Recorded there and excluded from every chunk: `startLeaseTimer` acts only on `CALL_LEASE_SUPERSEDED`, so a user removed from the host stream mid-call keeps a "connected" UI over a socket the server has already unbound (`signaling-gateway.ts:316-321`). Real adjacent bug; it needs its own copy and an action-less chip, so it belongs with stream-access work.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
