### PR TITLE
fix(board): show deleted messages as tombstones, and stop shipping their bodies

### DIFF
--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -72,6 +72,9 @@ export interface BoardPostMessage {
   linkPreviews: LinkPreviewSummary[]
   createdAt: Date
   editedAt: Date | null
+  /** Soft-delete stamp, or null when live. A deleted row is projected as a
+   * tombstone: `contentMarkdown` empty, no reactions/attachments/link previews. */
+  deletedAt: Date | null
 }
 
 /** A conversation surfaced as a feed post: the grouping, its origin message, and the latest replies. */
@@ -410,8 +413,13 @@ export class ConversationService {
    */
   private async hydrateBoardMessages(workspaceId: string, messages: Message[]): Promise<Map<string, BoardPostMessage>> {
     const byId = new Map<string, BoardPostMessage>()
-    const ids = messages.map((m) => m.id)
-    if (ids.length === 0) return byId
+    // A deleted row's rich content is discarded by the projection, so it is never
+    // hydrated — no presigned URL is ever minted for deleted content.
+    const ids = messages.filter((m) => m.deletedAt == null).map((m) => m.id)
+    if (ids.length === 0) {
+      for (const message of messages) byId.set(message.id, toBoardPostMessage(message, [], []))
+      return byId
+    }
     const attachmentsByMessage = await AttachmentRepository.findByMessageIds(this.pool, ids)
     const linkPreviewsByMessage = await LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, ids)
     const summariesByMessage = await hydrateAttachmentSummaries(this.pool, workspaceId, attachmentsByMessage)
@@ -1488,16 +1496,21 @@ function toBoardPostMessage(
   attachments: AttachmentSummary[],
   linkPreviews: LinkPreviewSummary[]
 ): BoardPostMessage {
+  const deleted = message.deletedAt != null
   return {
     id: message.id,
     streamId: message.streamId,
     authorId: message.authorId,
     authorType: message.authorType,
-    contentMarkdown: message.contentMarkdown,
-    reactions: message.reactions,
-    attachments,
-    linkPreviews,
+    // `messages` retains the body on soft delete and `findByIds` returns
+    // tombstones (other callers depend on that), so the deleted body is dropped
+    // HERE — a flag alone would keep shipping it, just labelled.
+    contentMarkdown: deleted ? "" : message.contentMarkdown,
+    reactions: deleted ? {} : message.reactions,
+    attachments: deleted ? [] : attachments,
+    linkPreviews: deleted ? [] : linkPreviews,
     createdAt: message.createdAt,
     editedAt: message.editedAt,
+    deletedAt: message.deletedAt,
   }
 }

--- a/apps/backend/tests/integration/conversation-board-messages.test.ts
+++ b/apps/backend/tests/integration/conversation-board-messages.test.ts
@@ -1,0 +1,203 @@
+/**
+ * getBoardMessages projection — the conversation panel's server backfill path.
+ *
+ * `MessageRepository.findByIds` returns soft-deleted rows (other callers depend
+ * on that) and `softDelete` retains `content_markdown`, so the projection is the
+ * only place a deleted body can be dropped. Verified against the real schema
+ * (INV-68): seed rows, run the real projection, assert on what comes back.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, spyOn } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, testMessageContent, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { AttachmentRepository } from "../../src/features/attachments"
+import { ConversationRepository, ConversationService } from "../../src/features/conversations"
+import { userId, workspaceId, streamId, messageId, conversationId, attachmentId } from "../../src/lib/id"
+
+describe("ConversationService.getBoardMessages", () => {
+  let pool: Pool
+  let service: ConversationService
+  let testUserId: string
+  let testWorkspaceId: string
+  let testStreamId: string
+  let convId: string
+  let liveMessageId: string
+  let deletedMessageId: string
+  let allDeletedConvId: string
+  let allDeletedMessageId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    service = new ConversationService(pool)
+
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+    testStreamId = streamId()
+    convId = conversationId()
+    liveMessageId = messageId()
+    deletedMessageId = messageId()
+    allDeletedConvId = conversationId()
+    allDeletedMessageId = messageId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Board Messages WS",
+        slug: `board-msgs-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      await StreamRepository.insert(client, {
+        id: testStreamId,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+      await MessageRepository.insert(client, {
+        id: liveMessageId,
+        streamId: testStreamId,
+        sequence: BigInt(1),
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("still here"),
+      })
+      await MessageRepository.insert(client, {
+        id: deletedMessageId,
+        streamId: testStreamId,
+        sequence: BigInt(2),
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("the secret pre-deletion body"),
+      })
+      await MessageRepository.addReaction(client, deletedMessageId, "🔥", testUserId)
+      const attachment = await AttachmentRepository.insert(client, {
+        id: attachmentId(),
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        uploadedBy: testUserId,
+        filename: "secret.png",
+        mimeType: "image/png",
+        sizeBytes: 128,
+        storagePath: `${testWorkspaceId}/secret.png`,
+      })
+      await AttachmentRepository.attachToMessage(client, [attachment.id], deletedMessageId, testStreamId)
+      const liveAttachment = await AttachmentRepository.insert(client, {
+        id: attachmentId(),
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        uploadedBy: testUserId,
+        filename: "public.png",
+        mimeType: "image/png",
+        sizeBytes: 64,
+        storagePath: `${testWorkspaceId}/public.png`,
+      })
+      await AttachmentRepository.attachToMessage(client, [liveAttachment.id], liveMessageId, testStreamId)
+      await MessageRepository.softDelete(client, deletedMessageId)
+      await ConversationRepository.insert(client, {
+        id: convId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+      })
+      await ConversationRepository.addPrimaryMessage(client, testWorkspaceId, convId, liveMessageId, testUserId)
+      await ConversationRepository.addPrimaryMessage(client, testWorkspaceId, convId, deletedMessageId, testUserId)
+
+      await MessageRepository.insert(client, {
+        id: allDeletedMessageId,
+        streamId: testStreamId,
+        sequence: BigInt(3),
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("wholly deleted conversation"),
+      })
+      await MessageRepository.softDelete(client, allDeletedMessageId)
+      await ConversationRepository.insert(client, {
+        id: allDeletedConvId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+      })
+      await ConversationRepository.addPrimaryMessage(
+        client,
+        testWorkspaceId,
+        allDeletedConvId,
+        allDeletedMessageId,
+        testUserId
+      )
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("returns a soft-deleted member as a tombstone", async () => {
+    const messages = await service.getBoardMessages(testWorkspaceId, convId)
+    const tombstone = messages.find((m) => m.id === deletedMessageId)
+    expect(tombstone?.deletedAt).toBeInstanceOf(Date)
+  })
+
+  test("a tombstone carries no content, reactions, attachments, or link previews", async () => {
+    const messages = await service.getBoardMessages(testWorkspaceId, convId)
+    const tombstone = messages.find((m) => m.id === deletedMessageId)!
+    expect({
+      contentMarkdown: tombstone.contentMarkdown,
+      reactions: tombstone.reactions,
+      attachments: tombstone.attachments,
+      linkPreviews: tombstone.linkPreviews,
+    }).toEqual({
+      contentMarkdown: "",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+    })
+  })
+
+  test("a live message in the same conversation is unaffected", async () => {
+    const messages = await service.getBoardMessages(testWorkspaceId, convId)
+    const live = messages.find((m) => m.id === liveMessageId)!
+    expect({
+      contentMarkdown: live.contentMarkdown,
+      deletedAt: live.deletedAt,
+      streamId: live.streamId,
+      authorId: live.authorId,
+    }).toEqual({
+      contentMarkdown: "still here",
+      deletedAt: null,
+      streamId: testStreamId,
+      authorId: testUserId,
+    })
+  })
+
+  test("hydration never sees a deleted id, so no presigned URL is minted for deleted content", async () => {
+    const findByMessageIds = spyOn(AttachmentRepository, "findByMessageIds")
+    try {
+      const messages = await service.getBoardMessages(testWorkspaceId, convId)
+      const live = messages.find((m) => m.id === liveMessageId)!
+      const tombstone = messages.find((m) => m.id === deletedMessageId)!
+      expect(findByMessageIds.mock.calls.map(([, ids]) => ids)).toEqual([[liveMessageId]])
+      expect({
+        liveFilenames: live.attachments.map((a) => a.filename),
+        tombstoneAttachments: tombstone.attachments,
+      }).toEqual({ liveFilenames: ["public.png"], tombstoneAttachments: [] })
+    } finally {
+      findByMessageIds.mockRestore()
+    }
+  })
+
+  test("a wholly-deleted conversation returns its tombstones without hydrating anything", async () => {
+    const findByMessageIds = spyOn(AttachmentRepository, "findByMessageIds")
+    try {
+      const messages = await service.getBoardMessages(testWorkspaceId, allDeletedConvId)
+      expect(findByMessageIds).not.toHaveBeenCalled()
+      expect(
+        messages.map((m) => ({ id: m.id, contentMarkdown: m.contentMarkdown, deleted: m.deletedAt instanceof Date }))
+      ).toEqual([{ id: allDeletedMessageId, contentMarkdown: "", deleted: true }])
+    } finally {
+      findByMessageIds.mockRestore()
+    }
+  })
+})

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -700,3 +700,86 @@ describe("BoardCard day dividers", () => {
     expect(screen.queryByText(formatDayDivider(new Date(localStartOfDayMs(afterMidnight))))).toBeNull()
   })
 })
+
+describe("BoardCard deleted messages", () => {
+  it("shows no tombstone in the collapsed card's reply preview", async () => {
+    // The rail's `deletedMessages` map is for the always-expanded conversation
+    // panel only: a tombstone must never take one of the card's 3 preview slots
+    // (nor show up as a body), because the "N more" gap counts displayable rows.
+    await db.events.bulkPut([
+      messageEvent("m_open", "Opening body.", 10),
+      messageEvent("m_r1", "A live reply.", 20),
+      messageEvent("m_r2", "The deleted body.", 30, "2026-06-22T12:05:00.000Z"),
+    ])
+    mountCard(makePost({ messageIds: ["m_open", "m_r1", "m_r2"] }))
+
+    expect(await screen.findByText("A live reply.")).toBeTruthy()
+    expect(screen.queryByText("This message was deleted")).toBeNull()
+    expect(screen.queryByText("The deleted body.")).toBeNull()
+  })
+
+  it("renders a tombstone, not a blank row, for a deleted reply on the cached projection", async () => {
+    // No IDB events: the rail never sees the conversation, so the card falls back
+    // to the server projection, whose deleted rows arrive blanked but flagged.
+    const post = makePost({ messageIds: ["m_open", "m_r1"] })
+    ;(post as unknown as { recentMessages: unknown[] }).recentMessages = [
+      {
+        id: "m_r1",
+        streamId: STREAM,
+        authorId: "usr_other",
+        authorType: "user",
+        contentMarkdown: "",
+        reactions: {},
+        attachments: [],
+        linkPreviews: [],
+        createdAt: "2026-06-22T12:05:00.000Z",
+        editedAt: null,
+        deletedAt: "2026-06-22T12:06:00.000Z",
+      },
+    ]
+    ;(post as unknown as { totalReplies: number }).totalReplies = 1
+    const { container } = mountCard(post)
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(container.querySelector('[data-message-id="m_r1"]')).toBeNull()
+  })
+
+  it("renders a tombstone, not a blank row, for a deleted reply from the expand backfill", async () => {
+    const getBoardMessages = vi.fn().mockResolvedValue([
+      openingMessage(),
+      {
+        id: "m_r2",
+        streamId: STREAM,
+        authorId: "usr_other",
+        authorType: "user",
+        contentMarkdown: "",
+        reactions: {},
+        attachments: [],
+        linkPreviews: [],
+        createdAt: "2026-06-22T12:10:00.000Z",
+        editedAt: null,
+        deletedAt: "2026-06-22T12:11:00.000Z",
+      },
+    ])
+    const post = makePost({ messageIds: ["m_open", "m_r2"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 1
+    const { container } = mountCard(post, { getBoardMessages })
+
+    await userEvent.click(await screen.findByText(/1 more message/))
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(container.querySelector('[data-message-id="m_r2"]')).toBeNull()
+  })
+})
+
+/** A `message_created` row on the card's stream, seeded into IDB so the card's
+ *  rail reads it like the timeline does. */
+function messageEvent(messageId: string, contentMarkdown: string, seconds: number, deletedAt?: string): CachedEvent {
+  return {
+    ...sessionEvent("agent_session:started", seconds, { messageId, contentMarkdown, reactions: {}, deletedAt }),
+    id: `evt_${messageId}`,
+    eventType: "message_created",
+    actorId: "usr_me",
+    actorType: "user",
+  }
+}

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -770,6 +770,55 @@ describe("BoardCard deleted messages", () => {
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
     expect(container.querySelector('[data-message-id="m_r2"]')).toBeNull()
   })
+
+  it("renders a tombstone for a deleted reply once the rail is complete", async () => {
+    // The rail path: every reply is local, so the card falls through to
+    // `railReplies` — which excludes deleted rows. Without the tombstone merge the
+    // deleted middle reply simply disappears here (and it IS drawn on the other two
+    // paths), so the card reflows as sync completes.
+    await db.events.bulkPut([
+      messageEvent("m_open", "Opening body.", 10),
+      messageEvent("m_r1", "First reply.", 11),
+      messageEvent("m_r2", "Second reply.", 12),
+      messageEvent("m_rd", "The deleted body.", 13, "2026-06-22T12:05:00.000Z"),
+      messageEvent("m_r3", "Third reply.", 14),
+      messageEvent("m_r4", "Fourth reply.", 15),
+      messageEvent("m_r5", "Fifth reply.", 16),
+    ])
+    const post = makePost({ messageIds: ["m_open", "m_r1", "m_r2", "m_rd", "m_r3", "m_r4", "m_r5"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 5
+    mountCard(post)
+
+    // Collapsed the card previews the trailing live replies only; expanding falls
+    // through to the complete local rail.
+    await userEvent.click(await screen.findByText(/2 more messages/))
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(screen.queryByText("The deleted body.")).toBeNull()
+    expect(screen.getByText("First reply.")).toBeTruthy()
+    expect(screen.getByText("Fifth reply.")).toBeTruthy()
+  })
+})
+
+describe("BoardCard unread dot on a deleted opening", () => {
+  it("keeps the dot off when the only known message is a deleted opening", async () => {
+    // Projection path (no IDB events): the opening arrives blanked but flagged.
+    // A tombstone renders no observable row, so auto-read can never clear a dot it
+    // lit — it must not reach the unread derivation at all. `hasUnread` here reports
+    // on whatever set the card hands it, so the assertion is about that set.
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: (messages) => messages.length > 0,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+    const post = makePost({ messageIds: ["m_open"] }, { contentMarkdown: "", deletedAt: "2026-06-22T12:06:00.000Z" })
+    mountCard(post)
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(screen.queryByLabelText("Unread")).toBeNull()
+  })
 })
 
 /** A `message_created` row on the card's stream, seeded into IDB so the card's

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -28,6 +28,7 @@ import { ConversationReadProvider, useConversationReadController } from "@/compo
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
+import { DeletedMessageEvent } from "@/components/timeline/deleted-message-event"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
@@ -389,7 +390,11 @@ export function BoardCard({
   // its visible tail reads the conversation up to there, exactly like invoking
   // "Mark as read up to here" on that row (Kris's dogfood ruling on PR #1174 —
   // having the conversation open is enough to mark it).
-  const autoReadRows = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
+  // A tombstone renders no `data-message-id` row, so it can never be observed —
+  // keep it out of the auto-read set entirely.
+  const autoReadRows = (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).filter(
+    (m) => !m.deletedAt
+  )
   useConversationAutoRead({
     containerRef: cardRef,
     messages: autoReadRows,
@@ -442,6 +447,9 @@ export function BoardCard({
   }, [])
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
+    // Mirrors the panel: a deleted row is a tombstone, never a blank MessageItem
+    // carrying an author, a timestamp and an action menu.
+    if (message.deletedAt) return <DeletedMessageEvent key={message.id} />
     // A conversation can span its root + threads (one root); render each row
     // against its own stream so reactions and the permalink target where the
     // message actually lives, falling back to the card's anchor stream.

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -137,6 +137,7 @@ export function BoardCard({
     events: railEvents,
     messagesById,
     taggedByConversation,
+    deletedById,
   } = useBoardCardMessages(post, streamType, {
     branchStreamIds: inlineComposer.branchStreamIds,
     extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
@@ -207,9 +208,12 @@ export function BoardCard({
     getReadTruth,
   } = useConversationReadController(workspaceId, conversation.id, streamId, currentUserId)
   // Over the card's known local messages (opening + the full local reply rail);
-  // own-authored rows are excluded inside `hasUnread`.
+  // own-authored rows are excluded inside `hasUnread`. A tombstone renders no
+  // observable row, so auto-read could never clear a dot it lit — it is excluded
+  // here exactly as it is from `autoReadRows` below, keeping "what lights the dot"
+  // and "what can clear it" the same set.
   const knownMessages = useMemo(
-    () => (openingMessage ? [openingMessage, ...railReplies] : railReplies),
+    () => (openingMessage ? [openingMessage, ...railReplies] : railReplies).filter((m) => !m.deletedAt),
     [openingMessage, railReplies]
   )
   const cardHasUnread = hasUnread(knownMessages)
@@ -368,7 +372,18 @@ export function BoardCard({
   // backfill's `data` lingers after `enabled` goes false).
   else if (incompleteLocally && allMessages)
     replies = (allMessages as RenderableMessage[]).filter((m) => m.id !== openingMessage?.id)
-  else replies = railReplies
+  else {
+    // The rail excludes deleted rows, so without this the tombstone the collapsed
+    // window and the backfill both draw would vanish here — and every row below it
+    // would shift up — the moment the rail caught up. Same merge as the panel
+    // (conversation-panel.tsx): the conversation's own deleted members, deduped.
+    // Expanded-only, so no count changes (`hiddenCount` is 0 here).
+    const railIds = new Set(railReplies.map((m) => m.id))
+    const tombstones = [...deletedById.values()].filter(
+      (m) => conversation.messageIds.includes(m.id) && m.id !== openingMessage?.id && !railIds.has(m.id)
+    )
+    replies = tombstones.length > 0 ? [...railReplies, ...tombstones] : railReplies
+  }
   // Merge this card's own just-sent replies with the confirmed set, skipping any
   // the rail or a backfill already carries, then sort by time: a pending reply
   // can be OLDER than a confirmed one (someone else's reply lands while yours is

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/stores/conversation-reply-open-store"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { formatDayDivider, localStartOfDayMs } from "@/lib/dates"
+import * as autoReadModule from "@/components/message/use-conversation-auto-read"
 
 const WORKSPACE_ID = "ws_1"
 const CONVERSATION_ID = "conv_1"
@@ -1112,5 +1113,90 @@ describe("ConversationPanel event rows", () => {
     const before = openReplySignal ?? 0
     await user.click(redirect)
     await waitFor(() => expect(openReplySignal ?? 0).toBeGreaterThan(before))
+  })
+})
+
+/** A `message_created` row on the conversation's stream, seeded into IDB so the
+ *  panel reads it off the same rail the board card does. */
+function cachedMessageEvent(messageId: string, contentMarkdown: string, seconds: number, deletedAt?: string) {
+  const event = cachedStreamEvent("message_created", seconds, { messageId, contentMarkdown, reactions: {}, deletedAt })
+  return { ...event, id: `evt_${messageId}`, actorId: "usr_me", actorType: "user" as const }
+}
+
+function postWithDeletedReply(): BoardPost {
+  const post = makePost()
+  post.conversation.messageIds = ["msg_1", "msg_2", "msg_3"]
+  post.openingMessage = makeMessage({ id: "msg_1", createdAt: "2026-06-22T12:00:10.000Z" })
+  post.recentMessages = [
+    makeMessage({ id: "msg_2", contentMarkdown: "Reply two body.", createdAt: "2026-06-22T12:00:20.000Z" }),
+  ]
+  post.totalReplies = 1
+  return post
+}
+
+describe("ConversationPanel deleted messages", () => {
+  beforeEach(async () => {
+    __clearBoardRailRegistry()
+    await db.events.clear()
+  })
+  afterEach(async () => {
+    __clearBoardRailRegistry()
+    await db.events.clear()
+  })
+
+  it("shows a tombstone in the deleted message's chronological slot", async () => {
+    await db.events.bulkPut([
+      cachedMessageEvent("msg_1", "Opening message body.", 10),
+      cachedMessageEvent("msg_2", "Reply two body.", 20),
+      cachedMessageEvent("msg_3", "The deleted body.", 30, "2026-06-22T12:05:00.000Z"),
+    ])
+    mountPanel({ cached: asCached(postWithDeletedReply()) })
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(screen.queryByText("The deleted body.")).toBeNull()
+    const bodies = screen.getAllByText(/Opening message body\.|Reply two body\.|This message was deleted/)
+    expect(bodies.map((el) => el.textContent)).toEqual([
+      "Opening message body.",
+      "Reply two body.",
+      "This message was deleted",
+    ])
+  })
+
+  it("shows a tombstone, not the pre-deletion body, when the conversation is backfilled from the server", async () => {
+    // No rail rows: the panel takes the server backfill path. The body is included
+    // on the wire row deliberately — the panel must render the tombstone off
+    // `deletedAt` alone, not trust the payload to be blank.
+    const post = postWithDeletedReply()
+    mountPanel({
+      cached: asCached({ ...post, totalReplies: 2 }),
+      getBoardMessages: async () => [
+        makeMessage({ id: "msg_2", contentMarkdown: "Reply two body.", createdAt: "2026-06-22T12:00:20.000Z" }),
+        makeMessage({
+          id: "msg_3",
+          contentMarkdown: "The deleted body.",
+          createdAt: "2026-06-22T12:00:30.000Z",
+          deletedAt: "2026-06-22T12:05:00.000Z",
+        }),
+      ],
+    })
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(screen.queryByText("The deleted body.")).toBeNull()
+  })
+
+  it("keeps a tombstone out of the auto-read participants", async () => {
+    const seen: string[][] = []
+    vi.spyOn(autoReadModule, "useConversationAutoRead").mockImplementation((opts) => {
+      seen.push(opts.messages.map((m) => m.id))
+    })
+    await db.events.bulkPut([
+      cachedMessageEvent("msg_1", "Opening message body.", 10),
+      cachedMessageEvent("msg_2", "Reply two body.", 20),
+      cachedMessageEvent("msg_3", "The deleted body.", 30, "2026-06-22T12:05:00.000Z"),
+    ])
+    mountPanel({ cached: asCached(postWithDeletedReply()) })
+
+    await screen.findByText("This message was deleted")
+    expect(seen.at(-1)).toEqual(["msg_1", "msg_2"])
   })
 })

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -48,6 +48,7 @@ import { cn } from "@/lib/utils"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
+import { DeletedMessageEvent } from "@/components/timeline/deleted-message-event"
 import { useConversationUnreadMarker } from "@/components/conversations/use-conversation-unread-marker"
 import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer, type ArmedReply } from "@/components/board/board-reply-composer"
@@ -423,6 +424,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     events: railEvents,
     messagesById,
     taggedByConversation,
+    deletedById,
   } = useBoardCardMessages(post, hostStreamType, {
     branchStreamIds: inlineComposer.branchStreamIds,
     extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
@@ -452,12 +454,25 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // Merge the viewer's own just-sent replies (deduped), then sort by time — a
   // pending reply can be older than a confirmed one.
   const seenReplyIds = new Set(replies.map((m) => m.id))
-  const displayedReplies = [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  // Tombstones for the conversation's deleted members. The backfill rows already
+  // carry theirs (the server projects them), so this fills the RAIL path — the
+  // panel is the always-expanded surface and shows "was deleted" rather than
+  // letting a message silently vanish. Deduped, then sorted in with the rest.
+  const deletedReplies = [...deletedById.values()].filter(
+    (m) => conversation.messageIds.includes(m.id) && m.id !== openingMessage?.id && !seenReplyIds.has(m.id)
   )
+  const displayedReplies = [
+    ...replies,
+    ...pendingReplies.filter((m) => !seenReplyIds.has(m.id)),
+    ...deletedReplies,
+  ].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   const loadingMore = incompleteLocally && !allMessages && !backfillFailed
 
   const all = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
+  // A tombstone is render-only: it never participates in read state (auto-read or
+  // the unread marker). It has no `data-message-id` row to scroll to, so anchoring
+  // the marker on one would draw a divider that never scrolls (R6).
+  const readableRows = all.filter((m) => !m.deletedAt)
 
   // Agent traces / memo captures / follow-ups on this conversation, interleaved
   // into the message rows. Render-only (STREAM_ROW_SPEC `bumps: false`) — kept out
@@ -560,11 +575,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     for (const [streamId, count] of Object.entries(unreadState.unreadCounts ?? {})) {
       if (count === 0) decidable.add(streamId)
     }
-    for (const message of all) {
+    for (const message of readableRows) {
       if (!decidable.has(message.streamId ?? conversation.streamId)) return false
     }
     return true
-  }, [unreadState, streamReadStates, all, conversation.streamId])
+  }, [unreadState, streamReadStates, readableRows, conversation.streamId])
   // Rows first, marker second: the marker may only anchor on a message that
   // actually gets a row (a message inside a depth-collapsed spanning subtree has
   // none, so a divider there would draw nothing and scroll nowhere).
