### PR TITLE
feat(agents): stamp what a tool call wrote onto its trace step

### DIFF
--- a/apps/backend/src/features/agents/runtime/session-trace-sink.ts
+++ b/apps/backend/src/features/agents/runtime/session-trace-sink.ts
@@ -5,7 +5,7 @@ import {
   type TraceStepSink,
   type TraceSubstepEntry,
 } from "@threa/agent-runtime"
-import type { AgentStepType, ToolVerificationStatus } from "@threa/types"
+import type { AgentStepType, AgentToolEffect, ToolVerificationStatus } from "@threa/types"
 import type { ActiveStep, SessionTrace } from "../trace-emitter"
 import { logger } from "../../../lib/logger"
 
@@ -45,6 +45,10 @@ export class SessionTraceStepSink implements TraceStepSink<ActiveStep> {
 
   async verify(params: { step: ActiveStep; status: ToolVerificationStatus; reason: string }): Promise<void> {
     await params.step.verify({ status: params.status, reason: params.reason })
+  }
+
+  async effects(params: { step: ActiveStep; effects: AgentToolEffect[] }): Promise<void> {
+    await params.step.effects(params.effects)
   }
 
   async substep(params: {

--- a/apps/backend/src/features/agents/trace-emitter.ts
+++ b/apps/backend/src/features/agents/trace-emitter.ts
@@ -1,6 +1,6 @@
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
-import type { AgentStepType, ToolVerificationStatus, TraceSource } from "@threa/types"
+import type { AgentStepType, AgentToolEffect, ToolVerificationStatus, TraceSource } from "@threa/types"
 import { AgentSessionRepository } from "./session-repository"
 import { stepId as generateStepId } from "../../lib/id"
 
@@ -285,6 +285,17 @@ export class ActiveStep {
       stepId: this.params.stepId,
       verification: { status: params.status, reason: params.reason },
     })
+  }
+
+  /**
+   * Record what this tool call wrote.
+   *
+   * Awaited, and with no socket emit of its own: the projector calls this
+   * before the finalize, so `complete`'s RETURNING row carries the effects into
+   * the `agent_session:step:completed` frame the live trace already consumes.
+   */
+  async effects(effects: AgentToolEffect[]): Promise<void> {
+    await AgentSessionRepository.updateStep(this.deps.pool, this.params.stepId, { effects })
   }
 
   /** Complete the step. Persists to DB + emits to socket. */

--- a/apps/backend/src/features/public-api/trace-steps.ts
+++ b/apps/backend/src/features/public-api/trace-steps.ts
@@ -216,6 +216,15 @@ export class BotInvocationTraceSink implements TraceStepSink<BotOpenStep> {
       "BotInvocationTraceSink cannot record a guardian verdict; guarded tools must not run on this surface"
     )
   }
