### PR TITLE
fix(harnessd): clear Claude boot dialogs on reconnect

### DIFF
--- a/extensions/harness-daemon/src/claude-boot.ts
+++ b/extensions/harness-daemon/src/claude-boot.ts
@@ -1,0 +1,44 @@
+import { capturePane, sendKeys } from "./tmux"
+
+// Boot dialogs (trust prompt, development-channel warning, MCP-server approval,
+// update notices) all end with an "Enter to confirm/continue" hint; the
+// composer's input line is a bare "❯" only once boot has settled (during a
+// dialog that line carries the highlighted option, e.g. "❯ 1. Use this MCP
+// server").
+const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
+const IDLE_PROMPT_RE = /^❯\s*$/m
+
+export interface ClaudeBootDeps {
+  capture: (paneId: string) => string
+  keys: (paneId: string, keys: string[]) => void
+  sleep: (ms: number) => Promise<void>
+}
+
+export function defaultClaudeBootDeps(): ClaudeBootDeps {
+  return { capture: capturePane, keys: sendKeys, sleep: Bun.sleep }
+}
+
+/**
+ * Walk Claude Code through its boot dialogs by pressing Enter until the
+ * composer prompt is idle. Polling capture-pane beats fixed sleeps: a fast
+ * boot isn't held for the full wait and a slow one isn't abandoned with a
+ * dialog still open (which left the channel half-wired often enough that the
+ * old two-blind-Enters approach needed constant retuning).
+ */
+export async function acceptClaudeBootPrompts(
+  paneId: string,
+  deps: ClaudeBootDeps = defaultClaudeBootDeps()
+): Promise<void> {
+  const deadline = Date.now() + Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000)
+  while (Date.now() < deadline) {
+    const text = deps.capture(paneId)
+    if (BOOT_DIALOG_RE.test(text)) {
+      deps.keys(paneId, ["Enter"])
+      await deps.sleep(1000)
+      continue
+    }
+    if (IDLE_PROMPT_RE.test(text)) return
+    await deps.sleep(500)
+  }
+  console.warn("harnessd: Claude Code boot did not settle before the wait deadline; continuing")
+}

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -61,11 +61,14 @@ function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
   }
 }
 