@@ -580,7 +595,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   for (const row of baseRows) if (row.kind === "message") renderedMessageIds.add(row.message.id)
   const { markerMessageId, unreadCount, isDimmed, dismiss } = useConversationUnreadMarker({
     conversationId: conversation.id,
-    rows: all,
+    rows: readableRows,
     rootStreamId: conversation.streamId,
     rowState: conversationReadValue.state,
     currentUserId,
@@ -603,6 +618,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     // Hide "New sub-topic" once a thread already exists under the message (a
     // populated thread would mix membership — "Split this thread" is the gesture
     // there, adjustment D).
+    if (message.deletedAt) return <DeletedMessageEvent key={message.id} />
     const canBranch = !structuralIndex.threadsByAnchorId.has(message.id)
     return (
       <MessageItem
@@ -734,7 +750,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // still backfilling, the cutoff through a rendered row also covers the not-
   // yet-fetched middle — deliberate, same as the board card: reading the
   // conversation's visible tail reads it up to there.
-  const autoReadRows = all
+  const autoReadRows = readableRows
   useConversationAutoRead({
     containerRef: listRef,
     messages: autoReadRows,

--- a/apps/frontend/src/components/message/message-item.test.tsx
+++ b/apps/frontend/src/components/message/message-item.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { isContinuation, type RenderableMessage } from "./message-item"
+
+function message(overrides: Partial<RenderableMessage> = {}): RenderableMessage {
+  return {
+    id: "m1",
+    authorId: "usr_1",
+    authorType: "user",
+    contentMarkdown: "hi",
+    reactions: {},
+    createdAt: "2026-07-28T10:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("isContinuation", () => {
+  it("groups a same-author message sent within the window", () => {
+    expect(isContinuation(message(), message({ id: "m2", createdAt: "2026-07-28T10:01:00.000Z" }))).toBe(true)
+  })
+
+  it("a deleted row never continues a same-author run, and never lets one continue across it", () => {
+    const live = message()
+    const tombstone = message({
+      id: "m2",
+      contentMarkdown: "",
+      createdAt: "2026-07-28T10:01:00.000Z",
+      deletedAt: "2026-07-28T10:02:00.000Z",
+    })
+    const after = message({ id: "m3", createdAt: "2026-07-28T10:02:00.000Z" })
+    expect({
+      intoTombstone: isContinuation(live, tombstone),
+      outOfTombstone: isContinuation(tombstone, after),
+    }).toEqual({ intoTombstone: false, outOfTombstone: false })
+  })
+})

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -94,9 +94,14 @@ export interface RenderableMessage {
   editedAt?: string | null
   attachments?: AttachmentSummary[]
   linkPreviews?: LinkPreviewSummary[]
+  /** Soft-delete stamp, or null/absent when live. A deleted row renders as a
+   * tombstone on the conversation surfaces — it carries no body, reactions,
+   * attachments or link previews. */
+  deletedAt?: string | null
 }
 
 export function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolean {
+  if (prev.deletedAt || cur.deletedAt) return false
   return (
     prev.authorId === cur.authorId &&
     prev.authorType === cur.authorType &&

--- a/apps/frontend/src/components/timeline/deleted-message-event.tsx
+++ b/apps/frontend/src/components/timeline/deleted-message-event.tsx
@@ -1,0 +1,9 @@
+/** The tombstone a deleted message leaves behind — shared by the stream timeline
+ *  and the conversation panel, so "was deleted" reads the same on both. */
+export function DeletedMessageEvent() {
+  return (
+    <div className="py-0.5 px-3 sm:px-6 text-center">
+      <p className="text-xs italic text-muted-foreground">This message was deleted</p>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -18,6 +18,7 @@ import { BriefUpdatedEvent } from "./brief-updated-event"
 import { DescriptionSetEvent } from "./description-set-event"
 import { CallCard } from "./call-card"
 import { SystemEvent } from "./system-event"
+import { DeletedMessageEvent } from "./deleted-message-event"
 
 interface EventItemProps {
   event: StreamEvent
@@ -97,7 +98,7 @@ export function EventItem({
       if (payload.deletedAt) {
         return (
           <div data-event-id={event.id}>
-            <DeletedMessageEvent event={event} />
+            <DeletedMessageEvent />
           </div>
         )
       }
@@ -124,7 +125,7 @@ export function EventItem({
     case "message_deleted":
       return (
         <div data-event-id={event.id}>
-          <DeletedMessageEvent event={event} />
+          <DeletedMessageEvent />
         </div>
       )
 
@@ -288,12 +289,4 @@ export function EventItem({
         </div>
       )
   }
-}
-
-function DeletedMessageEvent(_props: { event: StreamEvent }) {
-  return (
-    <div className="py-0.5 px-3 sm:px-6 text-center">
-      <p className="text-xs italic text-muted-foreground">This message was deleted</p>
-    </div>
-  )
 }

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -431,6 +431,38 @@ describe("useBoardCardMessages", () => {
     expect(result.current.totalReplies).toBe(1)
   })
 
+  it("exposes a soft-deleted reply on `deletedById` with blank content", async () => {
+    const deleted = msgEvent("r1", "gone", 2)
+    const deletedAt = new Date().toISOString()
+    ;(deleted.payload as { deletedAt?: string }).deletedAt = deletedAt
+    await db.events.bulkPut([msgEvent("m1", "opening", 1), deleted, msgEvent("r2", "here", 3)])
+    const post = makePost({ messageIds: ["m1", "r1", "r2"], openingId: "m1" })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.deletedById.get("r1")).toBeDefined())
+    expect(result.current.deletedById.get("r1")).toMatchObject({
+      id: "r1",
+      contentMarkdown: "",
+      reactions: {},
+      deletedAt,
+    })
+  })
+
+  it("keeps a soft-deleted reply out of `replies`, `messagesById`, and `totalReplies`", async () => {
+    const deleted = msgEvent("r1", "gone", 2)
+    ;(deleted.payload as { deletedAt?: string }).deletedAt = new Date().toISOString()
+    await db.events.bulkPut([msgEvent("m1", "opening", 1), deleted, msgEvent("r2", "here", 3)])
+    const post = makePost({ messageIds: ["m1", "r1", "r2"], openingId: "m1" })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect({
+      replies: result.current.replies.map((m) => m.id),
+      hasInMessagesById: result.current.messagesById.has("r1"),
+      totalReplies: result.current.totalReplies,
+    }).toEqual({ replies: ["r2"], hasInMessagesById: false, totalReplies: 1 })
+  })
+
   it("excludes soft-deleted messages from the rail", async () => {
     const deleted = msgEvent("r1", "gone", 2)
     ;(deleted.payload as { deletedAt?: string }).deletedAt = new Date().toISOString()

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -431,6 +431,21 @@ describe("useBoardCardMessages", () => {
     expect(result.current.totalReplies).toBe(1)
   })
 
+  it("keeps a soft-deleted opening message as a tombstone once the rail has synced it", async () => {
+    const deletedOpening = msgEvent("m1", "the opening body", 1)
+    const deletedAt = new Date().toISOString()
+    ;(deletedOpening.payload as { deletedAt?: string }).deletedAt = deletedAt
+    await db.events.bulkPut([deletedOpening, msgEvent("r1", "a reply", 2)])
+    const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1" })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    // `seen` covers the opener but `messages` does not, so resolving only through
+    // `messages` drops the row entirely the moment the rail syncs — the opener
+    // shows a tombstone before sync and nothing after.
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect(result.current.openingMessage).toMatchObject({ id: "m1", contentMarkdown: "", deletedAt })
+  })
+
   it("exposes a soft-deleted reply on `deletedById` with blank content", async () => {
     const deleted = msgEvent("r1", "gone", 2)
     const deletedAt = new Date().toISOString()

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -73,6 +73,12 @@ interface StreamRail {
   /** Every message id the stream has synced — INCLUDING soft-deleted tombstones,
    *  which are absent from `messages`. Lets a card tell "deleted" from "unsynced". */
   seen: Set<string>
+  /** Soft-deleted `message_created` rows as content-free tombstone rows, by id.
+   *  Deliberately SEPARATE from `messages`: the collapsed card's reply window and
+   *  its "N more" arithmetic count displayable replies only, so a tombstone must
+   *  not take a slot there. Only the always-expanded conversation panel reads
+   *  this, and renders each as "This message was deleted". */
+  deletedMessages: Map<string, RenderableMessage>
   /** Renderable rows that carry a `conversationId`, grouped by it, chronological.
    *  A board reply tags its optimistic event with the conversation it attaches to,
    *  and the swap carries that tag onto the real event (stream-sync), so this holds
@@ -99,6 +105,7 @@ interface StreamRail {
 const LOADING_RAIL: StreamRail = {
   messages: new Map(),
   seen: new Set(),
+  deletedMessages: new Map(),
   taggedByConversation: new Map(),
   supersededClientIds: new Set(),
   events: [],
@@ -108,6 +115,7 @@ const LOADING_RAIL: StreamRail = {
 function buildRail(events: CachedEvent[], overlay?: Map<string, CachedEvent>): StreamRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
+  const deletedMessages = new Map<string, RenderableMessage>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
   const supersededClientIds = new Set<string>()
   const eventRows: CachedEvent[] = []
@@ -129,7 +137,22 @@ function buildRail(events: CachedEvent[], overlay?: Map<string, CachedEvent>): S
     // clientMessageId, so a pending row can never suppress anything.
     if (payload.clientMessageId && !event._status) supersededClientIds.add(payload.clientMessageId)
     const message = eventToRenderable(event)
-    if (!message) continue
+    if (!message) {
+      if (payload.messageId && payload.deletedAt) {
+        deletedMessages.set(payload.messageId, {
+          id: payload.messageId,
+          streamId: event.streamId,
+          sequence: event.sequence,
+          authorId: event.actorId ?? "",
+          authorType: (event.actorType ?? "user") as AuthorType,
+          contentMarkdown: "",
+          reactions: {},
+          createdAt: event.createdAt,
+          deletedAt: payload.deletedAt,
+        })
+      }
+      continue
+    }
     messages.set(message.id, message)
     // Group every conversation-tagged row (optimistic OR the swapped real one,
     // any `_status`) so the card can show the reply continuously across the echo
@@ -144,7 +167,15 @@ function buildRail(events: CachedEvent[], overlay?: Map<string, CachedEvent>): S
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, taggedByConversation, supersededClientIds, events: eventRows, resolved: true }
+  return {
+    messages,
+    seen,
+    deletedMessages,
+    taggedByConversation,
+    supersededClientIds,
+    events: eventRows,
+    resolved: true,
+  }
 }
 
 interface StreamRailEntry {
@@ -328,6 +359,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   if (rails.length === 1) return { ...rails[0], allResolved: rails[0].resolved }
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
+  const deletedMessages = new Map<string, RenderableMessage>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
   const supersededClientIds = new Set<string>()
   const eventsById = new Map<string, CachedEvent>()
@@ -343,6 +375,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
     }
     for (const [id, message] of rail.messages) messages.set(id, message)
     for (const id of rail.seen) seen.add(id)
+    for (const [id, message] of rail.deletedMessages) deletedMessages.set(id, message)
     for (const id of rail.supersededClientIds) supersededClientIds.add(id)
     for (const event of rail.events) eventsById.set(event.id, event)
     for (const [conversationId, list] of rail.taggedByConversation) {
@@ -357,7 +390,16 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   const events = [...eventsById.values()].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   )
-  return { messages, seen, taggedByConversation, supersededClientIds, events, resolved, allResolved }
+  return {
+    messages,
+    seen,
+    deletedMessages,
+    taggedByConversation,
+    supersededClientIds,
+    events,
+    resolved,
+    allResolved,
+  }
 }
 
 /**
@@ -570,6 +612,10 @@ export interface BoardCardMessages {
    *  shows in its branch through its echo window before the branch's server
    *  `messageIds` lists it, the same union the card does for its own replies. */
   taggedByConversation: Map<string, RenderableMessage[]>
+  /** The merged rail's soft-deleted rows as content-free tombstones, by id. Absent
+   *  from every other field here (and from every count), so only the always-expanded
+   *  conversation panel draws them. */
+  deletedById: Map<string, RenderableMessage>
 }
 
 /** Extra rails a board card subscribes to beyond its conversation's own streams:
@@ -590,7 +636,7 @@ const NO_PENDING: RenderableMessage[] = []
 
 // The memoized per-render derivation below; the rail's message maps are appended
 // at the return boundary (they come straight off the merged rail, not the view).
-type BoardCardView = Omit<BoardCardMessages, "messagesById" | "taggedByConversation"> & {
+type BoardCardView = Omit<BoardCardMessages, "messagesById" | "taggedByConversation" | "deletedById"> & {
   nextRetained: RenderableMessage[]
 }
 
@@ -849,8 +895,13 @@ export function useBoardCardMessages(
   // above, whose branches build the card's OWN messages — the rail identity is
   // stable per snapshot, so the branch derivation memoizes on it downstream).
   return useMemo(
-    () => ({ ...view, messagesById: rail.messages, taggedByConversation: rail.taggedByConversation }),
-    [view, rail.messages, rail.taggedByConversation]
+    () => ({
+      ...view,
+      messagesById: rail.messages,
+      taggedByConversation: rail.taggedByConversation,
+      deletedById: rail.deletedMessages,
+    }),
+    [view, rail.messages, rail.taggedByConversation, rail.deletedMessages]
   )
 }
 

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -797,7 +797,11 @@ export function useBoardCardMessages(
     const conversationSeen = rail.resolved && (openingSeen || replyIds.some((id) => rail.seen.has(id)))
 
     let openingMessage = (post.openingMessage as RenderableMessage | null) ?? null
-    if (openingId !== null && rail.seen.has(openingId)) openingMessage = rail.messages.get(openingId) ?? null
+    // A deleted opener is in `seen` but not in `messages`; falling through to
+    // null would show its tombstone from the projection and then drop the row
+    // entirely once the rail syncs it.
+    if (openingId !== null && rail.seen.has(openingId))
+      openingMessage = rail.messages.get(openingId) ?? rail.deletedMessages.get(openingId) ?? null
 
     if (!conversationSeen) {
       // Cold/unsynced: capture a fresh pending row but never drop a live bridge.

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -779,6 +779,11 @@ export interface BoardPostMessage {
   /** When the message was last edited, or null if never — drives the "(edited)"
    * affordance and the revisions dialog on the row (parity with the timeline). */
   editedAt: string | null
+  /** When the message was soft-deleted, or null if live. A deleted row is
+   * projected as a tombstone — it carries no content, reactions, attachments or
+   * link previews — so a conversation can show "was deleted" without shipping
+   * the deleted body. */
+  deletedAt?: string | null
 }
 
 /**


### PR DESCRIPTION
Chunk 5 of 5 — [conversation panel ⇄ timeline parity](https://seer.build/ws_vbyzjvdg6g/b/conv-parity-plan-3d138c/). Stacked on #1649. The only chunk touching the backend and shared types.

## Problem

Kris's ruling: *"the board is same data, different view"* — a deleted message should read as deleted, not vanish, so a reader can tell "was deleted" from "was never here".

Underneath that sat a real leak. `MessageRepository.findByIds` has no `deleted_at IS NULL` filter (`repository.ts:218`) and `softDelete` only stamps `deleted_at`, retaining `content_markdown` (`:687`). `toBoardPostMessage` then dropped the flag from the wire. So every board projection was returning deleted rows **intact** and simply not saying they were deleted — and the conversation panel's backfill path and **both** board-card paths rendered them as live messages, full pre-deletion body, reactions, and hydrated attachments with presigned URLs minted.

## Solution

- **Blank at the projection, not just flag it.** A deleted row now goes over the wire as `contentMarkdown: ""`, `reactions: {}`, `attachments: []`, `linkPreviews: []`, `deletedAt: <Date>`. `hydrateBoardMessages` skips deleted ids, so no presigned URL is minted for deleted content. Adding `deletedAt` alone would have kept leaking, just labelled.
- **`findByIds` is deliberately left alone.** Other callers depend on it returning tombstones — which is exactly why the projection is the right place to blank.
- **Tombstones are a separate rail map.** `messages`, `seen`, `taggedByConversation`, `supersededClientIds` and `totalReplies` are untouched, so the collapsed card's "N more" arithmetic is unchanged and the four existing soft-delete tests stay green **unedited**.
- **Render-only, enforced in three places.** A tombstone renders no `data-message-id`, so it is filtered out of auto-read, out of the unread marker's candidate rows, and out of `readStateResolved`. The middle one matters: a marker anchored on a tombstone would draw a "New" divider that `findMarkerRow` can never locate and `scrollToMarker` can never satisfy — chunk 3's failure mode, reachable through chunk 5's data. The third matters too: `readStateResolved` iterating unfiltered rows would let a thread whose only member reply was deleted block the marker permanently, since threads get no `stream_members` row (INV-62).
- **`isContinuation` returns false on either side of a tombstone**, so a deleted row never joins or bridges a same-author run.

### The board card is included, and the plan said it wouldn't be

The plan asserted `listByWorkspace`'s projection was unchanged. That was wrong: `toBoardPostMessage`/`hydrateBoardMessages` are shared by `listByWorkspace`, `getBoardPostById` **and** the expanded card's `getBoardMessages` backfill. Without a card-side tombstone this PR would render a blanked row as a full `MessageItem` — avatar, author, timestamp, hover toolbar, and the action menu including **Edit and Delete on an already-deleted message**. Verified by mounting the real `BoardCard` on both paths (`TOMB=0 ROW=1`).

So the card gets the same `DeletedMessageEvent` the panel does. Net effect on that surface: privacy strictly improved (it was leaking full bodies before, on a path this chunk's risk analysis never claimed), presentation now correct instead of blank.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/domain.ts` | `BoardPostMessage.deletedAt?: string \| null` (optional — `LabeledMessage` aliases it) |
| `apps/backend/.../conversations/service.ts` | blank deleted rows in `toBoardPostMessage`; skip deleted ids in `hydrateBoardMessages` |
| `apps/backend/tests/integration/conversation-board-messages.test.ts` | **new** — 5 cases against a real schema (INV-68) |
| `components/timeline/deleted-message-event.tsx` | **new** — extracted from `event-item.tsx`, markup unchanged |
| `components/timeline/event-item.tsx` | import it instead of defining it |
| `components/message/message-item.tsx` | `RenderableMessage.deletedAt`; `isContinuation` false on either side |
| `hooks/use-board-card-messages.ts` | `deletedMessages` rail map → `deletedById`; counts untouched |
| `components/conversations/conversation-panel.tsx` | merge tombstones on both paths; render; keep out of read state, marker and resolution |
| `components/board/board-card.tsx` | same tombstone; deleted rows out of `autoReadRows` |

## Test plan

- [x] `packages/types` / `apps/backend` / `apps/frontend` typecheck + lint — clean
- [x] `apps/backend test:integration conversation-board-messages` — **5 passed against a live Postgres**
- [x] `apps/backend test:unit` — 3780 pass
- [x] vitest `hooks` + `components/{conversations,board,message,timeline}` — 148 files, 1632 pass
- [x] every new test neutralised → red → restored. Removing the projection blanking returns `contentMarkdown: "the secret pre-deletion body"` and the real reaction rows — which also proves the integration test is genuinely executing SQL. Removing the hydration skip makes `findByMessageIds` receive the deleted id. Removing the card's tombstone branch reddens exactly the two new card tests while the pre-existing rail-path guard stays green.
- [ ] no browser pass

Adversarial review found 4 issues after the first green run — one blocker (the board card above) and three minor — all fixed in-branch.

**Reported flake, not from this diff:** one full vitest run showed `src/hooks/use-stream-or-draft.test.tsx:449` failing on a `displayName` expectation; it passes in isolation and the identical re-run was 148/148. Cross-file ordering, unrelated to this change — recorded rather than called clean.

**Known, deliberate:** `DeletedMessageEvent` is props-less, so consecutive deletions render identical adjacent lines. A collapsed card can spend a preview slot on a tombstone (the row already occupied that slot; changing it would alter the "N more" arithmetic this PR deliberately leaves alone).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787871029&installation_model_id=20758&pr_number=1650&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1650&signature=1a6350ffd7866de7251a5edcd3ed30eb0fb6498e02800cc556e854cd82fb4c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Known issues (sub-threshold, recorded not dropped)

From `/code-review` on this PR:

- **Deploy window.** Pages deploys before Railway, so for one cache generation an old cached client can meet the new server: it receives a blanked deleted row without understanding `deletedAt` and renders an empty `MessageItem` with author, timestamp and action menu. New client + old server is safe (no `deletedAt`, status quo). This is the repo's recorded Pages-before-Railway wire-shape window; it is transient and strictly a privacy improvement over today (which ships the full body), but it is the same shape that caused a prior incident, so it is written down rather than assumed harmless.
- **Auto-read watermark.** A tombstone has no `data-message-id`, so if a conversation's last message is deleted the panel's watermark stops one row short. Already true on the rail path today; this PR extends it to the backfill path. The stream timeline still clears it.
- `deletedAt` is required on the backend's local interface but optional in `packages/types` — deliberate, so `LabeledMessage` and existing fixtures stay valid.


### Follow-ups deliberately not taken here (whole-stack review)

- The **collapsed** card still shows no tombstone in its 3-row preview, so a collapsed→expanded transition reveals a row that was not there. That is the direct consequence of "do not change any count" — drawing it collapsed would spend a preview slot. Wants a ruling if the collapsed window should carry it.
- `useBoardCardMessages` still returns `openingMessage` as the blanked projection row when the rail has not seen it, so an **opening** tombstone appears on the projection path and disappears once the rail resolves — the opening-message twin of the reply-path fix in this PR, on a different code path.
