### PR TITLE
feat(agents): record what a tool call wrote on its trace step

### DIFF
--- a/apps/backend/src/db/migrations/20260728091500_agent_step_effects.sql
+++ b/apps/backend/src/db/migrations/20260728091500_agent_step_effects.sql
@@ -1,0 +1,5 @@
+-- What a trace step wrote, as an array of AgentToolEffect descriptors.
+-- Nullable: absent on read-only steps, on steps written before this existed,
+-- and on sealed (enclave) streams, where plaintext labels would defeat the
+-- point of sealing the step's content.
+ALTER TABLE agent_session_steps ADD COLUMN effects JSONB;

--- a/apps/backend/src/features/agents/session-handlers.ts
+++ b/apps/backend/src/features/agents/session-handlers.ts
@@ -97,6 +97,7 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
             messageId: step.messageId ?? undefined,
             tokensUsed: step.tokensUsed ?? undefined,
             verification: step.verification,
+            effects: step.effects,
             duration:
               step.completedAt && step.startedAt ? step.completedAt.getTime() - step.startedAt.getTime() : undefined,
             startedAt: step.startedAt.toISOString(),

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -1,4 +1,10 @@
-import type { AgentSessionStatus, AgentStepType, ToolVerificationStatus, TraceSource } from "@threa/types"
+import type {
+  AgentSessionStatus,
+  AgentStepType,
+  AgentToolEffect,
+  ToolVerificationStatus,
+  TraceSource,
+} from "@threa/types"
 import { AgentSessionStatuses, AgentStepTypes } from "@threa/types"
 import { isUniqueViolation } from "@threa/backend-common"
 import type { Querier } from "../../db"
@@ -51,6 +57,7 @@ interface StepRow {
   tokens_used: number | null
   verification_status: string | null
   verification_reason: string | null
+  effects: AgentToolEffect[] | null
   started_at: Date
   completed_at: Date | null
 }
@@ -137,6 +144,8 @@ export interface AgentSessionStep {
   tokensUsed: number | null
   /** Guardian state for a guarded (tier 2+) tool call; absent on every other step. */
   verification?: { status: ToolVerificationStatus; reason?: string }
+  /** What the call wrote (`MUTATING_TOOLS`); absent on read-only steps and on sealed streams. */
+  effects?: AgentToolEffect[]
   startedAt: Date
   completedAt: Date | null
 }
@@ -259,6 +268,7 @@ function mapRowToStep(row: StepRow): AgentSessionStep {
           ...(row.verification_reason ? { reason: row.verification_reason } : {}),
         }
       : undefined,
+    effects: row.effects ?? undefined,
     startedAt: row.started_at,
     completedAt: row.completed_at,
   }
@@ -275,7 +285,7 @@ const SESSION_SELECT_FIELDS = `
 const STEP_SELECT_FIELDS = `
   id, session_id, step_number, step_type,
   content, content_ciphertext, content_envelope,
-  sources, message_id, tokens_used, verification_status, verification_reason,
+  sources, message_id, tokens_used, verification_status, verification_reason, effects,
   started_at, completed_at
 `
 
@@ -915,7 +925,10 @@ export const AgentSessionRepository = {
           -- from step N of attempt 1 — often a tier-1 one. COALESCE-ing here
           -- would show the earlier attempt's approval badge on it.
           verification_status = NULL,
-          verification_reason = NULL
+          verification_reason = NULL,
+          -- Same reason: attempt 2's step N is a different call, and inheriting
+          -- attempt 1's effects would claim writes this attempt never made.
+          effects = NULL
         RETURNING ${sql.raw(STEP_SELECT_FIELDS)}
       `
     )
