### PR TITLE
fix(board): stop the resting reply bar painting a stray focus ring after send

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -7,6 +7,7 @@ import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/
 import { spyOnExport } from "@/test"
 import * as composerModule from "@/components/composer"
 import * as usePointerModule from "@/hooks/use-pointer"
+import * as inputModeModule from "@/hooks/use-input-mode"
 import * as hooksModule from "@/hooks"
 import * as contextsModule from "@/contexts"
 import * as mentionablesModule from "@/hooks/use-mentionables"
@@ -98,6 +99,9 @@ beforeEach(() => {
   // portal opt in per-test. The gate reads the shared `useIsMobileOrCoarse`
   // predicate (the panel full-screen breadth), so drive that boundary directly.
   vi.spyOn(usePointerModule, "useIsMobileOrCoarse").mockReturnValue(false)
+  // Pinned per-test: the live hook keeps module-level state, so a touch test
+  // would otherwise bleed into every case after it.
+  vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("mouse")
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({ preferences: undefined } as never)
   vi.spyOn(mentionablesModule, "useMentionStreamContext").mockReturnValue(undefined as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
@@ -319,6 +323,34 @@ describe("InlineComposerForm restore-on-mount", () => {
     render(<Anchored>{form()}</Anchored>)
     await new Promise((resolve) => setTimeout(resolve, 30))
     expect(stashStub.handleRestoreStashed).not.toHaveBeenCalled()
+  })
+})
+
+describe("InlineComposerForm refocus-after-send", () => {
+  const lastComposerProps = (): MessageComposerProps => editorSpy.mock.calls.at(-1)![0] as MessageComposerProps
+
+  beforeEach(() => {
+    vi.spyOn(usePointerModule, "useIsMobileOrCoarse").mockReturnValue(false)
+    composerStub.canSend = true
+  })
+
+  it("returns focus to the resting bar when the user is driving with a mouse/keyboard", async () => {
+    const onClose = vi.fn()
+    render(<Anchored>{form({ onClose })}</Anchored>)
+
+    lastComposerProps().onSubmit()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: true }))
+  })
+
+  it("declines the refocus on a touch send — the resting button inherits :focus-visible from the editor, painting a ring no finger navigated to", async () => {
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
+    const onClose = vi.fn()
+    render(<Anchored>{form({ onClose })}</Anchored>)
+
+    lastComposerProps().onSubmit()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: false }))
   })
 })
 

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -334,23 +334,23 @@ describe("InlineComposerForm refocus-after-send", () => {
     composerStub.canSend = true
   })
 
-  it("returns focus to the resting bar when the user is driving with a mouse/keyboard", async () => {
+  it("returns focus to the resting bar with its ring when the user is driving with a mouse/keyboard", async () => {
     const onClose = vi.fn()
     render(<Anchored>{form({ onClose })}</Anchored>)
 
     lastComposerProps().onSubmit()
 
-    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: true }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: true, quiet: false }))
   })
 
-  it("declines the refocus on a touch send — the resting button inherits :focus-visible from the editor, painting a ring no finger navigated to", async () => {
+  it("still restores focus on a touch send, quietly — dropping it would strand a screen-reader user on <body>, but the ring would mark a control no finger navigated to", async () => {
     vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
     const onClose = vi.fn()
     render(<Anchored>{form({ onClose })}</Anchored>)
 
     lastComposerProps().onSubmit()
 
-    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: false }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith({ refocus: true, quiet: true }))
   })
 })
 
@@ -390,7 +390,7 @@ describe("InlineComposerForm stash + schedule", () => {
       conversation: { intent: "existing", conversationId: "conv_1" },
     })
     expect(composerStub.resolveDraft).toHaveBeenCalled()
