### PR TITLE
feat(harnessd): backfill identity where two sources already agree

### DIFF
--- a/extensions/harness-daemon/src/backfill.test.ts
+++ b/extensions/harness-daemon/src/backfill.test.ts
@@ -262,3 +262,37 @@ test("every subject appears in the disposition list exactly once", () => {
     { subject: "/repo/f", disposition: "recorded" },
   ])
 })
+
+test("each source is read once per pass, not once per subject", () => {
+  // Two tmux subprocesses and two full directory scans per subject, all while
+  // the startup path holds the shared lock.
+  let paneReads = 0
+  let linkReads = 0
+  const context = deps({
+    inventory: () => [agent(), agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" })],
+    links: () => {
+      linkReads += 1
+      return [link()]
+    },
+    panes: () => {
+      paneReads += 1
+      return []
+    },
+  })
+
+  backfillIdentities(context.deps, true)
+
+  expect({ paneReads, linkReads }).toEqual({ paneReads: 1, linkReads: 1 })
+})
+
+test("a corroborated subject with no instance id is not counted as a single source", () => {
+  const context = deps({
+    inventory: () => [agent({ instanceId: undefined })],
+    links: () => [link({ instanceId: "" })],
+  })
+
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "refused no instance id" }])
+  expect(context.written).toEqual([])
+})

