### PR TITLE
fix(streams): render a scratchpad's name instead of "New scratchpad"

### DIFF
--- a/apps/backend/src/features/streams/display-name.test.ts
+++ b/apps/backend/src/features/streams/display-name.test.ts
@@ -86,9 +86,11 @@ describe("scratchpad display names", () => {
 
   test("only a genuinely nameless scratchpad gets the placeholder", () => {
     expect(getEffectiveDisplayName(scratchpad())).toEqual({ displayName: "New scratchpad", source: "placeholder" })
-    expect(getEffectiveDisplayName(scratchpad({ displayName: "" }))).toEqual({
-      displayName: "New scratchpad",
-      source: "placeholder",
-    })
+    for (const blank of ["", "   "]) {
+      expect(getEffectiveDisplayName(scratchpad({ displayName: blank }))).toEqual({
+        displayName: "New scratchpad",
+        source: "placeholder",
+      })
+    }
   })
 })

--- a/apps/backend/src/features/streams/display-name.test.ts
+++ b/apps/backend/src/features/streams/display-name.test.ts
@@ -44,4 +44,51 @@ describe("thread placeholder display names", () => {
     )
     expect(result).toEqual({ displayName: "API redesign", source: "generated" })
   })
+
+  test("a name set at creation wins too, without an auto-namer timestamp", () => {
+    const result = getEffectiveDisplayName(thread({ displayName: "Handover" }), {
+      parentStream: { slug: "general", displayName: null },
+    })
+    expect(result).toEqual({ displayName: "Handover", source: "explicit" })
+  })
+})
+
+function scratchpad(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_scratchpad",
+    workspaceId: "ws_1",
+    type: "scratchpad",
+    displayName: null,
+    displayNameGeneratedAt: null,
+    slug: null,
+    ...overrides,
+  } as Stream
+}
+
+describe("scratchpad display names", () => {
+  // The exact row `StreamRepository.insert` writes for a bot-created
+  // scratchpad: display_name set, display_name_generated_at NULL (insert has no
+  // such column). Requiring the timestamp to render made every harnessd
+  // scratchpad read "New scratchpad" forever while its real name sat in the
+  // database — and `needsAutoNaming` (displayName === null) skipped them, so
+  // nothing ever set the timestamp either.
+  test("a name set at creation renders instead of the placeholder", () => {
+    const result = getEffectiveDisplayName(scratchpad({ displayName: "CC - threa.conversations-match-timeline" }))
+    expect(result).toEqual({ displayName: "CC - threa.conversations-match-timeline", source: "explicit" })
+  })
+
+  test("an auto-generated name still reports itself as generated", () => {
+    const result = getEffectiveDisplayName(
+      scratchpad({ displayName: "Board rollup", displayNameGeneratedAt: new Date() })
+    )
+    expect(result).toEqual({ displayName: "Board rollup", source: "generated" })
+  })
+
+  test("only a genuinely nameless scratchpad gets the placeholder", () => {
+    expect(getEffectiveDisplayName(scratchpad())).toEqual({ displayName: "New scratchpad", source: "placeholder" })
+    expect(getEffectiveDisplayName(scratchpad({ displayName: "" }))).toEqual({
+      displayName: "New scratchpad",
+      source: "placeholder",
+    })
+  })
 })

