### PR TITLE
fix(sync): stop a lock-time bootstrap snapshot stranding missed events

### DIFF
--- a/apps/frontend/src/api/workspaces.ts
+++ b/apps/frontend/src/api/workspaces.ts
@@ -38,8 +38,19 @@ export const workspacesApi = {
     return res.workspace
   },
 
-  async bootstrap(workspaceId: string): Promise<WorkspaceBootstrap> {
-    const res = await api.get<{ data: WorkspaceBootstrap }>(`/api/workspaces/${workspaceId}/bootstrap`)
+  /**
+   * `fresh` forbids the service worker's lock-time bootstrap snapshot from
+   * answering this request (sw.ts honours `cache: "no-store"` by dropping the
+   * entry). Set it whenever the caller is about to treat the response as the
+   * authority for everything at or below a separately-read sync head — a
+   * snapshot captured before the device went away would silently be older than
+   * that head.
+   */
+  async bootstrap(workspaceId: string, opts?: { fresh?: boolean }): Promise<WorkspaceBootstrap> {
+    const res = await api.get<{ data: WorkspaceBootstrap }>(
+      `/api/workspaces/${workspaceId}/bootstrap`,
+      opts?.fresh ? { cache: "no-store" } : undefined
+    )
     return res.data
   },
 

--- a/apps/frontend/src/api/workspaces.ts
+++ b/apps/frontend/src/api/workspaces.ts
@@ -1,4 +1,5 @@
 import { api, API_BASE, parseApiError } from "./client"
+import { BOOTSTRAP_FRESH_PARAM } from "@/lib/sw-bootstrap-prefetch"
 import type {
   Workspace,
   WorkspaceBootstrap,
@@ -40,17 +41,17 @@ export const workspacesApi = {
 
   /**
    * `fresh` forbids the service worker's lock-time bootstrap snapshot from
-   * answering this request (sw.ts honours `cache: "no-store"` by dropping the
-   * entry). Set it whenever the caller is about to treat the response as the
-   * authority for everything at or below a separately-read sync head — a
-   * snapshot captured before the device went away would silently be older than
-   * that head.
+   * answering this request — it drops the entry and goes to the network. Set it
+   * whenever the caller is about to treat the response as the authority for
+   * everything at or below a separately-read sync head: a snapshot captured
+   * before the device went away would silently be older than that head, and
+   * every entry between the two would be stranded.
    */
   async bootstrap(workspaceId: string, opts?: { fresh?: boolean }): Promise<WorkspaceBootstrap> {
-    const res = await api.get<{ data: WorkspaceBootstrap }>(
-      `/api/workspaces/${workspaceId}/bootstrap`,
-      opts?.fresh ? { cache: "no-store" } : undefined
-    )
+    // Both signals: the query flag survives every engine's request handling,
+    // `no-store` also keeps the HTTP cache out of it.
+    const path = `/api/workspaces/${workspaceId}/bootstrap${opts?.fresh ? `?${BOOTSTRAP_FRESH_PARAM}=1` : ""}`
+    const res = await api.get<{ data: WorkspaceBootstrap }>(path, opts?.fresh ? { cache: "no-store" } : undefined)
     return res.data
   },
 

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
@@ -289,6 +289,20 @@ describe("respondToBootstrapRequest", () => {
     expect(fetchImpl).toHaveBeenCalled()
   })
 
+  it("refuses the pre-fetched copy for a fresh-flagged request, matching the unflagged cache key", async () => {
+    // The flag rides in the URL because `Request.cache` fidelity inside a
+    // service worker varies by engine, and the uncertain engines are phones —
+    // the devices this protects. The entry is stored under the plain URL, so
+    // the lookup must strip the flag before deleting.
+    const cache = fakeCache(new Response("cached"))
+    const fetchImpl = vi.fn(async () => new Response("network"))
+
+    const res = await respondToBootstrapRequest(new Request(`${URL_}?fresh=1`), cache, fetchImpl)
+
+    expect(await res.text()).toBe("network")
+    expect(cache.store.has(URL_)).toBe(false)
+  })
+
   it("refuses the pre-fetched copy for a no-store request and discards it", async () => {
     // The caller is about to stamp a sync cursor against this snapshot, so a
     // copy captured when the tab last hid would strand every entry since. It

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { sharedMessageSlotKey, type StreamEvent } from "@threa/types"
 import { ThreaDatabase, accountDbName, db } from "@/db"
-import { parsePersistedSyncTarget, runBootstrapSync } from "./sw-bootstrap-prefetch"
+import { parsePersistedSyncTarget, respondToBootstrapRequest, runBootstrapSync } from "./sw-bootstrap-prefetch"
 
 const missingSlot = (messageId: string) => ({ type: "sharedMessage", state: "missing", messageId }) as const
 
@@ -253,5 +253,53 @@ describe("parsePersistedSyncTarget", () => {
     expect(parsePersistedSyncTarget({ workspaceId: "ws_1", streamId: 42 })).toBeNull()
     expect(parsePersistedSyncTarget({ workspaceId: "ws_1", messageId: {} })).toBeNull()
     expect(parsePersistedSyncTarget({ workspaceId: "ws_1", workosUserId: ["user_1"] })).toBeNull()
+  })
+})
+
+describe("respondToBootstrapRequest", () => {
+  const URL_ = "https://app.threa.io/api/workspaces/ws_1/bootstrap"
+
+  /** Minimal Cache stand-in — jsdom has no CacheStorage. */
+  function fakeCache(seed?: Response) {
+    const store = new Map<string, Response>()
+    if (seed) store.set(URL_, seed)
+    return {
+      store,
+      match: vi.fn(async (key: string) => store.get(key)),
+      delete: vi.fn(async (key: string) => store.delete(key)),
+    } as unknown as Cache & { store: Map<string, Response> }
+  }
+
+  it("serves the pre-fetched copy once, then drops it", async () => {
+    const cache = fakeCache(new Response("cached"))
+    const fetchImpl = vi.fn(async () => new Response("network"))
+
+    const res = await respondToBootstrapRequest(new Request(URL_), cache, fetchImpl)
+
+    expect(await res.text()).toBe("cached")
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(cache.delete).toHaveBeenCalledWith(URL_)
+  })
+
+  it("goes to the network when nothing is pre-fetched", async () => {
+    const cache = fakeCache()
+    const fetchImpl = vi.fn(async () => new Response("network"))
+
+    expect(await (await respondToBootstrapRequest(new Request(URL_), cache, fetchImpl)).text()).toBe("network")
+    expect(fetchImpl).toHaveBeenCalled()
+  })
+
+  it("refuses the pre-fetched copy for a no-store request and discards it", async () => {
+    // The caller is about to stamp a sync cursor against this snapshot, so a
+    // copy captured when the tab last hid would strand every entry since. It
+    // must also be deleted, not merely skipped — otherwise the next request
+    // with the same expectation is handed the same stale copy.
+    const cache = fakeCache(new Response("cached"))
+    const fetchImpl = vi.fn(async () => new Response("network"))
+
+    const res = await respondToBootstrapRequest(new Request(URL_, { cache: "no-store" }), cache, fetchImpl)
+
+    expect(await res.text()).toBe("network")
+    expect(cache.store.has(URL_)).toBe(false)
   })
 })

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -22,6 +22,35 @@ export const PENDING_SYNC_KEY = `/_sync/${BOOTSTRAP_SYNC_TAG}`
 /** Regex matching workspace bootstrap API paths. */
 export const WORKSPACE_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/bootstrap$/
 
+/**
+ * Answer a workspace-bootstrap request, consuming the pre-fetched copy when
+ * there is one. Split out of the sw.ts fetch listener so it can be driven with
+ * a fake Cache — jsdom has no CacheStorage.
+ *
+ * `no-store` means the caller is about to treat the snapshot as the authority
+ * for everything at or below a sync head it read separately. This entry was
+ * captured when the tab last hid, so it can predate that head; serving it would
+ * strand every entry in between. Delete rather than skip, so a later request
+ * carrying the same expectation can't be handed the same stale copy.
+ */
+export async function respondToBootstrapRequest(
+  request: Request,
+  cache: Cache,
+  fetchImpl: (request: Request) => Promise<Response>
+): Promise<Response> {
+  if (request.cache === "no-store") {
+    await cache.delete(request.url)
+    return fetchImpl(request)
+  }
+  const cached = await cache.match(request.url)
+  if (cached) {
+    // One-shot: serve and delete so the next fetch gets fresh data.
+    void cache.delete(request.url)
+    return cached
+  }
+  return fetchImpl(request)
+}
+
 export interface BootstrapSyncTarget {
   workspaceId: string
   streamId: string | null

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -23,29 +23,47 @@ export const PENDING_SYNC_KEY = `/_sync/${BOOTSTRAP_SYNC_TAG}`
 export const WORKSPACE_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/bootstrap$/
 
 /**
+ * Query flag marking a bootstrap request that must not be answered from the
+ * pre-fetched copy. Carried in the URL rather than only as `cache: "no-store"`
+ * because how faithfully `Request.cache` reaches a service worker's fetch
+ * handler varies by engine — and the browsers where it is least certain are
+ * phones, which are exactly the devices this protects. A query flag cannot be
+ * normalised away.
+ */
+export const BOOTSTRAP_FRESH_PARAM = "fresh"
+
+/** The cache is keyed on the plain URL; strip the flag before looking up. */
+function bootstrapCacheKey(url: string): string {
+  const parsed = new URL(url)
+  parsed.searchParams.delete(BOOTSTRAP_FRESH_PARAM)
+  return parsed.toString()
+}
+
+/**
  * Answer a workspace-bootstrap request, consuming the pre-fetched copy when
  * there is one. Split out of the sw.ts fetch listener so it can be driven with
  * a fake Cache — jsdom has no CacheStorage.
  *
- * `no-store` means the caller is about to treat the snapshot as the authority
- * for everything at or below a sync head it read separately. This entry was
- * captured when the tab last hid, so it can predate that head; serving it would
- * strand every entry in between. Delete rather than skip, so a later request
- * carrying the same expectation can't be handed the same stale copy.
+ * A fresh request means the caller is about to treat the snapshot as the
+ * authority for everything at or below a sync head it read separately. This
+ * entry was captured when the tab last hid, so it can predate that head;
+ * serving it would strand every entry in between. Delete rather than skip, so a
+ * later request carrying the same expectation can't be handed the same copy.
  */
 export async function respondToBootstrapRequest(
   request: Request,
   cache: Cache,
   fetchImpl: (request: Request) => Promise<Response>
 ): Promise<Response> {
-  if (request.cache === "no-store") {
-    await cache.delete(request.url)
+  const key = bootstrapCacheKey(request.url)
+  if (request.cache === "no-store" || new URL(request.url).searchParams.has(BOOTSTRAP_FRESH_PARAM)) {
+    await cache.delete(key)
     return fetchImpl(request)
   }
-  const cached = await cache.match(request.url)
+  const cached = await cache.match(key)
   if (cached) {
     // One-shot: serve and delete so the next fetch gets fresh data.
-    void cache.delete(request.url)
+    void cache.delete(key)
     return cached
   }
   return fetchImpl(request)

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -12,6 +12,7 @@ import {
   WORKSPACE_BOOTSTRAP_PATH_RE,
   parsePersistedSyncTarget,
   queueBootstrapSync,
+  respondToBootstrapRequest,
   runBootstrapSync,
 } from "./lib/sw-bootstrap-prefetch"
 import {
@@ -314,13 +315,7 @@ self.addEventListener("fetch", (event) => {
   event.respondWith(
     (async () => {
       const cache = await caches.open(PUSH_BOOTSTRAP_CACHE)
-      const cached = await cache.match(event.request.url)
-      if (cached) {
-        // One-shot: serve and delete so the next fetch gets fresh data
-        void cache.delete(event.request.url)
-        return cached
-      }
-      return fetch(event.request)
+      return respondToBootstrapRequest(event.request, cache, (req) => fetch(req))
     })()
   )
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1284,25 +1284,66 @@ describe("SyncEngine sync cursor (active mode)", () => {
     }
   }
 
-  it("seeds the cursor from head BEFORE the workspace bootstrap data fetch on first run", async () => {
+  it("stamps the first-run cursor from the bootstrap's own sync head, without reading head first", async () => {
+    // A client-read head and the snapshot are only interchangeable while the
+    // snapshot is guaranteed to come off the network. The service worker can
+    // answer the bootstrap with a copy captured when the tab last hid, so the
+    // head the server stamped INTO the snapshot is the only one known to
+    // describe it. Reading head separately first would win `advance`'s
+    // monotonic max and mask the real one.
     const order: string[] = []
     const catchUp = vi.fn(async () => {
       order.push("catchUp")
       return emptyPage("42")
     })
     const deps = makeActiveDeps(catchUp)
-    const innerBootstrap = deps.workspaceService.bootstrap
     deps.workspaceService.bootstrap = vi.fn(async () => {
       order.push("bootstrap")
-      return innerBootstrap()
+      return { ...makeWorkspaceBootstrap(), syncHead: "37" }
     })
     const engine = new SyncEngine(deps)
 
     await engine.onConnect(asSocket(new MockSocket()))
 
-    expect(order[0]).toBe("catchUp")
-    expect(order).toContain("bootstrap")
-    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", { after: "0", limit: 1 }, expect.any(AbortSignal))
+    expect(order[0]).toBe("bootstrap")
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("37"))
+    // The pre-bootstrap probe is gone: catch-up reads real pages from the
+    // stamped position, never an `after: "0", limit: 1` head probe.
+    expect(catchUp).not.toHaveBeenCalledWith("ws_1", { after: "0", limit: 1 }, expect.any(AbortSignal))
+    engine.destroy()
+  })
+
+  it("does not strand entries when a cache-served bootstrap is older than the log head", async () => {
+    // Regression: the service worker's lock-time bootstrap copy declares an
+    // older syncHead than the log's true head. The cursor must land on the
+    // SNAPSHOT's head so catch-up replays the entries the snapshot predates —
+    // stamping the newer network head here loses them permanently.
+    const catchUp = vi.fn(async () => ({
+      entries: [userAddedEntry("6", "user_missed")],
+      head: "6",
+    }))
+    const deps = makeActiveDeps(catchUp)
+    deps.workspaceService.bootstrap = vi.fn(async () => ({ ...makeWorkspaceBootstrap(), syncHead: "5" }))
+    const engine = new SyncEngine(deps)
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(() => expect(catchUp).toHaveBeenCalled())
+    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", expect.objectContaining({ after: "5" }), expect.any(AbortSignal))
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("user_missed")).toBeDefined())
+    engine.destroy()
+  })
+
+  it("falls back to a post-bootstrap seed when the snapshot declares no sync head", async () => {
+    // Payloads cached before `syncHead` shipped omit it. Nothing stamps the
+    // cursor, so catch-up's own retry seeds it — deliberately without bounding
+    // the splice, since that head is read after the snapshot.
+    const catchUp = vi.fn(async () => emptyPage("42"))
+    const deps = makeActiveDeps(catchUp)
+    const engine = new SyncEngine(deps)
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
     await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("42"))
     engine.destroy()
   })
@@ -1853,10 +1894,9 @@ describe("SyncEngine sync cursor (active mode)", () => {
       let resolveRetrySeed: ((value: SyncCatchUpResponse) => void) | undefined
       const catchUp = vi
         .fn()
-        // Pre-bootstrap seed fails (offline first run)...
-        .mockRejectedValueOnce(new Error("offline"))
-        // ...the catch-up run's fallback retry succeeds with a head read
-        // AFTER the bootstrap snapshot.
+        // The snapshot declares no syncHead, so nothing stamps the cursor
+        // during bootstrap and catch-up's own fallback seed runs instead —
+        // reading head AFTER the snapshot.
         .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveRetrySeed = resolve)))
         .mockResolvedValue(emptyPage("42"))
       const engine = new SyncEngine(makeActiveDeps(catchUp))

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -155,6 +155,17 @@ export class SyncEngine {
    *  drained into one follow-up backfill when the active one settles. */
   private queuedGapCursors = new Map<string, string>()
   private hasEverConnected = false
+  /**
+   * False until this session's cold-boot workspace snapshot has been applied
+   * (or definitively failed). While it is false a snapshot is still pending
+   * that will stamp the sync cursor from its own `syncHead`, so nothing may
+   * seed the cursor from a separately-read network head — `advance` is a
+   * monotonic max, so the higher network head would win and silently mask the
+   * snapshot's, stranding every entry between the two. The service worker can
+   * answer that bootstrap with a copy captured when the tab last hid, which is
+   * exactly when the two heads diverge.
+   */
+  private coldSnapshotSettled = false
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
 
@@ -344,7 +355,7 @@ export class SyncEngine {
       // would be strictly worse, because the service worker can answer the
       // bootstrap with a snapshot captured before this device went away —
       // leaving the cursor above the snapshot and stranding everything between.
-      await this.initializeActiveCursor({ seedFromHead: isReconnect })
+      await this.initializeActiveCursor()
       if (this.isDestroyed) return
     }
 
@@ -831,6 +842,9 @@ export class SyncEngine {
           this.syncLogCursor?.advance(bootstrap.syncHead)
           this.noteSeenHead(bootstrap.syncHead)
         }
+        // Snapshot applied: no pending cold snapshot can be masked any more, so
+        // catch-up's fallback seed may read head again from here on.
+        if (!_isReconnect) this.coldSnapshotSettled = true
       }
 
       this.lastWorkspaceError = null
@@ -842,6 +856,10 @@ export class SyncEngine {
       await this.subscribeMemberStreams(bootstrap.streamMemberships.map((sm) => sm.streamId))
     } catch (error) {
       this.lastWorkspaceError = error
+      // No snapshot landed, so none can be masked: release the seed guard or a
+      // failed cold bootstrap would leave the cursor unseedable for the whole
+      // session and catch-up would never gain a position.
+      if (!_isReconnect) this.coldSnapshotSettled = true
       const hasCachedData = (await db.workspaces.get(workspaceId)) !== undefined
       syncStatus.set(`workspace:${workspaceId}`, hasCachedData ? "stale" : "error")
       for (const streamId of visibleStreamIds) {
@@ -1325,16 +1343,17 @@ export class SyncEngine {
    * the service worker's lock-time bootstrap copy breaks that, and `advance` is
    * a monotonic max, so a head seeded here would win and mask the real one.
    */
-  private async initializeActiveCursor(opts?: { seedFromHead?: boolean }): Promise<void> {
-    const seedFromHead = opts?.seedFromHead ?? true
+  private async initializeActiveCursor(): Promise<void> {
     const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
     try {
       await cursorStore.load()
       if (cursorStore.get() !== null || this.isDestroyed) return
-      // Cold boot: leave the position unset so the bootstrap can stamp it from
-      // the snapshot it actually applied. Seeding here would win the monotonic
-      // max in `advance` and silently no-op that stamp.
-      if (!seedFromHead) return
+      // A cold snapshot is still pending: leave the position unset so that
+      // bootstrap stamps it from the snapshot it actually applied. Every caller
+      // funnels through this one guard, so a resume that fires before the first
+      // connect, or a reconnect racing the cold bootstrap, cannot seed a head
+      // the pending snapshot may predate. See `coldSnapshotSettled`.
+      if (!this.coldSnapshotSettled) return
       const abort = (this.catchUpAbort ??= new AbortController())
       const { head } = await this.deps.syncService!.catchUp(this.workspaceId, { after: "0", limit: 1 }, abort.signal)
       if (this.isDestroyed) return

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -342,19 +342,18 @@ export class SyncEngine {
 
     if (this.eventGate) {
       this.trackHeartbeat(socket)
-      // Read-before-stamp: the cursor position (head, on a first run) must be
-      // read BEFORE the bootstrap data fetch so any race falls on the
-      // duplicate side (entry also present in the snapshot — idempotent),
-      // never the gap side (entry stamped below a position read after the
-      // snapshot — permanent loss).
+      // Read-before-stamp: the cursor must never end up above the snapshot the
+      // bootstrap applies, so any race falls on the duplicate side (entry also
+      // present in the snapshot — idempotent) rather than the gap side (entry
+      // stamped below the position — permanent loss).
       //
-      // A cold boot skips the client-side head read entirely: its bootstrap
-      // stamps the cursor from the snapshot's own server-read `syncHead`
-      // instead, which is the same guarantee taken from the one party that can
-      // actually pair it with the snapshot it hands back. Reading head here
-      // would be strictly worse, because the service worker can answer the
-      // bootstrap with a snapshot captured before this device went away —
-      // leaving the cursor above the snapshot and stranding everything between.
+      // A reconnect satisfies that by reading head here, before the fetch. A
+      // cold boot cannot: the service worker may answer its bootstrap with a
+      // snapshot captured before this device went away, so a head read here
+      // would sit above it. It takes the guarantee from the snapshot's own
+      // server-read `syncHead` instead — the one party that can pair a head
+      // with the snapshot it hands back — and this call leaves the position
+      // unset until then (see `coldSnapshotSettled`).
       await this.initializeActiveCursor()
       if (this.isDestroyed) return
     }
@@ -1330,18 +1329,18 @@ export class SyncEngine {
   }
 
   /**
-   * Active mode, on connect: load the persisted cursor and, on a first run,
-   * seed it from head — BEFORE the workspace bootstrap data fetch, so the
-   * position is a lower bound of the snapshot (read-before-stamp). Errors are
-   * non-fatal: catch-up retries seeding later, and the bootstrap healing this
-   * phase keeps (INV-53) covers the rare first-run-plus-network-failure gap.
+   * Active mode, on connect: load the persisted cursor and, when it is unset
+   * and no cold snapshot is pending, seed it from head. Errors are non-fatal:
+   * catch-up retries seeding later, and the bootstrap healing this phase keeps
+   * (INV-53) covers the rare first-run-plus-network-failure gap.
    *
-   * `seedFromHead: false` (cold boot) loads the cursor but leaves an unset one
-   * unset, because that connect's bootstrap stamps it from the snapshot's own
-   * `syncHead`. Client-read head and server-stamped snapshot head are only
-   * interchangeable while the snapshot is guaranteed to come off the network;
-   * the service worker's lock-time bootstrap copy breaks that, and `advance` is
-   * a monotonic max, so a head seeded here would win and mask the real one.
+   * While `coldSnapshotSettled` is false this loads the cursor but leaves an
+   * unset one unset, because the pending bootstrap stamps it from the
+   * snapshot's own `syncHead`. Client-read head and server-stamped snapshot
+   * head are only interchangeable while the snapshot is guaranteed to come off
+   * the network; the service worker's lock-time bootstrap copy breaks that, and
+   * `advance` is a monotonic max, so a head seeded here would win and mask the
+   * real one.
    */
   private async initializeActiveCursor(): Promise<void> {
     const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -36,7 +36,9 @@ interface SyncEngineDeps {
   workspaceId: string
   syncStatus: SyncStatusStore
   queryClient: QueryClient
-  workspaceService: { bootstrap: (workspaceId: string) => Promise<WorkspaceBootstrap> }
+  workspaceService: {
+    bootstrap: (workspaceId: string, opts?: { fresh?: boolean }) => Promise<WorkspaceBootstrap>
+  }
   streamService: {
     bootstrap: (
       workspaceId: string,
@@ -334,7 +336,15 @@ export class SyncEngine {
       // duplicate side (entry also present in the snapshot — idempotent),
       // never the gap side (entry stamped below a position read after the
       // snapshot — permanent loss).
-      await this.initializeActiveCursor()
+      //
+      // A cold boot skips the client-side head read entirely: its bootstrap
+      // stamps the cursor from the snapshot's own server-read `syncHead`
+      // instead, which is the same guarantee taken from the one party that can
+      // actually pair it with the snapshot it hands back. Reading head here
+      // would be strictly worse, because the service worker can answer the
+      // bootstrap with a snapshot captured before this device went away —
+      // leaving the cursor above the snapshot and stranding everything between.
+      await this.initializeActiveCursor({ seedFromHead: isReconnect })
       if (this.isDestroyed) return
     }
 
@@ -682,7 +692,9 @@ export class SyncEngine {
         )
 
         const [workspaceBootstrap, streamResults] = await Promise.all([
-          workspaceService.bootstrap(workspaceId),
+          // A forceFull reconnect with visible streams lands here rather than in
+          // the single-fetch branch below, so it needs the same cache bypass.
+          workspaceService.bootstrap(workspaceId, { fresh: forceFull }),
           Promise.all(
             visibleStreamIds.map(async (streamId) => {
               try {
@@ -761,7 +773,10 @@ export class SyncEngine {
         }
       } else {
         // Fire the fetch immediately — freshness is never deferred over the wire.
-        bootstrap = await workspaceService.bootstrap(workspaceId)
+        // forceFull runs from the catch-up fallbacks, which stamp the cursor at
+        // a head they read themselves — so this snapshot must not be the
+        // service worker's lock-time copy (see workspaceService.bootstrap).
+        bootstrap = await workspaceService.bootstrap(workspaceId, { fresh: forceFull })
 
         // On the very first connect of a warm start, hold the IndexedDB write
         // until the cached reveal has painted. applyWorkspaceBootstrap writes the
@@ -1302,12 +1317,24 @@ export class SyncEngine {
    * position is a lower bound of the snapshot (read-before-stamp). Errors are
    * non-fatal: catch-up retries seeding later, and the bootstrap healing this
    * phase keeps (INV-53) covers the rare first-run-plus-network-failure gap.
+   *
+   * `seedFromHead: false` (cold boot) loads the cursor but leaves an unset one
+   * unset, because that connect's bootstrap stamps it from the snapshot's own
+   * `syncHead`. Client-read head and server-stamped snapshot head are only
+   * interchangeable while the snapshot is guaranteed to come off the network;
+   * the service worker's lock-time bootstrap copy breaks that, and `advance` is
+   * a monotonic max, so a head seeded here would win and mask the real one.
    */
-  private async initializeActiveCursor(): Promise<void> {
+  private async initializeActiveCursor(opts?: { seedFromHead?: boolean }): Promise<void> {
+    const seedFromHead = opts?.seedFromHead ?? true
     const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
     try {
       await cursorStore.load()
       if (cursorStore.get() !== null || this.isDestroyed) return
+      // Cold boot: leave the position unset so the bootstrap can stamp it from
+      // the snapshot it actually applied. Seeding here would win the monotonic
+      // max in `advance` and silently no-op that stamp.
+      if (!seedFromHead) return
       const abort = (this.catchUpAbort ??= new AbortController())
       const { head } = await this.deps.syncService!.catchUp(this.workspaceId, { after: "0", limit: 1 }, abort.signal)
       if (this.isDestroyed) return

--- a/tests/browser/sw-bootstrap-staleness.spec.ts
+++ b/tests/browser/sw-bootstrap-staleness.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, request as playwrightRequest, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, expectApiOk } from "./helpers"
+
+/**
+ * The service worker pre-fetches and caches the workspace bootstrap every time
+ * the tab hides — i.e. every phone lock — with no TTL. A preference changed
+ * while the device was away must still land when it comes back, rather than
+ * being overwritten by that lock-time snapshot.
+ *
+ * Only a real service worker exercises this: the dev server never registers one
+ * (`/sw.js` 404s to index.html), and jsdom has no CacheStorage. It therefore
+ * needs the production frontend build — `PLAYWRIGHT_PROD_FRONTEND=1` locally,
+ * which CI uses by default.
+ */
+
+async function swControls(page: Page): Promise<boolean> {
+  return page.evaluate(async () => {
+    if (!navigator.serviceWorker) return false
+    await navigator.serviceWorker.ready.catch(() => null)
+    return !!navigator.serviceWorker.controller
+  })
+}
+
+/** The composer action side the app has actually applied, read from IDB. */
+async function appliedSide(page: Page, workspaceId: string): Promise<string> {
+  return page.evaluate(async (wid) => {
+    for (const { name } of await indexedDB.databases()) {
+      if (!name) continue
+      const value = await new Promise<string | null>((resolve) => {
+        const req = indexedDB.open(name)
+        req.onerror = () => resolve(null)
+        req.onsuccess = () => {
+          const db = req.result
+          if (!db.objectStoreNames.contains("userPreferences")) return resolve(null)
+          const get = db.transaction("userPreferences", "readonly").objectStore("userPreferences").get(wid)
+          get.onerror = () => resolve(null)
+          get.onsuccess = () =>
+            resolve(
+              (get.result as { accessibility?: { composerActionSide?: string } })?.accessibility?.composerActionSide ??
+                null
+            )
+        }
+      })
+      if (value) return value
+    }
+    return "NOT_FOUND"
+  }, workspaceId)
+}
+
+test.describe("Service worker bootstrap staleness", () => {
+  test("a preference changed while the device was away survives the lock-time bootstrap snapshot", async ({
+    page,
+    context,
+  }) => {
+    await loginAndCreateWorkspace(page, "sw-stale")
+    const workspaceId = page.url().match(/\/w\/([^/?]+)/)![1]
+
+    test.skip(!(await swControls(page)), "No controlling service worker — needs PLAYWRIGHT_PROD_FRONTEND=1")
+
+    const mk = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+      data: { type: "scratchpad", displayName: "sw stale pad" },
+    })
+    await expectApiOk(mk, "create scratchpad")
+    const streamId = (await mk.json())?.stream?.id
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible({ timeout: 20000 })
+    expect(await appliedSide(page, workspaceId)).toBe("right")
+
+    // Lock the phone: the hide handler has the SW pre-fetch and cache the
+    // bootstrap as it stands right now.
+    await page.evaluate(() => {
+      Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (wid) => {
+            const cache = await caches.open("push-bootstrap")
+            return !!(await cache.match(`/api/workspaces/${wid}/bootstrap`))
+          }, workspaceId),
+        { timeout: 15000, message: "SW never cached the bootstrap on hide" }
+      )
+      .toBe(true)
+
+    // Away, so the live event cannot be delivered.
+    await context.setOffline(true)
+    await page.evaluate(() => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    // Another device flips the preference. Separate request context so it is
+    // unaffected by this one being offline.
+    const api = await playwrightRequest.newContext({
+      baseURL: page.url().split("/w/")[0],
+      storageState: await context.storageState(),
+    })
+    await expectApiOk(
+      await api.patch(`/api/workspaces/${workspaceId}/preferences`, {
+        data: { accessibility: { composerActionSide: "left" } },
+      }),
+      "flip the preference from the other device"
+    )
+
+    // Come back and cold-start, which is what an evicted locked PWA does. This
+    // is the first bootstrap GET since the change, so it is the one the
+    // lock-time snapshot would answer.
+    await context.setOffline(false)
+    await page.reload()
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible({ timeout: 20000 })
+
+    await expect
+      .poll(() => appliedSide(page, workspaceId), {
+        timeout: 20000,
+        message: "the away-change never landed — a stale snapshot won and nothing replayed it",
+      })
+      .toBe("left")
+
+    await api.dispose()
+  })
+})

--- a/tests/browser/sw-bootstrap-staleness.spec.ts
+++ b/tests/browser/sw-bootstrap-staleness.spec.ts
@@ -104,9 +104,30 @@ test.describe("Service worker bootstrap staleness", () => {
       "flip the preference from the other device"
     )
 
-    // Come back and cold-start, which is what an evicted locked PWA does. This
-    // is the first bootstrap GET since the change, so it is the one the
-    // lock-time snapshot would answer.
+    // Come back and cold-start, which is what an evicted locked PWA does. Clear
+    // the persisted sync cursor to pin that precondition rather than leave it to
+    // however the harness happens to treat IDB across a reload: an evicted app
+    // re-seeds its cursor, and that re-seed is the step under test. Without this
+    // the reload could resume from a surviving cursor and heal through ordinary
+    // catch-up, which would make the assertion below pass either way.
+    await page.evaluate(async () => {
+      for (const { name } of await indexedDB.databases()) {
+        if (!name) continue
+        await new Promise<void>((resolve) => {
+          const req = indexedDB.open(name)
+          req.onerror = () => resolve()
+          req.onsuccess = () => {
+            const db = req.result
+            if (!db.objectStoreNames.contains("syncCursors")) return resolve()
+            const tx = db.transaction("syncCursors", "readwrite")
+            tx.objectStore("syncCursors").clear()
+            tx.oncomplete = () => resolve()
+            tx.onerror = () => resolve()
+          }
+        })
+      }
+    })
+
     await context.setOffline(false)
     await page.reload()
     await expect(page.locator('[contenteditable="true"]').first()).toBeVisible({ timeout: 20000 })


### PR DESCRIPTION
## Problem

Kris changed a preference on his desktop; his locked phone kept the old value until a hard refresh. Reproduced end-to-end.

Two mechanisms combine. The service worker pre-fetches and caches `/api/workspaces/:id/bootstrap` on every `visibilitychange → hidden` — every phone lock — with no TTL, and answers the next bootstrap GET from it one-shot (`sw.ts`, `lib/sw-bootstrap-prefetch.ts:202-208`). Separately, `initializeActiveCursor` stamped the sync cursor from a head read over the **network**, then let the bootstrap snapshot be treated as authoritative for everything at or below it. Those two heads are interchangeable only while the snapshot is guaranteed to come off the network. When the SW answers with a snapshot captured before the device went away, the cursor sits **above** it, so the entries in between are never replayed — and never re-fetched, because resume deliberately does not re-bootstrap (`slimReconnectBootstrap`, `use-workspaces.ts:118-125` opts out of every automatic refetch). `SyncLogCursor.advance` is a monotonic max, so the correct snapshot-derived stamp that runs later (`advance(bootstrap.syncHead)`) is a silent no-op. The one-shot cache entry is why a hard refresh cleared it: the first load consumed the stale copy, the second went to the network.

Preferences are just the visible instance — anything carried only by the bootstrap payload and healed only by replay had the same exposure.

## Solution

**Never seed the cursor from a separately-read head while a snapshot that will stamp it is still pending.** One session flag, `coldSnapshotSettled`, gates the seed, so every caller funnels through the same guard rather than each call site deciding. It is released on both the success and failure paths — a failed cold bootstrap must not leave the cursor unseedable for the session, or catch-up would never gain a position at all. This closes three reachable flows, not just the obvious one: cold boot, a connectivity resume firing before the first socket connect (`refreshAfterConnectivityResume` has no first-connect guard), and a reconnect racing the cold bootstrap.

The cold bootstrap already stamps from the snapshot's own `syncHead`, which the backend reads immediately before assembling it (`workspaces/handlers.ts:165`, `:383`) — the same read-before-stamp guarantee, taken from the one party that can pair it with the snapshot it actually returns.

**`forceFull` bootstraps demand a network-fresh snapshot.** The below-floor and collapse catch-up fallbacks legitimately stamp from `response.head` and then force a bootstrap, so that bootstrap must not be answerable from the cache. Applied at both fetch sites — a forceFull reconnect *with* visible streams takes a different branch. Signalled by a URL flag as well as `cache: "no-store"`: how faithfully `Request.cache` reaches a service worker's fetch handler varies by engine, and the uncertain engines are phones, which is the entire audience here.

**No behaviour change when healthy.** For a network-served bootstrap `syncHead` and `response.head` are the same value, so the collapse still skips the ≥200-entry replay it exists to skip. Cold boot is marginally *faster*: it no longer awaits a head probe before `runBootstrap`. Catch-up remains fire-and-forget, so nothing was added to the first-paint path, and `fresh` only ever fires after a successful catch-up response, so it never runs offline.

Not done, deliberately: the below-floor/collapse sites still advance the cursor *before* their bootstrap, so a bootstrap failure there still breaks the pairing. That is pre-existing and unchanged; the freshness bypass narrows it but does not close it.

## Files

| File | Change |
| ---- | ---- |
| `sync/sync-engine.ts` | `coldSnapshotSettled` gate; `fresh: forceFull` at both bootstrap fetches |
| `lib/sw-bootstrap-prefetch.ts` | `respondToBootstrapRequest` extracted from `sw.ts` (testable — jsdom has no CacheStorage); honours the freshness signal |
| `sw.ts` | Delegates the bootstrap fetch handler |
| `api/workspaces.ts` | `bootstrap(id, { fresh })` |
| `tests/browser/sw-bootstrap-staleness.spec.ts` | **new** — end-to-end guard |

## Test plan

- [x] `bun run typecheck` (15 workspaces) and `bun run lint` clean
- [x] 1416 frontend tests pass; 3 sync-engine tests rewritten to encode the new invariant rather than the old one, 2 added, 3 for the SW responder
- [x] Browser E2E reproduces the original bug and passes with the fix — **verified failing without it** (`Expected "left", Received "right"`). It clears the persisted cursor before reloading to pin the evicted-app precondition rather than depend on how the harness treats IDB across a reload.
- [x] Adversarially reviewed by a second model; it found the first cut closed only the cold-boot call site, which is what the session flag replaced

Needs the production frontend build to exercise at all — the dev server never registers a service worker (`/sw.js` 404s to index.html) and jsdom has no CacheStorage. CI runs the prod build by default; locally use `PLAYWRIGHT_PROD_FRONTEND=1`.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787822467&installation_model_id=20758&pr_number=1627&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1627&signature=c3796a16fab5dd2ac63aaf6a0afc03c7f23d65f1f1da7995b855f69bd2617ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->