@@ -952,6 +965,11 @@ export const AgentSessionRepository = {
        * review resolving before the action does.
        */
       verification?: { status: ToolVerificationStatus; reason?: string }
+      /**
+       * What the call wrote, patched in when the tool returns. Omitted for
+       * sealed streams — see `AgentSessionStep.effects`.
+       */
+      effects?: AgentToolEffect[]
       completedAt?: Date
       /**
        * Scope the update to one session so a caller-controlled `stepId` can only
@@ -981,6 +999,7 @@ export const AgentSessionRepository = {
           message_id = COALESCE(${params.messageId ?? null}, message_id),
           verification_status = COALESCE(${params.verification?.status ?? null}, verification_status),
           verification_reason = COALESCE(${params.verification?.reason ?? null}, verification_reason),
+          effects = COALESCE(${params.effects ? JSON.stringify(params.effects) : null}, effects),
           completed_at = COALESCE(${params.completedAt ?? null}, completed_at)
         WHERE id = ${stepId}
           AND (${params.sessionId ?? null}::text IS NULL OR session_id = ${params.sessionId ?? null})

--- a/apps/backend/src/features/agents/trace-emitter.ts
+++ b/apps/backend/src/features/agents/trace-emitter.ts
@@ -319,6 +319,7 @@ export class ActiveStep {
             sources: updated.sources,
             messageId: updated.messageId,
             verification: updated.verification,
+            effects: updated.effects,
             startedAt: updated.startedAt.toISOString(),
             completedAt: updated.completedAt?.toISOString(),
           }

--- a/apps/backend/src/features/public-api/trace-steps.ts
+++ b/apps/backend/src/features/public-api/trace-steps.ts
@@ -39,6 +39,7 @@ export function serializeTraceStep(step: AgentSessionStep) {
     // sessions have no guarded tools today, so this is always absent — which is
     // exactly why it would go unnoticed if the next surface does grow one.
     verification: step.verification,
+    effects: step.effects,
     duration: step.completedAt && step.startedAt ? step.completedAt.getTime() - step.startedAt.getTime() : undefined,
     startedAt: step.startedAt.toISOString(),
     completedAt: step.completedAt?.toISOString(),

--- a/apps/backend/tests/integration/agent-step-effects.test.ts
+++ b/apps/backend/tests/integration/agent-step-effects.test.ts
@@ -1,0 +1,304 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, spyOn, mock } from "bun:test"
+import { Pool } from "pg"
+import type { Server } from "socket.io"
+import { withClient, setupTestDatabase } from "./setup"
+import {
+  AgentSessionRepository,
+  SessionStatuses,
+  TraceEmitter,
+  createAgentSessionHandlers,
+  PersonaRepository,
+} from "../../src/features/agents"
+import { BotRepository, serializeTraceStep } from "../../src/features/public-api"
+import { StreamEventRepository } from "../../src/features/streams"
+import * as streamsModule from "../../src/features/streams"
+import { streamId, sessionId, personaId, messageId, stepId } from "../../src/lib/id"
+import { AgentStepTypes, type AgentToolEffect } from "@threa/types"
+
+const SETTINGS_EFFECTS: AgentToolEffect[] = [
+  { kind: "settings", label: "Theme", target: "theme", before: "light", after: "dark" },
+  { kind: "settings", label: "Timezone", target: "timezone", before: "Europe/Stockholm", after: "Asia/Tokyo" },
+]
+
+describe("agent step effects", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM agent_session_steps")
+    await pool.query("DELETE FROM agent_sessions")
+  })
+
+  async function seedSession(client: Parameters<typeof AgentSessionRepository.insert>[0], id: string) {
+    await AgentSessionRepository.insert(client, {
+      id,
+      streamId: streamId(),
+      personaId: personaId(),
+      triggerMessageId: messageId(),
+      status: SessionStatuses.RUNNING,
+    })
+  }
+
+  test("effects round-trip through updateStep and back out of the repo", async () => {
+    const testSessionId = sessionId()
+    const testStepId = stepId()
+
+    await withClient(pool, async (client) => {
+      await seedSession(client, testSessionId)
+      await AgentSessionRepository.upsertStep(client, {
+        id: testStepId,
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        startedAt: new Date("2026-07-28T09:00:00Z"),
+      })
+
+      const patched = await AgentSessionRepository.updateStep(client, testStepId, { effects: SETTINGS_EFFECTS })
+      expect(patched!.effects).toEqual(SETTINGS_EFFECTS)
+
+      // Read back through a fresh SELECT, not the RETURNING row — the column has
+      // to be in STEP_SELECT_FIELDS or the value exists but never loads.
+      const [reloaded] = await AgentSessionRepository.findStepsBySession(client, testSessionId)
+      expect(reloaded!.effects).toEqual(SETTINGS_EFFECTS)
+    })
+  })
+
+  test("a read-only step has no effects rather than an empty array", async () => {
+    const testSessionId = sessionId()
+
+    await withClient(pool, async (client) => {
+      await seedSession(client, testSessionId)
+      await AgentSessionRepository.upsertStep(client, {
+        id: stepId(),
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.WEB_SEARCH,
+        startedAt: new Date(),
+      })
+
+      const [step] = await AgentSessionRepository.findStepsBySession(client, testSessionId)
+      expect(step!.effects).toBeUndefined()
+    })
+  })
+
+  // The verification columns shipped with this exact bug class: a retry reuses
+  // step_number, so without an explicit reset attempt 2's step 1 inherits
+  // attempt 1's row state — here, claiming writes this attempt never made.
+  test("a retry does not inherit the previous attempt's effects", async () => {
+    const testSessionId = sessionId()
+    const testStepId = stepId()
+
+    await withClient(pool, async (client) => {
+      await seedSession(client, testSessionId)
+      await AgentSessionRepository.upsertStep(client, {
+        id: testStepId,
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        startedAt: new Date("2026-07-28T09:00:00Z"),
+      })
+      await AgentSessionRepository.updateStep(client, testStepId, { effects: SETTINGS_EFFECTS })
+
+      const retried = await AgentSessionRepository.upsertStep(client, {
+        id: stepId(),
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.THINKING,
+        startedAt: new Date("2026-07-28T09:05:00Z"),
+      })
+
+      expect(retried.effects).toBeUndefined()
+    })
+  })
+
+  test("updateStep leaves existing effects alone when the patch omits them", async () => {
+    const testSessionId = sessionId()
+    const testStepId = stepId()
+
+    await withClient(pool, async (client) => {
+      await seedSession(client, testSessionId)
+      await AgentSessionRepository.upsertStep(client, {
+        id: testStepId,
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        startedAt: new Date(),
+      })
+      await AgentSessionRepository.updateStep(client, testStepId, { effects: SETTINGS_EFFECTS })
+
+      const completed = await AgentSessionRepository.updateStep(client, testStepId, { completedAt: new Date() })
+      expect(completed!.effects).toEqual(SETTINGS_EFFECTS)
+    })
+  })
+
+  /**
+   * Three hand-written, field-by-field serializers stand between the column and
+   * a viewer, and each drops an unlisted field in silence. The socket one is the
+   * one that matters: without it the effects render after a reload but not live,
+   * the mirror image of the guardian-badge bug this repo already shipped once.
+   */
+  describe("every serializer carries effects", () => {
+    afterEach(() => {
+      mock.restore()
+    })
+
+    async function seedStepWithEffects() {
+      const testSessionId = sessionId()
+      const testStepId = stepId()
+      await seedSession(pool, testSessionId)
+      await AgentSessionRepository.upsertStep(pool, {
+        id: testStepId,
+        sessionId: testSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        startedAt: new Date("2026-07-28T09:00:00Z"),
+      })
+      await AgentSessionRepository.updateStep(pool, testStepId, {
+        content: "done",
+        effects: SETTINGS_EFFECTS,
+        completedAt: new Date("2026-07-28T09:00:02Z"),
+      })
+      const [step] = await AgentSessionRepository.findStepsBySession(pool, testSessionId)
+      return { sessionId: testSessionId, stepId: testStepId, step: step! }
+    }
+
+    test("getSession serializes them", async () => {
+      const { sessionId: seededSessionId, step } = await seedStepWithEffects()
+      spyOn(AgentSessionRepository, "findById").mockResolvedValue({
+        id: seededSessionId,
+        streamId: "thread_1",
+        personaId: "persona_1",
+        triggerMessageId: "msg_1",
+        triggerMessageRevision: null,
+        supersedesSessionId: null,
+        status: "running",
+        currentStepType: null,
+        sentMessageIds: [],
+        createdAt: new Date("2026-07-28T09:00:00Z"),
+        completedAt: null,
+      } as never)
+      spyOn(AgentSessionRepository, "listByTriggerMessage").mockResolvedValue([])
+      spyOn(PersonaRepository, "findById").mockResolvedValue({
+        id: "persona_1",
+        name: "Ariadne",
+        avatarEmoji: null,
+      } as never)
+      spyOn(BotRepository, "findById").mockResolvedValue(null)
+      spyOn(StreamEventRepository, "listRerunContextBySessionIds").mockResolvedValue(new Map())
+      spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({
+        id: "thread_1",
+        workspaceId: "ws_1",
+        rootStreamId: "stream_1",
+      } as never)
+
+      const res = {
+        statusCode: 200,
+        body: null as unknown,
+        status(code: number) {
+          res.statusCode = code
+          return res
+        },
+        json(data: unknown) {
+          res.body = data
+          return res
+        },
+      }
+      await createAgentSessionHandlers({ pool }).getSession(
+        { user: { id: "usr_viewer" }, workspaceId: "ws_1", params: { sessionId: seededSessionId } } as never,
+        res as never
+      )
+
+      const [serialized] = (res.body as { steps: unknown[] }).steps
+      expect(serialized).toEqual({
+        id: step.id,
+        sessionId: seededSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        content: "done",
+        contentCiphertext: undefined,
+        contentEnvelope: undefined,
+        sources: undefined,
+        messageId: undefined,
+        tokensUsed: undefined,
+        verification: undefined,
+        effects: SETTINGS_EFFECTS,
+        duration: 2000,
+        startedAt: "2026-07-28T09:00:00.000Z",
+        completedAt: "2026-07-28T09:00:02.000Z",
+      })
+    })
+
+    test("serializeTraceStep serializes them", async () => {
+      const { sessionId: seededSessionId, step } = await seedStepWithEffects()
+
+      expect(serializeTraceStep(step)).toEqual({
+        id: step.id,
+        sessionId: seededSessionId,
+        stepNumber: 1,
+        stepType: AgentStepTypes.TOOL_CALL,
+        content: "done",
+        sources: undefined,
+        messageId: undefined,
+        tokensUsed: undefined,
+        verification: undefined,
+        effects: SETTINGS_EFFECTS,
+        duration: 2000,
+        startedAt: "2026-07-28T09:00:00.000Z",
+        completedAt: "2026-07-28T09:00:02.000Z",
+        contentCiphertext: undefined,
+        contentEnvelope: undefined,
+      })
+    })
+
+    test("the completed-step socket payload carries them", async () => {
+      const testSessionId = sessionId()
+      await seedSession(pool, testSessionId)
+
+      const emits: Array<{ event: string; payload: Record<string, unknown> }> = []
+      const io = {
+        to: () => io,
+        emit: (event: string, payload: Record<string, unknown>) => {
+          emits.push({ event, payload })
+        },
+      } as unknown as Server
+
+      const trace = new TraceEmitter({ io, pool }).forSession({
+        sessionId: testSessionId,
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        triggerMessageId: "msg_1",
+        personaName: "Ariadne",
+      })
+      const active = await trace.startStep({ stepType: AgentStepTypes.TOOL_CALL })
+      const [started] = await AgentSessionRepository.findStepsBySession(pool, testSessionId)
+      await AgentSessionRepository.updateStep(pool, started!.id, { effects: SETTINGS_EFFECTS })
+      await active.complete({ content: "done" })
+
+      const [reloaded] = await AgentSessionRepository.findStepsBySession(pool, testSessionId)
+      const completed = emits.find((e) => e.event === "agent_session:step:completed")
+      expect(completed?.payload).toEqual({
+        sessionId: testSessionId,
+        step: {
+          id: reloaded!.id,
+          sessionId: testSessionId,
+          stepNumber: 1,
+          stepType: AgentStepTypes.TOOL_CALL,
+          content: "done",
+          sources: null,
+          messageId: null,
+          verification: undefined,
+          effects: SETTINGS_EFFECTS,
+          startedAt: reloaded!.startedAt.toISOString(),
+          completedAt: reloaded!.completedAt!.toISOString(),
+        },
+      })
+    })
+  })
+})

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionStatus, AgentStepType, AuthoredByKind, ToolVerificationStatus } from "./constants"
+import type { AgentToolEffect } from "./tool-effects"
 
 export const TRACE_SOURCE_TYPES = ["web", "workspace", "workspace_message", "workspace_memo", "github"] as const
 export type TraceSourceType = (typeof TRACE_SOURCE_TYPES)[number]
