### PR TITLE
feat(board): open the conversation panel at its first unread

### DIFF
--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest"
 import type { RenderableMessage } from "@/components/message/message-item"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
-import { buildBoardRows, buildBranchedBoardRows, injectBoardDayDividers, type BoardRow } from "./board-row-item"
+import {
+  buildBoardRows,
+  buildBranchedBoardRows,
+  injectBoardDayDividers,
+  injectUnreadDivider,
+  type BoardRow,
+} from "./board-row-item"
 import { localStartOfDayMs } from "@/lib/dates"
 import { groupBranches, type BranchStreamNode, type BranchConversationView } from "@/lib/board/branch-grouping"
 
@@ -356,5 +362,22 @@ describe("injectBoardDayDividers", () => {
     expect(new Set(keys).size).toBe(keys.length)
     const dayMs = rows.filter((r) => r.kind === "day").map((r) => r.dayStartMs)
     expect(dayMs).toEqual([...dayMs].sort((x, y) => x - y))
+  })
+})
+
+describe("injectUnreadDivider", () => {
+  it("inserts exactly one unread row immediately before the marker's message row", () => {
+    const rows = injectUnreadDivider(
+      [messageRow("a", day1Morning), messageRow("b", day1Evening), messageRow("c", day2Morning)],
+      "b"
+    )
+    expect(rows.map((r) => r.key)).toEqual(["a", "unread", "b", "c"])
+    expect(rows.filter((r) => r.kind === "unread")).toHaveLength(1)
+  })
+
+  it("inserts nothing when the marker's message is not in the row list", () => {
+    const input = [messageRow("a", day1Morning), messageRow("b", day1Evening)]
+    expect(injectUnreadDivider(input, "missing")).toEqual(input)
+    expect(injectUnreadDivider(input, null)).toEqual(input)
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -31,6 +31,7 @@ export type BoardRow =
   | { kind: "branch-group"; key: string; branch: BranchConversationView; displayDepth?: number }
   | { kind: "continue-thread"; key: string; streamId: string; hiddenCount: number; displayDepth?: number }
   | { kind: "day"; key: string; dayStartMs: number; displayDepth?: number }
+  | { kind: "unread"; key: "unread"; isDimmed?: boolean; displayDepth?: number }
 
 function rowDayStartMs(row: BoardRow): number | null {
   // Only depth-0 rows are globally time-sorted; indented thread runs are spliced
@@ -70,6 +71,22 @@ export function injectBoardDayDividers(rows: BoardRow[]): BoardRow[] {
     }
     result.push(row)
   }
+  return result
+}
+
+/**
+ * Insert the single "New" divider row immediately before the marker's message
+ * row — after {@link injectBoardDayDividers}, so a marker that opens a new day
+ * reads `[day chip][New][message]`: the day labels the boundary, the New line
+ * stays adjacent to the row it overlays. Pure; no-op when there is no marker or
+ * its row is not in the list.
+ */
+export function injectUnreadDivider(rows: BoardRow[], markerMessageId: string | null, isDimmed = false): BoardRow[] {
+  if (!markerMessageId) return rows
+  const index = rows.findIndex((row) => row.kind === "message" && row.message.id === markerMessageId)
+  if (index < 0) return rows
+  const result = rows.slice()
+  result.splice(index, 0, { kind: "unread", key: "unread", isDimmed, displayDepth: rows[index].displayDepth })
   return result
 }
 

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
 import { DayDivider } from "@/components/timeline/day-divider"
+import { UnreadDivider } from "@/components/timeline/unread-divider"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
@@ -291,6 +292,15 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
       return <ContinueThreadRow key={row.key} to={continueThreadTo(row.streamId)} hiddenCount={row.hiddenCount} />
     case "day":
       return <DayDivider key={row.key} dayStartMs={row.dayStartMs} />
+    case "unread":
+      // UnreadDivider is absolute and overlays the gap above its row; the panel
+      // is not virtualized, so an in-flow spacer that reserves the gap is all it
+      // needs. It dims by colour, so nothing shifts when it settles (INV-21).
+      return (
+        <div key={row.key} className="relative h-6">
+          <UnreadDivider isDimmed={row.isDimmed} />
+        </div>
+      )
   }
 }
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -565,6 +565,291 @@ describe("ConversationPanel", () => {
     })
   })
 
