### PR TITLE
chore(ci): run the four shared packages' tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,6 @@ jobs:
       - name: Run cli tests
         run: bun run --cwd packages/cli test
 
-      # These four ran nowhere before: three had no `test` script at all and
-      # agent-runtime's pointed at vitest while every file imports bun:test, so
-      # it failed 20/20 on load. 47 test files, none of them gating a merge.
       - name: Run shared package tests
         run: |
           bun run --cwd packages/types test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,16 @@ jobs:
       - name: Run cli tests
         run: bun run --cwd packages/cli test
 
+      # These four ran nowhere before: three had no `test` script at all and
+      # agent-runtime's pointed at vitest while every file imports bun:test, so
+      # it failed 20/20 on load. 47 test files, none of them gating a merge.
+      - name: Run shared package tests
+        run: |
+          bun run --cwd packages/types test
+          bun run --cwd packages/backend-common test
+          bun run --cwd packages/prosemirror test
+          bun run --cwd packages/agent-runtime test
+
   frontend-tests:
     name: Frontend Tests (${{ matrix.shard_index }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -375,7 +375,6 @@
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5",
-        "vitest": "^4.0.16",
       },
     },
     "packages/backend-common": {

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "bun test src/"
   },
   "dependencies": {
     "@langchain/core": "^1.1.5",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "bun-types": "latest",
-    "typescript": "^5",
-    "vitest": "^4.0.16"
+    "typescript": "^5"
   }
 }