+
+  /**
+   * Same reasoning as `verify`: our mutating tools are built only in the
+   * companion's tool set, never on this surface, so an effect cannot arrive.
+   * Required all the same — the compiler is the only guard.
+   */
+  async effects(): Promise<void> {
+    throw new Error("BotInvocationTraceSink cannot record tool effects; mutating tools must not run on this surface")
+  }
   async substep(params: { stepType: AgentStepType; text: string; snapshot: TraceSubstepEntry[] }): Promise<void> {
     // Mirrors SessionTrace.emitSubstep's fan-out: ephemeral phase text to the
     // stream room (inline indicator) and the session room (trace dialog).
@@ -263,6 +272,15 @@ class SynthesizedTraceSink implements TraceStepSink<BotOpenStep> {
    */
   async verify(): Promise<void> {
     throw new Error("SynthesizedTraceSink cannot record a guardian verdict; guarded tools must not run on this surface")
+  }
+
+  /**
+   * Same reasoning as `verify`: these steps are reconstructed from a bot's own
+   * reported frames, not executed here, so an effect cannot arrive. Required
+   * all the same — the compiler is the only guard.
+   */
+  async effects(): Promise<void> {
+    throw new Error("SynthesizedTraceSink cannot record tool effects; mutating tools must not run on this surface")
   }
 
   constructor(

--- a/apps/backend/tests/integration/agent-step-effects.test.ts
+++ b/apps/backend/tests/integration/agent-step-effects.test.ts
@@ -8,12 +8,13 @@ import {
   TraceEmitter,
   createAgentSessionHandlers,
   PersonaRepository,
+  createSessionTraceProjector,
 } from "../../src/features/agents"
 import { BotRepository, serializeTraceStep } from "../../src/features/public-api"
 import { StreamEventRepository } from "../../src/features/streams"
 import * as streamsModule from "../../src/features/streams"
 import { streamId, sessionId, personaId, messageId, stepId } from "../../src/lib/id"
-import { AgentStepTypes, type AgentToolEffect } from "@threa/types"
+import { AgentStepTypes, AgentToolNames, type AgentToolEffect } from "@threa/types"
 
 const SETTINGS_EFFECTS: AgentToolEffect[] = [
   { kind: "settings", label: "Theme", target: "theme", before: "light", after: "dark" },
@@ -299,6 +300,85 @@ describe("agent step effects", () => {
           completedAt: reloaded!.completedAt!.toISOString(),
         },
       })
+    })
+  })
+  describe("driven through the projector", () => {
+    test("a tool:complete carrying effects persists them and ships them in the completed frame", async () => {
+      const testSessionId = sessionId()
+      await seedSession(pool, testSessionId)
+
+      const emits: Array<{ event: string; payload: Record<string, unknown> }> = []
+      const io = {
+        to: () => io,
+        emit: (event: string, payload: Record<string, unknown>) => {
+          emits.push({ event, payload })
+        },
+      } as unknown as Server
+
+      const trace = new TraceEmitter({ io, pool }).forSession({
+        sessionId: testSessionId,
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        triggerMessageId: "msg_1",
+        personaName: "Ariadne",
+      })
+      const projector = createSessionTraceProjector(trace)
+
+      await projector.handle({
+        type: "tool:start",
+        toolCallId: "tc_1",
+        toolName: AgentToolNames.UPDATE_USER_SETTINGS,
+        stepType: AgentStepTypes.TOOL_CALL,
+        input: {},
+      })
+      await projector.handle({
+        type: "tool:complete",
+        toolCallId: "tc_1",
+        toolName: AgentToolNames.UPDATE_USER_SETTINGS,
+        input: {},
+        output: "{}",
+        durationMs: 1000,
+        trace: { stepType: AgentStepTypes.TOOL_CALL, content: "done", effects: SETTINGS_EFFECTS },
+      })
+
+      const [persisted] = await AgentSessionRepository.findStepsBySession(pool, testSessionId)
+      expect(persisted!.effects).toEqual(SETTINGS_EFFECTS)
+
+      const completed = emits.find((e) => e.event === "agent_session:step:completed")
+      expect((completed?.payload as { step: { effects?: AgentToolEffect[] } }).step.effects).toEqual(SETTINGS_EFFECTS)
+    })
+
+    test("a tool that threw persists none", async () => {
+      const testSessionId = sessionId()
+      await seedSession(pool, testSessionId)
+
+      const io = { to: () => io, emit: () => {} } as unknown as Server
+      const trace = new TraceEmitter({ io, pool }).forSession({
+        sessionId: testSessionId,
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        triggerMessageId: "msg_1",
+        personaName: "Ariadne",
+      })
+      const projector = createSessionTraceProjector(trace)
+
+      await projector.handle({
+        type: "tool:start",
+        toolCallId: "tc_1",
+        toolName: AgentToolNames.UPDATE_USER_SETTINGS,
+        stepType: AgentStepTypes.TOOL_CALL,
+        input: {},
+      })
+      await projector.handle({
+        type: "tool:error",
+        toolCallId: "tc_1",
+        toolName: AgentToolNames.UPDATE_USER_SETTINGS,
+        error: "boom",
+        durationMs: 10,
+      })
+
+      const [persisted] = await AgentSessionRepository.findStepsBySession(pool, testSessionId)
+      expect(persisted!.effects).toBeUndefined()
     })
   })
 })

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -133,6 +133,17 @@ class EnclaveSealingSink implements TraceStepSink<EnclaveOpenStep> {
   async verify(): Promise<void> {
     throw new Error("EnclaveSealingSink cannot record a guardian verdict; guarded tools must not run on this surface")
   }
+
+  /**
+   * Every mutating tool is constructed only in the companion's tool set, which
+   * the enclave never builds, so an effect cannot arrive here. Required all the
+   * same — the compiler is the only guard. Sealing effect descriptors is
+   * deliberately deferred: a sealed stream surfaces no effects at all rather
+   * than a cleartext label beside sealed content.
+   */
+  async effects(): Promise<void> {
+    throw new Error("EnclaveSealingSink cannot record tool effects; mutating tools must not run on this surface")
+  }
   async substep(params: {
     stepType: AgentStepType
     step: EnclaveOpenStep

--- a/packages/agent-runtime/src/runtime/agent-events.ts
+++ b/packages/agent-runtime/src/runtime/agent-events.ts
@@ -1,4 +1,4 @@
-import type { AgentStepType, TraceSource, AuthorType, ToolVerificationStatus } from "@threa/types"
+import type { AgentStepType, AgentToolEffect, TraceSource, AuthorType, ToolVerificationStatus } from "@threa/types"
 
 export interface NewMessageInfo {
   sequence: bigint
@@ -73,7 +73,17 @@ export type AgentEvent =
       input: unknown
       output: string
       durationMs: number
-      trace: { stepType: AgentStepType; content: string; sources?: TraceSource[] }
+      trace: {
+        stepType: AgentStepType
+        content: string
+        sources?: TraceSource[]
+        /**
+         * What the call wrote. Absent on the guardian-denial completion and on
+         * every tool:error: neither ran to a write, and claiming one there is
+         * the failure this whole layer exists to prevent.
+         */
+        effects?: AgentToolEffect[]
+      }
     }
   | { type: "tool:error"; toolCallId: string; toolName: string; error: string; durationMs: number }
   | { type: "message:sent"; messageId: string; content: string; sources?: TraceSource[] }

--- a/packages/agent-runtime/src/runtime/agent-runtime.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from "bun:test"
 import { z } from "zod"
-import { AgentToolNames, AgentStepTypes, type SourceItem } from "@threa/types"
+import { AgentToolNames, AgentStepTypes, type AgentToolEffect, type SourceItem } from "@threa/types"
 import type { AgentEvent } from "./agent-events"
 import { AgentRuntime } from "./agent-runtime"
 import { defineAgentTool } from "./agent-tool"
@@ -1143,5 +1143,74 @@ describe("AgentRuntime thinking steps", () => {
     const thinking = events.find((e) => e.type === "thinking") as { content: string }
     expect(thinking.content).toBe("'s theme is already dark, so no change was made.")
     expect(thinking.content).not.toContain("[msg:")
+  })
+})
+
+describe("AgentRuntime tool effects", () => {
+  const runToolOnce = async (tool: ReturnType<typeof defineAgentTool>) => {
+    const events: AgentEvent[] = []
+    let firstCall = true
+    const generateTextWithTools = async () => {
+      if (firstCall) {
+        firstCall = false
+        return {
+          text: "",
+          toolCalls: [{ toolCallId: "tc_1", toolName: tool.name, input: {} }],
+          response: { messages: [{ role: "assistant" as const, content: "calling tool" } as any] },
+        }
+      }
+      return {
+        text: "Done.",
+        toolCalls: [],
+        response: { messages: [{ role: "assistant" as const, content: "Done." } as any] },
+      }
+    }
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "do it" }],
+      tools: [tool],
+      sendMessage: async () => ({ messageId: "msg_1", operation: "created" }),
+      observers: [{ handle: async (event: AgentEvent) => void events.push(event) }],
+    })
+
+    await runtime.run()
+    const complete = events.find((e) => e.type === "tool:complete") as Extract<AgentEvent, { type: "tool:complete" }>
+    return complete.trace.effects
+  }
+
+  const buildTool = (name: string, effects?: () => AgentToolEffect[]) =>
+    defineAgentTool({
+      name,
+      description: "test",
+      categories: [],
+      inputSchema: z.object({}),
+      execute: async () => ({ output: "{}" }),
+      trace: {
+        stepType: AgentStepTypes.WORKSPACE_SEARCH,
+        formatContent: () => "{}",
+        ...(effects ? { effects } : {}),
+      },
+    })
+
+  it("falls back to a shapeless marker for a mutating tool that declares nothing", async () => {
+    expect(await runToolOnce(buildTool(AgentToolNames.SAVE_MEMO))).toEqual([{ kind: "other" }])
+  })
+
+  it("emits nothing for a read-only tool", async () => {
+    expect(await runToolOnce(buildTool(AgentToolNames.SEARCH_MESSAGES))).toBeUndefined()
+  })
+
+  it("passes a declaring tool's array through verbatim", async () => {
+    const declared: AgentToolEffect[] = [{ kind: "memo", label: "Tide notes", target: "memo_1" }]
+    expect(await runToolOnce(buildTool(AgentToolNames.SAVE_MEMO, () => declared))).toEqual(declared)
+  })
+
+  it("emits nothing when a mutating tool declares an empty array", async () => {
+    // The declarer is authoritative: save_memo returns a successful result on a
+    // dedupe, and the fallback would turn that into a claimed write.
+    expect(await runToolOnce(buildTool(AgentToolNames.SAVE_MEMO, () => []))).toBeUndefined()
   })
 })

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel, ModelMessage, Tool, ToolResultPart } from "ai"
 import type { SourceItem, TraceSource } from "@threa/types"
