### PR TITLE
feat(board): give the conversation panel the timeline's composer and scroll behaviour

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { CornerDownRight, X } from "lucide-react"
 import { toast } from "sonner"
@@ -10,7 +10,7 @@ import {
   ScheduledMessagesPicker,
   StashedDraftsPicker,
   useFloatingComposerAnchor,
-  FLOATING_COMPOSER_HEIGHT_VAR,
+  useFloatingComposerHeight,
   type ComposerControlHandle,
 } from "@/components/composer"
 import { useIsMobileOrCoarse } from "@/hooks/use-pointer"
@@ -295,26 +295,11 @@ export function InlineComposerForm({
   // bottom space while the composer floats over it. Ownership-tagged: during a
   // slot hand-off the outgoing form unmounts after the incoming one has already
   // measured, and must not wipe the incoming form's value.
-  const shellRef = useRef<HTMLDivElement>(null)
-  useLayoutEffect(() => {
-    if (!holdsFloatingSlot || !anchorEl) return
-    const shell = shellRef.current
-    if (!shell) return
-    const write = () => {
-      anchorEl.style.setProperty(FLOATING_COMPOSER_HEIGHT_VAR, `${Math.ceil(shell.getBoundingClientRect().height)}px`)
-      anchorEl.dataset.floatingComposerOwner = formId
-    }
-    write()
-    const ro = new ResizeObserver(write)
-    ro.observe(shell)
-    return () => {
-      ro.disconnect()
-      if (anchorEl.dataset.floatingComposerOwner === formId) {
-        anchorEl.style.removeProperty(FLOATING_COMPOSER_HEIGHT_VAR)
-        delete anchorEl.dataset.floatingComposerOwner
-      }
-    }
-  }, [holdsFloatingSlot, anchorEl, formId])
+  const shellRef = useFloatingComposerHeight({
+    anchorEl,
+    ownerId: formId,
+    active: holdsFloatingSlot && anchorEl != null,
+  })
 
   // Keep the reply target visible: the marker sits where the form would render
   // in place, so scrolling it into view parks the tail of the conversation above

--- a/apps/frontend/src/components/composer/index.ts
+++ b/apps/frontend/src/components/composer/index.ts
@@ -5,6 +5,7 @@ export {
   useFloatingComposerAnchor,
   FLOATING_COMPOSER_HEIGHT_VAR,
 } from "./floating-composer-anchor"
+export { useFloatingComposerHeight } from "./use-floating-composer-height"
 export { StashedDraftsPicker } from "./stashed-drafts-picker"
 export { ScheduledMessagesPicker } from "./scheduled-messages-picker"
 export { ContextRefStrip } from "./context-ref-strip"

--- a/apps/frontend/src/components/composer/use-floating-composer-height.test.tsx
+++ b/apps/frontend/src/components/composer/use-floating-composer-height.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render } from "@testing-library/react"
+import { FLOATING_COMPOSER_HEIGHT_VAR } from "./floating-composer-anchor"
+import { useFloatingComposerHeight } from "./use-floating-composer-height"
+
+type ResizeCallback = () => void
+
+const observers: ResizeCallback[] = []
+class ManualResizeObserver {
+  constructor(cb: ResizeCallback) {
+    observers.push(cb)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ManualResizeObserver as unknown as typeof ResizeObserver
+
+afterEach(() => {
+  observers.length = 0
+  vi.restoreAllMocks()
+})
+
+/** A shell whose measured height is driven by the test. */
+function Shell({
+  anchorEl,
+  ownerId,
+  height,
+  active = true,
+  onHeightChange,
+}: {
+  anchorEl: HTMLElement
+  ownerId: string
+  height: { current: number }
+  active?: boolean
+  onHeightChange?: (px: number, opts: { initial: boolean }) => void
+}) {
+  const ref = useFloatingComposerHeight({ anchorEl, ownerId, active, onHeightChange })
+  return (
+    <div
+      ref={(node) => {
+        if (node) node.getBoundingClientRect = () => ({ height: height.current }) as DOMRect
+        ref.current = node
+      }}
+    />
+  )
+}
+
+function makeAnchor() {
+  const el = document.createElement("div")
+  document.body.appendChild(el)
+  return el
+}
+
+describe("useFloatingComposerHeight", () => {
+  it("publishes a non-zero height and tags the anchor with its owner id", () => {
+    const anchor = makeAnchor()
+    render(<Shell anchorEl={anchor} ownerId="owner-a" height={{ current: 84 }} />)
+
+    expect({
+      height: anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR),
+      owner: anchor.dataset.floatingComposerOwner,
+    }).toEqual({ height: "84px", owner: "owner-a" })
+  })
+
+  it("cleanup leaves a newer owner's height in place", () => {
+    const anchor = makeAnchor()
+    const a = render(<Shell anchorEl={anchor} ownerId="owner-a" height={{ current: 84 }} />)
+    render(<Shell anchorEl={anchor} ownerId="owner-b" height={{ current: 140 }} />)
+    a.unmount()
+
+    expect({
+      height: anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR),
+      owner: anchor.dataset.floatingComposerOwner,
+    }).toEqual({ height: "140px", owner: "owner-b" })
+  })
+
+  it("never publishes a zero height", () => {
+    const anchor = makeAnchor()
+    const height = { current: 84 }
+    render(<Shell anchorEl={anchor} ownerId="owner-a" height={height} />)
+
+    height.current = 0
+    for (const trigger of observers) trigger()
+
+    expect(anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR)).toBe("84px")
+  })
+
+  it("fires onHeightChange with initial:true exactly once, before any resize tick", () => {
+    const anchor = makeAnchor()
+    const height = { current: 84 }
+    const onHeightChange = vi.fn()
+    render(<Shell anchorEl={anchor} ownerId="owner-a" height={height} onHeightChange={onHeightChange} />)
+
+    expect(onHeightChange.mock.calls).toEqual([[84, { initial: true }]])
+
+    // A resize tick at the same height is not a change; a real growth is.
+    for (const trigger of observers) trigger()
+    height.current = 120
+    for (const trigger of observers) trigger()
+
+    expect(onHeightChange.mock.calls).toEqual([
+      [84, { initial: true }],
+      [120, { initial: false }],
+    ])
+  })
+
+  it("re-activating does not report initial again", () => {
+    const anchor = makeAnchor()
+    const height = { current: 84 }
+    const onHeightChange = vi.fn()
+    const view = render(<Shell anchorEl={anchor} ownerId="owner-a" height={height} onHeightChange={onHeightChange} />)
+
+    view.rerender(
+      <Shell anchorEl={anchor} ownerId="owner-a" height={height} active={false} onHeightChange={onHeightChange} />
+    )
+    view.rerender(<Shell anchorEl={anchor} ownerId="owner-a" height={height} onHeightChange={onHeightChange} />)
+
+    expect(onHeightChange.mock.calls.filter(([, opts]) => opts.initial)).toEqual([[84, { initial: true }]])
+  })
+
+  it("no-ops entirely while inactive", () => {
+    const anchor = makeAnchor()
+    const onHeightChange = vi.fn()
+    render(
+      <Shell
+        anchorEl={anchor}
+        ownerId="owner-a"
+        height={{ current: 84 }}
+        active={false}
+        onHeightChange={onHeightChange}
+      />
+    )
+
+    expect({
+      height: anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR),
+      owner: anchor.dataset.floatingComposerOwner,
+      calls: onHeightChange.mock.calls.length,
+    }).toEqual({ height: "", owner: undefined, calls: 0 })
+  })
+})

