### PR TITLE
feat(channel): fold queued messages into one turn instead of running them one by one

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -843,6 +843,20 @@ export const BotInvocationRepository = {
       supportedCapabilities: BotInvocationCapability[]
       claimTtlSeconds: number
       maxAttempts: number
+      /**
+       * Restrict the claim to invocations answering into this stream.
+       *
+       * A connector that folds several queued messages into one turn can only
+       * do so for messages sharing a response stream — the turn is delivered
+       * with one stream id, so folding across streams answers one question in
+       * another's stream and closes the rest unanswered. Sealing needs no
+       * separate predicate: sealing is a property of the stream, so one
+       * response stream is uniformly sealed or uniformly plaintext.
+       *
+       * Without this the connector would have to claim first and inspect
+       * after, and there is no way to release a claim it should not have taken.
+       */
+      responseStreamId?: string
     }
   ): Promise<BotInvocation | null> {
     // A composite message + steer shares one transaction timestamp; put the
@@ -863,6 +877,7 @@ export const BotInvocationRepository = {
           AND (i.target_instance_id IS NULL OR i.target_instance_id = ${params.instanceId})
           AND (i.target_runtime_session_id IS NULL OR i.target_runtime_session_id = ${params.runtimeSessionId ?? null})
           AND (i.status = 'pending' OR (i.status = 'claimed' AND i.claim_expires_at < NOW()))
+          AND (${params.responseStreamId ?? null}::text IS NULL OR i.response_stream_id = ${params.responseStreamId ?? null})
           AND i.attempts < ${params.maxAttempts}
           AND ${sealedStreamClaimGateSql(params.instanceId)}
         ORDER BY i.created_at ASC, CASE WHEN i.trigger = 'session-control' THEN 1 ELSE 0 END ASC, i.id ASC

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -742,6 +742,8 @@ export class BotRuntimeService {
     claimToken: string
     supportedCapabilities: BotInvocationCapability[]
     claimTtlSeconds: number
+    /** Only claim invocations answering into this stream (see `claimOne`). */
+    responseStreamId?: string
   }): Promise<BotInvocation | null> {
     return withTransaction(this.pool, async (db) => {
       // Reap invocations this bot has re-claimed to exhaustion before handing

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1291,6 +1291,7 @@ export function createPublicApiHandlers({
         runtimeSessionId: data.runtimeSessionId,
         supportedCapabilities: data.supportedCapabilities,
         claimTtlSeconds: data.claimTtlSeconds,
+        responseStreamId: data.responseStreamId,
         claimToken: randomUUID(),
       })
       // An empty claim poll read nothing — runtimes poll every few seconds

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -222,6 +222,11 @@ export const claimInvocationSchema = z.object({
   runtimeSessionId: z.string().min(1).max(256).optional(),
   supportedCapabilities: z.array(z.enum(BOT_INVOCATION_CAPABILITIES)).min(1),
   claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
+  // Restrict the claim to invocations answering into this stream. A connector
+  // folding several queued messages into one turn can only fold messages that
+  // share a response stream; without the filter it would have to claim first
+  // and inspect after, and a claim it should not have taken cannot be released.
+  responseStreamId: z.string().min(1).max(64).optional(),
 })
 
 export const renewInvocationClaimSchema = z.object({

--- a/apps/backend/tests/integration/bot-invocation-claim-scope.test.ts
+++ b/apps/backend/tests/integration/bot-invocation-claim-scope.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase } from "./setup"
+import { BotInvocationRepository } from "../../src/features/bot-runtimes"
+import { streamId, workspaceId, userId } from "../../src/lib/id"
+
+/**
+ * `claimOne`'s response-stream filter, against the real schema.
+ *
+ * A connector that folds several queued messages into one turn can only fold
+ * messages sharing a response stream — the turn is delivered with one stream
+ * id, so folding across streams answers one stream's question in another and
+ * closes the rest unanswered. There is no way to release a claim, so the filter
+ * has to keep the wrong invocation from being claimed at all rather than let
+ * the client claim and inspect.
+ */
+describe("BotInvocationRepository.claimOne response-stream scope", () => {
+  let pool: Pool
+  const ws = workspaceId()
+  const botId = `bot_${Math.random().toString(36).slice(2, 10)}`
+  const instanceId = "cc-scope-test"
+  const rootStream = streamId()
+  const threadStream = streamId()
+  const author = userId()
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM bot_invocations WHERE workspace_id = $1", [ws])
+    await pool.query("DELETE FROM bot_runtime_instances WHERE workspace_id = $1", [ws])
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM bot_invocations WHERE workspace_id = $1", [ws])
+    await pool.query("DELETE FROM bot_runtime_instances WHERE workspace_id = $1", [ws])
+    await pool.query(
+      `INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, instance_id, runtime_kind, status, accepting_invocations)
+       VALUES ($1, $2, $3, $4, 'claude-code-channel', 'available', TRUE)`,
+      [`bri_${instanceId}`, ws, botId, instanceId]
+    )
+  })
+
+  async function seed(id: string, responseStreamId: string, sourceMessageId: string): Promise<void> {
+    await BotInvocationRepository.insertIdempotent(pool, {
+      id,
+      workspaceId: ws,
+      rootStreamId: rootStream,
+      activeStreamId: responseStreamId,
+      sourceMessageId,
+      responseStreamId,
+      actorType: "bot",
+      actorId: botId,
+      trigger: "active-scratchpad",
+      requiredCapability: "active-scratchpad",
+      promptMarkdown: `prompt for ${responseStreamId}`,
+      authorUserId: author,
+      mentionedActorSlugs: [],
+      targetInstanceId: null,
+      targetRuntimeSessionId: null,
+      metadata: {},
+    })
+  }
+
+  const claim = (responseStreamId?: string) =>
+    BotInvocationRepository.claimOne(pool, {
+      workspaceId: ws,
+      botId,
+      instanceId,
+      runtimeKind: "claude-code-channel",
+      claimToken: `tok_${Math.random().toString(36).slice(2)}`,
+      supportedCapabilities: ["active-scratchpad"],
+      claimTtlSeconds: 60,
+      maxAttempts: 5,
+      ...(responseStreamId ? { responseStreamId } : {}),
+    })
+
+  test("a scoped claim skips a FIFO-earlier invocation belonging to another stream", async () => {
+    await seed("binv_thread_first", threadStream, "msg_thread")
+    await seed("binv_root_second", rootStream, "msg_root")
+
+    const scoped = await claim(rootStream)
+
+    expect(scoped?.id).toBe("binv_root_second")
+    expect(scoped?.responseStreamId).toBe(rootStream)
+    // The thread's invocation is untouched — still claimable in its own stream.
+    const remaining = await claim(threadStream)
+    expect(remaining?.id).toBe("binv_thread_first")
+  })
+
+  test("an unscoped claim is unchanged: strict FIFO across streams", async () => {
+    await seed("binv_thread_first", threadStream, "msg_thread")
+    await seed("binv_root_second", rootStream, "msg_root")
+
+    expect((await claim())?.id).toBe("binv_thread_first")
+  })
+
+  test("a scope with nothing queued for it claims nothing rather than falling back", async () => {
+    await seed("binv_thread_only", threadStream, "msg_thread")
+
+    expect(await claim(rootStream)).toBeNull()
+    expect((await claim(threadStream))?.id).toBe("binv_thread_only")
+  })
+})

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1734,7 +1734,8 @@
                     "type": "array",
                     "items": { "type": "string", "enum": ["mentionable", "active-scratchpad", "session-control"] }
                   },
-                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 }
+                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 },
+                  "responseStreamId": { "type": "string", "minLength": 1, "maxLength": 64 }
                 },
                 "required": ["runtimeKind", "instanceId", "supportedCapabilities", "claimTtlSeconds"],
                 "additionalProperties": false

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -1613,7 +1613,8 @@
                     "type": "array",
                     "items": { "type": "string", "enum": ["mentionable", "active-scratchpad", "session-control"] }
                   },
