### PR TITLE
fix(board): render delegations on board cards and conversation panels

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -379,6 +379,80 @@ describe("BoardCard agent activity", () => {
   })
 })
 
+/** A delegation event on the card's stream, seeded into IDB like the session ones. */
+function delegationEvent(
+  eventType: "delegation:created" | "delegation:status_changed",
+  seconds: number,
+  payload: Record<string, unknown>
+): CachedEvent {
+  return {
+    id: `${eventType}_${seconds}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType,
+    payload,
+    actorId: "persona_1",
+    actorType: "persona",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
+describe("BoardCard delegations", () => {
+  beforeEach(() => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => false,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+  })
+
+  it("shows a delegation card for a delegation created from its conversation", async () => {
+    await db.events.bulkPut([
+      delegationEvent("delegation:created", 30, {
+        delegationId: "dlg_1",
+        title: "Add rate limiting",
+        brief: "Token bucket.",
+        contextRefs: [],
+        sourceConversationId: "conv_1",
+      }),
+      // Another conversation's delegation must stay off this card.
+      delegationEvent("delegation:created", 40, {
+        delegationId: "dlg_2",
+        title: "Somebody else's task",
+        brief: "Not here.",
+        contextRefs: [],
+        sourceConversationId: "conv_other",
+      }),
+    ])
+    mountCard()
+    expect(await screen.findByText("Add rate limiting")).toBeTruthy()
+    expect(screen.queryByText("Somebody else's task")).toBeNull()
+  })
+
+  it("reflects the latest status patch on the delegation card", async () => {
+    await db.events.bulkPut([
+      delegationEvent("delegation:created", 30, {
+        delegationId: "dlg_1",
+        title: "Add rate limiting",
+        brief: "Token bucket.",
+        contextRefs: [],
+        sourceConversationId: "conv_1",
+      }),
+      delegationEvent("delegation:status_changed", 40, { delegationId: "dlg_1", status: "claimed" }),
+      delegationEvent("delegation:status_changed", 50, { delegationId: "dlg_1", status: "completed" }),
+    ])
+    mountCard()
+    await screen.findByText("Add rate limiting")
+    expect(screen.getByText(/· Completed$/)).toBeTruthy()
+    expect(screen.queryByText(/· Claimed$/)).toBeNull()
+  })
+})
+
 describe("BoardCard conversation actions", () => {
   beforeEach(() => {
     vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({

--- a/apps/frontend/src/components/board/board-row-item.render.test.tsx
+++ b/apps/frontend/src/components/board/board-row-item.render.test.tsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { BOARD_EVENT_ROW_TYPES, type EventType } from "@threa/types"
+// eslint-disable-next-line no-restricted-imports -- test builds the rail's own row type, not a component data read
+import type { CachedEvent } from "@/db"
+import * as hooksModule from "@/hooks"
+import { PanelProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { resolveBoardEventRows, type BoardEventRow } from "@/lib/board/board-event-rows"
+import { BoardEventRowItem } from "./board-row-item"
+
+const WS = "ws_1"
+const STREAM = "stream_1"
+const CONV = "conv_1"
+const MEMBER_MESSAGE = "msg_member"
+
+let seq = 0
+function cachedEvent(eventType: EventType, payload: Record<string, unknown>): CachedEvent {
+  seq += 1
+  return {
+    id: `evt_${seq}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType,
+    payload,
+    actorId: "persona_1",
+    actorType: "persona",
+    createdAt: `2026-07-04T10:00:0${seq}.000Z`,
+    _cachedAt: seq,
+  }
+}
+
+/**
+ * The read half of the anti-drift guard auto-derives from STREAM_ROW_SPEC; the
+ * render half cannot, so this fixture map is held to the same spec list. A
+ * session's terminal event keeps the row off the live-progress subscription.
+ */
+const SESSION_FIXTURE: CachedEvent[] = [
+  cachedEvent("agent_session:started", {
+    sessionId: "sess_1",
+    triggerMessageId: MEMBER_MESSAGE,
+    personaName: "Ariadne",
+  }),
+  cachedEvent("agent_session:completed", { sessionId: "sess_1", stepCount: 3, duration: 1200, messageCount: 1 }),
+]
+
+const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
+  "agent_session:started": SESSION_FIXTURE,
+  "agent_session:completed": SESSION_FIXTURE,
+  "agent_session:failed": SESSION_FIXTURE,
+  "agent_session:interrupted": SESSION_FIXTURE,
+  "agent_session:deleted": SESSION_FIXTURE,
+  "memos:captured": [
+    cachedEvent("memos:captured", {
+      conversationId: CONV,
+      memos: [{ memoId: "memo_1", title: "Rate limits decided", knowledgeType: "decision", sourceMessageIds: [] }],
+    }),
+  ],
+  "agent:follow_up_scheduled": [
+    cachedEvent("agent:follow_up_scheduled", {
+      followUpId: "fup_1",
+      sourceConversationId: CONV,
+      instructions: "Check the deploy",
+      scheduledFor: "2026-07-05T10:00:00.000Z",
+    }),
+  ],
+  "delegation:created": [
+    cachedEvent("delegation:created", {
+      delegationId: "dlg_1",
+      title: "Add rate limiting",
+      brief: "Token bucket.",
+      contextRefs: [],
+      sourceConversationId: CONV,
+    }),
+  ],
+}
+
+function rowsFor(events: CachedEvent[]): BoardEventRow[] {
+  return resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set([MEMBER_MESSAGE]) })
+}
+
+function renderRow(row: BoardEventRow) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+          <TraceProvider>
+            <PanelProvider>
+              <BoardEventRowItem row={row} workspaceId={WS} />
+            </PanelProvider>
+          </TraceProvider>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.spyOn(hooksModule, "useActors").mockReturnValue({
+    getActorName: () => "Ariadne",
+  } as unknown as ReturnType<typeof hooksModule.useActors>)
+  vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(false)
+  vi.spyOn(hooksModule, "useInputMode").mockReturnValue("mouse")
+})
+
+describe("BoardEventRowItem renders every spec-declared board row", () => {
+  it("has a fixture for exactly the BOARD_EVENT_ROW_TYPES set", () => {
+    expect(new Set(Object.keys(ROW_FIXTURES))).toEqual(new Set(BOARD_EVENT_ROW_TYPES))
+  })
+
+  it("renders visible content for every row kind those fixtures resolve to", () => {
+    const rendered: Record<string, string[]> = {}
+    for (const [type, events] of Object.entries(ROW_FIXTURES)) {
+      const kinds: string[] = []
+      for (const row of rowsFor(events)) {
+        const { container, unmount } = renderRow(row)
+        if ((container.textContent ?? "").trim().length > 0) kinds.push(row.kind)
+        unmount()
+      }
+      rendered[type] = kinds
+    }
+    expect(rendered).toEqual({
+      "agent_session:started": ["session"],
+      "agent_session:completed": ["session"],
+      "agent_session:failed": ["session"],
+      "agent_session:interrupted": ["session"],
+      "agent_session:deleted": ["session"],
+      "memos:captured": ["memo"],
+      "agent:follow_up_scheduled": ["followUp"],
+      "delegation:created": ["delegation"],
+    })
+    // A kind that renders nothing produces `[]`, and `[]` can be pasted into the
+    // expectation above to make it green. This half names the offending type and
+    // cannot be satisfied by editing an expectation.
+    expect(Object.entries(rendered).filter(([, kinds]) => kinds.length === 0)).toEqual([])
+  })
+
+  it("renders the delegation card with its title and latest status", () => {
+    const row = rowsFor([
+      ...ROW_FIXTURES["delegation:created"]!,
+      cachedEvent("delegation:status_changed", { delegationId: "dlg_1", status: "running" }),
+    ])[0]!
+    const { container } = renderRow(row)
+    expect(container.textContent).toContain("Add rate limiting")
+    expect(container.textContent).toContain("Running")
+  })
+})

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -4,6 +4,7 @@ import { isContinuation, type RenderableMessage } from "@/components/message/mes
 import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