--- a/extensions/harness-daemon/src/backfill.test.ts
+++ b/extensions/harness-daemon/src/backfill.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { HarnessLink } from "@threa/bot-runtime-client"
+import { backfillIdentities, type BackfillDeps, type BackfillOutcome } from "./backfill"
+import type { LocalTmuxPane } from "./discovery"
+import { writeMintedIdentity, type MintedIdentity, type WriteMintedIdentityResult } from "./identity-store"
+import type { ManagedAgent } from "./types"
+
+const WORKTREE = "/repo/threa.feature"
+
+let root: string
+const previousIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
+const previousLinks = process.env.THREA_HARNESS_LINKS_DIR
+const previousInventory = process.env.THREA_HARNESSD_INVENTORY
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-backfill-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "inventory.sqlite")
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  const restore = (name: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  restore("THREA_HARNESSD_IDENTITIES_DIR", previousIdentities)
+  restore("THREA_HARNESS_LINKS_DIR", previousLinks)
+  restore("THREA_HARNESSD_INVENTORY", previousInventory)
+})
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "feature",
+    runtime: "claude",
+    status: "online",
+    worktree: WORKTREE,
+    runtimeSessionId: "ccs-row",
+    instanceId: "cc-row",
+    command: [],
+    createdAt: "2026-07-29T00:00:00.000Z",
+    updatedAt: "2026-07-29T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function link(overrides: Partial<HarnessLink> = {}): HarnessLink {
+  return {
+    runtimeKind: "claude-code-channel",
+    runtimeSessionId: "ccs-row",
+    instanceId: "cc-ledger",
+    rootStreamId: "stream_root",
+    worktree: WORKTREE,
+    pid: 111,
+    updatedAt: "2026-07-29T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function pane(overrides: Partial<LocalTmuxPane> = {}): LocalTmuxPane {
+  return {
+    sessionName: "threa-agents",
+    windowName: "feature",
+    windowId: "@7",
+    paneId: "%8",
+    panePid: 999,
+    cwd: WORKTREE,
+    startCommand:
+      "env THREA_RUNTIME_SESSION_ID=ccs-row THREA_INSTANCE_ID=cc-launch claude --name threa.feature --dangerously-load-development-channels server:threa-channel",
+    ...overrides,
+  }
+}
+
+function deps(overrides: Partial<BackfillDeps> = {}): { deps: BackfillDeps; written: MintedIdentity[] } {
+  const written: MintedIdentity[] = []
+  return {
+    written,
+    deps: {
+      identities: () => [],
+      links: () => [],
+      panes: () => [],
+      inventory: () => [agent()],
+      claudeProcessesIn: () => [],
+      canonicalPath: (path) => path,
+      pathExists: () => true,
+      write: (record): WriteMintedIdentityResult => {
+        written.push(record)
+        return { status: "created", record }
+      },
+      now: () => new Date("2026-07-29T00:00:00.000Z"),
+      log: () => {},
+      ...overrides,
+    },
+  }
+}
+
+function pairs(outcomes: BackfillOutcome[]): Array<{ subject: string; disposition: string }> {
+  return outcomes.map(({ subject, disposition }) => ({ subject, disposition }))
+}
+
+test("an inventory row corroborated by a link record is recorded", () => {
+  const context = deps({ links: () => [link()] })
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "recorded" }])
+  expect(context.written).toEqual([
+    {
+      runtimeSessionId: "ccs-row",
+      instanceId: "cc-ledger",
+      worktree: WORKTREE,
+      runtimeKind: "claude-code-channel",
+      mintedAt: "2026-07-29T00:00:00.000Z",
+      source: "backfill",
+      attestedBy: "ledger",
+    },
+  ])
+})
+
+test("an inventory row nothing else attests is refused as a single source", () => {
+  const context = deps()
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "refused single source" }])
+  expect(context.written).toEqual([])
+})
+
+test("a live pane's declared launch corroborates an inventory row", () => {
+  // The pane's own Claude is registered in ~/.claude/sessions, so a veto whose
+  // pid arm cannot tell it from a stranger refuses every subject this arm
+  // exists for — measured on the real fleet as 0 recorded via launch. The pid
+  // is supplied here so the test pins a state production can actually reach.
+  const context = deps({ panes: () => [pane()], claudeProcessesIn: () => [pane().panePid] })
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "recorded" }])
+  expect(context.written).toEqual([
+    {
+      runtimeSessionId: "ccs-row",
+      instanceId: "cc-launch",
+      worktree: WORKTREE,
+      runtimeKind: "claude-code-channel",
+      mintedAt: "2026-07-29T00:00:00.000Z",
+      source: "backfill",
+      attestedBy: "launch",
+    },
+  ])
+})
+
+test("a directory with an unidentified live Claude is refused, not recorded", () => {
+  const context = deps({ links: () => [link()], claudeProcessesIn: () => [4242, 4243] })
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(outcomes).toEqual([
+    {
+      subject: WORKTREE,
+      disposition: "refused occupied",
+      detail: `an unidentified live Claude occupies ${WORKTREE} (pid 4242, 4243)`,
+    },
+  ])
+  expect(context.written).toEqual([])
+})
+
+test("sources that disagree on one worktree are refused, never merged", () => {
+  const context = deps({ links: () => [link({ runtimeSessionId: "ccs-ledger" })] })
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(outcomes).toEqual([
+    {
+      subject: WORKTREE,
+      disposition: "refused conflicting",
+      detail: `sources disagree on ${WORKTREE}: ccs-ledger, ccs-row`,
+    },
+  ])
+  expect(context.written).toEqual([])
+})
+
+test("a row whose worktree no longer exists is refused, not recorded", () => {
+  const context = deps({ links: () => [link()], pathExists: () => false })
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "refused worktree missing" }])
+  expect(context.written).toEqual([])
+})
+
+test("a dry run reports the same dispositions and writes nothing", () => {
+  // Both passes run against the REAL store, in separate directories, over two
+  // subjects whose evidence resolves to ONE id. A stubbed `write` cannot catch
+  // this: with nothing persisted, the wet run's later subjects see exactly the
+  // store the dry run sees, so the equality holds for any divergence.
+  const two = {
+    inventory: () => [agent(), agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" })],
+    links: () => [link(), link({ worktree: "/repo/threa.other" })],
+    pathExists: () => true,
+  }
+  const wetDir = join(root, "wet")
+  const dryDir = join(root, "dry")
+
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = wetDir
+  const wet = backfillIdentities({ ...deps(two).deps, write: writeMintedIdentity }, false)
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = dryDir
+  const preview = backfillIdentities({ ...deps(two).deps, write: writeMintedIdentity }, true)
+
+  expect(preview).toEqual(wet)
+  expect(wet.map((outcome) => outcome.disposition)).toEqual(["recorded", "refused conflicting"])
+  expect(existsSync(dryDir)).toBe(false)
+})
+
+test("the backfill never writes a harness link record", () => {
+  const linksDir = process.env.THREA_HARNESS_LINKS_DIR!
+  mkdirSync(linksDir, { recursive: true })
+  const before = readdirSync(linksDir)
+
+  const outcomes = backfillIdentities(deps({ links: () => [link()], write: writeMintedIdentity }).deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "recorded" }])
+  expect(readdirSync(linksDir)).toEqual(before)
+})
+
+test("every subject appears in the disposition list exactly once", () => {
+  const rows: ManagedAgent[] = [
+    agent({ id: "a", worktree: "/repo/a", runtimeSessionId: "ccs-a" }),
+    agent({ id: "b", worktree: "/repo/b", runtimeSessionId: "ccs-b" }),
+    agent({ id: "c", worktree: "/repo/c", runtimeSessionId: "ccs-c" }),
+    agent({ id: "d", worktree: "/repo/d", runtimeSessionId: "ccs-d" }),
+    agent({ id: "e", worktree: "/repo/e", runtimeSessionId: "ccs-e" }),
+    agent({ id: "f", worktree: "/repo/f", runtimeSessionId: "ccs-f" }),
+    agent({ id: "f-twin", worktree: "/repo/f", runtimeSessionId: "ccs-f" }),
+  ]
+  const context = deps({
+    inventory: () => rows,
+    links: () => [
+      link({ worktree: "/repo/a", runtimeSessionId: "ccs-a" }),
+      link({ worktree: "/repo/c", runtimeSessionId: "ccs-other" }),
+      link({ worktree: "/repo/d", runtimeSessionId: "ccs-d" }),
+      link({ worktree: "/repo/f", runtimeSessionId: "ccs-f" }),
+    ],
+    identities: () => [
+      {
+        runtimeSessionId: "ccs-e",
+        instanceId: "cc-e",
+        worktree: "/repo/e",
+        runtimeKind: "claude-code-channel",
+        mintedAt: "2026-07-29T00:00:00.000Z",
+        source: "mint",
+      },
+    ],
+    pathExists: (path) => path !== "/repo/b",
+    claudeProcessesIn: (worktree) => (worktree === "/repo/d" ? [77] : []),
+  })
+
+  expect(pairs(backfillIdentities(context.deps, false))).toEqual([
+    { subject: "/repo/a", disposition: "recorded" },
+    { subject: "/repo/b", disposition: "refused worktree missing" },
+    { subject: "/repo/c", disposition: "refused conflicting" },
+    { subject: "/repo/d", disposition: "refused occupied" },
+    { subject: "/repo/e", disposition: "already recorded" },
+    { subject: "/repo/f", disposition: "recorded" },
+  ])
+})

