### PR TITLE
fix(sidebar): align the Board/Chats entry row across modes, hide Customize sidebar on the board

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+import { render, screen } from "@/test"
+import * as Contexts from "@/contexts"
+import * as WorkspaceStore from "@/stores/workspace-store"
+import { setLastLocation } from "@/lib/last-location"
+import { BoardLinkRow, ChatsLinkRow } from "./board-link-row"
+
+const WS = "workspace_1"
+const USER = "user_1"
+
+function stub() {
+  vi.spyOn(Contexts, "useSidebar").mockReturnValue({
+    collapseOnMobile: vi.fn(),
+  } as unknown as ReturnType<typeof Contexts.useSidebar>)
+  vi.spyOn(WorkspaceStore, "useWorkspaceStreams").mockReturnValue([] as never)
+}
+
+function hrefOf(name: string): string {
+  return screen.getByRole("link", { name }).getAttribute("href") ?? ""
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  stub()
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe("ChatsLinkRow", () => {
+  it("points at the retained last stream", () => {
+    setLastLocation(USER, WS, { surface: "board", streamId: "stream_9", board: { search: "" } })
+    render(
+      <MemoryRouter>
+        <ChatsLinkRow workspaceId={WS} userId={USER} />
+      </MemoryRouter>
+    )
+    expect(hrefOf("Chats")).toBe(`/w/${WS}/s/stream_9`)
+  })
+
+  it("falls back to the workspace home when no stream was retained", () => {
+    render(
+      <MemoryRouter>
+        <ChatsLinkRow workspaceId={WS} userId={USER} />
+      </MemoryRouter>
+    )
+    expect(hrefOf("Chats")).toBe(`/w/${WS}`)
+  })
+})
+
+describe("BoardLinkRow", () => {
+  it("falls back to the bare board route when no board state was retained", () => {
+    render(
+      <MemoryRouter>
+        <BoardLinkRow workspaceId={WS} userId={USER} />
+      </MemoryRouter>
+    )
+    expect(hrefOf("Board")).toBe(`/w/${WS}/board`)
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
@@ -1,21 +1,24 @@
 import { Link } from "react-router-dom"
-import { ArrowRight, LayoutGrid } from "lucide-react"
+import { ArrowLeft, ArrowRight, LayoutGrid } from "lucide-react"
 import { useSidebar } from "@/contexts"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { buildBoardHref, getLastLocation } from "@/lib/last-location"
 
-interface BoardLinkRowProps {
+const ROW_CLASS =
+  "flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors text-muted-foreground hover:bg-muted/50"
+
+interface ModeLinkRowProps {
   workspaceId: string
-  /** The viewer's auth id — keys the last-location record for the board target. */
+  /** The viewer's auth id — keys the last-location record for the link target. */
   userId: string | null
 }
 
 /**
- * Chats-mode counterpart to BoardModeBlock's "← Chats" row: a first-class link
- * to the board, restoring the viewer's last board state. Same row styling as
- * "← Chats", and the href mirrors that block's `chatsHref` derivation.
+ * Chats-mode link to the board, restoring the viewer's last board state. Pairs
+ * with `ChatsLinkRow`: both sit at the same spot (above the quick links) so the
+ * cross-surface entry point doesn't move between modes.
  */
-export function BoardLinkRow({ workspaceId, userId }: BoardLinkRowProps) {
+export function BoardLinkRow({ workspaceId, userId }: ModeLinkRowProps) {
   const { collapseOnMobile } = useSidebar()
   const streams = useWorkspaceStreams(workspaceId)
 
@@ -30,14 +33,28 @@ export function BoardLinkRow({ workspaceId, userId }: BoardLinkRowProps) {
 
   return (
     <div className="mb-2 space-y-1">
-      <Link
-        to={boardHref}
-        onClick={collapseOnMobile}
-        className="flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors text-muted-foreground hover:bg-muted/50"
-      >
+      <Link to={boardHref} onClick={collapseOnMobile} className={ROW_CLASS}>
         <LayoutGrid className="h-4 w-4" />
         Board
         <ArrowRight className="ml-auto h-4 w-4" />
+      </Link>
+    </div>
+  )
+}
+
+/** Board-mode counterpart: back to the viewer's last stream (or the workspace
+ *  home when none was retained). */
+export function ChatsLinkRow({ workspaceId, userId }: ModeLinkRowProps) {
+  const { collapseOnMobile } = useSidebar()
+
+  const record = userId ? getLastLocation(userId, workspaceId) : null
+  const chatsHref = record?.streamId ? `/w/${workspaceId}/s/${record.streamId}` : `/w/${workspaceId}`
+
+  return (
+    <div className="mb-2 space-y-1">
+      <Link to={chatsHref} onClick={collapseOnMobile} className={ROW_CLASS}>
+        <ArrowLeft className="h-4 w-4" />
+        Chats
       </Link>
     </div>
   )

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -8,11 +8,9 @@ import * as ConversationsHooks from "@/hooks/use-conversations"
 import * as WorkspaceStore from "@/stores/workspace-store"
 import * as BoardExclusions from "@/stores/board-exclusions-store"
 import * as InputMode from "@/hooks/use-input-mode"
-import { setLastLocation } from "@/lib/last-location"
 import { BoardModeBlock } from "./board-mode-block"
 
 const WS = "workspace_1"
-const USER = "user_1"
 
 function view(over: Partial<BoardView> = {}): BoardView {
   return {
@@ -98,7 +96,7 @@ function mountAt(path: string, props: Partial<Parameters<typeof BoardModeBlock>[
   return render(
     <MemoryRouter initialEntries={[path]}>
       <LocationProbe />
-      <BoardModeBlock workspaceId={WS} userId={USER} {...props} />
+      <BoardModeBlock workspaceId={WS} {...props} />
     </MemoryRouter>
   )
 }
@@ -118,11 +116,10 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks())
 
 describe("BoardModeBlock", () => {
-  it("renders the ← Chats link, the Lenses section, and every lens", () => {
+  it("renders the Lenses section and every lens", () => {
     stub()
     mountAt(`/w/${WS}/board`)
 
-    expect(screen.getByText("Chats")).toBeInTheDocument()
     expect(screen.getByText("Lenses")).toBeInTheDocument()
     for (const label of ["All", "Active", "Needs resolution", "Decisions", "Mine"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument()
@@ -134,19 +131,6 @@ describe("BoardModeBlock", () => {
     mountAt(`/w/${WS}/board`)
 
     expect(screen.queryByText("Views")).not.toBeInTheDocument()
-  })
-
-  it("points ← Chats at the retained last stream", () => {
-    stub()
-    setLastLocation(USER, WS, { surface: "board", streamId: "stream_9", board: { search: "" } })
-    mountAt(`/w/${WS}/board`)
-    expect(hrefOf("Chats")).toBe(`/w/${WS}/s/stream_9`)
-  })
-
-  it("falls back to the workspace home when no stream was retained", () => {
-    stub()
-    mountAt(`/w/${WS}/board`)
-    expect(hrefOf("Chats")).toBe(`/w/${WS}`)
   })
 
   it("carries the current filters across every lens link", () => {

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { Link, useLocation, useSearchParams } from "react-router-dom"
-import { Archive, ArrowLeft, Bookmark, Check, CircleDot, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
+import { Archive, Bookmark, Check, CircleDot, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
 import { BOARD_LENSES, DEFAULT_BOARD_LENS, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { cn } from "@/lib/utils"
@@ -35,14 +35,11 @@ import {
   BOARD_UNREAD_PARAM,
 } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
-import { getLastLocation } from "@/lib/last-location"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { BoardFilterChips } from "./board-filter-chips"
 
 interface BoardModeBlockProps {
   workspaceId: string
-  /** The viewer's auth id — keys the last-location record for the "← Chats" target. */
-  userId: string | null
   /** Per-lens workspace topic totals for the Lenses row counts, from the sidebar's
    *  single stats pass; `null`/absent while it resolves (render no count). */
   lensTotals?: Record<BoardLens, number> | null
@@ -55,14 +52,14 @@ const SECTION_LABEL_CLASS =
 /**
  * The board block sits below the quick links in the sidebar while on `/board`
  * (board-centered-sidebar-exploration.md § V2 top blocks). Top-to-
- * bottom: a "← Chats" back link, the Filters group (the stream/type/label
+ * bottom: the Filters group (the stream/type/label
  * pickers + the unread/archived toggles the deleted filter header used to host),
  * the active-filter chips, the viewer's saved Views, and the board Lenses. Every
  * navigational entry is a `<Link>` — the board's whole state is URL
  * (INV-40/INV-59) — built with the same helpers the pickers use
  * (`lensHref`, `savedViewHref`) so the surfaces can't drift (INV-35).
  */
-export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlockProps) {
+export function BoardModeBlock({ workspaceId, lensTotals }: BoardModeBlockProps) {
   const { collapseOnMobile } = useSidebar()
   const location = useLocation()
   const prefs = usePreferencesOptional()
@@ -84,9 +81,6 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
 
   const sortedViews = useMemo(() => (views ? [...views].sort((a, b) => a.sortOrder - b.sortOrder) : []), [views])
 
-  const lastLocation = userId ? getLastLocation(userId, workspaceId) : null
-  const chatsHref = lastLocation?.streamId ? `/w/${workspaceId}/s/${lastLocation.streamId}` : `/w/${workspaceId}`
-
   const hasActiveFilters =
     selection.scopeStreamIds.length > 0 ||
     selection.scopeStreamTypes.length > 0 ||
@@ -101,15 +95,6 @@ export function BoardModeBlock({ workspaceId, userId, lensTotals }: BoardModeBlo
 
   return (
     <div className="mb-2 space-y-1">
-      <Link
-        to={chatsHref}
-        onClick={collapseOnMobile}
-        className={cn(ROW_CLASS, "text-muted-foreground hover:bg-muted/50")}
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Chats
-      </Link>
-
       <BoardModeFilters workspaceId={workspaceId} />
 
       {hasActiveFilters && <BoardFilterChips workspaceId={workspaceId} />}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -38,7 +38,7 @@ import { SidebarSearchPanel, useSearchPanel } from "@/components/search"
 import { SidebarHeader } from "./sidebar-header"
 import { SidebarQuickLinks } from "./quick-links"
 import { BoardModeBlock } from "./board-mode-block"
-import { BoardLinkRow } from "./board-link-row"
+import { BoardLinkRow, ChatsLinkRow } from "./board-link-row"
 import { SidebarStreamList } from "./sidebar-stream-list"
 import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skeletons"
 import { SidebarFooter } from "./sidebar-footer"
@@ -383,20 +383,18 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       unreadActivityCount={unreadActivityCount}
     />
   ) : null
-  // Board mode keeps the board block (its filters/views/lenses) available even
-  // when the user drops the quick-links section, so the quick links sit above it
-  // only when present. Chats mode pairs the `Board` entry row with the quick
-  // links and stays hidden without the section, as it always has.
+  // The cross-mode entry row sits at the same spot in both modes — above the
+  // quick links — so it doesn't move as the viewer crosses between them. Board
+  // mode keeps the board block (its filters/views/lenses) available even when the
+  // user drops the quick-links section; chats mode stays hidden without it, as it
+  // always has.
   let quickLinksSlot: ReactNode
   if (isBoardPage) {
     quickLinksSlot = (
       <>
+        <ChatsLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
         {quickLinks}
-        <BoardModeBlock
-          workspaceId={workspaceId}
-          userId={user?.id ?? null}
-          lensTotals={boardMode?.lensTotals ?? null}
-        />
+        <BoardModeBlock workspaceId={workspaceId} lensTotals={boardMode?.lensTotals ?? null} />
       </>
     )
   } else if (hasQuickLinksSection) {
@@ -657,7 +655,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           <SidebarHeader
             workspaceName={workspace?.name ?? ""}
             onEditLayout={() => setIsEditorOpen(true)}
-            hideViewToggle={!hasUserStreams}
+            hideViewToggle={!hasUserStreams || isBoardPage}
           />
         }
         body={


### PR DESCRIPTION
## Problem

The cross-mode entry row jumped position between the two sidebar modes: chats mode rendered `BoardLinkRow` ("Board →") above the quick links, board mode rendered "← Chats" *below* them, inside `BoardModeBlock`. Crossing between modes moved the only way back under seven quick-link rows.

Separately, "Customize sidebar" opens the layout editor (sections, quick links) — none of which the board sidebar renders, so on `/board` it opened a dialog with no effect on what's on screen.

## Solution

- `ChatsLinkRow` moves out of `BoardModeBlock` into `board-link-row.tsx` next to `BoardLinkRow`, sharing one `ROW_CLASS` and the same `getLastLocation` derivation. `sidebar.tsx` renders it above `{quickLinks}` in the board branch, mirroring the chats branch.
- `hideViewToggle={!hasUserStreams || isBoardPage}` on `SidebarHeader` — reuses the existing prop (and its trailing-spacer branch) rather than adding a second gate.
- `BoardModeBlock` loses its now-unused `userId` prop (INV-38); its two "← Chats" href tests move to a new `board-link-row.test.tsx`.

Deliberate: the editor is only hidden, not disabled — chats mode still reaches it, and the board sidebar's own layout stays non-configurable, as it was.

## Test plan

- [x] `vitest run src/components/layout` — 20 files, 241 pass
- [x] `bun run lint`, monorepo typecheck (lint-staged pre-commit) — clean
- [ ] not live-verified in a browser — the running dev stack is the main worktree, and this branch would need its own ports

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787860300&installation_model_id=20758&pr_number=1636&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1636&signature=fb565f6c75fc82d90f234cb014f120cc51211bce319300a837046c39b1e20f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->