### PR TITLE
fix(harnessd): derive a spawned session's identity from its worktree, not the caller's env

### DIFF
--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -21,7 +21,7 @@ import {
   ClaudeRuntimeSpawner,
   PiRuntimeSpawner,
   RuntimeSpawnError,
-  claudeRuntimeIdentity,
+  deriveClaudeRuntimeIdentity,
   configuredThreaBaseUrl,
   readPiRemoteConfig,
   readPiRemoteSession,
@@ -356,7 +356,7 @@ export async function reviveAgent(
     if (agent.runtime === "pi" && targetRuntimeSessionId) {
       targetInstanceId ??= deps.piLink(targetRuntimeSessionId)?.instanceId
     } else if (agent.runtime === "claude" && !targetInstanceId && !targetRuntimeSessionId && agent.worktree) {
-      const derived = claudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
+      const derived = deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
       targetInstanceId = derived.instanceId
       targetRuntimeSessionId = derived.runtimeSessionId
     }
@@ -477,7 +477,7 @@ export async function reviveAgent(
     instanceId = piLink!.instanceId
     runtimeSessionId = agent.runtimeSessionId!
   } else {
-    const derived = claudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
+    const derived = deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
     instanceId = agent.instanceId ?? derived.instanceId
     runtimeSessionId = agent.runtimeSessionId ?? derived.runtimeSessionId
   }

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -20,6 +20,7 @@ import { acquireProcessLock } from "./lock"
 import {
   claudeLaunchArgs,
   claudeLaunchCommand,
+  deriveClaudeRuntimeIdentity,
   normalizeChannelMcpConfig,
   piLaunchArgs,
   piLaunchCommand,
@@ -987,5 +988,41 @@ test("reading a missing inventory creates nothing on disk", () => {
   } finally {
     if (previousPath === undefined) delete process.env.THREA_HARNESSD_INVENTORY
     else process.env.THREA_HARNESSD_INVENTORY = previousPath
+  }
+})
+
+test("a revival derives identity from the worktree, never from the caller's environment", async () => {
+  // Every Claude channel session exports THREA_INSTANCE_ID and
+  // THREA_RUNTIME_SESSION_ID in its launch env, so `harnessd` run from inside
+  // one used to mint that session's identity for a DIFFERENT worktree: the new
+  // session linked to the caller's scratchpad and overwrote its harness link.
+  // Observed live on 2026-07-28 by spawning `threa.test` from a channel session.
+  // The other tests scrub these keys before running, which is precisely what
+  // kept the bug invisible — this one sets them on purpose.
+  const saved = [process.env.THREA_INSTANCE_ID, process.env.THREA_RUNTIME_SESSION_ID] as const
+  process.env.THREA_INSTANCE_ID = "cc-someone-else"
+  process.env.THREA_RUNTIME_SESSION_ID = "ccs-someone-else"
+  const preflights: Array<{ instanceId: string; runtimeSessionId: string }> = []
+  try {
+    const deps = reviveDeps({
+      preflight: async (params) => {
+        preflights.push({ instanceId: params.instanceId, runtimeSessionId: params.runtimeSessionId })
+        return { status: "linked", rootStreamId: "stream_01ABCDEF" }
+      },
+    })
+    // No recorded identity, so it has to be derived from the worktree.
+    await reviveAgent(linkedAgent({ instanceId: undefined, runtimeSessionId: undefined }), {}, deps)
+
+    const derived = deriveClaudeRuntimeIdentity("/tmp/worktrees/repair")
+    expect(preflights).toEqual([{ instanceId: derived.instanceId, runtimeSessionId: derived.runtimeSessionId }])
+    expect(preflights[0]?.runtimeSessionId).not.toBe("ccs-someone-else")
+  } finally {
+    for (const [key, value] of [
+      ["THREA_INSTANCE_ID", saved[0]],
+      ["THREA_RUNTIME_SESSION_ID", saved[1]],
+    ] as const) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
   }
 })

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -297,7 +297,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     ensureTmuxSession(session)
     const { worktree, branch } = this.createWorktree(options)
     const config = readThreaChannelConfig()
-    const identity = claudeRuntimeIdentity(worktree, config)
+    const identity = deriveClaudeRuntimeIdentity(worktree, config)
     const partial: Partial<SpawnResult> = {
       worktree,
       branch,
@@ -359,7 +359,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     if (!existsSync(mcpConfig)) this.writeMcpConfig(agent.name, channel, channelEntry)
     normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
     const config = readThreaChannelConfig()
-    const derived = claudeRuntimeIdentity(agent.worktree, config)
+    const derived = deriveClaudeRuntimeIdentity(agent.worktree, config)
     const identity = {
       instanceId: agent.instanceId ?? derived.instanceId,
       runtimeSessionId: agent.runtimeSessionId ?? derived.runtimeSessionId,
@@ -505,18 +505,6 @@ export function deriveClaudeRuntimeIdentity(
   return {
     instanceId: sanitizeId(config.instanceId || stableId("cc", seed)).slice(0, 64),
     runtimeSessionId: sanitizeId(config.runtimeSessionId || stableId("ccs", seed)).slice(0, 64),
-  }
-}
-
-export function claudeRuntimeIdentity(
-  worktree: string,
-  config: ThreaChannelConfig = {},
-  host = hostname()
-): { instanceId: string; runtimeSessionId: string } {
-  const derived = deriveClaudeRuntimeIdentity(worktree, config, host)
-  return {
-    instanceId: sanitizeId(process.env.THREA_INSTANCE_ID || derived.instanceId).slice(0, 64),
-    runtimeSessionId: sanitizeId(process.env.THREA_RUNTIME_SESSION_ID || derived.runtimeSessionId).slice(0, 64),
   }
 }
 


### PR DESCRIPTION
## Problem

`claudeRuntimeIdentity` preferred `THREA_INSTANCE_ID` / `THREA_RUNTIME_SESSION_ID` from the process environment over the identity derived from the worktree:

```ts
instanceId: sanitizeId(process.env.THREA_INSTANCE_ID || derived.instanceId).slice(0, 64)
```

Every Claude channel session exports both in its launch env. So running `harnessd` **from inside a channel session** — the ordinary way to use it — minted the *caller's* identity for a different worktree.

Found by running the obvious end-to-end test on a freshly deployed harnessd: `spawn claude --name test` from a live channel session produced a `threa.test` session that

- carried the caller's `ccs-c2550c302cf2e8fb` instead of deriving its own,
- linked to the **caller's scratchpad** rather than getting a new one, and
- overwrote the caller's harness link record to point at `/threa.test`.

Two live processes then claimed one stream and one runtime session — the same shape as the duplicate storms this repo spent the evening on, reached by a completely different route.

## Solution

Every call site wanted the worktree's own identity, so the override is deleted rather than threaded around. `deriveClaudeRuntimeIdentity` — already the derivation used by `adopt` and `reconnect` — becomes the single one, and `claudeRuntimeIdentity` is gone (INV-38/INV-49: no deprecated alias).

A deployment that genuinely needs to pin an identity still can, via `instanceId`/`runtimeSessionId` in `~/.claude/threa-channel/config.json`, which `deriveClaudeRuntimeIdentity` honours. What is no longer possible is inheriting one by accident from whatever shell invoked harnessd.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/spawners.ts` | `claudeRuntimeIdentity` removed; `spawn`/`resume` derive from the worktree |
| `extensions/harness-daemon/src/commands.ts` | `reviveAgent` derives from the worktree |
| `extensions/harness-daemon/src/resume.test.ts` | regression test |

## Test plan

- [x] `bun test` in `extensions/harness-daemon` — 169 pass, 0 fail
- [x] `bun run typecheck` + repo lint/typecheck (pre-commit hook) — clean
- [x] Regression test verified non-vacuous: restoring the env override turns it red
- [x] The bug reproduced live before the fix, and the damage was reverted by hand (window killed, link record restored, inventory row removed)
- [ ] Post-merge live re-run of `spawn claude --name test` to confirm the new worktree gets its own scratchpad — the fix isn't live until `/threa` is pulled

Note on why this survived: the existing revival tests **delete** these env keys before running, which is exactly what kept it invisible. The new test sets them on purpose.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787858873&installation_model_id=20758&pr_number=1635&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1635&signature=640b11ac5d3e0c6caaa3c1ee86f77552c4ec8fd5a6b0908750e2e66c88c42e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->