--- a/extensions/harness-daemon/src/backfill.ts
+++ b/extensions/harness-daemon/src/backfill.ts
@@ -1,0 +1,265 @@
+import { existsSync } from "node:fs"
+import { isSafeSessionFileName, readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
+import { liveClaudePidsIn } from "./claude-registry"
+import {
+  attestedRuntimes,
+  canonicalOrRaw,
+  ledgerIdentity,
+  listLocalTmuxPanes,
+  parseClaudeChannelLaunch,
+  type LocalTmuxPane,
+} from "./discovery"
+import {
+  identityRecordsFor,
+  readMintedIdentities,
+  writeMintedIdentity,
+  type MintedIdentity,
+  type WriteMintedIdentityResult,
+} from "./identity-store"
+import { readInventoryReadonly } from "./inventory"
+import { occupancyVeto } from "./mint"
+import type { ManagedAgent } from "./types"
+
+export type BackfillDisposition =
+  | "recorded"
+  | "already recorded"
+  | "refused single source"
+  | "refused occupied"
+  | "refused conflicting"
+  | "refused worktree missing"
+  | "refused unsafe id"
+
+export interface BackfillOutcome {
+  /** The canonical worktree: the key every store agrees on. */
+  subject: string
+  disposition: BackfillDisposition
+  detail?: string
+}
+
+export interface BackfillDeps {
+  identities: () => MintedIdentity[]
+  links: () => HarnessLink[]
+  panes: () => LocalTmuxPane[]
+  inventory: () => ManagedAgent[]
+  claudeProcessesIn: (worktree: string) => number[]
+  canonicalPath: (path: string) => string
+  pathExists: (path: string) => boolean
+  write: (record: MintedIdentity) => WriteMintedIdentityResult
+  now: () => Date
+  log: (message: string) => void
+}
+
+export function defaultBackfillDeps(): BackfillDeps {
+  return {
+    identities: readMintedIdentities,
+    links: readHarnessLinks,
+    panes: listLocalTmuxPanes,
+    inventory: readInventoryReadonly,
+    claudeProcessesIn: liveClaudePidsIn,
+    canonicalPath: canonicalOrRaw,
+    pathExists: existsSync,
+    write: writeMintedIdentity,
+    now: () => new Date(),
+    log: (message) => console.warn(message),
+  }
+}
+
+type Attestor = "ledger" | "launch" | "inventory"
+
+interface Evidence {
+  attestor: Attestor
+  runtimeSessionId: string
+  instanceId?: string
+  /** Set only by the launch attestor: the live process this evidence came from. */
+  panePid?: number
+}
+
+/** ledger over launch over inventory: the inventory row is immutable per launch and stale by construction. */
+const ATTESTOR_RANK: Attestor[] = ["ledger", "launch", "inventory"]
+
+function subjectsOf(agents: ManagedAgent[], canonical: (path: string) => string): Map<string, ManagedAgent[]> {
+  const subjects = new Map<string, ManagedAgent[]>()
+  for (const agent of agents) {
+    if (agent.runtime !== "claude" || !agent.worktree) continue
+    const worktree = canonical(agent.worktree)
+    const rows = subjects.get(worktree)
+    if (rows) rows.push(agent)
+    else subjects.set(worktree, [agent])
+  }
+  return subjects
+}
+
+function launchEvidence(worktree: string, deps: BackfillDeps): Evidence[] {
+  let panes: LocalTmuxPane[]
+  try {
+    panes = deps.panes()
+  } catch {
+    // No tmux server is the ordinary state on a cold boot. A missing rung is a
+    // missing rung, never a corroboration: the subject falls to single source.
+    return []
+  }
+  const evidence: Evidence[] = []
+  for (const pane of panes) {
+    if (deps.canonicalPath(pane.cwd) !== worktree) continue
+    const launch = parseClaudeChannelLaunch(pane.startCommand)
+    if (!launch?.runtimeSessionId) continue
+    evidence.push({
+      attestor: "launch",
+      runtimeSessionId: launch.runtimeSessionId,
+      instanceId: launch.instanceId,
+      panePid: pane.panePid,
+    })
+  }
+  return evidence
+}
+
+function decide(
+  worktree: string,
+  rows: ManagedAgent[],
+  deps: BackfillDeps,
+  dryRun: boolean,
+  claimed: Map<string, string>
+): BackfillOutcome {
+  const records = deps.identities()
+  const recorded = identityRecordsFor(worktree, records, deps.canonicalPath)
+  const attested = attestedRuntimes(deps.links(), deps.canonicalPath)
+
+  if (!deps.pathExists(worktree)) {
+    return { subject: worktree, disposition: "refused worktree missing", detail: worktree }
+  }
+
+  const evidence: Evidence[] = []
+  const ledger = ledgerIdentity(worktree, attested, deps.canonicalPath)
+  if (ledger) {
+    evidence.push({ attestor: "ledger", runtimeSessionId: ledger.runtimeSessionId, instanceId: ledger.instanceId })
+  }
+  evidence.push(...launchEvidence(worktree, deps))
+  for (const row of rows) {
+    if (row.runtimeSessionId) {
+      evidence.push({ attestor: "inventory", runtimeSessionId: row.runtimeSessionId, instanceId: row.instanceId })
+    }
+  }
+
+  const ids = new Set<string>([
+    ...evidence.map((item) => item.runtimeSessionId),
+    ...recorded.map((record) => record.runtimeSessionId),
+    ...attested.filter((entry) => entry.worktree === worktree).map((entry) => entry.runtimeSessionId),
+  ])
+  if (ids.size > 1) {
+    return {
+      subject: worktree,
+      disposition: "refused conflicting",
+      detail: `sources disagree on ${worktree}: ${[...ids].sort().join(", ")}`,
+    }
+  }
+
+  if (recorded.length > 0) {
+    return { subject: worktree, disposition: "already recorded", detail: recorded[0]!.runtimeSessionId }
+  }
+
+  const attestors = new Set(evidence.map((item) => item.attestor))
+  if (attestors.size < 2) {
+    return {
+      subject: worktree,
+      disposition: "refused single source",
+      detail: attestors.size === 0 ? "no source attests an identity" : `only the ${[...attestors][0]} attests it`,
+    }
+  }
+
+  const identified = new Set([
+    ...records.map((record) => record.runtimeSessionId),
+    ...attested.map((entry) => entry.runtimeSessionId),
+    ...ids,
+  ])
+  // A live Claude whose own launch declares the identity being recorded is not
+  // an unidentified occupant — it is the session this evidence came from.
+  const accounted = new Set(
+    evidence.filter((item) => item.panePid !== undefined && ids.has(item.runtimeSessionId)).map((item) => item.panePid!)
+  )
+  const veto = occupancyVeto(worktree, { ...deps, warn: deps.log }, identified, accounted)
+  if (veto) return { subject: worktree, disposition: "refused occupied", detail: veto }
+
+  const winner = evidence.sort((a, b) => ATTESTOR_RANK.indexOf(a.attestor) - ATTESTOR_RANK.indexOf(b.attestor))[0]!
+  const instanceId = winner.instanceId ?? evidence.find((item) => item.instanceId)?.instanceId
+  if (!instanceId) {
+    return { subject: worktree, disposition: "refused single source", detail: "no source attests an instance id" }
+  }
+  if (!isSafeSessionFileName(winner.runtimeSessionId)) {
+    return {
+      subject: worktree,
+      disposition: "refused unsafe id",
+      detail: `unsafe runtime session id: ${JSON.stringify(winner.runtimeSessionId)}`,
+    }
+  }
+
+  // Decided BEFORE the write, and against ids claimed earlier in this same pass,
+  // so a dry run reaches the identical branch. Leaving it to the write's EEXIST
+  // made the mandatory operator preview promise `recorded` for exactly the
+  // ambiguous subjects an operator runs it to scrutinise.
+  const priorWorktree =
+    claimed.get(winner.runtimeSessionId) ??
+    records.find((record) => record.runtimeSessionId === winner.runtimeSessionId)?.worktree
+  if (priorWorktree !== undefined && deps.canonicalPath(priorWorktree) !== worktree) {
+    return {
+      subject: worktree,
+      disposition: "refused conflicting",
+      detail: `${winner.runtimeSessionId} is already recorded for ${priorWorktree}, not ${worktree}`,
+    }
+  }
+  claimed.set(winner.runtimeSessionId, worktree)
+
+  if (dryRun) {
+    return { subject: worktree, disposition: "recorded", detail: `${winner.runtimeSessionId} via ${winner.attestor}` }
+  }
+  const written = deps.write({
+    runtimeSessionId: winner.runtimeSessionId,
+    instanceId,
+    worktree,
+    runtimeKind: "claude-code-channel",
+    mintedAt: deps.now().toISOString(),
+    source: "backfill",
+    attestedBy: winner.attestor,
+  })
+  if (written.status === "created") {
+    return { subject: worktree, disposition: "recorded", detail: `${winner.runtimeSessionId} via ${winner.attestor}` }
+  }
+  if (written.status === "exists") {
+    return deps.canonicalPath(written.existing.worktree) === worktree
+      ? { subject: worktree, disposition: "already recorded", detail: written.existing.runtimeSessionId }
+      : {
+          subject: worktree,
+          disposition: "refused conflicting",
+          detail: `${written.existing.runtimeSessionId} is already recorded for ${written.existing.worktree}, not ${worktree}`,
+        }
+  }
+  return { subject: worktree, disposition: "refused unsafe id", detail: written.reason }
+}
+
+/**
+ * Write down the identity every store already agrees on, so a session stops
+ * depending on `deriveClaudeRuntimeIdentity` — which hashes `os.hostname()` and
+ * changes with the wifi network.
+ *
+ * Two independent sources must agree before anything is written: a lone
+ * inventory row is reported as `refused single source`, never recorded. Every
+ * subject appears in the returned list with a disposition — a refusal is a
+ * reported reason, never a skipped iteration, because a backfill that silently
+ * does nothing looks exactly like one that worked (INV-11).
+ *
+ * The identity store is the only write target. The reaper reads `links/`, so a
+ * link record minted here is how a backfill bug becomes a deleted worktree.
+ */
+export function backfillIdentities(deps: BackfillDeps, dryRun: boolean): BackfillOutcome[] {
+  const subjects = subjectsOf(deps.inventory(), deps.canonicalPath)
+  // Ids claimed earlier in THIS pass. Without it a dry run and a wet run diverge
+  // whenever two subjects resolve to one id: the wet run sees the first write on
+  // disk and refuses, the dry run writes nothing and reports both as recorded.
+  const claimed = new Map<string, string>()
+  return [...subjects].map(([worktree, rows]) => decide(worktree, rows, deps, dryRun, claimed))
+}
+
+export function summarizeBackfill(outcomes: BackfillOutcome[]): Array<[BackfillDisposition, number]> {
+  const counts = new Map<BackfillDisposition, number>()
+  for (const outcome of outcomes) counts.set(outcome.disposition, (counts.get(outcome.disposition) ?? 0) + 1)
+  return [...counts.entries()]
+}

--- a/extensions/harness-daemon/src/backfill.ts
+++ b/extensions/harness-daemon/src/backfill.ts
@@ -27,6 +27,7 @@ export type BackfillDisposition =
   | "refused occupied"
   | "refused conflicting"
   | "refused worktree missing"
+  | "refused no instance id"
   | "refused unsafe id"
 
 export interface BackfillOutcome {
@@ -76,6 +77,25 @@ interface Evidence {
 
 /** ledger over launch over inventory: the inventory row is immutable per launch and stale by construction. */
 const ATTESTOR_RANK: Attestor[] = ["ledger", "launch", "inventory"]
+
+/** Memoized including the throw: `listLocalTmuxPanes` raises when there is no tmux server, and every subject must see that same answer. */
+function once<T>(read: () => T): () => T {
+  let value: T
+  let thrown: unknown
+  let done = false
+  return () => {
+    if (!done) {
+      try {
+        value = read()
+      } catch (error) {
+        thrown = error
+      }
+      done = true
+    }
+    if (thrown !== undefined) throw thrown
+    return value
+  }
+}
 
 function subjectsOf(agents: ManagedAgent[], canonical: (path: string) => string): Map<string, ManagedAgent[]> {
   const subjects = new Map<string, ManagedAgent[]>()
@@ -182,7 +202,7 @@ function decide(
   const winner = evidence.sort((a, b) => ATTESTOR_RANK.indexOf(a.attestor) - ATTESTOR_RANK.indexOf(b.attestor))[0]!
   const instanceId = winner.instanceId ?? evidence.find((item) => item.instanceId)?.instanceId
   if (!instanceId) {
-    return { subject: worktree, disposition: "refused single source", detail: "no source attests an instance id" }
+    return { subject: worktree, disposition: "refused no instance id", detail: winner.runtimeSessionId }
   }
   if (!isSafeSessionFileName(winner.runtimeSessionId)) {
     return {
@@ -194,8 +214,7 @@ function decide(
 
   // Decided BEFORE the write, and against ids claimed earlier in this same pass,
   // so a dry run reaches the identical branch. Leaving it to the write's EEXIST
-  // made the mandatory operator preview promise `recorded` for exactly the
-  // ambiguous subjects an operator runs it to scrutinise.
+  // reports `recorded` in a preview that then refuses.
   const priorWorktree =
     claimed.get(winner.runtimeSessionId) ??
     records.find((record) => record.runtimeSessionId === winner.runtimeSessionId)?.worktree
@@ -250,12 +269,17 @@ function decide(
  * link record minted here is how a backfill bug becomes a deleted worktree.
  */
 export function backfillIdentities(deps: BackfillDeps, dryRun: boolean): BackfillOutcome[] {
+  // Read once per pass, not once per subject. Nothing in this pass writes a link
+  // record or a pane, and at fleet scale the per-subject reads meant one `tmux
+  // list-panes` per subject in `launchEvidence` and a second inside the veto —
+  // all of it while the startup path holds the shared lock. `identities` stays
+  // per-subject: the wet run's own writes have to be visible to later subjects.
+  const passDeps: BackfillDeps = { ...deps, links: once(deps.links), panes: once(deps.panes) }
   const subjects = subjectsOf(deps.inventory(), deps.canonicalPath)
-  // Ids claimed earlier in THIS pass. Without it a dry run and a wet run diverge
-  // whenever two subjects resolve to one id: the wet run sees the first write on
-  // disk and refuses, the dry run writes nothing and reports both as recorded.
+  // Ids claimed earlier in THIS pass: without it a dry run and a wet run diverge
+  // whenever two subjects resolve to one id.
   const claimed = new Map<string, string>()
-  return [...subjects].map(([worktree, rows]) => decide(worktree, rows, deps, dryRun, claimed))
+  return [...subjects].map(([worktree, rows]) => decide(worktree, rows, passDeps, dryRun, claimed))
 }
 
 export function summarizeBackfill(outcomes: BackfillOutcome[]): Array<[BackfillDisposition, number]> {

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -29,6 +29,7 @@ Usage:
   threa-harnessd keys <agent-id-or-name> <tmux send-keys tokens...>
   threa-harnessd attach <agent-id-or-name>
   threa-harnessd resolve [<agent-id-or-name-or-runtime-session-id>]
+  threa-harnessd backfill-identities [--dry-run]  (record the identity two sources already agree on)
   threa-harnessd doctor
 
 Examples:
@@ -176,6 +177,14 @@ const ADOPT_FLAGS = new Set([
   "no-yolo",
   "yolo",
 ])
+
+export function parseBackfill(args: string[]): { dryRun: boolean } {
+  const flags = parseFlags(args)
+  for (const key of Object.keys(flags)) {
+    if (key !== "dry-run") die(`unexpected backfill-identities argument: --${key}`)
+  }
+  return { dryRun: boolFlag(flags, "dry-run") }
+}
 
 export function parseResolve(args: string[]): string | undefined {
   const ref = args.shift()

--- a/extensions/harness-daemon/src/commands.test.ts
+++ b/extensions/harness-daemon/src/commands.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { BackfillOutcome } from "./backfill"
-import { defaultStartupReconciliationDeps, startupReconciliation } from "./commands"
+import { STARTUP_LOCK_WAIT_MS, defaultStartupReconciliationDeps, startupReconciliation } from "./commands"
 import { resumeActiveLockPath } from "./lock"
 
 let root: string
@@ -100,4 +100,27 @@ test("a dry-run startup pass does not take the lock the live daemon holds", asyn
 
   expect(existsSync(path)).toBe(true)
   expect(readFileSync(path, "utf8")).toBe(String(process.pid))
+})
+
+test("a held lock delays startup by a bounded wait, not the default ten minutes", async () => {
+  // Until this resolves no transport is built and no reap runs, so an unbounded
+  // wait turns one wedged holder into a silent outage for as long as it lives.
+  expect(STARTUP_LOCK_WAIT_MS).toBeLessThanOrEqual(60_000)
+
+  const path = resumeActiveLockPath()
+  mkdirSync(join(path, ".."), { recursive: true })
+  writeFileSync(path, String(process.pid))
+  const swept: string[] = []
+  const logged: string[] = []
+
+  const startedAt = Date.now()
+  await startupReconciliation({
+    ...defaultStartupReconciliationDeps(() => void swept.push("sweep"), false, 60),
+    backfill: () => [],
+    log: (message) => void logged.push(message),
+  })
+
+  expect(Date.now() - startedAt).toBeLessThan(2_000)
+  expect(swept).toEqual(["sweep"])
+  expect(logged.join("\n")).toContain("backfill failed")
 })

--- a/extensions/harness-daemon/src/commands.test.ts
+++ b/extensions/harness-daemon/src/commands.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackfillOutcome } from "./backfill"
+import { defaultStartupReconciliationDeps, startupReconciliation } from "./commands"
+import { resumeActiveLockPath } from "./lock"
+
+let root: string
+const previousIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
+const previousLinks = process.env.THREA_HARNESS_LINKS_DIR
+const previousInventory = process.env.THREA_HARNESSD_INVENTORY
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-startup-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "inventory.sqlite")
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  const restore = (name: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  restore("THREA_HARNESSD_IDENTITIES_DIR", previousIdentities)
+  restore("THREA_HARNESS_LINKS_DIR", previousLinks)
+  restore("THREA_HARNESSD_INVENTORY", previousInventory)
+})
+
+const recorded: BackfillOutcome[] = [{ subject: "/repo/a", disposition: "recorded" }]
+
+test("startupReconciliation backfills before the first revive sweep", async () => {
+  const calls: string[] = []
+
+  await startupReconciliation({
+    backfill: () => {
+      calls.push("backfill")
+      return recorded
+    },
+    lock: async () => () => {},
+    sweep: () => {
+      calls.push("sweep")
+    },
+    log: (message) => calls.push(`log:${message}`),
+  })
+
+  expect(calls).toEqual(["backfill", "log:harnessd: identity backfill: 1 subject(s), 1 recorded", "sweep"])
+})
+
+test("a failing backfill logs and does not abort the startup pass", async () => {
+  const calls: string[] = []
+
+  await startupReconciliation({
+    backfill: () => {
+      throw new Error("inventory unreadable")
+    },
+    lock: async () => () => {},
+    sweep: () => {
+      calls.push("sweep")
+    },
+    log: (message) => calls.push(`log:${message}`),
+  })
+
+  expect(calls).toEqual(["log:harnessd: identity backfill failed: inventory unreadable", "sweep"])
+})
+
+test("a lock the startup pass cannot take is logged, and the sweep still runs", async () => {
+  // acquireProcessLock spins to a 10-minute deadline and throws when the holder
+  // is alive. Letting that escape exited the process, launchd restarted it, and
+  // it took the lock again — a crash loop with no transports and no reap.
+  const swept: string[] = []
+  const logged: string[] = []
+
+  await startupReconciliation({
+    backfill: () => [],
+    lock: async () => {
+      throw new Error("lock /tmp/resume-active.lock held by pid 4242 for over 600s")
+    },
+    sweep: () => void swept.push("sweep"),
+    log: (message) => void logged.push(message),
+  })
+
+  expect(swept).toEqual(["sweep"])
+  expect(logged.join("\n")).toContain("held by pid 4242")
+})
+
+test("a dry-run startup pass does not take the lock the live daemon holds", async () => {
+  // `resumeActive` and `reapArchived` both skip the lock for a dry run. A
+  // preview that takes it blocks the live daemon's revive and reap for its
+  // duration — and if the daemon holds it, the preview hangs ten minutes and
+  // then exits instead of printing a preview.
+  const path = resumeActiveLockPath()
+  mkdirSync(join(path, ".."), { recursive: true })
+  writeFileSync(path, String(process.pid))
+
+  const release = await defaultStartupReconciliationDeps(() => {}, true).lock()
+  release()
+
+  expect(existsSync(path)).toBe(true)
+  expect(readFileSync(path, "utf8")).toBe(String(process.pid))
+})

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -7,6 +7,7 @@ import {
 } from "@threa/bot-runtime-client"
 import { existsSync } from "node:fs"
 import { basename, join } from "node:path"
+import { backfillIdentities, defaultBackfillDeps, summarizeBackfill, type BackfillOutcome } from "./backfill"
 import { installBootResume } from "./boot"
 import { liveClaudePidsIn } from "./claude-registry"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
@@ -136,6 +137,83 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
   }
 }
 
+export interface StartupReconciliationDeps {
+  backfill: () => BackfillOutcome[]
+  /** Resolves to the release. A dry run resolves to a no-op, as every other dry-run path does. */
+  lock: () => Promise<() => void>
+  sweep: () => void | Promise<void>
+  log: (message: string) => void
+}
+
+export function defaultStartupReconciliationDeps(
+  sweep: () => void | Promise<void>,
+  dryRun: boolean
+): StartupReconciliationDeps {
+  return {
+    backfill: () => backfillIdentities(defaultBackfillDeps(), dryRun),
+    // A preview must not block the live daemon's revive and reap for its
+    // duration, nor hang behind them — `resumeActive` and `reapArchived` both
+    // skip the lock for a dry run, and so does this.
+    lock: async () => (dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath())),
+    sweep,
+    log: (message) => console.warn(message),
+  }
+}
+
+/**
+ * Record the identities the stores already agree on, then sweep.
+ *
+ * The lock is released before the sweep: `acquireProcessLock` is not reentrant —
+ * a lock file naming the current pid is neither stolen nor rejected, it is
+ * waited on until the 10-minute timeout — and the sweep takes the same lock.
+ *
+ * A failing backfill is logged and the sweep still runs: the backfill is an
+ * optimisation of what the resolver already computes, never a precondition for
+ * reviving a session.
+ */
+export async function startupReconciliation(deps: StartupReconciliationDeps): Promise<void> {
+  let release: (() => void) | undefined
+  try {
+    // Inside the try: acquireProcessLock does not steal a lock whose holder is
+    // ALIVE, it spins to a 10-minute deadline and throws. Outside, that throw
+    // propagated out of watchUnarchived and exited the process — which launchd
+    // restarts, which takes the lock again, so a single wedged holder turned the
+    // daemon into a crash loop with no transports and no reap backstop at all.
+    release = await deps.lock()
+    const outcomes = deps.backfill()
+    const counts = summarizeBackfill(outcomes)
+      .map(([disposition, count]) => `${count} ${disposition}`)
+      .join(", ")
+    deps.log(`harnessd: identity backfill: ${outcomes.length} subject(s)${counts ? `, ${counts}` : ""}`)
+  } catch (error) {
+    deps.log(`harnessd: identity backfill failed: ${error instanceof Error ? error.message : String(error)}`)
+  } finally {
+    release?.()
+  }
+  await deps.sweep()
+}
+
+export async function backfillIdentitiesCommand(options: { dryRun: boolean }): Promise<void> {
+  // Same lock as the revive and reap passes, and skipped for a dry run exactly
+  // as they skip it. Writing unlocked let the reaper retire an identity while
+  // this pass was recording it, leaving a record bound to a removed worktree
+  // that the next spawn of that name would reuse.
+  const release = options.dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath())
+  let outcomes
+  try {
+    outcomes = backfillIdentities(defaultBackfillDeps(), options.dryRun)
+  } finally {
+    release()
+  }
+  for (const outcome of outcomes) {
+    console.log(`${outcome.disposition}\t${outcome.subject}${outcome.detail ? `\t${outcome.detail}` : ""}`)
+  }
+  const counts = summarizeBackfill(outcomes)
+    .map(([disposition, count]) => `${count} ${disposition}`)
+    .join(", ")
+  console.log(`harnessd: ${outcomes.length} subject${outcomes.length === 1 ? "" : "s"}${counts ? `, ${counts}` : ""}`)
+}
+
 export async function watchUnarchived(options: ResumeOptions): Promise<void> {
   const watchStartedAtMs = Date.now()
   const session = options.tmux ?? "threa-agents"
@@ -194,6 +272,8 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
         console.error(`harnessd: reconciliation failed: ${error instanceof Error ? error.message : String(error)}`)
       })
   }
+
+  await startupReconciliation(defaultStartupReconciliationDeps(() => reconcile(), options.dryRun ?? false))
 
   const transports = targets.map(
     (target) =>

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -137,6 +137,9 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
   }
 }
 