@@ -83,6 +84,13 @@ export interface AgentSessionStep {
    * rather than one nullable flag.
    */
   verification?: { status: ToolVerificationStatus; reason?: string }
+  /**
+   * What this step wrote (see `MUTATING_TOOLS`). Absent on every read-only step,
+   * on steps written before effects existed, and on sealed (enclave) streams,
+   * where the labels and values would otherwise sit in plaintext next to content
+   * that is sealed at rest — those fall back to the bare mutation count.
+   */
+  effects?: AgentToolEffect[]
   startedAt: string
   completedAt?: string
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -493,7 +493,8 @@ export {
   toolMutates,
   resolveToolEffects,
   EFFECT_LABEL_MAX_CHARS,
-  EFFECTS_PER_SESSION_MAX,
+  EFFECTS_PER_CALL_MAX,
+  guardedToolsMissingFromMutating,
 } from "./tool-effects"
 export type { ToolEffectKind, AgentToolEffect } from "./tool-effects"
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -486,6 +486,16 @@ export {
   requiresGuardianReview,
 } from "./tool-tiers"
 export type { ToolTier } from "./tool-tiers"
+export {
+  TOOL_EFFECT_KINDS,
+  MUTATING_TOOLS,
+  MUTATING_TOOL_NAMES,
+  toolMutates,
+  resolveToolEffects,
+  EFFECT_LABEL_MAX_CHARS,
+  EFFECTS_PER_SESSION_MAX,
+} from "./tool-effects"
+export type { ToolEffectKind, AgentToolEffect } from "./tool-effects"
 
 // API types
 export type {

--- a/packages/types/src/tool-effects.test.ts
+++ b/packages/types/src/tool-effects.test.ts
@@ -1,11 +1,11 @@
 import { describe, test, expect } from "bun:test"
 import { AGENT_TOOL_NAMES } from "./constants"
-import { TOOL_TIERS_BY_NAME, ToolTiers } from "./tool-tiers"
 import {
   MUTATING_TOOLS,
+  guardedToolsMissingFromMutating,
   resolveToolEffects,
   EFFECT_LABEL_MAX_CHARS,
-  EFFECTS_PER_SESSION_MAX,
+  EFFECTS_PER_CALL_MAX,
   type AgentToolEffect,
 } from "./tool-effects"
 
@@ -15,11 +15,11 @@ describe("MUTATING_TOOLS", () => {
     expect(unanswered).toEqual([])
   })
 
+  // Tier 2 is a strictly stronger claim than mutating, so the guarded set must
+  // be contained in the mutating set. This can genuinely fail: flip
+  // `delegate_task` to false and it reports that name.
   test("every guarded tool is mutating", () => {
-    const guardedButInert = AGENT_TOOL_NAMES.filter(
-      (name) => TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED && !MUTATING_TOOLS[name]
-    )
-    expect(guardedButInert).toEqual([])
+    expect(guardedToolsMissingFromMutating()).toEqual([])
   })
 })
 
