### PR TITLE
fix(stream-context): jump as far back as the list goes, not nowhere

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useMemo, useRef } from "react"
 import type { VirtualizerHandle } from "virtua"
-import { toast } from "sonner"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
 import { localStartOfDayMs } from "@/lib/dates"
-import { markerIndexForDate } from "@/lib/stream-context/grouping"
+import { markerIndexForDate, oldestMarkerIndex } from "@/lib/stream-context/grouping"
 import { deriveStreamContext } from "@/lib/stream-context/derive"
 import { delegationContextItems, withDelegations } from "@/lib/stream-context/delegations"
 import { StreamContextRow } from "./stream-context-row"
@@ -75,13 +74,13 @@ export function StreamContextDerivedPanel({
   // and the jump is a no-op rather than a fetch.
   const jumpToDate = useCallback(
     (date: Date) => {
-      const index = markerIndexForDate(visible, localStartOfDayMs(date) + DAY_MS, new Date())
-      if (index === -1) {
-        // This path holds only the loaded window, so an older date has nothing
-        // to land on — say so rather than silently doing nothing.
-        toast.info("Nothing indexed on or before that date")
-        return
-      }
+      const now = new Date()
+      // Nothing that old in the loaded window: travel as far back as it goes
+      // rather than refusing (this path never pages, so its start of history is
+      // the window's).
+      let index = markerIndexForDate(visible, localStartOfDayMs(date) + DAY_MS, now)
+      if (index === -1) index = oldestMarkerIndex(visible, now)
+      if (index === -1) return
       listRef.current?.scrollToIndex(index, { align: "start" })
       scrollerRef.current?.focus({ preventScroll: true })
     },

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, Search, WifiOff, X } from "lucide-react"
-import { toast } from "sonner"
 import { streamContextApi } from "@/api"
 import { useIsOnline } from "@/components/layout/connection-status"
 import { extractSearchTerms } from "@/components/search/highlight"
@@ -16,7 +15,7 @@ import { contextItemFromCached } from "@/lib/stream-context/from-cached"
 import { collapseContextRows, countByCategory, filterContextRows } from "@/lib/stream-context/filter"
 import type { ContextCategory, ContextItem } from "@/lib/stream-context/types"
 import { localStartOfDayMs } from "@/lib/dates"
-import { markerIndexForDate } from "@/lib/stream-context/grouping"
+import { markerIndexForDate, oldestMarkerIndex } from "@/lib/stream-context/grouping"
 import { cn } from "@/lib/utils"
 import {
   contextGroupRef,
@@ -179,7 +178,9 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const jumpToDate = useCallback(
     async (date: Date) => {
       const endOfDayMs = localStartOfDayMs(date) + DAY_MS
-      let index = markerIndexForDate(items, endOfDayMs, new Date())
+      const now = new Date()
+      let candidates = items
+      let index = markerIndexForDate(candidates, endOfDayMs, now)
       // Paging to an unloaded date is several round trips; without this the
       // panel just sits there. Only set it when a fetch is actually needed, so
       // the common in-window jump stays instant and flicker-free.
@@ -202,20 +203,17 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
             after,
           })
         )
-        index = markerIndexForDate(
-          rebuilt.map(contextItemFromCached).filter((item): item is ContextItem => item !== null),
-          endOfDayMs,
-          new Date()
-        )
+        candidates = rebuilt.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
+        index = markerIndexForDate(candidates, endOfDayMs, now)
       }
       setJumping(false)
-      if (index === -1) {
-        // Same wording the timeline's date jump uses for the same dead end, so
-        // the two surfaces fail identically (INV-63: this needs attention and
-        // has no on-screen anchor of its own).
-        toast.info("Nothing indexed on or before that date")
-        return
-      }
+      // Past the start of history — either the stream's, or as far as the page
+      // bound reached. Travel to the oldest thing there is: asking for a year
+      // ago means "as far back as you can go", not "refuse unless you find that
+      // exact day". Only a genuinely empty list has nowhere to go, and its
+      // empty state already says so.
+      if (index === -1) index = oldestMarkerIndex(candidates, now)
+      if (index === -1) return
       listRef.current?.scrollToIndex(index, { align: "start" })
       // The marker that opened the menu is usually windowed out by the jump, so
       // Radix's focus-return lands on a removed node and focus falls to <body>.

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { toast } from "sonner"
 import { createElement, Fragment } from "react"
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -557,21 +556,25 @@ describe("StreamContextPanel — flag on", () => {
     await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
   })
 
-  it("stops paging for an unreachable date as soon as the server says history is exhausted", async () => {
+  it("lands on the oldest day when the picked date is older than the whole stream", async () => {
+    const scrollToIndex = vi.fn()
     vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
-      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex: vi.fn() }
+      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex }
       return createElement(Fragment, null, children)
     })
-    await db.streamContextItems.put(
+    // [marker 20th, row, marker 18th, row] — nothing anywhere near the 2nd.
+    await db.streamContextItems.bulkPut([
       cachedRow(
         serverItem({ category: "link", refId: "https://newest.example", occurredAt: "2026-07-20T10:00:00.000Z" })
-      )
-    )
+      ),
+      cachedRow(
+        serverItem({ category: "link", refId: "https://oldest.example", occurredAt: "2026-07-18T10:00:00.000Z" })
+      ),
+    ])
     // One page of history, then the end. `hasNextPage` on the render-time
     // snapshot stays true for the whole loop, so only the fetch's own result
     // can stop it before it burns all MAX_JUMP_PAGES iterations.
     const readRows = vi.spyOn(storeModule, "readStreamContextRows")
