### PR TITLE
feat(board): draw day boundaries in the conversation panel

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -27,6 +27,7 @@ import * as inputModeModule from "@/hooks/use-input-mode"
 import { setBoardFlash, resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { spyOnExport } from "@/test/spy"
 import { MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
+import { formatDayDivider, localStartOfDayMs } from "@/lib/dates"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -593,5 +594,35 @@ describe("BoardCard row layout", () => {
     const rows = document.querySelectorAll("[data-message-row]")
     expect(rows.length).toBe(2)
     for (const row of rows) expect(row.className).not.toContain("select-none")
+  })
+})
+
+describe("BoardCard day dividers", () => {
+  it("shows no day divider even when its messages straddle a calendar day", async () => {
+    // The injector lives at the conversation-panel call site; a collapsed card is
+    // a digest, not a timeline.
+    const lateNight = new Date(2026, 5, 21, 23, 0, 0)
+    const afterMidnight = new Date(2026, 5, 22, 0, 30, 0)
+    const post = makePost({ messageIds: ["m_open", "m_reply"] }, { createdAt: lateNight.toISOString() })
+    mountCard({
+      ...post,
+      recentMessages: [
+        {
+          id: "m_reply",
+          streamId: STREAM,
+          authorId: "usr_other",
+          authorType: "user",
+          contentMarkdown: "Reply body.",
+          reactions: {},
+          attachments: [],
+          linkPreviews: [],
+          createdAt: afterMidnight.toISOString(),
+          editedAt: null,
+        },
+      ],
+      totalReplies: 1,
+    } as unknown as BoardViewPost)
+    await screen.findByText("Reply body.")
+    expect(screen.queryByText(formatDayDivider(new Date(localStartOfDayMs(afterMidnight))))).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest"
 import type { RenderableMessage } from "@/components/message/message-item"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
-import { buildBoardRows, buildBranchedBoardRows } from "./board-row-item"
+import { buildBoardRows, buildBranchedBoardRows, injectBoardDayDividers, type BoardRow } from "./board-row-item"
+import { localStartOfDayMs } from "@/lib/dates"
 import { groupBranches, type BranchStreamNode, type BranchConversationView } from "@/lib/board/branch-grouping"
 
 function msg(id: string, authorId: string, minute: number, streamId?: string): RenderableMessage {
@@ -258,5 +259,102 @@ describe("buildBranchedBoardRows continuation", () => {
       "message",
       "late",
     ])
+  })
+})
+
+function msgAt(id: string, at: Date): RenderableMessage {
+  return {
+    id,
+    authorId: "u1",
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    createdAt: at.toISOString(),
+  }
+}
+
+function messageRow(id: string, at: Date): BoardRow {
+  return { kind: "message", key: id, message: msgAt(id, at), continuation: false }
+}
+
+// Local-clock dates so the bucketing is asserted in the device timezone (INV-42),
+// which is what the divider renders.
+const day1Morning = new Date(2026, 6, 4, 9, 0, 0)
+const day1Evening = new Date(2026, 6, 4, 23, 30, 0)
+const day2Morning = new Date(2026, 6, 5, 0, 30, 0)
+
+describe("injectBoardDayDividers", () => {
+  it("inserts a divider between two calendar days, never above the first row", () => {
+    const rows = injectBoardDayDividers([messageRow("a", day1Evening), messageRow("b", day2Morning)])
+    expect(rows.map((r) => r.key)).toEqual(["a", `day:${localStartOfDayMs(day2Morning)}`, "b"])
+  })
+
+  it("inserts no divider for rows inside one day", () => {
+    const input = [messageRow("a", day1Morning), messageRow("b", day1Evening)]
+    expect(injectBoardDayDividers(input)).toEqual(input)
+  })
+
+  it("a timestampless chrome row neither opens nor closes a day", () => {
+    const seam: BoardRow = { kind: "seam", key: "seam:thread", streamId: "thread", direction: "down" }
+    const sameDay = injectBoardDayDividers([messageRow("a", day1Morning), seam, messageRow("b", day1Evening)])
+    expect(sameDay.map((r) => r.key)).toEqual(["a", "seam:thread", "b"])
+
+    const acrossDays = injectBoardDayDividers([messageRow("a", day1Evening), seam, messageRow("b", day2Morning)])
+    expect(acrossDays.map((r) => r.key)).toEqual(["a", "seam:thread", `day:${localStartOfDayMs(day2Morning)}`, "b"])
+  })
+
+  it("a day-2 divider keeps its key when an older page is prepended", () => {
+    // The key must be derived from the day itself, not from position: an
+    // older-page prepend renumbers every index-based key and remounts the
+    // dividers. Fresh row objects on both passes, so nothing can be shared.
+    const beforePrepend = injectBoardDayDividers([messageRow("b", day2Morning)])
+    const afterPrepend = injectBoardDayDividers([messageRow("a", day1Evening), messageRow("b", day2Morning)])
+    const dividerKey = (rows: BoardRow[]) => rows.filter((r) => r.kind === "day").map((r) => r.key)
+    expect(afterPrepend.filter((r) => r.kind === "day")).toHaveLength(1)
+    expect(dividerKey(afterPrepend)).toEqual([`day:${localStartOfDayMs(day2Morning)}`])
+    // Injecting over a day-2-only list emits no divider (nothing precedes it),
+    // so the stability claim is pinned against a third list that does.
+    expect(beforePrepend.filter((r) => r.kind === "day")).toHaveLength(0)
+    const withEarlierDay2 = injectBoardDayDividers([
+      messageRow("a0", day1Morning),
+      messageRow("a", day1Evening),
+      messageRow("b", day2Morning),
+    ])
+    expect(dividerKey(withEarlierDay2)).toEqual(dividerKey(afterPrepend))
+  })
+
+  it("an indented row between two same-day base rows produces no divider", () => {
+    const indented: BoardRow = { ...messageRow("t1", day2Morning), displayDepth: 1 }
+    const rows = injectBoardDayDividers([messageRow("a", day1Morning), indented, messageRow("b", day1Evening)])
+    expect(rows.map((r) => r.key)).toEqual(["a", "t1", "b"])
+  })
+
+  it("a spanning grouping yields unique divider keys in non-decreasing day order", () => {
+    // Base rows are globally time-sorted, thread runs are spliced in beside
+    // their fork message — so a later-dated thread run sits between two earlier
+    // base rows and must not open a day.
+    const streams = new Map<string, BranchStreamNode>([
+      ["root", { parentStreamId: null, rootStreamId: null, parentAnchorId: null }],
+      ["tx", { parentStreamId: "root", rootStreamId: "root", parentAnchorId: "a" }],
+      ["ty", { parentStreamId: "root", rootStreamId: "root", parentAnchorId: "b" }],
+    ])
+    const at = (id: string, streamId: string, date: Date): RenderableMessage => ({
+      ...msgAt(id, date),
+      streamId,
+    })
+    const grouping = groupBranches(
+      [
+        at("a", "root", day1Morning),
+        at("b", "root", day1Evening),
+        at("tx1", "tx", day2Morning),
+        at("ty1", "ty", new Date(2026, 6, 5, 1, 0, 0)),
+      ],
+      { streams, conversation: { streamId: "root" } }
+    )
+    const rows = injectBoardDayDividers(buildBranchedBoardRows(grouping, [], new Map(), "a"))
+    const keys = rows.map((r) => r.key)
+    expect(new Set(keys).size).toBe(keys.length)
+    const dayMs = rows.filter((r) => r.kind === "day").map((r) => r.dayStartMs)
+    expect(dayMs).toEqual([...dayMs].sort((x, y) => x - y))
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useAgentActivity, type MessageAgentActivity } from "@/hooks/use-agent-activity"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import type { BranchGrouping, BranchNode, BranchConversationView } from "@/lib/board/branch-grouping"
+import { localStartOfDayMs } from "@/lib/dates"
 
 /**
  * One row in a board card / conversation panel: a member message (with its
@@ -29,6 +30,48 @@ export type BoardRow =
   | { kind: "seam"; key: string; streamId: string; direction: "down" | "up"; displayDepth?: number }
   | { kind: "branch-group"; key: string; branch: BranchConversationView; displayDepth?: number }
   | { kind: "continue-thread"; key: string; streamId: string; hiddenCount: number; displayDepth?: number }
+  | { kind: "day"; key: string; dayStartMs: number; displayDepth?: number }
+
+function rowDayStartMs(row: BoardRow): number | null {
+  // Only depth-0 rows are globally time-sorted; indented thread runs are spliced
+  // in beside their fork point, so letting them open a day would emit
+  // out-of-order and duplicate-keyed dividers.
+  if ((row.displayDepth ?? 0) !== 0) return null
+  switch (row.kind) {
+    case "message":
+      return localStartOfDayMs(new Date(row.message.createdAt))
+    case "event":
+      return localStartOfDayMs(new Date(row.row.sortMs))
+    case "day":
+      return row.dayStartMs
+    default:
+      return null
+  }
+}
+
+/**
+ * Insert a `day` row before the first row of each local calendar day (INV-42),
+ * the same rule `injectDayDividers` applies to the timeline: rows carrying no
+ * timestamp (`seam`, `branch-group`, `continue-thread`) pass through without
+ * opening or resetting the current day, and no divider is ever emitted above
+ * the first timestamped row. Pure, and injected at the conversation-panel call
+ * site only — a collapsed board card is a digest, not a timeline.
+ */
+export function injectBoardDayDividers(rows: BoardRow[]): BoardRow[] {
+  const result: BoardRow[] = []
+  let currentDayMs: number | null = null
+  for (const row of rows) {
+    const dayMs = rowDayStartMs(row)
+    if (dayMs !== null) {
+      if (currentDayMs !== null && dayMs !== currentDayMs) {
+        result.push({ kind: "day", key: `day:${dayMs}`, dayStartMs: dayMs })
+      }
+      currentDayMs = dayMs
+    }
+    result.push(row)
+  }
+  return result
+}
 
 /**
  * Interleave a chronological message list with the conversation's event rows by

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
+import { DayDivider } from "@/components/timeline/day-divider"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
@@ -288,6 +289,8 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
       )
     case "continue-thread":
       return <ContinueThreadRow key={row.key} to={continueThreadTo(row.streamId)} hiddenCount={row.hiddenCount} />
+    case "day":
+      return <DayDivider key={row.key} dayStartMs={row.dayStartMs} />
   }
 }
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -37,6 +37,7 @@ import {
   resetConversationReplyOpenStoreCache,
 } from "@/stores/conversation-reply-open-store"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { formatDayDivider, localStartOfDayMs } from "@/lib/dates"
 
 const WORKSPACE_ID = "ws_1"
 const CONVERSATION_ID = "conv_1"
@@ -248,6 +249,25 @@ describe("ConversationPanel", () => {
     expect(await screen.findByText("Reply two body.")).toBeTruthy()
     // A card already on the board never round-trips for its projection.
     expect(getBoardPost).not.toHaveBeenCalled()
+  })
+
+  it("shows a day divider between messages from different days", async () => {
+    // Local-clock times straddling midnight, so the bucket is the device day (INV-42).
+    const lateNight = new Date(2026, 5, 21, 23, 0, 0)
+    const afterMidnight = new Date(2026, 5, 22, 0, 30, 0)
+    const post = makePost()
+    const cached = asCached({
+      ...post,
+      openingMessage: makeMessage({ id: "msg_1", createdAt: lateNight.toISOString() }),
+      recentMessages: [
+        makeMessage({ id: "msg_2", contentMarkdown: "Reply two body.", createdAt: afterMidnight.toISOString() }),
+      ],
+    })
+    mountPanel({ cached })
+    await screen.findByText("Opening message body.")
+    expect(screen.getByText(formatDayDivider(new Date(localStartOfDayMs(afterMidnight))))).toBeTruthy()
+    // Never above the first row.
+    expect(screen.queryByText(formatDayDivider(new Date(localStartOfDayMs(lateNight))))).toBeNull()
   })
 
   it("docks the scoped reply composer (alwaysDocked — no resting button)", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -26,7 +26,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows, injectBoardDayDividers } from "@/components/board/board-row-item"
 import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
@@ -543,11 +543,13 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       }),
     [conversation.id, conversation.streamId, structuralIndex, conversationGraph]
   )
-  const rows = buildBranchedBoardRows(
-    groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
-    eventRows,
-    branchesByForkMessageId,
-    openingMessage?.id
+  const rows = injectBoardDayDividers(
+    buildBranchedBoardRows(
+      groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
+      eventRows,
+      branchesByForkMessageId,
+      openingMessage?.id
+    )
   )
   // "Move to sub-topic" re-file — same gesture as the board card (membership move
   // within one root; the hook hides the action when a row has nowhere to go).


### PR DESCRIPTION
Chunk 2 of 5 — [conversation panel ⇄ timeline parity](https://seer.build/ws_vbyzjvdg6g/b/conv-parity-plan-3d138c/). Stacked on #1641.

## Problem

The conversation panel ran messages from different calendar days together with nothing between them — a reply from last Tuesday sits flush against one from this morning, and only the per-head timestamp says otherwise. The timeline has drawn day dividers since `injectDayDividers` (`event-list.tsx:637`); the board's `BoardRow` union had no equivalent.

## Solution

One new row kind, one pure injector, one render case — reusing the timeline's `DayDivider`, which already resolves its label through `lib/dates` (INV-42), so no date is formatted at the call site.

- **`injectBoardDayDividers` is applied at the panel call site only**, not inside `buildBoardRows` / `buildBranchedBoardRows`. A collapsed board card is a digest, not a timeline; `board-card.test.tsx` carries the negative guard so that stays true.
- **Only depth-0 rows open a day.** This is the one non-obvious line. The timeline's rule assumes a strictly chronological item list — board rows are not one, because `buildBranchedBoardRows` sorts only *within* a run and then splices a thread's run in right after its fork message. Transcribing the rule unchanged produced, on a spanning conversation (two Jul-4 base messages each forking a Jul-5 thread reply), dividers reading Jul 5 → Jul 4 → Jul 5, and **two sibling dividers with the same `day:<ms>` React key** — undefined reconciliation, i.e. exactly the remount a stable key exists to prevent. Base-level rows *are* globally time-sorted, so restricting to depth 0 makes day order monotone and each key unique. It also drops the secondary artifact: a full-width depth-0 divider rendering above an indented thread row.
- **Timestampless rows pass through** — `seam`, `branch-group` and `continue-thread` neither open nor reset the current day, matching the timeline. A `seam` between two different-day messages yields exactly one divider, after the seam, which is what the timeline's rule produces (the divider is emitted when the next timestamped row is reached).

Out of scope, deliberate: no dividers inside a `BranchGroup`'s nested rows — a branch is a compact digest. Chunks 3–5 add unread landmarks, delegation rows, and deleted-message tombstones.

## Files

| File | Change |
| ---- | ------ |
| `components/board/board-row-item.tsx` | `BoardRow` gains a `day` kind; `rowDayStartMs` + exported `injectBoardDayDividers` |
| `components/board/branch-rows.tsx` | `renderRowContent` gains `case "day"` → the timeline's `DayDivider` |
| `components/conversations/conversation-panel.tsx` | wraps `buildBranchedBoardRows(...)` with the injector |
| `components/board/board-row-item.test.ts` | injector cases incl. the spanning-grouping key-uniqueness repro and the indented-row guard |
| `components/conversations/conversation-panel.test.tsx` | divider renders between messages from different days |
| `components/board/board-card.test.tsx` | negative guard: a collapsed card straddling midnight shows no divider |

## Test plan

- [x] `apps/frontend` typecheck — clean
- [x] `apps/frontend` lint — clean
- [x] vitest `components/{board,conversations,timeline}` — 59 files, 724 tests pass
- [x] every new test neutralised → confirmed red → restored. Removing the depth guard reproduces the duplicate-key repro exactly (`expected 6 to be 7`); an index-based key reddens the key-stability test.
- [ ] visual pass in a browser — not run; the evidence is an executed unit repro through the real `groupBranches` + `buildBranchedBoardRows`

Adversarial review after the first green run found the depth-ordering blocker above, and that the original "stable keys" test was a tautology (`f(x) === f(x)` over a pure function — an index-based key passed it). Both fixed in-branch; the test is rewritten to assert key identity across a *changed* list.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787864218&installation_model_id=20758&pr_number=1642&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1642&signature=a096cef60dbf2c0b67513e42dea7aedef3686a3ee9ca6841f05efb99e83a9b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->