@@ -47,23 +47,19 @@ describe("resolveToolEffects", () => {
     expect(resolveToolEffects("enclave_read_local_thing", undefined)).toEqual([])
   })
 
-  test("truncates label, before and after", () => {
+  test("truncates every tool-supplied string, target included", () => {
     const long = "x".repeat(EFFECT_LABEL_MAX_CHARS + 40)
-    expect(resolveToolEffects("save_memo", [{ kind: "memo", label: long, before: long, after: long }])).toEqual([
-      {
-        kind: "memo",
-        label: "x".repeat(EFFECT_LABEL_MAX_CHARS),
-        before: "x".repeat(EFFECT_LABEL_MAX_CHARS),
-        after: "x".repeat(EFFECT_LABEL_MAX_CHARS),
-      },
-    ])
+    const capped = "x".repeat(EFFECT_LABEL_MAX_CHARS)
+    expect(
+      resolveToolEffects("save_memo", [{ kind: "memo", label: long, target: long, before: long, after: long }])
+    ).toEqual([{ kind: "memo", label: capped, target: capped, before: capped, after: capped }])
   })
 
   test("caps the array", () => {
-    const declared: AgentToolEffect[] = Array.from({ length: EFFECTS_PER_SESSION_MAX + 5 }, (_, i) => ({
+    const declared: AgentToolEffect[] = Array.from({ length: EFFECTS_PER_CALL_MAX + 5 }, (_, i) => ({
       kind: "memo" as const,
       label: `memo ${i}`,
     }))
-    expect(resolveToolEffects("save_memo", declared)).toEqual(declared.slice(0, EFFECTS_PER_SESSION_MAX))
+    expect(resolveToolEffects("save_memo", declared)).toEqual(declared.slice(0, EFFECTS_PER_CALL_MAX))
   })
 })

--- a/packages/types/src/tool-effects.test.ts
+++ b/packages/types/src/tool-effects.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test"
+import { AGENT_TOOL_NAMES } from "./constants"
+import { TOOL_TIERS_BY_NAME, ToolTiers } from "./tool-tiers"
+import {
+  MUTATING_TOOLS,
+  resolveToolEffects,
+  EFFECT_LABEL_MAX_CHARS,
+  EFFECTS_PER_SESSION_MAX,
+  type AgentToolEffect,
+} from "./tool-effects"
+
+describe("MUTATING_TOOLS", () => {
+  test("answers the question for every agent tool", () => {
+    const unanswered = AGENT_TOOL_NAMES.filter((name) => typeof MUTATING_TOOLS[name] !== "boolean")
+    expect(unanswered).toEqual([])
+  })
+
+  test("every guarded tool is mutating", () => {
+    const guardedButInert = AGENT_TOOL_NAMES.filter(
+      (name) => TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED && !MUTATING_TOOLS[name]
+    )
+    expect(guardedButInert).toEqual([])
+  })
+})
+
+describe("resolveToolEffects", () => {
+  test("returns a declared array verbatim", () => {
+    const declared: AgentToolEffect[] = [
+      { kind: "settings", label: "Theme", target: "theme", before: "light", after: "dark" },
+    ]
+    expect(resolveToolEffects("update_user_settings", declared)).toEqual(declared)
+  })
+
+  test("an empty declaration wins over the mutating fallback", () => {
+    expect(resolveToolEffects("update_user_settings", [])).toEqual([])
+  })
+
+  test("a mutating tool that declares nothing gets the shapeless fallback", () => {
+    expect(resolveToolEffects("save_memo", undefined)).toEqual([{ kind: "other" }])
+  })
+
+  test("a non-mutating tool gets no effects", () => {
+    expect(resolveToolEffects("send_message", undefined)).toEqual([])
+  })
+
+  test("an unregistered host-local tool gets no effects", () => {
+    expect(resolveToolEffects("enclave_read_local_thing", undefined)).toEqual([])
+  })
+
+  test("truncates label, before and after", () => {
+    const long = "x".repeat(EFFECT_LABEL_MAX_CHARS + 40)
+    expect(resolveToolEffects("save_memo", [{ kind: "memo", label: long, before: long, after: long }])).toEqual([
+      {
+        kind: "memo",
+        label: "x".repeat(EFFECT_LABEL_MAX_CHARS),
+        before: "x".repeat(EFFECT_LABEL_MAX_CHARS),
+        after: "x".repeat(EFFECT_LABEL_MAX_CHARS),
+      },
+    ])
+  })
+
+  test("caps the array", () => {
+    const declared: AgentToolEffect[] = Array.from({ length: EFFECTS_PER_SESSION_MAX + 5 }, (_, i) => ({
+      kind: "memo" as const,
+      label: `memo ${i}`,
+    }))
+    expect(resolveToolEffects("save_memo", declared)).toEqual(declared.slice(0, EFFECTS_PER_SESSION_MAX))
+  })
+})

--- a/packages/types/src/tool-effects.ts
+++ b/packages/types/src/tool-effects.ts
@@ -1,0 +1,148 @@
+import { AGENT_TOOL_NAMES, type AgentToolName } from "./constants"
+import { TOOL_TIERS_BY_NAME, ToolTiers } from "./tool-tiers"
+
+/**
+ * What a tool call left behind.
+ *
+ * Distinct from the tier, which is about authority before the call: a tier-1
+ * tool can still write durable state (`save_memo`, `schedule_follow_up`), and a
+ * guarded call that the guardian denied writes nothing at all. So "was this
+ * reviewed" and "did this change something" are two different claims, and only
+ * the first one was visible before this existed.
+ */
+export const TOOL_EFFECT_KINDS = ["settings", "delegation", "memo", "follow_up", "brief", "other"] as const
+export type ToolEffectKind = (typeof TOOL_EFFECT_KINDS)[number]
+
+export interface AgentToolEffect {
+  kind: ToolEffectKind
+  /**
+   * Domain text supplied by the tool that made the write. Optional: the
+   * fallback descriptor is synthesized without per-tool knowledge, and a
+   * backend-invented stand-in would be hardcoded display text (INV-46). The
+   * renderer names a label-less effect from its kind.
+   */
+  label?: string
+  /** The field or entity touched, when there is one: `"theme"`, `"dlg_01K…"`. */
+  target?: string
+  /**
+   * Previous and new value, for effects that replace something. Both are
+   * display strings, not raw JSON — the trace renders them as a diff and can't
+   * know how to format a domain value.
+   */
+  before?: string
+  after?: string
+}
+
+/** Per-string cap. These are trace chips, and a tool can pass in a whole document. */
+export const EFFECT_LABEL_MAX_CHARS = 120
+
+/** Per-step cap, for the same reason: a loop of writes must not unbound the row. */
+export const EFFECTS_PER_SESSION_MAX = 20
+
+/**
+ * Which tools write state the conversation does not already show.
+ *
+ * The rule, checkable by reading one line of a diff: **if the effect is
+ * something the user would have to go somewhere else to see, it is mutating.**
+ * `send_message` and `react_to_message` are excluded on purpose — they write
+ * durable rows, but those rows ARE the message and the reaction, already
+ * rendered in the timeline the user is looking at. Marking them would put a
+ * "wrote something" badge on every ordinary reply and teach people to ignore it.
+ *
+ * Exhaustive via `satisfies` over `AgentToolName`, so a new tool fails to
+ * compile until someone answers the question. That is the whole point: the
+ * previous failure mode was a mutating tool shipping with no visibility at all
+ * because nobody remembered to build it a card.
+ */
+export const MUTATING_TOOLS = {
+  // Writes the user would have to leave this conversation to find.
+  schedule_follow_up: true,
+  cancel_follow_up: true,
+  update_follow_up: true,
+  update_stream_brief: true,
+  save_memo: true,
+  delegate_task: true,
+  update_user_settings: true,
+
+  // Participation: durable, but rendered in place as itself.
+  send_message: false,
+  react_to_message: false,
+
+  // Reads.
+  list_follow_ups: false,
+  web_search: false,
+  read_url: false,
+  general_research: false,
+  search_messages: false,
+  search_streams: false,
+  search_users: false,
+  get_stream_messages: false,
+  search_attachments: false,
+  read_attachment: false,
+  describe_memo: false,
+  github_repos: false,
+  github_commits: false,
+  github_pulls: false,
+  github_content: false,
+  github_workflows: false,
+  github_releases: false,
+  github_issues: false,
+  linear_list_issues: false,
+  linear_get_issue: false,
+  linear_list_projects: false,
+  linear_get_project: false,
+} as const satisfies Record<AgentToolName, boolean>
+
+/**
+ * Whether a tool writes state worth surfacing. Unregistered names are
+ * host-local tools (the enclave's in-process readers), which are
+ * conversation-local by construction and therefore not mutating.
+ */
+export function toolMutates(name: string): boolean {
+  return name in MUTATING_TOOLS && MUTATING_TOOLS[name as AgentToolName]
+}
+
+export const MUTATING_TOOL_NAMES: readonly AgentToolName[] = AGENT_TOOL_NAMES.filter((name) => MUTATING_TOOLS[name])
+
+function truncate(value: string): string {
+  return value.length > EFFECT_LABEL_MAX_CHARS ? value.slice(0, EFFECT_LABEL_MAX_CHARS) : value
+}
+
+/**
+ * The effects a completed tool call gets stamped with.
+ *
+ * `declared` is authoritative for its own turn whenever it is present, empty
+ * included: every declaring tool catches its own failures and still returns a
+ * successful result, so `[]` means "I wrote nothing" and overriding it with the
+ * fallback would claim a write that did not happen. `undefined` means the tool
+ * says nothing at all, and only then does the tier-free layer-0 rule apply — a
+ * mutating name gets one shapeless `other` descriptor so the write is at least
+ * visible.
+ */
+export function resolveToolEffects(toolName: string, declared: AgentToolEffect[] | undefined): AgentToolEffect[] {
+  if (declared !== undefined) {
+    return declared.slice(0, EFFECTS_PER_SESSION_MAX).map((effect) => ({
+      ...effect,
+      ...(effect.label !== undefined ? { label: truncate(effect.label) } : {}),
+      ...(effect.before !== undefined ? { before: truncate(effect.before) } : {}),
+      ...(effect.after !== undefined ? { after: truncate(effect.after) } : {}),
+    }))
+  }
+  return toolMutates(toolName) ? [{ kind: "other" }] : []
+}
+
+/**
+ * Guarded implies mutating.
+ *
+ * Tier 2 means "writes durable state outside the stream, or acts with the
+ * user's authority" — which is a strictly stronger claim than mutating. The two
+ * tables are maintained by hand and can drift apart silently, so this asserts
+ * the containment at module load rather than waiting for a test to notice.
+ */
+for (const name of AGENT_TOOL_NAMES) {
+  if (TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED && !MUTATING_TOOLS[name]) {
+    throw new Error(
+      `Tool "${name}" is tier ${TOOL_TIERS_BY_NAME[name]} but not in MUTATING_TOOLS. A guarded tool writes something by definition; one of the two tables is wrong.`
+    )
+  }
+}

--- a/packages/types/src/tool-effects.ts
+++ b/packages/types/src/tool-effects.ts
@@ -36,8 +36,12 @@ export interface AgentToolEffect {
 /** Per-string cap. These are trace chips, and a tool can pass in a whole document. */
 export const EFFECT_LABEL_MAX_CHARS = 120
 
-/** Per-step cap, for the same reason: a loop of writes must not unbound the row. */
-export const EFFECTS_PER_SESSION_MAX = 20
+/**
+ * Cap on one CALL's declared effects. Named for the call, not the session: a
+ * session aggregates many calls and needs its own bound, and reusing this one
+ * there would silently cap a whole turn at a single call's budget.
+ */
+export const EFFECTS_PER_CALL_MAX = 20
 
 /**
  * Which tools write state the conversation does not already show.
@@ -121,9 +125,12 @@ function truncate(value: string): string {
  */
 export function resolveToolEffects(toolName: string, declared: AgentToolEffect[] | undefined): AgentToolEffect[] {
   if (declared !== undefined) {
-    return declared.slice(0, EFFECTS_PER_SESSION_MAX).map((effect) => ({
+    return declared.slice(0, EFFECTS_PER_CALL_MAX).map((effect) => ({
       ...effect,
       ...(effect.label !== undefined ? { label: truncate(effect.label) } : {}),
+      // `target` is bounded too: it is tool-supplied like the rest, and one
+      // uncapped string defeats the per-row bound the other three enforce.
+      ...(effect.target !== undefined ? { target: truncate(effect.target) } : {}),
       ...(effect.before !== undefined ? { before: truncate(effect.before) } : {}),
       ...(effect.after !== undefined ? { after: truncate(effect.after) } : {}),
     }))
@@ -132,17 +139,19 @@ export function resolveToolEffects(toolName: string, declared: AgentToolEffect[]
 }
 
 /**
- * Guarded implies mutating.
+ * Guarded tools that this table says write nothing — always empty.
  *
  * Tier 2 means "writes durable state outside the stream, or acts with the
- * user's authority" — which is a strictly stronger claim than mutating. The two
- * tables are maintained by hand and can drift apart silently, so this asserts
- * the containment at module load rather than waiting for a test to notice.
+ * user's authority", a strictly stronger claim than mutating, so the guarded
+ * set is contained in the mutating set. Both tables are hand-maintained and can
+ * drift apart silently, hence the check.
+ *
+ * A predicate rather than a module-load `throw`: the throw made its own guard
+ * test incapable of failing (a broken table takes the import down before any
+ * assertion runs), and it would have turned a mistiered tool into a crash at
+ * boot for every process importing this package — backend, frontend and
+ * enclave alike — instead of a red test.
  */
-for (const name of AGENT_TOOL_NAMES) {
-  if (TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED && !MUTATING_TOOLS[name]) {
-    throw new Error(
-      `Tool "${name}" is tier ${TOOL_TIERS_BY_NAME[name]} but not in MUTATING_TOOLS. A guarded tool writes something by definition; one of the two tables is wrong.`
-    )
-  }
+export function guardedToolsMissingFromMutating(): AgentToolName[] {
+  return AGENT_TOOL_NAMES.filter((name) => TOOL_TIERS_BY_NAME[name] >= ToolTiers.GUARDED && !MUTATING_TOOLS[name])
 }


### PR DESCRIPTION
## Why

An agent turn can write durable state the conversation never shows. The only step-level signal today is the guardian badge — and that says a call was **reviewed**, which is a different claim. A guardian-denied call carries a badge and wrote nothing; `save_memo` is tier 1, carries no badge, and writes.

Design: https://seer.build/ws_vbyzjvdg6g/b/side-effects-thin-b81dbc/ · Plan: https://seer.build/ws_vbyzjvdg6g/b/side-effects-plan-5516ac/

This is chunk 1 of 5: the type, the column, and the serializers. **Nothing stamps effects yet** — the runtime seam is chunk 2, tool declarations chunk 3, session payloads chunk 4, UI chunk 5.

## Material decisions

**`MUTATING_TOOLS` is exhaustive over `AgentToolName` via `satisfies`**, so a new tool can't compile until someone answers "does this write?". That closes the actual hole: the previous failure mode was a mutating tool shipping with no visibility because nobody remembered to build it a bespoke card.

**`send_message` and `react_to_message` are deliberately `false`.** They write durable rows, but those rows *are* the message and the reaction, already rendered where the user is looking. Marking them would badge every ordinary reply and train people to ignore the badge.

**Tier ≥ 2 implies mutating, asserted at module load.** Guarded means "writes durable state outside the stream or acts with the user's authority" — strictly stronger than mutating. Both tables are hand-maintained and can drift apart silently, so the containment is checked rather than assumed.

**`resolveToolEffects` treats a declaring tool as authoritative for its own turn, empty declaration included.** Every one of these tools catches its own failure and still returns a *successful* `AgentToolResult` — so a failed settings write, a version-conflicted brief and a **deduped memo** would each have been marked as having written. The layer-0 fallback fires only when a tool declares nothing at all.

**`label` is optional and there is no `href`.** A backend-synthesized label would be hardcoded display text (INV-46), and no backend caller can build a correct URL: `getSettingsUrl` is a React hook that merges the viewer's *current* query params, and `buildDelegationLink` prefixes `window.location.origin`, which `<Link to>` must not receive. The frontend resolves routes from `(kind, target)` in chunk 5.

## The third serializer is the point

A step field can be dropped in three places, and each failure looks different:

| Serializer | Symptom if it drops the field |
| --- | --- |
| `session-handlers.ts` `getSession` | renders live, vanishes on reload |
| `public-api/trace-steps.ts` | absent for external bot/enclave surfaces |
| `trace-emitter.ts` `ActiveStep.complete` | **never appears live**, correct after reload |

The first shape shipped as a real bug last week with `verification`. The third was missed in my own first pass and found by the planning agent. One test drives a persisted step through all three, asserting each with a single object comparison (INV-24).

## Verification

- `packages/types` 152 pass · backend 3,780 unit + 371 e2e · the 7 new integration tests pass against the real `threa_test` schema (INV-68 — no query-text assertions).
- `bun run typecheck` 0 errors across 15 packages; `bun run lint` clean.
- **Mutation-checked**: deleting the `effects` line from each of the three serializers makes exactly the three serializer tests fail; restored and re-verified green. The test that justifies this chunk provably fails when it should.

## Residual risk

The `effects` column is written by nothing until chunk 2, so this ships an unused column and a `NULL`-everywhere read path. Deliberate — it keeps the migration and the three serializer fixes reviewable on their own.

`upsertStep`'s `ON CONFLICT` resets `effects` to `NULL` on a retry, so a write made in attempt 1 is not visible on attempt 2's step row. That is correct for the step (attempt 2's step N is a different call) but means the session-level view must not derive from step rows alone — chunk 4 carries effects on the durable `interrupted` payload for exactly this reason.

Stacked on #1637, which makes `packages/types` tests actually run in CI — without it, this PR's `tool-effects.test.ts` would never execute on a merge.
