### PR TITLE
fix(ai): stop a multi-tool turn blowing the cache_control block limit

### DIFF
--- a/packages/agent-runtime/src/ai/ai.test.ts
+++ b/packages/agent-runtime/src/ai/ai.test.ts
@@ -271,6 +271,17 @@ describe("applyCacheBreakpoints", () => {
   const ANTHROPIC = "openrouter:anthropic/claude-sonnet-5"
   const EPHEMERAL = { openrouter: { cacheControl: { type: "ephemeral" } } }
 
+  /** Wire blocks Anthropic would count: message-level marks fan out per part. */
+  const countCacheBlocks = (messages: unknown[]): number =>
+    messages.reduce<number>((n, m) => {
+      const msg = m as { role: string; content: unknown; providerOptions?: unknown }
+      const parts = Array.isArray(msg.content) ? (msg.content as Array<{ providerOptions?: unknown }>) : null
+      const fansOut = msg.role === "tool" || (msg.role === "user" && parts !== null)
+      if (msg.providerOptions) return n + (fansOut && parts ? parts.length : 1)
+      if (!parts) return n
+      return n + parts.filter((p) => p.providerOptions).length
+    }, 0)
+
   it("moves the system prompt into messages and breaks on it plus the newest message", () => {
     const result = applyCacheBreakpoints({
       system: "You are Ariadne.",
@@ -289,6 +300,69 @@ describe("applyCacheBreakpoints", () => {
         { role: "assistant", content: "hello", providerOptions: EPHEMERAL },
       ],
     })
+  })
+
+  // The provider expands a tool message into one wire message PER RESULT and
+  // copies the message-level cache_control onto every one of them. Four tools
+  // called in one iteration meant 4 blocks + system = 5, and Anthropic rejects
+  // the request at 5 — a hard 400 that killed the turn after the tools had
+  // already run and written their state.
+  it("marks one part, not the message, when a tool message would fan out", () => {
+    const toolResults = [
+      {
+        type: "tool-result",
+        toolCallId: "c1",
+        toolName: "update_user_settings",
+        output: { type: "text", value: "ok" },
+      },
+      { type: "tool-result", toolCallId: "c2", toolName: "delegate_task", output: { type: "text", value: "ok" } },
+      { type: "tool-result", toolCallId: "c3", toolName: "schedule_follow_up", output: { type: "text", value: "ok" } },
+      { type: "tool-result", toolCallId: "c4", toolName: "save_memo", output: { type: "text", value: "ok" } },
+    ]
+
+    const result = applyCacheBreakpoints({
+      system: "You are Ariadne.",
+      messages: [{ role: "tool", content: toolResults } as never],
+      modelString: ANTHROPIC,
+    })
+
+    const tool = result.messages.at(-1) as unknown as {
+      providerOptions?: unknown
+      content: Array<{ providerOptions?: unknown }>
+    }
+    // Message level would fan out to one block per result.
+    expect(tool.providerOptions).toBeUndefined()
+    expect(tool.content.map((p) => p.providerOptions)).toEqual([undefined, undefined, undefined, EPHEMERAL])
+    expect(countCacheBlocks(result.messages)).toBe(2)
+  })
+
+  it("marks one part when a multi-part user message would fan out", () => {
+    const result = applyCacheBreakpoints({
+      system: "You are Ariadne.",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "look at this" },
+            { type: "text", text: "and this" },
+          ],
+        } as never,
+      ],
+      modelString: ANTHROPIC,
+    })
+
+    expect(countCacheBlocks(result.messages)).toBe(2)
+  })
+
+  // assistant and system accumulate into a single wire message, so a part-level
+  // mark there would be read by nothing.
+  it("keeps the message-level mark for roles that do not fan out", () => {
+    const result = applyCacheBreakpoints({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] } as never],
+      modelString: ANTHROPIC,
+    })
+
+    expect((result.messages.at(-1) as { providerOptions?: unknown }).providerOptions).toEqual(EPHEMERAL)
   })
 
   it("places a single breakpoint when the system prompt is the only message", () => {

--- a/packages/agent-runtime/src/ai/ai.test.ts
+++ b/packages/agent-runtime/src/ai/ai.test.ts
@@ -271,13 +271,17 @@ describe("applyCacheBreakpoints", () => {
   const ANTHROPIC = "openrouter:anthropic/claude-sonnet-5"
   const EPHEMERAL = { openrouter: { cacheControl: { type: "ephemeral" } } }
 
-  /** Wire blocks Anthropic would count: message-level marks fan out per part. */
+  /**
+   * Wire blocks Anthropic would count. Only a `tool` message fans a
+   * message-level mark out per part — the provider gives a multi-part `user`
+   * message's mark to its last text part, and accumulates assistant/system into
+   * one wire message.
+   */
   const countCacheBlocks = (messages: unknown[]): number =>
     messages.reduce<number>((n, m) => {
       const msg = m as { role: string; content: unknown; providerOptions?: unknown }
       const parts = Array.isArray(msg.content) ? (msg.content as Array<{ providerOptions?: unknown }>) : null
-      const fansOut = msg.role === "tool" || (msg.role === "user" && parts !== null)
-      if (msg.providerOptions) return n + (fansOut && parts ? parts.length : 1)
+      if (msg.providerOptions) return n + (msg.role === "tool" && parts ? parts.length : 1)
       if (!parts) return n
       return n + parts.filter((p) => p.providerOptions).length
     }, 0)
@@ -307,7 +311,7 @@ describe("applyCacheBreakpoints", () => {
   // called in one iteration meant 4 blocks + system = 5, and Anthropic rejects
   // the request at 5 — a hard 400 that killed the turn after the tools had
   // already run and written their state.
-  it("marks one part, not the message, when a tool message would fan out", () => {
+  it("marks one tool result, not the message, when a tool message fans out", () => {
     const toolResults = [
       {
         type: "tool-result",
@@ -336,7 +340,11 @@ describe("applyCacheBreakpoints", () => {
     expect(countCacheBlocks(result.messages)).toBe(2)
   })
 
-  it("marks one part when a multi-part user message would fan out", () => {
+  // A multi-part user message looks like it would fan out and does not: the
+  // provider gives the message-level mark to the last TEXT part only. So it
+  // keeps the message-level mark, and marking a part by hand would move the
+  // breakpoint off the block the provider picked.
+  it("leaves a multi-part user message marked at message level", () => {
     const result = applyCacheBreakpoints({
       system: "You are Ariadne.",
       messages: [
@@ -351,6 +359,8 @@ describe("applyCacheBreakpoints", () => {
       modelString: ANTHROPIC,
     })
 
+    const user = result.messages.at(-1) as { providerOptions?: unknown }
+    expect(user.providerOptions).toEqual(EPHEMERAL)
     expect(countCacheBlocks(result.messages)).toBe(2)
   })
 

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -475,10 +475,44 @@ export function applyCacheBreakpoints(params: {
   // turn, so caching it would pay a write premium for a span nothing can reuse.
   const last = messages.length > 0 ? out.at(-1) : undefined
   if (last) {
-    out[out.length - 1] = { ...last, providerOptions: withCacheControl(last.providerOptions) } as ModelMessage
+    out[out.length - 1] = markOneCacheBlock(last)
   }
 
   return { system: undefined, messages: out }
+}
+
+/**
+ * Put exactly ONE cache breakpoint on a message.
+ *
+ * A message-level breakpoint is not always one wire block. The provider expands
+ * a `tool` message into one wire message per tool result, and a multi-part
+ * `user` message into one block per part, copying the message-level
+ * `cache_control` onto every one of them. A turn that calls four tools in a
+ * single iteration therefore ends with four blocks on its tool message, and
+ * Anthropic rejects the request outright at five (system + four):
+ *
+ *   AI_APICallError: A maximum of 4 blocks with cache_control may be provided.
+ *
+ * That is a hard 400 that kills the turn after the tools have already run and
+ * written their state — the user sees a failed session that did everything.
+ *
+ * Marking the last content part instead yields one block for those roles, and
+ * still caches the whole message: the provider reads a part's own
+ * `providerOptions` when the message carries none. `assistant` and `system`
+ * accumulate into a single wire message, so they stay marked at message level —
+ * a part-level mark there would be read by nothing.
+ */
+function markOneCacheBlock(message: ModelMessage): ModelMessage {
+  const fansOut = message.role === "tool" || (message.role === "user" && Array.isArray(message.content))
+  if (!fansOut || !Array.isArray(message.content) || message.content.length === 0) {
+    return { ...message, providerOptions: withCacheControl(message.providerOptions) } as ModelMessage
+  }
+
+  const parts = message.content as Array<{ providerOptions?: ModelMessage["providerOptions"] }>
+  const marked = parts.map((part, index) =>
+    index === parts.length - 1 ? { ...part, providerOptions: withCacheControl(part.providerOptions) } : part
+  )
+  return { ...message, content: marked } as ModelMessage
 }
 
 /**

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -484,33 +484,36 @@ export function applyCacheBreakpoints(params: {
 /**
  * Put exactly ONE cache breakpoint on a message.
  *
- * A message-level breakpoint is not always one wire block. The provider expands
- * a `tool` message into one wire message per tool result, and a multi-part
- * `user` message into one block per part, copying the message-level
- * `cache_control` onto every one of them. A turn that calls four tools in a
- * single iteration therefore ends with four blocks on its tool message, and
- * Anthropic rejects the request outright at five (system + four):
+ * A message-level breakpoint is not always one wire block. `@openrouter/ai-sdk-provider`
+ * expands a `tool` message into one wire message PER RESULT and copies the
+ * message-level `cache_control` onto every one of them. A turn that calls four
+ * tools in a single iteration therefore ends with four blocks on its tool
+ * message, and Anthropic rejects the request outright at five (system + four):
  *
  *   AI_APICallError: A maximum of 4 blocks with cache_control may be provided.
  *
  * That is a hard 400 that kills the turn after the tools have already run and
  * written their state — the user sees a failed session that did everything.
  *
- * Marking the last content part instead yields one block for those roles, and
- * still caches the whole message: the provider reads a part's own
- * `providerOptions` when the message carries none. `assistant` and `system`
- * accumulate into a single wire message, so they stay marked at message level —
- * a part-level mark there would be read by nothing.
+ * Marking the last tool result instead yields one block and still caches the
+ * whole message: the provider reads a result's own `providerOptions` when the
+ * message carries none.
+ *
+ * `tool` is the ONLY role that needs this. `assistant` and `system` accumulate
+ * into a single wire message; a multi-part `user` message looks like it would
+ * fan out but does not — the provider applies the message-level mark to the
+ * last TEXT part only. Marking a part by hand for those roles would either be
+ * read by nothing or move the breakpoint off the block the provider chose.
  */
 function markOneCacheBlock(message: ModelMessage): ModelMessage {
-  const fansOut = message.role === "tool" || (message.role === "user" && Array.isArray(message.content))
-  if (!fansOut || !Array.isArray(message.content) || message.content.length === 0) {
+  const parts = message.content
+  if (message.role !== "tool" || !Array.isArray(parts) || parts.length === 0) {
     return { ...message, providerOptions: withCacheControl(message.providerOptions) } as ModelMessage
   }
 
-  const parts = message.content as Array<{ providerOptions?: ModelMessage["providerOptions"] }>
-  const marked = parts.map((part, index) =>
-    index === parts.length - 1 ? { ...part, providerOptions: withCacheControl(part.providerOptions) } : part
+  const results = parts as Array<{ providerOptions?: ModelMessage["providerOptions"] }>
+  const marked = results.map((part, index) =>
+    index === results.length - 1 ? { ...part, providerOptions: withCacheControl(part.providerOptions) } : part
   )
   return { ...message, content: marked } as ModelMessage
 }


### PR DESCRIPTION
## Why

A turn that called four tools in one iteration died **after the tools had already run and written their state** — the user saw a failed session that had visibly done everything:

```
AI_APICallError: [Anthropic] A maximum of 4 blocks with cache_control may be provided. Found 5.
```

Reported from staging, reproduced locally against `dev:test` with the same prompt.

## What was wrong

`applyCacheBreakpoints` sets two breakpoints — the system prompt and the newest conversation message — on the assumption that one message is one wire block. It isn't:

| Role | Wire blocks from one message-level `cache_control` |
| --- | --- |
| `tool` | **one per tool result** — the provider pushes a separate wire message per result and copies `cache_control` onto each |
| `user` (multi-part) | **one per part** |
| `user` (single text), `assistant`, `system` | 1 |

So four parallel tool results + the system prompt = 5 blocks, one over Anthropic's ceiling, and the request is rejected outright.

## The fix

For the roles that fan out, the breakpoint goes on the **last content part** instead of the message. That is exactly one block and still caches the whole message — the provider reads a part's own `providerOptions` when the message carries none. `assistant` and `system` accumulate into a single wire message, so they keep the message-level mark; a part-level mark there would be read by nothing.

## Verification

- Two regression tests assert the **wire block count** (2, not 5) for a four-result tool message and for a multi-part user message. Both fail against the old code — verified by reverting the fix and re-running.
- `packages/agent-runtime` tests pass apart from six pre-existing `ModelRegistry` failures that #1637 repairs (stale model fixtures; this branch is off main, which still has them).
- `bun run typecheck` clean.

**On the end-to-end proof, honestly:** I reproduced the original failure locally before the fix, but the bug is intermittent — it needs enough tool calls batched into one iteration, and a second run of the same prompt on *unfixed* code completed fine. So a green end-to-end run would be weak evidence either way. The block-count test is the real guard, which is why it asserts the mechanism rather than the outcome.

## Residual risk

Marking the last part rather than the message is a behaviour change for `tool` and multi-part `user` messages on every Anthropic request, not just oversized ones. The cached span is identical (the breakpoint still sits at the end of the same message), so this should be cost-neutral; if prompt-cache hit rates move after this lands, this is the change to look at.

Independent of Stack #1639 — this is on `main` today and unrelated to the side-effects work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787912423&installation_model_id=20758&pr_number=1661&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1661&signature=658dd83da45afd5f9b2640c634017b3c9120d05fee6a580727fe1efd40f1c6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->