-    expect(onClose).toHaveBeenCalledWith({ refocus: true })
+    expect(onClose).toHaveBeenCalledWith({ refocus: true, quiet: false })
   })
 
   it("restores the content and stays open when scheduling fails", async () => {

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -113,8 +113,13 @@ interface InlineComposerFormProps {
   focusSignal?: number
   /** Perform the send. Throws to keep the composer open and restore the draft. */
   onSubmit: (input: InlineComposerSubmit) => Promise<void>
-  /** Collapse the composer (Escape / after-send / blur-when-empty). */
-  onClose: (opts?: { refocus?: boolean }) => void
+  /**
+   * Collapse the composer (Escape / after-send / blur-when-empty). `refocus`
+   * returns focus to the host's resting affordance; `quiet` asks it to restore
+   * that focus without painting a focus ring — for a close the user drove with
+   * a finger, where the ring would mark a control nobody navigated to.
+   */
+  onClose: (opts?: { refocus?: boolean; quiet?: boolean }) => void
 }
 
 /**
@@ -241,11 +246,12 @@ export function InlineComposerForm({
   // message. A docked host never floats: the footer is the dock, so it keeps the
   // in-place form on every device.
   const isMobileOrCoarse = useIsMobileOrCoarse()
-  // Refocusing the resting bar after a send restores keyboard position, but the
-  // button it lands on inherits :focus-visible from the editor it was focused
-  // out of — so on a finger-driven send it paints a focus ring nobody navigated
-  // to. Same rule as `handleFloatingClose` below.
-  const refocusOnClose = useInputMode() !== "touch"
+  // The resting bar is always refocused after a send — dropping focus on `<body>`
+  // strands a screen-reader or keyboard user. Only the ring's *paint* is
+  // conditional: the button inherits :focus-visible from the editor it was
+  // focused out of, so a finger-driven send would otherwise draw a ring nobody
+  // navigated to.
+  const quietFocusOnSend = useInputMode() === "touch"
   const anchor = useFloatingComposerAnchor()
   const floating = isMobileOrCoarse && anchor !== null && !docked
   const formId = useId()
@@ -384,7 +390,7 @@ export function InlineComposerForm({
       })
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: refocusOnClose })
+      onClose({ refocus: true, quiet: quietFocusOnSend })
     } catch {
       composer.setContent(normalizedContent)
       toast.error("Couldn't post. Please try again.")
@@ -424,7 +430,7 @@ export function InlineComposerForm({
       })
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: refocusOnClose })
+      onClose({ refocus: true, quiet: quietFocusOnSend })
     } catch {
       composer.setContent(normalizedContent)
       toast.error("Couldn't schedule. Please try again.")

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -14,6 +14,7 @@ import {
   type ComposerControlHandle,
 } from "@/components/composer"
 import { useIsMobileOrCoarse } from "@/hooks/use-pointer"
+import { useInputMode } from "@/hooks/use-input-mode"
 import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
 import { useDraftComposer, useScheduleMessage, useStashComposer } from "@/hooks"
 import { relocateLoadedDraft } from "@/hooks/use-draft-message"
@@ -240,6 +241,11 @@ export function InlineComposerForm({
   // message. A docked host never floats: the footer is the dock, so it keeps the
   // in-place form on every device.
   const isMobileOrCoarse = useIsMobileOrCoarse()
+  // Refocusing the resting bar after a send restores keyboard position, but the
+  // button it lands on inherits :focus-visible from the editor it was focused
+  // out of — so on a finger-driven send it paints a focus ring nobody navigated
+  // to. Same rule as `handleFloatingClose` below.
+  const refocusOnClose = useInputMode() !== "touch"
   const anchor = useFloatingComposerAnchor()
   const floating = isMobileOrCoarse && anchor !== null && !docked
   const formId = useId()
@@ -378,7 +384,7 @@ export function InlineComposerForm({
       })
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: true })
+      onClose({ refocus: refocusOnClose })
     } catch {
       composer.setContent(normalizedContent)
       toast.error("Couldn't post. Please try again.")
@@ -418,7 +424,7 @@ export function InlineComposerForm({
       })
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: true })
+      onClose({ refocus: refocusOnClose })
     } catch {
       composer.setContent(normalizedContent)
       toast.error("Couldn't schedule. Please try again.")

--- a/apps/frontend/src/components/board/board-reply-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { BoardReplyComposer } from "./board-reply-composer"
 import { spyOnExport } from "@/test"
@@ -97,6 +97,37 @@ describe("BoardReplyComposer alwaysDocked (docked-composer semantics)", () => {
     expect(form).toHaveAttribute("data-draft-key", "board:reply:conv_1")
     expect(form).toHaveAttribute("data-schedule-conv", "conv_1")
     expect(form).toHaveAttribute("data-reply-target-title", "")
+  })
+
+  it("quiet close: focus still lands on the resting bar, but its ring is withheld until the next keystroke", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "Write a reply…" }))
+
+    const onClose = (formSpy.mock.calls.at(-1)![0] as InlineComposerFormProps).onClose
+    act(() => onClose({ refocus: true, quiet: true }))
+
+    const resting = screen.getByRole("button", { name: "Write a reply…" })
+    // Focus is restored either way — dropping it strands a screen-reader user.
+    expect(document.activeElement).toBe(resting)
+    expect(resting.className).toContain("focus-visible:ring-0")
+
+    // Any keystroke means the user is navigating: the ring comes back.
+    await userEvent.keyboard("{Tab}")
+    expect(screen.getByRole("button", { name: "Write a reply…" }).className).not.toContain("focus-visible:ring-0")
+  })
+
+  it("loud close: focus and the ring both land on the resting bar", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "Write a reply…" }))
+
+    const onClose = (formSpy.mock.calls.at(-1)![0] as InlineComposerFormProps).onClose
+    act(() => onClose({ refocus: true, quiet: false }))
+
+    const resting = screen.getByRole("button", { name: "Write a reply…" })
+    expect(document.activeElement).toBe(resting)
+    expect(resting.className).not.toContain("focus-visible:ring-0")
   })
 
   it("board-card default: collapsed, and opening carries the advertised stash row for check-out", async () => {

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -6,6 +6,7 @@ import { useScopeDraftPreview } from "@/hooks"
 import { CollapsedComposerBar } from "@/components/composer/collapsed-composer-bar"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
 import { boardReplyDraftKey } from "@/lib/board/draft-keys"
+import { cn } from "@/lib/utils"
 import type { BoardPost } from "@threa/types"
 
 interface BoardReplyComposerProps {
@@ -112,16 +113,30 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   // Return focus to the resting button after an explicit collapse so keyboard
   // navigation isn't dropped onto <body>. A blur-driven collapse passes
   // refocus=false — the user already moved focus elsewhere.
-  const refocusOnCollapseRef = useRef(false)
+  const refocusOnCollapseRef = useRef<{ quiet: boolean } | null>(null)
+  // A quiet restore still moves focus (a screen reader or keyboard user must not
+  // be stranded on <body>); it only withholds the ring, because the button
+  // inherits :focus-visible from the editor it was focused out of and would
+  // otherwise mark itself for a user who tapped. One-shot: any keystroke means
+  // the ring has to come back, so the next keydown clears it.
+  const [quietFocus, setQuietFocus] = useState(false)
   useEffect(() => {
-    if (!open && refocusOnCollapseRef.current) {
-      refocusOnCollapseRef.current = false
-      buttonRef.current?.focus()
-    }
+    if (open) return
+    const pending = refocusOnCollapseRef.current
+    if (!pending) return
+    refocusOnCollapseRef.current = null
+    setQuietFocus(pending.quiet)
+    buttonRef.current?.focus()
   }, [open])
+  useEffect(() => {
+    if (!quietFocus) return
+    const clear = () => setQuietFocus(false)
+    window.addEventListener("keydown", clear, { capture: true })
+    return () => window.removeEventListener("keydown", clear, { capture: true })
+  }, [quietFocus])
 
-  const close = useCallback((opts?: { refocus?: boolean }) => {
-    refocusOnCollapseRef.current = opts?.refocus ?? false
+  const close = useCallback((opts?: { refocus?: boolean; quiet?: boolean }) => {
+    refocusOnCollapseRef.current = opts?.refocus ? { quiet: opts.quiet ?? false } : null
     setOpen(false)
   }, [])
 
@@ -151,7 +166,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     return (
       <CollapsedComposerBar
         buttonRef={buttonRef}
-        className="mt-3"
+        // twMerge keeps the last of a conflicting pair, so these win over the
+        // bar's own ring for as long as the quiet restore holds.
+        className={cn("mt-3", quietFocus && "focus-visible:ring-0 focus-visible:ring-offset-0")}
         draft={scopeDraft}
         placeholder="Write a reply…"
         onClick={() => setOpen(true)}
@@ -185,7 +202,7 @@ function BoardReplyComposerForm({
   docked,
   armedReply,
 }: BoardReplyComposerProps & {
-  onClose: (opts?: { refocus?: boolean }) => void
+  onClose: (opts?: { refocus?: boolean; quiet?: boolean }) => void
   pendingQuote: QuoteReplyData | null
   onQuoteConsumed: () => void
   restoreStashedId: string | null

--- a/apps/frontend/src/components/composer/collapsed-composer-bar.test.tsx
+++ b/apps/frontend/src/components/composer/collapsed-composer-bar.test.tsx
@@ -22,6 +22,15 @@ describe("CollapsedComposerBar", () => {
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 
+  it("styles its own focus ring so the UA's default (a black rectangle on Chrome Android) never paints", () => {
+    render(<CollapsedComposerBar placeholder="Write a reply…" onClick={vi.fn()} />)
+
+    const bar = screen.getByRole("button", { name: "Write a reply…" })
+    expect(bar.className).toContain("focus-visible:outline-none")
+    expect(bar.className).toContain("focus-visible:ring-2")
+    expect(bar.className).toContain("focus-visible:ring-ring")
+  })
+
   it("shows the draft's first line with the pencil marker instead of the placeholder", () => {
     const draft: ScopeDraftPreview = {
       draftId: "draft_1",

--- a/apps/frontend/src/components/composer/collapsed-composer-bar.tsx
+++ b/apps/frontend/src/components/composer/collapsed-composer-bar.tsx
@@ -13,6 +13,11 @@ export const COLLAPSED_COMPOSER_SHADOW =
 
 const CARD_CLASS = cn(
   "flex w-full min-w-0 rounded-[16px] border border-input bg-card px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground",
+  // Without this the raw <button> keeps the UA focus ring — a thick black
+  // rectangle on Chrome Android, which reads as a border on a card-shaped
+  // control. Same ring as Button/Input so a focused resting bar looks focused,
+  // not broken.
+  "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
   COLLAPSED_COMPOSER_SHADOW
 )
 


### PR DESCRIPTION
## Problem

On the board, the resting "Write a reply…" bar picks up a thick black rounded rectangle after every send on mobile — it reads as a stray border on a card-shaped control, not as focus.

<img src="https://seer.build/ws_vbyzjvdg6g/i/img_1f41pse0k8/board-reply-bar-focus-ring.webp" width="320" alt="Board card with a black rectangle around the Write a reply bar" />

Two causes stack:

- `CollapsedComposerBar` (`collapsed-composer-bar.tsx`) is a raw `<button>` with no `focus-visible` style, so it falls through to the UA ring. Chrome Android draws that as a black rectangle. Every other focusable surface in the app uses the Button/Input ring (`focus-visible:ring-2 focus-visible:ring-ring`); this one diverged because `MessageComposer`'s equivalent collapsed bar is a non-focusable `<div>` and never needed one.
- `InlineComposerForm.handleSubmit` closes with `onClose({ refocus: true })`, and `BoardReplyComposer` then calls `buttonRef.current?.focus()`. Per the `:focus-visible` spec, an element focused programmatically inherits focus-visible from the previously-focused element when that was a text field — the ProseMirror editor always is. So a finger tap on send lands a focus ring on the resting bar.

## Solution

- `CARD_CLASS` gets the app's standard ring (`ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`). Fixes both board card replies and the inline branch-composer bars, and a genuine keyboard tab-to-the-bar now looks focused instead of broken.
- The post-send close carries a `quiet` flag when the send was finger-driven (`useInputMode() === "touch"`), applied to `handleSubmit` and `handleSchedule`. `BoardReplyComposer` restores focus **either way** and withholds only the ring, clearing the suppression on the next `keydown` so a user who starts navigating gets it back.
- `useInputMode` over `useIsMobileOrCoarse` — the latter is a device-class guess, and a touch laptop driven by its trackpad would be misjudged. `useInputMode` follows the live pointer stream.
- Ring suppression via `focus-visible:ring-0` through `cn` (tailwind-merge keeps the last of a conflicting pair) rather than a new prop on the shared bar — the decision is the host's, not the bar's.

The first cut of this PR skipped the refocus entirely on touch. [Review](https://github.com/threahq/threa/pull/1633#issuecomment-5108112842) caught that `useInputMode()` is a pointer proxy, not an assistive-tech signal: a phone screen-reader user and a touchscreen laptop with a Bluetooth keyboard both read as `"touch"`, and dropping the focus left them on `<body>` with no `FocusScope` to catch it. Hence quiet-restore instead of no-restore.

Escape-to-collapse still refocuses loudly (keyboard by definition). Residual: a desktop mouse click on send also refocuses with the ring — `useInputMode` reports `"mouse"` for both a click and a keyboard Enter, and the two aren't distinguishable without threading a submit-source flag through `MessageComposer`'s public `onSubmit`.

## Test plan

- [x] `vitest run src/components/board src/components/composer` — 231 pass, including 5 new: the bar carries its own focus-ring classes; a mouse send closes `{refocus: true, quiet: false}`; a touch send closes `{refocus: true, quiet: true}`; a quiet close moves focus but withholds the ring and restores it on the next keystroke; a loud close does both
- [x] Both new focus tests verified failure-capable — neutralizing the guard reds them, restoring greens them
- [x] `bun run lint`, `bun run typecheck` — clean
- [ ] Not verified on a real Android device; the black-ring mechanism is inferred from the UA default + the `:focus-visible` programmatic-focus rule, matching the reported screenshot

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
