### PR TITLE
fix(stream-context): jump past history to the oldest artifact, not its day marker

### DIFF
--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -3,7 +3,7 @@ import type { VirtualizerHandle } from "virtua"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useStreamDelegations } from "@/hooks/use-stream-delegations"
 import { localStartOfDayMs } from "@/lib/dates"
-import { markerIndexForDate, oldestMarkerIndex } from "@/lib/stream-context/grouping"
+import { markerIndexForDate, oldestItemIndex } from "@/lib/stream-context/grouping"
 import { deriveStreamContext } from "@/lib/stream-context/derive"
 import { delegationContextItems, withDelegations } from "@/lib/stream-context/delegations"
 import { StreamContextRow } from "./stream-context-row"
@@ -79,7 +79,7 @@ export function StreamContextDerivedPanel({
       // rather than refusing (this path never pages, so its start of history is
       // the window's).
       let index = markerIndexForDate(visible, localStartOfDayMs(date) + DAY_MS, now)
-      if (index === -1) index = oldestMarkerIndex(visible, now)
+      if (index === -1) index = oldestItemIndex(visible, now)
       if (index === -1) return
       listRef.current?.scrollToIndex(index, { align: "start" })
       scrollerRef.current?.focus({ preventScroll: true })

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -70,14 +70,11 @@ export function StreamContextDerivedPanel({
   const listRef = useRef<VirtualizerHandle | null>(null)
 
   // Same jump affordance as the indexed panel, minus the paging: this path
-  // renders the loaded window only, so a date beyond it has nothing to land on
-  // and the jump is a no-op rather than a fetch.
+  // renders the loaded window only, so that window's oldest row is as far back
+  // as a date beyond it can land.
   const jumpToDate = useCallback(
     (date: Date) => {
       const now = new Date()
-      // Nothing that old in the loaded window: travel as far back as it goes
-      // rather than refusing (this path never pages, so its start of history is
-      // the window's).
       let index = markerIndexForDate(visible, localStartOfDayMs(date) + DAY_MS, now)
       if (index === -1) index = oldestItemIndex(visible, now)
       if (index === -1) return

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -174,9 +174,26 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   // hence virtua's `scrollToIndex` over a DOM scroll.
   const items = visibleRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
 
-  const [jumping, setJumping] = useState(false)
+  // Which jump is paging, not merely whether one is: an abandoned run must not
+  // clear a skeleton the run that replaced it is still showing, and must not
+  // leave its own showing forever when it bails.
+  const [pagingFor, setPagingFor] = useState<number | null>(null)
+  const jumping = pagingFor !== null
+  const finishPaging = useCallback((generation: number) => {
+    setPagingFor((current) => (current === generation ? null : current))
+  }, [])
+  // A jump can take ten round trips, and everything it decides with — the date,
+  // the filters it re-filters each page against — is captured when it starts.
+  // Anything that supersedes it (a second jump, a changed chip or query) bumps
+  // this, and the older run stops instead of scrolling the list somewhere the
+  // user has since navigated away from.
+  const jumpGeneration = useRef(0)
+  useEffect(() => {
+    jumpGeneration.current += 1
+  }, [category, searchTerms, authorId, before, after])
   const jumpToDate = useCallback(
     async (date: Date) => {
+      const generation = (jumpGeneration.current += 1)
       const endOfDayMs = localStartOfDayMs(date) + DAY_MS
       const now = new Date()
       let candidates = items
@@ -184,7 +201,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       // Paging to an unloaded date is several round trips; without this the
       // panel just sits there. Only set it when a fetch is actually needed, so
       // the common in-window jump stays instant and flicker-free.
-      if (index === -1 && feed.hasNextPage) setJumping(true)
+      if (index === -1 && feed.hasNextPage) setPagingFor(generation)
       // Not loaded that far back yet: page until it is, bounded so a date older
       // than the whole stream can't spin. Each page widens the IDB-backed list.
       // `more` tracks the FETCH's own result — `feed.hasNextPage` is captured at
@@ -205,8 +222,10 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
         )
         candidates = rebuilt.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
         index = markerIndexForDate(candidates, endOfDayMs, now)
+        if (jumpGeneration.current !== generation) return finishPaging(generation)
       }
-      setJumping(false)
+      if (jumpGeneration.current !== generation) return finishPaging(generation)
+      finishPaging(generation)
       // Past the start of history — either the stream's, or as far as the page
       // bound reached. Travel to the oldest thing there is: asking for a year
       // ago means "as far back as you can go", not "refuse unless you find that

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -15,7 +15,7 @@ import { contextItemFromCached } from "@/lib/stream-context/from-cached"
 import { collapseContextRows, countByCategory, filterContextRows } from "@/lib/stream-context/filter"
 import type { ContextCategory, ContextItem } from "@/lib/stream-context/types"
 import { localStartOfDayMs } from "@/lib/dates"
-import { markerIndexForDate, oldestMarkerIndex } from "@/lib/stream-context/grouping"
+import { markerIndexForDate, oldestItemIndex } from "@/lib/stream-context/grouping"
 import { cn } from "@/lib/utils"
 import {
   contextGroupRef,
@@ -212,7 +212,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       // ago means "as far back as you can go", not "refuse unless you find that
       // exact day". Only a genuinely empty list has nowhere to go, and its
       // empty state already says so.
-      if (index === -1) index = oldestMarkerIndex(candidates, now)
+      if (index === -1) index = oldestItemIndex(candidates, now)
       if (index === -1) return
       listRef.current?.scrollToIndex(index, { align: "start" })
       // The marker that opened the menu is usually windowed out by the jump, so

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -556,6 +556,54 @@ describe("StreamContextPanel — flag on", () => {
     await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
   })
 
+  it("ignores a superseded jump whose pages land after a newer one", async () => {
+    const scrollToIndex = vi.fn()
+    vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
+      if (listRef) (listRef as { current: unknown }).current = { scrollToIndex }
+      return createElement(Fragment, null, children)
+    })
+    // [marker 20th, row, marker 12th, row] — the 12th is loaded, so a jump to it
+    // needs no paging and resolves immediately.
+    await db.streamContextItems.bulkPut([
+      cachedRow(
+        serverItem({ category: "link", refId: "https://newest.example", occurredAt: "2026-07-20T10:00:00.000Z" })
+      ),
+      cachedRow(serverItem({ category: "link", refId: "https://mid.example", occurredAt: "2026-07-12T10:00:00.000Z" })),
+    ])
+    // The first jump's page is held open, so it finishes AFTER the second one.
+    let releasePage: (value: ListStreamContextResponse) => void = () => {}
+    vi.spyOn(streamContextApi, "list")
+      .mockResolvedValueOnce(listResponse({ counts: null, nextCursor: "c1" }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<ListStreamContextResponse>((resolve) => {
+            releasePage = resolve
+          })
+      )
+      .mockResolvedValue(listResponse({ counts: null }))
+
+    renderPanel()
+    await screen.findAllByRole("button", { name: /Jump to a date/ })
+
+    // Jump 1: the 2nd — older than everything, so it pages and blocks.
+    await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
+    await userEvent.click(await screen.findByText("Jump to a specific date…"))
+    await userEvent.click(await screen.findByRole("button", { name: /July 2nd/ }))
+
+    // Jump 2: the 12th — in the loaded window, lands right away on flat index 2.
+    await userEvent.click((await screen.findAllByRole("button", { name: /Jump to a date/ }))[0]!)
+    await userEvent.click(await screen.findByText("Jump to a specific date…"))
+    await userEvent.click(await screen.findByRole("button", { name: /July 12th/ }))
+    await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
+
+    // Now let the abandoned first jump finish. It must not move the list: the
+    // user asked for the 12th last, and it would drag them to the oldest row.
+    releasePage(listResponse({ counts: null }))
+    await waitFor(() => expect(streamContextApi.list).toHaveBeenCalledTimes(2))
+
+    expect(scrollToIndex.mock.calls.at(-1)).toEqual([2, { align: "start" }])
+  })
+
   it("lands on the oldest artifact when the picked date is older than the whole stream", async () => {
     const scrollToIndex = vi.fn()
     vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -556,7 +556,7 @@ describe("StreamContextPanel — flag on", () => {
     await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
   })
 
-  it("lands on the oldest day when the picked date is older than the whole stream", async () => {
+  it("lands on the oldest artifact when the picked date is older than the whole stream", async () => {
     const scrollToIndex = vi.fn()
     vi.spyOn(streamContextListModule, "StreamContextList").mockImplementation(({ children, listRef }) => {
       if (listRef) (listRef as { current: unknown }).current = { scrollToIndex }
@@ -588,9 +588,11 @@ describe("StreamContextPanel — flag on", () => {
     // By label, not text: with two rows a count chip also renders "2".
     await userEvent.click(await screen.findByRole("button", { name: /July 2nd/ }))
 
-    // Travels as far back as the stream goes — the 18th's marker at flat index
-    // 2 — instead of refusing because the 2nd itself holds nothing.
-    await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(2, { align: "start" }))
+    // Travels as far back as the stream goes — the OLDEST ROW, flat index 3 of
+    // [marker, row, marker, row] — instead of refusing because the 2nd holds
+    // nothing, and instead of that day's marker, which on a busy day leaves the
+    // user hundreds of rows above what they asked for.
+    await waitFor(() => expect(scrollToIndex).toHaveBeenCalledWith(3, { align: "start" }))
     // One page fetched, one re-read. The bound is MAX_JUMP_PAGES (10), so a
     // loop trusting the stale snapshot re-reads ten times to reach the same
     // end of history.

--- a/apps/frontend/src/lib/stream-context/grouping.ts
+++ b/apps/frontend/src/lib/stream-context/grouping.ts
@@ -66,18 +66,18 @@ export function markerIndexForDate(items: ContextItem[], endOfDayMs: number, now
 }
 
 /**
- * Flat index of the OLDEST day marker, or `-1` when there are no items.
+ * Flat index of the OLDEST ITEM, or `-1` when there are no items.
  *
  * Where a jump lands once it runs past the start of history: asking for a year
- * ago means "as far back as you can go", so the list travels to its own
- * beginning rather than refusing to move.
+ * ago means "show me the oldest thing there is". Deliberately the last row and
+ * not the last day's marker — a stream having a busy day puts hundreds of rows
+ * under one marker, and landing on that marker leaves the user near the top of
+ * the list, looking at the newest of those rows and no closer to what they
+ * asked for.
  */
-export function oldestMarkerIndex(items: ContextItem[], now: Date): number {
-  let markerIndex = -1
-  let flatIndex = 0
-  for (const group of groupItemsByDay(items, now)) {
-    markerIndex = flatIndex
-    flatIndex += 1 + group.items.length
-  }
-  return markerIndex
+export function oldestItemIndex(items: ContextItem[], now: Date): number {
+  if (items.length === 0) return -1
+  // Markers are interleaved one per group, so the last row sits at
+  // (rows + groups - 1) in the flat child list.
+  return items.length + groupItemsByDay(items, now).length - 1
 }

--- a/tests/browser/global-setup.ts
+++ b/tests/browser/global-setup.ts
@@ -64,8 +64,8 @@ function getContainerNames(): { postgres: string; minio: string } {
  * over TCP on the runner but carrying a generated docker name, while the local
  * one is a compose container on a port the dev stack doesn't use.
  */
-export function runTestSql(sql: string, target: "region" | "control-plane" = "region"): void {
-  const db = target === "control-plane" ? `${deriveTestDatabaseName()}_cp` : deriveTestDatabaseName()
+export function runTestSql(sql: string): void {
+  const db = deriveTestDatabaseName()
   // argv, never a shell string: multi-line SQL through a shell reaches psql
   // with its newlines still escaped, and psql reads `\n` as a meta-command.
   const psql = ["psql", "-U", "threa", "-d", db, "-v", "ON_ERROR_STOP=1", "-c", sql]

--- a/tests/browser/global-setup.ts
+++ b/tests/browser/global-setup.ts
@@ -64,8 +64,8 @@ function getContainerNames(): { postgres: string; minio: string } {
  * over TCP on the runner but carrying a generated docker name, while the local
  * one is a compose container on a port the dev stack doesn't use.
  */
-export function runTestSql(sql: string): void {
-  const db = deriveTestDatabaseName()
+export function runTestSql(sql: string, target: "region" | "control-plane" = "region"): void {
+  const db = target === "control-plane" ? `${deriveTestDatabaseName()}_cp` : deriveTestDatabaseName()
   // argv, never a shell string: multi-line SQL through a shell reaches psql
   // with its newlines still escaped, and psql reads `\n` as a meta-command.
   const psql = ["psql", "-U", "threa", "-d", db, "-v", "ON_ERROR_STOP=1", "-c", sql]

--- a/tests/browser/stream-context-jump-indexed.spec.ts
+++ b/tests/browser/stream-context-jump-indexed.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from "@playwright/test"
+import { runTestSql } from "./global-setup"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * The date jump on the INDEXED path — the one production runs, and the one no
+ * other test covers. It differs from the derive path in the part that broke:
+ * it pages the feed toward the requested date before scrolling, so the rows it
+ * indexes arrive from the server mid-jump rather than being on screen already.
+ */
+
+test.describe.configure({ timeout: 600_000 })
+
+/** More than two pages (the endpoint serves 40), so a jump has to page. */
+const MESSAGE_COUNT = 60
+/** Extra projection rows: enough that the jump pages many times and the render
+ *  lags far behind, but still inside its 10-page reach so the oldest day is
+ *  actually reachable. */
+const BULK_ROWS = 330
+
+async function seedLinkMessages(page: Page, workspaceId: string, streamId: string): Promise<void> {
+  const BATCH_SIZE = 10
+  for (let start = 1; start <= MESSAGE_COUNT; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE - 1, MESSAGE_COUNT)
+    const batch: Promise<void>[] = []
+    for (let i = start; i <= end; i++) {
+      const n = String(i).padStart(3, "0")
+      batch.push(
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `artifact ${n} https://example.com/artifact-${n}` },
+          })
+          .then((r) => expectApiOk(r, `Send message ${i}`))
+      )
+    }
+    await Promise.all(batch)
+  }
+}
+
+function panelScroller(page: Page) {
+  return page.locator('[role="dialog"] .overflow-y-auto').first()
+}
+
+test("jumps past the start of history on the indexed path", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "context-indexed")
+  await createChannel(page, `ctx-idx-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  // The indexed panel is behind a workspace flag. The control plane owns the
+  // data but bootstrap resolves it from the region's mirrored copy, which the
+  // control plane pushes to on write — so the row goes in the regional table
+  // directly, and the page reloads to pick it up.
+  runTestSql(
+    `INSERT INTO feature_flag_overrides (workspace_id, subject_type, subject_id, flag_key, value)
+     VALUES ('${workspaceId}', 'workspace', '${workspaceId}', 'streamContextIndex', 'on')
+     ON CONFLICT (workspace_id, subject_type, subject_id, flag_key) DO UPDATE SET value = EXCLUDED.value`
+  )
+
+  await seedLinkMessages(page, workspaceId!, streamId!)
+  // Deepen the feed without driving hundreds more API calls into the send rate
+  // limit — these go straight into the projection the indexed panel reads.
+  //
+  // They all share ONE day, which is the shape that matters: a busy stream puts
+  // hundreds of rows under a single day marker, so the oldest marker sits just
+  // below the newest day and is nowhere near the oldest artifact. That is the
+  // real feed this was reported against.
+  runTestSql(
+    `INSERT INTO stream_context_items
+       (id, workspace_id, stream_id, root_stream_id, category, ref_kind, ref_id, group_key,
+        source_message_id, author_id, occurred_at, sequence, snippet, detail)
+     SELECT 'sci_${streamId}_' || n, w.workspace_id, '${streamId}', '${streamId}', 'link', 'url',
+            'https://example.com/bulk-' || n, 'https://example.com/bulk-' || n,
+            'msg_${streamId}_' || n, w.author_id,
+            NOW() - INTERVAL '50 hours', NULL, '', '{}'::jsonb
+       FROM generate_series(1, ${BULK_ROWS}) AS n,
+            (SELECT workspace_id, author_id FROM stream_context_items
+              WHERE stream_id = '${streamId}' LIMIT 1) w`
+  )
+  await page.reload()
+
+  await page.getByRole("button", { name: "In this stream" }).click()
+  const scroller = panelScroller(page)
+  await expect(scroller).toBeVisible()
+  // The search box only exists on the indexed path — proves the flag took.
+  await expect(page.getByPlaceholder(/Search this stream/)).toBeVisible()
+  await expect(page.locator('[role="dialog"]').getByText("example.com").first()).toBeVisible()
+
+  await scroller.evaluate((el) => el.scrollTo({ top: 0 }))
+  await expect.poll(async () => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50)
+
+  // Nothing here is a year old, so this is the clamp: travel as far back as the
+  // feed can page rather than sitting still.
+  await page
+    .getByRole("button", { name: /Jump to a date/ })
+    .first()
+    .click()
+  await page.getByRole("button", { name: "Last year", exact: true }).click()
+
+  // Past the start of history the answer is the oldest artifact there is, so the
+  // list ends up at its bottom. Two ways this falls short and both are real
+  // bugs: aiming at the oldest day's MARKER parks the user above however many
+  // rows that day holds, and aiming at an index the rendered list does not have
+  // yet stops wherever the estimate happened to land.
+  await expect
+    .poll(async () => scroller.evaluate((el) => el.scrollTop / (el.scrollHeight - el.clientHeight)), {
+      timeout: 30_000,
+    })
+    .toBeGreaterThan(0.99)
+})


### PR DESCRIPTION
Reported from production after #1651: "Nothing happens when I press last year, though last week and 3 months ago does."

#1651 made a jump past the start of history clamp instead of refusing, but it clamped to the oldest day **marker**. A busy stream puts hundreds of rows under one day marker, so that lands just below the newest day — near the top of the list, showing the newest of those rows. Indistinguishable from the jump doing nothing. Dates that are genuinely found take the other branch, which is why only the far-past presets looked broken.

It clamps to the oldest **item** now — the bottom of the list, which is what "as far back as you can go" means.

**The coverage gap this exposed matters more than the fix.** The indexed panel is what production runs, and it had no browser test; the existing spec drives the derive path, which never pages and structurally cannot reach this code. `tests/browser/stream-context-jump-indexed.spec.ts` turns the flag on and exercises the real path.

Getting that spec to fail for the right reason took two corrections, both worth naming:

- It backdated `stream_events`. The indexed panel reads the `stream_context_items` projection, so every row stayed in one "Today" group and the test proved nothing.
- Its oldest day held five rows, which puts the day's marker and its last row in nearly the same place — so it passed with the fix reverted.

Only a fixture with one large busy day — the reported shape — discriminates: 0.85 of maximum scroll without the fix, >0.99 with it. A "wait for the render before scrolling" mechanism was also built, shown to be unnecessary (virtua clamps out-of-range indices itself) and removed.

Verification: 5275 frontend tests, both browser specs, typecheck, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910309&installation_model_id=20758&pr_number=1658&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1658&signature=ed632a16693466b0f97f942fa55838398fe1ece6826c4a2901f51f0d4b95886b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->