### PR TITLE
feat(sidebar): give the stream name the space the row is not using

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -4,8 +4,9 @@ import {
   useSidebar,
   useCoordinatedLoading,
   MIN_SIDEBAR_WIDTH,
-  MAX_SIDEBAR_WIDTH,
   SIDEBAR_COLLAPSE_THRESHOLD,
+  sidebarWidthCap,
+  clampSidebarWidth,
   type UrgencyBlock,
 } from "@/contexts"
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, useTouchCapable } from "@/hooks"
@@ -145,7 +146,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   const handleSidebarWidthChange = useCallback(
     (nextWidth: number) => {
       const willCollapse = nextWidth < SIDEBAR_COLLAPSE_THRESHOLD
-      const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, nextWidth))
+      const clampedWidth = clampSidebarWidth(nextWidth)
       const shellWidth = willCollapse ? "6px" : `${clampedWidth}px`
       shellRef.current?.style.setProperty("--nav-sidebar-width", `${clampedWidth}px`)
       shellRef.current?.style.setProperty("--nav-sidebar-shell-width", shellWidth)
@@ -446,7 +447,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
                   aria-orientation="vertical"
                   aria-valuenow={width}
                   aria-valuemin={MIN_SIDEBAR_WIDTH}
-                  aria-valuemax={MAX_SIDEBAR_WIDTH}
+                  aria-valuemax={sidebarWidthCap()}
                   aria-label="Resize sidebar"
                 />
               )}

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -186,6 +186,34 @@ describe("ScratchpadItem", () => {
     expect(screen.getByText("Labels…")).toBeInTheDocument()
   })
 
