### PR TITLE
refactor(harnessd): resolve identity in one place instead of five

### DIFF
--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -95,6 +95,7 @@ function deps(overrides: Partial<AdoptDeps> = {}): AdoptDeps & Recorded {
     inventory: () => [],
     panes: () => [],
     links: () => [link()],
+    identities: () => [],
     disk: disk(),
     isDirectory: () => true,
     scratchpadStatus: async () => "active",

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -280,7 +280,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // target NOTHING on this machine binds to this directory.
   const derived = resolveRuntimeIdentity(cwd, {}, config)
   const launch = pane ? parseClaudeChannelLaunch(pane.startCommand) : undefined
-  const minted = identityRecordsFor(cwd, identities, deps.disk.canonical).filter(
+  const minted = identityRecordsFor(cwd, identities, (path) => canonicalOrRaw(path, deps.disk.canonical)).filter(
     (record) => record.runtimeSessionId === options.runtimeSessionId
   )
   const attestations: Array<{ source: string; instanceId?: string }> = []

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -17,8 +17,10 @@ import {
   findLocalClaudeChannelPane,
   listLocalTmuxPanes,
   parseClaudeChannelLaunch,
+  resolveRuntimeIdentity,
   type LocalTmuxPane,
 } from "./discovery"
+import { identityRecordsFor, readMintedIdentities, type MintedIdentity } from "./identity-store"
 import { inventoryPath, readInventoryReadonly, upsertAgent } from "./inventory"
 import { acquireProcessLock, resumeActiveLockPath } from "./lock"
 import {
@@ -34,7 +36,6 @@ import {
   claudeLaunchArgs,
   claudeLaunchCommand,
   configuredThreaBaseUrl,
-  deriveClaudeRuntimeIdentity,
   mcpConfigPath,
   normalizeChannelMcpConfig,
   prepareClaudeChannel,
@@ -110,6 +111,7 @@ export interface AdoptDeps {
   inventory: () => ManagedAgent[]
   panes: () => LocalTmuxPane[]
   links: () => HarnessLink[]
+  identities: () => MintedIdentity[]
   disk: ClaudeDiskDeps
   isDirectory: (path: string) => boolean
   scratchpadStatus: (params: {
@@ -140,6 +142,7 @@ export function defaultAdoptDeps(): AdoptDeps {
     inventory: readInventoryReadonly,
     panes: listLocalTmuxPanes,
     links: readHarnessLinks,
+    identities: readMintedIdentities,
     disk: defaultClaudeDiskDeps(),
     isDirectory: (path) => {
       try {
@@ -207,6 +210,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // between two reads would attest a pane whose kind and root the guard never
   // checked.
   const links = deps.links()
+  const identities = deps.identities()
   const link = links.find((candidate) => candidate.runtimeSessionId === options.runtimeSessionId)
   if (link && link.runtimeKind !== "claude-code-channel" && link.runtimeKind !== "unknown") {
     return { status: "refused identity mismatch", detail: `harness link records runtime kind ${link.runtimeKind}` }
@@ -220,7 +224,14 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
 
   let pane: LocalTmuxPane | undefined
   try {
-    pane = findLocalClaudeChannelPane(options.runtimeSessionId, deps.panes(), config, hostname(), () => links)
+    pane = findLocalClaudeChannelPane(
+      options.runtimeSessionId,
+      deps.panes(),
+      config,
+      hostname(),
+      () => links,
+      () => identities
+    )
   } catch (error) {
     return { status: "refused ambiguous", detail: error instanceof Error ? error.message : String(error) }
   }
@@ -267,9 +278,13 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // different hostname keeps its original id for life, and the link record the
   // runtime wrote is the stronger evidence in that case. What is refused is a
   // target NOTHING on this machine binds to this directory.
-  const derived = deriveClaudeRuntimeIdentity(cwd, config)
+  const derived = resolveRuntimeIdentity(cwd, {}, config)
   const launch = pane ? parseClaudeChannelLaunch(pane.startCommand) : undefined
+  const minted = identityRecordsFor(cwd, identities, deps.disk.canonical).filter(
+    (record) => record.runtimeSessionId === options.runtimeSessionId
+  )
   const attestations: Array<{ source: string; instanceId?: string }> = []
+  if (minted.length === 1) attestations.push({ source: "identity record", instanceId: minted[0]!.instanceId })
   if (link) attestations.push({ source: "harness link", instanceId: link.instanceId || undefined })
   if (existing) attestations.push({ source: "inventory", instanceId: existing.instanceId })
   if (launch?.runtimeSessionId === options.runtimeSessionId) {
@@ -281,7 +296,7 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   if (attestations.length === 0) {
     return {
       status: "refused identity mismatch",
-      detail: `nothing binds ${options.runtimeSessionId} to ${cwd}: no harness link, no inventory row, no live launch, and the directory derives ${derived.runtimeSessionId}`,
+      detail: `nothing binds ${options.runtimeSessionId} to ${cwd}: no identity record, no harness link, no inventory row, no live launch, and the directory derives ${derived.runtimeSessionId}`,
     }
   }
   const claimed = attestations.filter((attestation): attestation is { source: string; instanceId: string } =>

--- a/extensions/harness-daemon/src/claude-reconnect.test.ts
+++ b/extensions/harness-daemon/src/claude-reconnect.test.ts
@@ -392,6 +392,33 @@ describe("reconnectClaude", () => {
     expect(d.calls[0]?.[2]).toContain(`'THREA_INSTANCE_ID=${identity.instanceId}'`)
   })
 
+  test("reconnect accepts a pane whose identity only the mint record attests", async () => {
+    // No THREA_ env, no link record: without the minted rung the pane derives a
+    // different id under this hostname and reconnect rejects its own session.
+    const launch = "claude --name threa.feature --dangerously-load-development-channels server:threa-channel"
+    const d = deps({
+      inventory: () => [agent({ instanceId: "cc-minted", runtimeSessionId: "ccs-minted" })],
+      identities: () => [
+        {
+          runtimeSessionId: "ccs-minted",
+          instanceId: "cc-minted",
+          worktree: CWD,
+          runtimeKind: "claude-code-channel",
+          mintedAt: "2026-07-29T00:00:00.000Z",
+          source: "mint",
+        },
+      ],
+      panes: (() => {
+        let reads = 0
+        return () => (++reads < 3 ? [pane({ startCommand: launch })] : [pane({ panePid: 5678 })])
+      })(),
+    })
+
+    await reconnectClaude({ runtimeSessionId: "ccs-minted", rootStreamId: "stream_one" }, d)
+
+    expect(d.calls[0]?.[2]).toContain("'THREA_INSTANCE_ID=cc-minted' 'THREA_RUNTIME_SESSION_ID=ccs-minted'")
+  })
+
   test("standalone dispatch rejects cross-runtime identity collisions", async () => {
     const claude = pane({
       startCommand: COMMAND.replaceAll(RUNTIME, NATIVE),

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -16,6 +16,7 @@ import {
   resolveManagedAgentPane,
   type LocalTmuxPane,
   type ManagedAgentPane,
+  type ResolvedRuntimeIdentity,
 } from "./discovery"
 import { die } from "./errors"
 import { identityConsistency, identityVerdict } from "./identity"
@@ -33,8 +34,9 @@ import {
   ClaudeRuntimeSpawner,
   PiRuntimeSpawner,
   RuntimeSpawnError,
-  deriveClaudeRuntimeIdentity,
+  claudeAgentIdentity,
   configuredThreaBaseUrl,
+  deriveClaudeRuntimeIdentity,
   readPiRemoteConfig,
   readPiRemoteSession,
   readThreaChannelConfig,
@@ -311,6 +313,8 @@ export interface ReviveDeps {
   restoreWorktree: (agent: ManagedAgent) => { restored: boolean; reason?: string }
   restorableWorktree: (agent: ManagedAgent) => { repo: string } | { reason: string }
   piLink: (runtimeSessionId: string) => PiRemoteSession | undefined
+  /** The one identity resolver, injected so a revival decision is testable without the local stores. */
+  claudeIdentity: (agent: ManagedAgent, config: ThreaChannelConfig) => ResolvedRuntimeIdentity
   resumeRuntime: (agent: ManagedAgent, options: ResumeOptions) => Promise<SpawnResult>
   persist: (agent: ManagedAgent) => void
   killWindow: (windowId: string) => void
@@ -328,6 +332,7 @@ export function defaultReviveDeps(): ReviveDeps {
     restoreWorktree: restoreManagedWorktree,
     restorableWorktree: restorableWorktreeSource,
     piLink: readPiRemoteSession,
+    claudeIdentity: claudeAgentIdentity,
     resumeRuntime: (agent, options) =>
       (agent.runtime === "pi" ? new PiRuntimeSpawner() : new ClaudeRuntimeSpawner()).resume(agent, options),
     persist: upsertAgent,
@@ -359,11 +364,16 @@ export async function reviveAgent(
   // would bury the line this exists to surface.
   if (!target || scratchpad?.streamId === target.rootStreamId) {
     const recorded = agent.runtimeSessionId ?? "-"
-    const derived =
-      agent.runtime === "claude" && agent.worktree
-        ? deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig).runtimeSessionId
-        : "-"
-    console.log(`resolve\t${agent.name}\t${identityVerdict(paneStatus, recorded, derived)}\t${recorded}\t${derived}`)
+    const claude = agent.runtime === "claude" && Boolean(agent.worktree)
+    const identity = claude ? deps.claudeIdentity(agent, deps.claudeConfig) : undefined
+    // `drifted` is measured against the DERIVATION, not the resolution. Scoring
+    // it against the resolved id makes it structurally unreachable — the
+    // inventory rung returns the recorded id, so the two always agree — and
+    // this is the line that surfaced the 2026-07-28 duplicate-session storm.
+    const derived = claude ? deriveClaudeRuntimeIdentity(agent.worktree!, deps.claudeConfig).runtimeSessionId : "-"
+    console.log(
+      `resolve\t${agent.name}\t${identityVerdict(paneStatus, recorded, derived)}\t${recorded}\t${derived}\t${identity?.runtimeSessionId ?? "-"}\t${identity?.source ?? "-"}`
+    )
   }
   // Ambiguity counts as alive: the next move is spawning a replacement, and a
   // duplicate agent is worse than a missed revival.
@@ -378,9 +388,9 @@ export async function reviveAgent(
     if (agent.runtime === "pi" && targetRuntimeSessionId) {
       targetInstanceId ??= deps.piLink(targetRuntimeSessionId)?.instanceId
     } else if (agent.runtime === "claude" && !targetInstanceId && !targetRuntimeSessionId && agent.worktree) {
-      const derived = deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
-      targetInstanceId = derived.instanceId
-      targetRuntimeSessionId = derived.runtimeSessionId
+      const identity = deps.claudeIdentity(agent, deps.claudeConfig)
+      targetInstanceId = identity.instanceId
+      targetRuntimeSessionId = identity.runtimeSessionId
     }
     if (
       !restoredSessionMatches(
@@ -499,9 +509,9 @@ export async function reviveAgent(
     instanceId = piLink!.instanceId
     runtimeSessionId = agent.runtimeSessionId!
   } else {
-    const derived = deriveClaudeRuntimeIdentity(agent.worktree, deps.claudeConfig)
-    instanceId = agent.instanceId ?? derived.instanceId
-    runtimeSessionId = agent.runtimeSessionId ?? derived.runtimeSessionId
+    const identity = deps.claudeIdentity(agent, deps.claudeConfig)
+    instanceId = identity.instanceId
+    runtimeSessionId = identity.runtimeSessionId
   }
 
   const configuredDisplayName =
@@ -769,6 +779,9 @@ export function doctor(): void {
     ["identity drift (link records)", drift.linkRecords],
     ["identity drift (live panes)", panes ? drift.livePanes : undefined],
   ]
+  console.log(
+    `${drift.identityless === 0 ? "ok" : "drift"}\tidentity (rows with no recorded identity)\t${drift.identityless} resolve only by deriving from the hostname`
+  )
   for (const [name, count] of driftChecks) {
     if (count === undefined) {
       console.log(`unknown\t${name}\tcould not inspect local tmux panes: ${paneError}`)

--- a/extensions/harness-daemon/src/discovery.test.ts
+++ b/extensions/harness-daemon/src/discovery.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { HarnessLink } from "@threa/bot-runtime-client"
+import type { MintedIdentity } from "./identity-store"
 import { deriveClaudeRuntimeIdentity } from "./spawners"
 import {
   findLocalClaudeChannelPane,
@@ -41,6 +42,18 @@ function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
 }
 
 const noLinks = () => []
+
+function identity(overrides: Partial<MintedIdentity> = {}): MintedIdentity {
+  return {
+    runtimeSessionId: "ccs-minted",
+    instanceId: "cc-minted",
+    worktree: "/Users/me/dev/threa.feature",
+    runtimeKind: "claude-code-channel",
+    mintedAt: "2026-07-29T00:00:00.000Z",
+    source: "mint",
+    ...overrides,
+  }
+}
 
 describe("parseTmuxPanes", () => {
   test("keeps live panes and their start command", () => {
@@ -273,6 +286,21 @@ describe("findLocalClaudeChannelPane ledger attestation", () => {
     expect(findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", links)).toBeUndefined()
     expect(findLocalClaudeChannelPane("ccs-rival", [candidate], {}, "host-a", links)).toBeUndefined()
     expect(findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", links)).toEqual(candidate)
+  })
+
+  test("a pane launched without THREA_ environment resolves to its minted identity", () => {
+    // The minted record is what the hostname derivation cannot reproduce, and
+    // it outranks the ledger for the same directory.
+    const candidate = pane()
+    const identities = () => [identity()]
+
+    expect(findLocalClaudeChannelPane("ccs-minted", [candidate], {}, "host-a", noLinks, identities)).toEqual(candidate)
+    expect(
+      findLocalClaudeChannelPane("ccs-real", [candidate], {}, "host-a", () => [link()], identities)
+    ).toBeUndefined()
+    expect(
+      findLocalClaudeChannelPane("ccs-4dca54f22ee90414", [candidate], {}, "host-a", noLinks, identities)
+    ).toBeUndefined()
   })
 
   test("a pi-local record never identifies a Claude pane", () => {

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -2,6 +2,7 @@ import { basename } from "node:path"
 import { hostname } from "node:os"
 import { realpathSync } from "node:fs"
 import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
+import { identityRecordsFor, readMintedIdentities, type MintedIdentity } from "./identity-store"
 import { output } from "./shell"
 import { deriveClaudeRuntimeIdentity, readThreaChannelConfig, sanitizeId } from "./spawners"
 import type { ManagedAgent, ThreaChannelConfig } from "./types"
@@ -400,14 +401,16 @@ export function resolveManagedAgentPane(
   panes: LocalTmuxPane[] = listLocalTmuxPanes(),
   config: ThreaChannelConfig = readThreaChannelConfig(),
   host = hostname(),
-  links: () => HarnessLink[] = readHarnessLinks
+  links: () => HarnessLink[] = readHarnessLinks,
+  identities: () => MintedIdentity[] = readMintedIdentities,
+  canonical: (path: string) => string = canonicalOrRaw
 ): ManagedAgentPane {
   if (agent.runtimeSessionId) {
     try {
       const pane =
         agent.runtime === "pi"
           ? findLocalPiPane(agent.runtimeSessionId, panes)
-          : findLocalClaudeChannelPane(agent.runtimeSessionId, panes, config, host, links)
+          : findLocalClaudeChannelPane(agent.runtimeSessionId, panes, config, host, links, identities, canonical)
       return pane ? { status: "found", pane } : { status: "missing" }
     } catch (error) {
       return { status: "ambiguous", reason: error instanceof Error ? error.message : String(error) }
@@ -428,7 +431,8 @@ export function resolveManagedAgentPane(
         }
       : { status: "missing" }
   }
-  const inWorktree = panes.filter((pane) => pane.cwd === agent.worktree)
+  const canonicalWorktree = canonical(agent.worktree)
+  const inWorktree = panes.filter((pane) => canonical(pane.cwd) === canonicalWorktree)
   if (inWorktree.length === 1) return { status: "found", pane: inWorktree[0]! }
   if (inWorktree.length === 0) return { status: "missing" }
   const recorded = inWorktree.find(
@@ -459,11 +463,14 @@ export interface AttestedRuntime {
 }
 
 /** Canonicalized once per resolution: a per-pane realpath is panes × records syscalls. */
-export function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
+export function attestedRuntimes(
+  links: HarnessLink[],
+  canonical: (path: string) => string = canonicalOrRaw
+): AttestedRuntime[] {
   return links
     .filter((link) => link.runtimeKind === "claude-code-channel" || link.runtimeKind === "unknown")
     .map((link) => ({
-      worktree: canonicalOrRaw(link.worktree),
+      worktree: canonical(link.worktree),
       runtimeSessionId: link.runtimeSessionId,
       instanceId: link.instanceId,
     }))
@@ -475,8 +482,12 @@ export function attestedRuntimes(links: HarnessLink[]): AttestedRuntime[] {
  * Two or more records naming one worktree is a broken ledger, not a tie to
  * break: guessing here binds a live pane to a stranger's session.
  */
-export function ledgerIdentity(cwd: string, attested: AttestedRuntime[]): AttestedRuntime | undefined {
-  const canonicalCwd = canonicalOrRaw(cwd)
+export function ledgerIdentity(
+  cwd: string,
+  attested: AttestedRuntime[],
+  canonical: (path: string) => string = canonicalOrRaw
+): AttestedRuntime | undefined {
+  const canonicalCwd = canonical(cwd)
   const matches = attested.filter((entry) => entry.worktree === canonicalCwd)
   return matches.length === 1 ? matches[0] : undefined
 }
@@ -485,25 +496,152 @@ export function ledgerRuntimeSessionId(cwd: string, attested: AttestedRuntime[])
   return ledgerIdentity(cwd, attested)?.runtimeSessionId
 }
 
+export type IdentitySource = "declared" | "minted" | "ledger" | "inventory" | "derived"
+
+export interface ResolvedRuntimeIdentity {
+  instanceId: string
+  runtimeSessionId: string
+  /** The rung the runtime session id came from. */
+  source: IdentitySource
+}
+
 /**
- * Identity by attestation before derivation: `deriveClaudeRuntimeIdentity`
- * hashes `os.hostname()`, which is DHCP-supplied on a laptop and changes with
- * the network, so a pane launched without `THREA_RUNTIME_SESSION_ID` derives a
- * different id than the one recorded for it and `up` starts a duplicate.
+ * What each rung of the resolver knows. An absent field is an absent rung, not
+ * an empty answer: `identities: []` means "the store was read and holds
+ * nothing", `identities: undefined` means "not consulted".
  */
+export interface IdentityEvidence {
+  /** The launch environment of the process itself. */
+  declared?: { instanceId?: string; runtimeSessionId?: string }
+  identities?: MintedIdentity[]
+  attested?: AttestedRuntime[]
+  /** The inventory row, immutable per launch and therefore stale by construction. */
+  inventory?: { instanceId?: string; runtimeSessionId?: string }
+  canonical?: (path: string) => string
+}
+
+function soleMintedIdentity(
+  cwd: string,
+  identities: MintedIdentity[],
+  canonical: (path: string) => string
+): MintedIdentity | undefined {
+  const records = identityRecordsFor(cwd, identities, canonical)
+  return records.length === 1 ? records[0] : undefined
+}
+
+function normalizedId(value: string): string {
+  return sanitizeId(value).slice(0, 64)
+}
+
+/**
+ * The one answer to "what identity does this directory have".
+ *
+ * Order: what the process itself declares, then the minted record, then the
+ * ledger's attestation, then the inventory row, and only then the derivation —
+ * which hashes `os.hostname()` and so changes with the wifi network, making a
+ * session unrecognisable to its own harness. Two records naming one worktree
+ * fall through rather than pick a winner: guessing binds a live pane to a
+ * stranger's session.
+ *
+ * This never answers "may a new process start here". Occupancy is the mint's
+ * veto and belongs to the write side; a read path that could refuse would make
+ * every lookup a policy decision.
+ */
+export function resolveRuntimeIdentity(
+  cwd: string,
+  evidence: IdentityEvidence = {},
+  config: ThreaChannelConfig = {},
+  host = hostname()
+): ResolvedRuntimeIdentity {
+  const canonical = evidence.canonical ?? canonicalOrRaw
+  const minted = evidence.identities && soleMintedIdentity(cwd, evidence.identities, canonical)
+  const ledger = evidence.attested && ledgerIdentity(cwd, evidence.attested, canonical)
+  // Only text this daemon did not write is normalized. A recorded id IS the
+  // primary key of a file in the link or identity store, and those stores allow
+  // characters `sanitizeId` rewrites (dots) with no length cap — normalizing one
+  // on the way out maps two distinct sessions onto one id, the exact failure
+  // `isSafeSessionFileName` refuses by design.
+  const rungs: Array<[IdentitySource, { instanceId?: string; runtimeSessionId?: string }, boolean]> = [
+    ["declared", evidence.declared ?? {}, true],
+    ["minted", minted ?? {}, false],
+    ["ledger", ledger ?? {}, false],
+    ["inventory", evidence.inventory ?? {}, false],
+    ["derived", deriveClaudeRuntimeIdentity(cwd, config, host), true],
+  ]
+  const winner = (field: "instanceId" | "runtimeSessionId") => rungs.find(([, value]) => Boolean(value[field]))!
+  const [source, session, normalizeSession] = winner("runtimeSessionId")
+  const [, instance, normalizeInstance] = winner("instanceId")
+  return {
+    instanceId: normalizeInstance ? normalizedId(instance.instanceId!) : instance.instanceId!,
+    runtimeSessionId: normalizeSession ? normalizedId(session.runtimeSessionId!) : session.runtimeSessionId!,
+    source,
+  }
+}
+
+/**
+ * Every distinct identity any store attests for `cwd`, when they disagree.
+ *
+ * The resolver ranks its rungs, which is right for a read: one answer, most
+ * trustworthy source first. A destructive caller needs the opposite question —
+ * *is the evidence consistent* — because ranking silently resolves a conflict
+ * the writer refused to create. `recordHarnessLink` supersedes by RAW string
+ * compare while every reader canonicalizes, so `/repo/x` and `/repo/x/` leave
+ * two live records; the mint refuses on that state, and so must anything that
+ * kills a window or removes a directory.
+ */
+export function conflictingAttestations(
+  cwd: string,
+  attested: AttestedRuntime[],
+  identities: MintedIdentity[],
+  canonical: (path: string) => string = canonicalOrRaw
+): string[] {
+  const target = canonical(cwd)
+  const ids = new Set<string>()
+  for (const entry of attested) if (entry.worktree === target) ids.add(entry.runtimeSessionId)
+  for (const record of identityRecordsFor(cwd, identities, canonical)) ids.add(record.runtimeSessionId)
+  return ids.size > 1 ? [...ids] : []
+}
+
+/**
+ * {@link resolveRuntimeIdentity} for the evidence a caller usually has to hand:
+ * a live pane, an inventory row, or neither. Unsupplied stores are read here,
+ * so every caller sees the same rungs.
+ */
+export function runtimeIdentityFor(params: {
+  cwd: string
+  pane?: LocalTmuxPane
+  agent?: { instanceId?: string; runtimeSessionId?: string }
+  identities?: MintedIdentity[]
+  attested?: AttestedRuntime[]
+  config?: ThreaChannelConfig
+  host?: string
+  canonical?: (path: string) => string
+}): ResolvedRuntimeIdentity {
+  const launch = params.pane ? parseClaudeChannelLaunch(params.pane.startCommand) : undefined
+  return resolveRuntimeIdentity(
+    params.cwd,
+    {
+      declared: launch ? { instanceId: launch.instanceId, runtimeSessionId: launch.runtimeSessionId } : undefined,
+      identities: params.identities ?? readMintedIdentities(),
+      attested: params.attested ?? attestedRuntimes(readHarnessLinks(), params.canonical),
+      inventory: params.agent,
+      canonical: params.canonical,
+    },
+    params.config,
+    params.host
+  )
+}
+
 function runtimeSessionIdForPane(
   pane: LocalTmuxPane,
   config: ThreaChannelConfig,
   host: string,
-  attested: AttestedRuntime[]
+  attested: AttestedRuntime[],
+  identities: MintedIdentity[],
+  canonical: (path: string) => string
 ): string | undefined {
-  const launch = parseClaudeChannelLaunch(pane.startCommand)
-  if (!launch) return undefined
-  return (
-    launch.runtimeSessionId ??
-    ledgerRuntimeSessionId(pane.cwd, attested) ??
-    deriveClaudeRuntimeIdentity(pane.cwd, config, host).runtimeSessionId
-  )
+  if (!parseClaudeChannelLaunch(pane.startCommand)) return undefined
+  return runtimeIdentityFor({ cwd: pane.cwd, pane, identities, attested, config, host, canonical }).runtimeSessionId
 }
 
 export function findLocalClaudeChannelPane(
@@ -511,10 +649,15 @@ export function findLocalClaudeChannelPane(
   panes: LocalTmuxPane[] = listLocalTmuxPanes(),
   config: ThreaChannelConfig = readThreaChannelConfig(),
   host = hostname(),
-  links: () => HarnessLink[] = readHarnessLinks
+  links: () => HarnessLink[] = readHarnessLinks,
+  identities: () => MintedIdentity[] = readMintedIdentities,
+  canonical: (path: string) => string = canonicalOrRaw
 ): LocalTmuxPane | undefined {
-  const attested = attestedRuntimes(links())
-  const matches = panes.filter((pane) => runtimeSessionIdForPane(pane, config, host, attested) === runtimeSessionId)
+  const attested = attestedRuntimes(links(), canonical)
+  const records = identities()
+  const matches = panes.filter(
+    (pane) => runtimeSessionIdForPane(pane, config, host, attested, records, canonical) === runtimeSessionId
+  )
   if (matches.length > 1) {
     throw new Error(
       `multiple live unmanaged Claude channel panes match ${runtimeSessionId}: ${matches.map((pane) => pane.paneId).join(", ")}`

--- a/extensions/harness-daemon/src/identity.test.ts
+++ b/extensions/harness-daemon/src/identity.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, expect, test } from "bun:test"
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import type { HarnessLink } from "@threa/bot-runtime-client"
@@ -11,6 +12,7 @@ import {
 } from "./identity"
 import { deriveClaudeRuntimeIdentity } from "./spawners"
 import type { LocalTmuxPane } from "./discovery"
+import type { MintedIdentity } from "./identity-store"
 import type { ManagedAgent } from "./types"
 
 const HOST = "identity-test-host"
@@ -69,10 +71,20 @@ function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
 }
 
 const originalLinksDir = process.env.THREA_HARNESS_LINKS_DIR
+const originalIdentitiesDir = process.env.THREA_HARNESSD_IDENTITIES_DIR
+let storeRoot: string
+
+beforeEach(() => {
+  storeRoot = mkdtempSync(join(tmpdir(), "harnessd-identity-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(storeRoot, "identities")
+})
 
 afterEach(() => {
+  rmSync(storeRoot, { recursive: true, force: true })
   if (originalLinksDir === undefined) delete process.env.THREA_HARNESS_LINKS_DIR
   else process.env.THREA_HARNESS_LINKS_DIR = originalLinksDir
+  if (originalIdentitiesDir === undefined) delete process.env.THREA_HARNESSD_IDENTITIES_DIR
+  else process.env.THREA_HARNESSD_IDENTITIES_DIR = originalIdentitiesDir
 })
 
 test("a recorded identity today's derivation no longer reproduces reports drifted", () => {
@@ -88,8 +100,10 @@ test("a recorded identity today's derivation no longer reproduces reports drifte
       kind: "row",
       name: "feature",
       recorded: "ccs-recorded",
+      minted: "-",
       ledger: "-",
       derived: derived(),
+      source: "inventory",
       pane: "-",
       verdict: "missing,drifted",
     },
@@ -109,8 +123,10 @@ test("a drifted row that still resolves reports both statuses", () => {
       kind: "row",
       name: "feature",
       recorded: "ccs-recorded",
+      minted: "-",
       ledger: "-",
       derived: derived(),
+      source: "inventory",
       pane: "%8",
       verdict: "found,drifted",
     },
@@ -130,8 +146,10 @@ test("a row identified through the ledger shows recorded, ledger and derived sep
       kind: "row",
       name: "feature",
       recorded: "ccs-ledger",
+      minted: "-",
       ledger: "ccs-ledger",
       derived: derived(),
+      source: "ledger",
       pane: "%8",
       verdict: "found,drifted",
     },
@@ -152,8 +170,10 @@ test("a live unmanaged pane with no inventory row is covered under its own ident
       kind: "pane",
       name: "slopenv",
       recorded: "ccs-unmanaged",
+      minted: "-",
       ledger: "-",
       derived: derived("/tmp/worktrees/slopenv"),
+      source: "declared",
       pane: "%12",
       verdict: "found,drifted",
     },
@@ -173,8 +193,10 @@ test("a row whose recorded identity matches today's derivation is not reported a
       kind: "row",
       name: "feature",
       recorded: derived(),
+      minted: "-",
       ledger: "-",
       derived: derived(),
+      source: "inventory",
       pane: "%8",
       verdict: "found",
     },
@@ -194,8 +216,10 @@ test("an unmanaged pane identified only by the ledger reports the attested ident
       kind: "pane",
       name: "slopenv",
       recorded: "-",
+      minted: "-",
       ledger: "ccs-attested",
       derived: derived("/tmp/worktrees/slopenv"),
+      source: "ledger",
       pane: "%12",
       verdict: "found",
     },
@@ -222,8 +246,10 @@ test("a live unmanaged Pi pane is covered under its session id", () => {
       kind: "pane",
       name: "pi-sol",
       recorded: "3f9a1c2e-4b5d-4e6f-8a9b-0c1d2e3f4a5b",
+      minted: "-",
       ledger: "-",
       derived: "-",
+      source: "-",
       pane: "%14",
       verdict: "found",
     },
@@ -262,11 +288,11 @@ test("the consistency check counts drifted records and survives an absent links 
       panes: [declaring("ccs-recorded"), declaring(derived(), { paneId: "%12" })],
       host: HOST,
     })
-  ).toEqual({ inventoryRows: 1, linkRecords: 0, livePanes: 1 })
+  ).toEqual({ inventoryRows: 1, linkRecords: 0, livePanes: 1, identityless: 0 })
 
   expect(
     identityConsistency({ agents: [], panes: [], links: [link({ runtimeSessionId: "ccs-drifted" })], host: HOST })
-  ).toEqual({ inventoryRows: 0, linkRecords: 1, livePanes: 0 })
+  ).toEqual({ inventoryRows: 0, linkRecords: 1, livePanes: 0, identityless: 0 })
 })
 
 test("a by-id lookup finds a pane whose identity only the ledger attests", () => {
@@ -278,14 +304,70 @@ test("a by-id lookup finds a pane whose identity only the ledger attests", () =>
     kind: "pane",
     name: "claude-slopenv",
     recorded: "-",
+    minted: "ccs-minted",
     ledger: "ccs-attested",
     derived: "ccs-derived",
+    source: "ledger",
     pane: "%12",
     verdict: "found",
   }
 
+  expect(rowMatchesRef(attested, "ccs-minted")).toBe(true)
   expect(rowMatchesRef(attested, "ccs-attested")).toBe(true)
   expect(rowMatchesRef(attested, "ccs-derived")).toBe(true)
   expect(rowMatchesRef(attested, "ccs-somebody-else")).toBe(false)
   expect(rowMatchesRef({ ...attested, recorded: "ccs-declared" }, "ccs-declared")).toBe(true)
+})
+
+function minted(overrides: Partial<MintedIdentity> = {}): MintedIdentity {
+  return {
+    runtimeSessionId: "ccs-minted",
+    instanceId: "cc-minted",
+    worktree: WORKTREE,
+    runtimeKind: "claude-code-channel",
+    mintedAt: "2026-07-29T00:00:00.000Z",
+    source: "mint",
+    ...overrides,
+  }
+}
+
+test("resolve prints the minted column and the winning source", () => {
+  const rows = buildIdentityRows({
+    agents: [agent({ runtimeSessionId: "ccs-minted" })],
+    panes: [pane()],
+    links: [link()],
+    identities: [minted()],
+    host: HOST,
+  })
+
+  expect(rows).toEqual([
+    {
+      kind: "row",
+      name: "feature",
+      recorded: "ccs-minted",
+      minted: "ccs-minted",
+      ledger: "ccs-ledger",
+      derived: derived(),
+      source: "minted",
+      pane: "%8",
+      verdict: "found,drifted",
+    },
+  ])
+  expect(rowMatchesRef(rows[0]!, "ccs-minted")).toBe(true)
+})
+
+test("doctor counts rows that carry no identity from any source", () => {
+  // The number that has to fall before the hostname derivation can go: these
+  // rows resolve only by hashing a name the wifi network supplies.
+  const identityless = agent({ id: "claude-2", worktree: "/tmp/worktrees/nameless", instanceId: undefined })
+
+  expect(
+    identityConsistency({
+      agents: [agent({ runtimeSessionId: "ccs-minted" }), identityless],
+      panes: [],
+      links: [],
+      identities: [minted()],
+      host: HOST,
+    })
+  ).toEqual({ inventoryRows: 1, linkRecords: 0, livePanes: 0, identityless: 1 })
 })

--- a/extensions/harness-daemon/src/identity.ts
+++ b/extensions/harness-daemon/src/identity.ts
@@ -7,8 +7,11 @@ import {
   parseClaudeChannelLaunch,
   parsePiLaunch,
   resolveManagedAgentPane,
+  resolveRuntimeIdentity,
+  type AttestedRuntime,
   type LocalTmuxPane,
 } from "./discovery"
+import { identityRecordsFor, readMintedIdentities, type MintedIdentity } from "./identity-store"
 import { die } from "./errors"
 import { findAgentOrUndefined, readInventoryReadonly } from "./inventory"
 import { deriveClaudeRuntimeIdentity, readThreaChannelConfig } from "./spawners"
@@ -20,8 +23,11 @@ export interface IdentityRow {
   kind: "row" | "pane"
   name: string
   recorded: string
+  minted: string
   ledger: string
   derived: string
+  /** Which rung the one resolver would answer from. */
+  source: string
   pane: string
   verdict: string
 }
@@ -30,6 +36,7 @@ export interface IdentityInputs {
   agents: ManagedAgent[]
   panes: LocalTmuxPane[]
   links: HarnessLink[]
+  identities?: MintedIdentity[]
   config?: ThreaChannelConfig
   host?: string
   includeUnmanagedPanes?: boolean
@@ -44,6 +51,8 @@ export interface IdentityConsistency {
   inventoryRows: number
   linkRecords: number
   livePanes: number
+  /** Inventory rows every rung but the derivation is silent about. */
+  identityless: number
 }
 
 /**
@@ -60,26 +69,30 @@ export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
   const config = inputs.config ?? {}
   const host = inputs.host ?? hostname()
   const attested = attestedRuntimes(inputs.links)
+  const identities = inputs.identities ?? readMintedIdentities()
   const links = () => inputs.links
+  const records = () => identities
   const rows: IdentityRow[] = []
   const claimedPanes = new Set<string>()
 
   for (const agent of inputs.agents) {
-    const resolved = resolveManagedAgentPane(agent, inputs.panes, config, host, links)
+    const resolved = resolveManagedAgentPane(agent, inputs.panes, config, host, links, records)
     const paneId = "pane" in resolved ? resolved.pane.paneId : NONE
     if (paneId !== NONE) claimedPanes.add(paneId)
     const recorded = agent.runtimeSessionId ?? NONE
     const ledger = agent.worktree ? (ledgerRuntimeSessionId(agent.worktree, attested) ?? NONE) : NONE
-    const derived =
-      agent.runtime === "claude" && agent.worktree
-        ? deriveClaudeRuntimeIdentity(agent.worktree, config, host).runtimeSessionId
-        : NONE
+    const claude = agent.runtime === "claude" && agent.worktree
+    const derived = claude ? deriveClaudeRuntimeIdentity(agent.worktree!, config, host).runtimeSessionId : NONE
     rows.push({
       kind: "row",
       name: agent.name,
       recorded,
+      minted: claude ? (mintedRuntimeSessionId(agent.worktree!, identities) ?? NONE) : NONE,
       ledger,
       derived,
+      source: claude
+        ? rowSource(agent.worktree!, { runtimeSessionId: agent.runtimeSessionId }, identities, attested, config, host)
+        : NONE,
       pane: paneId,
       verdict: identityVerdict(resolved.status, recorded, derived),
     })
@@ -95,8 +108,10 @@ export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
         kind: "pane",
         name: pane.windowName,
         recorded: pi.sessionId,
+        minted: NONE,
         ledger: NONE,
         derived: NONE,
+        source: NONE,
         pane: pane.paneId,
         verdict: identityVerdict("found", pi.sessionId, NONE),
       })
@@ -111,8 +126,10 @@ export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
       kind: "pane",
       name: pane.windowName,
       recorded,
+      minted: mintedRuntimeSessionId(pane.cwd, identities) ?? NONE,
       ledger,
       derived,
+      source: resolveRuntimeIdentity(pane.cwd, { declared: launch, identities, attested }, config, host).source,
       pane: pane.paneId,
       verdict: identityVerdict("found", recorded, derived),
     })
@@ -126,7 +143,23 @@ export function buildIdentityRows(inputs: IdentityInputs): IdentityRow[] {
  * worth looking up by id — so any column that attests one counts as a match.
  */
 export function rowMatchesRef(row: IdentityRow, ref: string): boolean {
-  return row.recorded === ref || row.ledger === ref || row.derived === ref
+  return row.recorded === ref || row.minted === ref || row.ledger === ref || row.derived === ref
+}
+
+function mintedRuntimeSessionId(worktree: string, identities: MintedIdentity[]): string | undefined {
+  const records = identityRecordsFor(worktree, identities)
+  return records.length === 1 ? records[0]!.runtimeSessionId : undefined
+}
+
+function rowSource(
+  worktree: string,
+  inventory: { instanceId?: string; runtimeSessionId?: string },
+  identities: MintedIdentity[],
+  attested: AttestedRuntime[],
+  config: ThreaChannelConfig,
+  host: string
+): string {
+  return resolveRuntimeIdentity(worktree, { identities, attested, inventory }, config, host).source
 }
 
 export function summarizeIdentityRows(rows: IdentityRow[]): IdentitySummary {
@@ -140,6 +173,7 @@ export function identityConsistency(
     agents?: ManagedAgent[]
     panes?: LocalTmuxPane[]
     links?: HarnessLink[]
+    identities?: MintedIdentity[]
     config?: ThreaChannelConfig
     host?: string
   } = {}
@@ -147,6 +181,8 @@ export function identityConsistency(
   const agents = inputs.agents ?? readInventoryReadonly()
   const panes = inputs.panes ?? []
   const links = inputs.links ?? readHarnessLinks()
+  const identities = inputs.identities ?? readMintedIdentities()
+  const attested = attestedRuntimes(links)
   const config = inputs.config ?? {}
   const host = inputs.host ?? hostname()
   const derived = (cwd: string) => deriveClaudeRuntimeIdentity(cwd, config, host).runtimeSessionId
@@ -168,7 +204,21 @@ export function identityConsistency(
     return Boolean(declared) && derived(pane.cwd) !== declared
   }).length
 
-  return { inventoryRows, linkRecords, livePanes }
+  // The number that has to fall before the derivation can be deleted: these
+  // rows have no identity anywhere but in a hostname hash.
+  const identityless = agents.filter(
+    (agent) =>
+      agent.runtime === "claude" &&
+      Boolean(agent.worktree) &&
+      resolveRuntimeIdentity(
+        agent.worktree!,
+        { identities, attested, inventory: { instanceId: agent.instanceId, runtimeSessionId: agent.runtimeSessionId } },
+        config,
+        host
+      ).source === "derived"
+  ).length
+
+  return { inventoryRows, linkRecords, livePanes, identityless }
 }
 
 export function resolveIdentity(ref?: string): void {
@@ -185,9 +235,13 @@ export function resolveIdentity(ref?: string): void {
     includeUnmanagedPanes: !managed,
   }).filter((row) => !ref || managed || rowMatchesRef(row, ref))
   if (ref && rows.length === 0) die(`no agent or live pane found for ${ref}`)
-  console.log(["kind", "name", "recorded", "ledger", "derived", "pane", "verdict"].join("\t"))
+  console.log(["kind", "name", "recorded", "minted", "ledger", "derived", "source", "pane", "verdict"].join("\t"))
   for (const row of rows) {
-    console.log([row.kind, row.name, row.recorded, row.ledger, row.derived, row.pane, row.verdict].join("\t"))
+    console.log(
+      [row.kind, row.name, row.recorded, row.minted, row.ledger, row.derived, row.source, row.pane, row.verdict].join(
+        "\t"
+      )
+    )
   }
   const summary = summarizeIdentityRows(rows)
   const counts = summary.counts.map(([verdict, count]) => `${count} ${verdict}`).join(", ")

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -1,7 +1,31 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import type { HarnessLink } from "@threa/bot-runtime-client"
 import { OBSERVER_WARMUP_MS, REAP_AFTER_MS, reapArchivedWorktrees, type ReapDeps } from "./reap"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import type { LocalTmuxPane } from "./discovery"
+
+// Every dep is injected, but a defaulted one would silently read the developer's
+// real stores — which is how a green test can depend on what happens to be in
+// ~/.threa/harnessd. Point them at an empty directory so a leak fails loudly.
+const ISOLATED = ["THREA_HARNESSD_IDENTITIES_DIR", "THREA_HARNESS_LINKS_DIR", "THREA_HARNESSD_INVENTORY"] as const
+const saved = new Map<string, string | undefined>()
+
+beforeAll(() => {
+  const root = mkdtempSync(join(tmpdir(), "harnessd-reap-"))
+  for (const name of ISOLATED) {
+    saved.set(name, process.env[name])
+    process.env[name] = join(root, name.toLowerCase())
+  }
+})
+
+afterAll(() => {
+  for (const [name, value] of saved) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
 
 const NOW = Date.parse("2026-07-27T12:00:00.000Z")
 const WORKTREE = "/repo/threa.feature"
@@ -46,6 +70,7 @@ function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded
   const recorded: Recorded = { woundDown: [], killed: [], forgotten: [], awaited: [], retired: [] }
   const deps: ReapDeps = {
     links: () => [link()],
+    identities: () => [],
     panes: () => [pane()],
     claudeProcessesIn: () => [],
     canonicalPath: (path) => path,
@@ -313,7 +338,10 @@ describe("reapArchivedWorktrees", () => {
 
   test("one failing link does not abort the sweep", async () => {
     const { deps, recorded } = makeDeps({
-      links: () => [link({ runtimeSessionId: "boom", rootStreamId: "stream_boom" }), link({ runtimeSessionId: "ok" })],
+      links: () => [
+        link({ runtimeSessionId: "boom", rootStreamId: "stream_boom", worktree: "/repo/threa.boom" }),
+        link({ runtimeSessionId: "ok" }),
+      ],
       panes: () => [],
       archivedAt: async (streamId) => {
         if (streamId === "stream_boom") throw new Error("threa unreachable")
@@ -380,7 +408,7 @@ describe("reapArchivedWorktrees", () => {
     const { deps, recorded } = makeDeps({
       observingSinceMs: NOW - OBSERVER_WARMUP_MS + 60_000,
       links: () => [
-        link({ runtimeSessionId: "unmarked" }),
+        link({ runtimeSessionId: "unmarked", worktree: "/repo/threa.unmarked" }),
         link({ runtimeSessionId: "marked", windDownRequestedAt: new Date(NOW - 1_000).toISOString() }),
       ],
       panes: () => [],
@@ -410,4 +438,108 @@ test("a wind-down that could not remove the directory keeps the identity record"
   // would let the next mint hand that live directory a second id.
   expect(recorded.retired).toEqual([])
   expect(recorded.forgotten).toEqual(["ccs-abc"])
+})
+
+test("the window decision uses the injected ledger and canonicalizer", async () => {
+  // `decideWindow` used to call the resolver with two arguments, so the
+  // ledger-attested branch was unreachable and a second canonicalizer
+  // (realpathSync) decided the one destructive call in the daemon.
+  const canonicalized: string[] = []
+  const { deps, recorded } = makeDeps({
+    // No THREA_ env: only the ledger can tie this pane to the record.
+    panes: () => [
+      pane({
+        cwd: `/raw${WORKTREE}`,
+        startCommand: "claude --dangerously-load-development-channels server:threa-channel",
+      }),
+    ],
+    // The pane's cwd and the record's worktree differ as RAW strings, so ONLY a
+    // canonicalizer applied inside the resolver can tie them together. Passing
+    // the raw path on both sides made the assertion pass either way, because
+    // canonicalOrRaw falls back to the raw string when realpathSync throws.
+    links: () => [link({ worktree: WORKTREE })],
+    canonicalPath: (path) => {
+      canonicalized.push(path)
+      return path.startsWith("/raw") ? path.slice("/raw".length) : path
+    },
+  })
+
+  const [outcome] = await reapArchivedWorktrees(deps)
+
+  expect(outcome).toMatchObject({ status: "reaped" })
+  expect(recorded.killed).toEqual(["@7"])
+  expect(canonicalized).toContain(`/raw${WORKTREE}`)
+})
+
+test("a worktree two link records disagree about is never reaped", async () => {
+  // recordHarnessLink supersedes by a RAW string compare while every reader
+  // canonicalizes, so a trailing slash leaves both records alive. The mint
+  // refuses on this state; so must the one pass that removes a directory.
+  const { deps, recorded } = makeDeps({
+    links: () => [link({ runtimeSessionId: "ccs-abc" }), link({ runtimeSessionId: "ccs-xyz" })],
+    panes: () => [],
+  })
+
+  const outcomes = await reapArchivedWorktrees(deps)
+
+  expect(outcomes.map((outcome) => outcome.status)).toEqual(["skipped ambiguous", "skipped ambiguous"])
+  expect(outcomes[0]?.detail).toContain("disagrees")
+  expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [], retired: [] })
+})
+
+test("a minted record naming the worktree a different session claims blocks the reap", async () => {
+  // The promotion that made this necessary: the minted rung outranks an
+  // ambiguous ledger, so a pane declaring nothing resolved to THIS record and
+  // the branch below killed a live, differently-identified session's window.
+  const { deps, recorded } = makeDeps({
+    identities: () => [
+      {
+        runtimeSessionId: "ccs-stranger",
+        instanceId: "cc-stranger",
+        worktree: WORKTREE,
+        runtimeKind: "claude-code-channel",
+        mintedAt: "2026-07-29T00:00:00.000Z",
+        source: "mint",
+      },
+    ],
+  })
+
+  const [outcome] = await reapArchivedWorktrees(deps)
+
+  expect(outcome?.status).toBe("skipped ambiguous")
+  expect(outcome?.detail).toContain("ccs-stranger")
+  expect(recorded.killed).toEqual([])
+  expect(recorded.woundDown).toEqual([])
+})
+
+test("only the injected identity store reaches the destructive decision", async () => {
+  // A record on disk that the deps do not expose must not influence which pane
+  // the reaper believes owns the worktree. Reading the ambient store here is how
+  // a green test comes to depend on whatever sits in ~/.threa/harnessd.
+  const dir = process.env.THREA_HARNESSD_IDENTITIES_DIR!
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, "ccs-ondisk.json"),
+    JSON.stringify({
+      runtimeSessionId: "ccs-ondisk",
+      instanceId: "cc-ondisk",
+      worktree: WORKTREE,
+      runtimeKind: "claude-code-channel",
+      mintedAt: "2026-07-29T00:00:00.000Z",
+      source: "mint",
+    })
+  )
+  try {
+    const { deps, recorded } = makeDeps({
+      identities: () => [],
+      panes: () => [pane({ startCommand: "claude --dangerously-load-development-channels server:threa-channel" })],
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome?.status).toBe("reaped")
+    expect(recorded.killed).toEqual(["@7"])
+  } finally {
+    rmSync(join(dir, "ccs-ondisk.json"), { force: true })
+  }
 })

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -471,13 +471,12 @@ test("the window decision uses the injected ledger and canonicalizer", async () 
   expect(canonicalized).toContain(`/raw${WORKTREE}`)
 })
 
-test("a worktree two link records disagree about is never reaped", async () => {
+test("an occupied worktree two link records disagree about is never reaped", async () => {
   // recordHarnessLink supersedes by a RAW string compare while every reader
   // canonicalizes, so a trailing slash leaves both records alive. The mint
   // refuses on this state; so must the one pass that removes a directory.
   const { deps, recorded } = makeDeps({
     links: () => [link({ runtimeSessionId: "ccs-abc" }), link({ runtimeSessionId: "ccs-xyz" })],
-    panes: () => [],
   })
 
   const outcomes = await reapArchivedWorktrees(deps)
@@ -485,6 +484,20 @@ test("a worktree two link records disagree about is never reaped", async () => {
   expect(outcomes.map((outcome) => outcome.status)).toEqual(["skipped ambiguous", "skipped ambiguous"])
   expect(outcomes[0]?.detail).toContain("disagrees")
   expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [], retired: [] })
+})
+
+test("disagreeing records do not wedge an EMPTY worktree out of reaping", async () => {
+  // reapLink is the only thing that clears a record, so refusing here would
+  // strand the directory forever — and nothing is at risk when nothing is in it.
+  const { deps, recorded } = makeDeps({
+    links: () => [link({ runtimeSessionId: "ccs-abc" }), link({ runtimeSessionId: "ccs-xyz" })],
+    panes: () => [],
+  })
+
+  const outcomes = await reapArchivedWorktrees(deps)
+
+  expect(outcomes.map((outcome) => outcome.status)).toEqual(["reaped", "reaped"])
+  expect(recorded.forgotten).toEqual(["ccs-abc", "ccs-xyz"])
 })
 
 test("a minted record naming the worktree a different session claims blocks the reap", async () => {

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -8,8 +8,15 @@ import {
 import { existsSync } from "node:fs"
 import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
 import { liveClaudePidsIn } from "./claude-registry"
-import { forgetMintedIdentitiesFor } from "./identity-store"
-import { canonicalOrRaw, listLocalTmuxPanes, resolveManagedAgentPane, type LocalTmuxPane } from "./discovery"
+import { forgetMintedIdentitiesFor, readMintedIdentities, type MintedIdentity } from "./identity-store"
+import {
+  attestedRuntimes,
+  canonicalOrRaw,
+  conflictingAttestations,
+  listLocalTmuxPanes,
+  resolveManagedAgentPane,
+  type LocalTmuxPane,
+} from "./discovery"
 import { processAlive } from "./lock"
 import { output } from "./shell"
 import { fetchScratchpadArchivedAt, fetchScratchpadStatus, type ScratchpadStatus } from "./resume"
@@ -74,6 +81,7 @@ export interface ReapDeps {
   /** Undefined for an explicit CLI run; set by the daemon so a just-woken pass waits out {@link OBSERVER_WARMUP_MS}. */
   observingSinceMs?: number
   links: () => HarnessLink[]
+  identities: () => MintedIdentity[]
   panes: () => LocalTmuxPane[]
   /** Live Claude pids in this worktree, corroborated against the process table. */
   claudeProcessesIn: (worktree: string) => number[]
@@ -95,6 +103,7 @@ export interface ReapDeps {
 export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; apiKey: string }): ReapDeps {
   return {
     links: readHarnessLinks,
+    identities: readMintedIdentities,
     panes: listLocalTmuxPanes,
     claudeProcessesIn: liveClaudePidsIn,
     canonicalPath: canonicalOrRaw,
@@ -148,6 +157,24 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
   const occupants = panes.filter((pane) => deps.canonicalPath(pane.cwd) === worktree)
   const livePids = deps.claudeProcessesIn(link.worktree)
 
+  // Ranking the rungs is right for a read and wrong here: a minted record that
+  // outranks an ambiguous ledger would resolve a pane declaring nothing to THIS
+  // record's session, and the branch below would then kill that window and
+  // force-remove the directory a live, differently-identified Claude is using.
+  const conflict = conflictingAttestations(
+    link.worktree,
+    attestedRuntimes(deps.links(), deps.canonicalPath),
+    deps.identities(),
+    deps.canonicalPath
+  )
+  if (conflict.length > 0) {
+    return {
+      kind: "refuse",
+      status: "skipped ambiguous",
+      reason: `identity evidence for ${link.worktree} disagrees: ${conflict.join(", ")}`,
+    }
+  }
+
   if (occupants.length === 0) {
     // Nobody is in the worktree: the offline case this reaper exists for —
     // unless a paneless Claude is still running there.
@@ -165,7 +192,12 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
       runtimeSessionId: link.runtimeSessionId,
       worktree: link.worktree,
     },
-    panes
+    panes,
+    undefined,
+    undefined,
+    deps.links,
+    deps.identities,
+    deps.canonicalPath
   )
   if (resolved.status === "found" && occupants.length === 1 && resolved.pane.paneId === occupants[0]!.paneId) {
     // The pane's own Claude is `panePid` (the same equivalence `reconnect`

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -157,10 +157,30 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
   const occupants = panes.filter((pane) => deps.canonicalPath(pane.cwd) === worktree)
   const livePids = deps.claudeProcessesIn(link.worktree)
 
-  // Ranking the rungs is right for a read and wrong here: a minted record that
-  // outranks an ambiguous ledger would resolve a pane declaring nothing to THIS
-  // record's session, and the branch below would then kill that window and
-  // force-remove the directory a live, differently-identified Claude is using.
+  if (occupants.length === 0) {
+    // Nobody is in the worktree: the offline case this reaper exists for —
+    // unless a paneless Claude is still running there.
+    if (livePids.length === 0) return { kind: "none" }
+    return {
+      kind: "refuse",
+      status: "skipped occupied",
+      reason: `Claude is still running in ${link.worktree} with no pane (pid ${livePids.join(", ")})`,
+    }
+  }
+
+  // Something is alive in there, so identity now decides whether killing it is
+  // this record's business. Ranking the rungs is right for a read and wrong
+  // here: a minted record that outranks an ambiguous ledger would resolve a pane
+  // declaring nothing to THIS record's session, and the branch below would kill
+  // that window and force-remove the directory a live, differently-identified
+  // Claude is using.
+  //
+  // Deliberately BELOW the empty branch. Duplicate records come from
+  // `recordHarnessLink` superseding by raw string compare while every reader
+  // canonicalizes, so one trailing slash creates this state — and refusing an
+  // EMPTY worktree would wedge it out of reaping forever, because `reapLink` is
+  // the only thing that clears a record. Nothing is at risk when nothing is
+  // there, and reaping one record per pass is what resolves the duplication.
   const conflict = conflictingAttestations(
     link.worktree,
     attestedRuntimes(deps.links(), deps.canonicalPath),
@@ -172,17 +192,6 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
       kind: "refuse",
       status: "skipped ambiguous",
       reason: `identity evidence for ${link.worktree} disagrees: ${conflict.join(", ")}`,
-    }
-  }
-
-  if (occupants.length === 0) {
-    // Nobody is in the worktree: the offline case this reaper exists for —
-    // unless a paneless Claude is still running there.
-    if (livePids.length === 0) return { kind: "none" }
-    return {
-      kind: "refuse",
-      status: "skipped occupied",
-      reason: `Claude is still running in ${link.worktree} with no pane (pid ${livePids.join(", ")})`,
     }
   }
 

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -13,25 +13,24 @@ import {
   attestedRuntimes,
   findLocalClaudeChannelPane,
   findLocalPiPane,
-  ledgerIdentity,
   listLocalTmuxPanes,
+  resolveRuntimeIdentity,
   parseClaudeLaunch,
   parsePiLaunch,
   type ClaudeLaunch,
   type LocalTmuxPane,
   type PiLaunch,
 } from "./discovery"
+import { readMintedIdentities, type MintedIdentity } from "./identity-store"
 import { readInventoryReadonly } from "./inventory"
 import { preflightRuntimeSession, type RuntimePreflightResult } from "./resume"
 import { shellQuote } from "./shell"
 import {
   configuredThreaBaseUrl,
-  deriveClaudeRuntimeIdentity,
   readPiRemoteConfig,
   readPiRemoteSession,
   type PiRemoteConfig,
   readThreaChannelConfig,
-  sanitizeId,
   type PiRemoteSession,
 } from "./spawners"
 import type { ThreaChannelConfig } from "./types"
@@ -67,6 +66,7 @@ export interface ReconnectDeps {
   claudeConfig?: () => ThreaChannelConfig
   claudeRegistry?: ClaudeRegistryDeps
   links?: () => HarnessLink[]
+  identities?: () => MintedIdentity[]
   mcpFile?: (path: string) => boolean
   sleep?: (ms: number) => Promise<void>
   claudeBoot?: Partial<ClaudeBootDeps>
@@ -221,7 +221,8 @@ function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): Cl
       deps.panes(),
       config,
       hostname(),
-      deps.links ?? readHarnessLinks
+      deps.links ?? readHarnessLinks,
+      deps.identities ?? readMintedIdentities
     )
     if (!pane) throw new Error(`no live Claude pane matched ${options.runtimeSessionId}`)
   }
@@ -239,17 +240,21 @@ function resolveClaudeTarget(options: ReconnectOptions, deps: ReconnectDeps): Cl
     }
     if (paneCwd !== managedCwd) throw new Error("managed Claude cwd does not match pane")
   }
-  const derived = deriveClaudeRuntimeIdentity(pane.cwd, config)
-  // Same attestation order the pane lookup just used. Re-deriving here would
-  // reject the very pane the ledger identified: a session launched under a
-  // different hostname derives a different id for life.
-  const attested = ledgerIdentity(pane.cwd, attestedRuntimes((deps.links ?? readHarnessLinks)()))
-  const explicitInstanceId = launch.environment.find(({ name }) => name === "THREA_INSTANCE_ID")?.value
-  const explicitRuntimeSessionId = launch.environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value
-  const instanceId = sanitizeId(explicitInstanceId || attested?.instanceId || derived.instanceId).slice(0, 64)
-  const runtimeSessionId = sanitizeId(
-    explicitRuntimeSessionId || attested?.runtimeSessionId || derived.runtimeSessionId
-  ).slice(0, 64)
+  // Same rungs, in the same order, the pane lookup just used. Re-deriving here
+  // would reject the very pane the ledger identified: a session launched under
+  // a different hostname derives a different id for life.
+  const { instanceId, runtimeSessionId } = resolveRuntimeIdentity(
+    pane.cwd,
+    {
+      declared: {
+        instanceId: launch.environment.find(({ name }) => name === "THREA_INSTANCE_ID")?.value,
+        runtimeSessionId: launch.environment.find(({ name }) => name === "THREA_RUNTIME_SESSION_ID")?.value,
+      },
+      identities: (deps.identities ?? readMintedIdentities)(),
+      attested: attestedRuntimes((deps.links ?? readHarnessLinks)()),
+    },
+    config
+  )
   if (!instanceId || !runtimeSessionId) throw new Error("Claude launch identity is empty after normalization")
   if (runtimeSessionId !== options.runtimeSessionId) throw new Error("Claude runtime identity mismatch")
   if (agent && (agent.runtimeSessionId !== runtimeSessionId || agent.instanceId !== instanceId)) {
@@ -398,7 +403,8 @@ export async function reconnectRuntime(
     panes,
     (deps.claudeConfig ?? readThreaChannelConfig)(),
     hostname(),
-    deps.links ?? readHarnessLinks
+    deps.links ?? readHarnessLinks,
+    deps.identities ?? readMintedIdentities
   )
   if (piPane && claudePane) throw new Error(`multiple live runtimes match ${options.runtimeSessionId}`)
   if (piPane) return reconnectPi(options, deps)

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite"
 import { afterEach, expect, mock, spyOn, test } from "bun:test"
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -12,12 +12,14 @@ import {
   recordedNoYolo,
 } from "./resume"
 import { launchAgentPlist } from "./boot"
-import { findLocalClaudeChannelPane, type LocalTmuxPane } from "./discovery"
+import { findLocalClaudeChannelPane, runtimeIdentityFor, type LocalTmuxPane } from "./discovery"
 import { parseResume, parseSpawn } from "./cli"
 import { kickAgent, restoredSessionMatches, reviveAgent, type ReviveDeps, type ReviveOutcome } from "./commands"
 import { findAgent, readInventory, readInventoryReadonly, upsertAgent } from "./inventory"
+import { writeMintedIdentity } from "./identity-store"
 import { acquireProcessLock } from "./lock"
 import {
+  claudeAgentIdentity,
   claudeLaunchArgs,
   claudeLaunchCommand,
   deriveClaudeRuntimeIdentity,
@@ -554,6 +556,8 @@ function reviveDeps(overrides: Partial<ReviveDeps> = {}): ReviveDeps {
     },
     restorableWorktree: () => ({ repo: "/tmp/repo" }),
     piLink: () => undefined,
+    claudeIdentity: (managed, config) =>
+      runtimeIdentityFor({ cwd: managed.worktree ?? "", agent: managed, identities: [], attested: [], config }),
     resumeRuntime: async () => {
       throw new Error("resumeRuntime must not be called")
     },
@@ -1031,4 +1035,61 @@ test("a revival derives identity from the worktree, never from the caller's envi
       else process.env[key] = value
     }
   }
+})
+
+test("revival reuses the minted identity instead of deriving a new one", () => {
+  // `ClaudeRuntimeSpawner.resume` used to derive from the current hostname, so
+  // a laptop that changed wifi revived its own session under an id the server
+  // had never seen and the harness started a duplicate.
+  const worktree = "/tmp/worktrees/minted-revival"
+  const root = mkdtempSync(join(tmpdir(), "harnessd-revive-identity-"))
+  const saved = ["THREA_HARNESSD_IDENTITIES_DIR", "THREA_HARNESS_LINKS_DIR"].map(
+    (name) => [name, process.env[name]] as const
+  )
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  try {
+    const written = writeMintedIdentity({
+      runtimeSessionId: "ccs-revived",
+      instanceId: "cc-revived",
+      worktree,
+      runtimeKind: "claude-code-channel",
+      mintedAt: "2026-07-29T00:00:00.000Z",
+      source: "mint",
+    })
+    expect(written.status).toBe("created")
+
+    expect(claudeAgentIdentity({ worktree }, {})).toEqual({
+      instanceId: "cc-revived",
+      runtimeSessionId: "ccs-revived",
+      source: "minted",
+    })
+    expect(deriveClaudeRuntimeIdentity(worktree).runtimeSessionId).not.toBe("ccs-revived")
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  }
+})
+
+test("the revival log scores drift against the derivation, not against its own resolution", async () => {
+  // The inventory rung returns the recorded id, so scoring `drifted` against the
+  // resolved id makes it structurally unreachable — and this is the line that
+  // surfaced the 2026-07-28 duplicate-session storm.
+  const lines: string[] = []
+  const log = spyOn(console, "log").mockImplementation((message: string) => void lines.push(message))
+  try {
+    await runRevive(linkedAgent({ runtimeSessionId: "ccs-recorded", instanceId: "cc-recorded" }), {}, reviveDeps())
+  } finally {
+    log.mockRestore()
+  }
+
+  const resolve = lines.find((line) => line.startsWith("resolve\t"))!
+  const [, , verdict, recorded, derived, , source] = resolve.split("\t")
+  expect(verdict).toContain("drifted")
+  expect(recorded).toBe("ccs-recorded")
+  expect(derived).not.toBe("ccs-recorded")
+  expect(source).toBe("inventory")
 })

--- a/extensions/harness-daemon/src/runtime-identity.test.ts
+++ b/extensions/harness-daemon/src/runtime-identity.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { HarnessLink } from "@threa/bot-runtime-client"
+import { attestedRuntimes, resolveRuntimeIdentity, runtimeIdentityFor, type LocalTmuxPane } from "./discovery"
+import type { MintedIdentity, WriteMintedIdentityResult } from "./identity-store"
+import { mintRuntimeIdentity, type MintDeps } from "./mint"
+import { deriveClaudeRuntimeIdentity, sanitizeId } from "./spawners"
+
+const CWD = "/repo/threa.feature"
+const HOST = "resolver-test-host"
+const raw = (path: string) => path
+
+let root: string
+const saved = ["THREA_HARNESSD_IDENTITIES_DIR", "THREA_HARNESS_LINKS_DIR", "THREA_HARNESSD_INVENTORY"].map(
+  (name) => [name, process.env[name]] as const
+)
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-resolver-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "inventory.sqlite")
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  for (const [name, value] of saved) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "threa-agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 4242,
+    cwd: CWD,
+    startCommand:
+      "env THREA_INSTANCE_ID=cc-declared THREA_RUNTIME_SESSION_ID=ccs-declared claude --dangerously-load-development-channels server:threa-channel",
+    ...overrides,
+  }
+}
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: "ccs-ledger",
+    instanceId: "cc-ledger",
+    rootStreamId: "stream_root",
+    worktree: CWD,
+    pid: 4242,
+    updatedAt: "2026-07-29T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function identity(overrides: Partial<MintedIdentity> = {}): MintedIdentity {
+  return {
+    runtimeSessionId: "ccs-minted",
+    instanceId: "cc-minted",
+    worktree: CWD,
+    runtimeKind: "claude-code-channel",
+    mintedAt: "2026-07-29T00:00:00.000Z",
+    source: "mint",
+    ...overrides,
+  }
+}
+
+function resolve(evidence: Parameters<typeof resolveRuntimeIdentity>[1]) {
+  return resolveRuntimeIdentity(CWD, { canonical: raw, ...evidence }, {}, HOST)
+}
+
+test("a pane's own declared environment beats every other source", () => {
+  expect(
+    runtimeIdentityFor({
+      cwd: CWD,
+      pane: pane(),
+      agent: { instanceId: "cc-row", runtimeSessionId: "ccs-row" },
+      identities: [identity()],
+      attested: attestedRuntimes([link()], raw),
+      host: HOST,
+      canonical: raw,
+    })
+  ).toEqual({ instanceId: "cc-declared", runtimeSessionId: "ccs-declared", source: "declared" })
+})
+
+test("a minted record beats the ledger for the same directory", () => {
+  expect(resolve({ identities: [identity()], attested: attestedRuntimes([link()], raw) })).toEqual({
+    instanceId: "cc-minted",
+    runtimeSessionId: "ccs-minted",
+    source: "minted",
+  })
+})
+
+test("the ledger beats a stale inventory row", () => {
+  // Inventory rows are immutable per launch, so the row is stale by
+  // construction the moment anything re-identifies the directory.
+  expect(
+    resolve({
+      identities: [],
+      attested: attestedRuntimes([link()], raw),
+      inventory: { instanceId: "cc-row", runtimeSessionId: "ccs-row" },
+    })
+  ).toEqual({ instanceId: "cc-ledger", runtimeSessionId: "ccs-ledger", source: "ledger" })
+})
+
+test("derivation is the last rung and is reported as such", () => {
+  const derived = deriveClaudeRuntimeIdentity(CWD, {}, HOST)
+
+  expect(resolve({ identities: [], attested: [] })).toEqual({ ...derived, source: "derived" })
+})
+
+test("two ledger records naming one worktree fall through instead of picking one", () => {
+  const derived = deriveClaudeRuntimeIdentity(CWD, {}, HOST)
+  const rivals = attestedRuntimes([link(), link({ runtimeSessionId: "ccs-rival", instanceId: "cc-rival" })], raw)
+
+  expect(resolve({ identities: [], attested: rivals })).toEqual({ ...derived, source: "derived" })
+})
+
+test("the resolver answers for a directory a mint would refuse", async () => {
+  // Occupancy is the mint's veto and belongs to the write side. A read path
+  // that could refuse would make "what identity does this directory have"
+  // answerable only when a new process is allowed to start there.
+  const mintDeps: MintDeps = {
+    identities: () => [],
+    links: () => [],
+    panes: () => [],
+    claudeProcessesIn: () => [4242],
+    canonicalPath: raw,
+    write: (record): WriteMintedIdentityResult => ({ status: "created", record }),
+    newSuffix: () => "f00dfeedbaadc0de",
+    now: () => new Date("2026-07-29T00:00:00.000Z"),
+    warn: () => {},
+  }
+
+  const minted = await mintRuntimeIdentity({ worktree: CWD, runtimeKind: "claude-code-channel" }, mintDeps)
+
+  expect(minted.status).toBe("refused")
+  expect(resolve({ identities: [], attested: [] })).toMatchObject({
+    runtimeSessionId: deriveClaudeRuntimeIdentity(CWD, {}, HOST).runtimeSessionId,
+    source: "derived",
+  })
+})
+
+test("identity ids are sanitized and truncated once, at the resolver", () => {
+  const declared = ["ccs", "x".repeat(33), "y".repeat(32)].join(" ")
+  expect(declared).toHaveLength(70)
+
+  // Exactly what `reconnect` produced before it delegated: sanitize, then cut.
+  const normalized = `ccs-${"x".repeat(33)}-${"y".repeat(26)}`
+  expect(normalized).toBe(sanitizeId(declared).slice(0, 64))
+
+  expect(resolve({ declared: { instanceId: declared, runtimeSessionId: declared } })).toEqual({
+    instanceId: normalized,
+    runtimeSessionId: normalized,
+    source: "declared",
+  })
+})
+
+test("a recorded id is returned verbatim, never rewritten to fit the sanitizer", () => {
+  // The link and identity stores allow dots and impose no length cap, and both
+  // key their files by this id. Normalizing it on the way out maps two distinct
+  // sessions onto one — the failure `isSafeSessionFileName` refuses by design.
+  const dotted = resolveRuntimeIdentity(CWD, {
+    attested: [{ worktree: CWD, runtimeSessionId: "ccs.abc", instanceId: "cc.abc" }],
+  })
+
+  expect(dotted).toEqual({ runtimeSessionId: "ccs.abc", instanceId: "cc.abc", source: "ledger" })
+
+  const long = "ccs-" + "a".repeat(80)
+  const untruncated = resolveRuntimeIdentity(CWD, {
+    identities: [
+      {
+        runtimeSessionId: long,
+        instanceId: "cc-long",
+        worktree: CWD,
+        runtimeKind: "claude-code-channel",
+        mintedAt: "2026-07-29T00:00:00.000Z",
+        source: "mint",
+      },
+    ],
+  })
+
+  expect(untruncated.runtimeSessionId).toBe(long)
+})

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -11,6 +11,7 @@ import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChann
 import { recordedNoYolo } from "./resume"
 import { mintRuntimeIdentity } from "./mint"
 import { ensureWorktree, plannedWorktreePath } from "./worktree"
+import { runtimeIdentityFor, type ResolvedRuntimeIdentity } from "./discovery"
 
 export function mcpConfigPath(name: string): string {
   return join(homedir(), ".threa", "harnessd", "mcp", `${name}.json`)
@@ -373,11 +374,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     if (!existsSync(mcpConfig)) this.writeMcpConfig(agent.name, channel, channelEntry)
     normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
     const config = readThreaChannelConfig()
-    const derived = deriveClaudeRuntimeIdentity(agent.worktree, config)
-    const identity = {
-      instanceId: agent.instanceId ?? derived.instanceId,
-      runtimeSessionId: agent.runtimeSessionId ?? derived.runtimeSessionId,
-    }
+    const identity = claudeAgentIdentity(agent, config)
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "claude", name: agent.name })
     ensureTmuxSession(session, true)
     const noYolo = recordedNoYolo(agent)
@@ -526,6 +523,22 @@ export function deriveClaudeRuntimeIdentity(
       64
     ),
   }
+}
+
+/**
+ * The identity a managed Claude row runs under, through the one resolver: a
+ * revival reuses the recorded identity instead of computing a new one from a
+ * hostname that has since changed.
+ */
+export function claudeAgentIdentity(
+  agent: Pick<ManagedAgent, "worktree" | "instanceId" | "runtimeSessionId">,
+  config: ThreaChannelConfig = readThreaChannelConfig()
+): ResolvedRuntimeIdentity {
+  return runtimeIdentityFor({
+    cwd: agent.worktree ?? "",
+    agent: { instanceId: agent.instanceId, runtimeSessionId: agent.runtimeSessionId },
+    config,
+  })
 }
 
 export function claudeLaunchCommand(


### PR DESCRIPTION
## Problem

Five independent implementations answered *"what identity does this directory have"*: `discovery.runtimeSessionIdForPane`, `reconnect.resolveClaudeTarget`, `adopt`'s attestation list, `identity.buildIdentityRows`, and `reviveAgent`'s three `deriveClaudeRuntimeIdentity` sites. Each drifted from the others — `sanitizeId` applied in two of them and not the third, the ledger consulted in some and not others. That divergence is the generator behind this class of bug rather than any one of its instances.

## Solution

One resolver in `discovery.ts`: **declared launch env → minted record → ledger attestation → inventory row → derivation**. `sanitizeId` is applied once, there. Every former site delegates, each with a regression test.

- **The resolver never answers "may a new process start here."** Occupancy is the mint's veto and belongs to the write side; a read path that could refuse makes every lookup a policy decision. Pinned by `the resolver answers for a directory a mint would refuse`.
- **Surviving `deriveClaudeRuntimeIdentity` callers**: its definition, the resolver's last rung, and the three drift counters that exist to measure it. Nothing else.

Three defects the adversarial pass found in the first version of this chunk, all reproduced before fixing:

- **Ranking rungs is right for a read and wrong for a destructive decision.** The minted rung outranks the ledger, so an *ambiguous* ledger — two link records naming one worktree, which `recordHarnessLink` can leave behind because it supersedes by raw string compare while every reader canonicalizes — was silently resolved instead of refused. A pane declaring nothing then resolved to the reaping record's own session, and `decideWindow` killed that window and force-removed a directory a **live, differently-identified Claude was using** — precisely what `decideWindow`'s own doc comment exists to prevent. Anything that kills a window or removes a directory now asks whether the evidence *agrees*, and refuses when it does not, exactly as the mint already did.
- **`ReapDeps` had no `identities`**, so the daemon's one destructive decision read the ambient identity store, uninjectable. Its tests were reading the developer's real `~/.threa/harnessd` — one of them passed only because that store happened to hold no record for the fixture path.
- **Normalizing recorded ids.** A recorded id *is* the primary key of a file in the link or identity store, and those stores allow characters `sanitizeId` rewrites (dots) with no length cap. Rewriting one on the way out maps two distinct sessions onto one id — the failure `isSafeSessionFileName` refuses by design. Only text this daemon did not write is normalized now.

Also folded in from #1648's deferred list: `decideWindow` passed 2 arguments to `resolveManagedAgentPane`, so the ledger branch was untested on the one destructive decision and two canonicalizers acted on it.

The revive log's `drifted` flag is scored against the **derivation**, not the resolution — scoring it against the resolved id makes it structurally unreachable, since the inventory rung returns the recorded id. That line is what surfaced the 2026-07-28 storm.

## Files

| File | Change |
| ---- | ------ |
| `src/discovery.ts` | `resolveRuntimeIdentity` / `runtimeIdentityFor` / `IdentitySource`; `conflictingAttestations` |
| `src/reap.ts` | conflict refusal before any kill; `ReapDeps.identities`; ledger + canonicalizer injected into the resolver |
| `src/reconnect.ts`, `src/adopt.ts`, `src/commands.ts`, `src/spawners.ts` | delegate to the resolver |
| `src/identity.ts` | `minted` + `source` columns, `identityless` counter for `doctor` |
| `src/runtime-identity.test.ts` | **new** |

## Test plan

- [x] `bun test` — 246 pass / 0 fail (228 on base); typecheck clean; full pre-commit monorepo gates pass
- [x] Mutation-tested, source restored byte-identical: conflict guard removed → 2 fail; `identities` not injected → 1; canonicalizer not injected → 1; recorded ids normalized again → 1; drift scored against the resolution → 1
- [ ] No live run — this is the resolution path for a real fleet; the destructive branch is exercised by tests

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/harnessd-profiles-9af997/ — chunk 3 of 6.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787913335&installation_model_id=20758&pr_number=1662&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1662&signature=b4ad2b7ce8375eb77c24f670158fa39804cabfa8fae9c3d3042843a2f749d89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->