### PR TITLE
feat(calls): a lock-screen media session for the whole call, including ringing out

### DIFF
--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -12,6 +12,7 @@ import { ApiError } from "@/api/client"
 import { getCallState, clearCallState, resetCallStoreCache, type CallRosterParticipant } from "@/stores/call-store"
 import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
 import { clearCallLifecycleLog, getCallLifecycleEvents } from "./lifecycle-log"
+import type { CallMediaSession, CallMediaSessionHandlers } from "./media-session"
 
 // Shared teardown-order log: the mic track, socket, and transport push into it so
 // the ordered-hangup test can pin emit-leave → close-transport → stop-tracks.
@@ -126,7 +127,39 @@ function makeSocket(): FakeSocket {
   return socket
 }
 
-function makeDeps(socket: FakeSocket, transport: MediaTransport) {
+interface FakeMediaSession extends CallMediaSession {
+  handlers: CallMediaSessionHandlers | null
+  releases: number
+  activations: Array<{ title: string; subtitle: string }>
+}
+
+/**
+ * A media session that records into the transport's event log, so a test can pin
+ * `activate` against `connect`/`publish:mic` in one ordering (INV-24).
+ */
+function makeMediaSession(events: string[]): FakeMediaSession {
+  const fake: FakeMediaSession = {
+    handlers: null,
+    releases: 0,
+    activations: [],
+    activate: vi.fn((metadata: { title: string; subtitle: string }) => {
+      fake.activations.push(metadata)
+      events.push("mediaSession:activate")
+    }),
+    setTitle: vi.fn(),
+    setHandlers: vi.fn((handlers: CallMediaSessionHandlers) => {
+      fake.handlers = handlers
+    }),
+    setMicrophoneActive: vi.fn(),
+    setCameraActive: vi.fn(),
+    release: vi.fn(() => {
+      fake.releases++
+    }),
+  }
+  return fake
+}
+
+function makeDeps(socket: FakeSocket, transport: MediaTransport, mediaSession: CallMediaSession | null = null) {
   let inc = 0
   const deps: CallManagerDeps = {
     startCallRest: vi.fn(async ({ workspaceId, streamId, mode }) => ({
@@ -152,6 +185,7 @@ function makeDeps(socket: FakeSocket, transport: MediaTransport) {
     locks: null,
     requestWakeLock: vi.fn(async () => null),
     mintIncarnation: vi.fn(() => `inc-${++inc}`),
+    createMediaSession: vi.fn(() => mediaSession),
     singleActiveCapture: false,
   }
   return deps
@@ -884,6 +918,111 @@ describe("CallManager", () => {
     expect(getCallState().phase).toBe("idle")
     // The bound start 409'd before admitting us — there is nothing to self-leave.
     expect(deps.leaveCallRest).not.toHaveBeenCalled()
+  })
+
+  // ── lock-screen media session ──────────────────────────────────────────────
+
+  describe("media session", () => {
+    async function startedWithMediaSession(overrides: { mode?: "audio_only" | "video" } = {}) {
+      const socket = makeSocket()
+      const transport = makeTransport()
+      const mediaSession = makeMediaSession(transport._events)
+      const deps = makeDeps(socket, transport, mediaSession)
+      const manager = newManager(deps, null)
+      await manager.startCall({
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        mode: overrides.mode ?? "audio_only",
+      })
+      return { manager, socket, transport, mediaSession }
+    }
+
+    it("activates the session before the transport connects, so a ringing-out call already owns one", async () => {
+      const { transport, mediaSession } = await startedWithMediaSession()
+
+      expect(mediaSession.activate).toHaveBeenCalledWith({ title: "Call", subtitle: "Threa" })
+      // Activation precedes both the transport connect and the first capture.
+      expect(transport._events.indexOf("mediaSession:activate")).toBe(0)
+      expect(transport._events.slice(0, 3)).toEqual(["mediaSession:activate", "connect", "publish:mic"])
+    })
+
+    it("the registered hangup handler leaves the call for real", async () => {
+      const { manager, socket, mediaSession } = await startedWithMediaSession()
+      socket.emitted.length = 0
+
+      mediaSession.handlers?.hangup()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(socket.emitted.map((e) => e.event)).toContain("call:leave")
+      expect(manager.isActive()).toBe(false)
+    })
+
+    it("mirrors mute and camera state onto the notification toggles", async () => {
+      const { manager, mediaSession } = await startedWithMediaSession({ mode: "video" })
+
+      manager.setMuted(true)
+      await manager.setCameraOn(true)
+
+      expect(mediaSession.setMicrophoneActive).toHaveBeenCalledWith(false)
+      expect(mediaSession.setCameraActive).toHaveBeenCalledWith(true)
+    })
+
+    it("setCallTitle pushes the resolved stream label at the live session", async () => {
+      const { manager, mediaSession } = await startedWithMediaSession()
+
+      manager.setCallTitle("#design")
+
+      expect(mediaSession.setTitle).toHaveBeenCalledWith("#design")
+    })
+
+    it("leaveCall releases the session exactly once", async () => {
+      const { manager, mediaSession } = await startedWithMediaSession()
+
+      await manager.leaveCall()
+
+      expect(mediaSession.releases).toBe(1)
+    })
+
+    it("the store-flush hangupSync path releases the session exactly once", async () => {
+      const { manager, mediaSession } = await startedWithMediaSession()
+
+      // Account switch / logout flush → hangupSync.
+      resetCallStoreCache()
+
+      expect(manager.isActive()).toBe(false)
+      expect(mediaSession.releases).toBe(1)
+    })
+
+    it("a later call on the same manager never opens under the previous call's label", async () => {
+      const { manager, mediaSession } = await startedWithMediaSession()
+      manager.setCallTitle("Grace")
+      await manager.leaveCall()
+
+      await manager.startCall({ workspaceId: "ws_1", streamId: "stream_2", mode: "audio_only" })
+
+      // The dock pushes the real label once the name resolves; until then the
+      // notification must not claim this call is with whoever the last one was.
+      expect(mediaSession.setTitle).toHaveBeenCalledWith("Grace")
+      expect(mediaSession.activations).toEqual([
+        { title: "Call", subtitle: "Threa" },
+        { title: "Call", subtitle: "Threa" },
+      ])
+    })
+
+    it("an unsupported platform (null media session) leaves the whole start path working", async () => {
+      const socket = makeSocket()
+      const transport = makeTransport()
+      const deps = makeDeps(socket, transport, null)
+      const manager = newManager(deps, null)
+
+      await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+      manager.setMuted(true)
+      manager.setCallTitle("#design")
+      await manager.setCameraOn(true)
+
+      expect(getCallState().phase).toBe("connected")
+      expect(manager.isActive()).toBe(true)
+    })
   })
 
   // ── lifecycle log (diagnostic only — no behavior reads it) ─────────────────

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -129,6 +129,8 @@ function makeSocket(): FakeSocket {
 
 interface FakeMediaSession extends CallMediaSession {
   handlers: CallMediaSessionHandlers | null
+  /** Which actions each `setHandlers` registered, in order — the gesture set, then the session set. */
+  registered: Array<Record<keyof CallMediaSessionHandlers, boolean>>
   releases: number
   activations: Array<{ title: string; subtitle: string }>
 }
@@ -140,6 +142,7 @@ interface FakeMediaSession extends CallMediaSession {
 function makeMediaSession(events: string[]): FakeMediaSession {
   const fake: FakeMediaSession = {
     handlers: null,
+    registered: [],
     releases: 0,
     activations: [],
     activate: vi.fn((metadata: { title: string; subtitle: string }) => {
@@ -149,6 +152,11 @@ function makeMediaSession(events: string[]): FakeMediaSession {
     setTitle: vi.fn(),
     setHandlers: vi.fn((handlers: CallMediaSessionHandlers) => {
       fake.handlers = handlers
+      fake.registered.push({
+        hangup: handlers.hangup !== null,
+        toggleMicrophone: handlers.toggleMicrophone !== null,
+        toggleCamera: handlers.toggleCamera !== null,
+      })
     }),
     setMicrophoneActive: vi.fn(),
     setCameraActive: vi.fn(),
@@ -950,11 +958,41 @@ describe("CallManager", () => {
       const { manager, socket, mediaSession } = await startedWithMediaSession()
       socket.emitted.length = 0
 
-      mediaSession.handlers?.hangup()
+      mediaSession.handlers?.hangup?.()
       await new Promise((r) => setTimeout(r, 0))
 
       expect(socket.emitted.map((e) => e.event)).toContain("call:leave")
       expect(manager.isActive()).toBe(false)
+    })
+
+    it("shows only hang-up while ringing out, then the toggles the call can actually honour", async () => {
+      const { mediaSession } = await startedWithMediaSession()
+
+      // In the gesture the session does not exist yet, so setMuted/setCameraOn
+      // would no-op; an audio-only call never gets a camera button at all.
+      expect(mediaSession.registered).toEqual([
+        { hangup: true, toggleMicrophone: false, toggleCamera: false },
+        { hangup: true, toggleMicrophone: true, toggleCamera: false },
+      ])
+    })
+
+    it("registers the camera toggle on a video call", async () => {
+      const { mediaSession } = await startedWithMediaSession({ mode: "video" })
+
+      expect(mediaSession.registered.at(-1)).toEqual({
+        hangup: true,
+        toggleMicrophone: true,
+        toggleCamera: true,
+      })
+    })
+
+    it("seeds the toggles from the live call, so the notification never opens showing it muted", async () => {
+      const { mediaSession } = await startedWithMediaSession()
+
+      // The API's toggles default to inactive; unseeded, the first lock-screen tap
+      // reads as "unmute" and mutes.
+      expect(mediaSession.setMicrophoneActive).toHaveBeenCalledWith(true)
+      expect(mediaSession.setCameraActive).toHaveBeenCalledWith(false)
     })
 
     it("mirrors mute and camera state onto the notification toggles", async () => {

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -995,6 +995,21 @@ describe("CallManager", () => {
       expect(mediaSession.setCameraActive).toHaveBeenCalledWith(false)
     })
 
+    it("seeds the camera toggle from a camera-on join, not from the pre-call default", async () => {
+      const socket = makeSocket()
+      const transport = makeTransport()
+      const mediaSession = makeMediaSession(transport._events)
+      const manager = newManager(makeDeps(socket, transport, mediaSession), null)
+
+      await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video", cameraOn: true })
+
+      // `runStart` sets `local.cameraOn` directly for a "Start with camera" join —
+      // it never goes through `setCameraOn`, the only other mirror — so seeding
+      // before that lands would claim camera-off on a call publishing video.
+      expect(mediaSession.setCameraActive).toHaveBeenCalledWith(true)
+      expect(mediaSession.setCameraActive).not.toHaveBeenCalledWith(false)
+    })
+
     it("mirrors mute and camera state onto the notification toggles", async () => {
       const { manager, mediaSession } = await startedWithMediaSession({ mode: "video" })
 

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -430,6 +430,7 @@ export class CallManager implements CallController {
         onDeviceChange: null,
       }
       this.session = session
+      this.wireMediaSessionToggles(session)
 
       // Composer dictation off for the call's life — one active capture only.
       setDictationExternalHold(true)
@@ -479,13 +480,38 @@ export class CallManager implements CallController {
     this.mediaSession = mediaSession
     if (!mediaSession) return
     mediaSession.activate({ title: this.callTitle ?? "Call", subtitle: "Threa" })
+    // Hang-up only until the session exists: `setMuted`/`setCameraOn` both
+    // early-return on a null session, so registering them here would put a mute
+    // button on the lock screen that does nothing for the whole ring-out window.
+    // `leaveCall` handles the starting path (it cancels the in-flight start).
+    mediaSession.setHandlers({
+      hangup: () => void this.leaveCall(),
+      toggleMicrophone: null,
+      toggleCamera: null,
+    })
+  }
+
+  /**
+   * Give the notification its toggles once they can act. Camera only on a video
+   * call — `setCameraOn` returns immediately on `audio_only`, and the server's
+   * mode isn't known inside the start gesture, so a handler registered there
+   * would be a dead button on the default launch mode.
+   */
+  private wireMediaSessionToggles(session: CallSession): void {
+    const mediaSession = this.mediaSession
+    if (!mediaSession) return
     // The controller's own methods, so the notification drives exactly the paths
     // the in-app controls drive (INV-35).
     mediaSession.setHandlers({
       hangup: () => void this.leaveCall(),
       toggleMicrophone: () => this.setMuted(!getCallState().local.muted),
-      toggleCamera: () => void this.setCameraOn(!getCallState().local.cameraOn),
+      toggleCamera: session.mode === "audio_only" ? null : () => void this.setCameraOn(!getCallState().local.cameraOn),
     })
+    // The API's toggles default to inactive, so an unseeded notification shows a
+    // live call as muted — and the first tap, read as "unmute", mutes.
+    const local = getCallState().local
+    mediaSession.setMicrophoneActive(!local.muted)
+    mediaSession.setCameraActive(local.cameraOn)
   }
 
   private releaseMediaSession(): void {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -430,7 +430,6 @@ export class CallManager implements CallController {
         onDeviceChange: null,
       }
       this.session = session
-      this.wireMediaSessionToggles(session)
 
       // Composer dictation off for the call's life — one active capture only.
       setDictationExternalHold(true)
@@ -455,6 +454,12 @@ export class CallManager implements CallController {
       if (joinWithCamera) patchCallLocal({ cameraOn: true })
       await this.captureAndPublish(session, { camera: joinWithCamera })
       this.assertStartLive(gen)
+      // After the capture, not before: the toggles are seeded from `local`, and a
+      // camera join sets `cameraOn` on the line above rather than through
+      // `setCameraOn` (the only site that mirrors it). Seeding earlier published a
+      // camera-off notification for a call whose camera is live — and the first
+      // lock-screen tap, read as "turn on", would have turned it off.
+      this.wireMediaSessionToggles(session)
 
       this.applyRoster(session, join.rosterVersion, join.roster)
       this.startLeaseTimer(session)

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -23,6 +23,7 @@ import {
   type CallDeviceState,
 } from "@/stores/call-store"
 import { recordCallLifecycleEvent, type CallLifecycleKind } from "./lifecycle-log"
+import { createCallMediaSession, type CallMediaSession } from "./media-session"
 import {
   CloudflareSfuTransport,
   type MediaTransport,
@@ -155,6 +156,12 @@ export interface CallManagerDeps {
   requestWakeLock(): Promise<WakeLockLike | null>
   mintIncarnation(): string
   /**
+   * The lock-screen media session for a call, or null where the platform has no
+   * Media Session API. Constructed once per call and injected, so no test touches
+   * a real `navigator.mediaSession`.
+   */
+  createMediaSession(): CallMediaSession | null
+  /**
    * True on platforms that allow only one active `getUserMedia` at a time (iOS
    * Safari): a recapture must stop the live tracks before acquiring, so an
    * acquire failure is rolled back to the prior constraints. False elsewhere,
@@ -251,6 +258,12 @@ export interface CallController {
   flipCamera(): Promise<void>
   setOutputDevice(deviceId: string): Promise<void>
   getVideoStream(endpointId: string): MediaStream | null
+  /**
+   * Push the call's human label (the stream/DM name) at the lock-screen media
+   * session. The manager holds a `streamId`, not a name, and the one stream-name
+   * resolver is a hook — so the label is pushed in, never pulled.
+   */
+  setCallTitle(title: string): void
 }
 
 /**
@@ -280,6 +293,11 @@ export class CallManager implements CallController {
   // — the iOS single-active-capture rule and the reentrancy latch in one chain.
   private captureChain: Promise<void> = Promise.resolve()
   private unregisterHangup: (() => void) | null = null
+  // The live call's lock-screen media session. Held on the manager, not the
+  // session, because it is activated inside the start gesture — before the
+  // session object exists — and `setCallTitle` can arrive at any point from then.
+  private mediaSession: CallMediaSession | null = null
+  private callTitle: string | null = null
   private readonly audioContainer: HTMLElement | null
 
   constructor(deps: CallManagerDeps, audioContainer?: HTMLElement | null) {
@@ -333,6 +351,9 @@ export class CallManager implements CallController {
     // Synchronous, in-gesture (see startCall doc). Held on a temp until the session exists.
     const audioContext = this.deps.createAudioContext()
     void audioContext?.resume().catch(() => {})
+    // Also synchronous and in-gesture: the silent element only plays from a user
+    // gesture, and a call that is merely ringing out must already own the session.
+    this.activateMediaSession()
 
     // Held on locals so the catch can release them even when a throw precedes
     // `this.session = session` (teardown early-returns on a null session).
@@ -453,6 +474,32 @@ export class CallManager implements CallController {
     }
   }
 
+  private activateMediaSession(): void {
+    const mediaSession = this.deps.createMediaSession()
+    this.mediaSession = mediaSession
+    if (!mediaSession) return
+    mediaSession.activate({ title: this.callTitle ?? "Call", subtitle: "Threa" })
+    // The controller's own methods, so the notification drives exactly the paths
+    // the in-app controls drive (INV-35).
+    mediaSession.setHandlers({
+      hangup: () => void this.leaveCall(),
+      toggleMicrophone: () => this.setMuted(!getCallState().local.muted),
+      toggleCamera: () => void this.setCameraOn(!getCallState().local.cameraOn),
+    })
+  }
+
+  private releaseMediaSession(): void {
+    this.mediaSession?.release()
+    this.mediaSession = null
+    // Or the next call opens its notification under this one's label.
+    this.callTitle = null
+  }
+
+  setCallTitle(title: string): void {
+    this.callTitle = title
+    this.mediaSession?.setTitle(title)
+  }
+
   /**
    * Throws {@link CallStartCancelledError} at a start checkpoint when `leaveCall`
    * cancelled the in-flight join, or when a newer generation superseded this one.
@@ -497,6 +544,7 @@ export class CallManager implements CallController {
         // ignore
       }
       void locals.audioContext?.close?.().catch(() => {})
+      this.releaseMediaSession()
       clearCallState()
     }
     if (locals.callId) {
@@ -550,6 +598,7 @@ export class CallManager implements CallController {
     const session = this.session
     if (!session) return
     if (session.micTrack) session.micTrack.enabled = !muted
+    this.mediaSession?.setMicrophoneActive(!muted)
     patchCallLocal({ muted })
     this.emitState(session, { muted })
   }
@@ -580,6 +629,7 @@ export class CallManager implements CallController {
         await session.transport.unpublish("camera")
         this.clearVideoStream(session, session.endpointId)
       }
+      this.mediaSession?.setCameraActive(on)
       patchCallLocal({ cameraOn: on })
       this.emitState(session, { cameraOn: on })
     })
@@ -1427,6 +1477,7 @@ export class CallManager implements CallController {
     // the just-switched-to account (the handlers also gate on gen, belt-and-braces).
     this.removeSocketHandlers(session)
     void session.wakeLock?.release().catch(() => {})
+    this.releaseMediaSession()
     session.releaseLock?.()
     setDictationExternalHold(false)
     try {
@@ -1451,6 +1502,7 @@ export class CallManager implements CallController {
     this.removeSessionListeners(session)
     session.releaseLock?.()
     await session.wakeLock?.release().catch(() => {})
+    this.releaseMediaSession()
     try {
       session.socket.disconnect()
     } catch {
@@ -1577,6 +1629,9 @@ export function defaultCallManagerDeps(): CallManagerDeps {
     },
     mintIncarnation() {
       return `mi_${ulid()}`
+    },
+    createMediaSession() {
+      return createCallMediaSession()
     },
     singleActiveCapture: detectSingleActiveCapture(),
   }

--- a/apps/frontend/src/calls/media-session.test.ts
+++ b/apps/frontend/src/calls/media-session.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from "vitest"
+import {
+  createCallMediaSession,
+  SILENT_WAV_SAMPLE_RATE,
+  type CallMediaSessionDeps,
+  type MediaSessionLike,
+} from "./media-session"
+
+/** Chromium's `kMinimumContentDuration`: below it a player is transient and gets no media session. */
+const CHROMIUM_MIN_CONTENT_SECONDS = 5
+
+function decodeWav(dataUri: string) {
+  const binary = atob(dataUri.slice("data:audio/wav;base64,".length))
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
+  const view = new DataView(bytes.buffer)
+  const dataBytes = view.getUint32(40, true)
+  const byteRate = view.getUint32(28, true)
+  return {
+    riff: binary.slice(0, 4),
+    wave: binary.slice(8, 12),
+    format: view.getUint16(20, true),
+    channels: view.getUint16(22, true),
+    sampleRate: view.getUint32(24, true),
+    bitsPerSample: view.getUint16(34, true),
+    dataBytes,
+    seconds: dataBytes / byteRate,
+    /** Unsigned 8-bit PCM silence is the midpoint; zeros would be full-scale negative. */
+    allSilent: bytes.slice(44).every((b) => b === 0x80),
+  }
+}
+
+interface FakeAudio {
+  src: string
+  loop: boolean
+  muted: boolean
+  play: ReturnType<typeof vi.fn>
+  pause: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+}
+
+function makeAudio(): FakeAudio {
+  return {
+    src: "",
+    loop: false,
+    muted: true,
+    play: vi.fn(async () => {}),
+    pause: vi.fn(),
+    remove: vi.fn(),
+  }
+}
+
+interface FakeMediaSession extends MediaSessionLike {
+  handlers: Map<string, (() => void) | null>
+  /** Actions whose `setActionHandler` throws `TypeError`, as an unsupported one does. */
+  unsupported: Set<string>
+}
+
+function makeMediaSession(unsupported: string[] = []): FakeMediaSession {
+  const handlers = new Map<string, (() => void) | null>()
+  return {
+    metadata: null,
+    playbackState: "none",
+    handlers,
+    unsupported: new Set(unsupported),
+    setActionHandler(action, handler) {
+      if (this.unsupported.has(action)) throw new TypeError(`Unsupported action: ${action}`)
+      handlers.set(action, handler)
+    },
+    setMicrophoneActive: vi.fn(),
+    setCameraActive: vi.fn(),
+  }
+}
+
+function build(unsupported: string[] = []) {
+  const audio = makeAudio()
+  const mediaSession = makeMediaSession(unsupported)
+  const deps: CallMediaSessionDeps = {
+    mediaSession,
+    createAudioElement: () => audio as unknown as HTMLAudioElement,
+    createMetadata: (init) => init,
+  }
+  const session = createCallMediaSession(deps)
+  if (!session) throw new Error("expected a media session")
+  return { session, audio, mediaSession }
+}
+
+describe("createCallMediaSession", () => {
+  it("activate plays a looping, unmuted silent element and publishes the metadata", () => {
+    const { session, audio, mediaSession } = build()
+
+    session.activate({ title: "#design", subtitle: "Threa" })
+
+    expect({
+      src: audio.src.startsWith("data:audio/wav;base64,"),
+      loop: audio.loop,
+      muted: audio.muted,
+      played: audio.play.mock.calls.length > 0,
+      metadata: mediaSession.metadata,
+      playbackState: mediaSession.playbackState,
+    }).toEqual({
+      src: true,
+      loop: true,
+      muted: false,
+      played: true,
+      metadata: { title: "#design", artist: "Threa" },
+      playbackState: "playing",
+    })
+  })
+
+  it("the silent element clears Chromium's transient-media floor, or there is no notification at all", () => {
+    const { session, audio } = build()
+
+    session.activate({ title: "#design", subtitle: "Threa" })
+    const wav = decodeWav(audio.src)
+
+    expect(wav.seconds).toBeGreaterThan(CHROMIUM_MIN_CONTENT_SECONDS)
+    expect({
+      riff: wav.riff,
+      wave: wav.wave,
+      format: wav.format,
+      channels: wav.channels,
+      sampleRate: wav.sampleRate,
+      bitsPerSample: wav.bitsPerSample,
+      dataBytes: wav.dataBytes,
+      allSilent: wav.allSilent,
+    }).toEqual({
+      riff: "RIFF",
+      wave: "WAVE",
+      format: 1,
+      channels: 1,
+      sampleRate: SILENT_WAV_SAMPLE_RATE,
+      bitsPerSample: 8,
+      dataBytes: wav.seconds * SILENT_WAV_SAMPLE_RATE,
+      allSilent: true,
+    })
+  })
+
+  it("setTitle rewrites the title, keeping the subtitle from activate", () => {
+    const { session, mediaSession } = build()
+    session.activate({ title: "Call", subtitle: "Threa" })
+
+    session.setTitle("Grace")
+
+    expect(mediaSession.metadata).toEqual({ title: "Grace", artist: "Threa" })
+  })
+
+  it("an unsupported action still leaves the supported handlers registered", () => {
+    const { session, mediaSession } = build(["hangup"])
+    const toggleMicrophone = vi.fn()
+
+    session.setHandlers({ hangup: vi.fn(), toggleMicrophone, toggleCamera: vi.fn() })
+
+    // `hangup` threw TypeError and never registered; the rest must be unaffected.
+    expect(mediaSession.handlers.has("hangup")).toBe(false)
+    mediaSession.handlers.get("togglemicrophone")?.()
+    expect(toggleMicrophone).toHaveBeenCalled()
+    expect(mediaSession.handlers.has("togglecamera")).toBe(true)
+  })
+
+  it("mirrors the mic and camera state onto the notification toggles", () => {
+    const { session, mediaSession } = build()
+
+    session.setMicrophoneActive(false)
+    session.setCameraActive(true)
+
+    expect(mediaSession.setMicrophoneActive).toHaveBeenCalledWith(false)
+    expect(mediaSession.setCameraActive).toHaveBeenCalledWith(true)
+  })
+
+  it("release pauses and removes the element, clears every handler and nulls the metadata", () => {
+    const { session, audio, mediaSession } = build()
+    session.activate({ title: "#design", subtitle: "Threa" })
+    session.setHandlers({ hangup: vi.fn(), toggleMicrophone: vi.fn(), toggleCamera: vi.fn() })
+
+    session.release()
+
+    expect({
+      paused: audio.pause.mock.calls.length,
+      removed: audio.remove.mock.calls.length,
+      handlers: Object.fromEntries(mediaSession.handlers),
+      metadata: mediaSession.metadata,
+      playbackState: mediaSession.playbackState,
+    }).toEqual({
+      paused: 1,
+      removed: 1,
+      handlers: { hangup: null, togglemicrophone: null, togglecamera: null },
+      metadata: null,
+      playbackState: "none",
+    })
+  })
+})

--- a/apps/frontend/src/calls/media-session.ts
+++ b/apps/frontend/src/calls/media-session.ts
@@ -69,10 +69,15 @@ export interface MediaSessionLike {
   setCameraActive?(active: boolean): void
 }
 
+/**
+ * A null handler unregisters its action, which also removes the control from the
+ * notification — the only way not to show a button that cannot work yet (mute
+ * before the session exists) or ever (camera on an audio-only call).
+ */
 export interface CallMediaSessionHandlers {
-  hangup: () => void
-  toggleMicrophone: () => void
-  toggleCamera: () => void
+  hangup: (() => void) | null
+  toggleMicrophone: (() => void) | null
+  toggleCamera: (() => void) | null
 }
 
 export interface CallMediaSession {

--- a/apps/frontend/src/calls/media-session.ts
+++ b/apps/frontend/src/calls/media-session.ts
@@ -1,0 +1,169 @@
+/**
+ * The web's closest approximation of a system call overlay: on Android the Media
+ * Session API renders a lock-screen notification carrying the call's title, a mute
+ * toggle and a hang-up button, and signals to the OS that this page is doing
+ * something worth keeping alive.
+ *
+ * A media session requires *actually playing* audio. `attachRemoteAudio` only
+ * creates an `<audio>` per pulled remote track, so a call that is ringing out — or
+ * a solo call, exactly when a lock-screen control matters most — has none. Hence
+ * one long-lived silent element owned for the session's life, additive to the
+ * per-track elements (which stay for the AEC reference and `setSinkId`).
+ */
+
+export const SILENT_WAV_SAMPLE_RATE = 8000
+/**
+ * Chromium classifies a player whose `duration` is under 5s as *transient*
+ * (`kMinimumContentDuration`, `media/base/media_content_type.cc`) — a
+ * notification blip, not content — and builds no controllable media session for
+ * it. `loop = true` does not raise `duration`, so a short clip yields no
+ * lock-screen notification at all. Stay clear of that floor.
+ */
+export const SILENT_WAV_SECONDS = 8
+
+let silentWavDataUri: string | null = null
+
+/**
+ * 8-bit mono PCM silence as a `data:` URI — no network fetch, and the same
+ * scheme the element used before it had to clear the 5s floor. Generated once
+ * rather than embedded, so ~64KB of zeros stays out of the bundle.
+ */
+function getSilentWav(): string {
+  if (silentWavDataUri) return silentWavDataUri
+  const dataBytes = SILENT_WAV_SECONDS * SILENT_WAV_SAMPLE_RATE
+  const bytes = new Uint8Array(44 + dataBytes)
+  const view = new DataView(bytes.buffer)
+  const ascii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i += 1) bytes[offset + i] = text.charCodeAt(i)
+  }
+  ascii(0, "RIFF")
+  view.setUint32(4, 36 + dataBytes, true)
+  ascii(8, "WAVEfmt ")
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, SILENT_WAV_SAMPLE_RATE, true)
+  view.setUint32(28, SILENT_WAV_SAMPLE_RATE, true)
+  view.setUint16(32, 1, true)
+  view.setUint16(34, 8, true)
+  ascii(36, "data")
+  view.setUint32(40, dataBytes, true)
+  // Silence in unsigned 8-bit PCM is the midpoint, not zero.
+  bytes.fill(0x80, 44)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  silentWavDataUri = `data:audio/wav;base64,${btoa(binary)}`
+  return silentWavDataUri
+}
+
+const CALL_ACTIONS = ["hangup", "togglemicrophone", "togglecamera"] as const
+
+type CallAction = (typeof CALL_ACTIONS)[number]
+
+/** The `navigator.mediaSession` surface this module touches. */
+export interface MediaSessionLike {
+  metadata: unknown
+  playbackState: string
+  setActionHandler(action: string, handler: (() => void) | null): void
+  setMicrophoneActive?(active: boolean): void
+  setCameraActive?(active: boolean): void
+}
+
+export interface CallMediaSessionHandlers {
+  hangup: () => void
+  toggleMicrophone: () => void
+  toggleCamera: () => void
+}
+
+export interface CallMediaSession {
+  activate(metadata: { title: string; subtitle: string }): void
+  setTitle(title: string): void
+  setHandlers(handlers: CallMediaSessionHandlers): void
+  setMicrophoneActive(active: boolean): void
+  setCameraActive(active: boolean): void
+  release(): void
+}
+
+/**
+ * Injected so no test touches a real `navigator.mediaSession` (jsdom has none)
+ * and no global is monkey-patched.
+ */
+export interface CallMediaSessionDeps {
+  mediaSession: MediaSessionLike
+  createAudioElement(): HTMLAudioElement
+  createMetadata(init: { title: string; artist: string }): unknown
+}
+
+function defaultDeps(): CallMediaSessionDeps | null {
+  if (typeof navigator === "undefined" || typeof document === "undefined") return null
+  const mediaSession = (navigator as Navigator & { mediaSession?: MediaSessionLike }).mediaSession
+  if (!mediaSession) return null
+  const MetadataCtor = (globalThis as { MediaMetadata?: new (init: unknown) => unknown }).MediaMetadata
+  return {
+    mediaSession,
+    createAudioElement: () => document.createElement("audio"),
+    createMetadata: (init) => (MetadataCtor ? new MetadataCtor(init) : null),
+  }
+}
+
+export function createCallMediaSession(deps?: CallMediaSessionDeps): CallMediaSession | null {
+  const resolved = deps ?? defaultDeps()
+  if (!resolved) return null
+  const { mediaSession } = resolved
+
+  let audio: HTMLAudioElement | null = null
+  let subtitle = ""
+
+  const writeMetadata = (title: string) => {
+    mediaSession.metadata = resolved.createMetadata({ title, artist: subtitle })
+  }
+
+  // Each handler is registered on its own: an action the browser does not know
+  // throws `TypeError`, and one unsupported action must not take the supported
+  // ones down with it. Per-action tolerance of a documented browser behaviour,
+  // not a swallowed error.
+  const setAction = (action: CallAction, handler: (() => void) | null) => {
+    try {
+      mediaSession.setActionHandler(action, handler)
+    } catch {
+      // Unsupported action — the remaining handlers still register.
+    }
+  }
+
+  return {
+    activate({ title, subtitle: sub }) {
+      subtitle = sub
+      const el = resolved.createAudioElement()
+      el.src = getSilentWav()
+      el.loop = true
+      // Not muted: a muted element gives the OS no session to attach to.
+      el.muted = false
+      audio = el
+      void el.play?.()?.catch(() => {})
+      writeMetadata(title)
+      mediaSession.playbackState = "playing"
+    },
+    setTitle(title) {
+      writeMetadata(title)
+    },
+    setHandlers(handlers) {
+      setAction("hangup", handlers.hangup)
+      setAction("togglemicrophone", handlers.toggleMicrophone)
+      setAction("togglecamera", handlers.toggleCamera)
+    },
+    setMicrophoneActive(active) {
+      mediaSession.setMicrophoneActive?.(active)
+    },
+    setCameraActive(active) {
+      mediaSession.setCameraActive?.(active)
+    },
+    release() {
+      audio?.pause?.()
+      audio?.remove?.()
+      audio = null
+      for (const action of CALL_ACTIONS) setAction(action, null)
+      mediaSession.metadata = null
+      mediaSession.playbackState = "none"
+    },
+  }
+}

--- a/apps/frontend/src/components/call/call-controls.test.tsx
+++ b/apps/frontend/src/components/call/call-controls.test.tsx
@@ -42,6 +42,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -82,6 +82,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }
@@ -466,6 +467,70 @@ describe("CallDock — mobile drawer vs desktop dock", () => {
     await userEvent.click(screen.getByText("launch"))
     expect(await screen.findByText(/Microphone access denied/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument()
+  })
+})
+
+describe("CallDock — lock-screen media session title", () => {
+  function seedStreams(
+    streams: Array<{ id: string; type: string; slug?: string | null; displayName?: string | null }>,
+    dmPeers: Array<{ streamId: string; userId: string }> = []
+  ) {
+    seedWorkspaceCache(WORKSPACE_ID, {
+      workspace: {
+        id: WORKSPACE_ID,
+        name: "Workspace",
+        slug: "workspace",
+        createdAt: "2026-03-01T10:00:00Z",
+        updatedAt: "2026-03-01T10:00:00Z",
+        _cachedAt: Date.now(),
+      },
+      users: [
+        user({ id: "usr_self", workosUserId: "workos_self", slug: "self", name: "Ada" }),
+        user({ id: "usr_peer", workosUserId: "workos_peer", slug: "peer", name: "Grace" }),
+      ],
+      streams: streams.map((s) => ({ ...s, workspaceId: WORKSPACE_ID, _cachedAt: Date.now() })),
+      memberships: [],
+      dmPeers: dmPeers.map((p) => ({ ...p, workspaceId: WORKSPACE_ID, _cachedAt: Date.now() })),
+      personas: [],
+      bots: [],
+    } as unknown as Parameters<typeof seedWorkspaceCache>[1])
+  }
+
+  it("pushes the resolved channel name at the manager", () => {
+    seedStreams([{ id: "stream_1", type: "channel", slug: "design", displayName: null }])
+    const manager = makeManager()
+    renderDock(manager)
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+    expect(manager.setCallTitle).toHaveBeenCalledWith("#design")
+  })
+
+  it("resolves the label during the launch window, before the store has a call session", () => {
+    // Ringing out is exactly when a locked phone reads the notification, and the
+    // store's workspace id is null for that whole window — only the launch request
+    // carries one. Clicked synchronously: awaiting lets the workspace store's IDB
+    // read (empty in jsdom) land and clobber the seeded cache.
+    seedStreams([{ id: "stream_1", type: "channel", slug: "design", displayName: null }])
+    const manager = makeManager({ startCall: vi.fn(() => new Promise<void>(() => {})) })
+    renderDock(manager)
+
+    act(() => screen.getByText("launch").click())
+
+    expect(getCallState().workspaceId).toBeNull()
+    expect(manager.setCallTitle).toHaveBeenCalledWith("#design")
+  })
+
+  it("resolves a DM to the peer's name — the case a hand-rolled lookup gets wrong", () => {
+    // A DM the viewer can open is not necessarily in the streams cache, and its
+    // `displayName` is null on the wire; only the peer lookup gets this right.
+    seedStreams([], [{ streamId: "stream_dm", userId: "usr_peer" }])
+    const manager = makeManager()
+    renderDock(manager)
+    act(() => {
+      setCallSession({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_dm", mode: "video" })
+      setCallPhase("connected")
+      setCallRoster([participant({ userId: "usr_self", endpointId: "callep_self" })], 1)
+    })
+    expect(manager.setCallTitle).toHaveBeenCalledWith("Grace")
   })
 })
 

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -39,6 +39,7 @@ import { FloatingCallSquare } from "./floating-call-square"
 import { DesktopCallFullscreen } from "./desktop-call-fullscreen"
 import { ActiveElsewhereChip } from "./active-elsewhere-chip"
 import { CallMovedChip } from "./call-moved-chip"
+import { useCallMediaSessionTitle } from "./use-call-media-session-title"
 
 /**
  * The docked call surface. Mounts at the app-layout level and is driven purely by
@@ -101,6 +102,13 @@ export function CallDock() {
     }
   }, [inCall])
 
+  const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
+  // The store's workspace id is null until the start REST call lands, and the
+  // resolver needs one — so the launch request supplies it for the ring-out
+  // window, which is exactly when a locked phone reads the notification.
+  const workspaceIdForLabel = workspaceId ?? (launch.status !== "idle" ? launch.request.workspaceId : null)
+  useCallMediaSessionTitle(workspaceIdForLabel, streamIdForLabel)
+
   // Nothing to show: idle with no launch in flight. Surface the displaced-call
   // chip if another device took this call over, then the cross-tab chip if another
   // tab holds it, otherwise render nothing.
@@ -122,8 +130,6 @@ export function CallDock() {
     }
     return null
   }
-
-  const streamIdForLabel = storeStreamId ?? (launch.status !== "idle" ? launch.request.streamId : null)
 
   // Mobile is unchanged: the 4-mode top drawer in-call, the same top island for
   // joining/permission (one surface, no bottom→top jump).

--- a/apps/frontend/src/components/call/call-stage-layout.test.tsx
+++ b/apps/frontend/src/components/call/call-stage-layout.test.tsx
@@ -64,6 +64,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/call-start-menu.test.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.test.tsx
@@ -21,6 +21,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
+++ b/apps/frontend/src/components/call/call-surface-avoidance.test.tsx
@@ -115,6 +115,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -75,6 +75,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -72,6 +72,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -78,6 +78,7 @@ function makeManager(overrides: Partial<CallController> = {}): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/frontend/src/components/call/use-call-media-session-title.ts
+++ b/apps/frontend/src/components/call/use-call-media-session-title.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useCallManager } from "./call-manager-context"
+
+/**
+ * Push the call's stream label at the lock-screen media session. The manager
+ * holds a `streamId`, and the single stream-name resolver is a hook — so the
+ * resolved label is pushed in rather than pulled (frontend `CLAUDE.md`: one
+ * resolver, no hand-rolled lookups).
+ */
+export function useCallMediaSessionTitle(workspaceId: string | null, streamId: string | null): void {
+  const manager = useCallManager()
+  const name = useStreamName(workspaceId ?? "", streamId ?? "", "generic")
+  useEffect(() => {
+    if (!name) return
+    manager.setCallTitle(name)
+  }, [manager, name])
+}

--- a/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
+++ b/apps/frontend/src/components/user-profile/user-profile-modal.test.tsx
@@ -81,6 +81,7 @@ function makeManager(): CallController {
     flipCamera: vi.fn(async () => {}),
     setOutputDevice: vi.fn(async () => {}),
     getVideoStream: vi.fn(() => null),
+    setCallTitle: vi.fn(),
   }
 }
 


### PR DESCRIPTION
Chunk 2 of 3. Stacked on [#1622](https://github.com/threahq/threa/pull/1622).

## Problem

A PWA cannot reach the system call overlay. Everything behind Slack's and Teams' in-call UI is native — Android `ConnectionService`, full-screen intent, `SYSTEM_ALERT_WINDOW`, a `microphone`-type foreground service, CallKit + PushKit — so we can neither join the system one nor draw our own. On a locked phone a Threa call is currently invisible and uncontrollable: no title, no mute, no way to hang up without unlocking.

The Media Session API is the closest the web gets, and we use none of it: `grep mediaSession apps/ packages/ tests/` is empty. There is also a precondition we fail. A media session needs actually-playing audio, and `attachRemoteAudio` (`call-manager.ts:1109`) creates an `<audio>` per pulled remote track — so a call that is ringing out, or a solo call, has no audio element at all. That is exactly the window where a lock-screen control matters most.

## Solution

One long-lived silent element for the session's life, plus metadata and the call-specific actions.

- `apps/frontend/src/calls/media-session.ts` — `createCallMediaSession()` owns an unmuted looping `<audio>` on a self-contained `data:` URI: no network fetch, and additive to the per-track elements, which stay for the AEC reference and `setSinkId`.
- **The clip is 8 seconds, not a token blip.** Chromium's `DurationToMediaContentType` maps a `duration` below `kMinimumContentDuration` (5s) to `kTransient`, and a transient player never becomes a controllable media session — `loop = true` does not raise `duration`. A short clip would have shipped the whole feature as a no-op on Android with every unit test green. Generated at runtime and cached, so ~64KB of zeros stays out of the bundle; `SILENT_WAV_SECONDS`/`SILENT_WAV_SAMPLE_RATE` are exported and the test decodes the real header.
- Activation is the first statement of `runStart` — synchronous, inside the click's transient activation, before the REST start, the transport connect and the first capture. `audio.play()` only succeeds from a gesture, and the ringing-out call has to already own the session. The test pins the ordering against the transport's own event log.
- Handlers route to `leaveCall` / `setMuted` / `setCameraOn` — the methods the in-app controls drive, not a parallel path (INV-35) — and `setMuted`/`setCameraOn` mirror into `setMicrophoneActive`/`setCameraActive` so the notification's toggles match the app.
- Each `setActionHandler` is caught individually. An action the browser does not know throws `TypeError`, and one unsupported action must not take the supported ones down with it. Per-action tolerance of a documented browser behaviour, commented as such — not a blanket swallow (INV-11).
- Injected as a `CallManagerDeps` collaborator (INV-12/13), so no test touches a real `navigator.mediaSession` and no global is patched (INV-48). A null handle (no Media Session API) leaves the whole start path working.
- Released in `teardown`, `hangupSync` and `rollbackStart`, each beside the wake-lock release.

**Deviation from the plan:** the handle lives on the `CallManager` (`this.mediaSession`), not on `CallSession`. Activation happens before the session object exists, and `setCallTitle` can arrive at any point in the join window — a session-owned field would silently drop the title pushed while joining, which is the normal case, since the dock resolves the name on first render.

The title is pushed in rather than pulled: the manager holds a `streamId`, and the one stream-name resolver (`useStreamName`, per `apps/frontend/CLAUDE.md`) is a hook. `CallDock` calls `useCallMediaSessionTitle` once, and takes the workspace id from the launch request while the store still has none — the ring-out window, which is precisely when a locked phone reads the notification.

Out of scope on purpose: consolidating remote audio into one element, `MediaMetadata.artwork` (needs a same-origin avatar pipeline), the service-worker notification (`docs/plans/calls-background-mobile.md` says why it buys nothing), and any lease-constant change.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/calls/media-session.ts` | **new** — the collaborator, the generated silent WAV, per-action handler registration |
| `apps/frontend/src/calls/media-session.test.ts` | **new** — activate/release, the transient-media floor, an unsupported action |
| `apps/frontend/src/calls/call-manager.ts` | `createMediaSession` dep, in-gesture activation, handler wiring, mute/camera mirrors, release on every exit, `setCallTitle` |
| `apps/frontend/src/calls/call-manager.test.ts` | ordering, hangup-for-real, mirrors, release-once on both paths, stale-title guard, null-platform path |
| `apps/frontend/src/components/call/use-call-media-session-title.ts` | **new** — resolves via `useStreamName`, pushes through the controller |
| `apps/frontend/src/components/call/call-dock.tsx` | calls the hook once; `workspaceIdForLabel` covers the launch window |
| `apps/frontend/src/components/call/call-dock.test.tsx` | channel name, DM peer name, launch-window resolution |
| 8 other test files | `setCallTitle` added to their `CallController` fakes |

## Test plan

- [x] `vitest src/calls/ src/components/call/ src/lib/no-happy-path-success-toast.test.ts` — 22 files, 250 tests pass
- [x] `tsc --noEmit` (`apps/frontend`) — clean; `bun run lint` (root) — clean
- [x] Adversarial review found 2, both accepted and fixed: the 20ms clip that would have produced no notification at all, and a stale `callTitle` that opened a later call under the previous call's label
- [x] `/code-review` found 3 more, all accepted and fixed in `2cb812bf`, all with one cause — the handlers were registered inside the start gesture, where nothing they call can act yet. The toggles were never seeded (the API defaults both to inactive, so the notification opened rendering a live unmuted call as muted, and the first tap muted the user); `togglecamera` was registered on audio-only calls, where `setCameraOn` returns immediately; `toggleMicrophone` was inert for the whole ring-out window. Activation now registers hang-up alone, and `wireMediaSessionToggles` adds mute — and camera only on a video call — once the session exists, seeded from the live state
- [x] Falsifiability: `SILENT_WAV_SECONDS = 1` reds the floor test; removing the `callTitle` reset reds the stale-label test; reverting `workspaceIdForLabel` reds the launch-window test; moving activation after `transport.connect` reds the ordering test
- [ ] Real hardware. Two things only a phone can answer: whether Chrome grants a session to a *silent* element, and whether hang-up from the lock screen actually ends the call

One harness note, so nobody tidies it back: the launch-window dock test clicks synchronously inside `act`. Awaiting lets the workspace store's IDB read (empty under jsdom) resolve and clobber the seeded memory cache, so the resolver returns null for reasons unrelated to the code under test.

<details>
<summary>📋 Full implementation plan</summary>

`docs/plans/calls-background-mobile.md` (added in [#1622](https://github.com/threahq/threa/pull/1622)), section 2.

```
main
 └── feat/calls-lifecycle-log          (#1622 — instrumentation)
      └── feat/calls-media-session     (this PR)
           └── feat/calls-ended-while-away  (DisplacedCall.reason + the iOS notice)
```

Unverified from source, per the plan's own list: whether Chrome grants a media session to a silent looping element. It is the standard trick and the shape of this chunk depends on it; if Android refuses, this is the piece to revisit — routing remote audio through one long-lived element would work but costs the per-track AEC/`setSinkId` shape. No fallback was invented for a failure mode nobody has observed (INV-36).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
