### PR TITLE
fix(channel): render the /status pane as a fenced code block

### DIFF
--- a/extensions/claude-code-remote/src/status.test.ts
+++ b/extensions/claude-code-remote/src/status.test.ts
@@ -45,8 +45,9 @@ describe("formatClaudeStatusReport", () => {
     expect(report).toContain("Work: **Working — 1 active invocation**")
     expect(report).toContain("Tmux: `1:feature` · pane `%8` · 180×48")
     expect(report).toContain("Branch: `feat/status`")
-    expect(report).toContain("Waiting for 1 workflow to finish.")
-    expect(report).toContain("    ``` nested fence")
+    // Fenced, not indented: Threa's markdown parser has no indented-code-block rule.
+    // An inner fence is indented so it can't close the block early.
+    expect(report).toEndWith("```\nWaiting for 1 workflow to finish.\n ``` nested fence\n```")
   })
 
   it("surfaces degraded connectivity and blockers", () => {

--- a/extensions/claude-code-remote/src/status.ts
+++ b/extensions/claude-code-remote/src/status.ts
@@ -18,10 +18,13 @@ function inlineCode(value: string): string {
 }
 
 function codeBlock(value: string): string {
-  return (value || "(pane is blank)")
+  // Threa's markdown parser closes a fence on any line starting with ``` regardless
+  // of fence length, so an inner fence is indented out of the way, not lengthened.
+  const body = (value || "(pane is blank)")
     .split("\n")
-    .map((line) => `    ${line}`)
+    .map((line) => (line.startsWith("```") ? ` ${line}` : line))
     .join("\n")
+  return `\`\`\`\n${body}\n\`\`\``
 }
 
 function connectivityLabel(context: ClaudeChannelStatusContext): string {


### PR DESCRIPTION
## Problem

`/status` in a Claude Code channel dumps the tmux pane as a 4-space-indented block (`extensions/claude-code-remote/src/status.ts` `codeBlock`). Threa's markdown parser (`packages/prosemirror/src/markdown.ts:588`) only has a fenced-code rule — no indented-code-block rule — so the pane arrived as an ordinary paragraph: soft-wrapped, inline markdown in the pane text interpreted, and `:record_button:` shortcodes expanded into emoji nodes. Example: `msg_01KYKTB0D3SKXZ8F7QG8SBSV63`.

## Solution

Emit a real ``` fence. Lines inside the dump that start with ``` get one leading space — Threa's parser closes a fence on any line starting with ```, regardless of fence length, so lengthening the outer fence would not have worked; indenting the inner one does.

Verified end-to-end by feeding `formatClaudeStatusReport` output through the real `parseMarkdown`: one `codeBlock` node, pane text preserved byte-for-byte apart from that leading space, shortcodes no longer expanded.

Deploy note: the harness loads this extension from its own checkout — merging doesn't change a running session until it restarts.

## Test plan

- [x] `bun test` in `extensions/claude-code-remote` — 70 pass, 2 pre-existing fails (`channel-server.test.ts` can't resolve `@threa/bot-runtime-client`; identical on the base commit)
- [x] Guard verified failable — reverting the fence turns the pane assertion red
- [x] `parseMarkdown` round-trip run manually (above); not committed as a test, the extension is outside the bun workspace and has no `@threa/prosemirror` dep

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787850497&installation_model_id=20758&pr_number=1629&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1629&signature=098cd055002a8bc8f3a00f2a9164dab9df9c087e9ed471a76c97879d1bd3b376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->