--- a/apps/backend/src/features/streams/display-name.ts
+++ b/apps/backend/src/features/streams/display-name.ts
@@ -14,8 +14,12 @@ export type DisplayNameSource = "slug" | "generated" | "explicit" | "participant
  * ungenerated enough to be invisible.
  */
 function storedDisplayName(stream: Stream): EffectiveDisplayName | undefined {
-  if (!stream.displayName) return undefined
-  return { displayName: stream.displayName, source: stream.displayNameGeneratedAt ? "generated" : "explicit" }
+  // Whitespace is not a name: rendering it gives a blank row, and
+  // `needsAutoNaming` would still count the stream as named, so nothing would
+  // ever replace it.
+  const name = stream.displayName?.trim()
+  if (!name) return undefined
+  return { displayName: name, source: stream.displayNameGeneratedAt ? "generated" : "explicit" }
 }
 
 export interface DisplayNameContext {

--- a/apps/backend/src/features/streams/display-name.ts
+++ b/apps/backend/src/features/streams/display-name.ts
@@ -1,6 +1,22 @@
 import type { Stream, StreamType } from "./repository"
 
-export type DisplayNameSource = "slug" | "generated" | "participants" | "placeholder"
+export type DisplayNameSource = "slug" | "generated" | "explicit" | "participants" | "placeholder"
+
+/**
+ * A stored name is authoritative however it got there.
+ *
+ * `display_name_generated_at` records that the auto-namer wrote the name; it is
+ * never set by `StreamRepository.insert`, so requiring it to render meant every
+ * scratchpad created WITH a name — which is what every bot runtime does — was
+ * displayed as "New scratchpad" forever. `needsAutoNaming` keys off
+ * `displayName === null`, so those streams were also skipped by the very
+ * namer that would have set the timestamp: named enough to be ineligible,
+ * ungenerated enough to be invisible.
+ */
+function storedDisplayName(stream: Stream): EffectiveDisplayName | undefined {
+  if (!stream.displayName) return undefined
+  return { displayName: stream.displayName, source: stream.displayNameGeneratedAt ? "generated" : "explicit" }
+}
 
 export interface DisplayNameContext {
   parentStream?: { slug: string | null; displayName: string | null } | null
@@ -34,13 +50,9 @@ export function getEffectiveDisplayName(stream: Stream, context?: DisplayNameCon
         source: "placeholder",
       }
 
-    case "thread":
-      if (stream.displayName && stream.displayNameGeneratedAt) {
-        return {
-          displayName: stream.displayName,
-          source: "generated",
-        }
-      }
+    case "thread": {
+      const stored = storedDisplayName(stream)
+      if (stored) return stored
       if (context?.parentStream) {
         // The # sigil is a channel affordance — a slugless parent (scratchpad,
         // DM) must not render as a phantom "#channel".
@@ -56,18 +68,10 @@ export function getEffectiveDisplayName(stream: Stream, context?: DisplayNameCon
         displayName: "New thread",
         source: "placeholder",
       }
+    }
 
     case "scratchpad":
-      if (stream.displayName && stream.displayNameGeneratedAt) {
-        return {
-          displayName: stream.displayName,
-          source: "generated",
-        }
-      }
-      return {
-        displayName: "New scratchpad",
-        source: "placeholder",
-      }
+      return storedDisplayName(stream) ?? { displayName: "New scratchpad", source: "placeholder" }
 
     default:
       return {

--- a/apps/backend/tests/integration/stream-naming.test.ts
+++ b/apps/backend/tests/integration/stream-naming.test.ts
@@ -143,17 +143,31 @@ describe("Stream Naming", () => {
         expect(result.source).toBe("placeholder")
       })
 
-      test("uses placeholder if displayName set but not generated", () => {
-        // displayName without displayNameGeneratedAt means manual name wasn't set properly
+      test("renders a name set at creation, with no auto-namer timestamp", () => {
+        // This assertion used to be the opposite, on the theory that a name
+        // without `displayNameGeneratedAt` meant it "wasn't set properly".
+        // `StreamRepository.insert` has no such column, so that description fit
+        // every scratchpad a bot ever created: the name was stored and never
+        // rendered, and `needsAutoNaming` (displayName === null) skipped those
+        // streams, so nothing ever set the timestamp either.
         const stream = createMockStream({
           type: "scratchpad",
           displayName: "Manual Name",
           displayNameGeneratedAt: null,
         })
         const result = getEffectiveDisplayName(stream)
-        // This case falls through to placeholder since displayNameGeneratedAt is null
-        expect(result.displayName).toBe("New scratchpad")
-        expect(result.source).toBe("placeholder")
+        expect(result.displayName).toBe("Manual Name")
+        expect(result.source).toBe("explicit")
+      })
+
+      test("only a genuinely nameless scratchpad gets the placeholder", () => {
+        for (const displayName of [null, "", "   "]) {
+          const stream = createMockStream({ type: "scratchpad", displayName, displayNameGeneratedAt: null })
+          expect(getEffectiveDisplayName(stream)).toEqual({
+            displayName: "New scratchpad",
+            source: "placeholder",
+          })
+        }
       })
     })
 


### PR DESCRIPTION
## Problem

Every scratchpad harnessd creates renders as **"New scratchpad"** — the six worktrees spawned tonight, and every one before them. The real name is in the database; it just can't be displayed.

Three things combine:

1. `StreamRepository.insert` never writes `display_name_generated_at` — the column isn't in the INSERT list. Only `update` can set it.
2. `getEffectiveDisplayName` returned a scratchpad's (or thread's) stored name **only if `displayNameGeneratedAt` was also set**, otherwise substituting the placeholder.
3. `needsAutoNaming` is `displayName === null`, so a stream created *with* a name is skipped by the auto-namer — the one thing that would have set the timestamp.

Named enough to be ineligible for auto-naming, ungenerated enough to be invisible. Nothing could get a stream out of that state. `stream_01KYMP3ZS6J6GFRB6S3S0JNTNP` stores `CC - threa.conversations-match-timeline` and renders "New scratchpad".

## Solution

A stored display name is authoritative however it got there. The timestamp now only decides provenance reporting: `source: "generated"` when the auto-namer wrote it, the new `"explicit"` otherwise.

- Fixed in the resolver rather than by backfilling `display_name_generated_at` — that repairs every existing stream at once, and writing the timestamp on an explicit create would claim the auto-namer produced a name it never saw.
- Widening `DisplayNameSource` is safe: no consumer switches on it. The only caller (`apps/backend/src/features/public-api/handlers.ts:167`) reads `.displayName`.
- Applies to threads too — same shape, same bug.
- Auto-naming behaviour is deliberately unchanged: an explicitly named stream still opts out of it.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/display-name.ts` | `storedDisplayName` helper; scratchpad + thread use it; `"explicit"` added to `DisplayNameSource` |
| `apps/backend/src/features/streams/display-name.test.ts` | 4 tests for the regression and the placeholder boundary |

## Test plan

- [x] `bun test apps/backend/src/features/streams/` — 246 pass, 0 fail
- [x] Backend typecheck + full repo lint/typecheck (pre-commit hook) — clean
- [x] Both new tests verified non-vacuous: restoring the `&& displayNameGeneratedAt` condition turns them red
- [ ] Not verified against prod rows — no DB access from this session. The stored name was read through the public API, which returns the *resolved* name, so the mechanism is established from the code path rather than from a `display_name` column read.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