-import { AgentToolNames, ToolVerificationStatuses, requiresGuardianReview } from "@threa/types"
+import { AgentToolNames, ToolVerificationStatuses, requiresGuardianReview, resolveToolEffects } from "@threa/types"
 import type { AI, CostContext, TelemetryMetadataValue } from "../ai/ai"
 import { logger } from "../logger"
 import { protectToolOutputText } from "./tool-trust-boundary"
@@ -901,6 +901,7 @@ export class AgentRuntime {
 
         const traceContent = agentTool.config.trace.formatContent(toolInput, toolResult)
         const traceSources = agentTool.config.trace.extractSources?.(toolInput, toolResult)
+        const traceEffects = resolveToolEffects(tc.toolName, agentTool.config.trace.effects?.(toolInput, toolResult))
 
         await this.emit({
           type: "tool:complete",
@@ -909,7 +910,12 @@ export class AgentRuntime {
           input: tc.input,
           output: toolResult.output,
           durationMs,
-          trace: { stepType: agentTool.config.trace.stepType, content: traceContent, sources: traceSources },
+          trace: {
+            stepType: agentTool.config.trace.stepType,
+            content: traceContent,
+            sources: traceSources,
+            ...(traceEffects.length > 0 ? { effects: traceEffects } : {}),
+          },
         })
 
         resultParts.push(makeToolResult(tc, protectToolOutputText(toolResult.output)))

--- a/packages/agent-runtime/src/runtime/agent-tool.ts
+++ b/packages/agent-runtime/src/runtime/agent-tool.ts
@@ -5,6 +5,7 @@ import {
   TOOL_TIERS_BY_NAME,
   tierOfTool,
   type AgentStepType,
+  type AgentToolEffect,
   type ToolPrivacyCategory,
   type ToolTier,
   type TraceSource,
@@ -106,6 +107,15 @@ export interface AgentToolConfig<TSchema extends z.ZodTypeAny = z.ZodTypeAny> {
     hidden?: boolean
     formatContent: (input: z.infer<TSchema>, result: AgentToolResult) => string
     extractSources?: (input: z.infer<TSchema>, result: AgentToolResult) => TraceSource[]
+    /**
+     * What this call wrote that the conversation does not already show.
+     *
+     * Authoritative when present, `[]` included: tools catch their own failures
+     * and still return a successful result, so a declaring tool is the only
+     * thing that knows whether the write happened. Absent means the name-keyed
+     * MUTATING_TOOLS fallback decides.
+     */
+    effects?: (input: z.infer<TSchema>, result: AgentToolResult) => AgentToolEffect[]
   }
 }
 

--- a/packages/agent-runtime/src/runtime/tool-guardian.test.ts
+++ b/packages/agent-runtime/src/runtime/tool-guardian.test.ts
@@ -152,6 +152,12 @@ describe("guardian gating", () => {
     const completion = events.find((e) => e.type === "tool:complete") as any
     expect(completion.toolName).toBe(AgentToolNames.DELEGATE_TASK)
     expect(completion.trace.content).toContain("The user never asked for a delegation.")
+
+    // Asserted at the emit site, not on a hand-built event: delegate_task is
+    // mutating, so anything that routed this denial through the normal effects
+    // resolution would stamp the layer-0 fallback and the trace would claim a
+    // write the guardian blocked. Nothing executed, so nothing was written.
+    expect(completion.trace.effects).toBeUndefined()
   })
 
   it("denies when the guardian throws, rather than letting the call through", async () => {

--- a/packages/agent-runtime/src/runtime/trace-projector.test.ts
+++ b/packages/agent-runtime/src/runtime/trace-projector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { AgentStepTypes, type TraceSource } from "@threa/types"
+import { AgentStepTypes, type AgentToolEffect, type TraceSource } from "@threa/types"
 import type { NewMessageInfo } from "./agent-events"
 import {
   TraceProjector,
@@ -28,6 +28,9 @@ function createSinkStub() {
     toolName: string
   }> = []
   const verified: Array<{ id: number; status: string; reason: string }> = []
+  const effected: Array<{ id: number; effects: AgentToolEffect[] }> = []
+  /** Sink calls in the order they arrived — effects must land before the finalize. */
+  const order: string[] = []
 
   const sink: TraceStepSink<{ id: number }> = {
     async record(step) {
@@ -39,6 +42,7 @@ function createSinkStub() {
       return handle
     },
     async complete(step, final) {
+      order.push("complete")
       completed.push({ id: step.id, final })
     },
     async substep(params) {
@@ -54,9 +58,13 @@ function createSinkStub() {
     async verify(params) {
       verified.push({ id: params.step.id, status: params.status, reason: params.reason })
     },
+    async effects(params) {
+      order.push("effects")
+      effected.push({ id: params.step.id, effects: params.effects })
+    },
   }
 
-  return { sink, records, opened, completed, substeps, verified }
+  return { sink, records, opened, completed, substeps, verified, effected, order }
 }
 
 const toolStart = (toolCallId: string, hidden?: boolean) =>
@@ -514,5 +522,121 @@ describe("TraceProjector guardian verdicts", () => {
     // step. Asserted structurally instead.
     const required: keyof typeof sink = "verify"
     expect(typeof sink[required]).toBe("function")
+  })
+})
+
+describe("TraceProjector tool effects", () => {
+  const complete = (overrides: { effects?: AgentToolEffect[]; content?: string }) =>
+    ({
+      type: "tool:complete",
+      toolCallId: "tc_1",
+      toolName: "save_memo",
+      input: {},
+      output: "{}",
+      durationMs: 20,
+      trace: {
+        stepType: AgentStepTypes.WORKSPACE_SEARCH,
+        content: overrides.content ?? "{}",
+        ...(overrides.effects !== undefined ? { effects: overrides.effects } : {}),
+      },
+    }) as const
+
+  it("stamps effects on the open step before finalizing it", async () => {
+    const { sink, effected, order } = createSinkStub()
+    const projector = new TraceProjector(sink)
+    const effects: AgentToolEffect[] = [{ kind: "memo", label: "Tide notes", target: "memo_1" }]
+
+    await projector.handle(toolStart("tc_1"))
+    await projector.handle(complete({ effects }))
+
+    // Order is load-bearing: the finalize's RETURNING row is what the
+    // step:completed frame carries, so effects must be durable before it runs.
+    expect(order).toEqual(["effects", "complete"])
+    expect(effected).toEqual([{ id: 1, effects }])
+  })
+
+  it("does not stamp an empty array", async () => {
+    const { sink, effected, completed } = createSinkStub()
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1"))
+    await projector.handle(complete({ effects: [] }))
+
+    expect(effected).toHaveLength(0)
+    expect(completed).toHaveLength(1)
+  })
+
+  it("does not stamp a completion that carries none", async () => {
+    const { sink, effected } = createSinkStub()
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1"))
+    await projector.handle(complete({}))
+
+    expect(effected).toHaveLength(0)
+  })
+
+  // The finalize outranks the effects write. Per-tool-call state is cleared
+  // before either runs, so a step that misses its finalize spins in the trace
+  // forever — including after a reload. Losing the effects of a completed step
+  // is a smaller loss than never completing it.
+  it("still finalizes the step when the effects write fails, and surfaces the failure", async () => {
+    const { sink, completed } = createSinkStub()
+    const boom = new Error("pool exhausted")
+    sink.effects = async () => {
+      throw boom
+    }
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1"))
+    await expect(projector.handle(complete({ effects: [{ kind: "memo", label: "Tide notes" }] }))).rejects.toThrow(boom)
+
+    expect(completed).toHaveLength(1)
+  })
+
+  it("stamps nothing for a guardian-denied call, which wrote nothing", async () => {
+    const { sink, effected, completed } = createSinkStub()
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1"))
+    await projector.handle({
+      type: "tool:verification",
+      toolCallId: "tc_1",
+      toolName: "delegate_task",
+      status: "denied",
+      reason: "Not what you asked for.",
+      durationMs: 5,
+    })
+    // The denial path emits its own tool:complete, effect-free by construction.
+    await projector.handle(complete({ content: "Not taken — waiting for your approval." }))
+
+    expect(effected).toHaveLength(0)
+    expect(completed).toHaveLength(1)
+  })
+
+  it("stamps nothing when the tool threw", async () => {
+    const { sink, effected } = createSinkStub()
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1"))
+    await projector.handle({
+      type: "tool:error",
+      toolCallId: "tc_1",
+      toolName: "save_memo",
+      error: "boom",
+      durationMs: 5,
+    })
+
+    expect(effected).toHaveLength(0)
+  })
+
+  it("stamps nothing for a hidden tool, which opened no step", async () => {
+    const { sink, effected } = createSinkStub()
+    const projector = new TraceProjector(sink)
+
+    await projector.handle(toolStart("tc_1", true))
+    await projector.handle(complete({ effects: [{ kind: "memo" }] }))
+
+    expect(effected).toHaveLength(0)
   })
 })

--- a/packages/agent-runtime/src/runtime/trace-projector.ts
+++ b/packages/agent-runtime/src/runtime/trace-projector.ts
@@ -2,6 +2,7 @@ import {
   AgentReconsiderationDecisions,
   AgentStepTypes,
   type AgentStepType,
+  type AgentToolEffect,
   type ToolVerificationStatus,
   type TraceSource,
 } from "@threa/types"
@@ -87,6 +88,18 @@ export interface TraceStepSink<OpenStep> {
    * decide, at build time, what it does with a verdict.
    */
   verify(params: { step: OpenStep; status: ToolVerificationStatus; reason: string }): Promise<void>
+  /**
+   * Attach what a completed tool call wrote to its open step.
+   *
+   * REQUIRED for the same reason `verify` is: `AgentRuntime.emit` swallows
+   * per-observer exceptions, so a projector that threw on a sink without this
+   * method would silently drop the write signal instead of failing. Mandatory
+   * makes every surface decide at build time.
+   *
+   * Called only with a non-empty array, and only from `tool:complete` for a
+   * call that actually executed.
+   */
+  effects(params: { step: OpenStep; effects: AgentToolEffect[] }): Promise<void>
 }
 
 /**
@@ -195,12 +208,27 @@ export class TraceProjector<OpenStep = unknown> implements AgentObserver {
         this.substepsByToolCallId.delete(event.toolCallId)
         this.hiddenToolCallIds.delete(event.toolCallId)
         if (!step) break // hidden tool — no step was opened
+        // Effects go first so the finalize's RETURNING row already carries them
+        // and the step:completed frame needs no companion event. But the
+        // finalize outranks them: a step that never completes spins forever in
+        // the trace, on reload too, because this state was already cleared
+        // above and nothing retries it. So an effects failure is held and
+        // rethrown after the finalize rather than replacing it.
+        let effectsError: unknown
+        if (event.trace.effects && event.trace.effects.length > 0) {
+          try {
+            await this.sink.effects({ step, effects: event.trace.effects })
+          } catch (error) {
+            effectsError = error
+          }
+        }
         await this.sink.complete(step, {
           stepType: event.trace.stepType,
           content: event.trace.content,
           sources: event.trace.sources,
           durationMs: event.durationMs,
         })
+        if (effectsError) throw effectsError
         break
       }
 


### PR DESCRIPTION
## Why

Chunk 1 added the `effects` column and the serializers. Nothing wrote to it. This wires the runtime so a mutating tool call stamps its step.

Design: https://seer.build/ws_vbyzjvdg6g/b/side-effects-thin-b81dbc/v/2/ · Plan: https://seer.build/ws_vbyzjvdg6g/b/side-effects-plan-5516ac/

Chunk 2 of 5. **Layer 0 only** — every mutating tool gets the shapeless `[{kind:"other"}]` fallback; no tool declares a real descriptor until chunk 3. Still nothing rendered (chunk 5).

## Material decisions

**A denied call and a thrown call carry no effects.** This is the worst failure the feature can have — a trace claiming a write that never happened. `tool:error` is structurally safe (that event variant has no `trace` field at all), but the guardian-denial path emits a real `tool:complete`, so it's asserted **at the emit site** rather than on a hand-built event. `delegate_task` is mutating, so anything that routed the denial through normal effects resolution would stamp the fallback on a call the guardian blocked.

**`TraceStepSink.effects` is required, not optional** — same reason `verify` is. `AgentRuntime.emit` catches observer exceptions, so a runtime throw there is a no-op; the compiler is the only guard that works. All four sinks are forced to answer. The two public-API sinks and the enclave sink throw, which is safe **by construction**: every mutating tool is constructed only in `companion/tool-set.ts`, which the enclave never uses. Verified by grepping every `create*Tool` factory rather than assumed.

**Effects are written before the finalize, but the finalize outranks them.** Ordering matters because the finalize's `RETURNING` row is what the `step:completed` socket frame carries — write effects after it and they'd never appear live. But per-tool-call state is cleared before either runs, so a step that misses its finalize spins in the trace forever, reload included. An effects failure is therefore held and rethrown *after* the finalize rather than replacing it — losing a completed step's effects is a smaller loss than never completing the step.

That last one came from the adversarial pass: as first written, a transient DB error in the effects write would have left the step permanently unfinished.

## Verification

- typecheck 0 errors (15 packages) · agent-runtime 301 pass · types 152 · backend 3,780 unit + 371 e2e · 9 integration tests against the real schema.
- **Both new guards mutation-checked.** Removing the finalize protection fails the ordering test; adding `effects` to the denial emit fails the guardian test. Restored and re-verified green each time.
- The required-method guard was confirmed to bite: before the sinks were updated, typecheck failed on the fake sink missing `effects`.

One note on process: the implementer reported a backend e2e failure as pre-existing. It isn't — re-running it clean gives 371/371. It was a flake (a 60s socket timeout waiting on a real model reply, while three agents were loading the machine).

## Residual risk

`sink.effects` failing now surfaces only as a `logger.warn` from `AgentRuntime.emit`, same as every other observer failure. The step still finalizes and the trace is still correct apart from the missing effects, but there is no retry and no user-visible signal. Acceptable while effects are decoration; would need revisiting if anything ever depended on them being complete.

Stacked on #1638.