+import { DelegationEvent } from "@/components/timeline/delegation-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
 import { useSocket } from "@/contexts"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -401,6 +402,19 @@ export function BoardEventRowItem({
           cancelledByEvent={row.cancelled}
         />
       )
+    case "delegation":
+      return (
+        <DelegationEvent
+          event={row.event as StreamEvent}
+          workspaceId={workspaceId}
+          streamId={row.streamId}
+          statusPatch={row.statusPatch}
+        />
+      )
+    default: {
+      const exhaustive: never = row
+      return exhaustive
+    }
   }
 }
 

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -301,6 +301,14 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
           <UnreadDivider isDimmed={row.isDimmed} />
         </div>
       )
+    // A new BoardRow kind with no case here would return undefined and render an
+    // invisible gap that still counts toward the row list — tsconfig sets no
+    // `noImplicitReturns` and ReactNode admits undefined, so only this makes it
+    // a compile error.
+    default: {
+      const exhaustive: never = row
+      return exhaustive
+    }
   }
 }
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -4,11 +4,15 @@ import { act, render, screen, waitFor, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter, useNavigate } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+import type { Socket } from "socket.io-client"
+import type { BoardPost, BoardPostMessage, ConversationWithStaleness, EventType } from "@threa/types"
 import { ConversationPanel } from "./conversation-panel"
