### PR TITLE
feat(harnessd): adopt and cold-take-over unmanaged Claude channel sessions

### DIFF
--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -21,23 +21,23 @@ Two paths, chosen by what is live:
 
 Everything is validated before anything changes. `--cwd`, the live pane, the harness link record (`~/.threa/harnessd/links/<session>.json`) and any inventory row must agree on the working directory; the link record and the row must agree with `--root-stream-id`; the instance id must be consistent across every source that names one; the scratchpad must read active. Only then does the bot-runtime preflight run (`ifArchived: "wait"`, `ifMissing: "error"`, returned root must equal the recorded one). A refusal writes no inventory, launches nothing, and never touches the scratchpad. `--dry-run` stops before the preflight, because that POST registers the session server-side.
 
-Identity must be *attested*, not merely derivable. The cwd derivation (`sha256("<host>:<cwd>")`) is the usual attestation, but a session started under a different hostname keeps its original id for life, so the link record or an existing row attests it instead. What is refused is a target nothing on this machine binds to that directory.
+Identity must be _attested_, not merely derivable. The cwd derivation (`sha256("<host>:<cwd>")`) is the usual attestation, but a session started under a different hostname keeps its original id for life, so the link record or an existing row attests it instead. What is refused is a target nothing on this machine binds to that directory.
 
 Idempotent: a second run against the same live pane reuses the row (`already managed`) rather than adding one, and a name already taken by a different session refuses with `--name` as the fix.
 
-| status | meaning |
-| --- | --- |
-| `adopted live` | unmanaged live pane, now recorded; nothing relaunched |
-| `already managed` | the row already tracks this live pane |
-| `taken over` | pane and process gone; the transcript was resumed in a new window |
-| `would adopt live` / `would take over` | `--dry-run` |
-| `refused live without pane` | a Claude process still runs in the cwd with no tmux pane — resuming would give two Claudes one conversation (`--force` overrides) |
-| `refused missing transcript` | no `~/.claude/projects` transcript for the cwd, or the pinned uuid has none |
-| `refused identity mismatch` | sources disagree on cwd, root stream, or instance id; or nothing binds the id to the directory |
-| `refused ambiguous` | two inventory rows, two panes, or a name collision |
-| `refused archived` / `refused inaccessible` / `refused unavailable` | scratchpad state, before or during the takeover (mid-takeover kills the new window) |
-| `refused missing cwd` / `refused missing credentials` | no directory or no Threa credentials |
-| `failed` | the launch or the post-launch inventory write errored; the window is killed rather than left untracked |
+| status                                                              | meaning                                                                                                                           |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `adopted live`                                                      | unmanaged live pane, now recorded; nothing relaunched                                                                             |
+| `already managed`                                                   | the row already tracks this live pane                                                                                             |
+| `taken over`                                                        | pane and process gone; the transcript was resumed in a new window                                                                 |
+| `would adopt live` / `would take over`                              | `--dry-run`                                                                                                                       |
+| `refused live without pane`                                         | a Claude process still runs in the cwd with no tmux pane — resuming would give two Claudes one conversation (`--force` overrides) |
+| `refused missing transcript`                                        | no `~/.claude/projects` transcript for the cwd, or the pinned uuid has none                                                       |
+| `refused identity mismatch`                                         | sources disagree on cwd, root stream, or instance id; or nothing binds the id to the directory                                    |
+| `refused ambiguous`                                                 | two inventory rows, two panes, or a name collision                                                                                |
+| `refused archived` / `refused inaccessible` / `refused unavailable` | scratchpad state, before or during the takeover (mid-takeover kills the new window)                                               |
+| `refused missing cwd` / `refused missing credentials`               | no directory or no Threa credentials                                                                                              |
+| `failed`                                                            | the launch or the post-launch inventory write errored; the window is killed rather than left untracked                            |
 
 An adopted session is an ordinary inventory row afterwards, so `up`, `kick`, `stop` and the watcher all apply — with one boundary: `up` relaunches Claude **without** `--resume`, so an automatic revival after adoption starts a fresh conversation. Conversation history survives `adopt`, not `up`.
 

--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -39,7 +39,7 @@ Idempotent: a second run against the same live pane reuses the row (`already man
 | `refused missing cwd` / `refused missing credentials`               | no directory or no Threa credentials                                                                                              |
 | `failed`                                                            | the launch or the post-launch inventory write errored; the window is killed rather than left untracked                            |
 
-An adopted session is an ordinary inventory row afterwards, so `up`, `kick`, `stop` and the watcher all apply — with one boundary: `up` relaunches Claude **without** `--resume`, so an automatic revival after adoption starts a fresh conversation. Conversation history survives `adopt`, not `up`.
+An adopted session is an ordinary inventory row afterwards, so `up`, `kick`, `stop` and the watcher all apply — and since `up` now resumes the worktree's conversation too, the history survives an automatic revival as well.
 
 ## `up` (alias `resume-active`)
 
@@ -61,6 +61,7 @@ A session starts only when ALL of these hold; otherwise it is reported with a sk
 | `skipped unavailable`         | Threa unreachable (5xx/timeout, or 429 after retries) — pass stops early                                                           |
 | `skipped missing session id`  | Pi without its original `--session-id` / remote link, or half-recorded Claude identity                                             |
 | `skipped missing cwd`         | worktree dir gone (see `--recreate-worktree`)                                                                                      |
+| `skipped occupied`            | a live Claude process already sits in the worktree (process table, not tmux) — never launch a second one on one conversation       |
 | `skipped identity mismatch`   | scratchpad origin/workspace differs from config, Pi link bound to another stream, or preflight returned a different `rootStreamId` |
 
 Flags:
@@ -74,6 +75,9 @@ Hard guarantees, regardless of flags:
 - Eligibility is checked against `GET /api/v1/workspaces/:ws/streams/:id`; archived, deleted, and inaccessible scratchpads never start.
 - Revival preflights `POST /api/v1/workspaces/:ws/bot-runtime/sessions` with `ifArchived: "wait"` and `ifMissing: "error"`, and requires the returned `rootStreamId` to equal the recorded stream — it never creates a replacement scratchpad; a would-be different stream is refused as `skipped identity mismatch`.
 - Claude sessions launch against the `threa-channel` MCP server (stale `threa` registrations are rewritten, `THREA_CHANNEL_SERVER_KEY=threa-channel` enforced) with `--dangerously-skip-permissions` unless the original launch recorded `--no-yolo`.
+- A Claude revival **resumes the worktree's conversation** (`--resume <newest transcript>`), so "back up" includes the history rather than an empty session on the same scratchpad. A transcript a live process still holds is skipped, never shared; a worktree with no transcript starts fresh.
+- Liveness has two independent sources: the tmux pane, and the Claude process table (`~/.claude/sessions/<pid>.json` corroborated against `ps -o lstart`). Either one saying "alive" refuses the launch. The pane check alone let nine consecutive passes each start another Claude in one worktree on 2026-07-28.
+- Nothing is typed into a revived session beyond the boot dialogs. Claude's own `/remote-control` (the mobile app / claude.ai/code) is **not** how a session reaches Threa — the channel MCP server is — and sending it parked every revival in a modal dialog (`"waitingFor":"dialog open"`). Set `THREA_HARNESSD_CLAUDE_REMOTE_CONTROL=1` to opt back in.
 - Pi sessions only reattach with their exact recorded `--session-id` and an enabled remote link bound to the same root stream.
 - After a launch, the scratchpad is re-checked: archived/inaccessible mid-launch → the new window is killed and the agent recorded `error`, never `online` (a wedged runtime would otherwise read as `already running` forever). If the post-launch inventory write fails, the window is killed rather than left running untracked under stale inventory fields.
 - Passes serialize through a pid-owned file lock (`resume-active.lock` beside the inventory) with stale-holder recovery — a crashed pass's lock is stolen on the next run instead of wedging every future revival (the old tmux `wait-for` lock survived its owner until the tmux server restarted).

--- a/extensions/harness-daemon/README.md
+++ b/extensions/harness-daemon/README.md
@@ -1,10 +1,45 @@
 # harness-daemon
 
-Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). If a Claude channel session was launched by the standalone worktree helper and has no inventory row, `kick` can still resolve its exact runtime session ID from a live `server:threa-channel` tmux pane and nudge it without adopting or reviving it. Run `threa-harnessd help` for the full command list.
+Local supervisor for Threa-linked agent sessions (Claude Code channel + Pi remote). `spawn` creates worktree + tmux window + harness and records the launch in `~/.threa/harnessd/inventory.sqlite`; `up` and the `watch-unarchived` LaunchAgent revive recorded sessions safely; `adopt` brings a hand-started Claude session into inventory, live or cold. `kick <ref>` sends Enter to a managed session (the same nudge exposed as `/kick` in its linked scratchpad). If a Claude channel session was launched by the standalone worktree helper and has no inventory row, `kick` can still resolve its exact runtime session ID from a live `server:threa-channel` tmux pane and nudge it without adopting or reviving it. Run `threa-harnessd help` for the full command list.
 
 ## Live reconnect
 
 `threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]` replaces a live Pi or Claude process in its existing tmux pane and resumes the same native session. It accepts only the narrow Threa launch shapes, preflights the exact linked root with create/replace disabled, then revalidates the pane generation before `tmux respawn-pane`. Claude reconnect additionally requires an idle, exact live registry entry and transcript, and verifies the replacement kept the same native UUID and cwd; `--force` permits replacing a busy Claude session. Managed inventory is preferred; a matching standalone pane may be used without writing or adopting it. Missing, ambiguous, stale, unsupported, or mismatched targets fail without launching a fresh session.
+
+## Adoption and cold takeover
+
+`threa-harnessd adopt <runtime-session-id> --root-stream-id <stream-id> [--cwd <path>] [--name <name>] [--claude-session-id <uuid>] [--tmux <session>] [--dry-run] [--force] [--no-yolo]`
+
+Brings a Claude channel session harnessd never launched under management. A hand-started session can have a valid deterministic identity, a live scratchpad and a full transcript and still be invisible: `reconnect` needs a live pane, `up` needs an inventory row, and a session with neither falls between them the moment its process exits.
+
+One explicit target per invocation, identified by runtime session id **and** root stream id. Nothing here sweeps: a local Claude directory has never been evidence that a session should run.
+
+Two paths, chosen by what is live:
+
+- **live pane** — the session is running. It is recorded in inventory and left alone; no relaunch, no keystrokes.
+- **cold takeover** — the pane and process are gone. The newest transcript under the cwd's `~/.claude/projects` directory is resumed (`--claude-session-id` pins a specific one) in a new tmux window, with harnessd's Claude command and `--mcp-config` wiring, `THREA_COLD_START_IF_ARCHIVED=wait` / `IF_MISSING=error` pinned to the given root, and the boot dialogs cleared by the same polling loop `spawn` and `reconnect` use. Bypass follows the adopted session — the live pane's own launch first, then what the row recorded — and `--no-yolo` overrides.
+
+Everything is validated before anything changes. `--cwd`, the live pane, the harness link record (`~/.threa/harnessd/links/<session>.json`) and any inventory row must agree on the working directory; the link record and the row must agree with `--root-stream-id`; the instance id must be consistent across every source that names one; the scratchpad must read active. Only then does the bot-runtime preflight run (`ifArchived: "wait"`, `ifMissing: "error"`, returned root must equal the recorded one). A refusal writes no inventory, launches nothing, and never touches the scratchpad. `--dry-run` stops before the preflight, because that POST registers the session server-side.
+
+Identity must be *attested*, not merely derivable. The cwd derivation (`sha256("<host>:<cwd>")`) is the usual attestation, but a session started under a different hostname keeps its original id for life, so the link record or an existing row attests it instead. What is refused is a target nothing on this machine binds to that directory.
+
+Idempotent: a second run against the same live pane reuses the row (`already managed`) rather than adding one, and a name already taken by a different session refuses with `--name` as the fix.
+
+| status | meaning |
+| --- | --- |
+| `adopted live` | unmanaged live pane, now recorded; nothing relaunched |
+| `already managed` | the row already tracks this live pane |
+| `taken over` | pane and process gone; the transcript was resumed in a new window |
+| `would adopt live` / `would take over` | `--dry-run` |
+| `refused live without pane` | a Claude process still runs in the cwd with no tmux pane — resuming would give two Claudes one conversation (`--force` overrides) |
+| `refused missing transcript` | no `~/.claude/projects` transcript for the cwd, or the pinned uuid has none |
+| `refused identity mismatch` | sources disagree on cwd, root stream, or instance id; or nothing binds the id to the directory |
+| `refused ambiguous` | two inventory rows, two panes, or a name collision |
+| `refused archived` / `refused inaccessible` / `refused unavailable` | scratchpad state, before or during the takeover (mid-takeover kills the new window) |
+| `refused missing cwd` / `refused missing credentials` | no directory or no Threa credentials |
+| `failed` | the launch or the post-launch inventory write errored; the window is killed rather than left untracked |
+
+An adopted session is an ordinary inventory row afterwards, so `up`, `kick`, `stop` and the watcher all apply — with one boundary: `up` relaunches Claude **without** `--resume`, so an automatic revival after adoption starts a fresh conversation. Conversation history survives `adopt`, not `up`.
 
 ## `up` (alias `resume-active`)
 

--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -138,17 +138,7 @@ describe("adoptClaudeSession live pane", () => {
         scratchpadUrl: `https://app.threa.io/w/ws_one/s/${ROOT}`,
         instanceId: IDENTITY.instanceId,
         runtimeSessionId: RUNTIME,
-        command: [
-          "threa-harnessd",
-          "adopt",
-          RUNTIME,
-          "--root-stream-id",
-          ROOT,
-          "--cwd",
-          CWD,
-          "--name",
-          "slopenv",
-        ],
+        command: ["threa-harnessd", "adopt", RUNTIME, "--root-stream-id", ROOT, "--cwd", CWD, "--name", "slopenv"],
         createdAt: dependencies.persisted[0]!.createdAt,
         updatedAt: dependencies.persisted[0]!.updatedAt,
       },
