### PR TITLE
feat(harnessd): announce a bypass downgrade adopt could not observe, and add --yolo

### DIFF
--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -84,10 +84,11 @@ interface Recorded {
   launches: unknown[]
   killed: string[]
   preflights: unknown[]
+  warnings: string[]
 }
 
 function deps(overrides: Partial<AdoptDeps> = {}): AdoptDeps & Recorded {
-  const recorded: Recorded = { persisted: [], launches: [], killed: [], preflights: [] }
+  const recorded: Recorded = { persisted: [], launches: [], killed: [], preflights: [], warnings: [] }
   return {
     ...recorded,
     claudeConfig: () => ({ baseUrl: "https://app.threa.io", workspaceId: "ws_one", apiKey: "key" }),
@@ -114,6 +115,7 @@ function deps(overrides: Partial<AdoptDeps> = {}): AdoptDeps & Recorded {
     persist: (record) => void recorded.persisted.push(record),
     killWindow: (windowId) => void recorded.killed.push(windowId),
     newId: () => "claude-new",
+    warn: (message) => void recorded.warnings.push(message),
     ...overrides,
   }
 }
@@ -127,7 +129,10 @@ describe("adoptClaudeSession live pane", () => {
     const dependencies = deps({ panes: () => [pane()] })
     const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
 
-    expect(outcome).toEqual({ status: "adopted live", detail: "1:claude-slopenv (%211, pid 34341)" })
+    expect(outcome).toEqual({
+      status: "adopted live",
+      detail: "1:claude-slopenv (%211, pid 34341), bypass enabled (live launch)",
+    })
     expect(dependencies.launches).toEqual([])
     expect(dependencies.persisted).toEqual([
       {
@@ -211,7 +216,7 @@ describe("adoptClaudeSession cold takeover", () => {
 
     expect(outcome).toEqual({
       status: "taken over",
-      detail: `1:slopenv resuming ${NATIVE}, bypass disabled`,
+      detail: `1:slopenv resuming ${NATIVE}, bypass disabled (default)`,
     })
     expect(dependencies.launches).toEqual([
       {
@@ -305,7 +310,10 @@ describe("adoptClaudeSession cold takeover", () => {
     const dependencies = deps()
     const outcome = await adoptClaudeSessionUnlocked(options({ dryRun: true }), dependencies)
 
-    expect(outcome).toEqual({ status: "would take over", detail: `${CWD} resuming ${NATIVE}` })
+    expect(outcome).toEqual({
+      status: "would take over",
+      detail: `${CWD} resuming ${NATIVE}, bypass disabled (default)`,
+    })
     expect(dependencies.preflights).toEqual([])
     expect(dependencies.persisted).toEqual([])
     expect(dependencies.launches).toEqual([])
@@ -319,6 +327,135 @@ describe("adoptClaudeSession cold takeover", () => {
     expect(outcome.status).toBe("refused archived")
     expect(dependencies.killed).toEqual(["@300"])
     expect(dependencies.persisted.at(-1)).toMatchObject({ status: "error" })
+  })
+})
+
+describe("adoptClaudeSession permission mode", () => {
+  test("a takeover that cannot observe the original permission mode announces the downgrade", async () => {
+    const dependencies = deps()
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(dependencies.launches).toMatchObject([{ noYolo: true }])
+    expect(dependencies.warnings).toHaveLength(1)
+    expect(dependencies.warnings[0]).toContain("--yolo")
+    expect(outcome.detail).toContain("bypass disabled (default)")
+  })
+
+  test("--yolo keeps bypass on when nothing attests the original mode", async () => {
+    const dependencies = deps()
+    const outcome = await adoptClaudeSessionUnlocked(options({ yolo: true }), dependencies)
+
+    expect(dependencies.launches).toMatchObject([{ noYolo: false }])
+    expect(outcome.detail).toContain("bypass enabled (--yolo)")
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("a live pane's own bypass flag still wins over the default", async () => {
+    const dependencies = deps({ panes: () => [pane()] })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.detail).toContain("bypass enabled (live launch)")
+    expect(dependencies.persisted[0]?.command).not.toContain("--no-yolo")
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("a live pane launched without bypass is followed, and that is not a downgrade", async () => {
+    const dependencies = deps({
+      panes: () => [pane({ startCommand: COMMAND.replace(" --dangerously-skip-permissions", "") })],
+    })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.detail).toContain("bypass disabled (live launch)")
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("an inventory row's recorded mode is followed when no pane is live", async () => {
+    const dependencies = deps({
+      inventory: () => [agent({ command: ["threa-harnessd", "spawn", "claude", "--no-yolo"] })],
+    })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.detail).toContain("bypass disabled (inventory row)")
+    expect(dependencies.launches).toMatchObject([{ noYolo: true }])
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("an inventory row spawned with bypass keeps it", async () => {
+    const dependencies = deps({ inventory: () => [agent()] })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.detail).toContain("bypass enabled (inventory row)")
+    expect(dependencies.launches).toMatchObject([{ noYolo: false }])
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("a refusal does not announce a downgrade it never applied", async () => {
+    const dependencies = deps({ disk: disk({ list: () => [] }) })
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("refused missing transcript")
+    expect(dependencies.launches).toEqual([])
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("a dry run previews the downgrade without announcing one", async () => {
+    const dependencies = deps()
+    const outcome = await adoptClaudeSessionUnlocked(options({ dryRun: true }), dependencies)
+
+    expect(outcome.detail).toContain("bypass disabled (default)")
+    expect(dependencies.warnings).toEqual([])
+  })
+
+  test("a flag that disagrees with the live pane is reported as not applied", async () => {
+    const dependencies = deps({ panes: () => [pane()] })
+    const outcome = await adoptClaudeSessionUnlocked(options({ noYolo: true }), dependencies)
+
+    expect(outcome.detail).toContain("bypass enabled (live launch)")
+    expect(dependencies.launches).toEqual([])
+    expect(dependencies.warnings).toHaveLength(1)
+    expect(dependencies.warnings[0]).toContain("not being restarted")
+  })
+
+  test("a live pane records the mode it is running, not the flag it was adopted with", async () => {
+    const dependencies = deps({ panes: () => [pane()] })
+    await adoptClaudeSessionUnlocked(options({ yolo: true }), dependencies)
+
+    expect(dependencies.persisted.at(-1)?.command).not.toContain("--yolo")
+    expect(dependencies.persisted.at(-1)?.command).not.toContain("--no-yolo")
+  })
+
+  test("a contradictory programmatic decision never records both flags", async () => {
+    const dependencies = deps()
+    await adoptClaudeSessionUnlocked(options({ yolo: true, noYolo: true }), dependencies)
+
+    const command = dependencies.persisted.at(-1)?.command ?? []
+    expect(command).toContain("--no-yolo")
+    expect(command).not.toContain("--yolo")
+  })
+
+  test("--yolo and --no-yolo together are refused at parse time", () => {
+    expect(() => parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--yolo", "--no-yolo"])).toThrow(/--yolo/)
+    expect(parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--yolo"])).toMatchObject({ yolo: true, noYolo: undefined })
+  })
+
+  test("a dry run reports the permission decision it would apply", async () => {
+    const outcome = await adoptClaudeSessionUnlocked(options({ dryRun: true }), deps())
+
+    expect(outcome.status).toBe("would take over")
+    expect(outcome.detail).toContain("bypass disabled (default)")
+  })
+
+  test("the recorded adopt command carries --yolo", async () => {
+    const stated = deps()
+    await adoptClaudeSessionUnlocked(options({ yolo: true }), stated)
+
+    expect(stated.persisted.at(-1)?.command).toContain("--yolo")
+    expect(stated.persisted.at(-1)?.command).not.toContain("--no-yolo")
+
+    const safe = deps()
+    await adoptClaudeSessionUnlocked(options(), safe)
+    expect(safe.persisted.at(-1)?.command).toContain("--no-yolo")
+    expect(safe.persisted.at(-1)?.command).not.toContain("--yolo")
   })
 })
 
@@ -697,6 +834,7 @@ describe("parseAdopt", () => {
       dryRun: true,
       force: true,
       noYolo: undefined,
+      yolo: undefined,
     })
     expect(parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--no-yolo"])).toMatchObject({ noYolo: true })
   })

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -68,6 +68,7 @@ export interface AdoptOptions {
   /** Take over even though a Claude process is still running in the cwd without a pane. */
   force?: boolean
   noYolo?: boolean
+  yolo?: boolean
 }
 
 export type AdoptStatus =
@@ -130,6 +131,7 @@ export interface AdoptDeps {
   persist: (agent: ManagedAgent) => void
   killWindow: (windowId: string) => void
   newId: () => string
+  warn: (message: string) => void
 }
 
 export function defaultAdoptDeps(): AdoptDeps {
@@ -154,6 +156,7 @@ export function defaultAdoptDeps(): AdoptDeps {
       output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
     },
     newId: () => `claude-${Date.now()}-${randomUUID().slice(0, 8)}`,
+    warn: (message) => console.warn(message),
   }
 }
 
@@ -342,20 +345,28 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
 
   const scratchpadUrl = existing?.scratchpadUrl ?? `${baseUrl}/w/${workspaceId}/s/${options.rootStreamId}`
   const identity = { instanceId, runtimeSessionId: options.runtimeSessionId }
-  // Bypass follows the session being adopted, not harnessd's spawn default: the
-  // live pane's own launch first, then what the row recorded.
   const observed = paneSkipsPermissions(pane)
-  // Nothing to follow means nothing is known about how the original ran, and a
-  // takeover is not the place to assume it had its guardrails off.
-  const noYolo = options.noYolo ?? (observed !== undefined ? !observed : existing ? recordedNoYolo(existing) : true)
-  const command = adoptCommand(options, { name, cwd, noYolo })
+  const resolved = resolveAdoptBypass({ yolo: options.yolo, noYolo: options.noYolo, observed, existing })
+  // A live pane is adopted in place, never relaunched, so the mode that applies
+  // to it is the one it is already running under. Reporting or recording this
+  // invocation's resolution there would describe a restart that never happened.
+  const bypass: AdoptBypassDecision = pane && observed !== undefined ? { noYolo: !observed, source: "live launch" } : resolved
+  const noYolo = bypass.noYolo
+  if (pane && observed !== undefined && resolved.noYolo !== bypass.noYolo) {
+    deps.warn(
+      `harnessd: ${options.runtimeSessionId} is already running with bypass ${observed ? "enabled" : "disabled"}; ` +
+        `${resolved.source} does not change a session that is not being restarted — stop it and adopt again to apply.`
+    )
+  }
+  const command = adoptCommand(options, { name, cwd, bypass })
+  const bypassDetail = `bypass ${noYolo ? "disabled" : "enabled"} (${bypass.source})`
 
   if (pane) {
     const alreadyManaged = Boolean(existing) && existing?.tmuxPaneId === pane.paneId && existing?.status === "online"
     if (options.dryRun) {
       return {
         status: alreadyManaged ? "already managed" : "would adopt live",
-        detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid})`,
+        detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid}), ${bypassDetail}`,
       }
     }
     const preflight = await deps.preflight(
@@ -382,7 +393,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     })
     return {
       status: alreadyManaged ? "already managed" : "adopted live",
-      detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid})`,
+      detail: `${pane.sessionName}:${pane.windowName} (${pane.paneId}, pid ${pane.panePid}), ${bypassDetail}`,
     }
   }
 
@@ -410,7 +421,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // Dry-run stops before the preflight for the same reason `up --dry-run` does:
   // that POST registers the session server-side.
   if (options.dryRun) {
-    return { status: "would take over", detail: `${cwd} resuming ${transcript.sessionId}` }
+    return { status: "would take over", detail: `${cwd} resuming ${transcript.sessionId}, ${bypassDetail}` }
   }
 
   const preflight = await deps.preflight(
@@ -431,6 +442,15 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
     command,
     createdAt: existing?.createdAt ?? now(),
     updatedAt: now(),
+  }
+
+  // Announced where it takes effect, and nowhere else: a refusal or a dry run
+  // that claimed a session had started degraded would be the same unfalsifiable
+  // report this announcement exists to replace.
+  if (bypass.source === "default" && noYolo) {
+    deps.warn(
+      `harnessd: could not observe how ${options.runtimeSessionId} was originally launched; starting it WITHOUT --dangerously-skip-permissions. Pass --yolo to state the opposite.`
+    )
   }
 
   let launched: TakeoverLaunch
@@ -484,8 +504,34 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   }
   return {
     status: "taken over",
-    detail: `${launched.tmuxSession}:${launched.tmuxWindow} resuming ${transcript.sessionId}, bypass ${noYolo ? "disabled" : "enabled"}`,
+    detail: `${launched.tmuxSession}:${launched.tmuxWindow} resuming ${transcript.sessionId}, ${bypassDetail}`,
   }
+}
+
+export type AdoptBypassSource = "--yolo" | "--no-yolo" | "live launch" | "inventory row" | "default"
+
+export interface AdoptBypassDecision {
+  noYolo: boolean
+  source: AdoptBypassSource
+}
+
+/**
+ * Bypass follows the session being adopted, not harnessd's spawn default: the
+ * operator's stated intent first, then the live pane's own launch, then what the
+ * row recorded. Nothing to follow means nothing is known about how the original
+ * ran, and a takeover is not the place to assume it had its guardrails off.
+ */
+export function resolveAdoptBypass(params: {
+  yolo?: boolean
+  noYolo?: boolean
+  observed?: boolean
+  existing?: ManagedAgent
+}): AdoptBypassDecision {
+  if (params.noYolo !== undefined) return { noYolo: params.noYolo, source: "--no-yolo" }
+  if (params.yolo) return { noYolo: false, source: "--yolo" }
+  if (params.observed !== undefined) return { noYolo: !params.observed, source: "live launch" }
+  if (params.existing) return { noYolo: recordedNoYolo(params.existing), source: "inventory row" }
+  return { noYolo: true, source: "default" }
 }
 
 function paneSkipsPermissions(pane: LocalTmuxPane | undefined): boolean | undefined {
@@ -493,7 +539,10 @@ function paneSkipsPermissions(pane: LocalTmuxPane | undefined): boolean | undefi
   return parseClaudeChannelLaunch(pane.startCommand)?.skipPermissions
 }
 
-function adoptCommand(options: AdoptOptions, resolved: { name: string; cwd: string; noYolo: boolean }): string[] {
+function adoptCommand(
+  options: AdoptOptions,
+  resolved: { name: string; cwd: string; bypass: AdoptBypassDecision }
+): string[] {
   const command = [
     "threa-harnessd",
     "adopt",
@@ -508,7 +557,11 @@ function adoptCommand(options: AdoptOptions, resolved: { name: string; cwd: stri
   // The pin is part of the target, not a preference: without it a re-run of the
   // recorded command adopts the newest transcript instead of the named one.
   if (options.claudeSessionId) command.push("--claude-session-id", options.claudeSessionId)
-  if (resolved.noYolo) command.push("--no-yolo")
+  if (resolved.bypass.noYolo) command.push("--no-yolo")
+  // Only a stated intent is recorded as one. Deriving this from `options.yolo`
+  // instead would emit both flags for a caller that passed both, and would
+  // launder an inference into a decision on a re-run.
+  else if (resolved.bypass.source === "--yolo") command.push("--yolo")
   return command
 }
 

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -21,7 +21,7 @@ Usage:
   threa-harnessd reconnect <runtime-session-id> --root-stream-id <stream-id> [--force]
   threa-harnessd adopt <runtime-session-id> --root-stream-id <stream-id>
       [--cwd <path>] [--name <name>] [--claude-session-id <uuid>] [--tmux <session>]
-      [--dry-run] [--force] [--no-yolo]
+      [--dry-run] [--force] [--no-yolo | --yolo]
   threa-harnessd stop <agent-id-or-name>
   threa-harnessd kick <agent-id-or-name-or-runtime-session-id>
   threa-harnessd interrupt <agent-id-or-name>
@@ -148,6 +148,9 @@ export function parseAdopt(args: string[]): AdoptOptions {
     if (!ADOPT_FLAGS.has(key)) die(`unexpected adopt argument: --${key}`)
   }
   const cwd = stringFlag(flags, "cwd")
+  const yolo = boolFlag(flags, "yolo")
+  const noYolo = boolFlag(flags, "no-yolo")
+  if (yolo && noYolo) die("adopt accepts --yolo or --no-yolo, not both")
   return {
     runtimeSessionId,
     rootStreamId: stringFlag(flags, "root-stream-id") ?? die("adopt requires --root-stream-id <stream-id>"),
@@ -157,7 +160,8 @@ export function parseAdopt(args: string[]): AdoptOptions {
     tmux: stringFlag(flags, "tmux"),
     dryRun: boolFlag(flags, "dry-run"),
     force: boolFlag(flags, "force"),
-    noYolo: boolFlag(flags, "no-yolo") || undefined,
+    noYolo: noYolo || undefined,
+    yolo: yolo || undefined,
   }
 }
 
@@ -170,6 +174,7 @@ const ADOPT_FLAGS = new Set([
   "dry-run",
   "force",
   "no-yolo",
+  "yolo",
 ])
 
 export function parseResolve(args: string[]): string | undefined {


### PR DESCRIPTION
## Problem

`harnessd adopt` is a **cold takeover**: it relaunches an agent session in a directory it did not spawn, and has to decide whether that relaunch gets `--dangerously-skip-permissions`. It follows what it can observe — the live pane's own start command, then what the inventory row recorded — and falls back to the safe mode when it can observe nothing. That default is correct and is unchanged here.

It was **silent**, which is not. On 2026-07-28 a takeover turned bypass off on a live session; the session started asking for permissions mid-task and the cause took a chain of investigation to find, because a safe default was indistinguishable from an observation. That is the same failure class as a check that never ran reading as a clean result (INV-11) — the shape this whole stack exists to remove.

## Solution

Make the fallback say so, and give the operator a way to state the opposite intent instead of having it inferred.

- New exported `resolveAdoptBypass` / `AdoptBypassDecision` replaces the inline expression in `adoptClaudeSessionUnlocked`. **Precedence is unchanged** — `--no-yolo` → `--yolo` → live launch → inventory row → default; only the winning source becomes reportable. The guard stays `noYolo !== undefined` rather than truthiness, so a programmatic `noYolo: false` still outranks an observed live launch: surprising, pre-existing, preserved deliberately.
- `--yolo` on the CLI, refused at parse time alongside `--no-yolo`, recorded by `adoptCommand` so a re-run reproduces the decision rather than re-inferring it.
- Every outcome detail — including both dry-run details, which carried no bypass information at all — reports `bypass enabled|disabled (<source>)`.
- The announcement fires **only immediately before `deps.launch`**. Emitting it at resolution time meant `refused missing transcript`, `refused identity mismatch` and `--dry-run` all printed "starting it WITHOUT `--dangerously-skip-permissions`" for a session that never started — the same unfalsifiable report this change exists to replace.
- **Applied ≠ resolved on the live-pane path.** A live pane is adopted in place, never relaunched, so what applies to it is the mode it is already running under. Reporting the resolution there described a restart that never happened (`adopt … --yolo` against a pane running without bypass printed `bypass enabled (--yolo)` while the process kept prompting), and recording it would have let a later `up` relaunch that session under a flag aimed at a takeover that never occurred. A flag disagreeing with the observation now warns that it does not apply without a restart.
- `adoptCommand` keys off the resolved decision alone — keying `--yolo` off raw `options.yolo` while `--no-yolo` came from the resolution let a caller passing both persist a command containing **both** flags, which `parseAdopt` then refuses to re-run.

Out of scope, deliberately: `up`'s own `recordedNoYolo` use in `commands.ts` is untouched, and nothing here reads or writes identity.

## Files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/adopt.ts` | `resolveAdoptBypass` + `AdoptBypassDecision`; applied-vs-resolved split on the pane path; downgrade warning moved to the launch site; disagreement warning; `adoptCommand` keys off the decision; `AdoptDeps.warn` |
| `extensions/harness-daemon/src/cli.ts` | `--yolo` in `ADOPT_FLAGS`, both-flags refusal in `parseAdopt`, usage string |
| `extensions/harness-daemon/src/adopt.test.ts` | 14 new tests; `warnings` recorder on the existing `AdoptDeps` fixture |

## Test plan

- [x] `bun test` (extensions/harness-daemon) — 206 pass / 0 fail (192 on base)
- [x] `bun run typecheck` — clean
- [x] Pre-commit: monorepo `lint`, `typecheck`, `astro check`, `generate:api-docs:check` — all pass
- [x] Mutation-tested: each new guard neutralised in turn, suite re-run, source restored byte-identical. Inventory-row branch hardcoded → 1 fail; warning moved back above the refusals → 3; pane branch reporting the resolution → 2; `adoptCommand` keyed off raw `options.yolo` → 2
- [ ] No live `adopt` run against the real fleet — this is the permission-mode decision path, and the safe way to exercise it is `--dry-run`, which now prints the decision it would apply

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/harnessd-profiles-9af997/ — chunk 1 of 6. Steps 4–8 of the harnessd identity plan; step 9 (deleting `deriveClaudeRuntimeIdentity`) is out of scope and gated.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909563&installation_model_id=20758&pr_number=1657&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1657&signature=953d7c3e3011b4ef3739c3e45ed7b46e499f05f165a5023c23ec62a57ecc3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->