### PR TITLE
fix(harnessd): identify a pane by its harness link record before deriving

### DIFF
--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
 import { existsSync, statSync } from "node:fs"
+import { hostname } from "node:os"
 import { basename, dirname, join } from "node:path"
 import { acceptClaudeBootPrompts } from "./claude-boot"
 import {
@@ -12,6 +13,7 @@ import {
 } from "./claude-registry"
 import { normalizeName, now } from "./cli"
 import {
+  canonicalOrRaw,
   findLocalClaudeChannelPane,
   listLocalTmuxPanes,
   parseClaudeChannelLaunch,
@@ -211,7 +213,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
 
   let pane: LocalTmuxPane | undefined
   try {
-    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config)
+    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config, hostname(), deps.links)
   } catch (error) {
     return { status: "refused ambiguous", detail: error instanceof Error ? error.message : String(error) }
   }
@@ -234,7 +236,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
       .panes()
       .filter(
         (candidate) =>
-          canonicalOrRaw(candidate.cwd, deps.disk) === cwd && parseClaudeChannelLaunch(candidate.startCommand)
+          canonicalOrRaw(candidate.cwd, deps.disk.canonical) === cwd && parseClaudeChannelLaunch(candidate.startCommand)
       )
     if (occupants.length > 1) {
       return {
@@ -564,7 +566,7 @@ function resolveCwd(
       detail: "no --cwd, live pane, harness link, or inventory row names a working directory",
     }
   }
-  const resolved = candidates.map(({ source, path }) => ({ source, path: canonicalOrRaw(path, deps.disk) }))
+  const resolved = candidates.map(({ source, path }) => ({ source, path: canonicalOrRaw(path, deps.disk.canonical) }))
   const distinct = [...new Set(resolved.map(({ path }) => path))]
   if (distinct.length > 1) {
     return {
@@ -573,14 +575,6 @@ function resolveCwd(
     }
   }
   return { cwd: distinct[0]!, source: resolved[0]!.source }
-}
-
-function canonicalOrRaw(path: string, disk: ClaudeDiskDeps): string {
-  try {
-    return disk.canonical(path)
-  } catch {
-    return path
-  }
 }
 
 /**

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -200,7 +200,11 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     }
   }
 
-  const link = deps.links().find((candidate) => candidate.runtimeSessionId === options.runtimeSessionId)
+  // One snapshot for both the guard and the pane lookup: a record written
+  // between two reads would attest a pane whose kind and root the guard never
+  // checked.
+  const links = deps.links()
+  const link = links.find((candidate) => candidate.runtimeSessionId === options.runtimeSessionId)
   if (link && link.runtimeKind !== "claude-code-channel" && link.runtimeKind !== "unknown") {
     return { status: "refused identity mismatch", detail: `harness link records runtime kind ${link.runtimeKind}` }
   }
@@ -213,7 +217,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
 
   let pane: LocalTmuxPane | undefined
   try {
-    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config, hostname(), deps.links)
+    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config, hostname(), () => links)
   } catch (error) {
     return { status: "refused ambiguous", detail: error instanceof Error ? error.message : String(error) }
   }

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -74,6 +74,7 @@ function deps(overrides: Partial<ReconnectDeps> = {}): ReconnectDeps & { calls: 
     piConfig: () => ({}),
     piLink: () => undefined,
     claudeConfig: () => ({ workspaceId: "ws", apiKey: "key" }),
+    links: () => [],
     claudeRegistry: {
       ...registry(),
       read: (path) =>

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -168,6 +168,37 @@ describe("resolveClaudeNativeSession", () => {
 })
 
 describe("reconnectClaude", () => {
+  test("reconnects a pane whose identity only the ledger attests", async () => {
+    // The pane this whole stack is about: launched without THREA_* env, so the
+    // hostname derivation yields an id that is not the one recorded for it.
+    // Finding the pane through the ledger and then re-deriving to check it
+    // rejected the very session the ledger had just identified.
+    const attested = "ccs-attested"
+    const bare = `/opt/claude --name threa.feature --mcp-config /tmp/threa.json --dangerously-load-development-channels server:threa-channel`
+    let paneReads = 0
+    const d = deps({
+      inventory: () => [],
+      panes: () => (++paneReads < 3 ? [pane({ startCommand: bare })] : [pane({ panePid: 5678, startCommand: bare })]),
+      links: () => [
+        {
+          runtimeKind: "claude-code-channel",
+          runtimeSessionId: attested,
+          instanceId: "cc-attested",
+          rootStreamId: "stream_one",
+          worktree: CWD,
+          pid: 1234,
+          updatedAt: "2026-07-28T00:00:00.000Z",
+        },
+      ],
+    })
+
+    await reconnectClaude({ runtimeSessionId: attested, rootStreamId: "stream_one" }, d)
+
+    expect(d.calls).toHaveLength(1)
+    expect(d.calls[0]![2]).toContain(`THREA_RUNTIME_SESSION_ID=${attested}`)
+    expect(d.calls[0]![2]).toContain("THREA_INSTANCE_ID=cc-attested")
+  })
+
   test("preflights and resumes exact native UUID with supported policy", async () => {
     const d = deps()
     await reconnectClaude({ runtimeSessionId: RUNTIME, rootStreamId: "stream_one" }, d)

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto"
-import { BotSupervisorTransport, type BotSessionRestoredPayload } from "@threa/bot-runtime-client"
+import {
+  BotSupervisorTransport,
+  readHarnessLinks,
+  type BotSessionRestoredPayload,
+  type HarnessLink,
+} from "@threa/bot-runtime-client"
 import { existsSync } from "node:fs"
 import { basename, dirname, join } from "node:path"
 import { installBootResume } from "./boot"
@@ -625,8 +630,12 @@ function agentPaneLives(agent: ManagedAgent): boolean {
  * stored ids are a tie-breaker, never the answer, so there is nothing to
  * repair.
  */
-function resolveAgentTarget(agent: ManagedAgent, panes?: LocalTmuxPane[]): LocalTmuxPane {
-  const resolved = panes ? resolveManagedAgentPane(agent, panes) : resolveManagedAgentPane(agent)
+function resolveAgentTarget(
+  agent: ManagedAgent,
+  panes?: LocalTmuxPane[],
+  links: () => HarnessLink[] = readHarnessLinks
+): LocalTmuxPane {
+  const resolved = resolveManagedAgentPane(agent, panes, undefined, undefined, links)
   if (resolved.status === "ambiguous") die(`${agent.name}: ${resolved.reason}`)
   if (resolved.status === "missing") die(`${agent.name} has no live tmux pane`)
   // Killing or typing into the wrong window is the failure this resolver
@@ -640,11 +649,12 @@ export function kickAgent(
   ref: string,
   send: typeof sendKeys = sendKeys,
   discover: (runtimeSessionId: string) => LocalTmuxPane | undefined = findLocalClaudeChannelPane,
-  panes?: LocalTmuxPane[]
+  panes?: LocalTmuxPane[],
+  links: () => HarnessLink[] = readHarnessLinks
 ): void {
   const managed = findAgentOrUndefined(ref, readInventoryReadonly())
   if (managed) {
-    const target = resolveAgentTarget(managed, panes).paneId
+    const target = resolveAgentTarget(managed, panes, links).paneId
     send(target, ["Enter"])
     console.log(`harnessd: kicked ${target}`)
     return

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { HarnessLink } from "@threa/bot-runtime-client"
 import { deriveClaudeRuntimeIdentity } from "./spawners"
 import {
   findLocalClaudeChannelPane,
@@ -22,6 +26,21 @@ function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
     ...overrides,
   }
 }
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: "ccs-real",
+    instanceId: "cc-real",
+    rootStreamId: "stream_real",
+    worktree: "/Users/me/dev/threa.feature",
+    pid: 33336,
+    updatedAt: "2026-07-28T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+const noLinks = () => []
 
 describe("parseTmuxPanes", () => {
   test("keeps live panes and their start command", () => {
@@ -112,7 +131,7 @@ describe("findLocalClaudeChannelPane", () => {
     const candidate = pane()
 
     expect(deriveClaudeRuntimeIdentity(candidate.cwd, {}, "host-a").runtimeSessionId).toBe("ccs-4dca54f22ee90414")
-    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a")).toEqual(candidate)
+    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", noLinks)).toEqual(candidate)
   })
 
   test("prefers and normalizes the runtime session id explicitly recorded in the launch command", () => {
@@ -121,7 +140,7 @@ describe("findLocalClaudeChannelPane", () => {
         '"env THREA_INSTANCE_ID=cc-one THREA_RUNTIME_SESSION_ID=ccs.explicit claude --dangerously-load-development-channels server:threa-channel"',
     })
 
-    expect(findLocalClaudeChannelPane("ccs-explicit", [candidate], {}, "other-host")).toEqual(candidate)
+    expect(findLocalClaudeChannelPane("ccs-explicit", [candidate], {}, "other-host", noLinks)).toEqual(candidate)
   })
 
   test("rejects non-channel, renamed legacy-channel, and non-Claude panes", () => {
@@ -135,7 +154,7 @@ describe("findLocalClaudeChannelPane", () => {
     ]
 
     expect(
-      findLocalClaudeChannelPane("ccs-target", candidates, { runtimeSessionId: "ccs-target" }, "host-a")
+      findLocalClaudeChannelPane("ccs-target", candidates, { runtimeSessionId: "ccs-target" }, "host-a", noLinks)
     ).toBeUndefined()
   })
 
@@ -145,7 +164,8 @@ describe("findLocalClaudeChannelPane", () => {
         "ccs-shared",
         [pane(), pane({ paneId: "%9", panePid: 44444, cwd: "/Users/me/dev/threa.other" })],
         { runtimeSessionId: "ccs-shared" },
-        "host-a"
+        "host-a",
+        noLinks
       )
     ).toThrow("multiple live unmanaged Claude channel panes match ccs-shared: %8, %9")
   })
@@ -179,7 +199,8 @@ describe("resolveManagedAgentPane", () => {
       },
       [pane({ cwd: "/Users/me/dev/threa.other", windowId: "@7", paneId: "%8" }), live],
       config,
-      host
+      host,
+      noLinks
     )
     expect(resolved).toEqual({ status: "found", pane: live })
   })
@@ -215,5 +236,78 @@ describe("resolveManagedAgentPane", () => {
     expect(resolveManagedAgentPane({ runtime: "claude", tmuxPaneId: "%404" }, [live], config, host)).toEqual({
       status: "missing",
     })
+  })
+})
+
+describe("findLocalClaudeChannelPane ledger attestation", () => {
+  test("a pane launched without THREA_ env is identified by its harness link record", () => {
+    const candidate = pane()
+
+    expect(deriveClaudeRuntimeIdentity(candidate.cwd, {}, "host-a").runtimeSessionId).not.toBe("ccs-real")
+    expect(findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", () => [link()])).toEqual(candidate)
+  })
+
+  test("a declared runtime session id wins over the ledger", () => {
+    const candidate = pane({
+      startCommand:
+        '"env THREA_RUNTIME_SESSION_ID=ccs-declared claude --dangerously-load-development-channels server:threa-channel"',
+    })
+    const links = () => [link({ runtimeSessionId: "ccs-other", worktree: candidate.cwd })]
+
+    expect(findLocalClaudeChannelPane("ccs-declared", [candidate], {}, "host-a", links)).toEqual(candidate)
+    expect(findLocalClaudeChannelPane("ccs-other", [candidate], {}, "host-a", links)).toBeUndefined()
+  })
+
+  test("falls back to the derived identity when no record names the cwd", () => {
+    const candidate = pane()
+    const links = () => [link({ worktree: "/Users/me/dev/threa.somebody-else" })]
+
+    expect(findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", links)).toBeUndefined()
+    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", links)).toEqual(candidate)
+  })
+
+  test("two records naming one worktree fall through to derivation rather than guessing", () => {
+    const candidate = pane()
+    const links = () => [link(), link({ runtimeSessionId: "ccs-rival", instanceId: "cc-rival" })]
+
+    expect(findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", links)).toBeUndefined()
+    expect(findLocalClaudeChannelPane("ccs-rival", [candidate], {}, "host-a", links)).toBeUndefined()
+    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", links)).toEqual(candidate)
+  })
+
+  test("a pi-local record never identifies a Claude pane", () => {
+    const candidate = pane()
+    const links = () => [link({ runtimeKind: "pi-local", runtimeSessionId: "ccs-pi" })]
+
+    expect(findLocalClaudeChannelPane("ccs-pi", [candidate], {}, "host-a", links)).toBeUndefined()
+    expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", links)).toEqual(candidate)
+  })
+
+  test("an un-canonicalized worktree in the record still matches the pane's real cwd", () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "discovery-links-"))
+    const real = join(root, "worktree")
+    mkdirSync(real)
+    const linked = join(root, "alias")
+    symlinkSync(real, linked)
+
+    const candidate = pane({ cwd: real })
+
+    expect(
+      findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", () => [link({ worktree: linked })])
+    ).toEqual(candidate)
+  })
+
+  test("a symlinked pane cwd still matches the record's canonical worktree", () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "discovery-panecwd-"))
+    const real = join(root, "worktree")
+    mkdirSync(real)
+    const linked = join(root, "alias")
+    symlinkSync(real, linked)
+
+    const candidate = pane({ cwd: linked })
+
+    expect(findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", () => [link({ worktree: real })])).toEqual(
+      candidate
+    )
   })
 })

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -452,16 +452,21 @@ export function canonicalOrRaw(path: string, canonical: (path: string) => string
   }
 }
 