@@ -180,7 +170,12 @@ describe("adoptClaudeSession live pane", () => {
     // no THREA_* env either, so only the link record still binds the two.
     const drifted = "ccs-ac050fb309510f5c"
     const dependencies = deps({
-      panes: () => [pane({ startCommand: "/usr/bin/claude --name threa.leftie --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions" })],
+      panes: () => [
+        pane({
+          startCommand:
+            "/usr/bin/claude --name threa.leftie --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions",
+        }),
+      ],
       links: () => [link({ runtimeSessionId: drifted, instanceId: "cc-ac050fb309510f5c" })],
     })
     const outcome = await adoptClaudeSessionUnlocked(options({ runtimeSessionId: drifted }), dependencies)

--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test"
 import type { HarnessLink } from "@threa/bot-runtime-client"
 import { adoptClaudeSessionUnlocked, type AdoptDeps, type AdoptOptions } from "./adopt"
 import { acceptClaudeBootPrompts } from "./claude-boot"
-import { findLiveClaudeSessions, resolveClaudeTranscript, type ClaudeDiskDeps } from "./claude-registry"
+import {
+  findLiveClaudeSessions,
+  resolveClaudeTranscript,
+  resumableClaudeTranscript,
+  type ClaudeDiskDeps,
+} from "./claude-registry"
 import { parseAdopt } from "./cli"
 import { parseClaudeLaunch, type LocalTmuxPane } from "./discovery"
 import { claudeLaunchArgs, claudeLaunchCommand, deriveClaudeRuntimeIdentity } from "./spawners"
@@ -553,6 +558,44 @@ describe("claude disk discovery", () => {
     expect(resolveClaudeTranscript(CWD, undefined, files).sessionId).toBe("123e4567-e89b-42d3-a456-426614174000")
     expect(resolveClaudeTranscript(CWD, NATIVE, files).sessionId).toBe(NATIVE)
     expect(() => resolveClaudeTranscript(CWD, "not-a-uuid", files)).toThrow("not a Claude session UUID")
+  })
+
+  test("a revival resumes the newest transcript no live process is holding", () => {
+    const OTHER = "123e4567-e89b-42d3-a456-426614174000"
+    const held = JSON.stringify({
+      pid: 34341,
+      sessionId: NATIVE,
+      cwd: CWD,
+      procStart: START,
+      name: "slopenv",
+      status: "idle",
+    })
+    const files = (live: boolean) =>
+      disk({
+        list: (path) => (path.endsWith("sessions") ? ["34341.json"] : [`${NATIVE}.jsonl`, `${OTHER}.jsonl`]),
+        read: () => held,
+        processStart: () => (live ? START : undefined),
+        modified: (path) => (path.includes(NATIVE) ? 9_000 : 2_000),
+      })
+
+    // Nothing alive: the newest transcript wins.
+    expect(resumableClaudeTranscript(CWD, files(false))?.sessionId).toBe(NATIVE)
+    // Its owner survived: fall through rather than put two Claudes on it.
+    expect(resumableClaudeTranscript(CWD, files(true))?.sessionId).toBe(OTHER)
+  })
+
+  test("a worktree with no transcript resumes nothing instead of failing", () => {
+    expect(resumableClaudeTranscript(CWD, disk({ list: () => [] }))).toBeUndefined()
+    expect(
+      resumableClaudeTranscript(
+        CWD,
+        disk({
+          canonical: () => {
+            throw new Error("gone")
+          },
+        })
+      )
+    ).toBeUndefined()
   })
 
   test("a registry entry whose process generation moved on is not live", () => {

--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -72,6 +72,7 @@ function disk(overrides: Partial<ClaudeDiskDeps> = {}): ClaudeDiskDeps {
     exists: (path) => path.endsWith(`${NATIVE}.jsonl`),
     read: () => "{}",
     processStart: () => undefined,
+    alive: () => false,
     list: (path) => (path.endsWith("projects/-Users-me-dev-slopenv") ? [`${NATIVE}.jsonl`] : []),
     modified: () => 1_000,
     ...overrides,
@@ -210,7 +211,7 @@ describe("adoptClaudeSession cold takeover", () => {
 
     expect(outcome).toEqual({
       status: "taken over",
-      detail: `1:slopenv resuming ${NATIVE}, bypass enabled`,
+      detail: `1:slopenv resuming ${NATIVE}, bypass disabled`,
     })
     expect(dependencies.launches).toEqual([
       {
@@ -220,7 +221,7 @@ describe("adoptClaudeSession cold takeover", () => {
         resumeSessionId: NATIVE,
         rootStreamId: ROOT,
         identity: IDENTITY,
-        noYolo: false,
+        noYolo: true,
       },
     ])
     expect(dependencies.persisted.at(-1)).toMatchObject({
@@ -233,7 +234,9 @@ describe("adoptClaudeSession cold takeover", () => {
     })
   })
 
-  test("preflights with the wait/error cold-start semantics against the exact root", async () => {
+  // The wait/error cold-start semantics live in `preflightRuntimeSession` and
+  // in the launch command, not in these params — see the launch-command test.
+  test("preflights the exact root with the adopted identity and cwd", async () => {
     const dependencies = deps()
     await adoptClaudeSessionUnlocked(options(), dependencies)
 
@@ -286,6 +289,16 @@ describe("adoptClaudeSession cold takeover", () => {
     await adoptClaudeSessionUnlocked(options(), dependencies)
 
     expect(dependencies.launches).toMatchObject([{ noYolo: true }])
+  })
+
+  test("records the pinned conversation in the provenance command", async () => {
+    const dependencies = deps({ disk: disk({ exists: () => true }) })
+    await adoptClaudeSessionUnlocked(options({ claudeSessionId: NATIVE }), dependencies)
+
+    // Without the pin, re-running the recorded command adopts the newest
+    // transcript rather than the one the operator named.
+    expect(dependencies.persisted.at(-1)?.command).toContain("--claude-session-id")
+    expect(dependencies.persisted.at(-1)?.command).toContain(NATIVE)
   })
 
   test("dry run names the transcript it would resume without registering the session", async () => {
@@ -361,7 +374,7 @@ describe("adoptClaudeSession refusals", () => {
     const outcome = await adoptClaudeSessionUnlocked(options(), deps({ disk: disk({ list: () => [] }) }))
 
     expect(outcome.status).toBe("refused missing transcript")
-    expect(outcome.detail).toContain("no Claude transcript under")
+    expect(outcome.detail).toContain("that a live process is not already holding")
   })
 
   test("refuses a pinned transcript that does not exist", async () => {
@@ -379,6 +392,7 @@ describe("adoptClaudeSession refusals", () => {
       read: () =>
         JSON.stringify({ pid: 34341, sessionId: NATIVE, cwd: CWD, procStart: START, name: "slopenv", status: "idle" }),
       processStart: () => START,
+      alive: () => true,
     })
     const dependencies = deps({ disk: live })
     const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
@@ -387,8 +401,34 @@ describe("adoptClaudeSession refusals", () => {
     expect(outcome.detail).toContain("34341")
     expect(dependencies.launches).toEqual([])
 
+    // --force waives the refusal to launch, NOT the rule that two Claudes never
+    // share one conversation: the survivor holds the only transcript here.
     const forced = deps({ disk: live })
-    expect((await adoptClaudeSessionUnlocked(options({ force: true }), forced)).status).toBe("taken over")
+    const forcedOutcome = await adoptClaudeSessionUnlocked(options({ force: true }), forced)
+    expect(forcedOutcome.status).toBe("refused missing transcript")
+    expect(forced.launches).toEqual([])
+
+    // With an unheld transcript to fall back to, --force takes over that one.
+    const OTHER = "123e4567-e89b-42d3-a456-426614174000"
+    const spare = deps({
+      disk: disk({
+        list: (path) => (path.endsWith("sessions") ? ["34341.json"] : [`${NATIVE}.jsonl`, `${OTHER}.jsonl`]),
+        read: () =>
+          JSON.stringify({
+            pid: 34341,
+            sessionId: NATIVE,
+            cwd: CWD,
+            procStart: START,
+            name: "slopenv",
+            status: "idle",
+          }),
+        processStart: () => START,
+        alive: () => true,
+        modified: (path) => (path.includes(NATIVE) ? 9_000 : 2_000),
+      }),
+    })
+    expect((await adoptClaudeSessionUnlocked(options({ force: true }), spare)).status).toBe("taken over")
+    expect(spare.launches).toMatchObject([{ resumeSessionId: OTHER }])
   })
 
   test("refuses an archived scratchpad before writing or launching anything", async () => {
@@ -425,6 +465,16 @@ describe("adoptClaudeSession refusals", () => {
 
     expect(outcome.status).toBe("refused identity mismatch")
     expect(outcome.detail).toContain("stream_elsewhere")
+  })
+
+  test("refuses an inventory row whose scratchpad names another workspace", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options(),
+      deps({ inventory: () => [agent({ scratchpadUrl: `https://app.threa.io/w/ws_wrong/s/${ROOT}` })] })
+    )
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("ws_wrong")
   })
 
   test("refuses without Threa credentials", async () => {
@@ -575,6 +625,7 @@ describe("claude disk discovery", () => {
         list: (path) => (path.endsWith("sessions") ? ["34341.json"] : [`${NATIVE}.jsonl`, `${OTHER}.jsonl`]),
         read: () => held,
         processStart: () => (live ? START : undefined),
+        alive: () => live,
         modified: (path) => (path.includes(NATIVE) ? 9_000 : 2_000),
       })
 
@@ -607,12 +658,22 @@ describe("claude disk discovery", () => {
       name: "slopenv",
       status: "idle",
     })
-    const base = { list: (path: string) => (path.endsWith("sessions") ? ["34341.json"] : []), read: () => row }
+    const base = {
+      list: (path: string) => (path.endsWith("sessions") ? ["34341.json"] : []),
+      read: () => row,
+      alive: () => true,
+    }
 
     expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => START }))).toHaveLength(1)
     expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => "Wed Jul 29 10:00:00 2026" }))).toEqual([])
-    expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => undefined }))).toEqual([])
     expect(findLiveClaudeSessions("/Users/me/dev/other", disk({ ...base, processStart: () => START }))).toEqual([])
+    // A dead pid is dead whatever the registry says.
+    expect(findLiveClaudeSessions(CWD, disk({ ...base, alive: () => false, processStart: () => START }))).toEqual([])
+    // `ps` cannot distinguish "no such pid" from "ps failed", so an
+    // indeterminate start time must NOT read as dead — one bad `ps` would
+    // otherwise hide a live Claude from the occupied guard and the held-
+    // transcript filter at the same instant.
+    expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => undefined }))).toHaveLength(1)
   })
 })
 

