### PR TITLE
feat(harnessd): show how each session's identity resolves

### DIFF
--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -28,6 +28,7 @@ Usage:
   threa-harnessd steer <agent-id-or-name> [follow-up text]
   threa-harnessd keys <agent-id-or-name> <tmux send-keys tokens...>
   threa-harnessd attach <agent-id-or-name>
+  threa-harnessd resolve [<agent-id-or-name-or-runtime-session-id>]
   threa-harnessd doctor
 
 Examples:
@@ -170,6 +171,13 @@ const ADOPT_FLAGS = new Set([
   "force",
   "no-yolo",
 ])
+
+export function parseResolve(args: string[]): string | undefined {
+  const ref = args.shift()
+  if (ref?.startsWith("--")) die(`unexpected resolve argument: ${ref}`)
+  if (args.length > 0) die(`unexpected resolve argument: ${args[0]}`)
+  return ref
+}
 
 export function parseSpawn(args: string[]): SpawnOptions {
   const runtime = args.shift() as RuntimeKind | undefined

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -356,19 +356,23 @@ export async function reviveAgent(
       console.log(`repair-inventory\t${agent.name}\tPi remote link recovered`)
     }
   }
+  const scratchpad = agent.scratchpadUrl ? parseScratchpadUrl(agent.scratchpadUrl) : undefined
   const paneStatus = deps.paneStatus(agent)
-  const recorded = agent.runtimeSessionId ?? "-"
-  const derived =
-    agent.runtime === "claude" && agent.worktree
-      ? deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig).runtimeSessionId
-      : "-"
-  console.log(`resolve\t${agent.name}\t${identityVerdict(paneStatus, recorded, derived)}\t${recorded}\t${derived}`)
+  // A targeted restore event decides one agent, so logging the whole inventory
+  // would bury the line this exists to surface.
+  if (!target || scratchpad?.streamId === target.rootStreamId) {
+    const recorded = agent.runtimeSessionId ?? "-"
+    const derived =
+      agent.runtime === "claude" && agent.worktree
+        ? deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig).runtimeSessionId
+        : "-"
+    console.log(`resolve\t${agent.name}\t${identityVerdict(paneStatus, recorded, derived)}\t${recorded}\t${derived}`)
+  }
   // Ambiguity counts as alive: the next move is spawning a replacement, and a
   // duplicate agent is worse than a missed revival.
   if (paneStatus !== "missing") return { status: "already running" }
   if (agent.status === "stopped") return { status: "skipped stopped" }
   if (!agent.scratchpadUrl) return { status: "skipped missing link", detail: "no scratchpad URL recorded" }