+  it("keeps the title's right reserve for the hover menu under mouse input, drops it under touch", () => {
+    const titleRow = () => screen.getByText("Notes").parentElement
+
+    const mouse = renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad()}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+    expect(titleRow()).toHaveClass("pr-8")
+    mouse.unmount()
+
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad()}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+    expect(titleRow()).not.toHaveClass("pr-8")
+  })
+
   it("copies the scratchpad's link", async () => {
     const writeText = vi.fn(async () => {})
     Object.assign(navigator, { clipboard: { writeText } })

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -334,7 +334,8 @@ export function ScratchpadItem({
                   showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
                 )}
               >
-                <div className="flex items-center gap-2 pr-8">
+                {/* Right reserve for the hover "…" menu only — see StreamItem. */}
+                <div className={cn("flex items-center gap-2", !isTouchInput && "pr-8")}>
                   {nameDecrypting ? (
                     <Skeleton className="h-4 w-28" />
                   ) : (

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -356,6 +356,31 @@ describe("StreamItem", () => {
     expect(screen.queryByRole("img", { name: "Unsent draft" })).not.toBeInTheDocument()
   })
 
+  it("spends the title's hover-menu reserve on the name under touch input", () => {
+    const stream = createStream()
+    const row = () => screen.getByText(/general/).parentElement
+    const renderRow = () =>
+      renderWithRouter(
+        <StreamItem
+          workspaceId="workspace_1"
+          stream={stream}
+          isActive={false}
+          unreadCount={0}
+          mentionCount={0}
+          allStreams={[stream]}
+        />
+      )
+
+    touchState.inputMode = "mouse"
+    const mouse = renderRow()
+    expect(row()).toHaveClass("pr-8")
+    mouse.unmount()
+
+    touchState.inputMode = "touch"
+    renderRow()
+    expect(row()).not.toHaveClass("pr-8")
+  })
+
   it("renders a desktop context-menu trigger for DMs", () => {
     touchState.inputMode = "mouse"
     touchState.touchCapable = false

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -654,7 +654,10 @@ export function StreamItem({
                   showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
                 )}
               >
-                <div className="flex items-center gap-2 pr-8">
+                {/* The right reserve exists only for the hover "…" menu, which never
+                    appears under touch input (long-press opens the drawer instead) —
+                    so a phone spends it on the name. */}
+                <div className={cn("flex items-center gap-2", !isTouchInput && "pr-8")}>
                   <span
                     className={cn(
                       "truncate text-sm",

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -62,6 +62,8 @@ export {
   MIN_SIDEBAR_WIDTH,
   MAX_SIDEBAR_WIDTH,
   SIDEBAR_COLLAPSE_THRESHOLD,
+  sidebarWidthCap,
+  clampSidebarWidth,
   type UrgencyBlock,
   type CollapseState,
 } from "./sidebar-context"

--- a/apps/frontend/src/contexts/sidebar-context.test.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.test.tsx
@@ -49,8 +49,11 @@ describe("SidebarContext.togglePinned (desktop)", () => {
 })
 
 describe("SidebarContext.setWidth", () => {
+  const viewportWidth = window.innerWidth
+
   beforeEach(() => {
     localStorage.removeItem(SIDEBAR_STATE_KEY)
+    window.innerWidth = viewportWidth
   })
 
   it("clamps a non-collapsing resize to the minimum width", () => {
@@ -70,6 +73,24 @@ describe("SidebarContext.setWidth", () => {
     act(() => result.current.setWidth(149))
 
     expect(result.current.state).toBe("collapsed")
+  })
+
+  it("clamps to the 500px ceiling on a wide window", () => {
+    window.innerWidth = 1600
+    const { result } = renderHook(() => useSidebar(), { wrapper })
+
+    act(() => result.current.setWidth(900))
+
+    expect(result.current.width).toBe(500)
+  })
+
+  it("clamps to half the window when that is narrower than the ceiling", () => {
+    window.innerWidth = 800
+    const { result } = renderHook(() => useSidebar(), { wrapper })
+
+    act(() => result.current.setWidth(900))
+
+    expect(result.current.width).toBe(400)
   })
 })
 

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -41,8 +41,22 @@ interface SidebarPersistedState {
 }
 
 export const MIN_SIDEBAR_WIDTH = 200
-export const MAX_SIDEBAR_WIDTH = 400
+export const MAX_SIDEBAR_WIDTH = 500
 export const SIDEBAR_COLLAPSE_THRESHOLD = MIN_SIDEBAR_WIDTH - 50
+
+/**
+ * The widest the sidebar may be right now: `min(500px, half the viewport)`. How
+ * wide is too wide is the user's call, but never more than half the window — on a
+ * small desktop window a flat 500px would swallow the content pane.
+ */
+export function sidebarWidthCap(viewportWidth?: number): number {
+  const viewport = viewportWidth ?? (typeof window === "undefined" ? MAX_SIDEBAR_WIDTH * 2 : window.innerWidth)
+  return Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, Math.round(viewport / 2)))
+}
+
+export function clampSidebarWidth(width: number): number {
+  return Math.max(MIN_SIDEBAR_WIDTH, Math.min(sidebarWidthCap(), width))
+}
 const DEFAULT_SIDEBAR_WIDTH = 260
 const SIDEBAR_STATE_KEY = "threa-sidebar-state"
 
@@ -177,8 +191,8 @@ function getStoredState(key: string): SidebarPersistedState {
       return {
         openState: parsed.openState === "collapsed" ? "collapsed" : "open",
         width:
-          typeof parsed.width === "number" && parsed.width >= MIN_SIDEBAR_WIDTH && parsed.width <= MAX_SIDEBAR_WIDTH
-            ? parsed.width
+          typeof parsed.width === "number" && parsed.width >= MIN_SIDEBAR_WIDTH
+            ? clampSidebarWidth(parsed.width)
             : DEFAULT_PERSISTED_STATE.width,
         sectionStates: readSectionStates(parsed),
       }
@@ -373,8 +387,7 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       })
 
       if (newWidth >= SIDEBAR_COLLAPSE_THRESHOLD) {
-        const clampedWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, newWidth))
-        updatePersistedState({ width: clampedWidth })
+        updatePersistedState({ width: clampSidebarWidth(newWidth) })
       }
     },
     [updatePersistedState]


### PR DESCRIPTION
## Problem

Two sidebar rows' worth of width goes unused. Every stream row reserves `pr-8` (2rem) on its title line for the hover "…" menu (`SidebarActionMenu`, `reveal-actions-hover-only`) — but that button is hidden under touch input, where a long-press opens `SidebarActionDrawer` instead. On a phone the reserve is dead space to the right of the label glyphs, and long generated scratchpad names ("CC - Conversations match…") truncate for no reason.

Separately, `MAX_SIDEBAR_WIDTH` was 400px, so a desktop user could not widen the sidebar enough for those names even though they own the drag handle.

## Solution

- `stream-item.tsx` / `scratchpad-item.tsx`: the title line takes `pr-8` only when `useInputMode() !== "touch"` — the same condition that decides whether the "…" trigger can appear. The `ml-auto` cluster (label dots, draft, mention) shifts right with it; the name gets the 2rem.
- `MAX_SIDEBAR_WIDTH` 400 → 500, capped at half the viewport: `sidebarWidthCap()` = `min(500, round(innerWidth / 2))`, applied through one `clampSidebarWidth()` used by the live drag (`app-shell`), `setWidth` persistence, and the stored-width read. Half-viewport over a flat 500 — the desktop layout starts at a 640px viewport (below that the sidebar is a `min(85vw, 320px)` overlay), where a flat 500 would leave 140px of content.
- The cap is read at clamp time, not tracked reactively: shrinking the window leaves an over-cap width until the next drag or reload. A resize listener for a rare case isn't worth it.
- Stored width outside the range is now clamped rather than reset to the 260 default.
- Switching input mode mid-session (mouse → touch on a convertible) reflows the row by 2rem. Deliberate: it's the same class of transition the hover-preview treatment already keys off, not a hint appearing over static content (INV-21).

## Test plan

- [x] `vitest run src/contexts/sidebar-context.test.tsx src/components/layout/` — 261 pass, incl. 3 new (touch drops the reserve on both row types; width clamps to 500 at 1600px and to 400 at 800px)
- [x] Each new test verified to fail when its change is neutralized
- [x] `bun run lint`, `bun run typecheck` — clean
- [ ] Not verified on a real phone — the screenshot that prompted this is the reference

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787856940&installation_model_id=20758&pr_number=1634&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1634&signature=a40452b3fcfb4f1e0318c164da9b99c4e56fa14508a27e8ed38aad7bad62c7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->