-import { ServicesProvider, SidebarProvider, PanelProvider } from "@/contexts"
+import { ServicesProvider, SidebarProvider, PanelProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { spyOnExport } from "@/test/spy"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
+import { db, type CachedEvent } from "@/db"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import * as editorModule from "@/components/editor"
 import * as messageEditFormModule from "@/components/timeline/message-edit-form"
 import * as messageHistoryDialogModule from "@/components/timeline/message-history-dialog"
@@ -179,10 +183,12 @@ function mountPanel(opts: {
         <ServicesProvider services={{ conversations: { getBoardPost, getBoardMessages } as never }}>
           <SidebarProvider>
             <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${startId}${mParam}`]}>
-              <PanelProvider>
-                <Navigator />
-                <ConversationPanel workspaceId={WORKSPACE_ID} onClose={vi.fn()} />
-              </PanelProvider>
+              <TraceProvider>
+                <PanelProvider>
+                  <Navigator />
+                  <ConversationPanel workspaceId={WORKSPACE_ID} onClose={vi.fn()} />
+                </PanelProvider>
+              </TraceProvider>
             </MemoryRouter>
           </SidebarProvider>
         </ServicesProvider>
@@ -1029,5 +1035,82 @@ describe("ConversationPanel", () => {
     // Clicking the indicator opens the revisions dialog.
     await user.click(edited)
     expect(await screen.findByText("stub-history")).toBeTruthy()
+  })
+})
+
+/** A non-message event on the conversation's stream, seeded into IDB so the panel
+ *  reads it off the same rail the board card does. */
+function cachedStreamEvent(eventType: EventType, seconds: number, payload: Record<string, unknown>): CachedEvent {
+  return {
+    id: `${eventType}_${seconds}`,
+    workspaceId: WORKSPACE_ID,
+    streamId: "stream_1",
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType,
+    payload,
+    actorId: "persona_1",
+    actorType: "persona",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
+describe("ConversationPanel event rows", () => {
+  beforeEach(async () => {
+    __clearBoardRailRegistry()
+    await db.events.clear()
+  })
+  afterEach(async () => {
+    __clearBoardRailRegistry()
+    await db.events.clear()
+  })
+
+  it("shows a delegation card for its conversation's delegation, and not another's", async () => {
+    await db.events.bulkPut([
+      cachedStreamEvent("delegation:created", 30, {
+        delegationId: "dlg_1",
+        title: "Add rate limiting",
+        brief: "Token bucket.",
+        contextRefs: [],
+        sourceConversationId: CONVERSATION_ID,
+      }),
+      cachedStreamEvent("delegation:status_changed", 40, { delegationId: "dlg_1", status: "running" }),
+      cachedStreamEvent("delegation:created", 50, {
+        delegationId: "dlg_2",
+        title: "Somebody else's task",
+        brief: "Not here.",
+        contextRefs: [],
+        sourceConversationId: "conv_other",
+      }),
+    ])
+    mountPanel({ cached: asCached(makePost()) })
+    expect(await screen.findByText("Add rate limiting")).toBeTruthy()
+    expect(screen.getByText(/· Running$/)).toBeTruthy()
+    expect(screen.queryByText("Somebody else's task")).toBeNull()
+  })
+
+  it("offers Redirect on a running agent trace, which bumps the panel composer's open signal", async () => {
+    const user = userEvent.setup()
+    const socket = { on: () => socket, off: () => socket } as unknown as Socket
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    let openReplySignal: number | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      openReplySignal = props.openReplySignal
+      return <div data-testid="panel-composer" />
+    })
+    await db.events.bulkPut([
+      cachedStreamEvent("agent_session:started", 30, {
+        sessionId: "sess_run",
+        triggerMessageId: "msg_1",
+        personaName: "Ariadne",
+      }),
+    ])
+    mountPanel({ cached: asCached(makePost()) })
+
+    const redirect = await screen.findByRole("button", { name: "Redirect" })
+    const before = openReplySignal ?? 0
+    await user.click(redirect)
+    await waitFor(() => expect(openReplySignal ?? 0).toBeGreaterThan(before))
   })
 })

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -831,6 +831,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
               renderBranchMessage={renderBranchMessage}
               renderBranchTail={inlineComposer.renderBranchTail}
               renderAfterMessage={inlineComposer.renderAfterMessage}
+              onRedirectSession={() => setFocusSeq((n) => n + 1)}
             />
             {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
             {backfillFailed && (

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -9,12 +9,22 @@ import type { BoardViewPost } from "./use-stable-board-view"
 
 /**
  * Event types the board rail reads alongside `message_created`: the non-message
- * rows the board draws (agent sessions, memo captures, follow-ups — derived from
- * the shared STREAM_ROW_SPEC) plus the follow-up *cancel* patch, which carries no
- * row of its own but flips a scheduled card to "Cancelled". Registering a new
- * conversation-scoped row kind in the spec adds it here automatically.
+ * rows the board draws (agent sessions, memo captures, follow-ups, delegations —
+ * derived from the shared STREAM_ROW_SPEC) plus the two patches that carry no row
+ * of their own: `agent:follow_up_cancelled` flips a scheduled card to "Cancelled",
+ * `delegation:status_changed` advances a delegation card's status. Registering a
+ * new conversation-scoped row kind in the spec adds it here automatically; a
+ * PATCH-classed type never derives, so it is listed by hand. Adding a row type
+ * whose live updates arrive as a patch means adding that patch HERE too —
+ * `board-event-rows.test.ts` ("BOARD_RAIL_EVENT_TYPES covers every patch
+ * belonging to a board row type") holds this list to it.
  */
-const BOARD_RAIL_EVENT_TYPES: EventType[] = [...BOARD_EVENT_ROW_TYPES, "agent:follow_up_cancelled", "message_created"]
+export const BOARD_RAIL_EVENT_TYPES: EventType[] = [
+  ...BOARD_EVENT_ROW_TYPES,
+  "agent:follow_up_cancelled",
+  "delegation:status_changed",
+  "message_created",
+]
 
 interface MessageCreatedPayloadShape {
   messageId?: string

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest"
+import { BOARD_EVENT_ROW_TYPES, EVENT_TYPES, STREAM_ROW_SPEC, type EventType } from "@threa/types"
 import type { CachedEvent } from "@/db"
+import { BOARD_RAIL_EVENT_TYPES } from "@/hooks/use-board-card-messages"
 import { resolveBoardEventRows } from "./board-event-rows"
 
 let seq = 0
@@ -150,5 +152,197 @@ describe("resolveBoardEventRows", () => {
     ]
     const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set(["msg_member"]) })
     expect(rows.map((r) => r.kind)).toEqual(["session", "memo"])
+  })
+
+  it("resolves a delegation created from this conversation into a row, dropping one from another", () => {
+    const events = [
+      cachedEvent({
+        id: "d_here",
+        eventType: "delegation:created",
+        createdAt: "2026-07-04T10:00:00Z",
+        payload: { delegationId: "dlg_1", title: "Ship it", sourceConversationId: CONV },
+      }),
+      cachedEvent({
+        id: "d_other",
+        eventType: "delegation:created",
+        createdAt: "2026-07-04T10:01:00Z",
+        payload: { delegationId: "dlg_2", title: "Elsewhere", sourceConversationId: "conv_other" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set() })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ kind: "delegation", key: "d_here", statusPatch: undefined })
+  })
+
+  it("carries the latest delegation:status_changed payload onto its delegation row", () => {
+    const events = [
+      cachedEvent({
+        id: "d1",
+        eventType: "delegation:created",
+        createdAt: "2026-07-04T10:00:00Z",
+        payload: { delegationId: "dlg_1", title: "Ship it", sourceConversationId: CONV },
+      }),
+      cachedEvent({
+        eventType: "delegation:status_changed",
+        createdAt: "2026-07-04T10:01:00Z",
+        payload: { delegationId: "dlg_1", status: "claimed", claimedByLabel: "Kris's MacBook" },
+      }),
+      cachedEvent({
+        eventType: "delegation:status_changed",
+        createdAt: "2026-07-04T10:02:00Z",
+        payload: { delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" },
+      }),
+      // Another delegation's patch must not leak onto this row.
+      cachedEvent({
+        eventType: "delegation:status_changed",
+        createdAt: "2026-07-04T10:03:00Z",
+        payload: { delegationId: "dlg_2", status: "failed" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set() })
+    expect(rows).toEqual([
+      {
+        kind: "delegation",
+        key: "d1",
+        sortMs: new Date("2026-07-04T10:00:00Z").getTime(),
+        streamId: "stream_1",
+        event: events[0],
+        statusPatch: { delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" },
+      },
+    ])
+  })
+
+  it("keeps the max-createdAt status patch when the patches arrive out of array order", () => {
+    // The board picks the latest patch by createdAt, deliberately unlike the
+    // timeline's collector, which takes last-in-array. Only a reversed feed
+    // distinguishes the two — every other patch case seeds ascending time.
+    const created = cachedEvent({
+      id: "d1",
+      eventType: "delegation:created",
+      createdAt: "2026-07-04T10:00:00Z",
+      payload: { delegationId: "dlg_1", title: "Ship it", sourceConversationId: CONV },
+    })
+    const later = cachedEvent({
+      eventType: "delegation:status_changed",
+      createdAt: "2026-07-04T10:02:00Z",
+      payload: { delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" },
+    })
+    const earlier = cachedEvent({
+      eventType: "delegation:status_changed",
+      createdAt: "2026-07-04T10:01:00Z",
+      payload: { delegationId: "dlg_1", status: "claimed", claimedByLabel: "Kris's MacBook" },
+    })
+    const rows = resolveBoardEventRows([created, later, earlier], {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+    })
+    expect(rows).toEqual([
+      {
+        kind: "delegation",
+        key: "d1",
+        sortMs: new Date("2026-07-04T10:00:00Z").getTime(),
+        streamId: "stream_1",
+        event: created,
+        statusPatch: { delegationId: "dlg_1", status: "completed", resultMessageId: "msg_result" },
+      },
+    ])
+  })
+})
+
+const MEMBER_MESSAGE = "msg_member"
+
+/**
+ * The minimal event set that must produce a row for each spec-declared
+ * conversation-scoped type. Session lifecycle types share one fixture whose
+ * `started` names a member trigger — the group is one row.
+ */
+const SESSION_FIXTURE: CachedEvent[] = [
+  cachedEvent({
+    eventType: "agent_session:started",
+    createdAt: "2026-07-04T10:00:00Z",
+    payload: { sessionId: "sess_fixture", triggerMessageId: MEMBER_MESSAGE },
+  }),
+]
+
+const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
+  "agent_session:started": SESSION_FIXTURE,
+  "agent_session:completed": SESSION_FIXTURE,
+  "agent_session:failed": SESSION_FIXTURE,
+  "agent_session:interrupted": SESSION_FIXTURE,
+  "agent_session:deleted": SESSION_FIXTURE,
+  "memos:captured": [
+    cachedEvent({ eventType: "memos:captured", createdAt: "2026-07-04T10:00:00Z", payload: { conversationId: CONV } }),
+  ],
+  "agent:follow_up_scheduled": [
+    cachedEvent({
+      eventType: "agent:follow_up_scheduled",
+      createdAt: "2026-07-04T10:00:00Z",
+      payload: { followUpId: "fup_fixture", sourceConversationId: CONV },
+    }),
+  ],
+  "delegation:created": [
+    cachedEvent({
+      eventType: "delegation:created",
+      createdAt: "2026-07-04T10:00:00Z",
+      payload: { delegationId: "dlg_fixture", title: "Fixture", sourceConversationId: CONV },
+    }),
+  ],
+}
+
+describe("resolveBoardEventRows covers every spec-declared board row type", () => {
+  it("has a fixture for exactly the BOARD_EVENT_ROW_TYPES set", () => {
+    expect(new Set(Object.keys(ROW_FIXTURES))).toEqual(new Set(BOARD_EVENT_ROW_TYPES))
+  })
+
+  it("produces a row for each fixture", () => {
+    const resolved: Record<string, string[]> = {}
+    for (const [type, events] of Object.entries(ROW_FIXTURES)) {
+      resolved[type] = resolveBoardEventRows(events, {
+        conversationId: CONV,
+        memberMessageIds: new Set([MEMBER_MESSAGE]),
+      }).map((row) => row.kind)
+    }
+    expect(resolved).toEqual({
+      "agent_session:started": ["session"],
+      "agent_session:completed": ["session"],
+      "agent_session:failed": ["session"],
+      "agent_session:interrupted": ["session"],
+      "agent_session:deleted": ["session"],
+      "memos:captured": ["memo"],
+      "agent:follow_up_scheduled": ["followUp"],
+      "delegation:created": ["delegation"],
+    })
+    // The object comparison above pins WHICH kind each type resolves to, but it
+    // stays satisfiable by pasting the produced diff back in — a type whose
+    // resolver case is missing yields `[]`, and `[]` can be written into the
+    // expectation. This half names the offender and cannot be edited green.
+    expect(Object.entries(resolved).filter(([, kinds]) => kinds.length === 0)).toEqual([])
+  })
+})
+
+/**
+ * The second wiring a new board row type needs: the Dexie rail filter. A row type
+ * that ships with a companion PATCH (the `delegation:created` /
+ * `delegation:status_changed` shape) gets its resolver and renderer forced by the
+ * guards above, but its patch is hand-listed in `BOARD_RAIL_EVENT_TYPES` and
+ * nothing above can observe it missing — both guards feed `resolveBoardEventRows`
+ * a caller-supplied array, bypassing the Dexie filter entirely.
+ *
+ * Derivation: a patch belongs to a row type when it shares that type's `prefix:`
+ * namespace (`delegation:status_changed` ↔ `delegation:created`,
+ * `agent:follow_up_cancelled` ↔ `agent:follow_up_scheduled`). That is the only
+ * relation the spec exposes today — `patchesRow` is a bare boolean with no
+ * pointer at the row it patches — and it reproduces today's hand-list exactly.
+ */
+describe("BOARD_RAIL_EVENT_TYPES covers every patch belonging to a board row type", () => {
+  it("subscribes to the patch types in each board row type's namespace", () => {
+    const rowNamespaces = new Set(
+      BOARD_EVENT_ROW_TYPES.filter((type) => type.includes(":")).map((type) => type.split(":")[0])
+    )
+    const requiredPatches = EVENT_TYPES.filter(
+      (type) => type.includes(":") && rowNamespaces.has(type.split(":")[0]) && STREAM_ROW_SPEC[type].patchesRow
+    )
+    const subscribed = new Set<EventType>(BOARD_RAIL_EVENT_TYPES)
+    expect(requiredPatches.filter((type) => !subscribed.has(type))).toEqual([])
   })
 })

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -1,4 +1,4 @@
-import { STREAM_ROW_SPEC } from "@threa/types"
+import { STREAM_ROW_SPEC, type DelegationStatusChangedEventPayload } from "@threa/types"
 import type { CachedEvent } from "@/db"
 import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "@/components/timeline/session-grouping"
 
@@ -6,7 +6,7 @@ import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "@/componen
  * A non-message stream event, resolved to the conversation it should draw on for
  * the board card / conversation panel. Agent-session lifecycle events are grouped
  * into one `session` row (start + complete/failed/deleted), matching the timeline;
- * memo captures and scheduled follow-ups are single rows. Every kind is
+ * memo captures, scheduled follow-ups and delegations are single rows. Every kind is
  * render-only — none is a conversation member and none bumps activity (INV: the
  * `bumps: false` contract in STREAM_ROW_SPEC).
  */
@@ -14,6 +14,14 @@ export type BoardEventRow =
   | { kind: "session"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
   | { kind: "memo"; key: string; sortMs: number; streamId: string; event: CachedEvent }
   | { kind: "followUp"; key: string; sortMs: number; streamId: string; event: CachedEvent; cancelled: boolean }
+  | {
+      kind: "delegation"
+      key: string
+      sortMs: number
+      streamId: string
+      event: CachedEvent
+      statusPatch?: DelegationStatusChangedEventPayload
+    }
 
 export interface ResolveBoardEventRowsCtx {
   /** The conversation the card renders. */
@@ -36,19 +44,31 @@ function timeMs(event: CachedEvent): number {
  * ordered, conversation-scoped rows the board draws. Pure over its inputs so the
  * placement rules are unit-testable in isolation.
  *
- * - `source-conversation` rows (memos:captured, follow-ups) match on the
- *   conversation id their payload names.
+ * - `source-conversation` rows (memos:captured, follow-ups, delegations) match on
+ *   the conversation id their payload names.
  * - `trigger-message` rows (agent sessions) are grouped by session id; the group
  *   shows iff the session's `started` event names a trigger that is a member.
  * - `agent:follow_up_cancelled` is a patch, not a row: it flips the matching
  *   scheduled card's `cancelled` flag (mirrors the timeline's cancel handling).
+ * - `delegation:status_changed` is likewise a patch: the latest one per
+ *   delegation rides on the delegation row as `statusPatch`.
  */
 export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEventRowsCtx): BoardEventRow[] {
   const cancelledFollowUpIds = new Set<string>()
+  const delegationStatusPatches = new Map<string, { payload: DelegationStatusChangedEventPayload; atMs: number }>()
   for (const event of events) {
-    if (event.eventType !== "agent:follow_up_cancelled") continue
-    const followUpId = (event.payload as { followUpId?: string })?.followUpId
-    if (followUpId) cancelledFollowUpIds.add(followUpId)
+    if (event.eventType === "agent:follow_up_cancelled") {
+      const followUpId = (event.payload as { followUpId?: string })?.followUpId
+      if (followUpId) cancelledFollowUpIds.add(followUpId)
+      continue
+    }
+    if (event.eventType === "delegation:status_changed") {
+      const payload = event.payload as DelegationStatusChangedEventPayload | undefined
+      if (!payload?.delegationId) continue
+      const atMs = timeMs(event)
+      const existing = delegationStatusPatches.get(payload.delegationId)
+      if (!existing || atMs >= existing.atMs) delegationStatusPatches.set(payload.delegationId, { payload, atMs })
+    }
   }
 
   const sessions = new Map<string, { events: CachedEvent[]; trigger: string | null }>()
@@ -82,6 +102,16 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
           streamId: event.streamId,
           event,
           cancelled: followUpId ? cancelledFollowUpIds.has(followUpId) : false,
+        })
+      } else if (event.eventType === "delegation:created") {
+        const delegationId = (event.payload as { delegationId?: string })?.delegationId
+        rows.push({
+          kind: "delegation",
+          key: event.id,
+          sortMs: timeMs(event),
+          streamId: event.streamId,
+          event,
+          statusPatch: delegationId ? delegationStatusPatches.get(delegationId)?.payload : undefined,
         })
       }
     }


### PR DESCRIPTION
Chunk 4 of 5 — [conversation panel ⇄ timeline parity](https://seer.build/ws_vbyzjvdg6g/b/conv-parity-plan-3d138c/). Stacked on #1645.

## Problem

`STREAM_ROW_SPEC["delegation:created"].conversationRef` is `"source-conversation"` (`stream-rows.ts:233`), and `stream-rows.test.ts:74` freezes it into `BOARD_EVENT_ROW_TYPES`. `BOARD_RAIL_EVENT_TYPES` spreads that list into the Dexie query, so delegation events were **already fetched and already sitting in `rail.events`**.

`resolveBoardEventRows` then threw them away. Its `source-conversation` branch hardcoded `if (memos:captured) … else if (agent:follow_up_scheduled) …` with no `else` — so a delegation fell through and was discarded, despite its payload carrying `sourceConversationId`, the exact field the two lines above already read. `grep -rn delegation` across `lib/board/`, `components/board/` and `components/conversations/` returned nothing.

A delegation created from a conversation was invisible on its board card and in its conversation panel, while the timeline rendered it fine.

**The delegation is the symptom.** The defect is that the resolver can silently drop a type the shared spec declares: the anti-drift guard covered the *read* path (which auto-derives) and not the *render* path.

## Solution

- **The resolver handles `delegation:created`**, and `delegation:status_changed` joins `BOARD_RAIL_EVENT_TYPES` by hand — it is a `PATCH`, so `BOARD_EVENT_ROW_TYPES` cannot derive it, exactly like `agent:follow_up_cancelled` already sitting there. `BoardEventRowItem` renders the timeline's own `DelegationEvent`; that component is untouched.
- **Three guards close the drift hole**, and they were built by attacking each other:
  1. Every `BOARD_EVENT_ROW_TYPES` entry must resolve to a row, and must render something non-empty.
  2. **No entry may be empty** — a separate `expect(Object.entries(resolved).filter(([, kinds]) => kinds.length === 0)).toEqual([])`. The `toEqual` map alone was defeatable: register a type, see the diff, paste `"handoff:created": []`, green. That was verified by doing it — resolver neutered *and* `[]` pasted, the whole describe passed. The new assertion cannot be satisfied by editing an expectation.
  3. `BoardEventRowItem`'s switch has a `never` backstop, so a `BoardEventRow` kind with no renderer is a compile error. Without it a probe member on the union typechecked clean (`noImplicitReturns` is off and React 19's `ReactNode` admits `undefined`), which would have let chunk 5's tombstone row render nothing silently.
- **The hand-listed patch entries get a guard too** — a test derives, from the spec, every `patchesRow` type sharing a namespace with a board row type and asserts it is in `BOARD_RAIL_EVENT_TYPES`. It evaluates to exactly today's hand-list, so it would have caught this omission. Stated limitation: a future patch that does *not* share its row type's prefix escapes it; catching that needs a `patchesRowType` pointer in the spec, which is out of scope here.
- **Status patches key on max `createdAt`**, not last-in-array like the timeline, because the board rail's event order is not guaranteed sequence-sorted. A test now feeds them reversed so the deviation is pinned rather than assumed.
- **The panel gains `onRedirectSession`** — `board-card.tsx:721,766` has always passed it; the panel never did, so its running agent traces had no Redirect.

## Board card impact (this is not panel-only)

A card whose conversation produced a delegation gains a delegation card — title, `actor · Status` line, action affordances — placed chronologically among memo/follow-up/trace rows, so **the card grows taller in the board feed**. Status tracks patches live and after reload. Cards with no delegation are unchanged. Asserted in `board-card.test.tsx`, not left to be discovered.

## Files

| File | Change |
| ---- | ------ |
| `lib/board/board-event-rows.ts` | `delegation` row kind; latest-status-patch pre-pass; `delegation:created` case |
| `hooks/use-board-card-messages.ts` | `delegation:status_changed` on the rail; exported for the new guard; comment names both patches |
| `components/board/board-row-item.tsx` | `case "delegation"`; `never` exhaustiveness backstop |
| `components/conversations/conversation-panel.tsx` | pass `onRedirectSession` |
| `lib/board/board-event-rows.test.ts` | delegation cases, out-of-order patch case, anti-drift + rail-coverage guards |
| `components/board/board-row-item.render.test.tsx` | **new** — render half of the anti-drift guard |
| `components/board/board-card.test.tsx` | delegation card appears; reflects the latest status patch |
| `components/conversations/conversation-panel.test.tsx` | delegation card in the panel; Redirect wiring |

## Test plan

- [x] `apps/frontend` typecheck + lint — clean
- [x] `packages/types` typecheck — clean; `git diff --stat packages/types` empty (the spec experiment was reverted)
- [x] vitest `lib/board`, `components/{board,conversations}`, `hooks` — 106 files, 1073 tests pass
- [x] anti-drift proven in both directions: removing the resolver case reddens "produces a row"; declaring a new conversation-scoped type in the spec reddens the fixture-set assertion
- [x] the paste-the-diff defeat reproduced and confirmed closed; the `never` probe now fails typecheck (`TS2322 … not assignable to type 'never'`); deleting `delegation:status_changed` from the rail reddens exactly one test
- [ ] no browser pass — the board-card appearance is asserted in tests, not visually confirmed

Adversarial review found 4 issues after the first green run, all in the guard rather than the feature; all fixed in-branch.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787868593&installation_model_id=20758&pr_number=1649&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1649&signature=21d07b3aa96c9b2f7ae7d73588026a4d2da346937ef69762a8a2375e9ce95def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

### Correction folded in after the whole-stack review

The `never` backstop originally landed on `BoardEventRowItem`, whose union is `BoardEventRow` — but the union `renderRowContent` switches on is `BoardRow`, which this stack extended twice (`day` in #1642, `unread` in #1645). The guard was on the one union the stack did not touch, so the claim above was only half true. `renderRowContent` now carries the same backstop; verified by a probe member on `BoardRow` failing typecheck at `branch-rows.tsx:309`.