--- a/apps/frontend/src/components/composer/use-floating-composer-height.ts
+++ b/apps/frontend/src/components/composer/use-floating-composer-height.ts
@@ -1,0 +1,85 @@
+import { useLayoutEffect, useRef, type RefObject } from "react"
+import { FLOATING_COMPOSER_HEIGHT_VAR } from "./floating-composer-anchor"
+
+interface UseFloatingComposerHeightOptions {
+  /** Anchor element the height is published on (the positioned slot container). */
+  anchorEl: HTMLElement | null | undefined
+  /** Identity written to `dataset.floatingComposerOwner` while this shell owns the slot. */
+  ownerId: string
+  /** False while this shell does not hold the floating slot — the effect no-ops. */
+  active: boolean
+  /**
+   * Fired for the first measurement of this mount (`initial: true`, inside the
+   * layout effect, before paint) and afterwards whenever the published height
+   * changes. Same contract as `useComposerHeightPublish`, so a surface can
+   * re-pin its scroller without touching `:root`.
+   */
+  onHeightChange?: (px: number, opts: { initial: boolean }) => void
+}
+
+/**
+ * Publishes a floating composer shell's height to
+ * {@link FLOATING_COMPOSER_HEIGHT_VAR} on the anchor, so the anchor's scrollable
+ * content can reserve bottom space while the composer floats over it.
+ *
+ * Ownership-tagged: during a slot hand-off the outgoing form unmounts after the
+ * incoming one has already measured, and must not wipe the incoming form's
+ * value. A measured height of 0 (a hidden shell) is never written for the same
+ * reason.
+ */
+export function useFloatingComposerHeight({
+  anchorEl,
+  ownerId,
+  active,
+  onHeightChange,
+}: UseFloatingComposerHeightOptions): RefObject<HTMLDivElement | null> {
+  const shellRef = useRef<HTMLDivElement>(null)
+  // Held in a ref so a new callback identity each render doesn't tear down and
+  // re-create the ResizeObserver (which would re-fire the initial measure).
+  const onHeightChangeRef = useRef(onHeightChange)
+  onHeightChangeRef.current = onHeightChange
+  // Per-mount, not per-activation: the slot is claimed and released repeatedly
+  // (mobile branch composer, new sub-topic), and consumers treat `initial` as a
+  // licence to force-scroll. Only the first published measurement of this
+  // mount's lifetime may carry it.
+  const hasPublished = useRef(false)
+
+  useLayoutEffect(() => {
+    if (!active || !anchorEl) return
+    const shell = shellRef.current
+    if (!shell) return
+
+    let lastPublished: number | null = null
+    let isInitialMeasure = true
+
+    const write = () => {
+      const px = Math.ceil(shell.getBoundingClientRect().height)
+      // A later 0 is a shell on its way out (a hand-off collapsing this pill) —
+      // writing it would wipe the incoming owner's reservation. The first
+      // measurement still publishes: this effect only runs while the shell holds
+      // the slot, so there is no value of anyone else's to clobber.
+      if (px <= 0 && lastPublished !== null) return
+      anchorEl.style.setProperty(FLOATING_COMPOSER_HEIGHT_VAR, `${px}px`)
+      anchorEl.dataset.floatingComposerOwner = ownerId
+      if (isInitialMeasure || px !== lastPublished) {
+        onHeightChangeRef.current?.(px, { initial: isInitialMeasure && !hasPublished.current })
+      }
+      lastPublished = px
+      isInitialMeasure = false
+      hasPublished.current = true
+    }
+
+    write()
+    const ro = new ResizeObserver(write)
+    ro.observe(shell)
+    return () => {
+      ro.disconnect()
+      if (anchorEl.dataset.floatingComposerOwner === ownerId) {
+        anchorEl.style.removeProperty(FLOATING_COMPOSER_HEIGHT_VAR)
+        delete anchorEl.dataset.floatingComposerOwner
+      }
+    }
+  }, [active, anchorEl, ownerId])
+
+  return shellRef
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -1,7 +1,8 @@
+import { useEffect } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render, screen, waitFor, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { MemoryRouter } from "react-router-dom"
+import { MemoryRouter, useNavigate } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 import { ConversationPanel } from "./conversation-panel"
@@ -26,6 +27,11 @@ import * as boardReplyComposerModule from "@/components/board/board-reply-compos
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as stashedDraftsModule from "@/hooks/use-stashed-drafts"
 import { boardReplyDraftKey } from "@/lib/board/draft-keys"
+import {
+  FLOATING_COMPOSER_HEIGHT_VAR,
+  useFloatingComposerAnchor,
+  useFloatingComposerHeight,
+} from "@/components/composer"
 import {
   requestConversationReplyOpen,
   resetConversationReplyOpenStoreCache,
@@ -91,32 +97,89 @@ function asCached(post: BoardPost): BoardViewPost {
   return { ...post, id: post.conversation.id, workspaceId: WORKSPACE_ID, _lastActivityMs: 0, _cachedAt: 0 }
 }
 
+/**
+ * jsdom has no layout: give every element a scrollable box and a real scrollTop
+ * so the panel's scroll wiring (which reads/writes exactly those three) is
+ * observable. Restored per test.
+ */
+function installScrollMetrics({ scrollHeight = 1000, clientHeight = 300 } = {}) {
+  const tops = new WeakMap<HTMLElement, number>()
+  const descriptors = {
+    scrollHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight"),
+    clientHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight"),
+    scrollTop: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollTop"),
+  }
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", { configurable: true, get: () => scrollHeight })
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => clientHeight })
+  Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return tops.get(this) ?? 0
+    },
+    set(this: HTMLElement, value: number) {
+      tops.set(this, value)
+    },
+  })
+  return () => {
+    for (const [name, descriptor] of Object.entries(descriptors)) {
+      if (descriptor) Object.defineProperty(HTMLElement.prototype, name, descriptor)
+      else delete (HTMLElement.prototype as unknown as Record<string, unknown>)[name]
+    }
+  }
+}
+
+function scroller(): HTMLElement {
+  const el = document.querySelector<HTMLElement>(".overflow-y-auto")
+  if (!el) throw new Error("panel scroller not found")
+  return el
+}
+
 function mountPanel(opts: {
   cached?: BoardViewPost | null
+  /** Per-conversation store rows, for a switch between two open conversations. */
+  cachedById?: Record<string, BoardViewPost>
   getBoardPost?: () => Promise<BoardPost>
   getBoardMessages?: () => Promise<BoardPostMessage[]>
   /** `?m=` deep-link target appended to the panel URL. */
   highlightMessageId?: string
   /** `?stash=` drafts-explorer restore param appended to the panel URL. */
   stashParam?: string
+  /** Conversation the panel opens on (defaults to the shared fixture id). */
+  conversationId?: string
 }) {
   const getBoardPost = vi.fn(opts.getBoardPost ?? (async () => makePost()))
   const getBoardMessages = vi.fn(
     opts.getBoardMessages ?? (async () => [makeMessage({ id: "msg_2", contentMarkdown: "Reply two body." })])
   )
-  vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(opts.cached as never)
+  if (opts.cachedById) {
+    const byId = opts.cachedById
+    vi.spyOn(boardStoreModule, "useBoardPost").mockImplementation(((id: string | null) =>
+      id ? (byId[id] ?? null) : null) as never)
+  } else {
+    vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(opts.cached as never)
+  }
 
   const mParam =
     (opts.highlightMessageId ? `&m=${opts.highlightMessageId}` : "") +
     (opts.stashParam ? `&stash=${opts.stashParam}` : "")
+  const startId = opts.conversationId ?? CONVERSATION_ID
+  // Captures the router's navigate so a test can switch the panel to another
+  // conversation in place (initialEntries only apply at mount).
+  const nav: { openConversation: (id: string) => void } = { openConversation: () => {} }
+  function Navigator() {
+    const navigate = useNavigate()
+    nav.openConversation = (id) => navigate(`/w/${WORKSPACE_ID}/board?panel=conv:${id}`)
+    return null
+  }
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <ServicesProvider services={{ conversations: { getBoardPost, getBoardMessages } as never }}>
           <SidebarProvider>
-            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${CONVERSATION_ID}${mParam}`]}>
+            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${startId}${mParam}`]}>
               <PanelProvider>