--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -1,0 +1,604 @@
+import { describe, expect, test } from "bun:test"
+import type { HarnessLink } from "@threa/bot-runtime-client"
+import { adoptClaudeSessionUnlocked, type AdoptDeps, type AdoptOptions } from "./adopt"
+import { acceptClaudeBootPrompts } from "./claude-boot"
+import { findLiveClaudeSessions, resolveClaudeTranscript, type ClaudeDiskDeps } from "./claude-registry"
+import { parseAdopt } from "./cli"
+import { parseClaudeLaunch, type LocalTmuxPane } from "./discovery"
+import { claudeLaunchArgs, claudeLaunchCommand, deriveClaudeRuntimeIdentity } from "./spawners"
+import type { ManagedAgent } from "./types"
+
+const CWD = "/Users/me/dev/slopenv"
+const ROOT = "stream_01KYHVWXR862XKKND7SPZARH8K"
+const NATIVE = "a65ee6cf-e1a5-44e3-842b-f9977f0907f7"
+const START = "Tue Jul 28 09:43:27 2026"
+const IDENTITY = deriveClaudeRuntimeIdentity(CWD)
+const RUNTIME = IDENTITY.runtimeSessionId
+const COMMAND = `env THREA_INSTANCE_ID=${IDENTITY.instanceId} THREA_RUNTIME_SESSION_ID=${RUNTIME} THREA_DISPLAY_NAME=CC claude --name slopenv --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions`
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "1",
+    windowName: "claude-slopenv",
+    windowId: "@204",
+    paneId: "%211",
+    panePid: 34341,
+    cwd: CWD,
+    startCommand: COMMAND,
+    ...overrides,
+  }
+}
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: RUNTIME,
+    instanceId: IDENTITY.instanceId,
+    rootStreamId: ROOT,
+    worktree: CWD,
+    pid: 34379,
+    updatedAt: "2026-07-28T09:43:29.959Z",
+    ...overrides,
+  }
+}
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-adopted",
+    name: "slopenv",
+    runtime: "claude",
+    status: "online",
+    worktree: CWD,
+    scratchpadUrl: `https://app.threa.io/w/ws_one/s/${ROOT}`,
+    instanceId: IDENTITY.instanceId,
+    runtimeSessionId: RUNTIME,
+    command: ["threa-harnessd", "adopt", RUNTIME],
+    createdAt: "2026-07-28T09:00:00.000Z",
+    updatedAt: "2026-07-28T09:00:00.000Z",
+    ...overrides,
+  }
+}
+
+/** A filesystem where the cwd holds one dead session's transcript and no live process. */
+function disk(overrides: Partial<ClaudeDiskDeps> = {}): ClaudeDiskDeps {
+  return {
+    home: "/home/me",
+    canonical: (path) => path,
+    exists: (path) => path.endsWith(`${NATIVE}.jsonl`),
+    read: () => "{}",
+    processStart: () => undefined,
+    list: (path) => (path.endsWith("projects/-Users-me-dev-slopenv") ? [`${NATIVE}.jsonl`] : []),
+    modified: () => 1_000,
+    ...overrides,
+  }
+}
+
+interface Recorded {
+  persisted: ManagedAgent[]
+  launches: unknown[]
+  killed: string[]
+  preflights: unknown[]
+}
+
+function deps(overrides: Partial<AdoptDeps> = {}): AdoptDeps & Recorded {
+  const recorded: Recorded = { persisted: [], launches: [], killed: [], preflights: [] }
+  return {
+    ...recorded,
+    claudeConfig: () => ({ baseUrl: "https://app.threa.io", workspaceId: "ws_one", apiKey: "key" }),
+    inventory: () => [],
+    panes: () => [],
+    links: () => [link()],
+    disk: disk(),
+    isDirectory: () => true,
+    scratchpadStatus: async () => "active",
+    preflight: async (params) => {
+      recorded.preflights.push(params)
+      return { status: "linked", rootStreamId: ROOT }
+    },
+    launch: async (params) => {
+      recorded.launches.push(params)
+      return {
+        tmuxSession: "1",
+        tmuxWindow: "slopenv",
+        tmuxWindowId: "@300",
+        tmuxPaneId: "%301",
+        output: "resumed",
+      }
+    },
+    persist: (record) => void recorded.persisted.push(record),
+    killWindow: (windowId) => void recorded.killed.push(windowId),
+    newId: () => "claude-new",
+    ...overrides,
+  }
+}
+
+function options(overrides: Partial<AdoptOptions> = {}): AdoptOptions {
+  return { runtimeSessionId: RUNTIME, rootStreamId: ROOT, ...overrides }
+}
+
+describe("adoptClaudeSession live pane", () => {
+  test("records an unmanaged live pane without relaunching it", async () => {
+    const dependencies = deps({ panes: () => [pane()] })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome).toEqual({ status: "adopted live", detail: "1:claude-slopenv (%211, pid 34341)" })
+    expect(dependencies.launches).toEqual([])
+    expect(dependencies.persisted).toEqual([
+      {
+        id: "claude-new",
+        name: "slopenv",
+        runtime: "claude",
+        status: "online",
+        worktree: CWD,
+        branch: undefined,
+        tmuxSession: "1",
+        tmuxWindow: "claude-slopenv",
+        tmuxWindowId: "@204",
+        tmuxPaneId: "%211",
+        scratchpadUrl: `https://app.threa.io/w/ws_one/s/${ROOT}`,
+        instanceId: IDENTITY.instanceId,
+        runtimeSessionId: RUNTIME,
+        command: [
+          "threa-harnessd",
+          "adopt",
+          RUNTIME,
+          "--root-stream-id",
+          ROOT,
+          "--cwd",
+          CWD,
+          "--name",
+          "slopenv",
+        ],
+        createdAt: dependencies.persisted[0]!.createdAt,
+        updatedAt: dependencies.persisted[0]!.updatedAt,
+      },
+    ])
+  })
+
+  test("preserves the original bypass setting on a session launched without it", async () => {
+    const dependencies = deps({
+      panes: () => [pane({ startCommand: COMMAND.replace(" --dangerously-skip-permissions", "") })],
+    })
+    await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(dependencies.persisted[0]?.command).toContain("--no-yolo")
+  })
+
+  test("re-running against the same live pane reuses the row instead of adding one", async () => {
+    const existing = agent({ tmuxPaneId: "%211" })
+    const dependencies = deps({ panes: () => [pane()], inventory: () => [existing] })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("already managed")
+    expect(dependencies.persisted).toHaveLength(1)
+    expect(dependencies.persisted[0]).toMatchObject({ id: "claude-adopted", createdAt: existing.createdAt })
+  })
+
+  test("adopts a session whose id the cwd no longer derives, on the link record's word", async () => {
+    // The shape a hostname change leaves behind: the runtime keeps the id it
+    // was born with, so `${host}:${cwd}` stops reproducing it. The pane carries
+    // no THREA_* env either, so only the link record still binds the two.
+    const drifted = "ccs-ac050fb309510f5c"
+    const dependencies = deps({
+      panes: () => [pane({ startCommand: "/usr/bin/claude --name threa.leftie --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions" })],
+      links: () => [link({ runtimeSessionId: drifted, instanceId: "cc-ac050fb309510f5c" })],
+    })
+    const outcome = await adoptClaudeSessionUnlocked(options({ runtimeSessionId: drifted }), dependencies)
+
+    expect(outcome.status).toBe("adopted live")
+    expect(dependencies.persisted[0]).toMatchObject({
+      runtimeSessionId: drifted,
+      instanceId: "cc-ac050fb309510f5c",
+      worktree: CWD,
+    })
+  })
+
+  test("dry run reports the live pane and touches nothing", async () => {
+    const dependencies = deps({ panes: () => [pane()] })
+    const outcome = await adoptClaudeSessionUnlocked(options({ dryRun: true }), dependencies)
+
+    expect(outcome.status).toBe("would adopt live")
+    expect(dependencies.persisted).toEqual([])
+    expect(dependencies.preflights).toEqual([])
+  })
+})
+
+describe("adoptClaudeSession cold takeover", () => {
+  test("resumes the recovered transcript in a new window and records it", async () => {
+    const dependencies = deps()
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome).toEqual({
+      status: "taken over",
+      detail: `1:slopenv resuming ${NATIVE}, bypass enabled`,
+    })
+    expect(dependencies.launches).toEqual([
+      {
+        name: "slopenv",
+        cwd: CWD,
+        tmux: undefined,
+        resumeSessionId: NATIVE,
+        rootStreamId: ROOT,
+        identity: IDENTITY,
+        noYolo: false,
+      },
+    ])
+    expect(dependencies.persisted.at(-1)).toMatchObject({
+      status: "online",
+      tmuxWindowId: "@300",
+      tmuxPaneId: "%301",
+      worktree: CWD,
+      runtimeSessionId: RUNTIME,
+      instanceId: IDENTITY.instanceId,
+    })
+  })
+
+  test("preflights with the wait/error cold-start semantics against the exact root", async () => {
+    const dependencies = deps()
+    await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(dependencies.preflights).toMatchObject([
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_one",
+        apiKey: "key",
+        runtimeKind: "claude-code-channel",
+        instanceId: IDENTITY.instanceId,
+        runtimeSessionId: RUNTIME,
+        localCwd: CWD,
+        expectedRootStreamId: ROOT,
+        labelName: "coding",
+      },
+    ])
+    // The display name follows THREA_DISPLAY_NAME / config, which the ambient
+    // environment sets; only the worktree suffix is this code's contribution.
+    expect((dependencies.preflights[0] as { displayName: string }).displayName).toEndWith(" - slopenv")
+  })
+
+  test("revives a stopped managed row through its own id, preserving the scratchpad", async () => {
+    const dependencies = deps({ inventory: () => [agent({ status: "stopped" })] })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("taken over")
+    expect(dependencies.persisted.at(-1)).toMatchObject({
+      id: "claude-adopted",
+      status: "online",
+      scratchpadUrl: `https://app.threa.io/w/ws_one/s/${ROOT}`,
+    })
+  })
+
+  test("reuses the newest of several per-launch rows instead of adding another", async () => {
+    const dependencies = deps({
+      inventory: () => [
+        agent({ id: "claude-first", updatedAt: "2026-07-28T09:00:00.000Z" }),
+        agent({ id: "claude-newest", updatedAt: "2026-07-28T09:31:00.000Z", branch: "fix/boot" }),
+      ],
+    })
+    await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(dependencies.persisted.at(-1)).toMatchObject({ id: "claude-newest", branch: "fix/boot" })
+  })
+
+  test("carries a recorded --no-yolo into the takeover launch", async () => {
+    const dependencies = deps({
+      inventory: () => [agent({ command: ["threa-harnessd", "spawn", "claude", "--no-yolo"] })],
+    })
+    await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(dependencies.launches).toMatchObject([{ noYolo: true }])
+  })
+
+  test("dry run names the transcript it would resume without registering the session", async () => {
+    const dependencies = deps()
+    const outcome = await adoptClaudeSessionUnlocked(options({ dryRun: true }), dependencies)
+
+    expect(outcome).toEqual({ status: "would take over", detail: `${CWD} resuming ${NATIVE}` })
+    expect(dependencies.preflights).toEqual([])
+    expect(dependencies.persisted).toEqual([])
+    expect(dependencies.launches).toEqual([])
+  })
+
+  test("kills the window and records error when the scratchpad is archived mid-takeover", async () => {
+    let probes = 0
+    const dependencies = deps({ scratchpadStatus: async () => (++probes === 1 ? "active" : "archived") })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("refused archived")
+    expect(dependencies.killed).toEqual(["@300"])
+    expect(dependencies.persisted.at(-1)).toMatchObject({ status: "error" })
+  })
+})
+
+describe("adoptClaudeSession refusals", () => {
+  test("refuses a runtime session nothing on this machine binds to the cwd", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options({ runtimeSessionId: "ccs-someone-else", cwd: CWD }),
+      deps({ links: () => [] })
+    )
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain(`derives ${RUNTIME}`)
+  })
+
+  test("refuses when the pane in the cwd is running a different runtime session", async () => {
+    const stranger = pane({
+      startCommand: COMMAND.replace(RUNTIME, "ccs-stranger"),
+    })
+    const outcome = await adoptClaudeSessionUnlocked(
+      options(),
+      deps({ panes: () => [stranger], links: () => [link()] })
+    )
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("ccs-stranger")
+  })
+
+  test("refuses when the attesting sources disagree about the instance id", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options(),
+      deps({ links: () => [link({ instanceId: "cc-elsewhere" })], inventory: () => [agent()] })
+    )
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("instance id disagreement")
+  })
+
+  test("refuses a root stream the harness link does not bind", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options({ rootStreamId: "stream_other" }), deps())
+
+    expect(outcome).toMatchObject({ status: "refused identity mismatch" })
+    expect(outcome.detail).toContain(ROOT)
+  })
+
+  test("refuses when the sources disagree about the working directory", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options({ cwd: "/Users/me/dev/other" }), deps())
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("sources disagree")
+  })
+
+  test("refuses a cold takeover with no transcript on disk", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options(), deps({ disk: disk({ list: () => [] }) }))
+
+    expect(outcome.status).toBe("refused missing transcript")
+    expect(outcome.detail).toContain("no Claude transcript under")
+  })
+
+  test("refuses a pinned transcript that does not exist", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options({ claudeSessionId: "123e4567-e89b-42d3-a456-426614174000" }),
+      deps()
+    )
+
+    expect(outcome.status).toBe("refused missing transcript")
+  })
+
+  test("refuses to take over while a paneless Claude still runs in the cwd", async () => {
+    const live = disk({
+      list: (path) => (path.endsWith("sessions") ? ["34341.json"] : [`${NATIVE}.jsonl`]),
+      read: () =>
+        JSON.stringify({ pid: 34341, sessionId: NATIVE, cwd: CWD, procStart: START, name: "slopenv", status: "idle" }),
+      processStart: () => START,
+    })
+    const dependencies = deps({ disk: live })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("refused live without pane")
+    expect(outcome.detail).toContain("34341")
+    expect(dependencies.launches).toEqual([])
+
+    const forced = deps({ disk: live })
+    expect((await adoptClaudeSessionUnlocked(options({ force: true }), forced)).status).toBe("taken over")
+  })
+
+  test("refuses an archived scratchpad before writing or launching anything", async () => {
+    const dependencies = deps({ scratchpadStatus: async () => "archived" })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome).toEqual({ status: "refused archived", detail: ROOT })
+    expect(dependencies.preflights).toEqual([])
+    expect(dependencies.persisted).toEqual([])
+    expect(dependencies.launches).toEqual([])
+  })
+
+  test("refuses an inaccessible scratchpad", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options(), deps({ scratchpadStatus: async () => "inaccessible" }))
+
+    expect(outcome.status).toBe("refused inaccessible")
+  })
+
+  test("refuses when the derived name belongs to a different session", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options(),
+      deps({ inventory: () => [agent({ id: "claude-stranger", runtimeSessionId: "ccs-stranger" })] })
+    )
+
+    expect(outcome.status).toBe("refused ambiguous")
+    expect(outcome.detail).toContain("--name")
+  })
+
+  test("refuses an inventory row bound to a different scratchpad", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(
+      options(),
+      deps({ inventory: () => [agent({ scratchpadUrl: "https://app.threa.io/w/ws_one/s/stream_elsewhere" })] })
+    )
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("stream_elsewhere")
+  })
+
+  test("refuses without Threa credentials", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options(), deps({ claudeConfig: () => ({}) }))
+
+    expect(outcome.status).toBe("refused missing credentials")
+  })
+
+  test("refuses a cwd that is not a directory", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options(), deps({ isDirectory: () => false }))
+
+    expect(outcome.status).toBe("refused missing cwd")
+  })
+
+  test("refuses when no source names a working directory", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options(), deps({ links: () => [] }))
+
+    expect(outcome).toMatchObject({ status: "refused missing cwd" })
+    expect(outcome.detail).toContain("no --cwd")
+  })
+
+  test("never launches when the preflight links a different root", async () => {
+    const dependencies = deps({
+      preflight: async () => ({ status: "mismatch", rootStreamId: "stream_replacement", expectedRootStreamId: ROOT }),
+    })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("stream_replacement")
+    expect(dependencies.launches).toEqual([])
+    expect(dependencies.persisted).toEqual([])
+  })
+})
+
+describe("boot dialogs", () => {
+  test("adoption records the session online only after the launch settles them", async () => {
+    const order: string[] = []
+    const dependencies = deps({
+      launch: async () => {
+        order.push("boot")
+        return {
+          tmuxSession: "1",
+          tmuxWindow: "slopenv",
+          tmuxWindowId: "@300",
+          tmuxPaneId: "%301",
+          output: "❯ ",
+        }
+      },
+      persist: (record) => void order.push(`persist:${record.status}`),
+    })
+    await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(order).toEqual(["boot", "persist:online"])
+  })
+
+  test("the takeover's boot loop clears the development-channel warning then stops at the idle prompt", async () => {
+    const screens = [
+      "Do you trust the files in this folder?\n❯ 1. Yes\nEnter to confirm",
+      "WARNING: development channels\n❯ 1. Continue\nEnter to continue",
+      "\n❯ \n",
+    ]
+    const keys: string[][] = []
+    let frame = 0
+    await acceptClaudeBootPrompts("%301", {
+      capture: () => screens[Math.min(frame++, screens.length - 1)]!,
+      keys: (_pane, sent) => void keys.push(sent),
+      sleep: async () => undefined,
+    })
+
+    expect(keys).toEqual([["Enter"], ["Enter"]])
+  })
+})
+
+describe("takeover launch command", () => {
+  test("is the managed shape reconnect can parse, resuming the recovered conversation", () => {
+    const command = claudeLaunchCommand(
+      claudeLaunchArgs({
+        claudeBin: "/opt/claude",
+        name: "slopenv",
+        channel: "threa-channel",
+        mcpConfig: "/tmp/threa.json",
+        resumeSessionId: NATIVE,
+      }),
+      IDENTITY,
+      {},
+      "wait",
+      "error",
+      ROOT
+    )
+
+    // The original hand-started launch (`--name slopenv`) is NOT parseable by
+    // the strict parser, which is why `reconnect` could never touch it. A taken
+    // over session is, so it stays reconnectable from then on.
+    expect(parseClaudeLaunch(command)).toMatchObject({
+      executable: "/opt/claude",
+      name: "threa.slopenv",
+      resumeSessionId: NATIVE,
+      channel: "threa-channel",
+      mcpConfig: "/tmp/threa.json",
+      skipPermissions: true,
+    })
+    expect(command).toContain("THREA_COLD_START_IF_ARCHIVED=wait")
+    expect(command).toContain("THREA_COLD_START_IF_MISSING=error")
+    expect(command).toContain(`THREA_EXPECTED_ROOT_STREAM_ID=${ROOT}`)
+    expect(parseClaudeLaunch(COMMAND)).toBeUndefined()
+  })
+
+  test("--no-yolo drops the permission bypass", () => {
+    const args = claudeLaunchArgs({
+      claudeBin: "/opt/claude",
+      name: "slopenv",
+      channel: "threa-channel",
+      mcpConfig: "/tmp/threa.json",
+      noYolo: true,
+      resumeSessionId: NATIVE,
+    })
+
+    expect(args).not.toContain("--dangerously-skip-permissions")
+    expect(args.slice(0, 3)).toEqual(["/opt/claude", "--resume", NATIVE])
+  })
+})
+
+describe("claude disk discovery", () => {
+  test("takes the newest transcript and honours an explicit pin", () => {
+    const files = disk({
+      list: () => [`${NATIVE}.jsonl`, "123e4567-e89b-42d3-a456-426614174000.jsonl", "notes.txt"],
+      modified: (path) => (path.includes(NATIVE) ? 2_000 : 9_000),
+      exists: () => true,
+    })
+
+    expect(resolveClaudeTranscript(CWD, undefined, files).sessionId).toBe("123e4567-e89b-42d3-a456-426614174000")
+    expect(resolveClaudeTranscript(CWD, NATIVE, files).sessionId).toBe(NATIVE)
+    expect(() => resolveClaudeTranscript(CWD, "not-a-uuid", files)).toThrow("not a Claude session UUID")
+  })
+
+  test("a registry entry whose process generation moved on is not live", () => {
+    const row = JSON.stringify({
+      pid: 34341,
+      sessionId: NATIVE,
+      cwd: CWD,
+      procStart: START,
+      name: "slopenv",
+      status: "idle",
+    })
+    const base = { list: (path: string) => (path.endsWith("sessions") ? ["34341.json"] : []), read: () => row }
+
+    expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => START }))).toHaveLength(1)
+    expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => "Wed Jul 29 10:00:00 2026" }))).toEqual([])
+    expect(findLiveClaudeSessions(CWD, disk({ ...base, processStart: () => undefined }))).toEqual([])
+    expect(findLiveClaudeSessions("/Users/me/dev/other", disk({ ...base, processStart: () => START }))).toEqual([])
+  })
+})
+
+describe("parseAdopt", () => {
+  test("requires an explicit target and root stream", () => {
+    expect(() => parseAdopt([])).toThrow("adopt requires a runtime session id")
+    expect(() => parseAdopt([RUNTIME])).toThrow("adopt requires --root-stream-id")
+    expect(() => parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--wat"])).toThrow("unexpected adopt argument: --wat")
+  })
+
+  test("parses the optional identifiers", () => {
+    expect(
+      parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--cwd", CWD, "--name", "slop", "--dry-run", "--force"])
+    ).toEqual({
+      runtimeSessionId: RUNTIME,
+      rootStreamId: ROOT,
+      cwd: CWD,
+      name: "slop",
+      claudeSessionId: undefined,
+      tmux: undefined,
+      dryRun: true,
+      force: true,
+      noYolo: undefined,
+    })
+    expect(parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--no-yolo"])).toMatchObject({ noYolo: true })
+  })
+})

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -1,0 +1,604 @@
+import { randomUUID } from "node:crypto"
+import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
+import { existsSync, statSync } from "node:fs"
+import { basename, dirname, join } from "node:path"
+import { acceptClaudeBootPrompts } from "./claude-boot"
+import {
+  defaultClaudeDiskDeps,
+  findLiveClaudeSessions,
+  resolveClaudeTranscript,
+  type ClaudeDiskDeps,
+} from "./claude-registry"
+import { normalizeName, now } from "./cli"
+import { findLocalClaudeChannelPane, listLocalTmuxPanes, parseClaudeChannelLaunch, type LocalTmuxPane } from "./discovery"
+import { inventoryPath, readInventoryReadonly, upsertAgent } from "./inventory"
+import { acquireProcessLock } from "./lock"
+import {
+  fetchScratchpadStatus,
+  parseScratchpadUrl,
+  preflightRuntimeSession,
+  recordedNoYolo,
+  type RuntimePreflightResult,
+  type ScratchpadStatus,
+} from "./resume"
+import { commandPath, output } from "./shell"
+import {
+  claudeLaunchArgs,
+  claudeLaunchCommand,
+  configuredThreaBaseUrl,
+  deriveClaudeRuntimeIdentity,
+  mcpConfigPath,
+  normalizeChannelMcpConfig,
+  prepareClaudeChannel,
+  readThreaChannelConfig,
+  writeChannelMcpConfig,
+} from "./spawners"
+import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, tmuxSession } from "./tmux"
+import type { ManagedAgent, ThreaChannelConfig } from "./types"
+
+/**
+ * Bring a Claude channel session harnessd never launched under management.
+ *
+ * A hand-started session can have a perfectly valid deterministic identity, a
+ * live scratchpad and a full transcript, and still be invisible to harnessd:
+ * `reconnect` needs a live pane, `up` needs an inventory row, and a session
+ * with neither falls between them the moment its process exits. Adoption is the
+ * explicit, one-target bridge — never a sweep. Nothing here adopts by scanning
+ * for local Claude directories, because a directory has never been evidence
+ * that a session should run (see `up`'s 2026-07-20 incident note).
+ */
+
+export interface AdoptOptions {
+  runtimeSessionId: string
+  rootStreamId: string
+  cwd?: string
+  name?: string
+  tmux?: string
+  /** Pin the native conversation instead of taking the newest transcript in the cwd. */
+  claudeSessionId?: string
+  dryRun?: boolean
+  /** Take over even though a Claude process is still running in the cwd without a pane. */
+  force?: boolean
+  noYolo?: boolean
+}
+
+export type AdoptStatus =
+  | "adopted live"
+  | "already managed"
+  | "taken over"
+  | "would adopt live"
+  | "would take over"
+  | "refused live without pane"
+  | "refused ambiguous"
+  | "refused identity mismatch"
+  | "refused missing cwd"
+  | "refused missing transcript"
+  | "refused missing credentials"
+  | "refused archived"
+  | "refused inaccessible"
+  | "refused unavailable"
+  | "failed"
+
+export interface AdoptOutcome {
+  status: AdoptStatus
+  detail?: string
+}
+
+export function adoptRefused(status: AdoptStatus): boolean {
+  return status.startsWith("refused") || status === "failed"
+}
+
+export interface TakeoverLaunch {
+  tmuxSession: string
+  tmuxWindow: string
+  tmuxWindowId: string
+  tmuxPaneId: string
+  output: string
+}
+
+export interface AdoptDeps {
+  claudeConfig: () => ThreaChannelConfig
+  inventory: () => ManagedAgent[]
+  panes: () => LocalTmuxPane[]
+  links: () => HarnessLink[]
+  disk: ClaudeDiskDeps
+  isDirectory: (path: string) => boolean
+  scratchpadStatus: (params: {
+    baseUrl: string
+    workspaceId: string
+    apiKey: string
+    streamId: string
+  }) => Promise<ScratchpadStatus>
+  preflight: (params: Parameters<typeof preflightRuntimeSession>[0]) => Promise<RuntimePreflightResult>
+  launch: (params: {
+    name: string
+    cwd: string
+    tmux?: string
+    resumeSessionId: string
+    rootStreamId: string
+    identity: { instanceId: string; runtimeSessionId: string }
+    noYolo: boolean
+  }) => Promise<TakeoverLaunch>
+  persist: (agent: ManagedAgent) => void
+  killWindow: (windowId: string) => void
+  newId: () => string
+}
+
+export function defaultAdoptDeps(): AdoptDeps {
+  return {
+    claudeConfig: readThreaChannelConfig,
+    inventory: readInventoryReadonly,
+    panes: listLocalTmuxPanes,
+    links: readHarnessLinks,
+    disk: defaultClaudeDiskDeps(),
+    isDirectory: (path) => {
+      try {
+        return statSync(path).isDirectory()
+      } catch {
+        return false
+      }
+    },
+    scratchpadStatus: fetchScratchpadStatus,
+    preflight: preflightRuntimeSession,
+    launch: launchTakeover,
+    persist: upsertAgent,
+    killWindow: (windowId) => {
+      output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+    },
+    newId: () => `claude-${Date.now()}-${randomUUID().slice(0, 8)}`,
+  }
+}
+
+const STREAM_RE = /^stream_[A-Za-z0-9]+$/
+
+/** Serialized against `up`/`reap` for the same reason they serialize against each other. */
+export async function adoptClaudeSession(
+  options: AdoptOptions,
+  deps: AdoptDeps = defaultAdoptDeps()
+): Promise<AdoptOutcome> {
+  if (options.dryRun) return adoptClaudeSessionUnlocked(options, deps)
+  const release = await acquireProcessLock(join(dirname(inventoryPath()), "resume-active.lock"))
+  try {
+    return await adoptClaudeSessionUnlocked(options, deps)
+  } finally {
+    release()
+  }
+}
+
+export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: AdoptDeps): Promise<AdoptOutcome> {
+  if (!STREAM_RE.test(options.rootStreamId)) {
+    return { status: "refused identity mismatch", detail: `not a root stream id: ${options.rootStreamId}` }
+  }
+  const config = deps.claudeConfig()
+  const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+  const apiKey = process.env.THREA_API_KEY || config.apiKey
+  if (!workspaceId || !apiKey) {
+    return { status: "refused missing credentials", detail: "no Claude channel Threa credentials configured" }
+  }
+  const baseUrl = configuredThreaBaseUrl(config)
+
+  // Inventory rows are immutable per launch, so several can legitimately record
+  // one session. The newest is the row `latestAgents` and `findAgentOrUndefined`
+  // would act on, and reusing its id is what keeps re-running adopt from adding
+  // a row every time.
+  const inventory = deps.inventory()
+  const existing = inventory
+    .filter((agent) => agent.runtimeSessionId === options.runtimeSessionId)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0]
+  if (existing && existing.runtime !== "claude") {
+    return { status: "refused identity mismatch", detail: `${existing.id} is recorded as a ${existing.runtime} session` }
+  }
+
+  const link = deps.links().find((candidate) => candidate.runtimeSessionId === options.runtimeSessionId)
+  if (link && link.runtimeKind !== "claude-code-channel" && link.runtimeKind !== "unknown") {
+    return { status: "refused identity mismatch", detail: `harness link records runtime kind ${link.runtimeKind}` }
+  }
+  if (link && link.rootStreamId !== options.rootStreamId) {
+    return {
+      status: "refused identity mismatch",
+      detail: `harness link binds ${options.runtimeSessionId} to ${link.rootStreamId}, not ${options.rootStreamId}`,
+    }
+  }
+
+  let pane: LocalTmuxPane | undefined
+  try {
+    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config)
+  } catch (error) {
+    return { status: "refused ambiguous", detail: error instanceof Error ? error.message : String(error) }
+  }
+
+  const resolvedCwd = resolveCwd(options, { pane, link, existing }, deps)
+  if ("status" in resolvedCwd) return resolvedCwd
+  const cwd = resolvedCwd.cwd
+  if (!deps.isDirectory(cwd)) {
+    return { status: "refused missing cwd", detail: `${cwd} (${resolvedCwd.source}) is not an existing directory` }
+  }
+
+  // A session whose launch carried no THREA_* environment is only findable by
+  // deriving from cwd, so the pane lookup above missed it whenever the derived
+  // id is not the one being adopted (a hostname change is enough). The
+  // directory's sole channel occupant is that pane — but only once something
+  // else already attests this cwd belongs to the target session, which is
+  // exactly what a link record or inventory row is.
+  if (!pane && (link || existing)) {
+    const occupants = deps
+      .panes()
+      .filter(
+        (candidate) =>
+          canonicalOrRaw(candidate.cwd, deps.disk) === cwd && parseClaudeChannelLaunch(candidate.startCommand)
+      )
+    if (occupants.length > 1) {
+      return {
+        status: "refused ambiguous",
+        detail: `${occupants.length} Claude channel panes occupy ${cwd}: ${occupants.map((candidate) => candidate.paneId).join(", ")}`,
+      }
+    }
+    const occupied = occupants[0]
+    const declared = occupied && parseClaudeChannelLaunch(occupied.startCommand)?.runtimeSessionId
+    if (occupied && declared && declared !== options.runtimeSessionId) {
+      return {
+        status: "refused identity mismatch",
+        detail: `${occupied.paneId} in ${cwd} is running ${declared}, not ${options.runtimeSessionId}`,
+      }
+    }
+    pane = occupied
+  }
+
+  // Identity has to be attested by something local. The cwd derivation is the
+  // usual attestation, but it is not the only one: a session started under a
+  // different hostname keeps its original id for life, and the link record the
+  // runtime wrote is the stronger evidence in that case. What is refused is a
+  // target NOTHING on this machine binds to this directory.
+  const derived = deriveClaudeRuntimeIdentity(cwd, config)
+  const launch = pane ? parseClaudeChannelLaunch(pane.startCommand) : undefined
+  const attestations: Array<{ source: string; instanceId?: string }> = []
+  if (link) attestations.push({ source: "harness link", instanceId: link.instanceId || undefined })
+  if (existing) attestations.push({ source: "inventory", instanceId: existing.instanceId })
+  if (launch?.runtimeSessionId === options.runtimeSessionId) {
+    attestations.push({ source: "live launch", instanceId: launch.instanceId })
+  }
+  if (derived.runtimeSessionId === options.runtimeSessionId) {
+    attestations.push({ source: "cwd", instanceId: derived.instanceId })
+  }
+  if (attestations.length === 0) {
+    return {
+      status: "refused identity mismatch",
+      detail: `nothing binds ${options.runtimeSessionId} to ${cwd}: no harness link, no inventory row, no live launch, and the directory derives ${derived.runtimeSessionId}`,
+    }
+  }
+  const claimed = attestations.filter(
+    (attestation): attestation is { source: string; instanceId: string } => Boolean(attestation.instanceId)
+  )
+  const conflict = claimed.find((attestation) => attestation.instanceId !== claimed[0]!.instanceId)
+  if (conflict) {
+    return {
+      status: "refused identity mismatch",
+      detail: `instance id disagreement: ${claimed[0]!.source}=${claimed[0]!.instanceId}, ${conflict.source}=${conflict.instanceId}`,
+    }
+  }
+  const instanceId = claimed[0]?.instanceId ?? derived.instanceId
+  if (existing?.scratchpadUrl) {
+    const recorded = parseScratchpadUrl(existing.scratchpadUrl)
+    if (!recorded || recorded.streamId !== options.rootStreamId) {
+      return {
+        status: "refused identity mismatch",
+        detail: `inventory records scratchpad ${existing.scratchpadUrl}, not ${options.rootStreamId}`,
+      }
+    }
+    if (recorded.baseUrl !== baseUrl) {
+      return { status: "refused identity mismatch", detail: "recorded scratchpad origin differs from configured base URL" }
+    }
+  }
+
+  const name = normalizeName(options.name ?? existing?.name ?? basename(cwd))
+  const clash = inventory.find(
+    (agent) => agent.name === name && agent.runtimeSessionId !== options.runtimeSessionId
+  )
+  if (clash) {
+    return {
+      status: "refused ambiguous",
+      detail: `inventory already has an agent named ${name} (${clash.id}); pass --name`,
+    }
+  }
+
+  const liveSessions = findLiveClaudeSessions(cwd, deps.disk)
+  if (!pane && liveSessions.length > 0 && !options.force) {
+    return {
+      status: "refused live without pane",
+      detail: `Claude is still running in ${cwd} (pid ${liveSessions.map((session) => session.pid).join(", ")}) with no tmux pane; kill it or pass --force`,
+    }
+  }
+
+  // Read-only: nothing on the server has been touched at this point, and
+  // nothing will be if this refuses.
+  const scratchpad = await deps.scratchpadStatus({ baseUrl, workspaceId, apiKey, streamId: options.rootStreamId })
+  if (scratchpad !== "active") return { status: `refused ${scratchpad}`, detail: options.rootStreamId }
+
+  const scratchpadUrl = existing?.scratchpadUrl ?? `${baseUrl}/w/${workspaceId}/s/${options.rootStreamId}`
+  const identity = { instanceId, runtimeSessionId: options.runtimeSessionId }
+  // Bypass follows the session being adopted, not harnessd's spawn default: the
+  // live pane's own launch first, then what the row recorded.
+  const observed = paneSkipsPermissions(pane)
+  const noYolo = options.noYolo ?? (observed !== undefined ? !observed : existing ? recordedNoYolo(existing) : false)
+  const command = adoptCommand(options, { name, cwd, noYolo })
+
+  if (pane) {
+    const alreadyManaged = Boolean(existing) && existing?.tmuxPaneId === pane.paneId && existing?.status === "online"
+    if (options.dryRun) {
+      return {
+        status: alreadyManaged ? "already managed" : "would adopt live",
+        detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid})`,
+      }
+    }
+    const preflight = await deps.preflight(
+      preflightParams({ baseUrl, workspaceId, apiKey, config, identity, cwd, rootStreamId: options.rootStreamId })
+    )
+    if (preflight.status !== "linked") return preflightRefusal(preflight)
+    deps.persist({
+      id: existing?.id ?? deps.newId(),
+      name,
+      runtime: "claude",
+      status: "online",
+      worktree: cwd,
+      branch: existing?.branch,
+      tmuxSession: pane.sessionName,
+      tmuxWindow: pane.windowName,
+      tmuxWindowId: pane.windowId,
+      tmuxPaneId: pane.paneId,
+      scratchpadUrl,
+      instanceId,
+      runtimeSessionId: options.runtimeSessionId,
+      command,
+      createdAt: existing?.createdAt ?? now(),
+      updatedAt: now(),
+    })
+    return {
+      status: alreadyManaged ? "already managed" : "adopted live",
+      detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid})`,
+    }
+  }
+
+  let transcript
+  try {
+    transcript = resolveClaudeTranscript(cwd, options.claudeSessionId, deps.disk)
+  } catch (error) {
+    return { status: "refused missing transcript", detail: error instanceof Error ? error.message : String(error) }
+  }
+
+  // Dry-run stops before the preflight for the same reason `up --dry-run` does:
+  // that POST registers the session server-side.
+  if (options.dryRun) {
+    return { status: "would take over", detail: `${cwd} resuming ${transcript.sessionId}` }
+  }
+
+  const preflight = await deps.preflight(
+    preflightParams({ baseUrl, workspaceId, apiKey, config, identity, cwd, rootStreamId: options.rootStreamId })
+  )
+  if (preflight.status !== "linked") return preflightRefusal(preflight)
+
+  const record: ManagedAgent = {
+    id: existing?.id ?? deps.newId(),
+    name,
+    runtime: "claude",
+    status: "online",
+    worktree: cwd,
+    branch: existing?.branch,
+    scratchpadUrl,
+    instanceId,
+    runtimeSessionId: options.runtimeSessionId,
+    command,
+    createdAt: existing?.createdAt ?? now(),
+    updatedAt: now(),
+  }
+
+  let launched: TakeoverLaunch
+  try {
+    launched = await deps.launch({
+      name,
+      cwd,
+      tmux: options.tmux,
+      resumeSessionId: transcript.sessionId,
+      rootStreamId: preflight.rootStreamId,
+      identity,
+      noYolo,
+    })
+  } catch (error) {
+    deps.persist({ ...record, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })
+    return { status: "failed", detail: `takeover launch failed: ${error instanceof Error ? error.message : String(error)}` }
+  }
+
+  // Same archive-during-launch TOCTOU `up` guards: a window whose scratchpad
+  // went away mid-launch wedges and reads as "already running" forever.
+  const recheck = await deps.scratchpadStatus({ baseUrl, workspaceId, apiKey, streamId: options.rootStreamId })
+  if (recheck === "archived" || recheck === "inaccessible") {
+    deps.killWindow(launched.tmuxWindowId)
+    deps.persist({
+      ...record,
+      status: "error",
+      updatedAt: now(),
+      lastOutput: `scratchpad became ${recheck} during takeover; window killed`,
+    })
+    return { status: `refused ${recheck}`, detail: "scratchpad state changed during takeover; window killed" }
+  }
+  try {
+    deps.persist({
+      ...record,
+      tmuxSession: launched.tmuxSession,
+      tmuxWindow: launched.tmuxWindow,
+      tmuxWindowId: launched.tmuxWindowId,
+      tmuxPaneId: launched.tmuxPaneId,
+      updatedAt: now(),
+      lastOutput: launched.output.slice(-4000),
+    })
+  } catch (error) {
+    deps.killWindow(launched.tmuxWindowId)
+    return {
+      status: "failed",
+      detail: `inventory write failed after takeover; window killed: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+  return {
+    status: "taken over",
+    detail: `${launched.tmuxSession}:${launched.tmuxWindow} resuming ${transcript.sessionId}, bypass ${noYolo ? "disabled" : "enabled"}`,
+  }
+}
+
+function paneSkipsPermissions(pane: LocalTmuxPane | undefined): boolean | undefined {
+  if (!pane) return undefined
+  return parseClaudeChannelLaunch(pane.startCommand)?.skipPermissions
+}
+
+function adoptCommand(
+  options: AdoptOptions,
+  resolved: { name: string; cwd: string; noYolo: boolean }
+): string[] {
+  const command = [
+    "threa-harnessd",
+    "adopt",
+    options.runtimeSessionId,
+    "--root-stream-id",
+    options.rootStreamId,
+    "--cwd",
+    resolved.cwd,
+    "--name",
+    resolved.name,
+  ]
+  if (resolved.noYolo) command.push("--no-yolo")
+  return command
+}
+
+function preflightParams(params: {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+  config: ThreaChannelConfig
+  identity: { instanceId: string; runtimeSessionId: string }
+  cwd: string
+  rootStreamId: string
+}): Parameters<typeof preflightRuntimeSession>[0] {
+  return {
+    baseUrl: params.baseUrl,
+    workspaceId: params.workspaceId,
+    apiKey: params.apiKey,
+    runtimeKind: "claude-code-channel",
+    instanceId: params.identity.instanceId,
+    runtimeSessionId: params.identity.runtimeSessionId,
+    displayName: `${process.env.THREA_DISPLAY_NAME || params.config.displayName || "Claude Code"} - ${basename(params.cwd)}`.slice(
+      0,
+      100
+    ),
+    localCwd: params.cwd,
+    expectedRootStreamId: params.rootStreamId,
+    labelName: process.env.THREA_DEFAULT_LABEL || params.config.defaultLabel || "coding",
+  }
+}
+
+function preflightRefusal(result: Exclude<RuntimePreflightResult, { status: "linked" }>): AdoptOutcome {
+  if (result.status === "mismatch") {
+    return {
+      status: "refused identity mismatch",
+      detail: `session preflight linked ${result.rootStreamId}, expected ${result.expectedRootStreamId}`,
+    }
+  }
+  return { status: `refused ${result.status}`, detail: result.reason }
+}
+
+/**
+ * Every source that claims to know the session's directory has to agree.
+ * Disagreement is the shape of a mistyped `--cwd` or a stale link record, and
+ * picking a winner silently would take over the wrong conversation.
+ */
+function resolveCwd(
+  options: AdoptOptions,
+  found: { pane?: LocalTmuxPane; link?: HarnessLink; existing?: ManagedAgent },
+  deps: AdoptDeps
+): { cwd: string; source: string } | AdoptOutcome {
+  const candidates: Array<{ source: string; path: string }> = []
+  if (options.cwd) candidates.push({ source: "--cwd", path: options.cwd })
+  if (found.pane) candidates.push({ source: "live pane", path: found.pane.cwd })
+  if (found.link) candidates.push({ source: "harness link", path: found.link.worktree })
+  if (found.existing?.worktree) candidates.push({ source: "inventory", path: found.existing.worktree })
+  if (candidates.length === 0) {
+    return {
+      status: "refused missing cwd",
+      detail: "no --cwd, live pane, harness link, or inventory row names a working directory",
+    }
+  }
+  const resolved = candidates.map(({ source, path }) => ({ source, path: canonicalOrRaw(path, deps.disk) }))
+  const distinct = [...new Set(resolved.map(({ path }) => path))]
+  if (distinct.length > 1) {
+    return {
+      status: "refused identity mismatch",
+      detail: `sources disagree on the working directory: ${resolved.map(({ source, path }) => `${source}=${path}`).join(", ")}`,
+    }
+  }
+  return { cwd: distinct[0]!, source: resolved[0]!.source }
+}
+
+function canonicalOrRaw(path: string, disk: ClaudeDiskDeps): string {
+  try {
+    return disk.canonical(path)
+  } catch {
+    return path
+  }
+}
+
+/**
+ * The real takeover launch: harnessd's supported Claude command and MCP wiring,
+ * in a new window, resuming the recovered native conversation.
+ */
+async function launchTakeover(params: {
+  name: string
+  cwd: string
+  tmux?: string
+  resumeSessionId: string
+  rootStreamId: string
+  identity: { instanceId: string; runtimeSessionId: string }
+  noYolo: boolean
+}): Promise<TakeoverLaunch> {
+  const claudeBin = process.env.THREA_HARNESSD_CLAUDE_BIN || commandPath("claude")
+  if (!claudeBin) throw new Error("claude binary not found; set THREA_HARNESSD_CLAUDE_BIN or put claude on PATH")
+  const channel = process.env.THREA_HARNESSD_CLAUDE_CHANNEL || "threa-channel"
+  const channelEntry = prepareClaudeChannel()
+  const mcpConfig = mcpConfigPath(params.name)
+  if (!existsSync(mcpConfig)) writeChannelMcpConfig(params.name, channel, channelEntry)
+  normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
+
+  const session = params.tmux ?? tmuxSession({ runtime: "claude", name: params.name })
+  ensureTmuxSession(session, true)
+  const window = pickTmuxWindow(session, params.name)
+  const { windowId, paneId } = createWindow(
+    session,
+    window,
+    params.cwd,
+    claudeLaunchCommand(
+      claudeLaunchArgs({
+        claudeBin,
+        name: params.name,
+        channel,
+        mcpConfig,
+        noYolo: params.noYolo,
+        resumeSessionId: params.resumeSessionId,
+      }),
+      params.identity,
+      readThreaChannelConfig(),
+      "wait",
+      "error",
+      params.rootStreamId
+    )
+  )
+  console.log(`harnessd: took over Claude Code in tmux ${session}:${window} (${windowId})`)
+  try {
+    await acceptClaudeBootPrompts(paneId)
+    return {
+      tmuxSession: session,
+      tmuxWindow: window,
+      tmuxWindowId: windowId,
+      tmuxPaneId: paneId,
+      output: capturePane(paneId),
+    }
+  } catch (error) {
+    output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+    throw error
+  }
+}

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -7,6 +7,7 @@ import {
   defaultClaudeDiskDeps,
   findLiveClaudeSessions,
   resolveClaudeTranscript,
+  resumableClaudeTranscript,
   type ClaudeDiskDeps,
 } from "./claude-registry"
 import { normalizeName, now } from "./cli"
@@ -299,6 +300,14 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
         detail: "recorded scratchpad origin differs from configured base URL",
       }
     }
+    // Preserving a URL whose workspace is not the one being preflighted would
+    // mint a row `up` then refuses forever as workspace-mismatched.
+    if (recorded.workspaceId && recorded.workspaceId !== workspaceId) {
+      return {
+        status: "refused identity mismatch",
+        detail: `inventory records workspace ${recorded.workspaceId}, configured ${workspaceId}`,
+      }
+    }
   }
 
   const name = normalizeName(options.name ?? existing?.name ?? basename(cwd))
@@ -330,7 +339,9 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // Bypass follows the session being adopted, not harnessd's spawn default: the
   // live pane's own launch first, then what the row recorded.
   const observed = paneSkipsPermissions(pane)
-  const noYolo = options.noYolo ?? (observed !== undefined ? !observed : existing ? recordedNoYolo(existing) : false)
+  // Nothing to follow means nothing is known about how the original ran, and a
+  // takeover is not the place to assume it had its guardrails off.
+  const noYolo = options.noYolo ?? (observed !== undefined ? !observed : existing ? recordedNoYolo(existing) : true)
   const command = adoptCommand(options, { name, cwd, noYolo })
 
   if (pane) {
@@ -369,11 +380,25 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     }
   }
 
+  // An explicit --claude-session-id is the operator naming a conversation, so
+  // it is taken as given. Without one, a transcript a surviving process still
+  // holds must never be picked: --force waives the refusal to launch, not the
+  // rule that two Claudes never share one conversation.
   let transcript
-  try {
-    transcript = resolveClaudeTranscript(cwd, options.claudeSessionId, deps.disk)
-  } catch (error) {
-    return { status: "refused missing transcript", detail: error instanceof Error ? error.message : String(error) }
+  if (options.claudeSessionId) {
+    try {
+      transcript = resolveClaudeTranscript(cwd, options.claudeSessionId, deps.disk)
+    } catch (error) {
+      return { status: "refused missing transcript", detail: error instanceof Error ? error.message : String(error) }
+    }
+  } else {
+    transcript = resumableClaudeTranscript(cwd, deps.disk)
+    if (!transcript) {
+      return {
+        status: "refused missing transcript",
+        detail: `no Claude transcript in ${cwd} that a live process is not already holding; pass --claude-session-id to name one`,
+      }
+    }
   }
 
   // Dry-run stops before the preflight for the same reason `up --dry-run` does:
@@ -474,6 +499,9 @@ function adoptCommand(options: AdoptOptions, resolved: { name: string; cwd: stri
     "--name",
     resolved.name,
   ]
+  // The pin is part of the target, not a preference: without it a re-run of the
+  // recorded command adopts the newest transcript instead of the named one.
+  if (options.claudeSessionId) command.push("--claude-session-id", options.claudeSessionId)
   if (resolved.noYolo) command.push("--no-yolo")
   return command
 }

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -10,7 +10,12 @@ import {
   type ClaudeDiskDeps,
 } from "./claude-registry"
 import { normalizeName, now } from "./cli"
-import { findLocalClaudeChannelPane, listLocalTmuxPanes, parseClaudeChannelLaunch, type LocalTmuxPane } from "./discovery"
+import {
+  findLocalClaudeChannelPane,
+  listLocalTmuxPanes,
+  parseClaudeChannelLaunch,
+  type LocalTmuxPane,
+} from "./discovery"
 import { inventoryPath, readInventoryReadonly, upsertAgent } from "./inventory"
 import { acquireProcessLock } from "./lock"
 import {
@@ -186,7 +191,10 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     .filter((agent) => agent.runtimeSessionId === options.runtimeSessionId)
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0]
   if (existing && existing.runtime !== "claude") {
-    return { status: "refused identity mismatch", detail: `${existing.id} is recorded as a ${existing.runtime} session` }
+    return {
+      status: "refused identity mismatch",
+      detail: `${existing.id} is recorded as a ${existing.runtime} session`,
+    }
   }
 
   const link = deps.links().find((candidate) => candidate.runtimeSessionId === options.runtimeSessionId)
@@ -266,8 +274,8 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
       detail: `nothing binds ${options.runtimeSessionId} to ${cwd}: no harness link, no inventory row, no live launch, and the directory derives ${derived.runtimeSessionId}`,
     }
   }
-  const claimed = attestations.filter(
-    (attestation): attestation is { source: string; instanceId: string } => Boolean(attestation.instanceId)
+  const claimed = attestations.filter((attestation): attestation is { source: string; instanceId: string } =>
+    Boolean(attestation.instanceId)
   )
   const conflict = claimed.find((attestation) => attestation.instanceId !== claimed[0]!.instanceId)
   if (conflict) {
@@ -286,14 +294,15 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
       }
     }
     if (recorded.baseUrl !== baseUrl) {
-      return { status: "refused identity mismatch", detail: "recorded scratchpad origin differs from configured base URL" }
+      return {
+        status: "refused identity mismatch",
+        detail: "recorded scratchpad origin differs from configured base URL",
+      }
     }
   }
 
   const name = normalizeName(options.name ?? existing?.name ?? basename(cwd))
-  const clash = inventory.find(
-    (agent) => agent.name === name && agent.runtimeSessionId !== options.runtimeSessionId
-  )
+  const clash = inventory.find((agent) => agent.name === name && agent.runtimeSessionId !== options.runtimeSessionId)
   if (clash) {
     return {
       status: "refused ambiguous",
@@ -301,11 +310,13 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     }
   }
 
-  const liveSessions = findLiveClaudeSessions(cwd, deps.disk)
-  if (!pane && liveSessions.length > 0 && !options.force) {
-    return {
-      status: "refused live without pane",
-      detail: `Claude is still running in ${cwd} (pid ${liveSessions.map((session) => session.pid).join(", ")}) with no tmux pane; kill it or pass --force`,
+  if (!pane && !options.force) {
+    const liveSessions = findLiveClaudeSessions(cwd, deps.disk)
+    if (liveSessions.length > 0) {
+      return {
+        status: "refused live without pane",
+        detail: `Claude is still running in ${cwd} (pid ${liveSessions.map((session) => session.pid).join(", ")}) with no tmux pane; kill it or pass --force`,
+      }
     }
   }
 
@@ -404,7 +415,10 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     })
   } catch (error) {
     deps.persist({ ...record, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })
-    return { status: "failed", detail: `takeover launch failed: ${error instanceof Error ? error.message : String(error)}` }
+    return {
+      status: "failed",
+      detail: `takeover launch failed: ${error instanceof Error ? error.message : String(error)}`,
+    }
   }
 
   // Same archive-during-launch TOCTOU `up` guards: a window whose scratchpad
@@ -448,10 +462,7 @@ function paneSkipsPermissions(pane: LocalTmuxPane | undefined): boolean | undefi
   return parseClaudeChannelLaunch(pane.startCommand)?.skipPermissions
 }
 
-function adoptCommand(
-  options: AdoptOptions,
-  resolved: { name: string; cwd: string; noYolo: boolean }
-): string[] {
+function adoptCommand(options: AdoptOptions, resolved: { name: string; cwd: string; noYolo: boolean }): string[] {
   const command = [
     "threa-harnessd",
     "adopt",
@@ -483,10 +494,11 @@ function preflightParams(params: {
     runtimeKind: "claude-code-channel",
     instanceId: params.identity.instanceId,
     runtimeSessionId: params.identity.runtimeSessionId,
-    displayName: `${process.env.THREA_DISPLAY_NAME || params.config.displayName || "Claude Code"} - ${basename(params.cwd)}`.slice(
-      0,
-      100
-    ),
+    displayName:
+      `${process.env.THREA_DISPLAY_NAME || params.config.displayName || "Claude Code"} - ${basename(params.cwd)}`.slice(
+        0,
+        100
+      ),
     localCwd: params.cwd,
     expectedRootStreamId: params.rootStreamId,
     labelName: process.env.THREA_DEFAULT_LABEL || params.config.defaultLabel || "coding",

--- a/extensions/harness-daemon/src/claude-registry.ts
+++ b/extensions/harness-daemon/src/claude-registry.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync } from "node:fs"
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { output } from "./shell"
@@ -35,8 +35,140 @@ export function defaultClaudeRegistryDeps(run: typeof output = output): ClaudeRe
   }
 }
 
-function projectDirectory(cwd: string): string {
+export function projectDirectory(cwd: string): string {
   return cwd.replace(/[^a-zA-Z0-9]/g, "-")
+}
+
+/**
+ * The extra filesystem reach a cold takeover needs: the live registry answers
+ * "which session is this pid running", but a takeover starts from a pid that is
+ * gone, so it enumerates instead.
+ */
+export interface ClaudeDiskDeps extends ClaudeRegistryDeps {
+  list(path: string): string[]
+  modified(path: string): number
+}
+
+export function defaultClaudeDiskDeps(run: typeof output = output): ClaudeDiskDeps {
+  return {
+    ...defaultClaudeRegistryDeps(run),
+    list: (path) => {
+      try {
+        return readdirSync(path)
+      } catch {
+        return []
+      }
+    },
+    modified: (path) => statSync(path).mtimeMs,
+  }
+}
+
+/**
+ * Every Claude process still running in `cwd`, by registry entry corroborated
+ * against the live process table.
+ *
+ * A cold takeover resumes a transcript, and resuming one that a surviving
+ * process still holds gives two Claudes writing the same conversation. The pane
+ * is not enough to rule that out: a process detached from tmux (or whose window
+ * was killed while it kept running) leaves no pane but is very much alive.
+ */
+export function findLiveClaudeSessions(cwd: string, deps: ClaudeDiskDeps): ClaudeNativeSession[] {
+  let target: string
+  try {
+    target = deps.canonical(cwd)
+  } catch {
+    return []
+  }
+  const directory = join(deps.home, ".claude", "sessions")
+  const live: ClaudeNativeSession[] = []
+  for (const entry of deps.list(directory)) {
+    const pid = Number(entry.match(/^(\d+)\.json$/)?.[1])
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue
+    let value: unknown
+    try {
+      value = JSON.parse(deps.read(join(directory, entry)))
+    } catch {
+      continue
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue
+    const row = value as Record<string, unknown>
+    if (
+      row.pid !== pid ||
+      typeof row.sessionId !== "string" ||
+      !UUID_RE.test(row.sessionId) ||
+      typeof row.cwd !== "string" ||
+      typeof row.procStart !== "string" ||
+      typeof row.status !== "string"
+    )
+      continue
+    let registryCwd: string
+    try {
+      registryCwd = deps.canonical(row.cwd)
+    } catch {
+      continue
+    }
+    if (registryCwd !== target) continue
+    // pids are recycled; the start instant is what makes the entry this process.
+    if (deps.processStart(pid) !== row.procStart) continue
+    live.push({
+      pid,
+      sessionId: row.sessionId,
+      cwd: registryCwd,
+      procStart: row.procStart,
+      name: typeof row.name === "string" ? row.name : undefined,
+      status: row.status,
+    })
+  }
+  return live
+}
+
+export interface ClaudeTranscript {
+  sessionId: string
+  path: string
+  modifiedMs: number
+}
+
+/**
+ * The conversation a cold takeover resumes. With the process gone, the newest
+ * transcript under the cwd's project directory is the last session that ran
+ * there — `pinned` is the escape hatch when an unrelated `claude` run in the
+ * same directory is newer.
+ */
+export function resolveClaudeTranscript(
+  cwd: string,
+  pinned: string | undefined,
+  deps: ClaudeDiskDeps
+): ClaudeTranscript {
+  let canonicalCwd: string
+  try {
+    canonicalCwd = deps.canonical(cwd)
+  } catch {
+    throw new Error(`cwd is not canonicalizable: ${cwd}`)
+  }
+  const directory = join(deps.home, ".claude", "projects", projectDirectory(canonicalCwd))
+  if (pinned) {
+    if (!UUID_RE.test(pinned)) throw new Error(`not a Claude session UUID: ${pinned}`)
+    const path = join(directory, `${pinned}.jsonl`)
+    if (!deps.exists(path)) throw new Error(`Claude transcript is missing: ${path}`)
+    return { sessionId: pinned, path, modifiedMs: readModified(path, deps) }
+  }
+  const candidates: ClaudeTranscript[] = []
+  for (const entry of deps.list(directory)) {
+    const sessionId = entry.match(/^(.+)\.jsonl$/)?.[1]
+    if (!sessionId || !UUID_RE.test(sessionId)) continue
+    const path = join(directory, entry)
+    candidates.push({ sessionId, path, modifiedMs: readModified(path, deps) })
+  }
+  if (candidates.length === 0) throw new Error(`no Claude transcript under ${directory}`)
+  return candidates.sort((left, right) => right.modifiedMs - left.modifiedMs)[0]!
+}
+
+function readModified(path: string, deps: ClaudeDiskDeps): number {
+  try {
+    return deps.modified(path)
+  } catch {
+    return 0
+  }
 }
 
 export function resolveClaudeNativeSession(

--- a/extensions/harness-daemon/src/claude-registry.ts
+++ b/extensions/harness-daemon/src/claude-registry.ts
@@ -152,6 +152,13 @@ export function resolveClaudeTranscript(
     if (!deps.exists(path)) throw new Error(`Claude transcript is missing: ${path}`)
     return { sessionId: pinned, path, modifiedMs: readModified(path, deps) }
   }
+  const candidates = listClaudeTranscripts(directory, deps)
+  if (candidates.length === 0) throw new Error(`no Claude transcript under ${directory}`)
+  return candidates[0]!
+}
+
+/** Newest first. */
+function listClaudeTranscripts(directory: string, deps: ClaudeDiskDeps): ClaudeTranscript[] {
   const candidates: ClaudeTranscript[] = []
   for (const entry of deps.list(directory)) {
     const sessionId = entry.match(/^(.+)\.jsonl$/)?.[1]
@@ -159,8 +166,28 @@ export function resolveClaudeTranscript(
     const path = join(directory, entry)
     candidates.push({ sessionId, path, modifiedMs: readModified(path, deps) })
   }
-  if (candidates.length === 0) throw new Error(`no Claude transcript under ${directory}`)
-  return candidates.sort((left, right) => right.modifiedMs - left.modifiedMs)[0]!
+  return candidates.sort((left, right) => right.modifiedMs - left.modifiedMs)
+}
+
+/**
+ * The conversation a revival should continue: the newest transcript in the
+ * worktree that no live process is already holding.
+ *
+ * Skipping held transcripts is the whole point of the filter — resuming one a
+ * surviving Claude still owns puts two processes on one conversation, which is
+ * how the 2026-07-28 duplicate storm compounded. Undefined when the directory
+ * has no usable transcript, so the caller starts fresh rather than failing.
+ */
+export function resumableClaudeTranscript(cwd: string, deps: ClaudeDiskDeps): ClaudeTranscript | undefined {
+  let canonicalCwd: string
+  try {
+    canonicalCwd = deps.canonical(cwd)
+  } catch {
+    return undefined
+  }
+  const held = new Set(findLiveClaudeSessions(canonicalCwd, deps).map((session) => session.sessionId))
+  const directory = join(deps.home, ".claude", "projects", projectDirectory(canonicalCwd))
+  return listClaudeTranscripts(directory, deps).find((transcript) => !held.has(transcript.sessionId))
 }
 
 function readModified(path: string, deps: ClaudeDiskDeps): number {

--- a/extensions/harness-daemon/src/claude-registry.ts
+++ b/extensions/harness-daemon/src/claude-registry.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { processAlive } from "./lock"
 import { output } from "./shell"
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -47,6 +48,7 @@ export function projectDirectory(cwd: string): string {
 export interface ClaudeDiskDeps extends ClaudeRegistryDeps {
   list(path: string): string[]
   modified(path: string): number
+  alive(pid: number): boolean
 }
 
 export function defaultClaudeDiskDeps(run: typeof output = output): ClaudeDiskDeps {
@@ -60,6 +62,7 @@ export function defaultClaudeDiskDeps(run: typeof output = output): ClaudeDiskDe
       }
     },
     modified: (path) => statSync(path).mtimeMs,
+    alive: processAlive,
   }
 }
 
@@ -108,8 +111,17 @@ export function findLiveClaudeSessions(cwd: string, deps: ClaudeDiskDeps): Claud
       continue
     }
     if (registryCwd !== target) continue
-    // pids are recycled; the start instant is what makes the entry this process.
-    if (deps.processStart(pid) !== row.procStart) continue
+    // Liveness first, and it must be decided by something that cannot fail
+    // ambiguously: `ps` exits nonzero both for "no such pid" and for "ps itself
+    // failed", so reading undefined as "dead" would let one bad `ps` hide a
+    // live Claude — defeating the occupied guard and the held-transcript filter
+    // in the same instant. kill(pid, 0) answers only the question asked.
+    if (!deps.alive(pid)) continue
+    // pids are recycled; the start instant is what makes the entry this
+    // process. Indeterminate (undefined) keeps it: a live pid the registry
+    // claims is Claude is not something to launch a second Claude next to.
+    const started = deps.processStart(pid)
+    if (started !== undefined && started !== row.procStart) continue
     live.push({
       pid,
       sessionId: row.sessionId,

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path"
+import type { AdoptOptions } from "./adopt"
 import { die } from "./errors"
 import type { ReconnectOptions } from "./reconnect"
 import type { ResumeOptions, RuntimeKind, SpawnOptions } from "./types"
@@ -18,6 +19,9 @@ Usage:
   threa-harnessd install-watch [--tmux <session>]
   threa-harnessd install-boot-resume [--tmux <session>]
   threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]
+  threa-harnessd adopt <runtime-session-id> --root-stream-id <stream-id>
+      [--cwd <path>] [--name <name>] [--claude-session-id <uuid>] [--tmux <session>]
+      [--dry-run] [--force] [--no-yolo]
   threa-harnessd stop <agent-id-or-name>
   threa-harnessd kick <agent-id-or-name-or-runtime-session-id>
   threa-harnessd interrupt <agent-id-or-name>
@@ -37,6 +41,7 @@ Examples:
   threa-harnessd interrupt fix-sidebar
   threa-harnessd steer fix-sidebar "also update the tests"
   threa-harnessd keys fix-sidebar /compact Enter
+  threa-harnessd adopt ccs-3ea859c21682385b --root-stream-id stream_01KY... --dry-run
 `)
   process.exit(0)
 }