+/** Long enough for an ordinary revive or reap to finish, short enough that a wedged holder cannot delay startup. */
+export const STARTUP_LOCK_WAIT_MS = 30_000
+
 export interface StartupReconciliationDeps {
   backfill: () => BackfillOutcome[]
   /** Resolves to the release. A dry run resolves to a no-op, as every other dry-run path does. */
@@ -147,14 +150,16 @@ export interface StartupReconciliationDeps {
 
 export function defaultStartupReconciliationDeps(
   sweep: () => void | Promise<void>,
-  dryRun: boolean
+  dryRun: boolean,
+  lockWaitMs = STARTUP_LOCK_WAIT_MS
 ): StartupReconciliationDeps {
   return {
     backfill: () => backfillIdentities(defaultBackfillDeps(), dryRun),
-    // A preview must not block the live daemon's revive and reap for its
-    // duration, nor hang behind them — `resumeActive` and `reapArchived` both
-    // skip the lock for a dry run, and so does this.
-    lock: async () => (dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath())),
+    // Bounded: the default deadline is ten minutes, and until this resolves no
+    // transport exists and no reap runs. The backfill is an optimisation of what
+    // the resolver already computes, so losing a pass costs nothing — the next
+    // restart runs it again.
+    lock: async () => (dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath(), { timeoutMs: lockWaitMs })),
     sweep,
     log: (message) => console.warn(message),
   }
@@ -174,11 +179,9 @@ export function defaultStartupReconciliationDeps(
 export async function startupReconciliation(deps: StartupReconciliationDeps): Promise<void> {
   let release: (() => void) | undefined
   try {
-    // Inside the try: acquireProcessLock does not steal a lock whose holder is
-    // ALIVE, it spins to a 10-minute deadline and throws. Outside, that throw
-    // propagated out of watchUnarchived and exited the process — which launchd
-    // restarts, which takes the lock again, so a single wedged holder turned the
-    // daemon into a crash loop with no transports and no reap backstop at all.
+    // Inside the try: a lock whose holder is alive is neither stolen nor
+    // rejected, it is waited on and then throws, and this runs on a path whose
+    // failure must not stop the daemon starting.
     release = await deps.lock()
     const outcomes = deps.backfill()
     const counts = summarizeBackfill(outcomes)
@@ -195,9 +198,8 @@ export async function startupReconciliation(deps: StartupReconciliationDeps): Pr
 
 export async function backfillIdentitiesCommand(options: { dryRun: boolean }): Promise<void> {
   // Same lock as the revive and reap passes, and skipped for a dry run exactly
-  // as they skip it. Writing unlocked let the reaper retire an identity while
-  // this pass was recording it, leaving a record bound to a removed worktree
-  // that the next spawn of that name would reuse.
+  // as they skip it: unlocked, the reaper can retire an identity while this pass
+  // is recording it.
   const release = options.dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath())
   let outcomes
   try {

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 
 import { adoptClaudeSession, adoptRefused } from "./adopt"
-import { parseAdopt, parseReconnect, parseResolve, parseResume, parseSpawn, usage } from "./cli"
+import { parseAdopt, parseBackfill, parseReconnect, parseResolve, parseResume, parseSpawn, usage } from "./cli"
 import {
   attachAgent,
+  backfillIdentitiesCommand,
   bootResume,
   doctor,
   inferAndRun,
@@ -58,6 +59,7 @@ async function main(): Promise<void> {
   if (command === "keys") return sendKeysToAgent(args[0] ?? die("keys requires an agent id or name"), args.slice(1))
   if (command === "attach") return attachAgent(args[0] ?? die("attach requires an agent id or name"))
   if (command === "resolve") return resolveIdentity(parseResolve(args))
+  if (command === "backfill-identities") return backfillIdentitiesCommand(parseBackfill(args))
   if (command === "doctor") return doctor()
   if (command === "do") return inferAndRun(args.join(" "))
   die(`unknown command: ${command}`)

--- a/extensions/harness-daemon/src/mint.ts
+++ b/extensions/harness-daemon/src/mint.ts
@@ -62,8 +62,24 @@ export function defaultMintDeps(): MintDeps {
  * so nothing else can see it. Minting a new identity over it would hand the
  * reaper a worktree it believes is free and let it kill a live session.
  */
-function occupancyVeto(worktree: string, deps: MintDeps, identifiedSessionIds: Set<string>): string | undefined {
-  const pids = deps.claudeProcessesIn(worktree)
+export type OccupancyDeps = Pick<MintDeps, "panes" | "claudeProcessesIn" | "canonicalPath" | "warn">
+
+export function occupancyVeto(
+  worktree: string,
+  deps: OccupancyDeps,
+  identifiedSessionIds: Set<string>,
+  /**
+   * Pids a caller has already tied to the identity it is about to record. The
+   * pid arm cannot identify anyone by itself — `~/.claude/sessions` keys on
+   * Claude's own session id, not a Threa runtime session id — so a caller that
+   * DOES know which pane owns the directory supplies its `panePid` here. That is
+   * the same pane-pid equivalence the reaper uses to tell its own session from a
+   * stranger. A mint supplies nothing: it has no candidate id yet, so every live
+   * pid is a stranger to it.
+   */
+  accountedPids: Set<number> = new Set()
+): string | undefined {
+  const pids = deps.claudeProcessesIn(worktree).filter((pid) => !accountedPids.has(pid))
   let panes: LocalTmuxPane[] = []
   let panesRead = true
   try {

--- a/extensions/harness-daemon/src/mint.ts
+++ b/extensions/harness-daemon/src/mint.ts
@@ -69,13 +69,12 @@ export function occupancyVeto(
   deps: OccupancyDeps,
   identifiedSessionIds: Set<string>,
   /**
-   * Pids a caller has already tied to the identity it is about to record. The
-   * pid arm cannot identify anyone by itself — `~/.claude/sessions` keys on
-   * Claude's own session id, not a Threa runtime session id — so a caller that
-   * DOES know which pane owns the directory supplies its `panePid` here. That is
-   * the same pane-pid equivalence the reaper uses to tell its own session from a
-   * stranger. A mint supplies nothing: it has no candidate id yet, so every live
-   * pid is a stranger to it.
+   * Pids a caller has already tied to the identity it is about to record. The pid
+   * arm cannot identify anyone by itself — `~/.claude/sessions` keys on Claude's
+   * own session id, not a Threa one — so a caller that knows which pane owns the
+   * directory supplies its `panePid`, the same equivalence the reaper uses. A
+   * mint supplies none: it has no candidate id yet, so every live pid is a
+   * stranger to it.
    */
   accountedPids: Set<number> = new Set()
 ): string | undefined {


### PR DESCRIPTION
## Problem

Chunks 2–3 record identity for **new** sessions and resolve it in one place. Everything that predates the store still falls through to `deriveClaudeRuntimeIdentity`, which hashes a DHCP-supplied hostname and so changes with the wifi network. Measured on the real fleet: **71 subjects**, most carrying no identity at all.

Chunk 5 un-collapses name-grouped inventory rows. It is only safe if those rows already have identity recorded, so this has to land first.

## Solution

Write down what the resolver already computes — and refuse far more often than write.

- **Two independent sources must agree**: inventory + ledger, inventory + a live declared launch, or ledger + a live pane. Inventory-only ⇒ `refused single source`. Singleton inventory evidence must never become reapable without corroboration.
- **Conflicting sources refuse**, naming both ids. Never merges, never picks.
- **The identity store is the only write target.** The reaper reads `links/`, so a link record written here is how a backfill bug becomes a deleted worktree. A test asserts the links dir is byte-identical before and after.
- **Every subject appears in the output with a disposition**, and the summary counts each. A backfill that silently skips looks exactly like one that worked (INV-11).

Four defects the adversarial pass found, all reproduced first:

- **The dry run was not disposition-identical.** The already-claimed-elsewhere case was left to the write's `EEXIST`, which a dry run never reaches — so the *mandatory operator preview* promised `recorded` for precisely the ambiguous subjects an operator runs it to scrutinise. Ids claimed earlier in the same pass diverged too, so the decision is now made before the write against a within-pass claim map.
- **`startupReconciliation` acquired the lock outside its try.** `acquireProcessLock` does not steal a lock whose holder is alive — it spins to a ten-minute deadline and throws. That throw left `watchUnarchived`, the process exited, launchd restarted it, and it took the lock again: **a crash loop with no transports and no reap backstop**, for as long as the holder lived. The 2026-07-28 wedged-`up` shape produces exactly this.
- **A dry run took the real lock**, unlike `resumeActive` and `reapArchived`, so `watch-unarchived --dry-run` mutually blocked the live daemon. And the **CLI path took no lock at all**, so the reaper could retire an identity while this pass was recording it.
- **The occupancy veto's pid arm cannot identify anyone by itself** — `~/.claude/sessions` keys on Claude's own session id, not a Threa one — so it vetoed the very sessions the launch-corroboration arm exists for. Measured before the fix: **0 recorded via launch**. A caller that knows which pane owns the directory now says which pids that accounts for, the same pane-pid equivalence the reaper already uses. The mint supplies none: it has no candidate id yet, so every live pid is a stranger to it.

## Operator preview (required before merge, run against the live fleet)

```
harnessd: 71 subjects, 51 refused worktree missing, 11 refused single source, 9 recorded
```

Nothing written — `~/.threa/harnessd/identities/` still does not exist. Zero conflicting, zero occupied, zero unsafe. The 9 recorded are all `via ledger` and include this session's own worktree.

## Files

| File | Change |
| ---- | ------ |
| `src/backfill.ts` | **new** — corroboration, dispositions, dry-run parity |
| `src/commands.ts` | `startupReconciliation` (lock inside the try, released before the sweep), `backfillIdentitiesCommand` |
| `src/mint.ts` | `occupancyVeto` exported; optional `accountedPids` |
| `src/cli.ts`, `src/index.ts` | `backfill-identities [--dry-run]` |
| `src/backfill.test.ts`, `src/commands.test.ts` | **new** — 13 tests |

## Test plan

- [x] `bun test` — 260 pass / 0 fail (247 on base); typecheck clean; full pre-commit gates pass
- [x] Live `--dry-run` preview above; store confirmed still absent afterwards
- [x] Mutation-tested, source restored byte-identical: dry-run parity removed → 1 fail; veto ignoring accounted pids → 1; lock acquired outside the try → 1; dry run taking the real lock → 1 (a 5s timeout, which is the symptom)
- [ ] No unattended restart exercised against the live daemon — `startupReconciliation` is covered by injected deps

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/harnessd-profiles-9af997/ — chunk 4 of 6.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787915157&installation_model_id=20758&pr_number=1663&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1663&signature=cc226c5271fcb7e6c988e9996dcab3740fe0eb7936a0161f254c3183917d3ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->