-interface AttestedRuntime {
+export interface AttestedRuntime {
   worktree: string
   runtimeSessionId: string
+  instanceId: string
 }
 
 /** Canonicalized once per resolution: a per-pane realpath is panes × records syscalls. */
-function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
+export function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
   return links
     .filter((link) => link.runtimeKind === "claude-code-channel" || link.runtimeKind === "unknown")
-    .map((link) => ({ worktree: canonicalOrRaw(link.worktree), runtimeSessionId: link.runtimeSessionId }))
+    .map((link) => ({
+      worktree: canonicalOrRaw(link.worktree),
+      runtimeSessionId: link.runtimeSessionId,
+      instanceId: link.instanceId,
+    }))
 }
 
 /**
@@ -470,10 +475,14 @@ function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
  * Two or more records naming one worktree is a broken ledger, not a tie to
  * break: guessing here binds a live pane to a stranger's session.
  */
-function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[]): string | undefined {
+export function ledgerIdentity(cwd: string, attested: AttestedRuntime[]): AttestedRuntime | undefined {
   const canonicalCwd = canonicalOrRaw(cwd)
   const matches = attested.filter((entry) => entry.worktree === canonicalCwd)
-  return matches.length === 1 ? matches[0]!.runtimeSessionId : undefined
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[]): string | undefined {
+  return ledgerIdentity(cwd, attested)?.runtimeSessionId
 }
 
 /**

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -1,5 +1,7 @@
 import { basename } from "node:path"
 import { hostname } from "node:os"
+import { realpathSync } from "node:fs"
+import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
 import { output } from "./shell"
 import { deriveClaudeRuntimeIdentity, readThreaChannelConfig, sanitizeId } from "./spawners"
 import type { ManagedAgent, ThreaChannelConfig } from "./types"
@@ -386,22 +388,26 @@ export type ManagedAgentPane =
  * tmux server restarts numbering at `@0`/`%0`, so a recorded `@169` routinely
  * resolves to an unrelated agent's window — acting on one has killed the wrong
  * worktree. Identity is the runtime session (from the pane's launch command,
- * or derived from its cwd for a Claude pane launched without the env vars),
+ * attested by the harness link ledger, or derived from its cwd),
  * with the worktree as the fallback key for rows predating it. The recorded
  * ids only break a tie between panes that already matched a real key.
+ *
+ * @param links the harness link ledger, read once per call: a per-pane read
+ * would re-scan the whole directory for every pane tmux reports.
  */
 export function resolveManagedAgentPane(
   agent: Pick<ManagedAgent, "runtime" | "runtimeSessionId" | "worktree" | "tmuxPaneId" | "tmuxWindowId">,
   panes: LocalTmuxPane[] = listLocalTmuxPanes(),
   config: ThreaChannelConfig = readThreaChannelConfig(),
-  host = hostname()
+  host = hostname(),
+  links: () => HarnessLink[] = readHarnessLinks
 ): ManagedAgentPane {
   if (agent.runtimeSessionId) {
     try {
       const pane =
         agent.runtime === "pi"
           ? findLocalPiPane(agent.runtimeSessionId, panes)
-          : findLocalClaudeChannelPane(agent.runtimeSessionId, panes, config, host)
+          : findLocalClaudeChannelPane(agent.runtimeSessionId, panes, config, host, links)
       return pane ? { status: "found", pane } : { status: "missing" }
     } catch (error) {
       return { status: "ambiguous", reason: error instanceof Error ? error.message : String(error) }
@@ -438,19 +444,68 @@ export function resolveManagedAgentPane(
       }
 }
 
-function runtimeSessionIdForPane(pane: LocalTmuxPane, config: ThreaChannelConfig, host: string): string | undefined {
+export function canonicalOrRaw(path: string, canonical: (path: string) => string = realpathSync): string {
+  try {
+    return canonical(path)
+  } catch {
+    return path
+  }
+}
+
+interface AttestedRuntime {
+  worktree: string
+  runtimeSessionId: string
+}
+
+/** Canonicalized once per resolution: a per-pane realpath is panes × records syscalls. */
+function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
+  return links
+    .filter((link) => link.runtimeKind === "claude-code-channel" || link.runtimeKind === "unknown")
+    .map((link) => ({ worktree: canonicalOrRaw(link.worktree), runtimeSessionId: link.runtimeSessionId }))
+}
+
+/**
+ * The attested identity of the runtime living in `cwd`, or nothing.
+ *
+ * Two or more records naming one worktree is a broken ledger, not a tie to
+ * break: guessing here binds a live pane to a stranger's session.
+ */
+function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[]): string | undefined {
+  const canonicalCwd = canonicalOrRaw(cwd)
+  const matches = attested.filter((entry) => entry.worktree === canonicalCwd)
+  return matches.length === 1 ? matches[0]!.runtimeSessionId : undefined
+}
+
+/**
+ * Identity by attestation before derivation: `deriveClaudeRuntimeIdentity`
+ * hashes `os.hostname()`, which is DHCP-supplied on a laptop and changes with
+ * the network, so a pane launched without `THREA_RUNTIME_SESSION_ID` derives a
+ * different id than the one recorded for it and `up` starts a duplicate.
+ */
+function runtimeSessionIdForPane(
+  pane: LocalTmuxPane,
+  config: ThreaChannelConfig,
+  host: string,
+  attested: AttestedRuntime[]
+): string | undefined {
   const launch = parseClaudeChannelLaunch(pane.startCommand)
   if (!launch) return undefined
-  return launch.runtimeSessionId ?? deriveClaudeRuntimeIdentity(pane.cwd, config, host).runtimeSessionId
+  return (
+    launch.runtimeSessionId ??
+    ledgerRuntimeSessionId(pane.cwd, attested) ??
+    deriveClaudeRuntimeIdentity(pane.cwd, config, host).runtimeSessionId
+  )
 }
 
 export function findLocalClaudeChannelPane(
   runtimeSessionId: string,
   panes: LocalTmuxPane[] = listLocalTmuxPanes(),
   config: ThreaChannelConfig = readThreaChannelConfig(),
-  host = hostname()
+  host = hostname(),
+  links: () => HarnessLink[] = readHarnessLinks
 ): LocalTmuxPane | undefined {
-  const matches = panes.filter((pane) => runtimeSessionIdForPane(pane, config, host) === runtimeSessionId)
+  const attested = attestedRuntimes(links())
+  const matches = panes.filter((pane) => runtimeSessionIdForPane(pane, config, host, attested) === runtimeSessionId)
   if (matches.length > 1) {
     throw new Error(
       `multiple live unmanaged Claude channel panes match ${runtimeSessionId}: ${matches.map((pane) => pane.paneId).join(", ")}`

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -10,8 +10,10 @@ import {
   type ClaudeRegistryDeps,
 } from "./claude-registry"
 import {
+  attestedRuntimes,
   findLocalClaudeChannelPane,
   findLocalPiPane,
+  ledgerIdentity,
   listLocalTmuxPanes,
   parseClaudeLaunch,
   parsePiLaunch,
@@ -238,12 +240,16 @@ function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): Cl
     if (paneCwd !== managedCwd) throw new Error("managed Claude cwd does not match pane")
   }
   const derived = deriveClaudeRuntimeIdentity(pane.cwd, config)
+  // Same attestation order the pane lookup just used. Re-deriving here would
+  // reject the very pane the ledger identified: a session launched under a
+  // different hostname derives a different id for life.
+  const attested = ledgerIdentity(pane.cwd, attestedRuntimes((deps.links ?? readHarnessLinks)()))
   const explicitInstanceId = launch.environment.find(({ name }) => name === "THREA_INSTANCE_ID")?.value
   const explicitRuntimeSessionId = launch.environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value
-  const instanceId = explicitInstanceId ? sanitizeId(explicitInstanceId).slice(0, 64) : derived.instanceId
-  const runtimeSessionId = explicitRuntimeSessionId
-    ? sanitizeId(explicitRuntimeSessionId).slice(0, 64)
-    : derived.runtimeSessionId
+  const instanceId = sanitizeId(explicitInstanceId || attested?.instanceId || derived.instanceId).slice(0, 64)
+  const runtimeSessionId = sanitizeId(
+    explicitRuntimeSessionId || attested?.runtimeSessionId || derived.runtimeSessionId
+  ).slice(0, 64)
   if (!instanceId || !runtimeSessionId) throw new Error("Claude launch identity is empty after normalization")
   if (runtimeSessionId !== options.runtimeSessionId) throw new Error("Claude runtime identity mismatch")
   if (agent && (agent.runtimeSessionId !== runtimeSessionId || agent.instanceId !== instanceId)) {

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -1,5 +1,7 @@
 import { statSync } from "node:fs"
+import { hostname } from "node:os"
 import { basename, resolve } from "node:path"
+import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
 import { acceptClaudeBootPrompts, defaultClaudeBootDeps, type ClaudeBootDeps } from "./claude-boot"
 import {
   defaultClaudeRegistryDeps,
@@ -62,6 +64,7 @@ export interface ReconnectDeps {
   respawn: (target: string, cwd: string, command: string) => void
   claudeConfig?: () => ThreaChannelConfig
   claudeRegistry?: ClaudeRegistryDeps
+  links?: () => HarnessLink[]
   mcpFile?: (path: string) => boolean
   sleep?: (ms: number) => Promise<void>
   claudeBoot?: Partial<ClaudeBootDeps>
@@ -211,7 +214,13 @@ function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): Cl
     if (matches.length !== 1) throw new Error(`managed Claude pane ${agent.tmuxPaneId} is missing or ambiguous`)
     pane = matches[0]
   } else {
-    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config)
+    pane = findLocalClaudeChannelPane(
+      options.runtimeSessionId,
+      deps.panes(),
+      config,
+      hostname(),
+      deps.links ?? readHarnessLinks
+    )
     if (!pane) throw new Error(`no live Claude pane matched ${options.runtimeSessionId}`)
   }
   const launch = parseClaudeLaunch(pane.startCommand)
@@ -381,7 +390,9 @@ export async function reconnectRuntime(
   const claudePane = findLocalClaudeChannelPane(
     options.runtimeSessionId,
     panes,
-    (deps.claudeConfig ?? readThreaChannelConfig)()
+    (deps.claudeConfig ?? readThreaChannelConfig)(),
+    hostname(),
+    deps.links ?? readHarnessLinks
   )
   if (piPane && claudePane) throw new Error(`multiple live runtimes match ${options.runtimeSessionId}`)
   if (piPane) return reconnectPi(options, deps)

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -149,7 +149,8 @@ test("kick sends Enter to the managed tmux pane without discovery", () => {
       () => {
         throw new Error("managed kick must not run discovery")
       },
-      [claudePane()]
+      [claudePane()],
+      () => []
     )
     expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
   } finally {
@@ -214,7 +215,8 @@ test("kick lookup leaves legacy inventory unchanged for managed and standalone a
         () => {
           throw new Error("exact managed match must take priority")
         },
-        [claudePane({ sessionName: "legacy", windowName: "managed", paneId: "%9", startCommand: "claude" })]
+        [claudePane({ sessionName: "legacy", windowName: "managed", paneId: "%9", startCommand: "claude" })],
+        () => []
       )
     ).toThrow("only a recycled tmux id")
     kickAgent(
@@ -248,9 +250,13 @@ test("kick lookup works with a read-only inventory file", () => {
     upsertAgent(agent({ worktree: "/repo/threa.repair", tmuxWindowId: "@7", tmuxPaneId: "%8" }))
     chmodSync(path, 0o444)
     const sent: Array<{ target: string; keys: string[] }> = []
-    kickAgent("claude-1", (target, keys) => sent.push({ target, keys }), findLocalClaudeChannelPane, [
-      claudePane({ cwd: "/repo/threa.repair", startCommand: "claude" }),
-    ])
+    kickAgent(
+      "claude-1",
+      (target, keys) => sent.push({ target, keys }),
+      findLocalClaudeChannelPane,
+      [claudePane({ cwd: "/repo/threa.repair", startCommand: "claude" })],
+      () => []
+    )
     expect(sent).toEqual([{ target: "%8", keys: ["Enter"] }])
   } finally {
     chmodSync(path, 0o644)


### PR DESCRIPTION
## Why

`deriveClaudeRuntimeIdentity` is `sha256(os.hostname() + ":" + worktree)`. On macOS with `scutil --get HostName` unset, `os.hostname()` returns the DHCP-supplied name and **changes with the network** — `kristoffers-mbp.lan` on one router, `Kristoffers-MacBook-Pro.local` on another.

`runtimeSessionIdForPane` used that derivation as its fallback for a pane launched without `THREA_RUNTIME_SESSION_ID`. The derived id no longer matched the recorded one, so `resolveManagedAgentPane` returned `missing`, and `up` started a duplicate session — nine consecutive passes on 2026-07-28, followed by `/kick` failing as *ambiguous* because the duplicates **do** stamp the id.

Measured on the affected machine: 7 of 16 harness link records and **6 of 10 live Claude channel panes** carry an identity today's derivation cannot reproduce. Every one of those panes has a link record, which is why the ledger is the fix.

## What changed

`runtimeSessionIdForPane` gains a middle step: declared env → **harness link record for the pane's canonical cwd** → derivation. The derivation is untouched and still the last resort.

- Ledger records are read **once per resolution** and pre-filtered/canonicalized into a view (`attestedRuntimes`), not re-canonicalized per pane — `agentPaneLives` calls the resolver once per inventory row, so the per-pane cost multiplies.
- Ambiguity falls through rather than guessing: two records naming one canonical cwd → derive. The reader does not assume `recordHarnessLink`'s supersede-by-worktree invariant held.
- `pi-local` records never identify a Claude pane.
- Both sides of the path comparison are canonicalized, degrading to the raw string when `realpath` throws. `canonicalOrRaw` was lifted out of `adopt.ts` rather than duplicated (INV-35/37).
- The `links` reader is injected through `adopt`, `reconnect` and `commands`, so tests no longer reach `$HOME`. `adopt` reads the directory **once** and shares that snapshot between its identity guard and its pane lookup — a record written between two reads would attest a pane whose `runtimeKind` and `rootStreamId` the guard never checked.

## Verification

176 pass / 0 fail, lint and typecheck clean, full pre-commit gates green.

Each new test was verified capable of failing by neutralising the specific guard it covers — removing the whole lookup only reds 2 of 7, because the negative-assertion tests pass vacuously without it:

| neutralisation | goes red |
| --- | --- |
| remove the ledger step | live case, record-side canonicalization |
| `matches.length === 1` → `matches[0]?` | ambiguity falls through |
| drop the `runtimeKind` filter | `pi-local` ignored |
| swap declared/ledger precedence | declared wins |
| `canonicalOrRaw(cwd)` → `cwd` | symlinked pane cwd |
| drop the derive fallback | derive still works, + 5 pre-existing |

That last row is the one an adversarial reviewer caught and I confirmed by running it: before the fix, the suite passed 175/0 with pane-side canonicalization deleted.

## Residual risk

Deliberately scoped to a **read-only additional attestation**. No minting, no backfill, no ledger writer, and the derivation is not removed — that needs a recovery path for a lost ledger, and the server has no GET endpoint for `bot-runtime/sessions` today.

`agentPaneLives` still reads the real ledger (production-only path, no test seam). Chunks 2 (`resolve`/`doctor`/watcher logging) and 3 (reaper process-table veto) follow in this stack.

Plan, including the adversarial review that reshaped it: https://seer.build/ws_vbyzjvdg6g/b/harnessd-identity-9c5f3c/

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Known issues (deferred, not fixed here)

- `attestedRuntimes` does not filter records by liveness (`pid`, `windDownRequestedAt`). Consistent with how every existing reader treats the links directory; revisit with the reaper work in chunk 3.
- `runtimeKind: "unknown"` is accepted, so a link record written before `runtimeKind` existed could attest a Claude pane even if it was a Pi session. This mirrors `adopt.ts`'s existing acceptance rule rather than introducing a new one.

### Correction

An earlier revision of this description claimed `adopt` previously used two ledger views and now uses one. That was wrong in both halves: before this PR the guard read the injected reader once and the pane lookup read the real `$HOME` directly. This PR initially made both use the injected reader but read it **twice**; the hoist above is what actually makes it one snapshot. Caught by `/code-review`.


## Whole-stack review finding, fixed here

`resolveClaudeTarget` found the pane through the ledger and then **re-derived its identity to verify it**, so a pane launched without `THREA_RUNTIME_SESSION_ID` — the exact class this work exists for — was rejected with `Claude runtime identity mismatch`. Pre-stack the same call failed with "no live Claude pane matched"; post-stack it failed with a message accusing the pane of belonging to somebody else, which is the opposite of what the ledger had just established. `instanceId` was derived the same way, so even a passing id check would have rebuilt the command with a host-derived instance id rather than the record's.

The verification now follows the same attestation order as the lookup: declared env → link record → derivation.

It had no coverage because every reconnect fixture pinned `links: () => []`. The new test drives it and reds without the fix.

This is the command I used to restart my own session tonight. It would still have failed for any session whose pane declares nothing.