@@ -133,6 +138,38 @@ export function parseReconnect(args: string[]): ReconnectOptions {
   if (!rootStreamId) die("reconnect requires --root-stream-id <stream-id>")
   return { runtimeSessionId, rootStreamId, force }
 }
+
+export function parseAdopt(args: string[]): AdoptOptions {
+  const runtimeSessionId = args.shift()
+  if (!runtimeSessionId || runtimeSessionId.startsWith("--")) die("adopt requires a runtime session id")
+  const flags = parseFlags(args)
+  for (const key of Object.keys(flags)) {
+    if (!ADOPT_FLAGS.has(key)) die(`unexpected adopt argument: --${key}`)
+  }
+  const cwd = stringFlag(flags, "cwd")
+  return {
+    runtimeSessionId,
+    rootStreamId: stringFlag(flags, "root-stream-id") ?? die("adopt requires --root-stream-id <stream-id>"),
+    cwd: cwd ? resolve(cwd) : undefined,
+    name: stringFlag(flags, "name"),
+    claudeSessionId: stringFlag(flags, "claude-session-id"),
+    tmux: stringFlag(flags, "tmux"),
+    dryRun: boolFlag(flags, "dry-run"),
+    force: boolFlag(flags, "force"),
+    noYolo: boolFlag(flags, "no-yolo") || undefined,
+  }
+}
+
+const ADOPT_FLAGS = new Set([
+  "root-stream-id",
+  "cwd",
+  "name",
+  "claude-session-id",
+  "tmux",
+  "dry-run",
+  "force",
+  "no-yolo",
+])
 
 export function parseSpawn(args: string[]): SpawnOptions {
   const runtime = args.shift() as RuntimeKind | undefined

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -3,6 +3,7 @@ import { BotSupervisorTransport, type BotSessionRestoredPayload } from "@threa/b
 import { existsSync } from "node:fs"
 import { basename, dirname, join } from "node:path"
 import { installBootResume } from "./boot"
+import { defaultClaudeDiskDeps, findLiveClaudeSessions } from "./claude-registry"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
 import { findLocalClaudeChannelPane, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
 import { die } from "./errors"
@@ -272,6 +273,7 @@ export type ReviveStatus =
   | "skipped missing credentials"
   | "skipped missing session id"
   | "skipped missing cwd"
+  | "skipped occupied"
   | "skipped identity mismatch"
   | "skipped archived"
   | "skipped inaccessible"
@@ -286,6 +288,8 @@ export interface ReviveDeps {
   claudeConfig: ThreaChannelConfig
   piConfig: PiRemoteConfig
   windowExists: (agent: ManagedAgent) => boolean
+  /** Live Claude pids already in this worktree, corroborated against the process table. */
+  claudeProcessesIn: (worktree: string) => number[]
   pathExists: (path: string) => boolean
   scratchpadStatus: (params: {
     baseUrl: string
@@ -307,6 +311,8 @@ export function defaultReviveDeps(): ReviveDeps {
     claudeConfig: readThreaChannelConfig(),
     piConfig: readPiRemoteConfig(),
     windowExists: (agent) => agentPaneLives(agent),
+    claudeProcessesIn: (worktree) =>
+      findLiveClaudeSessions(worktree, defaultClaudeDiskDeps()).map((session) => session.pid),
     pathExists: existsSync,
     scratchpadStatus: fetchScratchpadStatus,
     preflight: preflightRuntimeSession,
@@ -433,6 +439,21 @@ export async function reviveAgent(
   if (worktreeMissing) {
     const source = deps.restorableWorktree(agent)
     if ("reason" in source) return { status: "skipped missing cwd", detail: source.reason }
+  }
+  // Second, tmux-independent liveness source, checked only here because it
+  // costs a `ps` per registry entry and only a would-be launch needs it.
+  // On 2026-07-28 the pane check alone let nine passes each start another
+  // Claude in one worktree, all claiming the same runtime session; the process
+  // table would have said "occupied" on the second pass regardless of whatever
+  // the pane lookup was doing.
+  if (agent.runtime === "claude" && agent.worktree) {
+    const occupants = deps.claudeProcessesIn(agent.worktree)
+    if (occupants.length > 0) {
+      return {
+        status: "skipped occupied",
+        detail: `Claude already running in ${agent.worktree} (pid ${occupants.join(", ")})`,
+      }
+    }
   }
   // Dry-run exits before preflight: registering the bot-runtime session mutates server state.
   if (options.dryRun) {

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -57,12 +57,33 @@ describe("parseClaudeChannelLaunch", () => {
       parseClaudeChannelLaunch(
         '"/Users/me/.local/bin/claude --name threa.feature --dangerously-load-development-channels server:threa-channel "'
       )
-    ).toEqual({ runtimeSessionId: undefined })
+    ).toEqual({
+      runtimeSessionId: undefined,
+      name: "threa.feature",
+      mcpConfig: undefined,
+      skipPermissions: false,
+    })
     expect(
       parseClaudeChannelLaunch(
         "env 'THREA_RUNTIME_SESSION_ID=ccs.explicit' /opt/bin/claude --dangerously-load-development-channels=server:threa-channel"
       )
-    ).toEqual({ runtimeSessionId: "ccs-explicit" })
+    ).toEqual({ runtimeSessionId: "ccs-explicit", name: undefined, mcpConfig: undefined, skipPermissions: false })
+  })
+
+  test("reports the bypass, name, and MCP wiring an adoption has to match", () => {
+    expect(
+      parseClaudeChannelLaunch(
+        "env THREA_RUNTIME_SESSION_ID=ccs-slop claude --name slopenv --mcp-config /tmp/threa.json --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions"
+      )
+    ).toEqual({
+      runtimeSessionId: "ccs-slop",
+      name: "slopenv",
+      mcpConfig: "/tmp/threa.json",
+      skipPermissions: true,
+    })
+    expect(
+      parseClaudeChannelLaunch("claude --name=slopenv --dangerously-load-development-channels=server:threa-channel")
+    ).toMatchObject({ name: "slopenv", skipPermissions: false })
   })
 
   test("retains parent-compatible tmux parsing for single-quoted literal expansions", () => {
@@ -70,7 +91,7 @@ describe("parseClaudeChannelLaunch", () => {
       parseClaudeChannelLaunch(
         "\"env 'THREA_DISPLAY_NAME=price $5 `literal`' THREA_RUNTIME_SESSION_ID=ccs.parent claude --dangerously-load-development-channels server:threa-channel\""
       )
-    ).toEqual({ runtimeSessionId: "ccs-parent" })
+    ).toEqual({ runtimeSessionId: "ccs-parent", name: undefined, mcpConfig: undefined, skipPermissions: false })
   })
 
   test("rejects commands that only contain Claude channel tokens", () => {

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -14,8 +14,12 @@ export interface LocalTmuxPane {
   startCommand: string
 }
 
-interface ClaudeChannelLaunch {
+export interface ClaudeChannelLaunch {
   runtimeSessionId?: string
+  instanceId?: string
+  name?: string
+  mcpConfig?: string
+  skipPermissions: boolean
 }
 
 export interface ClaudeLaunch {
@@ -294,12 +298,14 @@ export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch |
   if (basename(words[index]!) === "env") index += 1
 
   let runtimeSessionId: string | undefined
+  let instanceId: string | undefined
   while (index < words.length) {
     const assignment = parseAssignment(words[index]!)
     if (!assignment) break
     if (assignment.name === "THREA_RUNTIME_SESSION_ID") {
       runtimeSessionId = sanitizeId(assignment.value).slice(0, 64)
     }
+    if (assignment.name === "THREA_INSTANCE_ID") instanceId = sanitizeId(assignment.value).slice(0, 64)
     index += 1
   }
 
@@ -307,19 +313,26 @@ export function parseClaudeChannelLaunch(command: string): ClaudeChannelLaunch |
   index += 1
 
   let channel = false
+  let name: string | undefined
+  let mcpConfig: string | undefined
+  let skipPermissions = false
   for (; index < words.length; index += 1) {
     const word = words[index]!
     if (word === "--") break
-    if (word === "--dangerously-load-development-channels" && words[index + 1] === "server:threa-channel") {
-      channel = true
-      break
-    }
-    if (word === "--dangerously-load-development-channels=server:threa-channel") {
-      channel = true
-      break
-    }
+    const [option, inlineValue] = word.includes("=") ? splitOption(word) : [word, undefined]
+    const value = inlineValue ?? words[index + 1]
+    if (option === "--dangerously-load-development-channels" && value === "server:threa-channel") channel = true
+    else if (option === "--dangerously-skip-permissions") skipPermissions = true
+    else if (option === "--name" && value) name = value
+    else if (option === "--mcp-config" && value && !value.startsWith("-") && !/^[{[]/.test(value.trim()))
+      mcpConfig = value
   }
-  return channel ? { runtimeSessionId } : undefined
+  return channel ? { runtimeSessionId, instanceId, name, mcpConfig, skipPermissions } : undefined
+}
+
+function splitOption(word: string): [string, string] {
+  const separator = word.indexOf("=")
+  return [word.slice(0, separator), word.slice(separator + 1)]
 }
 
 export function parseTmuxPanes(text: string): LocalTmuxPane[] {

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
-import { parseReconnect, parseResume, parseSpawn, usage } from "./cli"
+import { adoptClaudeSession, adoptRefused } from "./adopt"
+import { parseAdopt, parseReconnect, parseResume, parseSpawn, usage } from "./cli"
 import {
   attachAgent,
   bootResume,
@@ -27,6 +28,12 @@ async function main(): Promise<void> {
   if (command === "spawn") return spawnAgent(parseSpawn(args))
   if (command === "list") return listAgents()
   if (command === "reconnect") return reconnectRuntime(parseReconnect(args))
+  if (command === "adopt" || command === "takeover") {
+    const outcome = await adoptClaudeSession(parseAdopt(args))
+    console.log(`${outcome.status}${outcome.detail ? `\t${outcome.detail}` : ""}`)
+    if (adoptRefused(outcome.status)) process.exit(1)
+    return
+  }
   if (
     command === "up" ||
     command === "revive-unarchived" ||

--- a/extensions/harness-daemon/src/lock.test.ts
+++ b/extensions/harness-daemon/src/lock.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { acquireProcessLock } from "./lock"
+
+function lockPath(): string {
+  return join(mkdtempSync(join(tmpdir(), "harnessd-lock-")), "resume-active.lock")
+}
+
+describe("acquireProcessLock", () => {
+  test("a second waiter does not delete the lock the first just took from a dead holder", async () => {
+    // The interleaving that matters: 333 reads holder 111 and confirms it dead,
+    // and 222 steals and takes the lock in that same window. An unconditional
+    // unlink then removes 222's FRESH lock, leaving both convinced they hold
+    // the mutex — which is how a manual `adopt` and an unattended `up` pass end
+    // up launching the same session at once. Only a file still naming the dead
+    // pid may be removed, so the staleness check has to re-read.
+    const path = lockPath()
+    writeFileSync(path, "111")
+
+    let stolen = false
+    const second = acquireProcessLock(path, {
+      pid: 333,
+      isAlive: (pid) => {
+        if (pid === 111 && !stolen) {
+          stolen = true
+          writeFileSync(path, "222")
+        }
+        return pid !== 111
+      },
+      timeoutMs: 0,
+      pollMs: 1,
+    })
+
+    await expect(second).rejects.toThrow("held by pid 222")
+    expect(readFileSync(path, "utf8")).toBe("222")
+  })
+
+  test("a genuinely dead holder is still stolen", async () => {
+    const path = lockPath()
+    writeFileSync(path, "111")
+
+    const release = await acquireProcessLock(path, { pid: 222, isAlive: () => false })
+    expect(readFileSync(path, "utf8")).toBe("222")
+    release()
+  })
+
+  test("release only removes a lock this pid still owns", async () => {
+    const path = lockPath()
+    const release = await acquireProcessLock(path, { pid: 222, isAlive: () => false })
+    writeFileSync(path, "999")
+    release()
+
+    expect(readFileSync(path, "utf8")).toBe("999")
+  })
+})

--- a/extensions/harness-daemon/src/lock.ts
+++ b/extensions/harness-daemon/src/lock.ts
@@ -51,8 +51,12 @@ export async function acquireProcessLock(path: string, options: LockOptions = {}
       continue
     }
     if (holder !== undefined && holder !== pid && !isAlive(holder)) {
+      // Re-read immediately before removing: two waiters can observe the same
+      // dead holder, and an unconditional unlink lets the second delete the
+      // FIRST one's freshly taken lock, leaving both convinced they hold it.
+      // Only the file still naming the dead pid may be removed.
       try {
-        unlinkSync(path)
+        if (Number(readFileSync(path, "utf8")) === holder) unlinkSync(path)
       } catch {}
       continue
     }

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -538,6 +538,7 @@ function reviveDeps(overrides: Partial<ReviveDeps> = {}): ReviveDeps {
     claudeConfig: { workspaceId: "ws_1", apiKey: "key" },
     piConfig: { workspaceId: "ws_1", apiKey: "key" },
     windowExists: () => false,
+    claudeProcessesIn: () => [],
     pathExists: () => true,
     scratchpadStatus: async () => "active",
     preflight: async () => ({ status: "linked", rootStreamId: "stream_01ABCDEF" }),
@@ -738,6 +739,41 @@ test("up skips an already-running agent before touching the network", async () =
     },
   })
   expect(await runRevive(linkedAgent(), {}, deps)).toEqual({ status: "already running" })
+  expect(calls).toEqual([])
+})
+
+test("up refuses to launch into a worktree a live Claude already occupies", async () => {
+  // The 2026-07-28 duplicate storm: the pane lookup reported nothing nine
+  // passes running and each one started another Claude on the same runtime
+  // session. The process table is the second, tmux-independent opinion.
+  const launches: string[] = []
+  const deps = reviveDeps({
+    windowExists: () => false,
+    claudeProcessesIn: () => [18241, 22445],
+    resumeRuntime: async (agent) => {
+      launches.push(agent.name)
+      throw new Error("resumeRuntime must not be called")
+    },
+  })
+
+  expect(await runRevive(linkedAgent(), {}, deps)).toEqual({
+    status: "skipped occupied",
+    detail: "Claude already running in /tmp/worktrees/repair (pid 18241, 22445)",
+  })
+  expect(launches).toEqual([])
+})
+
+test("up refuses an occupied worktree before the preflight registers anything", async () => {
+  const calls: string[] = []
+  const deps = reviveDeps({
+    claudeProcessesIn: () => [18241],
+    preflight: async () => {
+      calls.push("preflight")
+      return { status: "linked", rootStreamId: "stream_01ABCDEF" }
+    },
+  })
+
+  expect((await runRevive(linkedAgent(), {}, deps))?.status).toBe("skipped occupied")
   expect(calls).toEqual([])
 })
 

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -50,13 +50,50 @@ export function claudeLaunchArgs(params: {
   channel: string
   mcpConfig?: string
   noYolo?: boolean
+  /** Set only by a takeover: continue this native conversation instead of starting one. */
+  resumeSessionId?: string
 }): string[] {
-  const args = [params.claudeBin, "--name", `threa.${params.name}`]
+  const args = [params.claudeBin]
+  if (params.resumeSessionId) args.push("--resume", params.resumeSessionId)
+  args.push("--name", `threa.${params.name}`)
   if (params.mcpConfig) {
     args.push("--mcp-config", params.mcpConfig, "--dangerously-load-development-channels", `server:${params.channel}`)
   }
   if (!params.noYolo) args.push("--dangerously-skip-permissions")
   return args
+}
+
+/**
+ * Session-scoped MCP wiring via `--mcp-config` instead of `claude mcp add
+ * --scope local`: Claude Code resolves every worktree of a repo to the same
+ * project entry, so a persisted local-scope registration from worktree A
+ * silently repoints worktree B's channel at A's code the next time B starts
+ * (and stacks a duplicate channel on top of a user-scope registration). A
+ * config file passed at launch binds this session to the supervisor's current
+ * channel implementation and leaves global config untouched. This also keeps
+ * revived feature branches from loading an obsolete connector.
+ */
+export function writeChannelMcpConfig(name: string, channel: string, channelEntry: string): string {
+  const path = mcpConfigPath(name)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        mcpServers: {
+          [channel]: {
+            type: "stdio",
+            command: "bun",
+            args: [channelEntry],
+            env: { THREA_CHANNEL_SERVER_KEY: channel },
+          },
+        },
+      },
+      null,
+      2
+    )
+  )
+  return path
 }
 
 export function normalizeChannelMcpConfig(path: string, channel: string, channelEntry: string): void {
@@ -230,7 +267,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
   }
 }
 
-function prepareClaudeChannel(): string {
+export function prepareClaudeChannel(): string {
   const channelDir = join(import.meta.dir, "..", "..", "claude-code-remote")
   const channelEntry = join(channelDir, "src", "index.ts")
   if (!existsSync(channelEntry)) die(`Claude channel entry not found: ${channelEntry}`)
@@ -369,37 +406,8 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     }
   }
 
-  /**
-   * Session-scoped MCP wiring via `--mcp-config` instead of `claude mcp add
-   * --scope local`: Claude Code resolves every worktree of a repo to the same
-   * project entry, so a persisted local-scope registration from worktree A
-   * silently repoints worktree B's channel at A's code the next time B starts
-   * (and stacks a duplicate channel on top of a user-scope registration). A
-   * config file passed at launch binds this session to the supervisor's current
-   * channel implementation and leaves global config untouched. This also keeps
-   * revived feature branches from loading an obsolete connector.
-   */
   private writeMcpConfig(name: string, channel: string, channelEntry: string): string {
-    const path = mcpConfigPath(name)
-    mkdirSync(dirname(path), { recursive: true })
-    writeFileSync(
-      path,
-      JSON.stringify(
-        {
-          mcpServers: {
-            [channel]: {
-              type: "stdio",
-              command: "bun",
-              args: [channelEntry],
-              env: { THREA_CHANNEL_SERVER_KEY: channel },
-            },
-          },
-        },
-        null,
-        2
-      )
-    )
-    return path
+    return writeChannelMcpConfig(name, channel, channelEntry)
   }
 
   private async prelinkScratchpad(

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
 import { basename, dirname, join } from "node:path"
 import { acceptClaudeBootPrompts } from "./claude-boot"
+import { defaultClaudeDiskDeps, resumableClaudeTranscript } from "./claude-registry"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
 import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
@@ -366,13 +367,30 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "claude", name: agent.name })
     ensureTmuxSession(session, true)
     const noYolo = recordedNoYolo(agent)
+    // "Bring it back up as it was" has to include the conversation. Without
+    // --resume a revival silently starts an empty session in the old worktree,
+    // still attached to the same scratchpad, and the history is only reachable
+    // by hand. A transcript a live process still holds is skipped, never shared.
+    const transcript = resumableClaudeTranscript(agent.worktree, defaultClaudeDiskDeps())
+    console.log(
+      transcript
+        ? `harnessd: resuming Claude conversation ${transcript.sessionId} for ${agent.name}`
+        : `harnessd: no resumable Claude transcript in ${agent.worktree}; starting a fresh conversation`
+    )
     const window = pickTmuxWindow(session, agent.name)
     const { windowId, paneId } = createWindow(
       session,
       window,
       agent.worktree,
       claudeLaunchCommand(
-        claudeLaunchArgs({ claudeBin, name: agent.name, channel, mcpConfig, noYolo }),
+        claudeLaunchArgs({
+          claudeBin,
+          name: agent.name,
+          channel,
+          mcpConfig,
+          noYolo,
+          resumeSessionId: transcript?.sessionId,
+        }),
         identity,
         config,
         "wait",
@@ -383,10 +401,16 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     console.log(`harnessd: resumed Claude Code in tmux ${session}:${window} (${windowId})`)
     try {
       await acceptClaudeBootPrompts(paneId)
-      sendKeys(paneId, ["/remote-control", "Enter"])
-      await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_REMOTE_WAIT_MS ?? 2000))
-      sendKeys(paneId, ["/rc", "Enter"])
-      await Bun.sleep(500)
+      // Claude's own /remote-control (claude.ai/code, the mobile app) is not
+      // how a session reaches Threa — the channel MCP server is, and it is
+      // already wired above. Sending it opened a MODAL dialog every revival
+      // then parked in ("waitingFor":"dialog open" in Claude's registry), and
+      // the /rc that followed was typed into that dialog as garbage. `spawn`
+      // never sent either. Opt-in for anyone who does want the mobile app.
+      if (process.env.THREA_HARNESSD_CLAUDE_REMOTE_CONTROL === "1") {
+        sendKeys(paneId, ["/remote-control", "Enter"])
+        await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_REMOTE_WAIT_MS ?? 2000))
+      }
       const output = capturePane(paneId)
       return {
         worktree: agent.worktree,


### PR DESCRIPTION
## Problem

A Claude channel session started by hand — not by `harnessd spawn` — is invisible to harnessd even when everything about it is valid. The slopenv session is the live example: correct deterministic identity (`ccs-3ea859c21682385b` = `sha256("<host>:/Users/…/slopenv")`), an active scratchpad, a harness link record, a 400 KB transcript, and zero inventory rows.

Neither recovery path reaches it. `reconnect` needs a live pane *and* rejects the launch outright — `parseClaudeLaunch` requires `--name threa.<x>` and slopenv's is a bare `--name slopenv`. `up` needs an inventory row. The moment such a process exits, nothing can bring it back, and its conversation is stranded on disk.

## Solution

`threa-harnessd adopt <runtime-session-id> --root-stream-id <stream-id> [--cwd] [--name] [--claude-session-id] [--tmux] [--dry-run] [--force] [--no-yolo]` — one explicit target per run. No sweep: a local Claude directory has never been evidence a session should run (`up`'s 2026-07-20 incident).

- **Live pane** → recorded in inventory, left running. No relaunch, no keystrokes.
- **Cold takeover** → the newest transcript under the cwd's `~/.claude/projects` dir is resumed in a new tmux window with `claudeLaunchArgs({ resumeSessionId })`, harnessd's `--mcp-config` wiring, `THREA_COLD_START_IF_ARCHIVED=wait` / `IF_MISSING=error` pinned to the given root, and `acceptClaudeBootPrompts` clearing the dialogs. `--claude-session-id` pins the conversation when an unrelated `claude` run in that directory is newer.
- Identity must be **attested**, not merely derivable — a real case forced this. `add-leftie-mode`'s link record binds `ccs-ac050fb309510f5c` while its cwd now derives `ccs-d293e4d185ae31f5` (hostname drift; a session keeps its birth id for life). Attestation = harness link, inventory row, live launch env, or cwd derivation; every source naming an instance id must agree; what is refused is a target *nothing* on this machine binds to that directory. Strict re-derivation over attestation was the first cut and would have refused a legitimate target.
- **`refused live without pane`** — `findLiveClaudeSessions` corroborates `~/.claude/sessions/<pid>.json` against `ps -o lstart` before any takeover. A process detached from tmux leaves no pane but is alive; resuming its transcript would put two Claudes on one conversation. `--force` overrides.
- Ordering mirrors `reviveAgent`: read-only scratchpad GET → preflight POST → launch → recheck (archived mid-launch kills the window and records `error`) → inventory write (failure kills the window rather than leave it untracked). `--dry-run` stops before the preflight, because that POST registers the session server-side. Serialized on `resume-active.lock`.
- Multiple rows per session are the normal immutable-per-launch shape, so the newest wins and its id is reused (`findAgentOrUndefined` semantics) — refusing on >1 row was wrong and did refuse a real target during verification.
- Bypass follows the adopted session: the live pane's own launch first, then what the row recorded, `--no-yolo` overrides.


## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/adopt.ts` | **new** — adoption/takeover decision, refusal statuses, real takeover launch |
| `extensions/harness-daemon/src/adopt.test.ts` | **new** — 33 tests |
| `extensions/harness-daemon/src/claude-registry.ts` | `ClaudeDiskDeps`, `findLiveClaudeSessions`, `resolveClaudeTranscript`; `projectDirectory` exported |
| `extensions/harness-daemon/src/discovery.ts` | `parseClaudeChannelLaunch` also reports instance id, name, mcp config, bypass; handles `--opt=value` |
| `extensions/harness-daemon/src/spawners.ts` | `claudeLaunchArgs` takes `resumeSessionId`; `prepareClaudeChannel` + `writeChannelMcpConfig` exported for reuse |
| `extensions/harness-daemon/src/cli.ts` | `parseAdopt`, usage |
| `extensions/harness-daemon/src/index.ts` | `adopt` / `takeover` command; refusals exit 1 |
| `extensions/harness-daemon/README.md` | adoption section + status table |

## Also in this PR: three `up` defects (2026-07-28 incident)

Adoption put slopenv within reach of `up`, which then started two duplicate Claude processes on its runtime session. The row is gone and the duplicates are killed, but the underlying defects predate adoption — the same log shows `up` starting nine duplicates of an ordinary spawned row.

- **`/remote-control` + `/rc` typed into every revival.** That is Claude's own mobile-app feature, not how a session reaches Threa (the channel MCP server is, wired one line earlier). It opens a **modal**, and every revived session sat in it — Claude's registry literally reads `"waitingFor":"dialog open"`. `/rc` then landed in that dialog as garbage (the `Usage: /key <name>` noise). `spawn` never sent either; only `resume` did. Now opt-in via `THREA_HARNESSD_CLAUDE_REMOTE_CONTROL=1`, off by default.
- **Revival lost the conversation.** `claudeLaunchArgs` got no `--resume`, so `up` started an empty session on the old scratchpad. It now resumes the worktree's newest transcript via `resumableClaudeTranscript`, skipping any a live process still holds. This is the boundary the first half of this PR declared out of scope — it is in scope now because `up` is what the watcher runs.
- **Liveness was tmux-pane-only.** `reviveAgent` now also consults the Claude process table (`~/.claude/sessions/<pid>.json` corroborated against `ps -o lstart`) before launching; either source saying "alive" gives `skipped occupied`. Checked only at the would-be launch, since it costs a `ps` per registry entry, and before the preflight so a refusal registers nothing.

Not established: **why** the pane check reported nothing for nine passes running. Those panes were cleaned up before I looked, and the guard behaves correctly against current state (three panes in one worktree → `ambiguous` → treated as alive). The process-table check is deliberately a second opinion rather than a fix for a mechanism I could not reproduce.

Added tests: `up` refuses an occupied worktree and does so before the preflight; `resumableClaudeTranscript` prefers the newest unheld transcript, falls through when its owner is alive, and returns undefined rather than throwing. Both `skipped occupied` tests verified non-vacuous by neutralising the guard.

## Test plan

- [x] `bun test` in `extensions/harness-daemon` — 159 pass, 0 fail (33 new)
- [x] `bun run typecheck` — clean
- [x] Guard verified non-vacuous: neutralising the paneless-live check turns `refuses to take over while a paneless Claude still runs in the cwd` red
- [x] Live dry-run against real slopenv → `would adopt live 1:claude-slopenv (%211, pid 34341)`; wrong root → `refused identity mismatch`; wound-down stream → `refused inaccessible`
- [x] **slopenv adopted for real** → `adopted live`, one inventory row; re-run → `already managed`, still one row; `up --dry-run` → `already running` (no double-start)
- [x] Cold takeover end-to-end with real tmux + real MCP wiring and a stub `claude` binary: window created, config written, launch command verified as `--resume <uuid> --name threa.<n> --mcp-config … COLD_START_IF_ARCHIVED=wait IF_MISSING=error EXPECTED_ROOT_STREAM_ID=…`, row persisted `online`; scratch session and config cleaned up
- [ ] Cold takeover against a live Threa scratchpad — every paneless link on this machine points at a wound-down stream, and manufacturing one means creating a throwaway scratchpad in the real workspace. Server interaction is covered by injected-preflight tests only.
- [x] `bun test` after the `up` fixes — 163 pass, 0 fail
- [ ] `bun run lint` — not applicable: repo lint covers `apps/` only; `extensions/harness-daemon` has no lint target (scripts are start/test/typecheck)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787825172&installation_model_id=20758&pr_number=1628&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1628&signature=aa75974924a7acc63ed2f67f5de1b0f775a6ce2e2bb6d24d99c54385ac3353df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
