### PR TITLE
feat(agents): let each mutating tool declare what it wrote

### DIFF
--- a/apps/backend/src/features/agents/companion/tool-set.test.ts
+++ b/apps/backend/src/features/agents/companion/tool-set.test.ts
@@ -22,7 +22,7 @@ function toolNames(config: Partial<ToolSetConfig>): string[] {
  * it would only be refused.
  */
 describe("update_user_settings availability", () => {
-  const settings = { updateSettings: async () => preferences }
+  const settings = { updateSettings: async () => ({ before: preferences, after: preferences }) }
 
   test("is built when the caller supplied settings deps", () => {
     expect(toolNames({ settings })).toContain(AgentToolNames.UPDATE_USER_SETTINGS)

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -889,8 +889,15 @@ export class PersonaAgent {
             e2eEnabled: stream.e2eEnabled === true,
           })
             ? {
-                updateSettings: (patch) =>
-                  this.deps.userPreferencesService.updatePreferences(workspaceId, settingsUserId, patch),
+                updateSettings: async (patch) => {
+                  const before = await this.deps.userPreferencesService.getPreferences(workspaceId, settingsUserId)
+                  const after = await this.deps.userPreferencesService.updatePreferences(
+                    workspaceId,
+                    settingsUserId,
+                    patch
+                  )
+                  return { before, after }
+                },
               }
             : undefined
 

--- a/apps/backend/src/features/agents/tools/cancel-follow-up-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/cancel-follow-up-tool.test.ts
@@ -30,3 +30,20 @@ describe("cancel_follow_up tool", () => {
     expect(body.followUpId).toBe("agfu_gone")
   })
 })
+
+describe("cancel_follow_up effects", () => {
+  const effectsOf = async (result: CancelFollowUpToolResult) => {
+    const tool = createCancelFollowUpTool({ cancelFollowUp: mock(async () => result) })
+    const input = { followUpId: "agfu_01" }
+    const out = await tool.config.execute(input, EXEC_OPTS)
+    return tool.config.trace.effects?.(input, out)
+  }
+
+  it("declares the follow-up it cancelled", async () => {
+    expect(await effectsOf({ ok: true, followUpId: "agfu_01" })).toEqual([{ kind: "follow_up", target: "agfu_01" }])
+  })
+
+  it("declares nothing when there was no pending follow-up to cancel", async () => {
+    expect(await effectsOf({ ok: false })).toEqual([])
+  })
+})

--- a/apps/backend/src/features/agents/tools/cancel-follow-up-tool.ts
+++ b/apps/backend/src/features/agents/tools/cancel-follow-up-tool.ts
@@ -54,6 +54,11 @@ export function createCancelFollowUpTool(deps: CancelFollowUpToolDeps) {
     trace: {
       stepType: AgentStepTypes.TOOL_CALL,
       formatContent: (input) => JSON.stringify({ tool: "cancel_follow_up", followUpId: input.followUpId }),
+      effects: (_input, result) => {
+        const parsed = JSON.parse(result.output) as { ok: boolean; followUpId?: string }
+        if (!parsed.ok || !parsed.followUpId) return []
+        return [{ kind: "follow_up", target: parsed.followUpId }]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/delegate-task-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/delegate-task-tool.test.ts
@@ -67,3 +67,21 @@ describe("delegate_task tool", () => {
     expect(body).toEqual({ ok: false, error: "Failed to create delegation" })
   })
 })
+
+describe("delegate_task effects", () => {
+  const effectsOf = async (result: DelegateTaskToolResult) => {
+    const tool = createDelegateTaskTool({ delegateTask: mock(async () => result) })
+    const out = await tool.config.execute(INPUT, EXEC_OPTS)
+    return tool.config.trace.effects?.(INPUT, out)
+  }
+
+  it("declares the delegation it created", async () => {
+    expect(await effectsOf({ ok: true, delegationId: "dlg_1", droppedRefs: [] })).toEqual([
+      { kind: "delegation", label: INPUT.title, target: "dlg_1" },
+    ])
+  })
+
+  it("declares nothing when the callback refused", async () => {
+    expect(await effectsOf({ ok: false, error: "delegations unavailable" })).toEqual([])
+  })
+})

--- a/apps/backend/src/features/agents/tools/delegate-task-tool.ts
+++ b/apps/backend/src/features/agents/tools/delegate-task-tool.ts
@@ -93,6 +93,11 @@ Use for work that is long-horizon, code-heavy, or needs the user's machine — n
       stepType: AgentStepTypes.TOOL_CALL,
       formatContent: (input) =>
         JSON.stringify({ tool: "delegate_task", title: input.title, contextRefs: input.contextRefs ?? [] }),
+      effects: (input, result) => {
+        const parsed = JSON.parse(result.output) as { ok: boolean; delegationId?: string }
+        if (!parsed.ok || !parsed.delegationId) return []
+        return [{ kind: "delegation", label: input.title, target: parsed.delegationId }]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/save-memo-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/save-memo-tool.test.ts
@@ -74,3 +74,27 @@ describe("save_memo tool", () => {
     expect(tool.config.inputSchema.safeParse({ ...input, sourceMessageIds: [] }).success).toBe(false)
   })
 })
+
+describe("save_memo effects", () => {
+  const effectsOf = async (result: SaveMemoToolResult) => {
+    const tool = createSaveMemoTool({ saveMemo: mock(async () => result) })
+    const out = await tool.config.execute(input, EXEC_OPTS)
+    return tool.config.trace.effects?.(input, out)
+  }
+
+  it("declares the memo it captured", async () => {
+    expect(await effectsOf({ ok: true, memoId: "memo_new", title: input.title, deduped: false })).toEqual([
+      { kind: "memo", label: input.title, target: "memo_new" },
+    ])
+  })
+
+  // A deduped save returned the memo that was already there; nothing was
+  // written, so claiming a capture would be a lie the fallback can't tell apart.
+  it("declares nothing when the save deduped", async () => {
+    expect(await effectsOf({ ok: true, memoId: "memo_existing", title: "Existing", deduped: true })).toEqual([])
+  })
+
+  it("declares nothing when the write failed", async () => {
+    expect(await effectsOf({ ok: false })).toEqual([])
+  })
+})

--- a/apps/backend/src/features/agents/tools/save-memo-tool.ts
+++ b/apps/backend/src/features/agents/tools/save-memo-tool.ts
@@ -117,6 +117,13 @@ Use when the user asks you to remember something, or when something clearly wort
       stepType: AgentStepTypes.TOOL_CALL,
       formatContent: (input) =>
         JSON.stringify({ tool: AgentToolNames.SAVE_MEMO, title: input.title, knowledgeType: input.knowledgeType }),
+      // A deduped save wrote nothing — it returned the memo that was already
+      // there — so it declares no effect rather than claiming a capture.
+      effects: (_input, result) => {
+        const parsed = JSON.parse(result.output) as { ok: boolean; memoId?: string; title?: string; deduped?: boolean }
+        if (!parsed.ok || parsed.deduped || !parsed.memoId) return []
+        return [{ kind: "memo", label: parsed.title, target: parsed.memoId }]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/schedule-follow-up-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/schedule-follow-up-tool.test.ts
@@ -106,3 +106,28 @@ describe("schedule_follow_up tool", () => {
     expect(body).toMatchObject({ ok: false, pendingCount: 10, limit: 10 })
   })
 })
+
+describe("schedule_follow_up effects", () => {
+  const effectsOf = async (result: ScheduleFollowUpToolResult) => {
+    const tool = createScheduleFollowUpTool({ scheduleFollowUp: mock(async () => result) })
+    const input = { note: "check the deploy", scheduledFor: new Date(Date.now() + 86_400_000).toISOString() }
+    const out = await tool.config.execute(input, EXEC_OPTS)
+    return tool.config.trace.effects?.(input, out)
+  }
+
+  it("declares the follow-up it scheduled", async () => {
+    expect(await effectsOf(okResult())).toEqual([{ kind: "follow_up", label: "check the deploy", target: "agfu_01" }])
+  })
+
+  it("declares nothing when the pending cap refused the write", async () => {
+    expect(await effectsOf({ ok: false, reason: "cap_reached", pendingCount: 10, limit: 10 })).toEqual([])
+  })
+
+  it("declares nothing when validation rejected the date before any write", async () => {
+    const tool = createScheduleFollowUpTool({ scheduleFollowUp: mock(async () => okResult()) })
+    const input = { note: "n", scheduledFor: new Date(Date.now() - 3_600_000).toISOString() }
+    const out = await tool.config.execute(input, EXEC_OPTS)
+
+    expect(tool.config.trace.effects?.(input, out)).toEqual([])
+  })
+})

--- a/apps/backend/src/features/agents/tools/schedule-follow-up-tool.ts
+++ b/apps/backend/src/features/agents/tools/schedule-follow-up-tool.ts
@@ -108,6 +108,11 @@ Use this instead of attempting long-horizon work in one turn: "check back tomorr
       stepType: AgentStepTypes.TOOL_CALL,
       formatContent: (input) =>
         JSON.stringify({ tool: "schedule_follow_up", note: input.note, scheduledFor: input.scheduledFor }),
+      effects: (input, result) => {
+        const parsed = JSON.parse(result.output) as { ok: boolean; followUpId?: string }
+        if (!parsed.ok || !parsed.followUpId) return []
+        return [{ kind: "follow_up", label: input.note, target: parsed.followUpId }]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/tool-definition-stability.test.ts
+++ b/apps/backend/src/features/agents/tools/tool-definition-stability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { z } from "zod"
+import { MUTATING_TOOL_NAMES } from "@threa/types"
 import { buildToolSet } from "../companion/tool-set"
 
 /**
@@ -70,6 +71,45 @@ describe("tool definition cache stability", () => {
   for (const name of [...new Set([...a.keys()])]) {
     test(`\`${name}\` is byte-identical across differing per-request values`, () => {
       expect(a.get(name)).toBe(b.get(name))
+    })
+  }
+})
+
+/**
+ * Layer-0 ratchet. A mutating tool with no `trace.effects` still gets an effect
+ * — one shapeless `other` descriptor — so the regression is invisible at
+ * runtime: the card keeps saying "wrote something" and stops saying what.
+ */
+describe("mutating tools declare their own effects", () => {
+  const built = new Map(
+    buildToolSet({
+      enabledTools: null,
+      tavilyApiKey: "test-key",
+      currentTime: "2026-07-26T10:00:00.000Z",
+      timezone: "Europe/Stockholm",
+      briefVersion: 1,
+      runWorkspaceAgent: stub,
+      runGeneralResearch: stub,
+      workspace: stub,
+      reactions: stub,
+      followUps: stub,
+      brief: stub,
+      delegation: stub,
+      saveMemo: stub,
+      settings: stub,
+      github: stub,
+      linear: stub,
+      supportsVision: true,
+    }).map((t) => [t.name, t])
+  )
+
+  test("every mutating tool this build constructs is present, so the loop can't pass vacuously", () => {
+    expect(MUTATING_TOOL_NAMES.filter((name) => built.has(name))).toEqual([...MUTATING_TOOL_NAMES])
+  })
+
+  for (const name of MUTATING_TOOL_NAMES) {
+    test(`\`${name}\` declares effects rather than falling back to layer 0`, () => {
+      expect(typeof built.get(name)?.config.trace.effects).toBe("function")
     })
   }
 })

--- a/apps/backend/src/features/agents/tools/tool-deps.ts
+++ b/apps/backend/src/features/agents/tools/tool-deps.ts
@@ -126,9 +126,13 @@ export interface UpdateStreamBriefToolDeps {
  * cross-user write cannot be expressed by the model at all. Returns the
  * preferences as stored, which is what the tool reports back (the stored value
  * can differ from the requested one, e.g. a cleared override).
+ *
+ * `before` is the snapshot read immediately ahead of the write: a key present in
+ * the patch whose value already matched changed nothing, and the tool can only
+ * tell the difference by comparing.
  */
 export interface UpdateUserSettingsToolDeps {
-  updateSettings: (patch: AgentSettablePreferences) => Promise<UserPreferences>
+  updateSettings: (patch: AgentSettablePreferences) => Promise<{ before: UserPreferences; after: UserPreferences }>
 }
 
 /**

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
@@ -76,7 +76,10 @@ describe("update_follow_up tool", () => {
 })
 
 describe("update_follow_up effects", () => {
-  it("declares the follow-up it moved, with the new time", async () => {
+  // The new time rides the LABEL, not a one-sided `after`: both surfaces render
+  // `before → after` or nothing, so an `after` alone would be dropped at render
+  // and a moved reminder would look identical to a note-only edit.
+  it("declares the follow-up it moved, with the new time in the label", async () => {
     const tool = createUpdateFollowUpTool({ updateFollowUp: mock(async () => okResult()) }, { timezone: "UTC" })
     const input = {
       followUpId: "agfu_01",
@@ -87,7 +90,7 @@ describe("update_follow_up effects", () => {
     const body = parse(out.output)
 
     expect(tool.config.trace.effects?.(input, out)).toEqual([
-      { kind: "follow_up", label: "new note", target: "agfu_01", after: body.scheduledForLocal as string },
+      { kind: "follow_up", label: `new note — moved to ${body.scheduledForLocal as string}`, target: "agfu_01" },
     ])
   })
 

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
@@ -76,10 +76,11 @@ describe("update_follow_up tool", () => {
 })
 
 describe("update_follow_up effects", () => {
-  // The new time rides the LABEL, not a one-sided `after`: both surfaces render
-  // `before → after` or nothing, so an `after` alone would be dropped at render
-  // and a moved reminder would look identical to a note-only edit.
-  it("declares the follow-up it moved, with the new time in the label", async () => {
+  // The time rides `after`, which the renderers draw as `→ <time>`. It is NOT
+  // in the label: a 2000-char note against a 120-char cap would truncate the
+  // time away, and the label is part of the session merge key, so two
+  // reschedules of one follow-up would stop collapsing.
+  it("declares the follow-up it moved, with the new time in after", async () => {
     const tool = createUpdateFollowUpTool({ updateFollowUp: mock(async () => okResult()) }, { timezone: "UTC" })
     const input = {
       followUpId: "agfu_01",
@@ -90,7 +91,7 @@ describe("update_follow_up effects", () => {
     const body = parse(out.output)
 
     expect(tool.config.trace.effects?.(input, out)).toEqual([
-      { kind: "follow_up", label: `new note — moved to ${body.scheduledForLocal as string}`, target: "agfu_01" },
+      { kind: "follow_up", label: "new note", target: "agfu_01", after: body.scheduledForLocal as string },
     ])
   })
 

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.test.ts
@@ -74,3 +74,44 @@ describe("update_follow_up tool", () => {
     expect(parsed.success).toBe(false)
   })
 })
+
+describe("update_follow_up effects", () => {
+  it("declares the follow-up it moved, with the new time", async () => {
+    const tool = createUpdateFollowUpTool({ updateFollowUp: mock(async () => okResult()) }, { timezone: "UTC" })
+    const input = {
+      followUpId: "agfu_01",
+      note: "new note",
+      scheduledFor: new Date(Date.now() + 3 * 86_400_000).toISOString(),
+    }
+    const out = await tool.config.execute(input, EXEC_OPTS)
+    const body = parse(out.output)
+
+    expect(tool.config.trace.effects?.(input, out)).toEqual([
+      { kind: "follow_up", label: "new note", target: "agfu_01", after: body.scheduledForLocal as string },
+    ])
+  })
+
+  // A note-only edit has no new time to report, and the callback returns no
+  // pre-write value, so there is nothing to put in `before`/`after`.
+  it("declares no time when only the note changed", async () => {
+    const tool = createUpdateFollowUpTool({ updateFollowUp: mock(async () => okResult()) })
+    const input = { followUpId: "agfu_01", note: "new note" }
+    const out = await tool.config.execute(input, EXEC_OPTS)
+
+    expect(tool.config.trace.effects?.(input, out)).toEqual([
+      { kind: "follow_up", label: "new note", target: "agfu_01" },
+    ])
+  })
+
+  for (const reason of ["not_found", "not_pending"] as const) {
+    it(`declares nothing on ${reason}`, async () => {
+      const tool = createUpdateFollowUpTool({
+        updateFollowUp: mock(async (): Promise<UpdateFollowUpToolResult> => ({ ok: false, reason })),
+      })
+      const input = { followUpId: "agfu_01", note: "n" }
+      const out = await tool.config.execute(input, EXEC_OPTS)
+
+      expect(tool.config.trace.effects?.(input, out)).toEqual([])
+    })
+  }
+})

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
@@ -102,12 +102,15 @@ export function createUpdateFollowUpTool(
           note: input.note,
           scheduledFor: input.scheduledFor,
         }),
-      // A reschedule has no `before` — the callback returns the row as written
-      // and nothing from before it — and a one-sided diff is not renderable:
-      // both surfaces draw `before → after` or nothing, so an `after` on its own
-      // would ride the payload and be dropped at render, leaving a moved
-      // reminder looking identical to a note-only edit. The new time goes in the
-      // label instead, where it is actually shown.
+      // The new time rides `after`, not the label. There is no `before` — the
+      // callback returns the row as written and nothing from before it — so the
+      // renderers draw this as `→ <time>`.
+      //
+      // It was in the label briefly and that was wrong twice over: a note runs
+      // to 2000 characters against a 120-character label cap, so the time was
+      // the part truncation ate; and the label is part of the session-level
+      // merge key, so two reschedules of the same follow-up stopped collapsing
+      // and the card showed the superseded time next to the current one.
       effects: (input, result) => {
         const parsed = JSON.parse(result.output) as {
           ok: boolean
@@ -116,14 +119,13 @@ export function createUpdateFollowUpTool(
           scheduledForLocal?: string
         }
         if (!parsed.ok || !parsed.followUpId) return []
-        const rescheduled = input.scheduledFor !== undefined && parsed.scheduledForLocal
+        const rescheduledTo = input.scheduledFor !== undefined ? parsed.scheduledForLocal : undefined
         return [
           {
             kind: "follow_up",
-            ...(rescheduled
-              ? { label: `${parsed.note ?? "Follow-up"} — moved to ${parsed.scheduledForLocal}` }
-              : { label: parsed.note }),
+            label: parsed.note,
             target: parsed.followUpId,
+            ...(rescheduledTo ? { after: rescheduledTo } : {}),
           },
         ]
       },

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
@@ -102,6 +102,25 @@ export function createUpdateFollowUpTool(
           note: input.note,
           scheduledFor: input.scheduledFor,
         }),
+      // No `before`: the callback returns the stored row after the write and
+      // nothing from before it, so only the new time is declarable.
+      effects: (input, result) => {
+        const parsed = JSON.parse(result.output) as {
+          ok: boolean
+          followUpId?: string
+          note?: string
+          scheduledForLocal?: string
+        }
+        if (!parsed.ok || !parsed.followUpId) return []
+        return [
+          {
+            kind: "follow_up",
+            label: parsed.note,
+            target: parsed.followUpId,
+            ...(input.scheduledFor !== undefined ? { after: parsed.scheduledForLocal } : {}),
+          },
+        ]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
+++ b/apps/backend/src/features/agents/tools/update-follow-up-tool.ts
@@ -102,8 +102,12 @@ export function createUpdateFollowUpTool(
           note: input.note,
           scheduledFor: input.scheduledFor,
         }),
-      // No `before`: the callback returns the stored row after the write and
-      // nothing from before it, so only the new time is declarable.
+      // A reschedule has no `before` — the callback returns the row as written
+      // and nothing from before it — and a one-sided diff is not renderable:
+      // both surfaces draw `before → after` or nothing, so an `after` on its own
+      // would ride the payload and be dropped at render, leaving a moved
+      // reminder looking identical to a note-only edit. The new time goes in the
+      // label instead, where it is actually shown.
       effects: (input, result) => {
         const parsed = JSON.parse(result.output) as {
           ok: boolean
@@ -112,12 +116,14 @@ export function createUpdateFollowUpTool(
           scheduledForLocal?: string
         }
         if (!parsed.ok || !parsed.followUpId) return []
+        const rescheduled = input.scheduledFor !== undefined && parsed.scheduledForLocal
         return [
           {
             kind: "follow_up",
-            label: parsed.note,
+            ...(rescheduled
+              ? { label: `${parsed.note ?? "Follow-up"} — moved to ${parsed.scheduledForLocal}` }
+              : { label: parsed.note }),
             target: parsed.followUpId,
-            ...(input.scheduledFor !== undefined ? { after: parsed.scheduledForLocal } : {}),
           },
         ]
       },

--- a/apps/backend/src/features/agents/tools/update-stream-brief-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/update-stream-brief-tool.test.ts
@@ -80,3 +80,51 @@ describe("update_stream_brief tool", () => {
     expect(parse(result.output).ok).toBe(false)
   })
 })
+
+describe("update_stream_brief effects", () => {
+  const INPUT = { content: "Goal: ship weekly", reason: "recorded the decision" }
+
+  // Target-less on purpose: the write lands on the stream the trace sits in.
+  it("declares the version it moved the brief from and to", async () => {
+    const tool = createUpdateStreamBriefTool(
+      { updateBrief: mock(async (): Promise<UpdateStreamBriefToolResult> => ({ ok: true, version: 4 })) },
+      { currentVersion: 3 }
+    )
+    const out = await tool.config.execute(INPUT, EXEC_OPTS)
+
+    expect(tool.config.trace.effects?.(INPUT, out)).toEqual([{ kind: "brief", before: "3", after: "4" }])
+  })
+
+  it("declares nothing on a version conflict", async () => {
+    const tool = createUpdateStreamBriefTool(
+      {
+        updateBrief: mock(
+          async (): Promise<UpdateStreamBriefToolResult> => ({
+            ok: false,
+            reason: "version_conflict",
+            currentContent: "theirs",
+            currentVersion: 5,
+          })
+        ),
+      },
+      { currentVersion: 3 }
+    )
+    const out = await tool.config.execute(INPUT, EXEC_OPTS)
+
+    expect(tool.config.trace.effects?.(INPUT, out)).toEqual([])
+  })
+
+  it("declares nothing when the write threw", async () => {
+    const tool = createUpdateStreamBriefTool(
+      {
+        updateBrief: mock(async (): Promise<UpdateStreamBriefToolResult> => {
+          throw new Error("db down")
+        }),
+      },
+      { currentVersion: 3 }
+    )
+    const out = await tool.config.execute(INPUT, EXEC_OPTS)
+
+    expect(tool.config.trace.effects?.(INPUT, out)).toEqual([])
+  })
+})

--- a/apps/backend/src/features/agents/tools/update-stream-brief-tool.ts
+++ b/apps/backend/src/features/agents/tools/update-stream-brief-tool.ts
@@ -87,6 +87,15 @@ export function createUpdateStreamBriefTool(deps: UpdateStreamBriefToolDeps, opt
     trace: {
       stepType: AgentStepTypes.TOOL_CALL,
       formatContent: (input) => JSON.stringify({ tool: "update_stream_brief", reason: input.reason }),
+      // Target-less: the write lands on the stream the trace is already in.
+      // `before` is the version written against — the repo advances the brief by
+      // exactly one per accepted write (`version = version + 1`, creation at 1
+      // from an expected 0), so it is derivable from the result alone.
+      effects: (_input, result) => {
+        const parsed = JSON.parse(result.output) as { ok: boolean; version?: number }
+        if (!parsed.ok || parsed.version === undefined) return []
+        return [{ kind: "brief", before: String(parsed.version - 1), after: String(parsed.version) }]
+      },
     },
   })
 }

--- a/apps/backend/src/features/agents/tools/update-user-settings-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/update-user-settings-tool.test.ts
@@ -22,8 +22,16 @@ const preferences: UserPreferences = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 }
 
+/** The write, against the stored defaults as `before`. */
 function toolWith(updateSettings: (patch: unknown) => Promise<UserPreferences>) {
-  return createUpdateUserSettingsTool({ updateSettings: updateSettings as never })
+  return createUpdateUserSettingsTool({
+    updateSettings: async (patch) => ({ before: preferences, after: await updateSettings(patch) }),
+  })
+}
+
+/** The write plus an explicit pre-write snapshot, for the before/after tests. */
+function toolWithBefore(before: UserPreferences, after: UserPreferences) {
+  return createUpdateUserSettingsTool({ updateSettings: async () => ({ before, after }) })
 }
 
 describe("update_user_settings schema", () => {
@@ -98,7 +106,11 @@ describe("update_user_settings tool", () => {
     const result = await tool.config.execute({ timezone: "Europe/Stockholm" }, { toolCallId: "call_1" })
 
     expect(updateSettings).toHaveBeenCalledWith({ timezone: "Europe/Stockholm" })
-    expect(JSON.parse(result.output)).toEqual({ ok: true, applied: { timezone: "Europe/Stockholm" } })
+    expect(JSON.parse(result.output)).toEqual({
+      ok: true,
+      applied: { timezone: "Europe/Stockholm" },
+      previous: { timezone: preferences.timezone },
+    })
   })
 
   // The runtime hands `execute` whatever the provider returned as arguments
@@ -200,5 +212,90 @@ describe("canOfferUserSettings", () => {
 
   test("withholds it when the root's owner is unknown", () => {
     expect(canOfferUserSettings({ ...allowed, rootStreamCreatedBy: null })).toBe(false)
+  })
+})
+
+describe("update_user_settings effects", () => {
+  const effectsOf = async (tool: ReturnType<typeof toolWith>, input: Record<string, unknown>) => {
+    const result = await tool.config.execute(input as never, { toolCallId: "call_1" })
+    return tool.config.trace.effects?.(input as never, result)
+  }
+
+  test("declares one effect per key it actually changed, with before and after", async () => {
+    const tool = toolWithBefore(
+      { ...preferences, theme: "light", timezone: "UTC" },
+      { ...preferences, theme: "dark", timezone: "Europe/Stockholm" }
+    )
+
+    expect(await effectsOf(tool, { theme: "dark", timezone: "Europe/Stockholm" })).toEqual([
+      { kind: "settings", target: "theme", before: "light", after: "dark" },
+      { kind: "settings", target: "timezone", before: "UTC", after: "Europe/Stockholm" },
+    ])
+  })
+
+  // The user asked for something already true. The write happened, but nothing
+  // moved, and reporting it as a change would be wrong.
+  test("declares nothing for a key whose value was already what was asked for", async () => {
+    const tool = toolWithBefore(
+      { ...preferences, theme: "dark", timezone: "UTC" },
+      { ...preferences, theme: "dark", timezone: "Europe/Stockholm" }
+    )
+
+    expect(await effectsOf(tool, { theme: "dark", timezone: "Europe/Stockholm" })).toEqual([
+      { kind: "settings", target: "timezone", before: "UTC", after: "Europe/Stockholm" },
+    ])
+  })
+
+  // The real shape, not a hand-rolled stand-in: a full week of shifts
+  // serializes past 200 characters, and both sides of the diff would truncate
+  // to the same 120-char prefix — a change that renders as no change. So a
+  // structured value declares the key it touched and no diff at all.
+  const FULL_WEEK = {
+    days: {
+      0: [],
+      1: [{ start: "09:00", end: "17:00" }],
+      2: [{ start: "09:00", end: "17:00" }],
+      3: [{ start: "09:00", end: "17:00" }],
+      4: [{ start: "09:00", end: "17:00" }],
+      5: [{ start: "09:00", end: "17:00" }],
+      6: [],
+    },
+  }
+
+  test("declares a structured value's key without a misleading diff", async () => {
+    const shortenedFriday = {
+      days: { ...FULL_WEEK.days, 5: [{ start: "09:00", end: "15:00" }] },
+    }
+    const tool = toolWithBefore(
+      { ...preferences, workSchedule: FULL_WEEK as never },
+      { ...preferences, workSchedule: shortenedFriday as never }
+    )
+
+    expect(await effectsOf(tool, { workSchedule: shortenedFriday as never })).toEqual([
+      { kind: "settings", target: "workSchedule" },
+    ])
+  })
+
+  test("still declares the change when a structured override is cleared", async () => {
+    const tool = toolWithBefore(
+      { ...preferences, workSchedule: FULL_WEEK as never },
+      { ...preferences, workSchedule: null as never }
+    )
+
+    expect(await effectsOf(tool, { workSchedule: null })).toEqual([{ kind: "settings", target: "workSchedule" }])
+  })
+
+  test("declares nothing when the patch never passed the schema", async () => {
+    const tool = toolWith(async () => preferences)
+
+    expect(await effectsOf(tool, { theme: 42 })).toEqual([])
+  })
+
+  test("declares nothing when the write threw", async () => {
+    const tool = toolWith(async () => {
+      throw new Error("Invalid timezone")
+    })
+
+    expect(await effectsOf(tool, { timezone: "Mars/Olympus" })).toEqual([])
   })
 })

--- a/apps/backend/src/features/agents/tools/update-user-settings-tool.ts
+++ b/apps/backend/src/features/agents/tools/update-user-settings-tool.ts
@@ -92,6 +92,26 @@ export function canOfferUserSettings(params: {
 }
 
 /**
+ * A scalar preference rendered for the trace's `before → after` diff, or null
+ * when the value has no honest one-line form.
+ *
+ * `workSchedule` is the one structured agent-settable key: serialized it runs
+ * past 200 characters, so both sides truncate to the same prefix and a real
+ * change renders as no change at all. A diff that says nothing moved is worse
+ * than no diff, so a structured value declares its key and stops there.
+ */
+function displayValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  return null
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+}
+
+/**
  * Change the invoking user's own preferences.
  *
  * The target user is bound at construction, never a tool parameter: a model
@@ -138,11 +158,14 @@ export function createUpdateUserSettingsTool(deps: UpdateUserSettingsToolDeps) {
       const changedKeys = Object.keys(patch).filter((key) => (patch as Record<string, unknown>)[key] !== undefined)
 
       try {
-        const preferences = await deps.updateSettings(patch)
+        const { before, after } = await deps.updateSettings(patch)
         const applied = Object.fromEntries(
-          changedKeys.map((key) => [key, (preferences as unknown as Record<string, unknown>)[key]])
+          changedKeys.map((key) => [key, (after as unknown as Record<string, unknown>)[key]])
         )
-        return { output: JSON.stringify({ ok: true, applied }) }
+        const previous = Object.fromEntries(
+          changedKeys.map((key) => [key, (before as unknown as Record<string, unknown>)[key]])
+        )
+        return { output: JSON.stringify({ ok: true, applied, previous }) }
       } catch (error) {
         logger.error({ err: error, changedKeys }, "update_user_settings failed")
         return {
@@ -162,6 +185,28 @@ export function createUpdateUserSettingsTool(deps: UpdateUserSettingsToolDeps) {
         const applied = parsed.applied ?? (input as Record<string, unknown>)
         const pairs = Object.entries(applied).map(([key, value]) => `${key} → ${JSON.stringify(value)}`)
         return `Changed ${pairs.join(", ")}`
+      },
+      effects: (_input, result) => {
+        const parsed = JSON.parse(result.output) as {
+          ok: boolean
+          applied?: Record<string, unknown>
+          previous?: Record<string, unknown>
+        }
+        if (!parsed.ok || !parsed.applied) return []
+        const previous = parsed.previous ?? {}
+        return Object.entries(parsed.applied)
+          .filter(([key, value]) => !sameValue(previous[key], value))
+          .map(([key, value]) => {
+            const before = displayValue(previous[key])
+            const after = displayValue(value)
+            return {
+              kind: "settings" as const,
+              target: key,
+              // Both or neither: a one-sided diff reads as "was empty, now X",
+              // which is a different claim from "changed, shown elsewhere".
+              ...(before !== null && after !== null ? { before, after } : {}),
+            }
+          })
       },
     },
   })


### PR DESCRIPTION
## Why

Chunk 2 stamps every mutating tool with the shapeless `[{kind:"other"}]` fallback. This replaces that with real descriptors: seven `trace.effects` implementations, each beside the tool's existing `formatContent` and parsing the same result it already parses.

Chunk 3 of 5. Plan: https://seer.build/ws_vbyzjvdg6g/b/side-effects-plan-5516ac/ · Design: https://seer.build/ws_vbyzjvdg6g/b/side-effects-thin-b81dbc/v/2/

## The rule that decides this chunk

**A tool declaring an empty array means "I wrote nothing", and that beats the fallback.**

Every one of these tools catches its own failure and still returns a *successful* `AgentToolResult`. Without this rule the trace would claim writes that never happened on: an invalid settings patch, a version-conflicted brief, a refused delegation, a cap-reached follow-up, a not-found cancel — and **`save_memo` with `deduped: true`**, which returns `ok: true` having written nothing at all. Each branch declares `[]` explicitly and each has a test.

## Material decisions

**`update_user_settings` declares one effect per key whose stored value actually moved.** A key present in the patch but already at that value declares nothing — the user asked for something already true, and reporting it as a write is wrong. Reading pre-write values meant `updateSettings` returning `{ before, after }`; those values ride the tool's output because `trace.effects` only receives `(input, result)` and there is no non-model side channel. That does make the previous values model-visible — noted below.

**`workSchedule` declares its key and no diff.** It's the one structured settable key: a full week serializes past 200 characters, so both sides truncate at the 120-char cap to a byte-identical prefix and a real schedule change would render as *no change*. A diff that says nothing moved is worse than no diff. Scalars still diff normally.

That one came from the adversarial pass, and the existing test couldn't have caught it — it used a hand-rolled 3-key schedule shape that doesn't match `workScheduleSchema` and stayed under the cap. The replacement builds the real shape.

**`update_stream_brief` ships target-less**, with `before`/`after` as version numbers. The repository advances version by exactly 1 per accepted write, so `before` is derivable; the write is on the stream the card is already in, so a target adds nothing.

**No `href` anywhere.** `target` is an id or a preference key. The frontend resolves routes in chunk 5.

## Verification

typecheck 0 errors · backend 3,811 unit + 371 e2e · agent-runtime 301 · types 152 · lint clean.

The ratchet in `tool-definition-stability.test.ts` was mutation-checked: deleting `effects` from `cancel-follow-up-tool.ts` turns it red. That's what stops a mutating tool silently regressing to layer 0.

## Residual risk

**The settings tool's output now carries `previous` alongside `applied`, which the model sees.** Only the user's own preference values, in their own scratchpad, echoed back to an agent that just wrote them — but it is more than the model saw before, and it exists solely to feed the trace. If that trade isn't wanted, the alternative is threading a side channel through `AgentToolResult`, which is a bigger change than this chunk should carry.

Nothing renders yet — session payloads are chunk 4, UI chunk 5.

Stacked on #1652.