+                <Navigator />
                 <ConversationPanel workspaceId={WORKSPACE_ID} onClose={vi.fn()} />
               </PanelProvider>
             </MemoryRouter>
@@ -125,7 +188,7 @@ function mountPanel(opts: {
       </TooltipProvider>
     </QueryClientProvider>
   )
-  return { getBoardPost, getBoardMessages }
+  return { getBoardPost, getBoardMessages, nav }
 }
 
 beforeEach(() => {
@@ -173,6 +236,12 @@ afterEach(() => {
 })
 
 describe("ConversationPanel", () => {
+  let restoreRect: (() => void) | null = null
+  afterEach(() => {
+    restoreRect?.()
+    restoreRect = null
+  })
+
   it("renders the conversation from the reactive store row without a by-id fetch", async () => {
     const { getBoardPost } = mountPanel({ cached: asCached(makePost()) })
     expect(await screen.findByText("Opening message body.")).toBeTruthy()
@@ -474,6 +543,151 @@ describe("ConversationPanel", () => {
       rootStreamId: "stream_1",
       sourceMessageId: "msg_1",
     })
+  })
+
+  it("opens at the tail of the conversation", async () => {
+    const restore = installScrollMetrics()
+    try {
+      mountPanel({ cached: asCached(makePost()) })
+      await screen.findByText("Reply two body.")
+      await waitFor(() => expect(scroller().scrollTop).toBe(1000))
+    } finally {
+      restore()
+    }
+  })
+
+  it("re-anchors to the tail when the panel switches to another conversation", async () => {
+    const restore = installScrollMetrics()
+    try {
+      const second = makePost()
+      second.conversation = { ...second.conversation, id: "conv_2" }
+      second.openingMessage = makeMessage({ id: "msg_9", contentMarkdown: "Second conversation opener." })
+      second.recentMessages = []
+      second.totalReplies = 0
+      const { nav } = mountPanel({
+        cachedById: { [CONVERSATION_ID]: asCached(makePost()), conv_2: asCached(second) },
+      })
+      await screen.findByText("Reply two body.")
+
+      // Park the user mid-list, then switch conversations: without resetKey the
+      // new conversation would inherit this scroll state and open mid-list.
+      // The wait outlasts the hook's 150ms post-programmatic-scroll grace, in
+      // which a scroll event does not clear the follow flag.
+      const el = scroller()
+      await new Promise((r) => setTimeout(r, 200))
+      el.scrollTop = 0
+      act(() => fireEvent.scroll(el))
+
+      act(() => nav.openConversation("conv_2"))
+      await screen.findByText("Second conversation opener.")
+      await waitFor(() => expect(scroller().scrollTop).toBe(1000))
+    } finally {
+      restore()
+    }
+  })
+
+  it("keeps the deep-linked row when the backfill lands", async () => {
+    const restore = installScrollMetrics()
+    try {
+      const post = makePost()
+      // Rail is short of the server's count → the panel backfills, growing the
+      // row list after first paint.
+      post.totalReplies = 3
+      mountPanel({
+        cached: asCached(post),
+        highlightMessageId: "msg_2",
+        getBoardMessages: async () => [
+          makeMessage({ id: "msg_2", contentMarkdown: "Reply two body." }),
+          makeMessage({ id: "msg_3", contentMarkdown: "Backfilled reply three." }),
+          makeMessage({ id: "msg_4", contentMarkdown: "Backfilled reply four." }),
+        ],
+      })
+      await screen.findByText("Backfilled reply four.")
+
+      expect(scroller().scrollTop).toBe(0)
+    } finally {
+      restore()
+    }
+  })
+
+  it("renders the reply composer in the shared floating shell, not a bordered footer", async () => {
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation(() => (
+      <div data-testid="docked-composer" />
+    ))
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    const composer = screen.getByTestId("docked-composer")
+    expect(composer.closest(".absolute.inset-x-0.bottom-0")).toBeTruthy()
+    expect(composer.closest(".border-t")).toBeNull()
+  })
+
+  it("hides the root pill and keeps a non-zero bottom reservation while a branch composer holds the anchor", async () => {
+    // The stub stands in for a branch composer that claims the floating slot and
+    // publishes its own height through the shared hook — the hand-off R2 is about.
+    const originalRect = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = () => ({ height: 64 }) as DOMRect
+    restoreRect = () => {
+      HTMLElement.prototype.getBoundingClientRect = originalRect
+    }
+    function BranchClaimant() {
+      const anchor = useFloatingComposerAnchor()
+      const anchorEl = anchor?.el ?? null
+      const claim = anchor?.claim
+      useEffect(() => {
+        claim?.("branch")
+      }, [claim])
+      const shellRef = useFloatingComposerHeight({
+        anchorEl,
+        ownerId: "branch",
+        active: anchor?.claimantId === "branch",
+      })
+      return <div ref={shellRef} data-testid="branch-pill" />
+    }
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation(() => <BranchClaimant />)
+
+    mountPanel({ cached: asCached(makePost()) })
+    const pill = await screen.findByTestId("branch-pill")
+
+    await waitFor(() => {
+      const anchorEl = document.querySelector<HTMLElement>("[data-floating-composer-owner]")
+      expect(anchorEl?.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR)).toBe("64px")
+    })
+    // The root pill is display:none while the branch owns the slot.
+    expect(pill.closest("div.hidden")).toBeTruthy()
+  })
+
+  it("shows Jump to latest only when scrolled far from the bottom, and returns to the tail on click", async () => {
+    const restore = installScrollMetrics()
+    try {
+      const user = userEvent.setup()
+      // Enough rows that 10 rows' worth of scroll is inside the 1000px box —
+      // the button's threshold is item-count relative.
+      const post = makePost()
+      post.recentMessages = Array.from({ length: 40 }, (_, i) =>
+        makeMessage({ id: `msg_${i + 2}`, contentMarkdown: `Reply ${i + 2} body.` })
+      )
+      post.conversation = { ...post.conversation, messageIds: ["msg_1", ...post.recentMessages.map((m) => m.id)] }
+      post.totalReplies = post.recentMessages.length
+      mountPanel({ cached: asCached(post), getBoardMessages: async () => post.recentMessages })
+      await screen.findByText(`Reply ${post.recentMessages.length + 1} body.`)
+      expect(screen.queryByRole("button", { name: "Jump to latest" })).toBeNull()
+
+      // The browser emits a scroll event once the opening bottom-pin settles;
+      // jsdom does not, and that event is what releases the force-scroll guard.
+      const el = scroller()
+      act(() => fireEvent.scroll(el))
+      el.scrollTop = 0
+      act(() => fireEvent.scroll(el))
+
+      const jump = await screen.findByRole("button", { name: "Jump to latest" })
+      await user.click(jump)
+
+      expect(el.scrollTop).toBe(1000)
+      await waitFor(() => expect(screen.queryByRole("button", { name: "Jump to latest" })).toBeNull())
+    } finally {
+      restore()
+    }
   })
 
   it("shows an (edited) indicator and a See revisions action on an edited row", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -11,6 +11,7 @@ import {
   Link2,
   Check,
   CircleCheck,
+  ArrowDown,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -48,7 +49,9 @@ import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer, type ArmedReply } from "@/components/board/board-reply-composer"
 import {
   FloatingComposerAnchorProvider,
+  FloatingComposerShell,
   useFloatingComposerAnchor,
+  useFloatingComposerHeight,
   FLOATING_COMPOSER_HEIGHT_VAR,
 } from "@/components/composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
@@ -64,6 +67,7 @@ import { useStreamFromStore } from "@/stores/stream-store"
 import { consumeConversationReplyOpen, subscribeConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { conversationKeys, useConversationBoardPost, useSplitThread } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
+import { useScrollBehavior } from "@/hooks/use-scroll-behavior"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
 import { buildConversationLink } from "@/lib/stream-links"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
@@ -569,11 +573,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         conversationId={conversation.id}
         conversationRootStreamId={conversation.streamId}
         isHighlighted={message.id === highlightMessageId}
-        // Break the row out of the list's px-4 and re-pad it, so an actor accent
-        // fills to the panel edges (the stream-view look) with content aligned —
-        // matching the board card and timeline.
-        surfaceClassName="bg-background px-4"
-        rowInsetClassName="-mx-4"
+        // Break the row out of the column's padding and re-pad it, so an actor
+        // accent fills to the column edges (the stream-view look) with content
+        // aligned — matching the board card and timeline.
+        surfaceClassName="bg-background px-3 sm:px-6"
+        rowInsetClassName="-mx-3 sm:-mx-6"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
         onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id)}
       />
@@ -626,7 +630,51 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
 
   // True while any of the panel's composers (footer reply, branch tail, new
   // sub-topic) floats in the mobile pill over this panel.
-  const floatingComposerOpen = useFloatingComposerAnchor()?.claimantId != null
+  const anchor = useFloatingComposerAnchor()
+  const anchorEl = anchor?.el ?? null
+  const floatingComposerOpen = anchor?.claimantId != null
+
+  const { scrollContainerRef, handleScroll, isScrolledFarFromBottom, scrollToBottom } = useScrollBehavior({
+    isLoading: loadingMore,
+    itemCount: rows.length,
+    resetKey: conversation.id,
+    // Only treat the user as "at the bottom" when they are essentially flush, so
+    // a small scroll-up to reference an older reply while typing is not snapped
+    // back when the composer grows (thread-path parity).
+    bottomThreshold: 4,
+    skipInitialScroll: highlightMessageId != null,
+  })
+  // Both consumers of `listRef` (text-selection quoting, viewport auto-read) are
+  // keyed to the scroller node, so the two refs name the same element.
+  const attachListRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      listRef.current = node
+      scrollContainerRef.current = node
+    },
+    [scrollContainerRef]
+  )
+
+  // The pill is absolutely positioned, so its growth changes only the scroller's
+  // padding-bottom — the scroller's own ResizeObserver never sees it. Re-pin from
+  // the published height instead: forced pre-paint on the first measurement (the
+  // opening anchor correction), and follow-flag-respecting afterwards so a user
+  // scrolled up to read history is not yanked to the tail.
+  const scrollToBottomRef = useRef(scrollToBottom)
+  scrollToBottomRef.current = scrollToBottom
+  const handleComposerHeightChange = useCallback(
+    (_px: number, opts: { initial: boolean }) => {
+      if (highlightMessageId != null) return
+      if (opts.initial) scrollToBottomRef.current({ force: true })
+      else requestAnimationFrame(() => scrollToBottomRef.current())
+    },
+    [highlightMessageId]
+  )
+  const shellRef = useFloatingComposerHeight({
+    anchorEl,
+    ownerId: "panel-root",
+    active: !floatingComposerOpen && anchorEl != null,
+    onHeightChange: handleComposerHeightChange,
+  })
 
   // Viewport auto-read: every rendered row is eligible. While older replies are
   // still backfilling, the cutoff through a rendered row also covers the not-
@@ -651,45 +699,66 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
         {moveToSubtopic.moveDialog}
         <div
-          ref={listRef}
+          ref={attachListRef}
+          onScroll={handleScroll}
           // pt-4 reserves headroom for the first row's hover toolbar, which floats
           // ~14px above its row (MessageItem's float-above chip). Without it the
           // scroll container's top edge clips the first message's toolbar — the
           // stream timeline reserves the same room via its header spacer.
-          className="min-h-0 flex-1 overflow-y-auto px-4 pt-4"
-          // pb-3 baseline, plus room for the mobile floating composer while one
-          // is open so the conversation tail can scroll above the pill.
+          className="min-h-0 flex-1 overflow-y-auto pt-4"
+          // pb-3 baseline, plus room for the floating composer pill so the
+          // conversation tail can scroll above it.
           style={{ paddingBottom: `calc(var(${FLOATING_COMPOSER_HEIGHT_VAR}, 0px) + 0.75rem)` }}
         >
-          {provenance && (
-            <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
-          )}
-          <BranchedBoardRows
-            rows={rows}
-            workspaceId={workspaceId}
-            renderMessage={renderMessage}
-            continueThreadTo={(streamId) => getPanelUrl(streamId)}
-            onSplitThread={(threadStreamId) => splitThread.mutate({ conversationId: conversation.id, threadStreamId })}
-            renderBranchMessage={renderBranchMessage}
-            renderBranchTail={inlineComposer.renderBranchTail}
-            renderAfterMessage={inlineComposer.renderAfterMessage}
-          />
-          {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
-          {backfillFailed && (
-            <button
-              type="button"
-              onClick={() => void refetchMessages()}
-              className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
-            >
-              Couldn't load the full conversation. Retry.
-            </button>
-          )}
+          <div className="mx-auto w-full min-w-0 max-w-[800px] px-3 sm:px-6">
+            {provenance && (
+              <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
+            )}
+            <BranchedBoardRows
+              rows={rows}
+              workspaceId={workspaceId}
+              renderMessage={renderMessage}
+              continueThreadTo={(streamId) => getPanelUrl(streamId)}
+              onSplitThread={(threadStreamId) =>
+                splitThread.mutate({ conversationId: conversation.id, threadStreamId })
+              }
+              renderBranchMessage={renderBranchMessage}
+              renderBranchTail={inlineComposer.renderBranchTail}
+              renderAfterMessage={inlineComposer.renderAfterMessage}
+            />
+            {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
+            {backfillFailed && (
+              <button
+                type="button"
+                onClick={() => void refetchMessages()}
+                className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+              >
+                Couldn't load the full conversation. Retry.
+              </button>
+            )}
+          </div>
         </div>
+        {isScrolledFarFromBottom && (
+          <div
+            className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2"
+            style={{ bottom: `calc(var(${FLOATING_COMPOSER_HEIGHT_VAR}, 0px) + 0.5rem)` }}
+          >
+            <Button
+              variant="secondary"
+              size="sm"
+              className="pointer-events-auto gap-1.5 shadow-lg"
+              onClick={() => scrollToBottom({ force: true })}
+            >
+              <ArrowDown className="h-3.5 w-3.5" />
+              Jump to latest
+            </Button>
+          </div>
+        )}
         {/* Hidden while a mobile composer floats over the panel (the pill replaces
             the footer's affordance; a second bottom bar under it would double up).
             `hidden`, not unmount — the reply composer inside must stay mounted to
             keep its portal, draft, and open state alive. */}
-        <div className={cn("border-t px-4 py-3", floatingComposerOpen && "hidden")}>
+        <FloatingComposerShell ref={shellRef} hidden={floatingComposerOpen}>
           <BoardReplyComposer
             workspaceId={workspaceId}
             post={post}
@@ -703,7 +772,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
             alwaysDocked
             armedReply={armedReply}
           />
-        </div>
+        </FloatingComposerShell>
       </QuoteReplyProvider>
     </ConversationReadProvider>
   )

--- a/apps/frontend/src/hooks/use-scroll-behavior.test.tsx
+++ b/apps/frontend/src/hooks/use-scroll-behavior.test.tsx
@@ -28,7 +28,7 @@ function makeScrollableDiv(initial: { scrollHeight: number; clientHeight: number
   const el = document.createElement("div")
   let scrollTop = initial.scrollTop ?? 0
   let clientHeight = initial.clientHeight
-  const scrollHeight = initial.scrollHeight
+  let scrollHeight = initial.scrollHeight
   Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight })
   Object.defineProperty(el, "clientHeight", {
     configurable: true,
@@ -48,6 +48,9 @@ function makeScrollableDiv(initial: { scrollHeight: number; clientHeight: number
     },
     setClientHeight: (h: number) => {
       clientHeight = h
+    },
+    setScrollHeight: (h: number) => {
+      scrollHeight = h
     },
   }
 }
@@ -159,6 +162,86 @@ describe("useScrollBehavior", () => {
     } finally {
       restore()
     }
+  })
+
+  it("skipInitialScroll leaves the list at the top on first content", () => {
+    const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+    const options = { isLoading: false, itemCount: 0, skipInitialScroll: true }
+    const ref: { current: HookApi | undefined } = { current: undefined }
+    function Probe({ itemCount }: { itemCount: number }) {
+      const api = useScrollBehavior({ ...options, itemCount })
+      api.scrollContainerRef.current = scrollable.el
+      ref.current = api
+      return null
+    }
+    const { rerender } = render(<Probe itemCount={0} />)
+    rerender(<Probe itemCount={5} />)
+
+    expect(scrollable.scrollTop).toBe(0)
+  })
+
+  it("skipInitialScroll does not disable a later forced scrollToBottom", () => {
+    const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+    const apiRef = renderHookWithElement({ isLoading: false, itemCount: 5, skipInitialScroll: true }, scrollable.el)
+    expect(scrollable.scrollTop).toBe(0)
+
+    act(() => apiRef.current.scrollToBottom({ force: true }))
+    expect(scrollable.scrollTop).toBe(5000)
+  })
+
+  it("scrolls to the bottom on first content when the option is omitted (thread path)", () => {
+    const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+    const ref: { current: HookApi | undefined } = { current: undefined }
+    function Probe({ itemCount }: { itemCount: number }) {
+      const api = useScrollBehavior({ isLoading: false, itemCount })
+      api.scrollContainerRef.current = scrollable.el
+      ref.current = api
+      return null
+    }
+    const { rerender } = render(<Probe itemCount={0} />)
+    rerender(<Probe itemCount={5} />)
+
+    expect(scrollable.scrollTop).toBe(5000)
+  })
+
+  it("re-anchors to the bottom when resetKey changes with an unchanged itemCount", () => {
+    const scrollable = makeScrollableDiv({ scrollHeight: 4000, clientHeight: 800 })
+    const ref: { current: HookApi | undefined } = { current: undefined }
+    function Probe({ resetKey, itemCount }: { resetKey: string; itemCount: number }) {
+      const api = useScrollBehavior({ isLoading: false, itemCount, resetKey })
+      api.scrollContainerRef.current = scrollable.el
+      ref.current = api
+      return null
+    }
+    const { rerender } = render(<Probe resetKey="conv_a" itemCount={0} />)
+    rerender(<Probe resetKey="conv_a" itemCount={12} />)
+    expect(scrollable.scrollTop).toBe(4000)
+
+    // Conversation B is taller but happens to have the same row count.
+    scrollable.setScrollHeight(9000)
+    rerender(<Probe resetKey="conv_b" itemCount={12} />)
+
+    expect(scrollable.scrollTop).toBe(9000)
+  })
+
+  it("flipping skipInitialScroll true→false does not reset scroll state", () => {
+    const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+    const ref: { current: HookApi | undefined } = { current: undefined }
+    function Probe({ skipInitialScroll, itemCount }: { skipInitialScroll: boolean; itemCount: number }) {
+      const api = useScrollBehavior({ isLoading: false, itemCount, resetKey: "conv_a", skipInitialScroll })
+      api.scrollContainerRef.current = scrollable.el
+      ref.current = api
+      return null
+    }
+    const { rerender } = render(<Probe skipInitialScroll itemCount={5} />)
+    scrollable.el.scrollTop = 1000
+
+    // `?m=` is stripped from the URL 3s after a deep link lands; the panel is
+    // still parked on the deep-linked row and must stay there.
+    rerender(<Probe skipInitialScroll={false} itemCount={5} />)
+    rerender(<Probe skipInitialScroll={false} itemCount={6} />)
+
+    expect(scrollable.scrollTop).toBe(1000)
   })
 
   it("anchors to the bottom on resize when shouldAutoScroll is true", () => {

--- a/apps/frontend/src/hooks/use-scroll-behavior.ts
+++ b/apps/frontend/src/hooks/use-scroll-behavior.ts
@@ -26,6 +26,13 @@ interface UseScrollBehaviorOptions {
   triggerItemCount?: number
   /** When this key changes, all scroll state resets (e.g. streamId). */
   resetKey?: string
+  /**
+   * Start (and re-start on every `resetKey` change) with auto-scroll off, so
+   * neither the initial scroll nor an append steals the viewport — for surfaces
+   * opened on a specific row (a `?m=` deep link) whose own scroll must win.
+   * A forced `scrollToBottom` still works.
+   */
+  skipInitialScroll?: boolean
 }
 
 interface UseScrollBehaviorReturn {
@@ -61,6 +68,7 @@ export function useScrollBehavior({
   bottomThreshold = 100,
   triggerItemCount = Math.floor(EVENT_PAGE_SIZE * SCROLL_FETCH_RATIO),
   resetKey,
+  skipInitialScroll = false,
 }: UseScrollBehaviorOptions): UseScrollBehaviorReturn {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const shouldAutoScroll = useRef(true)
@@ -81,13 +89,18 @@ export function useScrollBehavior({
   // from falsely clearing shouldAutoScroll when content grows rapidly (the native
   // scroll event fires before the new scrollTop settles).
   const lastProgrammaticScrollAt = useRef(0)
+  // Read through a ref so the reset below keys on `resetKey` alone: the option is
+  // derived from live URL state (`?m=`), which other surfaces strip while the
+  // panel is open — a dep on it would re-reset scroll mid-conversation.
+  const skipInitialScrollRef = useRef(skipInitialScroll)
+  skipInitialScrollRef.current = skipInitialScroll
 
   // Reset all scroll state when the content source changes (e.g. stream switch).
   // Must be useLayoutEffect (not useEffect) so the reset runs synchronously
   // BEFORE the scroll-adjustment useLayoutEffect below — otherwise the scroll
   // logic reads stale prevItemCount from the old stream.
   useLayoutEffect(() => {
-    shouldAutoScroll.current = true
+    shouldAutoScroll.current = !skipInitialScrollRef.current
     prevItemCount.current = 0
     prevScrollHeight.current = 0
     prevIsFetchingOlder.current = false
@@ -160,7 +173,10 @@ export function useScrollBehavior({
         scrollToBottom()
       }
     }
-  }, [isLoading, itemCount, scrollToBottom, isFetchingOlder])
+    // `resetKey` is a dep so a conversation switch re-anchors even when the new
+    // content has the same itemCount: the reset effect above just set
+    // prevItemCount to 0, and only a run of this effect consumes that.
+  }, [isLoading, itemCount, scrollToBottom, isFetchingOlder, resetKey])
 
   // Capture previous-render values AFTER the adjustment effect has read them.
   // No dep array → runs every render, defined after adjustment so it runs second.


### PR DESCRIPTION
Chunk 1 of 5 — [conversation panel ⇄ timeline parity](https://seer.build/ws_vbyzjvdg6g/b/conv-parity-plan-3d138c/).

## Problem

`StreamPanel` renders `<StreamContent />`, so a thread panel inherits every timeline behaviour for free. The conversation panel (`?panel=conv:<id>`) hand-rolled its surface instead: a bare `overflow-y-auto` div and a `border-t` footer composer. It contained **no scroll logic at all** — no `scrollTo`, no `onScroll`, no `ResizeObserver`. `listRef` existed only for text-selection quoting and viewport auto-read.

Everything reported follows from that: the panel opened at `scrollTop = 0`, never followed the tail, never re-anchored when the mobile keyboard opened, and had no jump-to-latest. On a phone the message you had just sent was clipped behind the composer — what you were replying to and what you wrote were both hidden.

## Solution

The panel owns a `FloatingComposerShell` the way `MessageInput` does, and adopts `useScrollBehavior` — already the authority for `StreamContent`'s thread scroller — so open-at-bottom, tail-follow, keyboard re-anchor and jump-to-latest all come from one implementation.

- **`useFloatingComposerHeight`** (new) — the ownership-tagged height publish that was inlined in `board-inline-composer.tsx` is extracted and shared (INV-35), so the panel's root pill and a branch pill hand the anchor's `--floating-composer-height` reservation back and forth through one code path. `board-inline-composer.test.tsx` is unedited and green, which is the proof the extraction preserved behaviour.
- **Publishes to the anchor, not `:root`** — `useComposerHeightPublish` over `FLOATING_COMPOSER_HEIGHT_VAR` was rejected: it writes `document.documentElement` and localStorage last-writer-wins, and the panel is mounted *beside* the timeline via `PanelHost`. Using it would hand the call dock the wrong bottom offset and poison the timeline's persisted boot fallback.
- **Composer growth re-pins through `onHeightChange`, not the scroller's observer** — once the pill is `absolute`, growing it changes only `padding-bottom`, which `useScrollBehavior`'s container observer never sees. Forced pre-paint on the first measurement, `requestAnimationFrame` + the un-forced `scrollToBottom` afterwards, so a user scrolled up to read history is not yanked back.
- **`skipInitialScroll`** (additive, default `false`) — the panel passes it when `?m=` is present so the new auto-scroll doesn't fight `MessageItem`'s existing deep-link `scrollIntoView`. Read through a ref inside the reset effect, deliberately **not** a dep: `m` is not panel-owned (`stream-content.tsx` strips it 3s after a deep link lands, "works for both the main view and panels"), so a dep would re-reset scroll state mid-conversation and throw the reader to the tail on the next arriving row.
- **`resetKey` joins the adjustment effect's deps** — the reset effect zeroes `prevItemCount` but never scrolls, and `resetKey` wasn't in the only effect that does. Switching between two conversations with the same row count ran nothing and kept the previous `scrollTop`. Latent on the thread path too (`resetKey: streamId`), so that surface is fixed by the same line.
- **Column rhythm** — rows move into `mx-auto max-w-[800px]` at `px-3 sm:px-6`, matching `event-list.tsx` and the pill's own inner width.

Out of scope, deliberate: no virtualization (the panel still renders every row); no content-box observer for late-growing images/embeds — the timeline's plain thread scroller has none either, and matching it is the parity bar. Chunks 2–5 add day dividers, unread landmarks, delegation rows, and deleted-message tombstones.

## Files

| File | Change |
| ---- | ------ |
| `components/composer/use-floating-composer-height.ts` | **new** — shared ownership-tagged height publish + `onHeightChange(px, { initial })` |
| `components/composer/use-floating-composer-height.test.tsx` | **new** — 6 cases: publish+tag, hand-off cleanup, zero guard, initial-once, re-activation, inactive no-op |
| `components/composer/index.ts` | export the hook |
| `components/board/board-inline-composer.tsx` | inlined publish block → the shared hook; nothing else |
| `hooks/use-scroll-behavior.ts` | `skipInitialScroll` option (ref-read); `resetKey` added to the adjustment effect's deps |
| `hooks/use-scroll-behavior.test.tsx` | 5 cases incl. the equal-`itemCount` reset repro and the `skipInitialScroll` flip |
| `components/conversations/conversation-panel.tsx` | `useScrollBehavior` wiring, merged list/scroll ref, `FloatingComposerShell`, 800px column, jump-to-latest |
| `components/conversations/conversation-panel.test.tsx` | 6 cases: opens at tail, re-anchors on switch, deep-link survives backfill, floating shell not a footer, branch-composer reservation, jump-to-latest |

## Test plan

- [x] `apps/frontend` typecheck — clean
- [x] `apps/frontend` lint — clean
- [x] vitest `use-scroll-behavior` + `components/{composer,conversations,board,timeline}` — 71 files, 835 tests pass
- [x] every new test neutralised → confirmed red → restored. Honest exception: "opens at the tail" is guarded by two mechanisms and only goes red under a combined mutation, so it is not a single-cause test.
- [ ] manual pass on a real phone (keyboard open/close, branch-composer hand-off) — not run

Three blockers were found by adversarial review after the first green run and fixed in-branch: the equal-`itemCount` switch, the `?m=` reset, and `initial: true` re-firing on every re-activation of the height hook (which force-scrolled to the tail whenever a mobile branch composer closed — plan risk R4). None of them showed up in the suites.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787862965&installation_model_id=20758&pr_number=1641&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1641&signature=399047454e831c0d8aec335f1fc8c681bf0dd625a89ac11a72736d7209e1ed08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->