--- a/packages/agent-runtime/src/ai/model-registry.test.ts
+++ b/packages/agent-runtime/src/ai/model-registry.test.ts
@@ -6,25 +6,18 @@ describe("ModelRegistry", () => {
 
   describe("getCapabilities", () => {
     test("returns capabilities for registered vision model", () => {
-      const caps = registry.getCapabilities("openrouter:anthropic/claude-sonnet-4.5")
+      const caps = registry.getCapabilities("openrouter:anthropic/claude-sonnet-5")
 
       expect(caps).toMatchObject({
-        name: "Claude Sonnet 4.5",
+        name: "Claude Sonnet 5",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
       })
     })
 
-    test("returns capabilities for text-only model", () => {
-      const caps = registry.getCapabilities("openrouter:openai/gpt-oss-120b")
-
-      expect(caps).toMatchObject({
-        name: "GPT-OSS 120B",
-        inputModalities: ["text"],
-        outputModalities: ["text"],
-      })
-    })
-
+    // No text-only *language* model is registered any more — every current
+    // generation accepts images. The embedding model below is the only
+    // text-input-only entry left, so it carries that coverage.
     test("returns capabilities for embedding model", () => {
       const caps = registry.getCapabilities("openrouter:openai/text-embedding-3-small")
 
@@ -44,16 +37,14 @@ describe("ModelRegistry", () => {
 
   describe("supportsVision", () => {
     test("returns true for models with image input modality", () => {
-      expect(registry.supportsVision("openrouter:anthropic/claude-sonnet-4.5")).toBe(true)
+      expect(registry.supportsVision("openrouter:anthropic/claude-sonnet-5")).toBe(true)
       expect(registry.supportsVision("openrouter:anthropic/claude-haiku-4.5")).toBe(true)
       expect(registry.supportsVision("openrouter:google/gemini-2.5-flash")).toBe(true)
-      expect(registry.supportsVision("openrouter:openai/gpt-5")).toBe(true)
-      expect(registry.supportsVision("openrouter:openai/gpt-5-mini")).toBe(true)
+      expect(registry.supportsVision("openrouter:openai/gpt-5.6-sol")).toBe(true)
+      expect(registry.supportsVision("openrouter:openai/gpt-5.4-mini")).toBe(true)
     })
 
-    test("returns false for text-only models", () => {
-      expect(registry.supportsVision("openrouter:openai/gpt-oss-120b")).toBe(false)
-      expect(registry.supportsVision("openrouter:openai/gpt-5-nano")).toBe(false)
+    test("returns false for models without image input", () => {
       expect(registry.supportsVision("openrouter:openai/text-embedding-3-small")).toBe(false)
     })
 
@@ -64,12 +55,12 @@ describe("ModelRegistry", () => {
 
   describe("supportsInputModality", () => {
     test("returns true when model supports the modality", () => {
-      expect(registry.supportsInputModality("openrouter:anthropic/claude-sonnet-4.5", "text")).toBe(true)
-      expect(registry.supportsInputModality("openrouter:anthropic/claude-sonnet-4.5", "image")).toBe(true)
+      expect(registry.supportsInputModality("openrouter:anthropic/claude-sonnet-5", "text")).toBe(true)
+      expect(registry.supportsInputModality("openrouter:anthropic/claude-sonnet-5", "image")).toBe(true)
     })
 
     test("returns false when model does not support the modality", () => {
-      expect(registry.supportsInputModality("openrouter:openai/gpt-oss-120b", "image")).toBe(false)
+      expect(registry.supportsInputModality("openrouter:openai/text-embedding-3-small", "image")).toBe(false)
     })
 
     test("returns false for unknown models", () => {
@@ -79,7 +70,7 @@ describe("ModelRegistry", () => {
 
   describe("supportsOutputModality", () => {
     test("returns true for text output on language models", () => {
-      expect(registry.supportsOutputModality("openrouter:anthropic/claude-sonnet-4.5", "text")).toBe(true)
+      expect(registry.supportsOutputModality("openrouter:anthropic/claude-sonnet-5", "text")).toBe(true)
     })
 
     test("returns true for embedding output on embedding models", () => {
@@ -87,7 +78,7 @@ describe("ModelRegistry", () => {
     })
 
     test("returns false for embedding output on language models", () => {
-      expect(registry.supportsOutputModality("openrouter:anthropic/claude-sonnet-4.5", "embedding")).toBe(false)
+      expect(registry.supportsOutputModality("openrouter:anthropic/claude-sonnet-5", "embedding")).toBe(false)
     })
 
     test("returns false for text output on embedding models", () => {
@@ -103,9 +94,8 @@ describe("ModelRegistry", () => {
     test("returns all registered model IDs", () => {
       const modelIds = registry.getModelIds()
 
-      expect(modelIds).toContain("openrouter:anthropic/claude-sonnet-4.5")
+      expect(modelIds).toContain("openrouter:anthropic/claude-sonnet-5")
       expect(modelIds).toContain("openrouter:anthropic/claude-haiku-4.5")
-      expect(modelIds).toContain("openrouter:openai/gpt-oss-120b")
       expect(modelIds).toContain("openrouter:openai/text-embedding-3-small")
       expect(modelIds.length).toBeGreaterThan(5)
     })

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/"
   },
   "dependencies": {
     "@threa/types": "workspace:*",

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/"
   },
   "dependencies": {
     "@threa/types": "workspace:*"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/"
   },
   "peerDependencies": {
     "typescript": "^5"


### PR DESCRIPTION
## Why

47 test files across four shared packages have never gated a merge.

- `packages/types` (15 files), `packages/backend-common` (9), `packages/prosemirror` (3) had **no `test` script at all**.
- `packages/agent-runtime` (20) had one, but it ran `vitest run` against files that every last one of which imports `bun:test` — **20/20 failed to load, "no tests"**. No CI job invoked it, so the breakage was invisible.

Found while wiring a feature whose deliverable tests land in `packages/types` and `packages/agent-runtime`: they'd have passed locally and never run in CI.

## What changed

- `test` script added to types, backend-common, prosemirror; agent-runtime's repointed from `vitest run` to `bun test src/`.
- One CI step in the Tests job runs all four.
- **Six real ModelRegistry failures**, surfaced by actually running the suite. The fixtures referenced `claude-sonnet-4.5`, `gpt-oss-120b`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano` — none survive in `models.yaml`. Repointed to models that exist.

Two of those assertions were **passing for the wrong reason**: `supportsVision("openrouter:openai/gpt-oss-120b") === false` held only because the registry returns `false` for anything it doesn't know. The model wasn't text-only; it was absent. The "text-only language model" case has no subject left at all now that every current generation accepts images, so it's gone and the embedding model carries that coverage.

## Verification

| Package | Before | After |
| --- | --- | --- |
| types | not run | 143 pass |
| backend-common | not run | 47 pass |
| prosemirror | not run | 151 pass |
| agent-runtime | 20/20 files failed to load | 290 pass |

`bun run lint` and `bun run typecheck` clean (0 errors, 15 packages).

## Residual risk

CI gets one more step (~5s). If any of these suites is flaky under load it will now block merges — that is the point, but it is a new gate on 47 previously-unrun files.

Bottom of a stack; the feature chunks build on it.