-  const scratchpad = parseScratchpadUrl(agent.scratchpadUrl)
   if (!scratchpad) return { status: "skipped missing link", detail: `invalid scratchpad URL: ${agent.scratchpadUrl}` }
   if (target && scratchpad.streamId !== target.rootStreamId) return undefined
   if (target) {
@@ -752,19 +756,27 @@ export function doctor(): void {
   for (const [name, ok, note] of checks) {
     console.log(`${ok ? "ok" : "missing"}\t${name}\t${note}`)
   }
-  let panes: LocalTmuxPane[] = []
+  // A pane scan that never ran must not report zero drift: "0 of nothing" is
+  // indistinguishable from a clean fleet, which is the shape of miss this
+  // command exists to catch (INV-11).
+  let panes: LocalTmuxPane[] | undefined
+  let paneError: string | undefined
   try {
     panes = listLocalTmuxPanes()
-  } catch {
-    panes = []
+  } catch (error) {
+    paneError = error instanceof Error ? error.message : String(error)
   }
-  const drift = identityConsistency({ panes, config: readThreaChannelConfig() })
-  const driftChecks: Array<[string, number]> = [
+  const drift = identityConsistency({ panes: panes ?? [], config: readThreaChannelConfig() })
+  const driftChecks: Array<[string, number | undefined]> = [
     ["identity drift (inventory rows)", drift.inventoryRows],
     ["identity drift (link records)", drift.linkRecords],
-    ["identity drift (live panes)", drift.livePanes],
+    ["identity drift (live panes)", panes ? drift.livePanes : undefined],
   ]
   for (const [name, count] of driftChecks) {
+    if (count === undefined) {
+      console.log(`unknown\t${name}\tcould not inspect local tmux panes: ${paneError}`)
+      continue
+    }
     console.log(
       `${count === 0 ? "ok" : "drift"}\t${name}\t${count} carry an identity today's derivation cannot reproduce`
     )

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -10,8 +10,15 @@ import { basename, dirname, join } from "node:path"
 import { installBootResume } from "./boot"
 import { defaultClaudeDiskDeps, findLiveClaudeSessions } from "./claude-registry"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
-import { findLocalClaudeChannelPane, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
+import {
+  findLocalClaudeChannelPane,
+  listLocalTmuxPanes,
+  resolveManagedAgentPane,
+  type LocalTmuxPane,
+  type ManagedAgentPane,
+} from "./discovery"
 import { die } from "./errors"
+import { identityConsistency, identityVerdict } from "./identity"
 import {
   findAgent,
   findAgentOrUndefined,
@@ -292,7 +299,7 @@ export interface ReviveOutcome {
 export interface ReviveDeps {
   claudeConfig: ThreaChannelConfig
   piConfig: PiRemoteConfig
-  windowExists: (agent: ManagedAgent) => boolean
+  paneStatus: (agent: ManagedAgent) => ManagedAgentPane["status"]
   /** Live Claude pids already in this worktree, corroborated against the process table. */
   claudeProcessesIn: (worktree: string) => number[]
   pathExists: (path: string) => boolean
@@ -315,7 +322,7 @@ export function defaultReviveDeps(): ReviveDeps {
   return {
     claudeConfig: readThreaChannelConfig(),
     piConfig: readPiRemoteConfig(),
-    windowExists: (agent) => agentPaneLives(agent),
+    paneStatus: (agent) => resolveManagedAgentPane(agent).status,
     claudeProcessesIn: (worktree) =>
       findLiveClaudeSessions(worktree, defaultClaudeDiskDeps()).map((session) => session.pid),
     pathExists: existsSync,
@@ -349,7 +356,16 @@ export async function reviveAgent(
       console.log(`repair-inventory\t${agent.name}\tPi remote link recovered`)
     }
   }
-  if (deps.windowExists(agent)) return { status: "already running" }
+  const paneStatus = deps.paneStatus(agent)
+  const recorded = agent.runtimeSessionId ?? "-"
+  const derived =
+    agent.runtime === "claude" && agent.worktree
+      ? deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig).runtimeSessionId
+      : "-"
+  console.log(`resolve\t${agent.name}\t${identityVerdict(paneStatus, recorded, derived)}\t${recorded}\t${derived}`)
+  // Ambiguity counts as alive: the next move is spawning a replacement, and a
+  // duplicate agent is worse than a missed revival.
+  if (paneStatus !== "missing") return { status: "already running" }
   if (agent.status === "stopped") return { status: "skipped stopped" }
   if (!agent.scratchpadUrl) return { status: "skipped missing link", detail: "no scratchpad URL recorded" }
   const scratchpad = parseScratchpadUrl(agent.scratchpadUrl)
@@ -616,15 +632,6 @@ export function stopAgent(ref: string): void {
 }
 
 /**
- * Whether the agent still occupies a live pane. Ambiguity counts as alive: the
- * caller's next move is spawning a replacement, and a duplicate agent is worse
- * than a missed revival.
- */
-function agentPaneLives(agent: ManagedAgent): boolean {
-  return resolveManagedAgentPane(agent).status !== "missing"
-}
-
-/**
  * The pane to act on, resolved by runtime identity rather than the recorded
  * tmux id — which a new tmux server hands to somebody else. Read-only: the
  * stored ids are a tie-breaker, never the answer, so there is nothing to
@@ -744,6 +751,23 @@ export function doctor(): void {
   ]
   for (const [name, ok, note] of checks) {
     console.log(`${ok ? "ok" : "missing"}\t${name}\t${note}`)
+  }
+  let panes: LocalTmuxPane[] = []
+  try {
+    panes = listLocalTmuxPanes()
+  } catch {
+    panes = []
+  }
+  const drift = identityConsistency({ panes, config: readThreaChannelConfig() })
+  const driftChecks: Array<[string, number]> = [
+    ["identity drift (inventory rows)", drift.inventoryRows],
+    ["identity drift (link records)", drift.linkRecords],
+    ["identity drift (live panes)", drift.livePanes],
+  ]
+  for (const [name, count] of driftChecks) {
+    console.log(
+      `${count === 0 ? "ok" : "drift"}\t${name}\t${count} carry an identity today's derivation cannot reproduce`
+    )
   }
   console.log(`inventory\t${inventoryPath()}`)
   console.log(`repo\t${defaultRepo()}`)

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -481,7 +481,7 @@ export function ledgerIdentity(cwd: string, attested: AttestedRuntime[]): Attest
   return matches.length === 1 ? matches[0] : undefined
 }
 
-function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[]): string | undefined {
+export function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[]): string | undefined {
   return ledgerIdentity(cwd, attested)?.runtimeSessionId
 }
 

--- a/extensions/harness-daemon/src/identity.test.ts
+++ b/extensions/harness-daemon/src/identity.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, expect, test } from "bun:test"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { HarnessLink } from "@threa/bot-runtime-client"
+import { buildIdentityRows, identityConsistency, summarizeIdentityRows } from "./identity"
+import { deriveClaudeRuntimeIdentity } from "./spawners"
+import type { LocalTmuxPane } from "./discovery"
+import type { ManagedAgent } from "./types"
+
+const HOST = "identity-test-host"
+const WORKTREE = "/tmp/worktrees/feature"
+
+function derived(worktree = WORKTREE): string {
+  return deriveClaudeRuntimeIdentity(worktree, {}, HOST).runtimeSessionId
+}
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "feature",
+    runtime: "claude",
+    status: "online",
+    worktree: WORKTREE,
+    command: ["threa-harnessd", "spawn", "claude"],
+    createdAt: "2026-07-28T00:00:00.000Z",
+    updatedAt: "2026-07-28T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "threa-agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 4242,
+    cwd: WORKTREE,
+    startCommand:
+      '"claude --name threa.feature --dangerously-load-development-channels server:threa-channel --dangerously-skip-permissions "',
+    ...overrides,
+  }
+}
+
+function declaring(runtimeSessionId: string, overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return pane({
+    startCommand: `"env THREA_RUNTIME_SESSION_ID=${runtimeSessionId} claude --dangerously-load-development-channels server:threa-channel "`,
+    ...overrides,
+  })
+}
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: "ccs-ledger",
+    instanceId: "cc-ledger",
+    rootStreamId: "stream_1",
+    worktree: WORKTREE,
+    pid: 4242,
+    updatedAt: "2026-07-28T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+const originalLinksDir = process.env.THREA_HARNESS_LINKS_DIR
+
+afterEach(() => {
+  if (originalLinksDir === undefined) delete process.env.THREA_HARNESS_LINKS_DIR
+  else process.env.THREA_HARNESS_LINKS_DIR = originalLinksDir
+})
+
+test("a recorded identity today's derivation no longer reproduces reports drifted", () => {
+  const rows = buildIdentityRows({
+    agents: [agent({ runtimeSessionId: "ccs-recorded" })],
+    panes: [],
+    links: [],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "row",
+      name: "feature",
+      recorded: "ccs-recorded",
+      ledger: "-",
+      derived: derived(),
+      pane: "-",
+      verdict: "missing,drifted",
+    },
+  ])
+})
+
+test("a drifted row that still resolves reports both statuses", () => {
+  const rows = buildIdentityRows({
+    agents: [agent({ runtimeSessionId: "ccs-recorded" })],
+    panes: [declaring("ccs-recorded")],
+    links: [],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "row",
+      name: "feature",
+      recorded: "ccs-recorded",
+      ledger: "-",
+      derived: derived(),
+      pane: "%8",
+      verdict: "found,drifted",
+    },
+  ])
+})
+
+test("a row identified through the ledger shows recorded, ledger and derived separately and resolves", () => {
+  const rows = buildIdentityRows({
+    agents: [agent({ runtimeSessionId: "ccs-ledger" })],
+    panes: [pane()],
+    links: [link()],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "row",
+      name: "feature",
+      recorded: "ccs-ledger",
+      ledger: "ccs-ledger",
+      derived: derived(),
+      pane: "%8",
+      verdict: "found,drifted",
+    },
+  ])
+  expect(rows[0]!.derived).not.toBe(rows[0]!.ledger)
+})
+
+test("a live unmanaged pane with no inventory row is covered under its own identity", () => {
+  const rows = buildIdentityRows({
+    agents: [],
+    panes: [declaring("ccs-unmanaged", { windowName: "slopenv", paneId: "%12", cwd: "/tmp/worktrees/slopenv" })],
+    links: [],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "pane",
+      name: "slopenv",
+      recorded: "ccs-unmanaged",
+      ledger: "-",
+      derived: derived("/tmp/worktrees/slopenv"),
+      pane: "%12",
+      verdict: "found,drifted",
+    },
+  ])
+})
+
+test("a row whose recorded identity matches today's derivation is not reported as drifted", () => {
+  const rows = buildIdentityRows({
+    agents: [agent({ runtimeSessionId: derived() })],
+    panes: [declaring(derived())],
+    links: [],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "row",
+      name: "feature",
+      recorded: derived(),
+      ledger: "-",
+      derived: derived(),
+      pane: "%8",
+      verdict: "found",
+    },
+  ])
+})
+
+test("an unmanaged pane identified only by the ledger reports the attested identity", () => {
+  const rows = buildIdentityRows({
+    agents: [],
+    panes: [pane({ windowName: "slopenv", paneId: "%12", cwd: "/tmp/worktrees/slopenv" })],
+    links: [link({ runtimeSessionId: "ccs-attested", worktree: "/tmp/worktrees/slopenv" })],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "pane",
+      name: "slopenv",
+      recorded: "-",
+      ledger: "ccs-attested",
+      derived: derived("/tmp/worktrees/slopenv"),
+      pane: "%12",
+      verdict: "found",
+    },
+  ])
+})
+
+test("a live unmanaged Pi pane is covered under its session id", () => {
+  const rows = buildIdentityRows({
+    agents: [],
+    panes: [
+      pane({
+        windowName: "pi-sol",
+        paneId: "%14",
+        cwd: "/tmp/worktrees/sol",
+        startCommand: '"pi --session-id 3f9a1c2e-4b5d-4e6f-8a9b-0c1d2e3f4a5b "',
+      }),
+    ],
+    links: [],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "pane",
+      name: "pi-sol",
+      recorded: "3f9a1c2e-4b5d-4e6f-8a9b-0c1d2e3f4a5b",
+      ledger: "-",
+      derived: "-",
+      pane: "%14",
+      verdict: "found",
+    },
+  ])
+  expect(summarizeIdentityRows(rows)).toEqual({ total: 1, counts: [["found", 1]] })
+})
+
+test("the summary counts every emitted row under its own verdict", () => {
+  const rows = buildIdentityRows({
+    agents: [
+      agent({ runtimeSessionId: "ccs-recorded" }),
+      agent({ id: "claude-2", name: "other", worktree: "/tmp/worktrees/other" }),
+    ],
+    panes: [declaring("ccs-recorded"), declaring("ccs-unmanaged", { paneId: "%12", cwd: "/tmp/worktrees/loose" })],
+    links: [],
+    host: HOST,
+  })
+
+  const summary = summarizeIdentityRows(rows)
+  expect(rows).toHaveLength(3)
+  expect(summary).toEqual({
+    total: 3,
+    counts: [
+      ["found,drifted", 2],
+      ["missing", 1],
+    ],
+  })
+})
+
+test("the consistency check counts drifted records and survives an absent links directory", () => {
+  process.env.THREA_HARNESS_LINKS_DIR = join(tmpdir(), "harnessd-identity-test-absent")
+
+  expect(
+    identityConsistency({
+      agents: [agent({ runtimeSessionId: "ccs-recorded" }), agent({ id: "claude-2", runtimeSessionId: derived() })],
+      panes: [declaring("ccs-recorded"), declaring(derived(), { paneId: "%12" })],
+      host: HOST,
+    })
+  ).toEqual({ inventoryRows: 1, linkRecords: 0, livePanes: 1 })
+
+  expect(
+    identityConsistency({ agents: [], panes: [], links: [link({ runtimeSessionId: "ccs-drifted" })], host: HOST })
+  ).toEqual({ inventoryRows: 0, linkRecords: 1, livePanes: 0 })
+})

--- a/extensions/harness-daemon/src/identity.test.ts
+++ b/extensions/harness-daemon/src/identity.test.ts
@@ -2,7 +2,13 @@ import { afterEach, expect, test } from "bun:test"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import type { HarnessLink } from "@threa/bot-runtime-client"
-import { buildIdentityRows, identityConsistency, summarizeIdentityRows } from "./identity"
+import {
+  buildIdentityRows,
+  identityConsistency,
+  rowMatchesRef,
+  summarizeIdentityRows,
+  type IdentityRow,
+} from "./identity"
 import { deriveClaudeRuntimeIdentity } from "./spawners"
 import type { LocalTmuxPane } from "./discovery"
 import type { ManagedAgent } from "./types"
@@ -261,4 +267,25 @@ test("the consistency check counts drifted records and survives an absent links 
   expect(
     identityConsistency({ agents: [], panes: [], links: [link({ runtimeSessionId: "ccs-drifted" })], host: HOST })
   ).toEqual({ inventoryRows: 0, linkRecords: 1, livePanes: 0 })
+})
+
+test("a by-id lookup finds a pane whose identity only the ledger attests", () => {
+  // The pane worth looking up is exactly the one that declares nothing, so its
+  // `recorded` column is "-" and the id lives in `ledger`. Matching on
+  // `recorded` alone returned a definitive false negative for the drifted case
+  // and succeeded only for panes that were never broken.
+  const attested: IdentityRow = {
+    kind: "pane",
+    name: "claude-slopenv",
+    recorded: "-",
+    ledger: "ccs-attested",
+    derived: "ccs-derived",
+    pane: "%12",
+    verdict: "found",
+  }
+
+  expect(rowMatchesRef(attested, "ccs-attested")).toBe(true)
+  expect(rowMatchesRef(attested, "ccs-derived")).toBe(true)
+  expect(rowMatchesRef(attested, "ccs-somebody-else")).toBe(false)
+  expect(rowMatchesRef({ ...attested, recorded: "ccs-declared" }, "ccs-declared")).toBe(true)
 })

--- a/extensions/harness-daemon/src/identity.ts
+++ b/extensions/harness-daemon/src/identity.ts
@@ -121,6 +121,14 @@ export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
   return rows
 }
 
+/**
+ * A pane that declares no identity records `-`, and that is precisely the pane
+ * worth looking up by id — so any column that attests one counts as a match.
+ */
+export function rowMatchesRef(row: IdentityRow, ref: string): boolean {
+  return row.recorded === ref || row.ledger === ref || row.derived === ref
+}
+
 export function summarizeIdentityRows(rows: IdentityRow[]): IdentitySummary {
   const counts = new Map<string, number>()
   for (const row of rows) counts.set(row.verdict, (counts.get(row.verdict) ?? 0) + 1)
@@ -175,7 +183,7 @@ export function resolveIdentity(ref?: string): void {
     links: readHarnessLinks(),
     config: readThreaChannelConfig(),
     includeUnmanagedPanes: !managed,
-  }).filter((row) => !ref || managed || row.recorded === ref)
+  }).filter((row) => !ref || managed || rowMatchesRef(row, ref))
   if (ref && rows.length === 0) die(`no agent or live pane found for ${ref}`)
   console.log(["kind", "name", "recorded", "ledger", "derived", "pane", "verdict"].join("\t"))
   for (const row of rows) {

--- a/extensions/harness-daemon/src/identity.ts
+++ b/extensions/harness-daemon/src/identity.ts
@@ -1,0 +1,183 @@
+import { hostname } from "node:os"
+import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
+import {
+  attestedRuntimes,
+  ledgerRuntimeSessionId,
+  listLocalTmuxPanes,
+  parseClaudeChannelLaunch,
+  parsePiLaunch,
+  resolveManagedAgentPane,
+  type LocalTmuxPane,
+} from "./discovery"
+import { die } from "./errors"
+import { findAgentOrUndefined, readInventoryReadonly } from "./inventory"
+import { deriveClaudeRuntimeIdentity, readThreaChannelConfig } from "./spawners"
+import type { ManagedAgent, ThreaChannelConfig } from "./types"
+
+const NONE = "-"
+
+export interface IdentityRow {
+  kind: "row" | "pane"
+  name: string
+  recorded: string
+  ledger: string
+  derived: string
+  pane: string
+  verdict: string
+}
+
+export interface IdentityInputs {
+  agents: ManagedAgent[]
+  panes: LocalTmuxPane[]
+  links: HarnessLink[]
+  config?: ThreaChannelConfig
+  host?: string
+  includeUnmanagedPanes?: boolean
+}
+
+export interface IdentitySummary {
+  total: number
+  counts: Array<[string, number]>
+}
+
+export interface IdentityConsistency {
+  inventoryRows: number
+  linkRecords: number
+  livePanes: number
+}
+
+/**
+ * `drifted` is orthogonal to the resolution status: the row that preceded the
+ * 2026-07-28 duplicate storm resolved fine and still carried an identity today's
+ * derivation no longer reproduces, so both have to be printed.
+ */
+export function identityVerdict(status: string, recorded: string, derived: string): string {
+  const drifted = recorded !== NONE && derived !== NONE && recorded !== derived
+  return drifted ? `${status},drifted` : status
+}
+
+export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
+  const config = inputs.config ?? {}
+  const host = inputs.host ?? hostname()
+  const attested = attestedRuntimes(inputs.links)
+  const links = () => inputs.links
+  const rows: IdentityRow[] = []
+  const claimedPanes = new Set<string>()
+
+  for (const agent of inputs.agents) {
+    const resolved = resolveManagedAgentPane(agent, inputs.panes, config, host, links)
+    const paneId = "pane" in resolved ? resolved.pane.paneId : NONE
+    if (paneId !== NONE) claimedPanes.add(paneId)
+    const recorded = agent.runtimeSessionId ?? NONE
+    const ledger = agent.worktree ? (ledgerRuntimeSessionId(agent.worktree, attested) ?? NONE) : NONE
+    const derived =
+      agent.runtime === "claude" && agent.worktree
+        ? deriveClaudeRuntimeIdentity(agent.worktree, config, host).runtimeSessionId
+        : NONE
+    rows.push({
+      kind: "row",
+      name: agent.name,
+      recorded,
+      ledger,
+      derived,
+      pane: paneId,
+      verdict: identityVerdict(resolved.status, recorded, derived),
+    })
+  }
+
+  if (inputs.includeUnmanagedPanes === false) return rows
+
+  for (const pane of inputs.panes) {
+    if (claimedPanes.has(pane.paneId)) continue
+    const pi = parsePiLaunch(pane.startCommand)
+    if (pi) {
+      rows.push({
+        kind: "pane",
+        name: pane.windowName,
+        recorded: pi.sessionId,
+        ledger: NONE,
+        derived: NONE,
+        pane: pane.paneId,
+        verdict: identityVerdict("found", pi.sessionId, NONE),
+      })
+      continue
+    }
+    const launch = parseClaudeChannelLaunch(pane.startCommand)
+    if (!launch) continue
+    const recorded = launch.runtimeSessionId ?? NONE
+    const ledger = ledgerRuntimeSessionId(pane.cwd, attested) ?? NONE
+    const derived = deriveClaudeRuntimeIdentity(pane.cwd, config, host).runtimeSessionId
+    rows.push({
+      kind: "pane",
+      name: pane.windowName,
+      recorded,
+      ledger,
+      derived,
+      pane: pane.paneId,
+      verdict: identityVerdict("found", recorded, derived),
+    })
+  }
+
+  return rows
+}
+
+export function summarizeIdentityRows(rows: IdentityRow[]): IdentitySummary {
+  const counts = new Map<string, number>()
+  for (const row of rows) counts.set(row.verdict, (counts.get(row.verdict) ?? 0) + 1)
+  return { total: rows.length, counts: [...counts.entries()] }
+}
+
+export function identityConsistency(
+  inputs: {
+    agents?: ManagedAgent[]
+    panes?: LocalTmuxPane[]
+    links?: HarnessLink[]
+    config?: ThreaChannelConfig
+    host?: string
+  } = {}
+): IdentityConsistency {
+  const agents = inputs.agents ?? readInventoryReadonly()
+  const panes = inputs.panes ?? []
+  const links = inputs.links ?? readHarnessLinks()
+  const config = inputs.config ?? {}
+  const host = inputs.host ?? hostname()
+  const derived = (cwd: string) => deriveClaudeRuntimeIdentity(cwd, config, host).runtimeSessionId
+
+  const inventoryRows = agents.filter(
+    (agent) =>
+      agent.runtime === "claude" &&
+      Boolean(agent.worktree) &&
+      Boolean(agent.runtimeSessionId) &&
+      derived(agent.worktree!) !== agent.runtimeSessionId
+  ).length
+  const linkRecords = links.filter(
+    (link) =>
+      (link.runtimeKind === "claude-code-channel" || link.runtimeKind === "unknown") &&
+      derived(link.worktree) !== link.runtimeSessionId
+  ).length
+  const livePanes = panes.filter((pane) => {
+    const declared = parseClaudeChannelLaunch(pane.startCommand)?.runtimeSessionId
+    return Boolean(declared) && derived(pane.cwd) !== declared
+  }).length
+
+  return { inventoryRows, linkRecords, livePanes }
+}
+
+export function resolveIdentity(ref?: string): void {
+  const inventory = readInventoryReadonly()
+  const agents = ref ? [findAgentOrUndefined(ref, inventory) ?? die(`no agent found for ${ref}`)] : inventory
+  const rows = buildIdentityRows({
+    agents,
+    panes: listLocalTmuxPanes(),
+    links: readHarnessLinks(),
+    config: readThreaChannelConfig(),
+    includeUnmanagedPanes: !ref,
+  })
+  console.log(["kind", "name", "recorded", "ledger", "derived", "pane", "verdict"].join("\t"))
+  for (const row of rows) {
+    console.log([row.kind, row.name, row.recorded, row.ledger, row.derived, row.pane, row.verdict].join("\t"))
+  }
+  const summary = summarizeIdentityRows(rows)
+  const counts = summary.counts.map(([verdict, count]) => `${count} ${verdict}`).join(", ")
+  console.log(`harnessd: ${summary.total} subjects${counts ? `, ${counts}` : ""}`)
+}

--- a/extensions/harness-daemon/src/identity.ts
+++ b/extensions/harness-daemon/src/identity.ts
@@ -165,19 +165,23 @@ export function identityConsistency(
 
 export function resolveIdentity(ref?: string): void {
   const inventory = readInventoryReadonly()
-  const agents = ref ? [findAgentOrUndefined(ref, inventory) ?? die(`no agent found for ${ref}`)] : inventory
+  // A ref that names no inventory row may still name a live unmanaged pane —
+  // the usage string advertises a runtime session id, and `resolve` is how you
+  // find a cold-takeover candidate in the first place.
+  const managed = ref ? findAgentOrUndefined(ref, inventory) : undefined
   const rows = buildIdentityRows({
-    agents,
+    agents: ref ? (managed ? [managed] : []) : inventory,
     panes: listLocalTmuxPanes(),
     links: readHarnessLinks(),
     config: readThreaChannelConfig(),
-    includeUnmanagedPanes: !ref,
-  })
+    includeUnmanagedPanes: !managed,
+  }).filter((row) => !ref || managed || row.recorded === ref)
+  if (ref && rows.length === 0) die(`no agent or live pane found for ${ref}`)
   console.log(["kind", "name", "recorded", "ledger", "derived", "pane", "verdict"].join("\t"))
   for (const row of rows) {
     console.log([row.kind, row.name, row.recorded, row.ledger, row.derived, row.pane, row.verdict].join("\t"))
   }
   const summary = summarizeIdentityRows(rows)
   const counts = summary.counts.map(([verdict, count]) => `${count} ${verdict}`).join(", ")
-  console.log(`harnessd: ${summary.total} subjects${counts ? `, ${counts}` : ""}`)
+  console.log(`harnessd: ${summary.total} subject${summary.total === 1 ? "" : "s"}${counts ? `, ${counts}` : ""}`)
 }

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { adoptClaudeSession, adoptRefused } from "./adopt"
-import { parseAdopt, parseReconnect, parseResume, parseSpawn, usage } from "./cli"
+import { parseAdopt, parseReconnect, parseResolve, parseResume, parseSpawn, usage } from "./cli"
 import {
   attachAgent,
   bootResume,
@@ -20,6 +20,7 @@ import {
   watchUnarchived,
 } from "./commands"
 import { die } from "./errors"
+import { resolveIdentity } from "./identity"
 import { reconnectRuntime } from "./reconnect"
 
 async function main(): Promise<void> {
@@ -56,6 +57,7 @@ async function main(): Promise<void> {
     return steerAgent(args[0] ?? die("steer requires an agent id or name"), args.slice(1).join(" "))
   if (command === "keys") return sendKeysToAgent(args[0] ?? die("keys requires an agent id or name"), args.slice(1))
   if (command === "attach") return attachAgent(args[0] ?? die("attach requires an agent id or name"))
+  if (command === "resolve") return resolveIdentity(parseResolve(args))
   if (command === "doctor") return doctor()
   if (command === "do") return inferAndRun(args.join(" "))
   die(`unknown command: ${command}`)

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -544,7 +544,7 @@ function reviveDeps(overrides: Partial<ReviveDeps> = {}): ReviveDeps {
   return {
     claudeConfig: { workspaceId: "ws_1", apiKey: "key" },
     piConfig: { workspaceId: "ws_1", apiKey: "key" },
-    windowExists: () => false,
+    paneStatus: () => "missing",
     claudeProcessesIn: () => [],
     pathExists: () => true,
     scratchpadStatus: async () => "active",
@@ -739,7 +739,7 @@ test("inaccessible probes back off for hours where unavailable ones cap at minut
 test("up skips an already-running agent before touching the network", async () => {
   const calls: string[] = []
   const deps = reviveDeps({
-    windowExists: () => true,
+    paneStatus: () => "found",
     scratchpadStatus: async () => {
       calls.push("status")
       return "active"
@@ -755,7 +755,7 @@ test("up refuses to launch into a worktree a live Claude already occupies", asyn
   // session. The process table is the second, tmux-independent opinion.
   const launches: string[] = []
   const deps = reviveDeps({
-    windowExists: () => false,
+    paneStatus: () => "missing",
     claudeProcessesIn: () => [18241, 22445],
     resumeRuntime: async (agent) => {
       launches.push(agent.name)


### PR DESCRIPTION
## Why

On 2026-07-28 `harnessd up` started a duplicate session on nine consecutive passes. The sweep log says `started	harnessd-claude-cold-takeover	bypass enabled` nine times and **never says what it resolved or why it believed nothing was running**. Diagnosing it meant reading the resolver source and writing a throwaway script.

Chunk 1 (#1644) made resolution consult the harness link ledger. This makes the resolution visible.

## What changed

**`threa-harnessd resolve [<ref>]`** — one row per inventory row and per live unmanaged pane:

```
kind  name                                 recorded              ledger                derived               pane  verdict
row   fix-harnessd-reconnect-boot-prompts  ccs-57beefe8d07946a8  ccs-57beefe8d07946a8  ccs-986978510fbe4e77  -     missing,drifted
row   bootcheck-probe                      ccs-57beefe8d07946a8  -                     ccs-04b31cd452a1960b  -     missing,drifted
row   harnessd-claude-cold-takeover        ccs-c2550c302cf2e8fb  ccs-c2550c302cf2e8fb  ccs-3f5d02a029db8cbc  %212  found,drifted
pane  claude-slopenv                       ccs-3ea859c21682385b  ccs-3ea859c21682385b  ccs-d12c28c2951925e5  %211  found,drifted
harnessd: 104 subjects, 92 missing, 2 missing,drifted, 4 found,drifted, 6 found
```

Recorded and ledger agree; the derivation disagrees on every live session. That is the whole incident, in one line.

`drifted` is computed **independently of** the resolution status, so both print when both apply. A session that still resolves while its derivation has moved is the state that *preceded* the incident — it has to be visible before it breaks, not after.

The output above also surfaced something unrelated and real: `fix-harnessd-reconnect-boot-prompts` and `bootcheck-probe` are two different worktrees sharing one identity.

**`doctor`** reports the same drift counts across inventory rows, link records and live panes. Reported, never fatal — it is a diagnosis, not a gate.

**`reviveAgent`** logs its resolution verdict before the revival decision, one line per agent per pass. `agentPaneLives`'s boolean collapse is gone; the status is threaded through instead of resolving twice.

Read-only throughout: no writes to `~/.threa/harnessd/`, no repair command.

## Verification

185 pass / 0 fail, lint and typecheck clean, full pre-commit gates green.

Row-building is a pure exported function over injected inputs, so no test reaches `$HOME`, the real tmux, or the real inventory. Every test was verified capable of failing by neutralising the specific guard it covers:

| neutralisation | reds |
| --- | --- |
| `drifted = recorded !== NONE` (drops the equality half) | healthy-row test, Pi-pane test |
| `return drifted ? "drifted" : status` (drops the status half) | 5 tests |
| `ledger = NONE` on the inventory path | ledger-distinct test |
| `ledger = NONE` on the unmanaged-pane path | attested-pane test |
| restore the `continue` that skipped Pi panes | Pi-pane test |
| summary counts only `kind === "row"` | summary test |
| default `readHarnessLinks()` → throw | absent-links-dir test |

Three of these existed only because an adversarial pass measured the gap first. Notably `drifted = recorded !== NONE` passed **182/0** before the fix: the equality branch had zero coverage. That is harmless while everything is drifted, but the follow-up work re-mints identities so `recorded === derived` — at which point the regression would flag every healthy agent as drifted on every 60s pass, with CI green.

## Residual risk

Strictly diagnostic. No minting, no backfill, no ledger writer, no repair path, and `deriveClaudeRuntimeIdentity` is untouched.

Plan: https://seer.build/ws_vbyzjvdg6g/b/harnessd-identity-9c5f3c/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-review fixes

`/code-review` found two, both accepted:

- **`doctor` reported an unrunnable pane scan as zero drift** (INV-11). A `listLocalTmuxPanes()` failure was caught into an empty array, so the live-pane row printed `ok … 0` when nothing had been inspected — a check that never ran reading as a clean fleet, which is precisely the shape of miss this command exists to catch. It now prints `unknown` with the error.
- **The `resolve` log line was emitted before the targeted-restore filter**, so a single `bot.session.restored` event printed one line per inventory row (104 today) to decide one agent, burying the line the PR exists to surface. Now gated on the agent matching the target.

Also fixed while in there: `resolve <ref>` died on the runtime session id of a live *unmanaged* pane, despite the usage string advertising a runtime session id — and finding a cold-takeover candidate is the main reason to type one. Verified live against all three ref forms:

```
$ threa-harnessd resolve ccs-3ea859c21682385b        # unmanaged pane — previously died
pane  claude-slopenv  ccs-3ea859c21682385b  ccs-3ea859c21682385b  ccs-d12c28c2951925e5  %211  found,drifted
$ threa-harnessd resolve harnessd-claude-cold-takeover   # managed row
row   harnessd-claude-cold-takeover  ccs-c2550c302cf2e8fb  ccs-c2550c302cf2e8fb  ccs-3f5d02a029db8cbc  %212  found,drifted
$ threa-harnessd resolve no-such-thing
harnessd: no agent or live pane found for no-such-thing
```

### Test coverage of these three, stated plainly

The `resolve <ref>` behaviour is verified by the live runs above, not by a unit test — `resolveIdentity` does real I/O (inventory, tmux, links) and the brief deliberately kept row-building pure instead of capturing stdout. `doctor`'s `unknown` state is likewise verified by reading, because `doctor()` is not injectable. The log-placement change is covered indirectly by the existing `reviveAgent` suite (185 pass) but not by an assertion on the log line itself. Calling that out rather than implying the whole batch is unit-tested.


## Whole-stack review finding, fixed here

`resolve <ref>` matched on the `recorded` column alone. A pane launched without `THREA_RUNTIME_SESSION_ID` records `-` there and carries its identity in `ledger` — so a by-id lookup returned a definitive **"not found" for exactly the drifted pane the command exists to surface**, and succeeded only for panes that declare their id, which were never broken.

My live verification of the earlier `resolve <ref>` fix passed for precisely that reason: the pane I tested against declares its id. Matching now covers `recorded`, `ledger` and `derived`, with the predicate extracted so it is unit-testable; the new test reds when reverted to `recorded`-only.