-function deps(overrides: Partial<ReconnectDeps> = {}): ReconnectDeps & { calls: string[][] } {
+function deps(overrides: Partial<ReconnectDeps> = {}): ReconnectDeps & { calls: string[][]; bootKeys: string[][] } {
   const calls: string[][] = []
+  const bootKeys: string[][] = []
   let paneReads = 0
   return {
     calls,
+    bootKeys,
+    claudeBoot: { capture: () => "❯ ", keys: (_pane, keys) => void bootKeys.push(keys) },
     inventory: () => [agent()],
     panes: () => (++paneReads < 3 ? [pane()] : [pane({ panePid: 5678, startCommand: "claude --resume native" })]),
     piConfig: () => ({}),
@@ -173,6 +176,49 @@ describe("reconnectClaude", () => {
       CWD,
       `'env' 'THREA_DISPLAY_NAME=Claude' 'THREA_INSTANCE_ID=cc-one' 'THREA_RUNTIME_SESSION_ID=${RUNTIME}' 'THREA_COLD_START_IF_ARCHIVED=wait' 'THREA_COLD_START_IF_MISSING=error' 'THREA_EXPECTED_ROOT_STREAM_ID=stream_one' '/opt/claude' '--resume' '${NATIVE}' '--name' 'threa.feature' '--mcp-config' '/tmp/threa.json' '--dangerously-load-development-channels' 'server:threa-channel' '--dangerously-skip-permissions'`,
     ])
+  })
+
+  test("clears the development-channel warning before verifying the native session", async () => {
+    const events: string[] = []
+    let captures = 0
+    const d = deps({
+      claudeRegistry: {
+        ...registry(),
+        read: (path) => {
+          const pid = Number(path.match(/(\d+)\.json$/)?.[1])
+          events.push(`registry:${pid}`)
+          return JSON.stringify({
+            pid,
+            sessionId: NATIVE,
+            cwd: CWD,
+            procStart: START,
+            name: "threa.feature",
+            status: "idle",
+          })
+        },
+      },
+      claudeBoot: {
+        capture: () => {
+          events.push("capture")
+          return ++captures <= 2
+            ? "WARNING: Loading development channels from unverified sources\n\nPress Enter to continue"
+            : "❯ "
+        },
+        keys: (paneId, keys) => void events.push(`keys:${paneId}:${keys.join(" ")}`),
+      },
+    })
+
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+
+    expect(events.filter((event) => event.startsWith("keys:"))).toEqual(["keys:%8:Enter", "keys:%8:Enter"])
+    expect(events.lastIndexOf("keys:%8:Enter")).toBeLessThan(events.lastIndexOf("registry:5678"))
+    expect(d.calls).toHaveLength(1)
+  })
+
+  test("an already-idle boot presses nothing", async () => {
+    const d = deps()
+    await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)
+    expect({ bootKeys: d.bootKeys, respawns: d.calls.length }).toEqual({ bootKeys: [], respawns: 1 })
   })
 
   test("reconnects a generated launch again with exactly the same native UUID", async () => {

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -1,5 +1,6 @@
 import { statSync } from "node:fs"
 import { basename, resolve } from "node:path"
+import { acceptClaudeBootPrompts, defaultClaudeBootDeps, type ClaudeBootDeps } from "./claude-boot"
 import {
   defaultClaudeRegistryDeps,
   resolveClaudeNativeSession,
@@ -63,6 +64,7 @@ export interface ReconnectDeps {
   claudeRegistry?: ClaudeRegistryDeps
   mcpFile?: (path: string) => boolean
   sleep?: (ms: number) => Promise<void>
+  claudeBoot?: Partial<ClaudeBootDeps>
 }
 
 export function defaultReconnectDeps(): ReconnectDeps {
@@ -335,10 +337,20 @@ export async function reconnectClaude(
     reconstructClaudeCommand(target, options.runtimeSessionId, result.rootStreamId)
   )
   const sleep = deps.sleep ?? Bun.sleep
+  const boot = { ...defaultClaudeBootDeps(), sleep, ...deps.claudeBoot }
+  let booted = false
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await sleep(250)
     const replacement = deps.panes().find((pane) => pane.paneId === target.pane.paneId)
     if (!replacement || replacement.panePid === target.pane.panePid || replacement.cwd !== target.pane.cwd) continue
+    // The respawn faces the same boot dialogs a spawn does (the
+    // development-channel warning above all), and clearing them can outlast
+    // this loop's 20x250ms budget, so it happens before the native-session
+    // check rather than after it.
+    if (!booted) {
+      await acceptClaudeBootPrompts(target.pane.paneId, boot)
+      booted = true
+    }
     try {
       const replacementNative = resolveClaudeNativeSession(
         replacement.panePid,

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
 import { basename, dirname, join } from "node:path"
+import { acceptClaudeBootPrompts } from "./claude-boot"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
 import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
@@ -229,13 +230,6 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
   }
 }
 
-// Boot dialogs (trust prompt, MCP-server approval, update notices) all end
-// with an "Enter to confirm/continue" hint; the composer's input line is a
-// bare "❯" only once boot has settled (during a dialog that line carries the
-// highlighted option, e.g. "❯ 1. Use this MCP server").
-const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
-const IDLE_PROMPT_RE = /^❯\s*$/m
-
 function prepareClaudeChannel(): string {
   const channelDir = join(import.meta.dir, "..", "..", "claude-code-remote")
   const channelEntry = join(channelDir, "src", "index.ts")
@@ -295,7 +289,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
       Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Claude Code in tmux ${session}:${window} (${windowId})`)
 
-      if (!options.noAutoAccept) await this.acceptBootPrompts(paneId)
+      if (!options.noAutoAccept) await acceptClaudeBootPrompts(paneId)
 
       const outputText = capturePane(paneId)
       return {
@@ -351,7 +345,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     )
     console.log(`harnessd: resumed Claude Code in tmux ${session}:${window} (${windowId})`)
     try {
-      await this.acceptBootPrompts(paneId)
+      await acceptClaudeBootPrompts(paneId)
       sendKeys(paneId, ["/remote-control", "Enter"])
       await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_REMOTE_WAIT_MS ?? 2000))
       sendKeys(paneId, ["/rc", "Enter"])
@@ -406,28 +400,6 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
       )
     )
     return path
-  }
-
-  /**
-   * Walk Claude Code through its boot dialogs by pressing Enter until the
-   * composer prompt is idle. Polling capture-pane beats fixed sleeps: a fast
-   * boot isn't held for the full wait and a slow one isn't abandoned with a
-   * dialog still open (which left the channel half-wired often enough that the
-   * old two-blind-Enters approach needed constant retuning).
-   */
-  private async acceptBootPrompts(paneId: string): Promise<void> {
-    const deadline = Date.now() + Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000)
-    while (Date.now() < deadline) {
-      const text = capturePane(paneId)
-      if (BOOT_DIALOG_RE.test(text)) {
-        sendKeys(paneId, ["Enter"])
-        await Bun.sleep(1000)
-        continue
-      }
-      if (IDLE_PROMPT_RE.test(text)) return
-      await Bun.sleep(500)
-    }
-    console.warn("harnessd: Claude Code boot did not settle before the wait deadline; continuing")
   }
 
   private async prelinkScratchpad(


### PR DESCRIPTION
## Problem

`reconnectClaude` (`extensions/harness-daemon/src/reconnect.ts`) respawns the pane with `--dangerously-load-development-channels` and then goes straight into the native-session verify loop. Nothing walks the respawned process through Claude's boot dialogs, so the "Loading development channels" warning sits there waiting for a keypress nobody sends — the session looks reconnected while the composer never reaches idle and the channel stays half-wired. `ClaudeRuntimeSpawner.spawn`/`resume` never had this gap: both call the capture-pane poller.

## Solution

Reuse that poller on the reconnect path.

- `acceptClaudeBootPrompts` moves out of `ClaudeRuntimeSpawner` into `src/claude-boot.ts`, unchanged: same `Enter to confirm|Enter to continue` dialog match, same bare-`❯` idle test, same `THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS` (45s default) deadline and warn-and-continue tail. Deps (`capture`/`keys`/`sleep`) are injectable so reconnect can drive it under test; the spawner keeps the zero-arg default.
- `reconnectClaude` runs it once, inside the existing post-respawn loop, on the first iteration where the pane has flipped generation — after the pid change so it can't read the dead process's screen (a stale idle `❯` would end the poll instantly), and before `resolveClaudeNativeSession` because a held dialog outlasts that loop's 20×250ms budget.
- Extending the poller over blind Enter presses: the reconnect command is reconstructed per-pane, so the dialog set varies (MCP config present or not, trust prompt on a fresh worktree); a fixed key sequence is what the spawner path already abandoned.

Untouched: `resolveClaudeTarget` identity normalization, `samePaneGeneration`, MCP-file checks, preflight, and the `--resume <uuid>` reconstruction — the reconnect command bytes are asserted identical by the existing test.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/claude-boot.ts` | **new** — `acceptClaudeBootPrompts` + injectable `ClaudeBootDeps` |
| `extensions/harness-daemon/src/spawners.ts` | drops the private method and regexes; calls the shared helper |
| `extensions/harness-daemon/src/reconnect.ts` | optional `claudeBoot` dep; accepts boot prompts before native-session verification |
| `extensions/harness-daemon/src/claude-reconnect.test.ts` | boot stub in the shared `deps()` factory; two regression tests |

## Test plan

- [x] `bun test` in `extensions/harness-daemon` — 122 pass, 0 fail (needed `bun install` in `extensions/harness-daemon` and `extensions/bot-runtime-client` first; without it 2 suites fail to resolve `@threa/bot-runtime-client`/`socket.io-client` on `main` too)
- [x] `bun run typecheck` (harness-daemon) — clean; `prettier --check` on the four files — clean
- [x] New test proven non-vacuous: deleting the `acceptClaudeBootPrompts` call makes "clears the development-channel warning before verifying the native session" fail
- [ ] No live reconnect against a real tmux pane — the boot screen is only reachable on a real Claude start; the poller itself is the code path spawn has been running in production

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787816814&installation_model_id=20758&pr_number=1626&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1626&signature=d7b497890c627b063c4a4c98733c2b494458a1f421a1e51399f07e4d15bd66fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->