### PR TITLE
feat(calls): say why a call left this device instead of guessing takeover

### DIFF
--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -407,6 +407,7 @@ describe("CallManager", () => {
       workspaceId: "ws_1",
       streamId: "stream_1",
       mode: "video",
+      reason: "taken_over",
     })
   })
 
@@ -422,7 +423,7 @@ describe("CallManager", () => {
     expect(getCallState().displacedCall).toBeNull()
   })
 
-  it("lands on the same displaced state when only the lease renew reports the takeover", async () => {
+  it("still explains itself when only the lease renew reports the lost endpoint", async () => {
     vi.useFakeTimers()
     const socket = makeSocket()
     const manager = newManager(makeDeps(socket, makeTransport()), null)
@@ -435,7 +436,13 @@ describe("CallManager", () => {
     vi.advanceTimersByTime(15_000)
     await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
 
-    expect(getCallState().displacedCall).toMatchObject({ callId: "call_1", streamId: "stream_1" })
+    // NOT `taken_over`: a swept lease and a superseded one are the same null from
+    // `renewLease`, so this signal cannot name another device.
+    expect(getCallState().displacedCall).toMatchObject({
+      callId: "call_1",
+      streamId: "stream_1",
+      reason: "connection_lost",
+    })
   })
 
   it("mute gates track.enabled and emits call:state", async () => {
@@ -832,7 +839,7 @@ describe("CallManager", () => {
 
   // ── F3: a reconnect that returns a different endpoint id must not stay connected ──
 
-  it("F3: a reconnect returning a NEW endpoint id tears down instead of staying connected", async () => {
+  it("F3: a reconnect returning a NEW endpoint id tears down and says the connection was lost", async () => {
     const socket = makeSocket()
     const transport = makeTransport()
     const manager = newManager(makeDeps(socket, transport), null)
@@ -848,8 +855,134 @@ describe("CallManager", () => {
 
     // The transport is bound to the old endpoint — a changed id is unrecoverable.
     expect(manager.isActive()).toBe(false)
-    expect(getCallState().phase).not.toBe("connected")
     expect(getCallState().phase).toBe("idle")
+    // Never a silent vanish — and never a takeover claim: the page never froze, so
+    // the lease most likely lapsed across a network gap. Only the endpoint-closed
+    // push can name another device.
+    expect(getCallState().displacedCall).toEqual({
+      callId: "call_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      mode: "audio_only",
+      reason: "connection_lost",
+    })
+  })
+
+  it("F3: the same reconnect after a freeze says the call ended while the page was away", async () => {
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    document.dispatchEvent(new Event("freeze"))
+    socket.joinAck = { ...socket.joinAck, endpointId: "ep_2" }
+    socket.fire("disconnect")
+    socket.fire("connect")
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCallState().displacedCall).toMatchObject({ callId: "call_1", reason: "ended_while_away" })
+  })
+
+  it("F3: a pagehide is the same evidence as a freeze", async () => {
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    window.dispatchEvent(new Event("pagehide"))
+    socket.joinAck = { ...socket.joinAck, endpointId: "ep_2" }
+    socket.fire("disconnect")
+    socket.fire("connect")
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCallState().displacedCall).toMatchObject({ reason: "ended_while_away" })
+  })
+
+  it("F3: a rejoin that fails outright says so instead of vanishing", async () => {
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    document.dispatchEvent(new Event("freeze"))
+    socket.failJoin = true
+    socket.fire("disconnect")
+    socket.fire("connect")
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCallState().phase).toBe("idle")
+    expect(getCallState().displacedCall).toMatchObject({ callId: "call_1", reason: "ended_while_away" })
+  })
+
+  it("F3: leaving during an in-flight rejoin ends the call without a notice", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    // Reconnecting, rejoin ack outstanding, and the user gives up and hangs up.
+    // The link is dead both ways, so the leave ack never comes back either and
+    // `emitLeave` holds the session for its full 2s timeout.
+    socket.deferJoin = true
+    socket.joinAck = { ...socket.joinAck, endpointId: "ep_2" }
+    socket.fire("disconnect")
+    socket.fire("connect")
+    const emit = socket.emit
+    socket.emit = ((event: string, payload: unknown, ack?: (r: unknown) => void) => {
+      if (event === "call:leave") return
+      emit.call(socket, event, payload, ack)
+    }) as CallSocket["emit"]
+
+    const leaving = manager.leaveCall()
+    // Mid-leave, the rejoin lands with a new endpoint id. A deliberate hangup
+    // must not be explained away as the call having gone somewhere.
+    socket.pendingJoinAck?.({ ok: true, data: socket.joinAck })
+    await vi.advanceTimersByTimeAsync(2_000)
+    await leaving
+
+    expect(getCallState().displacedCall).toBeNull()
+  })
+
+  it("F3: a successful lease renew clears the suspended evidence, so a later loss is not blamed on the lock", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    document.dispatchEvent(new Event("freeze"))
+    vi.advanceTimersByTime(15_000)
+    socket.leaseRenewAck = { ok: false, code: "CALL_LEASE_SUPERSEDED" }
+    vi.advanceTimersByTime(15_000)
+    await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
+
+    // The renew proved the lease survived the freeze, so whatever killed it after
+    // that is not the lock — and is still not evidence of another device.
+    expect(getCallState().displacedCall).toMatchObject({ reason: "connection_lost" })
+  })
+
+  it("F3: a lease superseded while still suspended reads as ended-while-away", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "audio_only" })
+
+    document.dispatchEvent(new Event("freeze"))
+    socket.leaseRenewAck = { ok: false, code: "CALL_LEASE_SUPERSEDED" }
+    vi.advanceTimersByTime(15_000)
+    await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
+
+    expect(getCallState().displacedCall).toMatchObject({ reason: "ended_while_away" })
+  })
+
+  it("F3: the endpoint-closed push stays a takeover even after a freeze", async () => {
+    const socket = makeSocket()
+    const manager = newManager(makeDeps(socket, makeTransport()), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    // The server addressed this endpoint under the call-row lock: unambiguous,
+    // whatever the page was doing.
+    document.dispatchEvent(new Event("freeze"))
+    socket.fire("call:endpoint:closed", { callId: "call_1", endpointId: "ep_1", reason: "taken_over" })
+    await vi.waitFor(() => expect(getCallState().phase).toBe("idle"))
+
+    expect(getCallState().displacedCall).toMatchObject({ reason: "taken_over" })
   })
 
   // ── F4: a failed camera publish must not leave a live undisclosed camera track ──

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -3,6 +3,7 @@ import { io } from "socket.io-client"
 import { api } from "@/api/client"
 import { getCachedWsConfig } from "@/lib/cached-ws-config"
 import { setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
+import { isIosWebKit } from "@/lib/platform"
 import {
   setCallSession,
   setCallPhase,
@@ -1637,14 +1638,11 @@ function resolveCallsUrl(workspaceId: string): string | null {
 
 /**
  * iOS/iPadOS Safari allows only one active `getUserMedia` at a time — a second
- * concurrent capture mutes the first. iPadOS reports as "MacIntel", so fall
- * through to the touch-point probe there.
+ * concurrent capture mutes the first. Kept as its own name because that is a
+ * capture rule, not a platform fact; the probe itself is shared (INV-35).
  */
 function detectSingleActiveCapture(): boolean {
-  if (typeof navigator === "undefined") return false
-  const ua = navigator.userAgent ?? ""
-  if (/iPad|iPhone|iPod/.test(ua)) return true
-  return navigator.platform === "MacIntel" && (navigator.maxTouchPoints ?? 0) > 1
+  return isIosWebKit()
 }
 
 export function defaultCallManagerDeps(): CallManagerDeps {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -21,6 +21,7 @@ import {
   getCallState,
   type CallRosterParticipant,
   type CallDeviceState,
+  type DisplacedCallReason,
 } from "@/stores/call-store"
 import { recordCallLifecycleEvent, type CallLifecycleKind } from "./lifecycle-log"
 import { createCallMediaSession, type CallMediaSession } from "./media-session"
@@ -212,6 +213,13 @@ interface CallSession {
   meterRaf: number | null
   wakeLock: WakeLockLike | null
   releaseLock: (() => void) | null
+  /**
+   * The page was frozen or hidden by a `pagehide` since the last lease renew
+   * that succeeded — i.e. we were suspended and have NOT proven the lease
+   * survived. `freeze`/`pagehide` only: a desktop tab switch fires
+   * `visibilitychange` and would mislabel a genuine takeover.
+   */
+  suspendedSinceRenew: boolean
   /** Detaches every page-lifecycle listener installed for this session. */
   onLifecycle: (() => void) | null
   onDeviceChange: (() => void) | null
@@ -426,6 +434,7 @@ export class CallManager implements CallController {
         meterRaf: null,
         wakeLock: null,
         releaseLock,
+        suspendedSinceRenew: false,
         onLifecycle: null,
         onDeviceChange: null,
       }
@@ -611,6 +620,11 @@ export class CallManager implements CallController {
     }
     const session = this.session
     if (!session) return
+    // Retire the generation before awaiting the leave ack (up to 2s, and longer
+    // in the reconnecting case this is most often used from). Until now nothing
+    // read it during that window; a re-join continuation landing in it would
+    // write a displaced notice for a call the user deliberately ended.
+    this.sessionGen++
     await this.emitLeave(session)
     await this.teardown()
   }
@@ -817,7 +831,7 @@ export class CallManager implements CallController {
       if (!s) return
       const evt = payload as { callId?: string; endpointId?: string }
       if (evt.callId !== s.callId || evt.endpointId !== s.endpointId) return
-      void this.handleTakenOver(s)
+      void this.handleTakenOver(s, "taken_over")
     })
     session.socket.on("disconnect", () => {
       // A socket drop is NOT a call end (the lease holds the slot). Demote to
@@ -851,7 +865,7 @@ export class CallManager implements CallController {
           // (a fresh incarnation on the fresh endpoint).
           if (join.endpointId !== s.endpointId) {
             recordCallLifecycleEvent({ kind: "rejoin_new_endpoint", detail: join.endpointId })
-            void this.teardown()
+            void this.handleTakenOver(s, this.ambiguousDisplacedReason(s))
             return
           }
           recordCallLifecycleEvent({ kind: "rejoin_same_endpoint" })
@@ -862,35 +876,52 @@ export class CallManager implements CallController {
         .catch((err: unknown) => {
           // Same recheck: a stale failed rejoin for the OLD call must not tear
           // down whatever `this.session` now is (possibly a newly started call).
-          if (!this.sessionForGen(gen)) return
+          const s = this.sessionForGen(gen)
+          if (!s) return
           recordCallLifecycleEvent({ kind: "rejoin_failed", detail: err instanceof Error ? err.message : undefined })
-          void this.teardown()
+          void this.handleTakenOver(s, this.ambiguousDisplacedReason(s))
         })
     })
   }
 
   /**
-   * Give the call up to the device that took it over, and say where it went.
+   * Give the call up and say why it is gone: another device took it over, or a
+   * lease lapsed while this page was suspended. Every path that loses the call
+   * without the user asking lands here, so none of them can vanish silently.
    *
    * Local teardown ONLY — this must not leave server-side. `call:leave` would
    * cancel this user's own outgoing ring (taking over a still-ringing DM call
    * would kill the ring the new device wants), and the endpoint-free REST leave
    * closes EVERY live endpoint of the user, including the one that just took
-   * over. The server already closed this endpoint under the call-row lock;
-   * there is nothing left here to settle.
+   * over. The endpoint here is already closed or reaped server-side; there is
+   * nothing left to settle.
    *
    * The notice is written after `teardown` (which clears the store) so it
    * survives — {@link DisplacedCall}.
    */
-  private async handleTakenOver(session: CallSession): Promise<void> {
+  private async handleTakenOver(session: CallSession, reason: DisplacedCallReason): Promise<void> {
     const displaced = {
       callId: session.callId,
       workspaceId: session.workspaceId,
       streamId: session.streamId,
       mode: session.mode,
+      reason,
     }
     await this.teardown()
     setDisplacedCall(displaced)
+  }
+
+  /**
+   * A lost endpoint with no cause attached. `renewLease` returns the same null
+   * for a superseded lease as for one the sweeper reaped, and a re-join that
+   * fails or returns a new endpoint id says nothing about who holds the call —
+   * so none of these may claim a takeover, which only the
+   * `call:endpoint:closed` push proves. Being suspended since the last good
+   * renew is the only evidence the client has, and it separates a locked phone
+   * from a network gap longer than the lease TTL.
+   */
+  private ambiguousDisplacedReason(session: CallSession): DisplacedCallReason {
+    return session.suspendedSinceRenew ? "ended_while_away" : "connection_lost"
   }
 
   private applyRoster(session: CallSession, version: number, roster: CallRosterParticipant[]): void {
@@ -1273,15 +1304,17 @@ export class CallManager implements CallController {
         // stale ack never tears down a newer call.
         if (!this.sessionForGen(gen)) return
         const ack = result as Ack<{ leaseExpiresAt: string }>
-        if (ack?.ok) recordCallLifecycleEvent({ kind: "lease_renew_ok" })
-        else recordCallLifecycleEvent({ kind: "lease_renew_failed", detail: ack?.code })
+        if (ack?.ok) {
+          session.suspendedSinceRenew = false
+          recordCallLifecycleEvent({ kind: "lease_renew_ok" })
+        } else recordCallLifecycleEvent({ kind: "lease_renew_failed", detail: ack?.code })
         // A superseded lease means our endpoint was taken over — the call is lost
         // on this incarnation. The socket push above normally gets here first;
         // this is the backstop for a device that lost the socket, and it lands on
         // the same displaced state so the outcome doesn't depend on which won.
         if (!ack?.ok && ack?.code === "CALL_LEASE_SUPERSEDED") {
           const s = this.sessionForGen(gen)
-          if (s) void this.handleTakenOver(s)
+          if (s) void this.handleTakenOver(s, this.ambiguousDisplacedReason(s))
         }
       })
     }, interval)
@@ -1369,13 +1402,18 @@ export class CallManager implements CallController {
       if (this.session !== session) return
       recordCallLifecycleEvent({ kind })
     }
+    const suspendRecorder = (kind: CallLifecycleKind) => () => {
+      if (this.session !== session) return
+      session.suspendedSinceRenew = true
+      recordCallLifecycleEvent({ kind })
+    }
     const bindings: Array<[EventTarget, string, () => void]> = [
       [document, "visibilitychange", onVisibility],
-      [document, "freeze", recorder("freeze")],
+      [document, "freeze", suspendRecorder("freeze")],
       [document, "resume", recorder("resume")],
     ]
     if (typeof window !== "undefined") {
-      bindings.push([window, "pagehide", recorder("pagehide")], [window, "pageshow", recorder("pageshow")])
+      bindings.push([window, "pagehide", suspendRecorder("pagehide")], [window, "pageshow", recorder("pageshow")])
     }
     for (const [target, event, handler] of bindings) target.addEventListener(event, handler)
     session.onLifecycle = () => {

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -174,7 +174,15 @@ describe("CallDock — idle", () => {
     renderDock(manager)
     // The manager writes this after its teardown; the surface it was rendering is
     // already gone, so this chip is the only thing left that explains why.
-    act(() => setDisplacedCall({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    act(() =>
+      setDisplacedCall({
+        callId: "call_1",
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_1",
+        mode: "video",
+        reason: "taken_over",
+      })
+    )
 
     expect(screen.getByText(/moved to another device/i)).toBeInTheDocument()
     await userEvent.click(screen.getByRole("button", { name: "Rejoin here" }))
@@ -187,9 +195,57 @@ describe("CallDock — idle", () => {
 
   it("dismisses the moved-call chip", async () => {
     renderDock(makeManager())
-    act(() => setDisplacedCall({ callId: "call_1", workspaceId: WORKSPACE_ID, streamId: "stream_1", mode: "video" }))
+    act(() =>
+      setDisplacedCall({
+        callId: "call_1",
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_1",
+        mode: "video",
+        reason: "taken_over",
+      })
+    )
     await userEvent.click(screen.getByRole("button", { name: "Dismiss" }))
     expect(screen.queryByText(/moved to another device/i)).toBeNull()
+  })
+
+  it("says the call ended while the phone was locked, with the same one-tap rejoin", async () => {
+    const manager = makeManager()
+    renderDock(manager)
+    act(() =>
+      setDisplacedCall({
+        callId: "call_1",
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_1",
+        mode: "video",
+        reason: "ended_while_away",
+      })
+    )
+
+    expect(screen.getByText(/ended while your phone was locked/i)).toBeInTheDocument()
+    expect(screen.queryByText(/moved to another device/i)).toBeNull()
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Rejoin here" }))
+    // Still a takeover launch: this device's own stale endpoint may hold the lease.
+    expect(manager.startCall).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: "stream_1", expectedCallId: "call_1", takeover: true })
+    )
+  })
+
+  it("blames the connection, not another device, when there is no evidence of a takeover", () => {
+    renderDock(makeManager())
+    act(() =>
+      setDisplacedCall({
+        callId: "call_1",
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_1",
+        mode: "video",
+        reason: "connection_lost",
+      })
+    )
+
+    expect(screen.getByText(/lost its connection/i)).toBeInTheDocument()
+    expect(screen.queryByText(/moved to another device/i)).toBeNull()
+    expect(screen.getByRole("button", { name: "Rejoin here" })).toBeInTheDocument()
   })
 })
 

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -156,6 +156,32 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+describe("CallDock — opening surface mode", () => {
+  const REAL_UA = navigator.userAgent
+  function setUserAgent(value: string) {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, get: () => value })
+  }
+  afterEach(() => setUserAgent(REAL_UA))
+
+  it("opens an audio call at compact", () => {
+    setUserAgent("Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/150")
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+
+    expect(getCallState().surfaceMode).toBe("compact")
+  })
+
+  it("opens an audio call at standard on iOS, the only mode that shows the lock warning", () => {
+    // `compact` is a fixed 72px pill with no room for the notice, so a warning
+    // gated to the taller modes would never reach the user it is written for.
+    setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15")
+    renderDock(makeManager())
+    enterConnectedCall([participant({ userId: "usr_self", endpointId: "callep_self" })])
+
+    expect(getCallState().surfaceMode).toBe("standard")
+  })
+})
+
 describe("CallDock — idle", () => {
   it("renders nothing when idle with no launch or cross-tab call", () => {
     const { container } = renderDock(makeManager())

--- a/apps/frontend/src/components/call/call-dock.tsx
+++ b/apps/frontend/src/components/call/call-dock.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect, useRef } from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
+import { isIosWebKit } from "@/lib/platform"
 import { getCallState, setCallSurfaceMode, setDesktopSurfaceOverride } from "@/stores/call-store"
 import {
   resolveDesktopSurface,
@@ -96,9 +97,14 @@ export function CallDock() {
   // (standard/gallery) when joining with the camera on, so a video join lands on
   // tiles. Guarded on the initial `min` so it runs once and later drags win;
   // `surfaceMode` is read only by the sidebar dock (the square uses its own state).
+  //
+  // iOS opens at `standard` regardless: `compact` is a fixed 72px pill with no
+  // room for the lock-ends-the-call notice, and a warning the user never sees on
+  // the surface an audio call lands on is not a warning. Drag down still works.
   useLayoutEffect(() => {
     if (inCall && getCallState().surfaceMode === "min") {
-      setCallSurfaceMode(getCallState().local.cameraOn ? "standard" : "compact")
+      const open = getCallState().local.cameraOn || isIosWebKit()
+      setCallSurfaceMode(open ? "standard" : "compact")
     }
   }, [inCall])
 

--- a/apps/frontend/src/components/call/call-moved-chip.tsx
+++ b/apps/frontend/src/components/call/call-moved-chip.tsx
@@ -1,39 +1,50 @@
-import { PhoneForwarded, X } from "lucide-react"
+import { PhoneForwarded, PhoneOff, X, type LucideIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { setDisplacedCall, type DisplacedCallReason } from "@/stores/call-store"
 import { useCallLaunch } from "./call-launch-context"
 import { useDisplacedCall } from "./call-store-hooks"
 
-/**
- * Shown after the call left this device without the user ending it: another
- * device took it over ("Join on this device" there), or the lease lapsed while
- * this page was frozen. The dock has already torn down — without this the call
- * surface would simply vanish mid-conversation.
- *
- * A chip with actions rather than a toast (INV-63): it needs a decision, and a
- * toast would expire before a user who was looking at their other device sees it.
- * This chip exists BECAUSE the other device holds the call, so its action asks
- * for takeover directly — routing through a plain join would 409 and re-ask a
- * question the chip already answered. Harmless if that device has since left:
- * with no live endpoint, takeover mints a fresh one.
- *
- * The pill caps at the viewport so a phone truncates the message instead of
- * pushing the actions off the left edge (it is `fixed right-4` with no left
- * anchor, and this branch of the dock is shared with mobile).
- */
 const DISPLACED_TEXT: Record<DisplacedCallReason, string> = {
   taken_over: "Call moved to another device",
   ended_while_away: "Call ended while your phone was locked",
   connection_lost: "Call ended — this device lost its connection",
 }
 
+// The forwarded-call glyph asserts a takeover as loudly as the words do, and a
+// user reads it first. Only the reason that proves one keeps it.
+const DISPLACED_ICON: Record<DisplacedCallReason, LucideIcon> = {
+  taken_over: PhoneForwarded,
+  ended_while_away: PhoneOff,
+  connection_lost: PhoneOff,
+}
+
+/**
+ * Shown after the call left this device without the user ending it: another
+ * device took it over ("Join on this device" there), or the endpoint's lease
+ * lapsed — because this page was suspended, or because the connection was gone
+ * longer than the lease TTL. The dock has already torn down — without this the
+ * call surface would simply vanish mid-conversation.
+ *
+ * A chip with actions rather than a toast (INV-63): it needs a decision, and a
+ * toast would expire before a user who was looking at their other device sees it.
+ * The action asks for takeover on every reason, not only `taken_over`: a live
+ * endpoint still holding this call is the common case either way — the other
+ * device on a takeover, this device's own reaped-but-not-yet-swept endpoint
+ * otherwise — and a plain join would 409 and re-ask a question the chip already
+ * answered. Harmless with no live endpoint: takeover then mints a fresh one.
+ *
+ * The pill caps at the viewport so a phone truncates the message instead of
+ * pushing the actions off the left edge (it is `fixed right-4` with no left
+ * anchor, and this branch of the dock is shared with mobile).
+ */
 export function CallMovedChip() {
   const displaced = useDisplacedCall()
   const { launch } = useCallLaunch()
   if (!displaced) return null
+  const Icon = DISPLACED_ICON[displaced.reason]
   return (
     <div className="flex max-w-[calc(100vw-2rem)] items-center gap-1.5 rounded-full border bg-background py-1.5 pl-3 pr-1.5 text-xs shadow-lg">
-      <PhoneForwarded className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
       <span className="min-w-0 truncate text-muted-foreground">{DISPLACED_TEXT[displaced.reason]}</span>
       <Button
         size="sm"

--- a/apps/frontend/src/components/call/call-moved-chip.tsx
+++ b/apps/frontend/src/components/call/call-moved-chip.tsx
@@ -1,13 +1,14 @@
 import { PhoneForwarded, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { setDisplacedCall } from "@/stores/call-store"
+import { setDisplacedCall, type DisplacedCallReason } from "@/stores/call-store"
 import { useCallLaunch } from "./call-launch-context"
 import { useDisplacedCall } from "./call-store-hooks"
 
 /**
- * Shown after another of this user's devices took the call over ("Join on this
- * device" there). The server closed this endpoint, so the dock has already torn
- * down — without this the call surface would simply vanish mid-conversation.
+ * Shown after the call left this device without the user ending it: another
+ * device took it over ("Join on this device" there), or the lease lapsed while
+ * this page was frozen. The dock has already torn down — without this the call
+ * surface would simply vanish mid-conversation.
  *
  * A chip with actions rather than a toast (INV-63): it needs a decision, and a
  * toast would expire before a user who was looking at their other device sees it.
@@ -20,6 +21,12 @@ import { useDisplacedCall } from "./call-store-hooks"
  * pushing the actions off the left edge (it is `fixed right-4` with no left
  * anchor, and this branch of the dock is shared with mobile).
  */
+const DISPLACED_TEXT: Record<DisplacedCallReason, string> = {
+  taken_over: "Call moved to another device",
+  ended_while_away: "Call ended while your phone was locked",
+  connection_lost: "Call ended — this device lost its connection",
+}
+
 export function CallMovedChip() {
   const displaced = useDisplacedCall()
   const { launch } = useCallLaunch()
@@ -27,7 +34,7 @@ export function CallMovedChip() {
   return (
     <div className="flex max-w-[calc(100vw-2rem)] items-center gap-1.5 rounded-full border bg-background py-1.5 pl-3 pr-1.5 text-xs shadow-lg">
       <PhoneForwarded className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-      <span className="min-w-0 truncate text-muted-foreground">Call moved to another device</span>
+      <span className="min-w-0 truncate text-muted-foreground">{DISPLACED_TEXT[displaced.reason]}</span>
       <Button
         size="sm"
         variant="secondary"

--- a/apps/frontend/src/components/call/desktop-call-dock.test.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.test.tsx
@@ -149,6 +149,35 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+describe("DesktopCallDock — iOS lock notice", () => {
+  const REAL_UA = navigator.userAgent
+  function setUserAgent(value: string) {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, get: () => value })
+  }
+  afterEach(() => setUserAgent(REAL_UA))
+
+  it("warns on an iPad, which is above the mobile breakpoint and never sees the drawer", () => {
+    // `useIsMobile()` is viewport-based, so an iPad — and an iPhone in landscape —
+    // gets the desktop surfaces. Gating the warning to the drawer would hide it
+    // from devices `isIosWebKit()` goes out of its way to detect.
+    setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15")
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("standard") // what `CallDock` forces on iOS; `min` is the collapsed rail
+
+    expect(screen.getByTestId("call-ios-lock-notice")).toBeInTheDocument()
+  })
+
+  it("stays quiet where backgrounding does not end the call", () => {
+    setUserAgent("Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/150")
+    renderDock()
+    enterConnected(TWO_PEERS)
+    setMode("standard")
+
+    expect(screen.queryByTestId("call-ios-lock-notice")).toBeNull()
+  })
+})
+
 describe("DesktopCallDock — side dock presentations", () => {
   it("min renders the Rail: restore chevron + timer + collapsed controls", () => {
     renderDock()

--- a/apps/frontend/src/components/call/desktop-call-dock.tsx
+++ b/apps/frontend/src/components/call/desktop-call-dock.tsx
@@ -28,6 +28,7 @@ import { CallControls } from "./call-controls"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
+import { IosLockNotice } from "./ios-lock-notice"
 import { CallJoiningBody } from "./pre-join-gate"
 import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
@@ -217,6 +218,7 @@ function SideTilesView({
         surfacePickerTriggerRef={surfacePickerTriggerRef}
       />
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <IosLockNotice className="mx-3 mt-2" />
       <div className={cn("grid flex-1 gap-2 overflow-y-auto p-3", joined.length > 1 ? "grid-cols-2" : "grid-cols-1")}>
         {joined.map((p) => (
           <CallTile

--- a/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
+++ b/apps/frontend/src/components/call/desktop-call-fullscreen.tsx
@@ -13,6 +13,7 @@ import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { setCallFilmstripSide, useCallPrefs, type DesktopSurface } from "@/stores/call-prefs-store"
 import { CallControls } from "./call-controls"
 import { CaptureErrorBanner } from "./call-capture-error"
+import { IosLockNotice } from "./ios-lock-notice"
 import { CallStageLayout } from "./call-stage-layout"
 import { CallTimer } from "./call-timer"
 import { DesktopCallSurfacePicker } from "./desktop-call-surface-picker"
@@ -95,6 +96,7 @@ export function DesktopCallFullscreen({
       }}
     >
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <IosLockNotice className="mx-3 mt-2" />
       <div className="flex items-center gap-2 px-3 py-2">
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-medium">{title}</span>

--- a/apps/frontend/src/components/call/floating-call-square.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.tsx
@@ -20,6 +20,7 @@ import { CallControls } from "./call-controls"
 import { CallTimer } from "./call-timer"
 import { CameraButton, LeaveButton, MuteButton } from "./call-control-buttons"
 import { CaptureErrorBanner } from "./call-capture-error"
+import { IosLockNotice } from "./ios-lock-notice"
 import { useCallCaptureError, useCallConnectedAt, useCallPhase, useCallRoster } from "./call-store-hooks"
 import {
   anchorSurfaceAtPointer,
@@ -168,6 +169,7 @@ function ConnectedBody({
   return (
     <>
       {captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+      <IosLockNotice className="mx-3 mt-2" />
       <div
         className={cn(
           "grid min-h-0 flex-1 gap-2 overflow-y-auto p-3",

--- a/apps/frontend/src/components/call/ios-lock-notice.tsx
+++ b/apps/frontend/src/components/call/ios-lock-notice.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils"
+import { isIosWebKit } from "@/lib/platform"
+
+/**
+ * iOS suspends a backgrounded page, which ends the call — say so before it
+ * happens rather than landing the user on a call that vanished. Static from
+ * mount and never dismissable, so it costs no layout shift (INV-21).
+ */
+export function IosLockNotice({ className }: { className?: string }) {
+  if (!isIosWebKit()) return null
+  return (
+    <p
+      className={cn("rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground", className)}
+      data-testid="call-ios-lock-notice"
+    >
+      Locking your phone ends this call.
+    </p>
+  )
+}

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -25,6 +25,7 @@ import { CallManagerProvider } from "./call-manager-context"
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
 
 const WORKSPACE_ID = "workspace_1"
+const IOS_UA_ORIGINAL = navigator.userAgent
 
 function user(overrides: Partial<CachedWorkspaceUser>): CachedWorkspaceUser {
   return {
@@ -289,6 +290,42 @@ describe("MobileCallDrawer — capture error visible in every mode", () => {
       expect(screen.getByTestId("call-capture-error")).toBeInTheDocument()
     })
   }
+})
+
+describe("MobileCallDrawer — iOS lock notice", () => {
+  function setUserAgent(value: string) {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, get: () => value })
+  }
+
+  afterEach(() => {
+    setUserAgent(IOS_UA_ORIGINAL)
+  })
+
+  it("warns an iOS user that locking the phone ends the call, in the modes that have room", () => {
+    setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15")
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+
+    for (const m of ["standard", "full"] as CallSurfaceMode[]) {
+      setMode(m)
+      expect(screen.getByTestId("call-ios-lock-notice")).toBeInTheDocument()
+    }
+    // `min` and `compact` are fixed-height dark pills — 72px in compact, all of it
+    // taken by the control row. A banner there clips the controls it sits above.
+    for (const m of ["min", "compact"] as CallSurfaceMode[]) {
+      setMode(m)
+      expect(screen.queryByTestId("call-ios-lock-notice")).toBeNull()
+    }
+  })
+
+  it("never warns on a platform that keeps the call alive in the background", () => {
+    setUserAgent("Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/150")
+    renderDrawer()
+    enterConnected([participant({ userId: "usr_self" })])
+    setMode("full")
+
+    expect(screen.queryByTestId("call-ios-lock-notice")).toBeNull()
+  })
 })
 
 describe("MobileCallDrawer — global", () => {

--- a/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.test.tsx
@@ -312,6 +312,8 @@ describe("MobileCallDrawer — iOS lock notice", () => {
     }
     // `min` and `compact` are fixed-height dark pills — 72px in compact, all of it
     // taken by the control row. A banner there clips the controls it sits above.
+    // `CallDock` therefore opens an iOS call at `standard`, so the mode the user
+    // lands on is one that shows this (see the dock's own test).
     for (const m of ["min", "compact"] as CallSurfaceMode[]) {
       setMode(m)
       expect(screen.queryByTestId("call-ios-lock-notice")).toBeNull()

--- a/apps/frontend/src/components/call/mobile-call-drawer.tsx
+++ b/apps/frontend/src/components/call/mobile-call-drawer.tsx
@@ -18,6 +18,7 @@ import { CameraButton, FlipButton, LeaveButton, MuteButton } from "./call-contro
 import { ISLAND_SURFACE } from "./call-island"
 import { CallTimer } from "./call-timer"
 import { CaptureErrorBanner } from "./call-capture-error"
+import { IosLockNotice } from "./ios-lock-notice"
 import { LayoutToggle } from "./layout-toggle"
 import { useCallCaptureError, useCallConnectedAt, useCallRoster, useCallSurfaceMode } from "./call-store-hooks"
 import { DRAWER_MIN_HEIGHT, nearestMode } from "./mobile-call-drawer-snap"
@@ -300,6 +301,10 @@ export function MobileCallDrawer({ workspaceId, streamId }: { workspaceId: strin
         style={{ height: dragging && dragHeight != null ? `${dragHeight}px` : RESTING_HEIGHT[contentMode] }}
       >
         {contentMode !== "min" && captureError && <CaptureErrorBanner error={captureError} className="mx-3 mt-2" />}
+        {/* Not `min`/`compact`: both are fixed-height dark pills (72px for compact,
+            all of it spoken for by the control row) that would clip the row and
+            paint a light banner on a dark surface. */}
+        {(contentMode === "standard" || contentMode === "full") && <IosLockNotice className="mx-3 mt-2" />}
         <div className="min-h-0 flex-1 overflow-hidden">
           {contentMode === "min" && <TabView connectedAt={connectedAt} captureError={captureError} />}
           {contentMode === "compact" && <BarView {...viewProps} />}

--- a/apps/frontend/src/lib/platform.test.ts
+++ b/apps/frontend/src/lib/platform.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { isIosWebKit } from "./platform"
+
+const REAL = {
+  userAgent: navigator.userAgent,
+  platform: navigator.platform,
+  maxTouchPoints: navigator.maxTouchPoints,
+}
+
+function stubNavigator(values: { userAgent?: string; platform?: string; maxTouchPoints?: number }) {
+  for (const [key, value] of Object.entries({ ...REAL, ...values })) {
+    Object.defineProperty(navigator, key, { configurable: true, get: () => value })
+  }
+}
+
+afterEach(() => stubNavigator(REAL))
+
+describe("isIosWebKit", () => {
+  it("matches an iPhone by user agent", () => {
+    stubNavigator({ userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15" })
+    expect(isIosWebKit()).toBe(true)
+  })
+
+  it("matches iPadOS, which reports a desktop platform and no iPad in the UA", () => {
+    // Since iPadOS 13 Safari claims Macintosh; touch points are the only tell, and
+    // this branch is why the probe cannot be a plain UA test.
+    stubNavigator({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15",
+      platform: "MacIntel",
+      maxTouchPoints: 5,
+    })
+    expect(isIosWebKit()).toBe(true)
+  })
+
+  it("does not match a real Mac, which reports the same platform with no touch", () => {
+    stubNavigator({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/150",
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+    })
+    expect(isIosWebKit()).toBe(false)
+  })
+
+  it("does not match Android", () => {
+    stubNavigator({
+      userAgent: "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/150",
+      platform: "Linux armv8l",
+      maxTouchPoints: 5,
+    })
+    expect(isIosWebKit()).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/platform.ts
+++ b/apps/frontend/src/lib/platform.ts
@@ -5,6 +5,6 @@
  */
 export function isIosWebKit(): boolean {
   if (typeof navigator === "undefined") return false
-  if (/iPhone|iPad|iPod/.test(navigator.userAgent)) return true
-  return navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1
+  if (/iPad|iPhone|iPod/.test(navigator.userAgent ?? "")) return true
+  return navigator.platform === "MacIntel" && (navigator.maxTouchPoints ?? 0) > 1
 }

--- a/apps/frontend/src/lib/platform.ts
+++ b/apps/frontend/src/lib/platform.ts
@@ -1,0 +1,10 @@
+/**
+ * iOS/iPadOS WebKit, where backgrounding the page suspends the call outright.
+ * iPadOS reports a desktop `MacIntel` platform, so touch points are the only
+ * tell there.
+ */
+export function isIosWebKit(): boolean {
+  if (typeof navigator === "undefined") return false
+  if (/iPhone|iPad|iPod/.test(navigator.userAgent)) return true
+  return navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1
+}

--- a/apps/frontend/src/stores/call-store.ts
+++ b/apps/frontend/src/stores/call-store.ts
@@ -84,17 +84,36 @@ export interface CallCaptureErrorInfo {
 }
 
 /**
- * The call this device was displaced from when the user joined it on another
- * device ("Join on this device"). Survives the teardown that removes the call
- * itself — the manager writes it AFTER `clearCallState` — so the dock can say
- * where the call went and offer it back instead of the surface silently
- * vanishing. Cleared by a dismiss, by the next call, and by an account switch.
+ * Why the call left this device, in descending order of what we actually know.
+ *
+ * `taken_over` is claimed ONLY for the `call:endpoint:closed` push — the server
+ * closed this endpoint under the call-row lock, so it is the one signal that
+ * proves another device took the call. Every other signal is a lost endpoint
+ * with no cause attached: `renewLease` returns the same null for a superseded
+ * lease as for one the sweeper reaped, and a re-join that fails or comes back
+ * with a new endpoint id says nothing about who has the call now. Those split on
+ * the only evidence the client holds — whether this page was suspended since its
+ * last good renew — into `ended_while_away` (it was) and `connection_lost` (it
+ * was not, so the likely cause is a network gap longer than the lease TTL).
+ *
+ * Guessing `taken_over` for the ambiguous cases is what this type exists to
+ * prevent: it tells a user their call moved to a device they never touched.
+ */
+export type DisplacedCallReason = "taken_over" | "ended_while_away" | "connection_lost"
+
+/**
+ * The call this device lost without the user ending it. Survives the teardown
+ * that removes the call itself — the manager writes it AFTER `clearCallState` —
+ * so the dock can say what happened and offer the call back instead of the
+ * surface silently vanishing. Cleared by a dismiss, by the next call, and by an
+ * account switch.
  */
 export interface DisplacedCall {
   callId: string
   workspaceId: string
   streamId: string
   mode: CallMode
+  reason: DisplacedCallReason
 }
 
 export interface CallState {

--- a/docs/plans/calls-background-mobile.md
+++ b/docs/plans/calls-background-mobile.md
@@ -274,7 +274,9 @@ when the truth is "your phone was locked and the lease lapsed".
 **Deliverables**
 
 - `apps/frontend/src/stores/call-store.ts`: `DisplacedCall` gains
-  `reason: "taken_over" | "ended_while_away"`. The interface name stays —
+  `reason: "taken_over" | "ended_while_away" | "connection_lost"`. **Built with a
+  third reason the plan did not have** — see the mapping correction below. The
+  interface name stays —
   renaming it (and `CallMovedChip`, `useDisplacedCall`, the dock branch, the e2e
   selector) is churn with no behavior in it.
 - `call-manager.ts`: `CallSession.suspendedSinceRenew: boolean`, set by the
@@ -286,19 +288,31 @@ when the truth is "your phone was locked and the lease lapsed".
     server addressed it to this endpoint under the call-row lock; it is the one
     unambiguous takeover signal. Existing copy and the e2e assertion at
     `tests/browser/calls.spec.ts:236` are unchanged by design.
-  - re-join returning a different endpoint id (`:767`), a failed re-join
-    (`:775`), and a `CALL_LEASE_SUPERSEDED` renew (`:1192`) →
-    `suspendedSinceRenew ? "ended_while_away" : "taken_over"`. All three are
+  - re-join returning a different endpoint id, a failed re-join, and a
+    `CALL_LEASE_SUPERSEDED` renew →
+    `suspendedSinceRenew ? "ended_while_away" : "connection_lost"`. All three are
     ambiguous from the client (a reaped lease and a superseded one are the same
     null from `renewLease`); the freeze/pagehide evidence is the only thing that
     tells them apart, which is why this chunk sits on top of the instrumentation.
+
+    **Correction to the plan as first written.** It mapped these to
+    `suspendedSinceRenew ? "ended_while_away" : "taken_over"`, which reintroduces
+    the exact falsehood the chunk exists to remove. Nothing in that branch is
+    evidence of another device: a >45s network gap on a desktop that never froze
+    (tunnel, Wi-Fi switch, VPN flap) reaps the lease the same way, and the socket
+    `disconnect` handler only demotes to `reconnecting`, so a session can sit
+    there indefinitely waiting for it. Only the `call:endpoint:closed` push
+    proves a takeover, so only it may claim one.
+
   - The two `teardown()`-only branches now write the notice **after** teardown,
     the ordering `handleTakenOver` already uses (teardown clears the store, so a
     notice written before it would be wiped).
+
 - `apps/frontend/src/components/call/call-moved-chip.tsx`: copy switches on
   `reason` — `"taken_over"` keeps "Call moved to another device" / "Rejoin
-  here"; `"ended_while_away"` reads "Call ended while your phone was locked" with
-  the same one-tap action. The action stays a `takeover: true` launch bound to
+  here"; `"ended_while_away"` reads "Call ended while your phone was locked";
+  `"connection_lost"` reads "Call ended — this device lost its connection". All
+  three keep the same one-tap action. The action stays a `takeover: true` launch bound to
   `expectedCallId`: the user's own stale endpoint may still hold a lease, so a
   plain join would 409 and re-ask a question the chip already answered.
   **No auto-rejoin** — it would re-open the mic with no gesture.
@@ -306,10 +320,14 @@ when the truth is "your phone was locked and the lease lapsed".
   plus `MacIntel` + `maxTouchPoints > 1` for iPadOS).
 - `apps/frontend/src/components/call/ios-lock-notice.tsx` — a one-line banner
   shaped exactly like `CaptureErrorBanner` (INV-35), rendered by
-  `MobileCallDrawer` at the same place (`mobile-call-drawer.tsx:302`, so
-  `contentMode !== "min"`), only when `isIosWebKit()`: locking the phone ends the
-  call. Static from mount, fixed row — no layout shift (INV-21), no toast, no
-  dismissal state.
+  `MobileCallDrawer` beside the capture banner, only when `isIosWebKit()`:
+  locking the phone ends the call. Static from mount, fixed row — no layout
+  shift (INV-21), no toast, no dismissal state. **Built for `standard`/`full`
+  only, not the plan's `contentMode !== "min"`:** `min` and `compact` are
+  fixed-height dark pills (compact is a hard 72px, all of it spoken for by the
+  control row), so a permanent banner there clips the controls and paints a
+  light surface on a dark one. `CaptureErrorBanner` shares that placement but is
+  transient and exceptional; this notice is permanent for every iOS user.
 
 **Tests**
 

--- a/docs/plans/calls-background-mobile.md
+++ b/docs/plans/calls-background-mobile.md
@@ -1,8 +1,14 @@
 # Calls in the background on a phone
 
-Status: **Planned, not built.** Nothing here is measured on real hardware yet.
-Every code claim below was checked against the source at `b6760411`; the
-`Verified` / `Unverified` notes say which is which.
+Status: **Built, not measured.** All three chunks shipped as PRs #1622, #1623 and
+#1625 (Stack #1624); nothing here has been run on real hardware yet, which is
+what the §Verification list is for.
+
+"What the code actually does today" and every line reference below describe the
+source **as of `b6760411`**, before this stack — that is what the chunks were
+planned against, and it is deliberately not rewritten, so the problem statement
+still reads as it did. Where the build diverged from the plan, the divergence is
+recorded in place, next to the deliverable it changed.
 
 ## The ceiling, stated up front
 
@@ -190,17 +196,38 @@ worth keeping alive.
   `setMicrophoneActive(active)`, `setCameraActive(active)`, `release()`.
   It owns **one long-lived `<audio>`** for the session's life: a self-contained
   silent-WAV `data:` URI (no network, CSP-safe), `loop = true`, not muted,
-  started inside the start gesture. Every `navigator.mediaSession.setActionHandler`
+  started inside the start gesture.
+
+  **Built at 8 seconds, generated at runtime.** Chromium classifies a player
+  whose `duration` is under `kMinimumContentDuration` (5s) as _transient_ and
+  builds no controllable media session for it, and `loop` does not raise
+  `duration` — so the short clip the plan implied would have shipped the whole
+  chunk as a no-op on Android with every unit test green. `SILENT_WAV_SECONDS` /
+  `SILENT_WAV_SAMPLE_RATE` are the source of truth; generating rather than
+  embedding keeps ~64KB of zeros out of the bundle.
+
+  Every `navigator.mediaSession.setActionHandler`
   call is individually `try`/`catch`ed — an unsupported action throws
   `TypeError` and must not take the supported ones down with it. `release()`
   pauses and removes the element, clears each handler, nulls `metadata`, and sets
   `playbackState = "none"`.
+
 - `call-manager.ts`: `CallManagerDeps.createMediaSession(): CallMediaSession | null`
   (production wires `createCallMediaSession()` when `navigator.mediaSession`
   exists, else null — INV-12/13, constructed once, injected, so no test touches a
-  real Media Session). `CallSession.mediaSession` holds the handle.
+  real Media Session). **Built on `CallManager` (`this.mediaSession`), not on
+  `CallSession`:** activation happens inside the start gesture, before the
+  session object exists, and `setCallTitle` can arrive at any point in the join
+  window — a session-owned field would silently drop the title pushed while
+  joining, which is the normal case.
   - `runStart` activates it **before** the transport connect and before the first
-    capture, so a call that is only ringing out already owns a session.
+    capture, so a call that is only ringing out already owns a session. Only the
+    hang-up action is registered there: `setMuted`/`setCameraOn` both early-return
+    without a session, and a null handler is what removes a control from the
+    notification, so no button is shown before it can act. `wireMediaSessionToggles`
+    adds mute — and camera only on a video call — after the capture, seeded from
+    the live state (the API's toggles default to inactive, so an unseeded
+    notification shows a live call as muted and the first tap mutes).
   - Handlers: `hangup → void this.leaveCall()`,
     `toggleMicrophone → this.setMuted(!muted)`,
     `toggleCamera → void this.setCameraOn(!cameraOn)` — the existing controller
@@ -363,12 +390,24 @@ when the truth is "your phone was locked and the lease lapsed".
   adjacent bug, found while reading this path. It needs its own copy and an
   action-less chip (Rejoin is wrong when access is gone), so it belongs with
   stream-access work, not here. Recorded so it is not lost.
-- Touching `detectSingleActiveCapture` (`call-manager.ts:1491`) or
-  `use-visual-viewport.ts`'s private `isIOS`. Both are iOS probes with slightly
-  different predicates; unifying them changes load-bearing capture behavior and a
-  545-line viewport suite from a chunk about copy. Three probes remain, one of
-  them new and shared — stated, not hidden.
+- `use-visual-viewport.ts`'s private `isIOS`. Folding it in changes a 545-line
+  viewport suite from a chunk about copy.
 - Lease tuning. Still gated on the §3 data.
+
+**Built beyond this section, deliberately:**
+
+- `detectSingleActiveCapture` now delegates to `isIosWebKit()`. The plan excluded
+  touching it, on the assumption the predicates differed; they were byte-identical
+  at `b6760411`, so the delegation preserves behaviour exactly and INV-35 is
+  better served by one probe than two. It keeps its own name and doc, because a
+  single-active-capture rule is a different claim from a platform fact.
+- `CallDock` opens an iOS call at `standard` rather than `compact`. The notice is
+  gated to the modes with room for it, and `compact` is what an audio call would
+  otherwise land on — a warning the user never sees is not a warning.
+- `IosLockNotice` also renders on the three desktop surfaces, beside their capture
+  banners (INV-35). `useIsMobile()` is viewport-based, so an iPad — and an iPhone
+  in landscape — never mounts `MobileCallDrawer`, and gating the warning there
+  would hide it from exactly the devices `isIosWebKit()` detects.
 
 **Why this boundary:** a reviewer sees one store field, one derived reason, three
 call sites that already tore down now saying why, and one banner. It is also the


### PR DESCRIPTION
Chunk 3 of 3, the top of the stack. Stacked on [#1623](https://github.com/threahq/threa/pull/1623).

## Problem

Three signals can end a call the user did not end, and none of them told the truth.

Two tore down **silently**: a re-join that returns a different endpoint id, and a re-join that fails outright. The user unlocks their phone to no call and no reason.

The third is worse, because it speaks. A `CALL_LEASE_SUPERSEDED` renew ack routes to `handleTakenOver`, which renders "Call moved to another device" — but `CallEndpointRepository.renewLease` returns the same `null` for a lease the sweeper reaped as for one another device superseded. A phone whose lease lapsed while it was locked is told its call moved to a device the user never touched.

## Solution

`DisplacedCall.reason` carries what we actually know, and every path that loses a call lands on it.

- **`taken_over` is claimed only for the `call:endpoint:closed` push.** The server addressed that to this endpoint under the call-row lock — it is the one signal that proves another device has the call. Its copy, its behaviour and its existing tests are unchanged.
- **The three ambiguous signals** (new endpoint id on re-join, failed re-join, `CALL_LEASE_SUPERSEDED`) split on `CallSession.suspendedSinceRenew` into `ended_while_away` and `connection_lost`. The flag is set by the `freeze`/`pagehide` listeners from [#1622](https://github.com/threahq/threa/pull/1622) and cleared by every successful renew — it means "we were suspended and have not proven the lease survived". `freeze`/`pagehide` only: a desktop tab switch fires `visibilitychange`, and reading that as a locked phone would mislabel a genuine takeover.
- The two silent branches route through `handleTakenOver`, inheriting its teardown-then-write ordering (teardown clears the store, so a notice written first is wiped) rather than growing a second copy of it.
- `leaveCall` retires the session generation **before** awaiting the leave ack. That await runs up to 2s — the full 2s on the dead link this is most often used from — and until now nothing read the generation during it, so an in-flight re-join landing in that window explained a deliberate hangup as a displacement. `hangupSync` already had this guard.
- `IosLockNotice`, gated on `isIosWebKit()`, in the drawer's `standard`/`full` modes: WebKit suspends a backgrounded page and there is no web fix, so say it before the call vanishes.

**`connection_lost` is a third reason the plan did not have.** The plan mapped the ambiguous signals to `suspendedSinceRenew ? "ended_while_away" : "taken_over"`, which reintroduces the exact falsehood this PR exists to remove: nothing in that branch is evidence of another device. A network gap longer than the 45s TTL — a tunnel, a Wi-Fi switch, a VPN flap — reaps the lease the same way, and the socket `disconnect` handler only demotes to `reconnecting`, so a desktop session can sit there indefinitely waiting for it. `docs/plans/calls-background-mobile.md` records the correction.

No auto-rejoin — it would re-open the mic with no gesture. The chip's action stays a `takeover: true` launch bound to `expectedCallId`, because this device's own stale endpoint may still hold the lease.

Out of scope, recorded in the plan so it is not lost: `startLeaseTimer` acts only on `CALL_LEASE_SUPERSEDED`, so a user removed from the host stream mid-call keeps a "connected" UI over a socket the server already unbound (`signaling-gateway.ts:316-321`). It needs its own copy and an action-less chip — Rejoin is wrong when access is gone — so it belongs with stream-access work.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/stores/call-store.ts` | `DisplacedCallReason`, `DisplacedCall.reason` |
| `apps/frontend/src/calls/call-manager.ts` | `suspendedSinceRenew`, `handleTakenOver(session, reason)`, `ambiguousDisplacedReason`, the three wirings, the `leaveCall` generation bump |
| `apps/frontend/src/calls/call-manager.test.ts` | reason per signal, the renew clearing the flag, the leave-during-rejoin guard |
| `apps/frontend/src/components/call/call-moved-chip.tsx` | copy per reason |
| `apps/frontend/src/components/call/call-dock.test.tsx` | copy + actions per reason |
| `apps/frontend/src/lib/platform.ts` | **new** — `isIosWebKit()` |
| `apps/frontend/src/components/call/ios-lock-notice.tsx` | **new** |
| `apps/frontend/src/components/call/mobile-call-drawer.tsx` | renders the notice in `standard`/`full` |
| `docs/plans/calls-background-mobile.md` | records both divergences from the plan |

`detectSingleActiveCapture` now delegates to `isIosWebKit`, keeping its own name and doc because a single-active-capture rule is not the same claim as a platform fact. `use-visual-viewport`'s private `isIOS` is deliberately left alone — folding it in changes a 545-line viewport suite from a chunk about copy.

## Test plan

- [x] `vitest src/calls/ src/components/call/ src/stores/ src/lib/` — 1299 tests pass
- [x] `tsc --noEmit` (`apps/frontend`) — clean; `bun run lint` (root) — 0 errors
- [x] `tests/browser/calls.spec.ts` unchanged. The push branch is untouched, so its takeover assertion still holding is the regression signal
- [x] Adversarial review found 4, all accepted and fixed — the two false-takeover cases above, the `leaveCall` race, and an iOS notice that clipped the compact drawer's control row (a hard 72px `overflow-hidden` frame, and the mode `CallDock` opens to for every camera-off join)
- [x] `/code-review` found 4 more, all accepted and fixed in `ca110606`: the iOS notice was gated to the modes with room for it, but `CallDock` opens an audio call at `compact` — so the one user it is written for never saw it (iOS now opens at `standard`); `PhoneForwarded` asserted a takeover in the glyph after the copy stopped asserting it in the string; the chip's doc block had drifted onto the new copy table and still claimed the chip exists because another device holds the call; and `detectSingleActiveCapture` was a second copy of the same iOS probe (INV-35), now delegating to `isIosWebKit`
- [x] Falsifiability: forcing `ambiguousDisplacedReason` to a constant reds 4 tests one way and 7 the other; reverting the iOS opening mode reds the new dock test; removing the `sessionGen` bump reds the leave-during-rejoin test — which was **vacuous** in its first form, since an immediately-acked leave nulls the session before the join continuation runs, so it now defers the leave ack and drives the real 2s timeout
- [ ] Real hardware: lock the phone past the 45s lease and confirm the chip says *ended while locked*, not *moved to another device*; and that a takeover from a second device still says *moved*

<details>
<summary>📋 Full implementation plan</summary>

`docs/plans/calls-background-mobile.md`, section 3, with both divergences recorded in place.

```
main
 └── feat/calls-lifecycle-log          (#1622 — instrumentation)
      └── feat/calls-media-session     (#1623 — lock-screen media session)
           └── feat/calls-ended-while-away  (this PR)
```

One process note worth recording: the first attempt at this chunk was built on a branch `gh stack init` had rooted at the local `main`, 20 commits stale — a tree with no `DisplacedCall`, no `CallMovedChip` and no `call:endpoint:closed`. It concluded that machinery was absent and built parallel copies. Discarded; the stack was rebased onto `origin/main` and the chunk rebuilt against the real tree.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