+  /**
+   * The panel's read state comes from the workspace caches (INV-62: read state
+   * lives in stream_read_state, never on membership) — seed a frontier row and
+   * the unread singleton so `deriveRowState` resolves for real. `frontier` is a
+   * live box so a test can flip rows to read mid-session (what auto-read does).
+   */
+  function installReadState(initial: { lastReadAt: string | null }) {
+    const box = { lastReadAt: initial.lastReadAt }
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamReadStates").mockImplementation((() => [
+      {
+        id: `${WORKSPACE_ID}:stream_1`,
+        workspaceId: WORKSPACE_ID,
+        streamId: "stream_1",
+        lastReadEventId: "evt_1",
+        lastReadSequence: null,
+        lastReadAt: box.lastReadAt,
+        _cachedAt: 0,
+      },
+    ]) as never)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockImplementation((() => ({
+      workspaceId: WORKSPACE_ID,
+      readMessageIds: {},
+      unreadCounts: {},
+      _cachedAt: 0,
+    })) as never)
+    return box
+  }
+
+  /** Two rows from another author, an hour apart, so a frontier can split them.
+   *  The backfill returns the same rows, so the server path can't quietly
+   *  replace the unread reply with the default own-authored fixture. */
+  function unreadFixture() {
+    const reply = makeMessage({
+      id: "msg_2",
+      authorId: "usr_other",
+      contentMarkdown: "Reply two body.",
+      createdAt: "2026-06-22T12:00:00.000Z",
+    })
+    return { cached: asCached(postWithUnread()), getBoardMessages: async () => [reply] }
+  }
+
+  function postWithUnread(): BoardPost {
+    const post = makePost()
+    post.openingMessage = makeMessage({
+      id: "msg_1",
+      authorId: "usr_other",
+      createdAt: "2026-06-22T11:00:00.000Z",
+    })
+    post.recentMessages = [
+      makeMessage({
+        id: "msg_2",
+        authorId: "usr_other",
+        contentMarkdown: "Reply two body.",
+        createdAt: "2026-06-22T12:00:00.000Z",
+      }),
+    ]
+    return post
+  }
+
+  /** Records the element every scrollIntoView call landed on. */
+  function captureScrollIntoView() {
+    const targets: HTMLElement[] = []
+    const original = Element.prototype.scrollIntoView
+    Element.prototype.scrollIntoView = function (this: HTMLElement) {
+      targets.push(this)
+    }
+    return {
+      targets,
+      restore: () => {
+        Element.prototype.scrollIntoView = original
+      },
+      hitRow: (messageId: string) => targets.some((el) => el.closest(`[data-message-id="${messageId}"]`) != null),
+    }
+  }
+
+  function dividerIsRightBefore(messageId: string) {
+    const divider = screen.getByText("New")
+    const row = document.querySelector(`[data-message-id="${messageId}"]`)
+    if (!row) throw new Error(`row ${messageId} not rendered`)
+    // DOCUMENT_POSITION_FOLLOWING: the row comes after the divider.
+    return (divider.compareDocumentPosition(row) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+  }
+
+  it("opens at the unread divider instead of the tail when unread rows exist", async () => {
+    installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    const scrolls = captureScrollIntoView()
+    try {
+      mountPanel(unreadFixture())
+      await screen.findByText("Reply two body.")
+
+      await waitFor(() => expect(scrolls.hitRow("msg_2")).toBe(true))
+      expect(dividerIsRightBefore("msg_2")).toBe(true)
+      // The tail scroll never ran — the marker owns the opening position.
+      expect(scroller().scrollTop).toBe(0)
+    } finally {
+      scrolls.restore()
+      restore()
+    }
+  })
+
+  it("opens at the tail when everything is read", async () => {
+    installReadState({ lastReadAt: "2026-06-22T23:00:00.000Z" })
+    const restore = installScrollMetrics()
+    try {
+      mountPanel(unreadFixture())
+      await screen.findByText("Reply two body.")
+
+      expect(screen.queryByText("New")).toBeNull()
+      await waitFor(() => expect(scroller().scrollTop).toBe(1000))
+    } finally {
+      restore()
+    }
+  })
+
+  it("lets the ?m= deep link win over the unread marker", async () => {
+    installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    const scrolls = captureScrollIntoView()
+    try {
+      // Deep link to the READ row while msg_2 is the marker: only one of the two
+      // can own the viewport, and the explicit link is the user's intent.
+      mountPanel({ ...unreadFixture(), highlightMessageId: "msg_1" })
+      await screen.findByText("Reply two body.")
+
+      await waitFor(() => expect(scrolls.hitRow("msg_1")).toBe(true))
+      expect(scrolls.hitRow("msg_2")).toBe(false)
+      // The divider still draws — the marker is a landmark, not a scroll claim.
+      expect(dividerIsRightBefore("msg_2")).toBe(true)
+    } finally {
+      scrolls.restore()
+      restore()
+    }
+  })
+
+  it("shows the N-new banner while the divider sits above the viewport, and dismissing it tails the bottom", async () => {
+    installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    const scrolls = captureScrollIntoView()
+    // jsdom has no layout: put the scroller's top edge below every row's, so the
+    // marker row reads as scrolled off the top.
+    const originalRect = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+      return { top: this.classList.contains("overflow-y-auto") ? 100 : 0 } as DOMRect
+    }
+    try {
+      const user = userEvent.setup()
+      mountPanel(unreadFixture())
+      await screen.findByText("Reply two body.")
+
+      const banner = await screen.findByRole("button", { name: "1 new message" })
+      // The open-at-marker one-shot already scrolled to msg_2, and the capture
+      // only appends — clear it so the assertion discriminates the click.
+      scrolls.targets.length = 0
+      await user.click(banner)
+      expect(scrolls.hitRow("msg_2")).toBe(true)
+
+      await user.click(screen.getByRole("button", { name: "Dismiss unread marker" }))
+      expect(scroller().scrollTop).toBe(1000)
+      await waitFor(() => expect(screen.queryByText("New")).toBeNull())
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalRect
+      scrolls.restore()
+      restore()
+    }
+  })
+
+  it("re-scrolls to the marker when the panel returns to a conversation it already opened at", async () => {
+    // The body is not keyed on the conversation, so a switch away and back keeps
+    // the same mount: the one-shot must reset per conversation, or the revisit
+    // re-latches the same message id, matches the stale ref, and scrolls nowhere
+    // at all (skipInitialScroll suppresses the tail scroll too).
+    installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    const scrolls = captureScrollIntoView()
+    try {
+      const second = postWithUnread()
+      second.conversation = { ...second.conversation, id: "conv_2", messageIds: ["msg_9"] }
+      second.openingMessage = makeMessage({
+        id: "msg_9",
+        authorId: "usr_other",
+        contentMarkdown: "Second conversation opener.",
+        // Below the frontier: B is fully read, so its marker is null and the
+        // one-shot effect early-returns without ever touching the ref.
+        createdAt: "2026-06-22T11:00:00.000Z",
+      })
+      second.recentMessages = []
+      second.totalReplies = 0
+      const { nav } = mountPanel({
+        cachedById: { [CONVERSATION_ID]: asCached(postWithUnread()), conv_2: asCached(second) },
+        getBoardMessages: async () => [
+          makeMessage({
+            id: "msg_2",
+            authorId: "usr_other",
+            contentMarkdown: "Reply two body.",
+            createdAt: "2026-06-22T12:00:00.000Z",
+          }),
+        ],
+      })
+      await screen.findByText("Reply two body.")
+      await waitFor(() => expect(scrolls.hitRow("msg_2")).toBe(true))
+
+      act(() => nav.openConversation("conv_2"))
+      await screen.findByText("Second conversation opener.")
+
+      scrolls.targets.length = 0
+      act(() => nav.openConversation(CONVERSATION_ID))
+      await screen.findByText("Reply two body.")
+      await waitFor(() => expect(scrolls.hitRow("msg_2")).toBe(true))
+    } finally {
+      scrolls.restore()
+      restore()
+    }
+  })
+
+  it("re-pins the tail when the composer grows while the user sits at the bottom of a marked conversation", async () => {
+    // R4's symptom: the pill is absolutely positioned, so only the scroller's
+    // padding grows. The opening guard (the marker owns the first scroll) must
+    // not swallow the runtime re-pin, or the last message slides behind the
+    // composer for exactly the conversations this feature targets.
+    installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    const composerHeight = { current: 40 }
+    const originalRect = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+      return { top: 0, height: composerHeight.current } as DOMRect
+    }
+    const originalRO = global.ResizeObserver
+    const observers: (() => void)[] = []
+    global.ResizeObserver = class {
+      constructor(cb: () => void) {
+        observers.push(cb)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+    try {
+      mountPanel(unreadFixture())
+      await screen.findByText("Reply two body.")
+
+      // The user scrolls down to the live tail (past the programmatic-scroll
+      // grace period, so the scroll event is taken at face value).
+      const el = scroller()
+      await new Promise((r) => setTimeout(r, 200))
+      el.scrollTop = 700
+      act(() => fireEvent.scroll(el))
+
+      // The composer grows: every observer fires, but only the shell's height
+      // actually changed (the scroller's clientHeight is fixed).
+      composerHeight.current = 140
+      act(() => {
+        for (const cb of observers) cb()
+      })
+
+      await waitFor(() => expect(el.scrollTop).toBe(1000))
+    } finally {
+      global.ResizeObserver = originalRO
+      HTMLElement.prototype.getBoundingClientRect = originalRect
+      restore()
+    }
+  })
+
+  it("keeps the divider in place when auto-read marks the rows read (R6)", async () => {
+    // The regression the whole chunk exists to avoid: auto-read starts clearing
+    // the live unread the moment the panel paints. A marker latched anywhere but
+    // in render would move to the tail or vanish on that commit.
+    const frontier = installReadState({ lastReadAt: "2026-06-22T11:30:00.000Z" })
+    const restore = installScrollMetrics()
+    try {
+      mountPanel(unreadFixture())
+      await screen.findByText("Reply two body.")
+      expect(dividerIsRightBefore("msg_2")).toBe(true)
+
+      // Everything is read now; force a re-render through an unrelated signal.
+      frontier.lastReadAt = "2026-06-22T23:00:00.000Z"
+      act(() => requestConversationReplyOpen(CONVERSATION_ID))
+
+      await waitFor(() => expect(screen.getByText("New")).toBeTruthy())
+      expect(dividerIsRightBefore("msg_2")).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
   it("opens at the tail of the conversation", async () => {
     const restore = installScrollMetrics()
     try {

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -640,12 +640,22 @@ describe("ConversationPanel", () => {
     }
   }
 
-  function dividerIsRightBefore(messageId: string) {
+  /**
+   * True adjacency, not just ordering: the divider must follow `afterMessageId`
+   * and precede `messageId`. Asserting only "the divider comes before the row"
+   * passes for a divider misplaced any number of rows earlier, which is the
+   * failure this helper exists to catch.
+   */
+  function dividerIsRightBefore(messageId: string, afterMessageId: string | null) {
     const divider = screen.getByText("New")
     const row = document.querySelector(`[data-message-id="${messageId}"]`)
     if (!row) throw new Error(`row ${messageId} not rendered`)
-    // DOCUMENT_POSITION_FOLLOWING: the row comes after the divider.
-    return (divider.compareDocumentPosition(row) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+    const followsTarget = (divider.compareDocumentPosition(row) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+    if (!followsTarget) return false
+    if (afterMessageId === null) return true
+    const previous = document.querySelector(`[data-message-id="${afterMessageId}"]`)
+    if (!previous) throw new Error(`row ${afterMessageId} not rendered`)
+    return (divider.compareDocumentPosition(previous) & Node.DOCUMENT_POSITION_PRECEDING) !== 0
   }
 
   it("opens at the unread divider instead of the tail when unread rows exist", async () => {
@@ -657,7 +667,7 @@ describe("ConversationPanel", () => {
       await screen.findByText("Reply two body.")
 
       await waitFor(() => expect(scrolls.hitRow("msg_2")).toBe(true))
-      expect(dividerIsRightBefore("msg_2")).toBe(true)
+      expect(dividerIsRightBefore("msg_2", "msg_1")).toBe(true)
       // The tail scroll never ran — the marker owns the opening position.
       expect(scroller().scrollTop).toBe(0)
     } finally {
@@ -693,7 +703,7 @@ describe("ConversationPanel", () => {
       await waitFor(() => expect(scrolls.hitRow("msg_1")).toBe(true))
       expect(scrolls.hitRow("msg_2")).toBe(false)
       // The divider still draws — the marker is a landmark, not a scroll claim.
-      expect(dividerIsRightBefore("msg_2")).toBe(true)
+      expect(dividerIsRightBefore("msg_2", "msg_1")).toBe(true)
     } finally {
       scrolls.restore()
       restore()
@@ -837,14 +847,14 @@ describe("ConversationPanel", () => {
     try {
       mountPanel(unreadFixture())
       await screen.findByText("Reply two body.")
-      expect(dividerIsRightBefore("msg_2")).toBe(true)
+      expect(dividerIsRightBefore("msg_2", "msg_1")).toBe(true)
 
       // Everything is read now; force a re-render through an unrelated signal.
       frontier.lastReadAt = "2026-06-22T23:00:00.000Z"
       act(() => requestConversationReplyOpen(CONVERSATION_ID))
 
       await waitFor(() => expect(screen.getByText("New")).toBeTruthy())
-      expect(dividerIsRightBefore("msg_2")).toBe(true)
+      expect(dividerIsRightBefore("msg_2", "msg_1")).toBe(true)
     } finally {
       restore()
     }

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -12,6 +12,8 @@ import {
   Check,
   CircleCheck,
   ArrowDown,
+  ArrowUp,
+  X,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -26,7 +28,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBranchedBoardRows, injectBoardDayDividers } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows, injectBoardDayDividers, injectUnreadDivider } from "@/components/board/board-row-item"
 import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
@@ -41,10 +43,12 @@ import { useInlineBranchComposer, type ArmBranchTarget } from "@/components/boar
 import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
+import { useWorkspaceStreamReadStates, useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { cn } from "@/lib/utils"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
+import { useConversationUnreadMarker } from "@/components/conversations/use-conversation-unread-marker"
 import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer, type ArmedReply } from "@/components/board/board-reply-composer"
 import {
@@ -543,7 +547,28 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       }),
     [conversation.id, conversation.streamId, structuralIndex, conversationGraph]
   )
-  const rows = injectBoardDayDividers(
+  // The panel's read state resolves with the workspace unread bootstrap AND the
+  // per-stream frontiers the derivation actually consumes: a row whose leg has
+  // no frontier yet derives as `ungated`, so latching before every spanned
+  // stream can be decided would anchor the marker below the true first unread —
+  // and the latch is one-way, so it would never correct.
+  const unreadState = useWorkspaceUnreadState(workspaceId)
+  const streamReadStates = useWorkspaceStreamReadStates(workspaceId)
+  const readStateResolved = useMemo(() => {
+    if (unreadState === undefined) return false
+    const decidable = new Set(streamReadStates.map((row) => row.streamId))
+    for (const [streamId, count] of Object.entries(unreadState.unreadCounts ?? {})) {
+      if (count === 0) decidable.add(streamId)
+    }
+    for (const message of all) {
+      if (!decidable.has(message.streamId ?? conversation.streamId)) return false
+    }
+    return true
+  }, [unreadState, streamReadStates, all, conversation.streamId])
+  // Rows first, marker second: the marker may only anchor on a message that
+  // actually gets a row (a message inside a depth-collapsed spanning subtree has
+  // none, so a divider there would draw nothing and scroll nowhere).
+  const baseRows = injectBoardDayDividers(
     buildBranchedBoardRows(
       groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
       eventRows,
@@ -551,6 +576,22 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       openingMessage?.id
     )
   )
+  const renderedMessageIds = new Set<string>()
+  for (const row of baseRows) if (row.kind === "message") renderedMessageIds.add(row.message.id)
+  const { markerMessageId, unreadCount, isDimmed, dismiss } = useConversationUnreadMarker({
+    conversationId: conversation.id,
+    rows: all,
+    rootStreamId: conversation.streamId,
+    rowState: conversationReadValue.state,
+    currentUserId,
+    readStateResolved,
+    renderedMessageIds,
+  })
+  // Set while this conversation holds an unread marker: the composer's opening
+  // re-pin must not force the tail out from under the marker's scroll (which
+  // lands first, so a "pending" flag would already be clear by then).
+  const markerHeldRef = useRef(false)
+  const rows = injectUnreadDivider(baseRows, markerMessageId, isDimmed)
   // "Move to sub-topic" re-file — same gesture as the board card (membership move
   // within one root; the hook hides the action when a row has nowhere to go).
   const moveToSubtopic = useMoveToSubtopic({ workspaceId, conversation, branchesByForkMessageId })
@@ -636,16 +677,17 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const anchorEl = anchor?.el ?? null
   const floatingComposerOpen = anchor?.claimantId != null
 
-  const { scrollContainerRef, handleScroll, isScrolledFarFromBottom, scrollToBottom } = useScrollBehavior({
-    isLoading: loadingMore,
-    itemCount: rows.length,
-    resetKey: conversation.id,
-    // Only treat the user as "at the bottom" when they are essentially flush, so
-    // a small scroll-up to reference an older reply while typing is not snapped
-    // back when the composer grows (thread-path parity).
-    bottomThreshold: 4,
-    skipInitialScroll: highlightMessageId != null,
-  })
+  const { scrollContainerRef, handleScroll, isScrolledFarFromBottom, scrollToBottom, disableAutoScroll } =
+    useScrollBehavior({
+      isLoading: loadingMore,
+      itemCount: rows.length,
+      resetKey: conversation.id,
+      // Only treat the user as "at the bottom" when they are essentially flush, so
+      // a small scroll-up to reference an older reply while typing is not snapped
+      // back when the composer grows (thread-path parity).
+      bottomThreshold: 4,
+      skipInitialScroll: highlightMessageId != null || markerMessageId != null,
+    })
   // Both consumers of `listRef` (text-selection quoting, viewport auto-read) are
   // keyed to the scroller node, so the two refs name the same element.
   const attachListRef = useCallback(
@@ -665,9 +707,19 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   scrollToBottomRef.current = scrollToBottom
   const handleComposerHeightChange = useCallback(
     (_px: number, opts: { initial: boolean }) => {
-      if (highlightMessageId != null) return
-      if (opts.initial) scrollToBottomRef.current({ force: true })
-      else requestAnimationFrame(() => scrollToBottomRef.current())
+      // Only the OPENING force-scroll defers to the panel's opening anchor (a
+      // `?m=` row, or an unread marker held until dismissed): a child layout
+      // effect runs before the parent's marker effect, so on a first-commit
+      // latch this fires first and the guard is what saves the marker's scroll.
+      // The runtime re-pin is unconditional — it is the un-forced call, which
+      // no-ops unless the user is already at the bottom, so the tail can't slide
+      // behind a growing composer.
+      if (opts.initial) {
+        if (highlightMessageId != null || markerHeldRef.current) return
+        scrollToBottomRef.current({ force: true })
+      } else {
+        requestAnimationFrame(() => scrollToBottomRef.current())
+      }
     },
     [highlightMessageId]
   )
@@ -693,6 +745,58 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     getReadTruth,
   })
 
+  const findMarkerRow = useCallback(() => {
+    const container = listRef.current
+    if (!container || !markerMessageId) return null
+    return container.querySelector<HTMLElement>(`[data-message-id="${markerMessageId}"]`)
+  }, [markerMessageId])
+  const scrollToMarker = useCallback(() => {
+    const row = findMarkerRow()
+    if (!row) return false
+    disableAutoScroll()
+    row.scrollIntoView({ block: "start" })
+    return true
+  }, [findMarkerRow, disableAutoScroll])
+
+  // Open at the first unread instead of the tail. Runs on every render until it
+  // lands: the one-shot is consumed ONLY once a scroll actually happened, so a
+  // render where the marker's row is not in the DOM yet (rows still loading)
+  // leaves it armed rather than parking the panel at the bottom with a divider
+  // the user was never taken to. `?m=` wins — its own row scroll is the intent.
+  // The body is not keyed on the conversation, so it survives a switch: the
+  // one-shot is reset here in render on conversation change, never inferred from
+  // the key differing — a switch away and back re-latches the same message id,
+  // and a ref still holding it would leave the revisit scrolling nowhere at all.
+  const scrolledMarkerRef = useRef<{ conversationId: string; key: string | null }>({
+    conversationId: conversation.id,
+    key: null,
+  })
+  if (scrolledMarkerRef.current.conversationId !== conversation.id) {
+    scrolledMarkerRef.current = { conversationId: conversation.id, key: null }
+  }
+  markerHeldRef.current = markerMessageId != null
+  const markerScrollKey = markerMessageId
+  useEffect(() => {
+    if (highlightMessageId != null || markerScrollKey == null) return
+    if (scrolledMarkerRef.current.key === markerScrollKey) return
+    if (scrollToMarker()) scrolledMarkerRef.current.key = markerScrollKey
+  })
+
+  // The banner shows only while the divider has left the top of the viewport.
+  const [markerAboveViewport, setMarkerAboveViewport] = useState(false)
+  const syncMarkerPosition = useCallback(() => {
+    const container = listRef.current
+    const row = findMarkerRow()
+    setMarkerAboveViewport(
+      container != null && row != null && row.getBoundingClientRect().top < container.getBoundingClientRect().top
+    )
+  }, [findMarkerRow])
+  useEffect(syncMarkerPosition)
+  const handleListScroll = useCallback(() => {
+    handleScroll()
+    syncMarkerPosition()
+  }, [handleScroll, syncMarkerPosition])
+
   return (
     // Quote reply from a row routes into this conversation's reply composer.
     <ConversationReadProvider value={conversationReadValue}>
@@ -702,7 +806,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         {moveToSubtopic.moveDialog}
         <div
           ref={attachListRef}
-          onScroll={handleScroll}
+          onScroll={handleListScroll}
           // pt-4 reserves headroom for the first row's hover toolbar, which floats
           // ~14px above its row (MessageItem's float-above chip). Without it the
           // scroll container's top edge clips the first message's toolbar — the
@@ -740,6 +844,39 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
             )}
           </div>
         </div>
+        {markerMessageId != null && markerAboveViewport && unreadCount > 0 && (
+          // Same affordance as the timeline's, in the same place: below the
+          // header, clear of the top-center chrome.
+          <div
+            className="pointer-events-none absolute left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5"
+            style={{ top: "3.5rem" }}
+          >
+            <Button
+              variant="secondary"
+              size="sm"
+              className="pointer-events-auto gap-1.5 shadow-lg"
+              onClick={() => scrollToMarker()}
+            >
+              <ArrowUp className="h-3.5 w-3.5" />
+              {unreadCount} new message{unreadCount === 1 ? "" : "s"}
+            </Button>
+            {/* Drop the marker and tail the live bottom without scrolling up.
+                Read state is not written here — the panel is read-only over it
+                (INV-62); auto-read handles rows as they enter the viewport. */}
+            <Button
+              variant="secondary"
+              size="icon"
+              className="pointer-events-auto h-9 w-9 shadow-lg"
+              onClick={() => {
+                dismiss()
+                scrollToBottom({ force: true })
+              }}
+              aria-label="Dismiss unread marker"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
         {isScrolledFarFromBottom && (
           <div
             className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2"

--- a/apps/frontend/src/components/conversations/use-conversation-unread-marker.test.tsx
+++ b/apps/frontend/src/components/conversations/use-conversation-unread-marker.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { useConversationUnreadMarker } from "./use-conversation-unread-marker"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+const ROOT_STREAM_ID = "stream_1"
+
+function makeRow(id: string, authorId: string): RenderableMessage {
+  return {
+    id,
+    streamId: ROOT_STREAM_ID,
+    authorId,
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    createdAt: "2026-06-22T12:00:00.000Z",
+  }
+}
+
+function stateFrom(byId: Record<string, RowReadState>) {
+  return (_streamId: string, messageId: string) => byId[messageId] ?? "read"
+}
+
+function mountMarker(opts: {
+  rows: RenderableMessage[]
+  byId: Record<string, RowReadState>
+  conversationId?: string
+  readStateResolved?: boolean
+}) {
+  return renderHook(
+    (props: { rows: RenderableMessage[]; byId: Record<string, RowReadState>; conversationId: string }) =>
+      useConversationUnreadMarker({
+        conversationId: props.conversationId,
+        rows: props.rows,
+        rootStreamId: ROOT_STREAM_ID,
+        rowState: stateFrom(props.byId),
+        currentUserId: "usr_me",
+        readStateResolved: opts.readStateResolved ?? true,
+      }),
+    { initialProps: { rows: opts.rows, byId: opts.byId, conversationId: opts.conversationId ?? "conv_1" } }
+  )
+}
+
+describe("useConversationUnreadMarker", () => {
+  it("anchors on the first unread row from another author", () => {
+    const rows = [makeRow("msg_1", "usr_other"), makeRow("msg_2", "usr_other"), makeRow("msg_3", "usr_other")]
+    const { result } = mountMarker({ rows, byId: { msg_1: "read", msg_2: "unread", msg_3: "unread" } })
+    expect({ markerMessageId: result.current.markerMessageId, unreadCount: result.current.unreadCount }).toEqual({
+      markerMessageId: "msg_2",
+      unreadCount: 2,
+    })
+  })
+
+  it("skips the viewer's own rows when choosing the marker", () => {
+    const rows = [makeRow("msg_1", "usr_me"), makeRow("msg_2", "usr_other")]
+    const { result } = mountMarker({ rows, byId: { msg_1: "unread", msg_2: "unread" } })
+    expect(result.current.markerMessageId).toBe("msg_2")
+  })
+
+  it("does not anchor on an ungated row", () => {
+    const rows = [makeRow("msg_1", "usr_other"), makeRow("msg_2", "usr_other")]
+    const { result } = mountMarker({ rows, byId: { msg_1: "ungated", msg_2: "ungated" } })
+    expect(result.current.markerMessageId).toBeNull()
+  })
+
+  it("holds the latched marker after the rows become read", () => {
+    // The R6 shape at hook level: auto-read clears the live unread the moment
+    // the panel paints; a marker that moved or vanished then would leave the
+    // divider drawn somewhere the user was never taken to.
+    const rows = [makeRow("msg_1", "usr_other"), makeRow("msg_2", "usr_other")]
+    const { result, rerender } = mountMarker({ rows, byId: { msg_1: "unread", msg_2: "unread" } })
+    expect(result.current.markerMessageId).toBe("msg_1")
+
+    rerender({ rows, byId: { msg_1: "read", msg_2: "read" }, conversationId: "conv_1" })
+    expect({
+      markerMessageId: result.current.markerMessageId,
+      unreadCount: result.current.unreadCount,
+      isDimmed: result.current.isDimmed,
+    }).toEqual({ markerMessageId: "msg_1", unreadCount: 0, isDimmed: true })
+  })
+
+  it("re-latches when the hook is recycled onto another conversation", () => {
+    const first = [makeRow("msg_1", "usr_other")]
+    const second = [makeRow("msg_9", "usr_other")]
+    const { result, rerender } = mountMarker({ rows: first, byId: { msg_1: "unread" } })
+    expect(result.current.markerMessageId).toBe("msg_1")
+
+    rerender({ rows: second, byId: { msg_9: "unread" }, conversationId: "conv_2" })
+    expect(result.current.markerMessageId).toBe("msg_9")
+  })
+
+  it("clears a dismissal when the conversation changes, so a revisit with fresh unread marks again", () => {
+    const first = [makeRow("msg_1", "usr_other")]
+    const second = [makeRow("msg_9", "usr_other")]
+    const { result, rerender } = mountMarker({ rows: first, byId: { msg_1: "unread" } })
+    act(() => result.current.dismiss())
+    expect(result.current.markerMessageId).toBeNull()
+
+    rerender({ rows: second, byId: { msg_9: "read" }, conversationId: "conv_2" })
+    // Back on A, which has picked up a new reply while we were away.
+    const revisited = [makeRow("msg_1", "usr_other"), makeRow("msg_2", "usr_other")]
+    rerender({ rows: revisited, byId: { msg_1: "read", msg_2: "unread" }, conversationId: "conv_1" })
+    expect(result.current.markerMessageId).toBe("msg_2")
+  })
+
+  it("keeps a settled divider dimmed when a later message arrives unread", () => {
+    const rows = [makeRow("msg_1", "usr_other")]
+    const { result, rerender } = mountMarker({ rows, byId: { msg_1: "unread" } })
+    expect(result.current.isDimmed).toBe(false)
+
+    rerender({ rows, byId: { msg_1: "read" }, conversationId: "conv_1" })
+    expect(result.current.isDimmed).toBe(true)
+
+    const grown = [...rows, makeRow("msg_2", "usr_other")]
+    rerender({ rows: grown, byId: { msg_1: "read", msg_2: "unread" }, conversationId: "conv_1" })
+    expect({ isDimmed: result.current.isDimmed, unreadCount: result.current.unreadCount }).toEqual({
+      isDimmed: true,
+      unreadCount: 1,
+    })
+  })
+
+  it("latches nothing until the read state resolves, then latches on the first decidable render", () => {
+    const rows = [makeRow("msg_1", "usr_other"), makeRow("msg_2", "usr_other")]
+    const { result, rerender } = renderHook(
+      (props: { readStateResolved: boolean }) =>
+        useConversationUnreadMarker({
+          conversationId: "conv_1",
+          rows,
+          rootStreamId: ROOT_STREAM_ID,
+          rowState: stateFrom({ msg_1: "unread", msg_2: "unread" }),
+          currentUserId: "usr_me",
+          readStateResolved: props.readStateResolved,
+        }),
+      { initialProps: { readStateResolved: false } }
+    )
+    expect(result.current.markerMessageId).toBeNull()
+
+    rerender({ readStateResolved: true })
+    expect(result.current.markerMessageId).toBe("msg_1")
+  })
+
+  it("never latches a marker on a message with no rendered row", () => {
+    // A message inside a depth-collapsed spanning subtree has no row: a divider
+    // there draws nothing and the open-at-marker scroll has no target.
+    const rows = [makeRow("msg_hidden", "usr_other"), makeRow("msg_2", "usr_other")]
+    const rendered = new Set(["msg_2"])
+    const mount = (byId: Record<string, RowReadState>) =>
+      renderHook(() =>
+        useConversationUnreadMarker({
+          conversationId: "conv_1",
+          rows,
+          rootStreamId: ROOT_STREAM_ID,
+          rowState: stateFrom(byId),
+          currentUserId: "usr_me",
+          readStateResolved: true,
+          renderedMessageIds: rendered,
+        })
+      )
+    // The unrendered row is skipped; the marker moves to the next drawn row.
+    expect(mount({ msg_hidden: "unread", msg_2: "unread" }).result.current.markerMessageId).toBe("msg_2")
+    // Only the unrendered row is unread → nothing latches at all.
+    expect(mount({ msg_hidden: "unread", msg_2: "read" }).result.current.markerMessageId).toBeNull()
+  })
+
+  it("counts only unread, non-own rows at or after the marker", () => {
+    const rows = [
+      makeRow("msg_1", "usr_other"),
+      makeRow("msg_2", "usr_other"),
+      makeRow("msg_3", "usr_me"),
+      makeRow("msg_4", "usr_other"),
+    ]
+    const { result } = mountMarker({
+      rows,
+      byId: { msg_1: "unread", msg_2: "read", msg_3: "unread", msg_4: "unread" },
+    })
+    expect({ markerMessageId: result.current.markerMessageId, unreadCount: result.current.unreadCount }).toEqual({
+      markerMessageId: "msg_1",
+      unreadCount: 2,
+    })
+  })
+})

--- a/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
+++ b/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
@@ -1,0 +1,106 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+import type { ConversationRowRead } from "@/components/message/conversation-read-context"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+interface UseConversationUnreadMarkerOptions {
+  /** Resets the latch — one marker decision per conversation, per open. */
+  conversationId: string
+  /** The conversation's message rows, in render order. */
+  rows: RenderableMessage[]
+  /** Stream a row falls back to when it carries none (the conversation's anchor). */
+  rootStreamId: string
+  /** Per-row read state from {@link ConversationRowRead} — `"ungated"` never anchors. */
+  rowState: ConversationRowRead["state"]
+  currentUserId: string | null
+  /** False until the workspace read state has loaded; the marker waits for it. */
+  readStateResolved: boolean
+  /** Ids that actually get a rendered row — a marker inside a collapsed subtree
+   *  would draw no divider and have no scroll target. `null` = no filtering. */
+  renderedMessageIds?: ReadonlySet<string> | null
+}
+
+interface UseConversationUnreadMarkerResult {
+  markerMessageId: string | null
+  /** Unread, non-own rows at or after the marker — live, so it decays as auto-read runs. */
+  unreadCount: number
+  /** The marker's rows have all been read: the divider settles from red to muted. */
+  isDimmed: boolean
+  dismiss: () => void
+}
+
+/**
+ * The conversation panel's first-unread landmark: where the "New" divider sits
+ * and what the "N new messages" banner counts. Sibling to
+ * `hooks/use-unread-divider.ts` — that one is single-stream (`StreamEvent[]` +
+ * one `lastReadSequence`), this one is cross-stream (conversation rows, each
+ * resolved through its own stream's frontier by `rowState`).
+ */
+export function useConversationUnreadMarker({
+  conversationId,
+  rows,
+  rootStreamId,
+  rowState,
+  currentUserId,
+  readStateResolved,
+  renderedMessageIds = null,
+}: UseConversationUnreadMarkerOptions): UseConversationUnreadMarkerResult {
+  const firstUnreadId = useMemo(() => {
+    if (!readStateResolved) return null
+    for (const row of rows) {
+      if (row.authorId === currentUserId) continue
+      if (renderedMessageIds && !renderedMessageIds.has(row.id)) continue
+      if (rowState(row.streamId ?? rootStreamId, row.id, row.sequence, row.createdAt) !== "unread") continue
+      return row.id
+    }
+    return null
+  }, [rows, rowState, currentUserId, rootStreamId, readStateResolved, renderedMessageIds])
+
+  // Latched in RENDER, not an effect. Auto-read starts clearing the live unread
+  // the moment the panel paints, and an effect-based latch would read the
+  // already-cleared value on the commit that matters — the divider would be
+  // drawn at the tail, or not at all. The ref resets on conversation change and
+  // then captures the first non-null first-unread; nothing after that moves it.
+  const latchRef = useRef<{ conversationId: string; messageId: string | null; dimmed: boolean }>({
+    conversationId,
+    messageId: null,
+    dimmed: false,
+  })
+  // Explicit dismissal (the banner's ✕). A latched marker has no clear-on-read,
+  // so a separate flag overrides it. Per-open like the marker itself: it clears
+  // on a conversation change, so returning to a conversation with fresh unread
+  // gets its own marker rather than staying silently downgraded.
+  const [dismissed, setDismissed] = useState<string | null>(null)
+  if (latchRef.current.conversationId !== conversationId) {
+    latchRef.current = { conversationId, messageId: null, dimmed: false }
+    if (dismissed !== null) setDismissed(null)
+  }
+  if (firstUnreadId && latchRef.current.messageId === null) {
+    latchRef.current.messageId = firstUnreadId
+  }
+
+  const dismiss = useCallback(() => setDismissed(conversationId), [conversationId])
+
+  const latched = latchRef.current.messageId
+  const markerMessageId = dismissed === conversationId ? null : latched
+
+  const unreadCount = useMemo(() => {
+    if (!markerMessageId) return 0
+    const start = rows.findIndex((row) => row.id === markerMessageId)
+    if (start < 0) return 0
+    let count = 0
+    for (let i = start; i < rows.length; i++) {
+      const row = rows[i]
+      if (row.authorId === currentUserId) continue
+      if (rowState(row.streamId ?? rootStreamId, row.id, row.sequence, row.createdAt) === "unread") count += 1
+    }
+    return count
+  }, [markerMessageId, rows, rowState, currentUserId, rootStreamId])
+
+  // Settling is one-way, like the timeline's: once the marker's rows have all
+  // been read the divider stays muted for this open. A later arrival must not
+  // re-redden a divider that now points at rows the user has already read.
+  if (markerMessageId != null && unreadCount === 0) latchRef.current.dimmed = true
+  const isDimmed = markerMessageId != null && latchRef.current.dimmed
+
+  return { markerMessageId, unreadCount, isDimmed, dismiss }
+}


### PR DESCRIPTION
Chunk 3 of 5 — [conversation panel ⇄ timeline parity](https://seer.build/ws_vbyzjvdg6g/b/conv-parity-plan-3d138c/). Stacked on #1642.

## Problem

The conversation panel already computes per-row read truth — `useConversationReadController`'s `state(streamId, messageId, sequence, createdAt)` runs on every row — but drew nothing with it. No "New" divider, no unread banner, and the panel always opened at the tail, so on a conversation with twenty unread replies you landed at the bottom and scrolled up hunting for where you left off.

## Solution

The timeline's three landmarks, over conversation rows: a latched first-unread marker, the `UnreadDivider` drawn at it, and the "N new messages" banner while it sits above the viewport. Read-only over read state — `dismiss()` is local `useState`, everything else is derivation and scrolling (INV-62).

- **The marker latches in render, not in an effect**, keyed on `conversationId`. Auto-read starts clearing the live unread the moment the panel paints; an effect-based latch reads the already-cleared value on the commit that matters, and the divider ends up at the tail or absent. This is the failure recorded in `project_open_at_first_unread_stack_1579`, and it is why this chunk is its own PR.
- **The scroll one-shot clears only after it has actually scrolled**, and resets on conversation change rather than inferring it from a composite `conv:msg` key. `ConversationPanelBody` is not keyed and `useConversationBoardPost` returns cached posts synchronously, so switching A→B→A never unmounts it: A re-latches the *same* message id, a ref still holding that key skips the scroll, and `skipInitialScroll` suppresses the fallback — the divider is drawn at an offset the user was never taken to. Caught by adversarial review with an executed repro.
- **The opening force-scroll defers to the marker; the runtime composer re-pin does not.** The guard sits *inside* the `opts.initial` branch. Guarding both would have killed chunk 1's growth re-pin for every conversation with unread — reintroducing the last-message-behind-the-composer bug this stack opened by fixing. The runtime call is the un-forced `scrollToBottom()`, which no-ops unless the user is at the bottom, and `scrollToMarker()` calls `disableAutoScroll()` first, so it cannot yank a reader off the marker.
- **The marker only considers rows that will actually render** — the candidate set is filtered by the injected `BoardRow[]`, so a message inside a depth-collapsed spanning subtree can't latch a marker with no divider and no scroll target.
- **`readStateResolved` is derived from what the marker consumes** — the unread bootstrap having landed *and* every spanned stream being decidable (a `stream_read_state` row, or `unreadCounts[streamId] === 0`, mirroring `deriveRowState`'s two decidable paths). A weaker check let the one-way latch anchor below the true first unread when a thread leg's frontier landed late.
- **Dismissal and dimming are per-open**, reset with the latch. Sticky dismissal silently downgraded a returning conversation to pre-feature behaviour; non-monotone dimming let a settled divider turn red again.

**Not a reuse candidate:** `hooks/use-unread-divider.ts` is single-stream (`StreamEvent[]` + one `lastReadSequence`); this is cross-stream (conversation rows each resolved through their own stream's frontier). Sibling, not shared code — deliberate, so nobody "fixes" it by merging them.

The banner's ✕ is labelled **"Dismiss unread marker"**, not the timeline's "Mark all read": it clears the latch and tails the bottom, and writes nothing. The timeline's label is accurate there because `escapeUnread` really does mark read.

## Files

| File | Change |
| ---- | ------ |
| `components/conversations/use-conversation-unread-marker.ts` | **new** — render-latched marker, live count, latched dimming, per-open dismissal |
| `components/conversations/use-conversation-unread-marker.test.tsx` | **new** — latch, own-row skip, `ungated`, hold-after-read, re-latch, count, unresolved read state, rendered-set filter |
| `components/board/board-row-item.tsx` | `BoardRow` gains an `unread` kind; `injectUnreadDivider` |
| `components/board/branch-rows.tsx` | `case "unread"` → `UnreadDivider` in a `relative h-6` spacer |
| `components/conversations/conversation-panel.tsx` | hook wiring, divider injection, open-at-marker one-shot, banner, scoped composer guard |
| `components/conversations/conversation-panel.test.tsx` | opens at divider / at tail, `?m=` wins, banner + dismiss, R6 regression, A→B→A revisit, composer re-pin |
| `components/board/board-row-item.test.ts` | injector: exactly one row before the marker; no-op when absent |

## Test plan

- [x] `apps/frontend` typecheck — clean
- [x] `apps/frontend` lint — clean
- [x] vitest `components/{conversations,board,timeline}` + `hooks` — 143 files, 1585 tests pass
- [x] every new test neutralised → confirmed red → restored. Removing the per-conversation one-shot reset makes the revisit test fail with nothing scrolling; restoring the composer guard to its pre-fix position makes the re-pin test fail `expected 1000, received 700`.
- [ ] manual pass with a second device generating unread — not run

Adversarial review after the first green run found 7 issues including both blockers above; all fixed in-branch. One finding was **refuted**: dividers don't reset the following row's `continuation` flag, which is parity with the stream timeline's own `annotateAuthorGroups` + `injectDayDividers`, not a defect.

Known gap, stated rather than hidden: the F7 rendered-set guard is proven at hook level, but no panel test builds a real depth-collapsed spanning subtree — that needs the structural index wired well past what the harness stubs, and a hand-faked version would not be evidence.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787866682&installation_model_id=20758&pr_number=1645&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1645&signature=0add47aa135861d8efda161a03e0b73c159def8035bbddfa2e1948aec08be5f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Known issues (sub-threshold, carried to the whole-stack pass)

From `/code-review` on this PR — each scored below its reporting bar, recorded rather than silently dropped:

- Open-at-marker scrolls the **message** row with `block: "start"`, so the "New" line's 24px spacer sits just above the top edge. The timeline avoids this with `offset: -UNREAD_MARKER_TOP_GAP_PX`. Cosmetic, but it undercuts the feature's promise slightly — you land on the first unread message rather than on the line announcing it.
- `skipInitialScroll` is sampled only in `useScrollBehavior`'s `resetKey` layout effect, so a post-mount `readStateResolved` flip can let the tail scroll run first and be corrected a frame later.
- `unreadCount` counts over all rows while the marker is filtered by `renderedMessageIds`, so an unread inside a collapsed subtree can inflate the banner count.