-    const toastInfo = vi.spyOn(toast, "info").mockReturnValue("" as ReturnType<typeof toast.info>)
     vi.spyOn(streamContextApi, "list")
       .mockResolvedValueOnce(listResponse({ counts: null, nextCursor: "c1" }))
       .mockResolvedValue(listResponse({ counts: null }))
@@ -582,12 +585,15 @@ describe("StreamContextPanel — flag on", () => {
 
     await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
     await userEvent.click(await screen.findByText("Jump to a specific date…"))
-    await userEvent.click(await screen.findByText("2"))
+    // By label, not text: with two rows a count chip also renders "2".
+    await userEvent.click(await screen.findByRole("button", { name: /July 2nd/ }))
 
-    await waitFor(() => expect(toastInfo).toHaveBeenCalledWith("Nothing indexed on or before that date"))
+    // Travels as far back as the stream goes — the 18th's marker at flat index
+    // 2 — instead of refusing because the 2nd itself holds nothing.
+    await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
     // One page fetched, one re-read. The bound is MAX_JUMP_PAGES (10), so a
     // loop trusting the stale snapshot re-reads ten times to reach the same
-    // dead end.
+    // end of history.
     expect(readRows).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/frontend/src/lib/stream-context/grouping.ts
+++ b/apps/frontend/src/lib/stream-context/grouping.ts
@@ -64,3 +64,20 @@ export function markerIndexForDate(items: ContextItem[], endOfDayMs: number, now
   }
   return -1
 }
+
+/**
+ * Flat index of the OLDEST day marker, or `-1` when there are no items.
+ *
+ * Where a jump lands once it runs past the start of history: asking for a year
+ * ago means "as far back as you can go", so the list travels to its own
+ * beginning rather than refusing to move.
+ */
+export function oldestMarkerIndex(items: ContextItem[], now: Date): number {
+  let markerIndex = -1
+  let flatIndex = 0
+  for (const group of groupItemsByDay(items, now)) {
+    markerIndex = flatIndex
+    flatIndex += 1 + group.items.length
+  }
+  return markerIndex
+}

--- a/tests/browser/stream-context-panel.spec.ts
+++ b/tests/browser/stream-context-panel.spec.ts
@@ -112,4 +112,17 @@ test("windows its rows and jumps to a date from a day marker", async ({ page }) 
   await page.getByRole("button", { name: "Last week", exact: true }).click()
 
   await expect.poll(async () => scroller.evaluate((el) => el.scrollTop), { timeout: 10_000 }).toBeGreaterThan(300)
+
+  // ── Past the start of history: "Last year" matches no day here, and the
+  // useful answer is to travel as far back as the list goes rather than refuse.
+  await scroller.evaluate((el) => el.scrollTo({ top: 0 }))
+  await expect.poll(async () => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50)
+
+  await page
+    .getByRole("button", { name: /Jump to a date/ })
+    .first()
+    .click()
+  await page.getByRole("button", { name: "Last year", exact: true }).click()
+
+  await expect.poll(async () => scroller.evaluate((el) => el.scrollTop), { timeout: 10_000 }).toBeGreaterThan(300)
 })


### PR DESCRIPTION
Follow-up to #1601, from using it: picking a date older than anything indexed showed a toast and left the list where it was. Kris, on hitting it — "it's true, but it's fucking useless… it should go back as close as it can. That's how the stream works."

He's right, and the flaw was in the rule rather than the wiring. "Nearest earlier" has no answer once you're past the start of history, and that case was made a dead end instead of a clamp. Asking for a year ago means "as far back as you can go".

Both panels now fall back to the oldest day marker when nothing matches at or before the picked date. The indexed path still pages toward the date first, so the clamp engages only once history actually runs out — or once the 10-page bound stops it, which still leaves you far deeper than where the jump started. The toast is deleted rather than reworded: it could only fire on an empty list, and that list already renders an empty state (INV-63).

`oldestMarkerIndex` lives beside `markerIndexForDate` in `grouping.ts`, because both encode the same easy-to-get-wrong detail — the flat child list interleaves a marker before each group, so these are marker indices, not row indices.

Verification: 5140 frontend tests, typecheck, lint. Both clamps were confirmed to fail when removed — the component test for the indexed path, and `tests/browser/stream-context-panel.spec.ts` for the derive path, which drives a real virtualizer with "Last year" against a list that only reaches back 10 days (jsdom can't run `scrollToIndex`, so that assertion only exists in the browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787899368&installation_model_id=20758&pr_number=1651&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1651&signature=90d3c904cf5450e896f22660cb62560819ae97bae560d7f025afc2649bd9c62e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->