### PR TITLE
fix(harnessd): stop the reaper deleting a worktree a paneless session is using

### DIFF
--- a/extensions/harness-daemon/src/archive-wind-down.test.ts
+++ b/extensions/harness-daemon/src/archive-wind-down.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { pushBranchAndScheduleRemoval } from "./archive-wind-down"
+import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
 
 const noLog = () => undefined
 
@@ -40,64 +40,59 @@ function originHasBranch(origin: string, branch: string): boolean {
   return result.exitCode === 0
 }
 
-describe("pushBranchAndScheduleRemoval", () => {
-  test("commits dirty work, pushes the branch, and schedules removal of a linked worktree", async () => {
+describe("pushBranchAndRemoveWorktree", () => {
+  test("commits dirty work, pushes the branch, and removes the linked worktree before returning", () => {
+    // Synchronous by contract: the caller holds `resume-active.lock`, so a
+    // removal that outlived the return could delete a worktree a revive had
+    // already recreated under the lock.
     const { worktree, origin } = makeFixture()
     writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
 
-    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    const report = pushBranchAndRemoveWorktree(worktree, noLog)
 
-    expect(report).toMatchObject({ committed: true, pushed: true, removalScheduled: true })
+    expect(report).toMatchObject({ committed: true, pushed: true, removed: true })
+    expect(existsSync(worktree)).toBe(false)
     expect(originHasBranch(origin, "feature/archive-test")).toBe(true)
     const pushedMessage = sh(origin, `git log -1 --format=%s feature/archive-test`)
     expect(pushedMessage).toBe("wip: auto-commit — scratchpad archived")
-    // The detached remover fires after its 5s grace; poll briefly for it.
-    const { existsSync } = await import("node:fs")
-    const deadline = Date.now() + 10_000
-    while (existsSync(worktree) && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 500))
-    }
-    expect(existsSync(worktree)).toBe(false)
-  }, 20_000)
+  })
 
   test("pushes a clean worktree without inventing a commit", () => {
     const { worktree, origin } = makeFixture()
-    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    const report = pushBranchAndRemoveWorktree(worktree, noLog)
     expect(report.committed).toBe(false)
     expect(report.pushed).toBe(true)
     expect(originHasBranch(origin, "feature/archive-test")).toBe(true)
   })
 
-  test("leaves the worktree when the push fails (no remote)", async () => {
+  test("leaves the worktree when the push fails (no remote)", () => {
     const { main, worktree } = makeFixture()
     sh(main, `git remote remove origin`)
     writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
 
-    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    const report = pushBranchAndRemoveWorktree(worktree, noLog)
 
     expect(report.pushed).toBe(false)
-    expect(report.removalScheduled).toBe(false)
+    expect(report.removed).toBe(false)
     expect(report.reason).toContain("push failed")
-    // Committed (preserving the work) but still on disk well past any grace delay.
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    const { existsSync } = await import("node:fs")
+    // Committed (preserving the work) but still on disk.
     expect(existsSync(join(worktree, "wip.txt"))).toBe(true)
   })
 
   test("refuses to touch main and never removes the main checkout", () => {
     const { main } = makeFixture()
-    const report = pushBranchAndScheduleRemoval(main, noLog)
+    const report = pushBranchAndRemoveWorktree(main, noLog)
     expect(report.pushed).toBe(false)
-    expect(report.removalScheduled).toBe(false)
+    expect(report.removed).toBe(false)
     expect(report.reason).toContain("protected")
   })
 
   test("pushes from the main checkout on a feature branch but does not remove it", () => {
     const { main, origin } = makeFixture()
     sh(main, `git checkout -b feature/from-main`)
-    const report = pushBranchAndScheduleRemoval(main, noLog)
+    const report = pushBranchAndRemoveWorktree(main, noLog)
     expect(report.pushed).toBe(true)
-    expect(report.removalScheduled).toBe(false)
+    expect(report.removed).toBe(false)
     expect(report.reason).toContain("main repository checkout")
     expect(originHasBranch(origin, "feature/from-main")).toBe(true)
   })
@@ -117,7 +112,7 @@ describe("pushBranchAndScheduleRemoval", () => {
     writeFileSync(hook, "#!/bin/sh\necho 'lint failed' >&2\nexit 1\n")
     chmodSync(hook, 0o755)
 
-    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    const report = pushBranchAndRemoveWorktree(worktree, noLog)
 
     expect(report).toMatchObject({ committed: true, pushed: true })
     expect(sh(origin, `git log -1 --format=%s feature/archive-test`)).toBe("wip: auto-commit — scratchpad archived")
@@ -132,9 +127,9 @@ describe("pushBranchAndScheduleRemoval", () => {
     const gitDir = sh(worktree, "git rev-parse --path-format=absolute --git-dir")
     writeFileSync(join(gitDir, "index"), "not an index\n")
 
-    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    const report = pushBranchAndRemoveWorktree(worktree, noLog)
 
-    expect(report).toMatchObject({ committed: false, pushed: false, removalScheduled: false })
+    expect(report).toMatchObject({ committed: false, pushed: false, removed: false })
     expect(report.reason).toContain("could not read worktree status")
     expect(originHasBranch(origin, "feature/archive-test")).toBe(false)
     expect(existsSync(join(worktree, "wip.txt"))).toBe(true)
@@ -142,8 +137,8 @@ describe("pushBranchAndScheduleRemoval", () => {
 
   test("reports a non-repo directory without doing anything", () => {
     const dir = mkdtempSync(join(tmpdir(), "not-a-repo-"))
-    const report = pushBranchAndScheduleRemoval(dir, noLog)
-    expect(report).toMatchObject({ committed: false, pushed: false, removalScheduled: false })
+    const report = pushBranchAndRemoveWorktree(dir, noLog)
+    expect(report).toMatchObject({ committed: false, pushed: false, removed: false })
     expect(report.reason).toContain("not a git worktree")
   })
 })

--- a/extensions/harness-daemon/src/archive-wind-down.ts
+++ b/extensions/harness-daemon/src/archive-wind-down.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process"
+import { spawnSync } from "node:child_process"
 import { dirname, resolve } from "node:path"
 
 /**
@@ -10,9 +10,8 @@ import { dirname, resolve } from "node:path"
  *   1. dirty tree → `git add -A` + a wip commit (uncommitted work must never
  *      die with the worktree)
  *   2. `git push origin HEAD:<branch>`
- *   3. push succeeded AND this is a linked worktree → schedule removal via a
- *      detached shell (the caller may die moments later, so the removal must
- *      outlive it)
+ *   3. push succeeded AND this is a linked worktree → `git worktree remove
+ *      --force`, synchronously
  *
  * Never touches `main`/`master`/detached HEAD, and never removes the main
  * repository checkout — only linked worktrees.
@@ -22,13 +21,17 @@ import { dirname, resolve } from "node:path"
  * revive can be recreating the very worktree this would force-remove, and the
  * two race the server independently — so the destructive half of the wind-down
  * belongs where that lock is held. A runtime that decides to wind down marks
- * its link record (`windDownRequestedAt`) and exits instead.
+ * its link record (`windDownRequestedAt`) and exits instead. That is also why
+ * the removal is synchronous: deferring it past the return deferred it past the
+ * lock too, so a revive that acquired the lock inside the delay could recreate
+ * the worktree and then watch it disappear. The caller kills the occupying tmux
+ * window BEFORE calling this, so nothing is left holding the directory.
  */
 
 export interface ArchiveCleanupReport {
   committed: boolean
   pushed: boolean
-  removalScheduled: boolean
+  removed: boolean
   reason?: string
 }
 
@@ -38,6 +41,9 @@ const GIT_TIMEOUT_MS = 30_000
 // query, and this one must not be the thing that loses the work.
 const COMMIT_TIMEOUT_MS = 120_000
 const PUSH_TIMEOUT_MS = 120_000
+// Removing a large worktree is filesystem-bound, and this runs while
+// `resume-active.lock` is held — a hang here blocks every revive.
+const REMOVE_TIMEOUT_MS = 120_000
 
 function git(cwd: string, args: string[], timeoutMs = GIT_TIMEOUT_MS): { ok: boolean; stdout: string } {
   try {
@@ -48,8 +54,8 @@ function git(cwd: string, args: string[], timeoutMs = GIT_TIMEOUT_MS): { ok: boo
   }
 }
 
-export function pushBranchAndScheduleRemoval(cwd: string, log: (message: string) => void): ArchiveCleanupReport {
-  const report: ArchiveCleanupReport = { committed: false, pushed: false, removalScheduled: false }
+export function pushBranchAndRemoveWorktree(cwd: string, log: (message: string) => void): ArchiveCleanupReport {
+  const report: ArchiveCleanupReport = { committed: false, pushed: false, removed: false }
 
   if (!git(cwd, ["rev-parse", "--is-inside-work-tree"]).ok) {
     report.reason = "not a git worktree"
@@ -104,23 +110,11 @@ export function pushBranchAndScheduleRemoval(cwd: string, log: (message: string)
   }
 
   const mainRepo = dirname(resolve(commonDir))
-  try {
-    // Detached with a grace delay: this process dies with its tmux window
-    // moments after returning, and a directory can't be removed out from under
-    // the processes still holding it.
-    const child = spawn(
-      "sh",
-      ["-c", `sleep 5; git -C ${shellQuote(mainRepo)} worktree remove --force ${shellQuote(cwd)}`],
-      { detached: true, stdio: "ignore" }
-    )
-    child.unref()
-    report.removalScheduled = true
-  } catch {
-    report.reason = "could not schedule worktree removal (branch is pushed; remove manually)"
+  const removal = git(mainRepo, ["worktree", "remove", "--force", cwd], REMOVE_TIMEOUT_MS)
+  if (!removal.ok) {
+    report.reason = "could not remove the worktree (branch is pushed; remove manually)"
+    return report
   }
+  report.removed = true
   return report
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`
 }

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -38,10 +38,11 @@ interface Recorded {
   woundDown: string[]
   killed: string[]
   forgotten: string[]
+  awaited: number[]
 }
 
 function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded: Recorded } {
-  const recorded: Recorded = { woundDown: [], killed: [], forgotten: [] }
+  const recorded: Recorded = { woundDown: [], killed: [], forgotten: [], awaited: [] }
   const deps: ReapDeps = {
     links: () => [link()],
     panes: () => [pane()],
@@ -56,6 +57,7 @@ function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded
       return { pushed: true, removed: true }
     },
     killWindow: (windowId) => void recorded.killed.push(windowId),
+    awaitExit: async (pid) => void recorded.awaited.push(pid),
     forgetLink: (id) => void recorded.forgotten.push(id),
     now: () => NOW,
     log: () => {},
@@ -71,7 +73,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome).toMatchObject({ status: "reaped", worktree: WORKTREE })
-    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"] })
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"], awaited: [4242] })
   })
 
   test("leaves the owning runtime its full detection window plus grace", async () => {
@@ -93,7 +95,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped active")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("an unreadable scratchpad is never grounds to delete", async () => {
@@ -116,7 +118,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(["skipped ambiguous", "skipped occupied"]).toContain(outcome.status)
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("refuses a worktree now occupied by a session the record does not own", async () => {
@@ -136,7 +138,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped occupied")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("refuses a worktree where a paneless Claude is still running", async () => {
@@ -150,7 +152,7 @@ describe("reapArchivedWorktrees", () => {
 
     expect(outcome.status).toBe("skipped occupied")
     expect(outcome.detail).toContain("9911")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("still reaps a live Claude the record's own pane accounts for", async () => {
@@ -161,7 +163,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("reaped")
-    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"] })
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"], awaited: [4242] })
   })
 
   test("refuses when a second, paneless Claude shares the record's worktree", async () => {
@@ -172,7 +174,7 @@ describe("reapArchivedWorktrees", () => {
 
     expect(outcome.status).toBe("skipped occupied")
     expect(outcome.detail).toContain("5150")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("an occupying pane is still found when the record stored a non-canonical path", async () => {
@@ -193,7 +195,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped occupied")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("the window is closed before the wind-down removes the directory under it", async () => {
@@ -202,6 +204,7 @@ describe("reapArchivedWorktrees", () => {
     const order: string[] = []
     const { deps } = makeDeps({
       killWindow: () => void order.push("kill"),
+      awaitExit: async () => void order.push("awaitExit"),
       windDown: () => {
         order.push("windDown")
         return { pushed: true, removed: true }
@@ -210,7 +213,9 @@ describe("reapArchivedWorktrees", () => {
 
     await reapArchivedWorktrees(deps)
 
-    expect(order).toEqual(["kill", "windDown"])
+    // `tmux kill-window` returns on signal delivery, not on exit. Removing the
+    // directory in that gap deletes the cwd of a Claude still flushing.
+    expect(order).toEqual(["kill", "awaitExit", "windDown"])
   })
 
   test("a freshly woken daemon gives runtimes their own detection window first", async () => {
@@ -223,7 +228,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped observer too young")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("an explicit run has no warmup gate — a human asking is the signal", async () => {
@@ -241,7 +246,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped worktree missing")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: ["ccs-abc"] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: ["ccs-abc"], awaited: [] })
   })
 
   test("a link with no live pane is still reaped — that is the offline case", async () => {
@@ -252,7 +257,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("reaped")
-    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: [], forgotten: ["ccs-abc"] })
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: [], forgotten: ["ccs-abc"], awaited: [] })
   })
 
   test("the window closes even when the cleanup refuses, and the worktree is left behind", async () => {
@@ -280,7 +285,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps, true)
 
     expect(outcome.status).toBe("would reap")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("one failing link does not abort the sweep", async () => {
@@ -343,7 +348,7 @@ describe("reapArchivedWorktrees", () => {
     const [outcome] = await reapArchivedWorktrees(deps)
 
     expect(outcome.status).toBe("skipped active")
-    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [] })
   })
 
   test("the observer warmup holds back unmarked records only", async () => {

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -45,13 +45,15 @@ function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded
   const deps: ReapDeps = {
     links: () => [link()],
     panes: () => [pane()],
+    claudeProcessesIn: () => [],
+    canonicalPath: (path) => path,
     scratchpadStatus: async () => "archived",
     // Long enough ago that the owning runtime has had its full chance.
     archivedAt: async () => new Date(NOW - REAP_AFTER_MS - 60_000).toISOString(),
     pathExists: () => true,
     windDown: (cwd) => {
       recorded.woundDown.push(cwd)
-      return { pushed: true }
+      return { pushed: true, removed: true }
     },
     killWindow: (windowId) => void recorded.killed.push(windowId),
     forgetLink: (id) => void recorded.forgotten.push(id),
@@ -137,6 +139,80 @@ describe("reapArchivedWorktrees", () => {
     expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
   })
 
+  test("refuses a worktree where a paneless Claude is still running", async () => {
+    // A Claude detached from tmux, or whose window was killed while it kept
+    // running, leaves no pane and is very much alive. Reaping on the pane scan
+    // alone would push a half-done tree and delete the directory out from
+    // under it.
+    const { deps, recorded } = makeDeps({ panes: () => [], claudeProcessesIn: () => [9911] })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped occupied")
+    expect(outcome.detail).toContain("9911")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("still reaps a live Claude the record's own pane accounts for", async () => {
+    // The ordinary case: the owning runtime is still up when the reaper runs.
+    // Its pid IS the pane's pid, so the process-table veto must not fire.
+    const { deps, recorded } = makeDeps({ claudeProcessesIn: () => [4242] })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("reaped")
+    expect(recorded).toEqual({ woundDown: [WORKTREE], killed: ["@7"], forgotten: ["ccs-abc"] })
+  })
+
+  test("refuses when a second, paneless Claude shares the record's worktree", async () => {
+    // Killing the record's window does not stop the other one.
+    const { deps, recorded } = makeDeps({ claudeProcessesIn: () => [4242, 5150] })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped occupied")
+    expect(outcome.detail).toContain("5150")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("an occupying pane is still found when the record stored a non-canonical path", async () => {
+    // Link records store a raw `process.cwd()`; tmux reports the resolved path.
+    // Comparing them raw reads an occupied worktree as empty — the one
+    // misreading that ends in a force-remove.
+    const { deps, recorded } = makeDeps({
+      links: () => [link({ worktree: `/tmp${WORKTREE}` })],
+      panes: () => [
+        pane({
+          startCommand:
+            "env THREA_RUNTIME_SESSION_ID=ccs-somebody-else claude --dangerously-load-development-channels server:threa-channel",
+        }),
+      ],
+      canonicalPath: (path) => (path.startsWith("/tmp") ? path.slice("/tmp".length) : path),
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome.status).toBe("skipped occupied")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [] })
+  })
+
+  test("the window is closed before the wind-down removes the directory under it", async () => {
+    // The removal is synchronous now, and the pane's shell sits in the
+    // worktree — killing after would be removing it out from under a live shell.
+    const order: string[] = []
+    const { deps } = makeDeps({
+      killWindow: () => void order.push("kill"),
+      windDown: () => {
+        order.push("windDown")
+        return { pushed: true, removed: true }
+      },
+    })
+
+    await reapArchivedWorktrees(deps)
+
+    expect(order).toEqual(["kill", "windDown"])
+  })
+
   test("a freshly woken daemon gives runtimes their own detection window first", async () => {
     // archivedAt keeps accruing while the machine sleeps, but the runtime that
     // owns the worktree was asleep too and only starts its detection+grace on
@@ -183,13 +259,17 @@ describe("reapArchivedWorktrees", () => {
     const { deps, recorded } = makeDeps({
       windDown: (cwd) => {
         recorded.woundDown.push(cwd)
-        return { pushed: false, reason: "branch 'HEAD' is protected or detached — leaving everything as is" }
+        return {
+          pushed: false,
+          removed: false,
+          reason: "branch 'HEAD' is protected or detached — leaving everything as is",
+        }
       },
     })
 
     const [outcome] = await reapArchivedWorktrees(deps)
 
-    expect(outcome.status).toBe("reaped")
+    expect(outcome.status).toBe("reaped, worktree left")
     expect(outcome.detail).toContain("pushed=false")
     expect(recorded.killed).toEqual(["@7"])
   })

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -9,6 +9,7 @@ import { existsSync } from "node:fs"
 import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
 import { defaultClaudeDiskDeps, findLiveClaudeSessions } from "./claude-registry"
 import { canonicalOrRaw, listLocalTmuxPanes, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
+import { processAlive } from "./lock"
 import { output } from "./shell"
 import { fetchScratchpadArchivedAt, fetchScratchpadStatus, type ScratchpadStatus } from "./resume"
 
@@ -42,6 +43,10 @@ import { fetchScratchpadArchivedAt, fetchScratchpadStatus, type ScratchpadStatus
  * and making it wait again would turn ordinary cleanup from 5 into 25 minutes.
  */
 export const REAP_AFTER_MS = WS_BACKSTOP_POLL_MS + ARCHIVE_RESTORE_GRACE_MS * 2
+
+/** Long enough for a SIGHUP'd Claude to finish flushing; short enough not to stall the sweep. */
+const KILL_GRACE_MS = 5_000
+const KILL_POLL_MS = 100
 
 export type ReapStatus =
   | "reaped"
@@ -77,6 +82,8 @@ export interface ReapDeps {
   pathExists: (path: string) => boolean
   windDown: (cwd: string, log: (message: string) => void) => { pushed: boolean; removed: boolean; reason?: string }
   killWindow: (windowId: string) => void
+  /** Resolves once the killed pane's process is gone, or after a bounded wait. */
+  awaitExit: (pid: number) => Promise<void>
   forgetLink: (runtimeSessionId: string) => void
   now: () => number
   log: (message: string) => void
@@ -95,6 +102,11 @@ export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; 
     windDown: pushBranchAndRemoveWorktree,
     killWindow: (windowId) => {
       output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+    },
+    awaitExit: async (pid) => {
+      for (let waited = 0; waited < KILL_GRACE_MS && processAlive(pid); waited += KILL_POLL_MS) {
+        await Bun.sleep(KILL_POLL_MS)
+      }
     },
     forgetLink: clearHarnessLink,
     now: Date.now,
@@ -223,7 +235,15 @@ export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolea
   // branch). A refusal leaves the worktree on disk for a human — nothing is
   // lost. It goes FIRST because the wind-down now removes the directory
   // synchronously, and the pane's shell sits in it.
-  if (window.kind === "kill") deps.killWindow(window.pane.windowId)
+  //
+  // `tmux kill-window` returns once it has delivered the signal, not once the
+  // process is gone. Removing the directory in that gap deletes the cwd of a
+  // Claude still flushing its transcript, so wait for the pane to actually
+  // exit — the grace the old detached `sleep 5` provided by accident.
+  if (window.kind === "kill") {
+    deps.killWindow(window.pane.windowId)
+    await deps.awaitExit(window.pane.panePid)
+  }
   const report = deps.windDown(link.worktree, (message) => deps.log(`${link.worktree}: ${message}`))
   // Forgotten either way, matching the pre-existing contract for a refused
   // wind-down: the branch is the thing that had to survive, and a directory

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -6,8 +6,9 @@ import {
   type HarnessLink,
 } from "@threa/bot-runtime-client"
 import { existsSync } from "node:fs"
-import { pushBranchAndScheduleRemoval } from "./archive-wind-down"
-import { listLocalTmuxPanes, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
+import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
+import { defaultClaudeDiskDeps, findLiveClaudeSessions } from "./claude-registry"
+import { canonicalOrRaw, listLocalTmuxPanes, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
 import { output } from "./shell"
 import { fetchScratchpadArchivedAt, fetchScratchpadStatus, type ScratchpadStatus } from "./resume"
 
@@ -44,6 +45,8 @@ export const REAP_AFTER_MS = WS_BACKSTOP_POLL_MS + ARCHIVE_RESTORE_GRACE_MS * 2
 
 export type ReapStatus =
   | "reaped"
+  /** Branch preserved, directory still on disk: the removal failed and nothing will retry it. */
+  | "reaped, worktree left"
   | "would reap"
   | "skipped active"
   | "skipped grace"
@@ -66,10 +69,13 @@ export interface ReapDeps {
   observingSinceMs?: number
   links: () => HarnessLink[]
   panes: () => LocalTmuxPane[]
+  /** Live Claude pids in this worktree, corroborated against the process table. */
+  claudeProcessesIn: (worktree: string) => number[]
+  canonicalPath: (path: string) => string
   scratchpadStatus: (streamId: string) => Promise<ScratchpadStatus>
   archivedAt: (streamId: string) => Promise<string | undefined>
   pathExists: (path: string) => boolean
-  windDown: (cwd: string, log: (message: string) => void) => { pushed: boolean; reason?: string }
+  windDown: (cwd: string, log: (message: string) => void) => { pushed: boolean; removed: boolean; reason?: string }
   killWindow: (windowId: string) => void
   forgetLink: (runtimeSessionId: string) => void
   now: () => number
@@ -80,10 +86,13 @@ export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; 
   return {
     links: readHarnessLinks,
     panes: listLocalTmuxPanes,
+    claudeProcessesIn: (worktree) =>
+      findLiveClaudeSessions(worktree, defaultClaudeDiskDeps()).map((session) => session.pid),
+    canonicalPath: canonicalOrRaw,
     scratchpadStatus: (streamId) => fetchScratchpadStatus({ ...target, streamId }),
     archivedAt: (streamId) => fetchScratchpadArchivedAt({ ...target, streamId }),
     pathExists: existsSync,
-    windDown: pushBranchAndScheduleRemoval,
+    windDown: pushBranchAndRemoveWorktree,
     killWindow: (windowId) => {
       output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
     },
@@ -107,11 +116,33 @@ type WindowDecision =
  * would push and delete the live session's work under the label "scratchpad
  * archived". Identity comes from `resolveManagedAgentPane`, the resolver built
  * for exactly this failure; occupancy is then the veto.
+ *
+ * Panes alone cannot answer occupancy. A Claude detached from tmux, or whose
+ * window was killed while it kept running, leaves no pane and is very much
+ * alive — and the empty-pane branch below is precisely the one that authorises
+ * a force-remove. So the process table is a second, independent veto, the same
+ * one `up` grew after the pane check alone let it launch duplicates. It is not
+ * gated on `runtimeKind`: what is being destroyed is a directory, and a live
+ * Claude in it is fatal whichever runtime the record names.
  */
-function decideWindow(link: HarnessLink, panes: LocalTmuxPane[]): WindowDecision {
-  const occupants = panes.filter((pane) => pane.cwd === link.worktree)
-  // Nobody is in the worktree: the offline case this reaper exists for.
-  if (occupants.length === 0) return { kind: "none" }
+function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps): WindowDecision {
+  // Link records store a raw `process.cwd()` while tmux reports a resolved
+  // path; on macOS /tmp vs /private/tmp alone is enough to read an occupied
+  // worktree as empty, which is the one misreading that ends in a removal.
+  const worktree = deps.canonicalPath(link.worktree)
+  const occupants = panes.filter((pane) => deps.canonicalPath(pane.cwd) === worktree)
+  const livePids = deps.claudeProcessesIn(link.worktree)
+
+  if (occupants.length === 0) {
+    // Nobody is in the worktree: the offline case this reaper exists for —
+    // unless a paneless Claude is still running there.
+    if (livePids.length === 0) return { kind: "none" }
+    return {
+      kind: "refuse",
+      status: "skipped occupied",
+      reason: `Claude is still running in ${link.worktree} with no pane (pid ${livePids.join(", ")})`,
+    }
+  }
 
   const resolved = resolveManagedAgentPane(
     {
@@ -122,7 +153,16 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[]): WindowDecision
     panes
   )
   if (resolved.status === "found" && occupants.length === 1 && resolved.pane.paneId === occupants[0]!.paneId) {
-    return { kind: "kill", pane: resolved.pane }
+    // The pane's own Claude is `panePid` (the same equivalence `reconnect`
+    // relies on). Any other live pid in the directory is a session killing this
+    // window would not stop.
+    const strangers = livePids.filter((pid) => pid !== resolved.pane.panePid)
+    if (strangers.length === 0) return { kind: "kill", pane: resolved.pane }
+    return {
+      kind: "refuse",
+      status: "skipped occupied",
+      reason: `${link.worktree} also holds a Claude this record's pane does not account for (pid ${strangers.join(", ")})`,
+    }
   }
   return {
     kind: "refuse",
@@ -167,7 +207,7 @@ export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolea
     why = `archived ${Math.round(age / 60_000)}m ago`
   }
 
-  const window = decideWindow(link, deps.panes())
+  const window = decideWindow(link, deps.panes(), deps)
   if (window.kind === "refuse") return { ...base, status: window.status, detail: window.reason }
 
   if (!deps.pathExists(link.worktree)) {
@@ -178,15 +218,20 @@ export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolea
 
   if (dryRun) return { ...base, status: "would reap", detail: why }
 
-  const report = deps.windDown(link.worktree, (message) => deps.log(`${link.worktree}: ${message}`))
   // The window goes either way: the scratchpad is archived, so the session is
-  // over even when the cleanup refused (detached HEAD, unpushable branch). A
-  // refusal leaves the worktree on disk for a human — nothing is lost.
+  // over even when the cleanup refuses below (detached HEAD, unpushable
+  // branch). A refusal leaves the worktree on disk for a human — nothing is
+  // lost. It goes FIRST because the wind-down now removes the directory
+  // synchronously, and the pane's shell sits in it.
   if (window.kind === "kill") deps.killWindow(window.pane.windowId)
+  const report = deps.windDown(link.worktree, (message) => deps.log(`${link.worktree}: ${message}`))
+  // Forgotten either way, matching the pre-existing contract for a refused
+  // wind-down: the branch is the thing that had to survive, and a directory
+  // left behind is for a human. What must not happen is reporting it gone.
   deps.forgetLink(link.runtimeSessionId)
   return {
     ...base,
-    status: "reaped",
+    status: report.removed ? "reaped" : "reaped, worktree left",
     detail: `pushed=${report.pushed}${report.reason ? ` (${report.reason})` : ""}${window.kind === "kill" ? ` window=${window.pane.windowId}` : ""}`,
   }
 }


### PR DESCRIPTION
## Why

The reaper is the only component in harnessd that **destroys work**: it auto-commits a dirty tree, pushes, then `git worktree remove --force`s the directory — taking untracked and ignored files, which were never on the remote.

`decideWindow` decided occupancy from **tmux panes alone**, and its `occupants.length === 0` branch is the one that authorises the removal. But `claude-registry.ts:74-77` documents that a Claude detached from tmux — or whose window was killed while it kept running — leaves no pane and is very much alive. `up` grew a process-table check for exactly this (`commands.ts:449-457`) after the pane check alone let nine consecutive passes each start another Claude in one worktree on 2026-07-28. **The reaper never got one.**

So: stale link record + live paneless session = push a half-done tree and delete the directory under a running agent. Two independent adversarial reviewers rated this critical.

## What changed

**1. Process-table veto.** `claudeProcessesIn` is a new injected `ReapDeps` field, defaulting to the same `findLiveClaudeSessions` call `up` uses. It refuses from the empty-pane branch, *and* from the sole-occupant branch for any live pid the record's own pane does not account for — killing that window would not stop the other process. Not gated on `runtimeKind`: what is being destroyed is a directory, and a live Claude in it is fatal whichever runtime the record names.

**2. Canonical path comparison.** Records store a raw `process.cwd()`; tmux reports a resolved path. On macOS `/tmp` vs `/private/tmp` alone was enough to read an occupied worktree as empty — feeding straight into the branch above. Both sides now canonicalize via `canonicalOrRaw`, reused from chunk 1 rather than copied a third time.

**3. Removal no longer outlives the lock.** The detached `sh -c 'sleep 5; git worktree remove --force …'` survived `resume-active.lock`, so a revive acquiring the lock inside that window could recreate the worktree and then lose it. It is now synchronous inside the lock.

Option (a) over (b): (b) would have required re-deriving occupancy inside a detached `sh -c` — a second, shell-shaped copy of the logic deliverable 1 just built in TypeScript, still with a gap between its check and the `rm`. (a) deletes code instead. The original detachment rationale ("the caller dies with its tmux window moments later") is **stale**: since the wind-down moved into harnessd the caller is `reapLink`, which does not run inside the worktree. The only holder is the pane's shell, so `killWindow` now runs *before* the wind-down. `shellQuote` became dead and was removed — argv, not a shell string, so the quoting hazard went with it.

Renamed `pushBranchAndScheduleRemoval` → `pushBranchAndRemoveWorktree` and `removalScheduled` → `removed`, no alias kept (INV-10, INV-49).

## Verification

190 pass / 0 fail, lint and typecheck clean, full pre-commit gates green.

Each new test was verified capable of failing, and **each neutralisation reddened exactly one test — only its own**:

| neutralisation | reds |
| --- | --- |
| empty-pane branch returns `none` unconditionally | paneless-Claude refusal |
| stranger veto made absolute (`strangers = livePids`) | still-reaps-the-record's-own-pane |
| stranger veto disabled (`strangers = []`) | second-paneless-Claude refusal |
| occupant filter reverted to raw string comparison | non-canonical-path occupancy |
| `killWindow` moved back after `windDown` | window-closes-before-removal |
| synchronous removal reverted to the detached `sleep 5` | commits-pushes-and-removes |
| `status: "reaped"` unconditionally | reaped-worktree-left |

The middle pair matters: an absolute veto breaks the ordinary reap, and no veto misses the duplicate. Both directions are pinned.

## Review finding, accepted

A removal that fails still reported `reaped` and forgot the link record, so nothing would ever retry it. Now reports **`reaped, worktree left`**. The link is still forgotten and the directory still left for a human — that is the pre-existing contract for a refused wind-down (`reap.ts`'s own comment: "A refusal leaves the worktree on disk for a human — nothing is lost"), and the branch is pushed either way. What was wrong was reporting it gone, not the cleanup policy; changing that policy would exceed this chunk.

## Residual risk

**Out of scope by design:** the cleanup-rung redesign (`autoCommitWip` / `push` / `removeDirectory` / `stopSession`) and any restructuring of the commit ⊃ push ⊃ remove ladder. Both reviewers showed those knobs cannot express "a profile may only subtract permission" — the safety property is the ladder *ordering*, not the flags, and `{autoCommitWip: false, push: true, removeDirectory: true}` on a dirty tree satisfies "no removal without a successful push" while destroying uncommitted work. That needs a profile schema and a decision that is not mine to make.

Plan, including both adversarial reviews: https://seer.build/ws_vbyzjvdg6g/b/harnessd-identity-9c5f3c/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Whole-stack review — deferred, recorded not fixed

A final adversarial pass over `origin/main...reaper-safety` raised three things scoped out of this PR:

1. **The veto detector is Claude-specific.** `findLiveClaudeSessions` reads `~/.claude/sessions`, so a `pi-local` link record with a dead pane and a live *paneless Pi* still reaches the force-remove. The check is not gated on `runtimeKind` — the detector is. Not a regression (before this PR there was no process check at all, for any runtime), but the improvement is incomplete and the comment overstates it.
2. **`decideWindow` calls `resolveManagedAgentPane(agent, panes)` with two arguments**, so `config` and `links` fall back to real disk reads rather than the injected `ReapDeps`. Consequences: the ledger-attested branch of the reaper's identity check cannot be driven through deps and is therefore untested (every fixture here declares `THREA_RUNTIME_SESSION_ID`), and two different canonicalizers — `deps.canonicalPath` in `decideWindow`, `realpathSync` inside the resolver — decide one destructive question.
3. **`claudeProcessesIn` runs unconditionally**, including under `--dry-run` and before the `pathExists` check, costing a readdir plus a `ps` per registry entry per link.

(1) and (2) are the ones worth doing next; both belong with the identity work in plan steps 4–6 rather than here, since (2) is really "the reaper should consume the same injected ledger as everything else".