-                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 }
+                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 },
+                  "responseStreamId": { "type": "string", "minLength": 1, "maxLength": 64 }
                 },
                 "required": ["runtimeKind", "instanceId", "supportedCapabilities", "claimTtlSeconds"],
                 "additionalProperties": false

--- a/docs/public-api/versions/2026-07-22.json
+++ b/docs/public-api/versions/2026-07-22.json
@@ -1613,7 +1613,8 @@
                     "type": "array",
                     "items": { "type": "string", "enum": ["mentionable", "active-scratchpad", "session-control"] }
                   },
-                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 }
+                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 },
+                  "responseStreamId": { "type": "string", "minLength": 1, "maxLength": 64 }
                 },
                 "required": ["runtimeKind", "instanceId", "supportedCapabilities", "claimTtlSeconds"],
                 "additionalProperties": false

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -1734,7 +1734,8 @@
                     "type": "array",
                     "items": { "type": "string", "enum": ["mentionable", "active-scratchpad", "session-control"] }
                   },
-                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 }
+                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 },
+                  "responseStreamId": { "type": "string", "minLength": 1, "maxLength": 64 }
                 },
                 "required": ["runtimeKind", "instanceId", "supportedCapabilities", "claimTtlSeconds"],
                 "additionalProperties": false

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1687,24 +1687,50 @@ describe("no-socket poll backoff", () => {
 describe("folding queued messages into one turn", () => {
   const asInternal = (session: RemoteSession) => session as unknown as { claimDrain: () => Promise<boolean> }
 
-  function makeFoldSession(queue: ClaimedInvocation[]) {
+  function makeFoldSession(queue: ClaimedInvocation[], overrides: { deliverTurn?: () => Promise<void> } = {}) {
     const delivered: Array<{ invocationId: string; content: string }> = []
     const completed: Array<{ id: string; body: Record<string, unknown> }> = []
+    const failed: Array<{ id: string; body: Record<string, unknown> }> = []
+    const claims: Array<Record<string, unknown>> = []
+    const interrupts: number[] = []
     const client = {
-      claim: async () => queue.shift() ?? null,
+      claim: async (body: Record<string, unknown>) => {
+        claims.push(body)
+        const scope = body.responseStreamId
+        const caps = (body.supportedCapabilities ?? []) as string[]
+        // The server-side predicates, modelled: a claim only returns work whose
+        // required capability was offered, and a scoped claim only returns an
+        // invocation answering into that stream.
+        const index = queue.findIndex(
+          (item) => caps.includes(item.requiredCapability) && (!scope || item.responseStreamId === scope)
+        )
+        return index === -1 ? null : queue.splice(index, 1)[0]
+      },
       complete: async (id: string, body: Record<string, unknown>) => {
         completed.push({ id, body })
       },
-      fail: async () => {},
+      fail: async (id: string, body: Record<string, unknown>) => {
+        failed.push({ id, body })
+      },
       sendMessage: async () => {},
     } as unknown as ThreaClient
     const { transport } = makeFakeTransport()
     const session = makeSession(client, transport, {
-      deliverTurn: async (turn: { invocationId: string; content: string }) => {
-        delivered.push({ invocationId: turn.invocationId, content: turn.content })
+      deliverTurn:
+        overrides.deliverTurn ??
+        (async (turn: { invocationId: string; content: string }) => {
+          delivered.push({ invocationId: turn.invocationId, content: turn.content })
+        }),
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => {
+          interrupts.push(Date.now())
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
       },
     })
-    return { session, delivered, completed }
+    return { session, delivered, completed, failed, claims, interrupts }
   }
 
   test("N messages queued behind one become a single turn that sees all of them", async () => {
@@ -1750,7 +1776,7 @@ describe("folding queued messages into one turn", () => {
       requiredCapability: "session-control",
       metadata: { command: { executionKind: "bot-runtime", id: "cmd_1", name: "stop", args: "" } },
     })
-    const { session, delivered } = makeFoldSession([
+    const { session, delivered, interrupts } = makeFoldSession([
       makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
       makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
       stop,
@@ -1762,6 +1788,63 @@ describe("folding queued messages into one turn", () => {
     expect(delivered[0]?.content).toContain("first")
     expect(delivered[0]?.content).toContain("second")
     expect(delivered[0]?.content).not.toContain("/stop")
+    // The point of not folding it: it has to actually stop the turn the fold
+    // just started. Asserting only on the prompt text proved nothing.
+    expect(interrupts).toHaveLength(1)
+    await session.shutdown()
+  })
+
+  test("the sweep is scoped to the primary's stream, so a thread message is never folded in", async () => {
+    // `claimOne` is FIFO per bot and has no stream predicate of its own; without
+    // the scope the sweep would fold a message belonging to another stream and
+    // answer it in the primary's, closing it unanswered where it was asked.
+    const { session, delivered, completed, claims } = makeFoldSession([
+      makeInvocation({ id: "binv_root", promptMarkdown: "root question", responseStreamId: "stream_root" }),
+      makeInvocation({ id: "binv_thread", promptMarkdown: "thread question", responseStreamId: "stream_thread" }),
+    ])
+
+    await asInternal(session).claimDrain()
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.content).toContain("root question")
+    expect(delivered[0]?.content).not.toContain("thread question")
+    // Untouched: still queued, still answerable in its own stream.
+    expect(completed).toEqual([])
+    // First claim is the unscoped primary; the sweep that follows is scoped.
+    // (The later busy claim stays unscoped on purpose — a /stop from any stream
+    // still has to reach the session.)
+    expect(claims[0]?.responseStreamId).toBeUndefined()
+    expect(claims[1]?.responseStreamId).toBe("stream_root")
+    await session.shutdown()
+  })
+
+  test("a delivery failure fails the messages loudly and still runs a swept /stop", async () => {
+    const { session, failed, interrupts } = makeFoldSession(
+      [
+        makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
+        makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
+        makeInvocation({
+          id: "binv_stop",
+          promptMarkdown: "/stop",
+          trigger: "session-control",
+          requiredCapability: "session-control",
+          metadata: { command: { executionKind: "bot-runtime", id: "cmd_1", name: "stop", args: "" } },
+        }),
+      ],
+      {
+        deliverTurn: async () => {
+          throw new Error("pane is gone")
+        },
+      }
+    )
+
+    await asInternal(session).claimDrain()
+
+    // Claimed but undeliverable must not vanish into a silent close.
+    expect(failed.map((item) => item.id).sort()).toEqual(["binv_1", "binv_2"])
+    expect(failed[0]?.body.errorMessage).toContain("pane is gone")
+    // And the swept /stop still runs rather than hanging to its claim TTL.
+    expect(interrupts).toHaveLength(1)
     await session.shutdown()
   })
 })

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1818,6 +1818,58 @@ describe("folding queued messages into one turn", () => {
     await session.shutdown()
   })
 
+  test("a failed delivery does not leave the session falsely busy", async () => {
+    // No /stop in this queue on purpose: a queued stop clears `inflight` via
+    // completeInterruptedTurns, which would mask the leak this pins.
+    const { session, failed } = makeFoldSession(
+      [
+        makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
+        makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
+      ],
+      {
+        deliverTurn: async () => {
+          throw new Error("pane is gone")
+        },
+      }
+    )
+
+    await asInternal(session).claimDrain()
+
+    expect(failed.map((item) => item.id).sort()).toEqual(["binv_1", "binv_2"])
+    // Left registered, the session reports busy — claiming session control only
+    // — until the idle timeout fires on an already-terminal invocation.
+    expect((session as unknown as { inflight: Map<string, unknown> }).inflight.size).toBe(0)
+    await session.shutdown()
+  })
+
+  test("an archive landing mid-sweep leaves the folded messages claimed, not discarded", async () => {
+    // The primary is left claimed for the restore to re-run; closing the folded
+    // ones here would throw their content away for good.
+    const { session, delivered, completed, failed } = makeFoldSession([
+      makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
+      makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
+    ])
+    const internal = session as unknown as {
+      claimNext: (busy: boolean, scope?: string) => Promise<unknown>
+      stopped: boolean
+    }
+    const realClaim = internal.claimNext.bind(session)
+    internal.claimNext = async (busy: boolean, scope?: string) => {
+      const claimed = await realClaim(busy, scope)
+      // The session goes down while the sweep is awaiting its next claim —
+      // same guard the archive path trips.
+      internal.stopped = true
+      return claimed
+    }
+
+    await asInternal(session).claimDrain()
+
+    expect(delivered).toEqual([])
+    expect(completed).toEqual([])
+    expect(failed).toEqual([])
+    await session.shutdown()
+  })
+
   test("a delivery failure fails the messages loudly and still runs a swept /stop", async () => {
     const { session, failed, interrupts } = makeFoldSession(
       [

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1683,3 +1683,85 @@ describe("no-socket poll backoff", () => {
     expect(session.nextPollDelay(false)).toBe(3000)
   })
 })
+
+describe("folding queued messages into one turn", () => {
+  const asInternal = (session: RemoteSession) => session as unknown as { claimDrain: () => Promise<boolean> }
+
+  function makeFoldSession(queue: ClaimedInvocation[]) {
+    const delivered: Array<{ invocationId: string; content: string }> = []
+    const completed: Array<{ id: string; body: Record<string, unknown> }> = []
+    const client = {
+      claim: async () => queue.shift() ?? null,
+      complete: async (id: string, body: Record<string, unknown>) => {
+        completed.push({ id, body })
+      },
+      fail: async () => {},
+      sendMessage: async () => {},
+    } as unknown as ThreaClient
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport, {
+      deliverTurn: async (turn: { invocationId: string; content: string }) => {
+        delivered.push({ invocationId: turn.invocationId, content: turn.content })
+      },
+    })
+    return { session, delivered, completed }
+  }
+
+  test("N messages queued behind one become a single turn that sees all of them", async () => {
+    // The lag this fixes: each queued message used to become its own turn, so
+    // the reply to the first arrived after the user had sent three more.
+    const { session, delivered, completed } = makeFoldSession([
+      makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
+      makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
+      makeInvocation({ id: "binv_3", promptMarkdown: "third" }),
+    ])
+
+    await asInternal(session).claimDrain()
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.invocationId).toBe("binv_1")
+    expect(delivered[0]?.content).toContain("Handle all of the following together (most recent last)")
+    for (const text of ["first", "second", "third"]) expect(delivered[0]?.content).toContain(text)
+    // The primary keeps the reply; the folded ones close without one, exactly
+    // as the steer sweep closes what it folds.
+    expect(completed.map((item) => item.id)).toEqual(["binv_2", "binv_3"])
+    await session.shutdown()
+  })
+
+  test("a lone message is delivered verbatim, with no fold wrapper", async () => {
+    const { session, delivered, completed } = makeFoldSession([
+      makeInvocation({ id: "binv_1", promptMarkdown: "just the one" }),
+    ])
+
+    await asInternal(session).claimDrain()
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.content).not.toContain("Handle all of the following together")
+    expect(delivered[0]?.content).toContain("just the one")
+    expect(completed).toEqual([])
+    await session.shutdown()
+  })
+
+  test("a queued /stop is never folded as text — it stops the turn the fold started", async () => {
+    const stop = makeInvocation({
+      id: "binv_stop",
+      promptMarkdown: "/stop",
+      trigger: "session-control",
+      requiredCapability: "session-control",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_1", name: "stop", args: "" } },
+    })
+    const { session, delivered } = makeFoldSession([
+      makeInvocation({ id: "binv_1", promptMarkdown: "first" }),
+      makeInvocation({ id: "binv_2", promptMarkdown: "second" }),
+      stop,
+    ])
+
+    await asInternal(session).claimDrain()
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.content).toContain("first")
+    expect(delivered[0]?.content).toContain("second")
+    expect(delivered[0]?.content).not.toContain("/stop")
+    await session.shutdown()
+  })
+})

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -693,7 +693,17 @@ export class RemoteSession {
           if (isStop) break
           continue
         }
-        await this.handleClaimed(invocation)
+        const deferred = await this.startFoldedTurn(invocation)
+        // Session control queued behind the folded messages still runs, and
+        // still runs against the turn the fold just started — a queued /stop
+        // must stop it, not the turn after it.
+        for (const control of deferred) {
+          if (parseSessionControlCommand(control)?.name === "stop") {
+            await this.handleSessionControl(control)
+            return claimedAny
+          }
+          await this.handleSessionControl(control)
+        }
       }
     } catch (error) {
       this.log(`claim failed: ${this.summarize(error)}`)
@@ -774,9 +784,43 @@ export class RemoteSession {
     return true
   }
 
-  private async handleClaimed(invocation: ClaimedInvocation): Promise<void> {
-    const content = await this.buildTurnContent(invocation)
-    await this.deliverTurn(invocation, content)
+  /**
+   * Start one turn that sees every ordinary message already queued behind this
+   * one, and return any session-control commands the sweep pulled up with them.
+   *
+   * Without this, N messages sent while the session was busy became N
+   * sequential turns, each answering a question the user had already moved
+   * past — the reply to message 1 arriving after they had sent 4 more. `/steer`
+   * has always folded the backlog (`sweepQueuedForSteer`); an ordinary message
+   * got no such treatment, and that asymmetry is the whole of the lag.
+   *
+   * The primary invocation keeps the reply; the folded ones close without a
+   * response of their own, exactly as the steer sweep closes what it folds.
+   * Session control is never folded as text — a queued `/stop` has to stop the
+   * turn, not become a line in its prompt — so it is handed back to the caller.
+   */
+  private async startFoldedTurn(invocation: ClaimedInvocation): Promise<ClaimedInvocation[]> {
+    const parts = [await this.buildTurnContent(invocation)]
+    const folded: ClaimedInvocation[] = []
+    const control: ClaimedInvocation[] = []
+    for (let i = 1; i < STEER_DRAIN_LIMIT; i++) {
+      const extra = await this.claimNext(false).catch(() => null)
+      if (!extra) break
+      if (await this.interceptInvocation(extra)) continue
+      if (isSessionControlInvocation(extra)) {
+        control.push(extra)
+        // Stop folding at a control command: everything after it belongs to
+        // whatever that command decides.
+        break
+      }
+      folded.push(extra)
+      parts.push(await this.buildTurnContent(extra))
+    }
+    await this.deliverTurn(invocation, buildSteerContent(parts))
+    // Only after the turn is registered: a delivery that throws must leave the
+    // folded messages claimed-but-open rather than silently closed.
+    await Promise.all(folded.map((item) => this.completeNoResponse(item)))
+    return control
   }
 
   /** Register an invocation as the in-flight turn and push its content to the runtime. */

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -675,7 +675,7 @@ export class RemoteSession {
         // tool approval whose verdict arrives as an ordinary message) keeps
         // draining with full caps via `interceptHoldsClaims`. Without runtime
         // control there's nothing to claim while busy: strict one-at-a-time.
-        if (this.reconnectHandoff) break
+        if (this.reconnectHandoff || this.stopped || this.archive.detached) break
         const busy = this.inflight.size > 0 && !this.interceptHoldsClaims
         if (busy && !this.sessionControlEnabled) break
         const invocation = await this.claimNext(busy)
@@ -832,8 +832,10 @@ export class RemoteSession {
       // An archive can land while the sweep awaits; delivering into a detached
       // link publishes busy for a turn whose reply cannot arrive.
       if (this.stopped || this.archive.detached) {
-        await Promise.all(folded.map((item) => this.completeNoResponse(item)))
-        folded.length = 0
+        // Leave the folded messages claimed, exactly as the primary is left:
+        // closing them here would discard their content for good, while the
+        // primary comes back on the next drain. The drain's own guard says the
+        // restore re-runs the pass — that has to mean all of it.
         return control
       }
       await this.deliverTurn(invocation, buildSteerContent(parts))
@@ -846,6 +848,11 @@ export class RemoteSession {
       // interrupts an unrelated turn once its claim expires. The messages fail
       // loudly instead of vanishing into a silent close.
       const reason = `Could not start the turn: ${this.summarize(error)}`
+      // The primary was registered in `inflight` before the delegate ran, so a
+      // throw would otherwise leave the session reporting busy — claiming
+      // session-control only — until the idle timeout fired on an invocation
+      // that is already terminal.
+      this.clearInflight(invocation.id)
       await this.failInvocation(invocation, reason).catch(() => undefined)
       await Promise.all(folded.map((item) => this.failInvocation(item, reason).catch(() => undefined)))
     }
@@ -864,6 +871,12 @@ export class RemoteSession {
     this.activeTurnStream = invocation.responseStreamId
     await this.syncPresence()
     await this.recordForwardedStep(invocation).catch(() => undefined)
+    // `syncPresence` yields, and an archive landing in that window fails this
+    // invocation and clears it from `inflight`. Handing it to the runtime
+    // anyway would execute a turn whose reply the server has already closed.
+    if (this.stopped || this.archive.detached || !this.inflight.has(invocation.id)) {
+      throw new Error("session went offline before the turn could be delivered")
+    }
     await this.delegate.deliverTurn({
       invocationId: invocation.id,
       streamId: invocation.responseStreamId,
@@ -1127,15 +1140,25 @@ export class RemoteSession {
     await this.deliverTurn(invocation, buildSteerContent(parts))
   }
 
-  /** Claim messages queued while the runtime was busy and fold their text in (steer text last). */
+  /**
+   * Claim messages queued while the runtime was busy and fold their text in
+   * (steer text last).
+   *
+   * Scoped to the stream the steered turn answers into, for the same reason the
+   * fold's sweep is: a message belonging to another stream would be folded
+   * here, closed unanswered where it was asked, and answered somewhere else.
+   * Unscoped when nothing is in flight — there is no turn whose stream to
+   * inherit, and the steer itself is then the only thing being folded into.
+   */
   private async sweepQueuedForSteer(
     text: string
   ): Promise<{ parts: string[]; swept: ClaimedInvocation[]; interceptedCount: number }> {
     const parts: string[] = []
     const swept: ClaimedInvocation[] = []
     let interceptedCount = 0
+    const running = [...this.inflight.values()][0]?.invocation.responseStreamId
     for (let i = 0; i < STEER_DRAIN_LIMIT; i++) {
-      const extra = await this.claimNext(false).catch(() => null)
+      const extra = await this.claimNext(false, running).catch(() => null)
       if (!extra) break
       // A swept message the connector intercepts (e.g. a permission verdict) is
       // consumed and closed here, never folded into the steer text — and never

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -729,8 +729,11 @@ export class RemoteSession {
    * loudly (scrubbed reason) and reports "nothing claimed" rather than throwing
    * the drain into a TTL-recycle loop.
    */
-  private async claimNext(busy: boolean): Promise<ClaimedInvocation | null> {
-    const invocation = await this.client.claim(this.claimBody(busy))
+  private async claimNext(busy: boolean, responseStreamId?: string): Promise<ClaimedInvocation | null> {
+    const invocation = await this.client.claim({
+      ...this.claimBody(busy),
+      ...(responseStreamId ? { responseStreamId } : {}),
+    })
     if (!invocation || invocation.sealedContext === undefined) return invocation
     const fail = async (reason: string): Promise<null> => {
       this.log(`sealed claim ${invocation.id} unusable: ${reason}`)
@@ -803,23 +806,49 @@ export class RemoteSession {
     const parts = [await this.buildTurnContent(invocation)]
     const folded: ClaimedInvocation[] = []
     const control: ClaimedInvocation[] = []
-    for (let i = 1; i < STEER_DRAIN_LIMIT; i++) {
-      const extra = await this.claimNext(false).catch(() => null)
-      if (!extra) break
-      if (await this.interceptInvocation(extra)) continue
-      if (isSessionControlInvocation(extra)) {
-        control.push(extra)
-        // Stop folding at a control command: everything after it belongs to
-        // whatever that command decides.
-        break
+    try {
+      for (let i = 1; i < STEER_DRAIN_LIMIT; i++) {
+        // Scoped to the primary's response stream, server-side. Folding across
+        // streams would answer one stream's question in another and close the
+        // rest unanswered, and a claim taken by mistake cannot be released —
+        // so the filter has to keep it from being claimed at all. Sealing rides
+        // along: a stream is uniformly sealed or uniformly plaintext.
+        const extra = await this.claimNext(false, invocation.responseStreamId).catch(() => null)
+        if (!extra) break
+        if (await this.interceptInvocation(extra)) continue
+        if (isSessionControlInvocation(extra)) {
+          control.push(extra)
+          // Stop folding at a control command: everything after it belongs to
+          // whatever that command decides.
+          break
+        }
+        folded.push(extra)
+        // formatInvocationContent, not buildTurnContent: the latter downloads
+        // attachments, and nothing claimed during the sweep is renewed yet, so
+        // a slow queue would expire every claim it is holding. The steer sweep
+        // folds prompt text only for the same reason.
+        parts.push(formatInvocationContent(extra))
       }
-      folded.push(extra)
-      parts.push(await this.buildTurnContent(extra))
+      // An archive can land while the sweep awaits; delivering into a detached
+      // link publishes busy for a turn whose reply cannot arrive.
+      if (this.stopped || this.archive.detached) {
+        await Promise.all(folded.map((item) => this.completeNoResponse(item)))
+        folded.length = 0
+        return control
+      }
+      await this.deliverTurn(invocation, buildSteerContent(parts))
+      // Only after the turn is registered: a delivery that throws must leave the
+      // folded messages claimed-but-open rather than silently closed.
+      await Promise.all(folded.map((item) => this.completeNoResponse(item)))
+    } catch (error) {
+      // Never throw past here. Control claimed by the sweep has to run even when
+      // delivery failed — otherwise a swept /stop is claimed, never handled, and
+      // interrupts an unrelated turn once its claim expires. The messages fail
+      // loudly instead of vanishing into a silent close.
+      const reason = `Could not start the turn: ${this.summarize(error)}`
+      await this.failInvocation(invocation, reason).catch(() => undefined)
+      await Promise.all(folded.map((item) => this.failInvocation(item, reason).catch(() => undefined)))
     }
-    await this.deliverTurn(invocation, buildSteerContent(parts))
-    // Only after the turn is registered: a delivery that throws must leave the
-    // folded messages claimed-but-open rather than silently closed.
-    await Promise.all(folded.map((item) => this.completeNoResponse(item)))
     return control
   }
 


### PR DESCRIPTION
## Problem

A message sent while a turn is in flight stays queued, and each queued message then becomes its **own sequential turn**. The reply to the first arrives after the user has already sent three more — every answer addressing a question they had moved past.

`claimDrain` is explicit about it:

```ts
const busy = this.inflight.size > 0 && !this.interceptHoldsClaims
if (busy && !this.sessionControlEnabled) break
```

Strict one normal turn at a time. `/steer` has always folded the backlog into a single prompt (`sweepQueuedForSteer`, up to `STEER_DRAIN_LIMIT`); an ordinary message got no such treatment. That asymmetry is the whole of the lag — and because the steer sweep closes what it folds with `completeNoResponse`, from the user's side the queued messages read as consumed without ever being answered.

## Solution

`startFoldedTurn` sweeps the queue as a turn starts and delivers **one** turn that sees every queued message, most recent last, through the same `buildSteerContent` the steer path uses.

- The primary invocation keeps the reply; folded ones close without one — identical to how the steer sweep closes what it folds.
- Closing happens **after** `deliverTurn` returns, so a delivery that throws leaves them claimed-but-open rather than silently closed.
- Session control is never folded as text. A queued `/stop` has to stop the turn the fold just started, not become a line in its prompt, so the sweep stops at the first control command and hands it back to the drain, which runs it against the turn now in flight.
- Intercepted invocations (tool-approval verdicts arriving as ordinary messages) keep their existing path — consumed by `interceptInvocation`, never folded.
- A single queued message is unchanged: `buildSteerContent` returns the lone part verbatim, no wrapper.

`STEER_DRAIN_LIMIT` (10) is reused rather than a second knob.

This touches the shared runtime behind both the Claude channel and Pi.

## Files

| File | Change |
| ---- | ------ |
| `extensions/remote-session/src/session.ts` | `startFoldedTurn` replaces `handleClaimed`; drain runs swept control commands after it |
| `extensions/remote-session/src/session.test.ts` | 3 tests: N-into-one, lone message unchanged, queued `/stop` not folded |

## Test plan

- [x] `bun test` in `extensions/remote-session` — 145 pass, 0 fail
- [x] `bun test` in `extensions/claude-code-remote` — 122 pass, 0 fail
- [x] Typecheck + full repo lint/typecheck (pre-commit hook) — clean
- [x] Tests verified non-vacuous: restoring the old one-at-a-time delivery turns two of the three red
- [x] The `/stop` test caught its own fixture bug first — `isSessionControlInvocation` needs `trigger: "session-control"` *and* `executionKind: "bot-runtime"`, and the first fixture had neither, so the command folded as text. Fixed the fixture; the assertion was right.
- [ ] Not exercised against a live session — this changes turn delivery for every channel, so it wants a real two-messages-while-busy check before it goes near the running sessions.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---

## ⚠️ Draft — adversarial review found this unsafe as built

Sol (gpt-5.6-sol) and Fable reviewed independently and converged. **Do not merge.**

**The blocker.** `BotInvocationRepository.claimOne` has no stream predicate — it is strictly FIFO per bot/instance and never constrains `response_stream_id`, `root_stream_id`, or sealing. So the sweep can claim an invocation belonging to a *different* stream, fold its text into the primary's turn, close it with `completeNoResponse`, and post the reply only to the primary's stream. The other stream's question is closed unanswered where it was asked. Reachable on an everyday path: a message in the scratchpad root plus one in a thread, or an untargeted `@mention` in a channel (`mentionable` is in `SUPPORTED_CAPABILITIES`). Sol HIGH/100, Fable F1 HIGH/90.

Worse variant, same root: a sealed E2E invocation folded into a plaintext primary would deliver decrypted content and reply in the clear. Sol CRITICAL/99, Fable F1b/65.

**Everything else traces back to the same decision** — claiming invocations the fold then holds without registering or renewing them:

- A `completeNoResponse` that fails (503) leaves the invocation claimed, unrenewed, and re-delivered after the 120s TTL — a duplicate answer with duplicate side effects. Sol HIGH/99, Fable F3a.
- `buildTurnContent` per folded item downloads attachments; nothing is renewed during the sweep, so a slow queue blows the TTL and everything re-delivers. Sol HIGH/97, Fable F3b. (`sweepQueuedForSteer` folds `promptMarkdown` only — the precedent I should have followed.)
- A retained `/stop` can run after the turn it was meant to stop has already ended (Sol HIGH/98) or be lost entirely if `deliverTurn` throws, then interrupt an unrelated later turn (Fable F2 MEDIUM/80).
- An archive landing mid-sweep is not re-checked before delivery. Sol HIGH/98.
- The third test is vacuous for its headline claim: it proves control text isn't folded, not that the stop stops anything. Fable F4.

**Why this isn't a patch.** There is no release/unclaim endpoint — a claimed invocation can only be completed, failed, or left to expire. So the client cannot safely claim ahead. The correct fix is an optional `responseStreamId` (and sealing) filter on the claim endpoint, so a connector only ever receives invocations it can fold. That is a backend layer, and it makes the client side trivially safe. Patching the client to hold and renew mismatched claims is the alternative, and it is strictly more machinery for a worse guarantee.

Held for that decision rather than reworked at 2am, on the shared runtime behind every Claude and Pi session, on the same night a different part of it spawned ten duplicate processes.

The clean verdicts are worth keeping: the steer-vs-fold interleaving cannot race (`this.claiming` serializes the only entry path), `return claimedAny` preserves the old stop-loop semantics, and the first two fold tests are non-vacuous.


---

## Re-review round 2 — blocker confirmed fixed

Sol and Fable both re-reviewed the scoped-claim rework.

**The blocker is closed, and the assumption it rests on was verified rather than assumed.** `responseStreamId` is always the message's own stream (checked across every producer), and `markStreamE2e` runs only in the creating transaction, so a response stream cannot mix sealed and plaintext invocations — one filter covers both the cross-stream fold and the sealed-into-plaintext leak. SQL composition, `SKIP LOCKED`/ordering/sealed-gate interaction, scoped-claim starvation, and the new public-API field's authorization surface all came back clean.

Fixed in `7c90ebe88`:

- **The same bug class was alive one function down.** `sweepQueuedForSteer` still claimed unscoped, so a `/steer` could fold a thread's or a channel mention's message into the running turn and answer it elsewhere. It now inherits the running turn's response stream, and stays unscoped only when nothing is in flight.
- **An archive mid-sweep discarded the folded messages** while leaving the primary claimed for retry — asymmetric and lossy. Folded messages are now left claimed exactly as the primary is.
- `claimDrain` re-checks lifecycle between iterations; `deliverTurn` re-checks after `syncPresence` yields (an archive in that window fails the invocation, and handing it to the runtime anyway ran a turn whose reply was already closed); a failed delivery clears the in-flight entry instead of leaving the session falsely busy.

Residual, both pre-existing and shared with the steer path: a `completeNoResponse` that fails transiently leaves a folded message claimed until TTL, after which it is answered a second time. That is the queue's at-least-once nature rather than something this layer introduced.

Still not exercised against a live session — it changes turn delivery for every channel, Pi included.
