### PR TITLE
feat(harnessd): select inventory rows by identity, and tombstone the dead ones

### DIFF
--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -30,6 +30,7 @@ Usage:
   threa-harnessd attach <agent-id-or-name>
   threa-harnessd resolve [<agent-id-or-name-or-runtime-session-id>]
   threa-harnessd backfill-identities [--dry-run]  (record the identity two sources already agree on)
+  threa-harnessd tombstone [--dry-run]           (retire rows whose worktree is gone and whose scratchpad is archived)
   threa-harnessd doctor
 
 Examples:
@@ -182,6 +183,14 @@ export function parseBackfill(args: string[]): { dryRun: boolean } {
   const flags = parseFlags(args)
   for (const key of Object.keys(flags)) {
     if (key !== "dry-run") die(`unexpected backfill-identities argument: --${key}`)
+  }
+  return { dryRun: boolFlag(flags, "dry-run") }
+}
+
+export function parseTombstone(args: string[]): { dryRun: boolean } {
+  const flags = parseFlags(args)
+  for (const key of Object.keys(flags)) {
+    if (key !== "dry-run") die(`unexpected tombstone argument: --${key}`)
   }
   return { dryRun: boolFlag(flags, "dry-run") }
 }

--- a/extensions/harness-daemon/src/commands.test.ts
+++ b/extensions/harness-daemon/src/commands.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { BackfillOutcome } from "./backfill"
+import type { TombstoneOutcome } from "./tombstone"
 import { STARTUP_LOCK_WAIT_MS, defaultStartupReconciliationDeps, startupReconciliation } from "./commands"
 import { resumeActiveLockPath } from "./lock"
 
@@ -30,8 +31,13 @@ afterEach(() => {
 })
 
 const recorded: BackfillOutcome[] = [{ subject: "/repo/a", disposition: "recorded" }]
+const tombstoned: TombstoneOutcome[] = [{ subject: "claude-1", disposition: "tombstoned" }]
 
-test("startupReconciliation backfills before the first revive sweep", async () => {
+test("startupReconciliation backfills, then sweeps, then tombstones", async () => {
+  // The tombstone pass is the only half that talks to the network, and nothing
+  // the sweep does depends on it — ahead of the sweep it delayed every boot
+  // revival by one request per worktree-gone row. The lock is held across each
+  // half and released before the sweep either way.
   const calls: string[] = []
 
   await startupReconciliation({
@@ -39,14 +45,55 @@ test("startupReconciliation backfills before the first revive sweep", async () =
       calls.push("backfill")
       return recorded
     },
-    lock: async () => () => {},
+    tombstone: async () => {
+      calls.push("tombstone")
+      return tombstoned
+    },
+    lock: async () => {
+      calls.push("lock")
+      return () => calls.push("release")
+    },
     sweep: () => {
       calls.push("sweep")
     },
     log: (message) => calls.push(`log:${message}`),
   })
 
-  expect(calls).toEqual(["backfill", "log:harnessd: identity backfill: 1 subject(s), 1 recorded", "sweep"])
+  expect(calls).toEqual([
+    "lock",
+    "backfill",
+    "log:harnessd: identity backfill: 1 subject(s), 1 recorded",
+    "release",
+    "sweep",
+    "lock",
+    "tombstone",
+    "log:harnessd: tombstone: 1 row(s), 1 tombstoned",
+    "release",
+  ])
+})
+
+test("a failing tombstone logs and does not abort the startup pass", async () => {
+  // It is the half that does network I/O, so it is by far the likelier to throw
+  // — and `threaTarget` throws outright when no credentials are readable.
+  const calls: string[] = []
+
+  await startupReconciliation({
+    backfill: () => [],
+    tombstone: async () => {
+      throw new Error("threa unreachable")
+    },
+    lock: async () => () => calls.push("release"),
+    sweep: () => void calls.push("sweep"),
+    log: (message) => calls.push(`log:${message}`),
+  })
+
+  expect(calls).toEqual([
+    "log:harnessd: identity backfill: 0 subject(s)",
+    "release",
+    "sweep",
+    "release",
+    "log:harnessd: tombstone pass failed: threa unreachable",
+  ])
 })
 
 test("a failing backfill logs and does not abort the startup pass", async () => {
@@ -56,6 +103,7 @@ test("a failing backfill logs and does not abort the startup pass", async () => 
     backfill: () => {
       throw new Error("inventory unreadable")
     },
+    tombstone: async () => [],
     lock: async () => () => {},
     sweep: () => {
       calls.push("sweep")
@@ -63,7 +111,11 @@ test("a failing backfill logs and does not abort the startup pass", async () => 
     log: (message) => calls.push(`log:${message}`),
   })
 
-  expect(calls).toEqual(["log:harnessd: identity backfill failed: inventory unreadable", "sweep"])
+  expect(calls).toEqual([
+    "log:harnessd: identity backfill failed: inventory unreadable",
+    "sweep",
+    "log:harnessd: tombstone: 0 row(s)",
+  ])
 })
 
 test("a lock the startup pass cannot take is logged, and the sweep still runs", async () => {
@@ -75,6 +127,7 @@ test("a lock the startup pass cannot take is logged, and the sweep still runs", 
 
   await startupReconciliation({
     backfill: () => [],
+    tombstone: async () => [],
     lock: async () => {
       throw new Error("lock /tmp/resume-active.lock held by pid 4242 for over 600s")
     },
@@ -117,6 +170,7 @@ test("a held lock delays startup by a bounded wait, not the default ten minutes"
   await startupReconciliation({
     ...defaultStartupReconciliationDeps(() => void swept.push("sweep"), false, 60),
     backfill: () => [],
+    tombstone: async () => [],
     log: (message) => void logged.push(message),
   })
 

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -46,7 +46,7 @@ import {
 } from "./spawners"
 import {
   fetchScratchpadStatus,
-  latestAgents,
+  latestAgentsByIdentity,
   parseScratchpadUrl,
   preflightRuntimeSession,
   probeSuppressed,
@@ -59,6 +59,7 @@ import {
 import { attachedTmuxSession, ensureTmuxSession, sendKeys } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
 import { defaultReapDeps, reapArchivedWorktrees } from "./reap"
+import { defaultTombstoneDeps, summarizeTombstones, tombstoneAbandonedRows, type TombstoneOutcome } from "./tombstone"
 import { restorableWorktreeSource, restoreManagedWorktree } from "./worktree"
 import { runWatchLoop, unavailableBackoffMs, uniqueSupervisorTargets, watchIntervalMs } from "./watch"
 
@@ -137,11 +138,26 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
   }
 }
 
+/** The first Threa target the local configs and environment agree on, for a pass that must talk to the server. */
+function threaTarget(purpose: string): { baseUrl: string; workspaceId: string; apiKey: string } {
+  const targetFor = (config: { baseUrl?: string; workspaceId?: string; apiKey?: string }) => {
+    const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
+    const apiKey = process.env.THREA_API_KEY || config.apiKey
+    if (!workspaceId || !apiKey) return undefined
+    return { baseUrl: configuredThreaBaseUrl(config), workspaceId, apiKey }
+  }
+  const [target] = uniqueSupervisorTargets([targetFor(readThreaChannelConfig()), targetFor(readPiRemoteConfig())])
+  if (!target) throw new Error(`harnessd: no Threa credentials found for ${purpose}`)
+  return target
+}
+
 /** Long enough for an ordinary revive or reap to finish, short enough that a wedged holder cannot delay startup. */
 export const STARTUP_LOCK_WAIT_MS = 30_000
 
 export interface StartupReconciliationDeps {
   backfill: () => BackfillOutcome[]
+  /** Runs after the backfill on the same pass: the backfill records identity, tombstoning uses it. */
+  tombstone: () => Promise<TombstoneOutcome[]>
   /** Resolves to the release. A dry run resolves to a no-op, as every other dry-run path does. */
   lock: () => Promise<() => void>
   sweep: () => void | Promise<void>
@@ -155,6 +171,7 @@ export function defaultStartupReconciliationDeps(
 ): StartupReconciliationDeps {
   return {
     backfill: () => backfillIdentities(defaultBackfillDeps(), dryRun),
+    tombstone: () => tombstoneAbandonedRows(defaultTombstoneDeps(threaTarget("the tombstone pass")), dryRun),
     // Bounded: the default deadline is ten minutes, and until this resolves no
     // transport exists and no reap runs. The backfill is an optimisation of what
     // the resolver already computes, so losing a pass costs nothing — the next
@@ -193,7 +210,28 @@ export async function startupReconciliation(deps: StartupReconciliationDeps): Pr
   } finally {
     release?.()
   }
+
   await deps.sweep()
+
+  // AFTER the sweep, deliberately. Tombstoning is the only half that talks to
+  // the network — one request per worktree-gone row, serially — and nothing the
+  // sweep does depends on its result, since a row a tombstone could retire is
+  // already refused by the revive path's own status gate. Ahead of the sweep it
+  // delayed every boot revival by the length of that round trip.
+  try {
+    const release = await deps.lock()
+    try {
+      const tombstones = await deps.tombstone()
+      const counts = summarizeTombstones(tombstones)
+        .map(([disposition, count]) => `${count} ${disposition}`)
+        .join(", ")
+      deps.log(`harnessd: tombstone: ${tombstones.length} row(s)${counts ? `, ${counts}` : ""}`)
+    } finally {
+      release()
+    }
+  } catch (error) {
+    deps.log(`harnessd: tombstone pass failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
 }
 
 export async function backfillIdentitiesCommand(options: { dryRun: boolean }): Promise<void> {
@@ -214,6 +252,26 @@ export async function backfillIdentitiesCommand(options: { dryRun: boolean }): P
     .map(([disposition, count]) => `${count} ${disposition}`)
     .join(", ")
   console.log(`harnessd: ${outcomes.length} subject${outcomes.length === 1 ? "" : "s"}${counts ? `, ${counts}` : ""}`)
+}
+
+export async function tombstoneCommand(options: { dryRun: boolean }): Promise<void> {
+  const deps = defaultTombstoneDeps(threaTarget("the tombstone pass"))
+  // Same lock as the revive, reap and backfill passes, and skipped for a dry run
+  // exactly as they skip it.
+  const release = options.dryRun ? () => {} : await acquireProcessLock(resumeActiveLockPath())
+  let outcomes
+  try {
+    outcomes = await tombstoneAbandonedRows(deps, options.dryRun)
+  } finally {
+    release()
+  }
+  for (const outcome of outcomes) {
+    console.log(`${outcome.disposition}\t${outcome.subject}${outcome.detail ? `\t${outcome.detail}` : ""}`)
+  }
+  const counts = summarizeTombstones(outcomes)
+    .map(([disposition, count]) => `${count} ${disposition}`)
+    .join(", ")
+  console.log(`harnessd: ${outcomes.length} row${outcomes.length === 1 ? "" : "s"}${counts ? `, ${counts}` : ""}`)
 }
 
 export async function watchUnarchived(options: ResumeOptions): Promise<void> {
@@ -305,16 +363,7 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
  * reboots, so the backstop lives here.
  */
 export async function reapArchived(options: { dryRun?: boolean; observingSinceMs?: number } = {}): Promise<void> {
-  const claudeConfig = readThreaChannelConfig()
-  const piConfig = readPiRemoteConfig()
-  const targetFor = (config: { baseUrl?: string; workspaceId?: string; apiKey?: string }) => {
-    const workspaceId = process.env.THREA_WORKSPACE_ID || config.workspaceId
-    const apiKey = process.env.THREA_API_KEY || config.apiKey
-    if (!workspaceId || !apiKey) return undefined
-    return { baseUrl: configuredThreaBaseUrl(config), workspaceId, apiKey }
-  }
-  const [target] = uniqueSupervisorTargets([targetFor(claudeConfig), targetFor(piConfig)])
-  if (!target) throw new Error("harnessd: no Threa credentials found for the reap pass")
+  const target = threaTarget("the reap pass")
 
   // Same lock as resumeActive: a revive can be recreating the very worktree
   // this pass would force-remove, and they race the server independently.
@@ -676,7 +725,7 @@ export async function reviveAgent(
 
 async function resumeActiveUnlocked(options: ResumeOptions, target?: BotSessionRestoredPayload): Promise<boolean> {
   const deps = defaultReviveDeps()
-  const agents = latestAgents(readInventory())
+  const agents = latestAgentsByIdentity(readInventory())
   if (agents.length === 0) {
     console.log("No managed agents.")
     return false
@@ -711,7 +760,10 @@ export function listAgents(): void {
   }
   for (const agent of agents) {
     const tmux = agent.tmuxSession && agent.tmuxWindow ? `${agent.tmuxSession}:${agent.tmuxWindow}` : "-"
-    console.log(`${agent.id}\t${agent.status}\t${agent.runtime}\t${agent.name}\t${tmux}\t${agent.scratchpadUrl ?? "-"}`)
+    const marker = agent.tombstonedAt ? "\ttombstoned" : ""
+    console.log(
+      `${agent.id}\t${agent.status}\t${agent.runtime}\t${agent.name}\t${tmux}\t${agent.scratchpadUrl ?? "-"}${marker}`
+    )
   }
 }
 

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -292,7 +292,10 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
   let reconcileChain = Promise.resolve()
   let unavailablePasses = 0
   let retryTimer: ReturnType<typeof setTimeout> | undefined
-  const reconcile = (target?: BotSessionRestoredPayload) => {
+  // Returns the chain, not void: `startupReconciliation` runs the tombstone pass
+  // after the sweep specifically so it does not hold the lock while boot revival
+  // waits, and a fire-and-forget sweep would put them back in a race for it.
+  const reconcile = (target?: BotSessionRestoredPayload): Promise<void> => {
     reconcileChain = reconcileChain
       .then(async () => {
         if (!options.dryRun) ensureTmuxSession(session, true)
@@ -331,6 +334,7 @@ export async function watchUnarchived(options: ResumeOptions): Promise<void> {
       .catch((error) => {
         console.error(`harnessd: reconciliation failed: ${error instanceof Error ? error.message : String(error)}`)
       })
+    return reconcileChain
   }
 
   await startupReconciliation(defaultStartupReconciliationDeps(() => reconcile(), options.dryRun ?? false))
@@ -725,7 +729,12 @@ export async function reviveAgent(
 
 async function resumeActiveUnlocked(options: ResumeOptions, target?: BotSessionRestoredPayload): Promise<boolean> {
   const deps = defaultReviveDeps()
-  const agents = latestAgentsByIdentity(readInventory())
+  const rows = readInventory()
+  // A targeted restore is the server saying this scratchpad came back, which is
+  // exactly the evidence a tombstone lacks.
+  const agents = latestAgentsByIdentity(rows, undefined, Boolean(target))
+  const excluded = target ? 0 : rows.filter((agent) => agent.tombstonedAt).length
+  if (excluded > 0) console.log(`harnessd: ${excluded} tombstoned row(s) not evaluated`)
   if (agents.length === 0) {
     console.log("No managed agents.")
     return false

--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -632,6 +632,28 @@ export function runtimeIdentityFor(params: {
   )
 }
 
+/** The identity a row is selected and grouped by, or undefined when nothing attests one. */
+export type AgentIdentityResolver = (agent: ManagedAgent) => string | undefined
+
+/**
+ * Resolve each row's identity through {@link runtimeIdentityFor} (INV-35), reading
+ * the stores once for the whole batch.
+ *
+ * A `derived` answer is not an identity: it hashes `os.hostname()`, so it renames
+ * itself with the wifi network. Such a row falls back to whatever it recorded,
+ * and to no identity at all when it recorded nothing.
+ */
+export function defaultAgentIdentityResolver(
+  identities: MintedIdentity[] = readMintedIdentities(),
+  attested: AttestedRuntime[] = attestedRuntimes(readHarnessLinks(), canonicalOrRaw)
+): AgentIdentityResolver {
+  return (agent) => {
+    if (!agent.worktree) return agent.runtimeSessionId
+    const resolved = runtimeIdentityFor({ cwd: agent.worktree, agent, identities, attested, canonical: canonicalOrRaw })
+    return resolved.source === "derived" ? agent.runtimeSessionId : resolved.runtimeSessionId
+  }
+}
+
 function runtimeSessionIdForPane(
   pane: LocalTmuxPane,
   config: ThreaChannelConfig,

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,7 +1,16 @@
 #!/usr/bin/env bun
 
 import { adoptClaudeSession, adoptRefused } from "./adopt"
-import { parseAdopt, parseBackfill, parseReconnect, parseResolve, parseResume, parseSpawn, usage } from "./cli"
+import {
+  parseAdopt,
+  parseBackfill,
+  parseReconnect,
+  parseResolve,
+  parseResume,
+  parseSpawn,
+  parseTombstone,
+  usage,
+} from "./cli"
 import {
   attachAgent,
   backfillIdentitiesCommand,
@@ -17,6 +26,7 @@ import {
   spawnAgent,
   steerAgent,
   stopAgent,
+  tombstoneCommand,
   reapArchived,
   watchUnarchived,
 } from "./commands"
@@ -60,6 +70,7 @@ async function main(): Promise<void> {
   if (command === "attach") return attachAgent(args[0] ?? die("attach requires an agent id or name"))
   if (command === "resolve") return resolveIdentity(parseResolve(args))
   if (command === "backfill-identities") return backfillIdentitiesCommand(parseBackfill(args))
+  if (command === "tombstone") return tombstoneCommand(parseTombstone(args))
   if (command === "doctor") return doctor()
   if (command === "do") return inferAndRun(args.join(" "))
   die(`unknown command: ${command}`)

--- a/extensions/harness-daemon/src/inventory.test.ts
+++ b/extensions/harness-daemon/src/inventory.test.ts
@@ -1,0 +1,196 @@
+import { Database } from "bun:sqlite"
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { AgentIdentityResolver } from "./discovery"
+import { findAgentOrUndefined, readInventory, readInventoryReadonly, upsertAgent } from "./inventory"
+import { latestAgentsByIdentity } from "./resume"
+import type { ManagedAgent } from "./types"
+
+let root: string
+const previousIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
+const previousLinks = process.env.THREA_HARNESS_LINKS_DIR
+const previousInventory = process.env.THREA_HARNESSD_INVENTORY
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-selection-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "inventory.sqlite")
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  const restore = (name: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  restore("THREA_HARNESSD_IDENTITIES_DIR", previousIdentities)
+  restore("THREA_HARNESS_LINKS_DIR", previousLinks)
+  restore("THREA_HARNESSD_INVENTORY", previousInventory)
+})
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "feature",
+    runtime: "claude",
+    status: "offline",
+    worktree: "/repo/threa.feature",
+    command: ["threa-harnessd", "spawn", "claude"],
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+/** The identity each worktree resolves to, standing in for the stores the real resolver reads. */
+function resolverFor(byWorktree: Record<string, string>): AgentIdentityResolver {
+  return (managed) => (managed.worktree ? byWorktree[managed.worktree] : undefined)
+}
+
+test("two rows sharing a name but resolving to different identities are both revival candidates", () => {
+  const one = agent({ id: "claude-1", worktree: undefined, runtimeSessionId: "ccs-one" })
+  const two = agent({
+    id: "claude-2",
+    worktree: undefined,
+    runtimeSessionId: "ccs-two",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+  })
+
+  const candidates = latestAgentsByIdentity([one, two], (managed) => managed.runtimeSessionId)
+
+  expect(candidates).toEqual([one, two])
+})
+
+test("two rows for one identity collapse to the newest, whatever their names", () => {
+  // A rename changes the agent's name, not its directory, so the rows this is
+  // meant to merge share a worktree.
+  const renamed = agent({
+    id: "claude-2",
+    name: "renamed",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+  })
+
+  const candidates = latestAgentsByIdentity([agent(), renamed], resolverFor({ "/repo/threa.feature": "ccs-one" }))
+
+  expect(candidates).toEqual([renamed])
+})
+
+test("one identity recorded for two different worktrees does not silently drop one", () => {
+  // The live inventory still carries a pair like this, left by the
+  // identity-inheritance bug fixed in 647a99978: a spawn inherited the caller's
+  // id instead of deriving from its own worktree. Collapsing them means one of
+  // two real directories is never revived, and nothing reports it.
+  const other = agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" })
+
+  const candidates = latestAgentsByIdentity(
+    [agent(), other],
+    resolverFor({ "/repo/threa.feature": "ccs-one", "/repo/threa.other": "ccs-one" })
+  )
+
+  expect(candidates.map((candidate) => candidate.id).sort()).toEqual(["claude-1", "claude-2"])
+})
+
+test("a tombstoned row is never a revival candidate", () => {
+  const live = agent({ id: "claude-2", name: "live", worktree: "/repo/threa.live" })
+
+  const candidates = latestAgentsByIdentity(
+    [agent({ tombstonedAt: "2026-07-29T00:00:00.000Z" }), live],
+    resolverFor({ "/repo/threa.feature": "ccs-one", "/repo/threa.live": "ccs-two" })
+  )
+
+  expect(candidates).toEqual([live])
+})
+
+test("a tombstoned row is still findable by explicit id", () => {
+  const retired = agent({ tombstonedAt: "2026-07-29T00:00:00.000Z" })
+
+  expect(findAgentOrUndefined("claude-1", [retired], () => "ccs-one")).toEqual(retired)
+  expect(findAgentOrUndefined("feature", [retired], () => "ccs-one")).toBeUndefined()
+})
+
+test("a ref matching two live identities is refused with both ids named", () => {
+  const rows = [
+    agent({ id: "claude-1", worktree: "/repo/threa.one" }),
+    agent({ id: "claude-2", worktree: "/repo/threa.two" }),
+  ]
+
+  expect(() =>
+    findAgentOrUndefined("feature", rows, resolverFor({ "/repo/threa.one": "ccs-one", "/repo/threa.two": "ccs-two" }))
+  ).toThrow("multiple agents match feature: ccs-one, ccs-two; use id")
+})
+
+test("a row with no identity anywhere is still selectable by canonical worktree", () => {
+  const rows = [
+    agent({ id: "claude-1", worktree: "/repo/threa.one" }),
+    agent({ id: "claude-2", worktree: "/repo/threa.two" }),
+  ]
+
+  expect(findAgentOrUndefined("/repo/threa.two", rows, () => undefined)).toEqual(rows[1]!)
+})
+
+test("opening an inventory created before tombstoned_at adds the column in place", () => {
+  const path = join(root, "legacy.sqlite")
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE managed_agents (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, runtime TEXT NOT NULL, status TEXT NOT NULL,
+      worktree TEXT, branch TEXT, tmux_session TEXT, tmux_window TEXT, scratchpad_url TEXT,
+      command_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_output TEXT
+    )
+  `)
+  db.exec(
+    `INSERT INTO managed_agents (id, name, runtime, status, command_json, created_at, updated_at)
+     VALUES ('claude-1', 'feature', 'claude', 'offline', '[]', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`
+  )
+  db.close()
+  process.env.THREA_HARNESSD_INVENTORY = path
+
+  expect(readInventory()).toEqual([agent({ command: [], worktree: undefined })])
+  upsertAgent(agent({ command: [], worktree: undefined, tombstonedAt: "2026-07-29T00:00:00.000Z" }))
+  expect(readInventory()).toEqual([
+    agent({ command: [], worktree: undefined, tombstonedAt: "2026-07-29T00:00:00.000Z" }),
+  ])
+})
+
+test("the readonly reader projects NULL for a column the file predates", () => {
+  const path = join(root, "old.sqlite")
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE managed_agents (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, runtime TEXT NOT NULL, status TEXT NOT NULL,
+      worktree TEXT, branch TEXT, tmux_session TEXT, tmux_window TEXT, scratchpad_url TEXT,
+      command_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_output TEXT
+    )
+  `)
+  db.exec(
+    `INSERT INTO managed_agents (id, name, runtime, status, command_json, created_at, updated_at)
+     VALUES ('claude-1', 'feature', 'claude', 'offline', '[]', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`
+  )
+  db.close()
+  process.env.THREA_HARNESSD_INVENTORY = path
+
+  expect(readInventoryReadonly()).toEqual([agent({ command: [], worktree: undefined })])
+
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "current.sqlite")
+  upsertAgent(agent({ tombstonedAt: "2026-07-29T00:00:00.000Z" }))
+  expect(readInventoryReadonly()).toEqual([agent({ tombstonedAt: "2026-07-29T00:00:00.000Z" })])
+})
+
+test("a ref names a row by the identity a store attests, not only the one it recorded", () => {
+  // The rung that distinguishes identity-based selection from a recorded-id plus
+  // path lookup: a row the backfill has not reached records nothing, but the
+  // minted or link store attests its worktree, so `stop`/`kick`/`resolve` on
+  // that id still find it.
+  const unrecorded = agent({ runtimeSessionId: undefined })
+
+  const found = findAgentOrUndefined(
+    "ccs-attested",
+    [unrecorded],
+    resolverFor({ "/repo/threa.feature": "ccs-attested" })
+  )
+
+  expect(found?.id).toBe("claude-1")
+})

--- a/extensions/harness-daemon/src/inventory.test.ts
+++ b/extensions/harness-daemon/src/inventory.test.ts
@@ -194,3 +194,19 @@ test("a ref names a row by the identity a store attests, not only the one it rec
 
   expect(found?.id).toBe("claude-1")
 })
+
+test("a ref whose identity names two worktrees is refused, not resolved to the newest", () => {
+  // stopAgent kills the pane the ref resolves to. Picking the newest here points
+  // it at a directory the operator never named.
+  const other = agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" })
+  const resolver = resolverFor({ "/repo/threa.feature": "ccs-one", "/repo/threa.other": "ccs-one" })
+
+  expect(() => findAgentOrUndefined("ccs-one", [agent(), other], resolver)).toThrow(/two worktrees|2 worktrees/)
+})
+
+test("a targeted restore considers a tombstoned row; an untargeted sweep does not", () => {
+  const dead = agent({ tombstonedAt: "2026-07-29T00:00:00.000Z" })
+
+  expect(latestAgentsByIdentity([dead], resolverFor({}))).toEqual([])
+  expect(latestAgentsByIdentity([dead], resolverFor({}), true)).toEqual([dead])
+})

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite"
 import { existsSync, mkdirSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname } from "node:path"
+import { canonicalOrRaw, defaultAgentIdentityResolver, type AgentIdentityResolver } from "./discovery"
 import { die } from "./errors"
 import type { AgentStatus, ManagedAgent, RuntimeKind } from "./types"
 
@@ -27,6 +28,7 @@ interface ManagedAgentRow {
   last_output: string | null
   probe_failures: number | null
   probe_backoff_until: string | null
+  tombstoned_at: string | null
 }
 
 export function inventoryPath(): string {
@@ -57,7 +59,8 @@ function openInventory(): Database {
       updated_at TEXT NOT NULL,
       last_output TEXT,
       probe_failures INTEGER,
-      probe_backoff_until TEXT
+      probe_backoff_until TEXT,
+      tombstoned_at TEXT
     )
   `)
   // CREATE TABLE IF NOT EXISTS won't extend an existing inventory, so add new columns in place.
@@ -69,6 +72,7 @@ function openInventory(): Database {
     ["runtime_session_id", "TEXT"],
     ["probe_failures", "INTEGER"],
     ["probe_backoff_until", "TEXT"],
+    ["tombstoned_at", "TEXT"],
   ]
   for (const [column, type] of added) {
     if (!columns.some((existing) => existing.name === column)) {
@@ -99,6 +103,7 @@ function rowToAgent(row: ManagedAgentRow): ManagedAgent {
     lastOutput: row.last_output ?? undefined,
     probeFailures: row.probe_failures ?? undefined,
     probeBackoffUntil: row.probe_backoff_until ?? undefined,
+    tombstonedAt: row.tombstoned_at ?? undefined,
   }
 }
 
@@ -136,6 +141,7 @@ export function readInventoryReadonly(): ManagedAgent[] {
       "last_output",
       "probe_failures",
       "probe_backoff_until",
+      "tombstoned_at",
     ]
     const projection = optional.map((name) => (columns.has(name) ? name : `NULL AS ${name}`))
     const rows = db
@@ -157,8 +163,8 @@ export function upsertAgent(agent: ManagedAgent): void {
       INSERT INTO managed_agents (
         id, name, runtime, status, worktree, branch, tmux_session, tmux_window,
         tmux_window_id, tmux_pane_id, scratchpad_url, instance_id, runtime_session_id, command_json,
-        created_at, updated_at, last_output, probe_failures, probe_backoff_until
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, last_output, probe_failures, probe_backoff_until, tombstoned_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         runtime = excluded.runtime,
@@ -176,7 +182,8 @@ export function upsertAgent(agent: ManagedAgent): void {
         updated_at = excluded.updated_at,
         last_output = excluded.last_output,
         probe_failures = excluded.probe_failures,
-        probe_backoff_until = excluded.probe_backoff_until
+        probe_backoff_until = excluded.probe_backoff_until,
+        tombstoned_at = excluded.tombstoned_at
     `
     ).run(
       agent.id,
@@ -197,24 +204,57 @@ export function upsertAgent(agent: ManagedAgent): void {
       agent.updatedAt,
       agent.lastOutput ?? null,
       agent.probeFailures ?? null,
-      agent.probeBackoffUntil ?? null
+      agent.probeBackoffUntil ?? null,
+      agent.tombstonedAt ?? null
     )
   } finally {
     db.close()
   }
 }
 
-export function findAgentOrUndefined(ref: string, agents: ManagedAgent[] = readInventory()): ManagedAgent | undefined {
+function newest(agents: ManagedAgent[]): ManagedAgent | undefined {
+  return [...agents].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0]
+}
+
+/**
+ * Selection is by identity, not by name: two rows called `feature` are two
+ * sessions, and a renamed session is still one.
+ *
+ * A tombstoned row matches by explicit id only, so `list` and `resolve` keep
+ * showing history while nothing selects it for revival.
+ */
+export function findAgentOrUndefined(
+  ref: string,
+  agents: ManagedAgent[] = readInventory(),
+  resolve?: AgentIdentityResolver
+): ManagedAgent | undefined {
   const byId = agents.find((agent) => agent.id === ref)
   if (byId) return byId
 
-  const byRuntimeSession = agents
-    .filter((agent) => agent.runtimeSessionId === ref)
-    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-  if (byRuntimeSession[0]) return byRuntimeSession[0]
+  const live = agents.filter((agent) => !agent.tombstonedAt)
+  const byRecordedSession = newest(live.filter((agent) => agent.runtimeSessionId === ref))
+  if (byRecordedSession) return byRecordedSession
 
-  const matches = agents.filter((agent) => agent.name === ref)
-  if (matches.length > 1) die(`multiple agents match ${ref}; use id`)
+  // Built once, and only when a rung actually needs it: it reads the identity
+  // and link stores.
+  let resolver: AgentIdentityResolver | undefined = resolve
+  const identityOf = (agent: ManagedAgent) => (resolver ??= defaultAgentIdentityResolver())(agent)
+
+  if (live.some((agent) => agent.worktree)) {
+    const byResolvedSession = newest(live.filter((agent) => identityOf(agent) === ref))
+    if (byResolvedSession) return byResolvedSession
+
+    const target = canonicalOrRaw(ref)
+    const byWorktree = newest(live.filter((agent) => agent.worktree && canonicalOrRaw(agent.worktree) === target))
+    if (byWorktree) return byWorktree
+  }
+
+  const matches = live.filter((agent) => agent.name === ref)
+  if (matches.length > 1) {
+    const competing = [...new Set(matches.map((agent) => identityOf(agent) ?? agent.id))].sort()
+    if (competing.length > 1) die(`multiple agents match ${ref}: ${competing.join(", ")}; use id`)
+    return newest(matches)
+  }
   return matches[0]
 }
 

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -241,8 +241,14 @@ export function findAgentOrUndefined(
   const identityOf = (agent: ManagedAgent) => (resolver ??= defaultAgentIdentityResolver())(agent)
 
   if (live.some((agent) => agent.worktree)) {
-    const byResolvedSession = newest(live.filter((agent) => identityOf(agent) === ref))
-    if (byResolvedSession) return byResolvedSession
+    const byResolvedSession = live.filter((agent) => identityOf(agent) === ref)
+    // One identity can name two directories — the live inventory carries such a
+    // pair from the identity-inheritance bug fixed in 647a99978. Picking the
+    // newest would point `stop` and `kick` at a pane in a directory the operator
+    // never named, so the worktrees have to be told apart or refused.
+    const claimed = [...new Set(byResolvedSession.map((agent) => canonicalOrRaw(agent.worktree ?? agent.id)))].sort()
+    if (claimed.length > 1) die(`${ref} names ${claimed.length} worktrees: ${claimed.join(", ")}; use id`)
+    if (byResolvedSession.length > 0) return newest(byResolvedSession)
 
     const target = canonicalOrRaw(ref)
     const byWorktree = newest(live.filter((agent) => agent.worktree && canonicalOrRaw(agent.worktree) === target))
@@ -253,6 +259,8 @@ export function findAgentOrUndefined(
   if (matches.length > 1) {
     const competing = [...new Set(matches.map((agent) => identityOf(agent) ?? agent.id))].sort()
     if (competing.length > 1) die(`multiple agents match ${ref}: ${competing.join(", ")}; use id`)
+    const directories = [...new Set(matches.map((agent) => canonicalOrRaw(agent.worktree ?? agent.id)))].sort()
+    if (directories.length > 1) die(`${ref} names ${directories.length} worktrees: ${directories.join(", ")}; use id`)
     return newest(matches)
   }
   return matches[0]

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   fetchScratchpadStatus,
-  latestAgents,
+  latestAgentsByIdentity,
   parseScratchpadUrl,
   preflightRuntimeSession,
   probeSuppressed,
@@ -78,7 +78,10 @@ test("parses a stream id from a scratchpad URL", () => {
 
 test("selects only the latest inventory row for an agent name", () => {
   const newest = agent({ id: "claude-2", updatedAt: "2026-07-02T00:00:00.000Z" })
-  expect(latestAgents([agent(), newest, agent({ name: "other" })])).toEqual([agent({ name: "other" }), newest])
+  expect(latestAgentsByIdentity([agent(), newest, agent({ name: "other" })], () => undefined)).toEqual([
+    agent({ name: "other" }),
+    newest,
+  ])
 })
 
 test("migrates legacy inventory and persists runtime identity", () => {

--- a/extensions/harness-daemon/src/resume.ts
+++ b/extensions/harness-daemon/src/resume.ts
@@ -34,11 +34,17 @@ export function parseScratchpadUrl(value: string): ScratchpadRef | undefined {
  */
 export function latestAgentsByIdentity(
   agents: ManagedAgent[],
-  resolve: AgentIdentityResolver = defaultAgentIdentityResolver()
+  resolve: AgentIdentityResolver = defaultAgentIdentityResolver(),
+  includeTombstoned = false
 ): ManagedAgent[] {
   const byIdentity = new Map<string, ManagedAgent>()
   for (const agent of agents) {
-    if (agent.tombstonedAt) continue
+    // A tombstone says "provably dead", and only the caller knows whether the
+    // server has since said otherwise: an unarchive is an explicit revive
+    // request, and dropping the row here would make it unrevivable with nothing
+    // reported. The count goes back to the caller so the exclusion is visible
+    // either way (INV-11).
+    if (agent.tombstonedAt && !includeTombstoned) continue
     // Identity AND worktree, never identity alone. Two rows can record one
     // runtime session id for DIFFERENT directories — the live inventory still
     // carries a pair left by the identity-inheritance bug fixed in 647a99978 —

--- a/extensions/harness-daemon/src/resume.ts
+++ b/extensions/harness-daemon/src/resume.ts
@@ -1,3 +1,4 @@
+import { canonicalOrRaw, defaultAgentIdentityResolver, type AgentIdentityResolver } from "./discovery"
 import type { ManagedAgent } from "./types"
 import { inaccessibleBackoffMs } from "./watch"
 
@@ -22,14 +23,38 @@ export function parseScratchpadUrl(value: string): ScratchpadRef | undefined {
   }
 }
 
-/** An inventory row is immutable per launch, so resume only the newest launch for each name. */
-export function latestAgents(agents: ManagedAgent[]): ManagedAgent[] {
-  const byName = new Map<string, ManagedAgent>()
+/**
+ * An inventory row is immutable per launch, so resume only the newest launch of
+ * each session — grouped by identity, because a name is neither unique nor
+ * stable: two rows called `feature` are two sessions, and a renamed session is
+ * still one.
+ *
+ * Tombstoned rows are never candidates: their worktree is gone and their
+ * scratchpad archived, and the watcher recreates worktrees.
+ */
+export function latestAgentsByIdentity(
+  agents: ManagedAgent[],
+  resolve: AgentIdentityResolver = defaultAgentIdentityResolver()
+): ManagedAgent[] {
+  const byIdentity = new Map<string, ManagedAgent>()
   for (const agent of agents) {
-    const existing = byName.get(agent.name)
-    if (!existing || agent.updatedAt > existing.updatedAt) byName.set(agent.name, agent)
+    if (agent.tombstonedAt) continue
+    // Identity AND worktree, never identity alone. Two rows can record one
+    // runtime session id for DIFFERENT directories — the live inventory still
+    // carries a pair left by the identity-inheritance bug fixed in 647a99978 —
+    // and collapsing those silently drops one worktree from every sweep, which
+    // is the opposite of what un-collapsing set out to do.
+    const identity = resolve(agent)
+    const worktree = agent.worktree ? canonicalOrRaw(agent.worktree) : undefined
+    const key = identity
+      ? `identity:${identity}${worktree ? `@${worktree}` : ""}`
+      : worktree
+        ? `worktree:${worktree}`
+        : `name:${agent.name}`
+    const existing = byIdentity.get(key)
+    if (!existing || agent.updatedAt > existing.updatedAt) byIdentity.set(key, agent)
   }
-  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+  return [...byIdentity.values()].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
 }
 
 export function recordedNoYolo(agent: ManagedAgent): boolean {

--- a/extensions/harness-daemon/src/tombstone.test.ts
+++ b/extensions/harness-daemon/src/tombstone.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { readInventory, upsertAgent } from "./inventory"
+import type { ScratchpadStatus } from "./resume"
+import { tombstoneAbandonedRows, type TombstoneDeps } from "./tombstone"
+import type { ManagedAgent } from "./types"
+
+const WORKTREE = "/repo/threa.feature"
+const SCRATCHPAD = "https://app.threa.io/w/ws_01WORKSPACE/s/stream_01ABCDEF"
+
+let root: string
+const previousIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
+const previousLinks = process.env.THREA_HARNESS_LINKS_DIR
+const previousInventory = process.env.THREA_HARNESSD_INVENTORY
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-tombstone-"))
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+  process.env.THREA_HARNESS_LINKS_DIR = join(root, "links")
+  process.env.THREA_HARNESSD_INVENTORY = join(root, "inventory.sqlite")
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  const restore = (name: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  restore("THREA_HARNESSD_IDENTITIES_DIR", previousIdentities)
+  restore("THREA_HARNESS_LINKS_DIR", previousLinks)
+  restore("THREA_HARNESSD_INVENTORY", previousInventory)
+})
+
+function agent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "claude-1",
+    name: "feature",
+    runtime: "claude",
+    status: "offline",
+    worktree: WORKTREE,
+    scratchpadUrl: SCRATCHPAD,
+    runtimeSessionId: "ccs-row",
+    instanceId: "cc-row",
+    command: ["threa-harnessd", "spawn", "claude"],
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+/** Writes through the real inventory, so a dry run and a wet run are compared against real state. */
+function deps(overrides: Partial<TombstoneDeps> = {}): { deps: TombstoneDeps; persisted: ManagedAgent[] } {
+  const persisted: ManagedAgent[] = []
+  return {
+    persisted,
+    deps: {
+      inventory: readInventory,
+      pathExists: () => false,
+      scratchpadStatus: async (): Promise<ScratchpadStatus> => "archived",
+      persist: (managed) => {
+        persisted.push(managed)
+        upsertAgent(managed)
+      },
+      now: () => new Date("2026-07-29T00:00:00.000Z"),
+      ...overrides,
+    },
+  }
+}
+
+test("a row whose worktree is gone and whose scratchpad is archived is tombstoned, never deleted", async () => {
+  upsertAgent(agent())
+  const context = deps()
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([{ subject: "claude-1", disposition: "tombstoned", detail: "feature" }])
+  expect(readInventory()).toEqual([
+    agent({ tombstonedAt: "2026-07-29T00:00:00.000Z", updatedAt: "2026-07-29T00:00:00.000Z" }),
+  ])
+})
+
+test("a row whose worktree is gone but whose scratchpad is still active is kept", async () => {
+  upsertAgent(agent())
+  const context = deps({ scratchpadStatus: async () => "active" })
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([{ subject: "claude-1", disposition: "kept scratchpad active", detail: "feature" }])
+  expect(readInventory()).toEqual([agent()])
+})
+
+test("a row whose scratchpad cannot be read is kept", async () => {
+  upsertAgent(agent())
+  const context = deps({ scratchpadStatus: async () => "inaccessible" })
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([{ subject: "claude-1", disposition: "kept scratchpad unreadable", detail: "inaccessible" }])
+  expect(readInventory()).toEqual([agent()])
+})
+
+test("a row whose worktree still exists is kept even when the scratchpad is archived", async () => {
+  upsertAgent(agent())
+  const context = deps({ pathExists: () => true })
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([{ subject: "claude-1", disposition: "kept worktree present", detail: WORKTREE }])
+  expect(readInventory()).toEqual([agent()])
+})
+
+test("an already tombstoned row is reported, not rewritten", async () => {
+  upsertAgent(agent({ tombstonedAt: "2026-07-20T00:00:00.000Z" }))
+  const context = deps()
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([
+    { subject: "claude-1", disposition: "already tombstoned", detail: "2026-07-20T00:00:00.000Z" },
+  ])
+  expect(context.persisted).toEqual([])
+})
+
+test("a dry run reports the same dispositions and writes nothing", async () => {
+  upsertAgent(agent())
+  upsertAgent(agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" }))
+  upsertAgent(agent({ id: "claude-3", name: "live", scratchpadUrl: undefined }))
+  const preview = deps()
+
+  const previewed = await tombstoneAbandonedRows(preview.deps, true)
+  const before = readInventory()
+  const wet = deps()
+  const applied = await tombstoneAbandonedRows(wet.deps, false)
+
+  expect(preview.persisted).toEqual([])
+  expect(before).toEqual([
+    agent(),
+    agent({ id: "claude-2", name: "other", worktree: "/repo/threa.other" }),
+    agent({ id: "claude-3", name: "live", scratchpadUrl: undefined }),
+  ])
+  expect(previewed).toEqual(applied)
+  expect(wet.persisted.map((managed) => managed.id)).toEqual(["claude-1", "claude-2"])
+})
+
+test("a row the revive path is already backing off is not probed again", async () => {
+  // Same endpoint, same rows. Re-asking hammers exactly the scratchpads the
+  // backoff exists to protect — and because a row is never deleted and an
+  // inaccessible one can never be tombstoned, that set only ever grows.
+  upsertAgent(agent({ probeFailures: 27, probeBackoffUntil: "2026-07-29T06:00:00.000Z" }))
+  let probes = 0
+  const context = deps({
+    scratchpadStatus: async (): Promise<ScratchpadStatus> => {
+      probes += 1
+      return "archived"
+    },
+  })
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes).toEqual([
+    { subject: "claude-1", disposition: "kept probe suppressed", detail: "2026-07-29T06:00:00.000Z" },
+  ])
+  expect(probes).toBe(0)
+  expect(context.persisted).toEqual([])
+})
+
+test("a row whose backoff has expired is probed and tombstoned", async () => {
+  upsertAgent(agent({ probeFailures: 27, probeBackoffUntil: "2026-07-28T00:00:00.000Z" }))
+  const context = deps()
+
+  const outcomes = await tombstoneAbandonedRows(context.deps, false)
+
+  expect(outcomes.map((outcome) => outcome.disposition)).toEqual(["tombstoned"])
+})

--- a/extensions/harness-daemon/src/tombstone.ts
+++ b/extensions/harness-daemon/src/tombstone.ts
@@ -1,0 +1,108 @@
+import { existsSync } from "node:fs"
+import { readInventory, upsertAgent } from "./inventory"
+import { fetchScratchpadStatus, parseScratchpadUrl, type ScratchpadStatus, probeSuppressed } from "./resume"
+import type { ManagedAgent } from "./types"
+
+export type TombstoneDisposition =
+  | "tombstoned"
+  | "kept worktree present"
+  | "kept scratchpad active"
+  | "kept scratchpad unreadable"
+  | "already tombstoned"
+  | "kept probe suppressed"
+
+export interface TombstoneOutcome {
+  /** The inventory row id: the only thing that identifies a row uniquely. */
+  subject: string
+  disposition: TombstoneDisposition
+  detail?: string
+}
+
+export interface TombstoneDeps {
+  inventory: () => ManagedAgent[]
+  pathExists: (path: string) => boolean
+  scratchpadStatus: (agent: ManagedAgent) => Promise<ScratchpadStatus>
+  persist: (agent: ManagedAgent) => void
+  now: () => Date
+}
+
+export function defaultTombstoneDeps(target: { baseUrl: string; workspaceId: string; apiKey: string }): TombstoneDeps {
+  return {
+    inventory: readInventory,
+    pathExists: existsSync,
+    scratchpadStatus: async (agent) => {
+      const ref = agent.scratchpadUrl ? parseScratchpadUrl(agent.scratchpadUrl) : undefined
+      if (!ref) return "unavailable"
+      return fetchScratchpadStatus({
+        ...target,
+        workspaceId: ref.workspaceId ?? target.workspaceId,
+        streamId: ref.streamId,
+      })
+    },
+    persist: upsertAgent,
+    now: () => new Date(),
+  }
+}
+
+async function decide(agent: ManagedAgent, deps: TombstoneDeps, dryRun: boolean): Promise<TombstoneOutcome> {
+  if (agent.tombstonedAt) {
+    return { subject: agent.id, disposition: "already tombstoned", detail: agent.tombstonedAt }
+  }
+  if (agent.worktree && deps.pathExists(agent.worktree)) {
+    return { subject: agent.id, disposition: "kept worktree present", detail: agent.worktree }
+  }
+  if (!agent.scratchpadUrl || !parseScratchpadUrl(agent.scratchpadUrl)) {
+    return { subject: agent.id, disposition: "kept scratchpad unreadable", detail: "no scratchpad url" }
+  }
+  // Last, because everything above is local. The revive path already decided
+  // this row is not worth asking about yet, and this pass probes the same
+  // endpoint — re-asking hammers exactly the scratchpads the backoff protects,
+  // and since a row is never deleted and an inaccessible one can never be
+  // tombstoned, that set only ever grows.
+  if (probeSuppressed(agent, deps.now().getTime())) {
+    return { subject: agent.id, disposition: "kept probe suppressed", detail: agent.probeBackoffUntil }
+  }
+  const status = await deps.scratchpadStatus(agent)
+  if (status === "active") return { subject: agent.id, disposition: "kept scratchpad active", detail: agent.name }
+  // Kris's ruling: an inaccessible (403/404) scratchpad is never grounds — the
+  // same rule the reaper follows. Losing sight of a scratchpad is not evidence
+  // its session ended.
+  if (status !== "archived") {
+    return { subject: agent.id, disposition: "kept scratchpad unreadable", detail: status }
+  }
+  if (!dryRun) {
+    const tombstonedAt = deps.now().toISOString()
+    deps.persist({ ...agent, tombstonedAt, updatedAt: tombstonedAt })
+  }
+  return { subject: agent.id, disposition: "tombstoned", detail: agent.name }
+}
+
+/**
+ * Retire the inventory rows that can never be revived again.
+ *
+ * Kris's ruling, binding: tombstone a row only when its worktree is gone AND its
+ * scratchpad is archived. **Never delete history outright** — a tombstoned row
+ * still reads back, still lists, and is still findable by its explicit id.
+ *
+ * This is inventory hygiene, NOT a safety bound — the plan claimed otherwise and
+ * the claim does not survive contact with the code. What stops a newly visible
+ * dormant row recreating a stale worktree is `reviveAgent`'s `status === "active"`
+ * gate, which precedes `restoreWorktree`. A tombstone's precondition (worktree
+ * gone AND scratchpad archived) is a strict SUBSET of that gate's refusal, so
+ * every row this could retire is already refused. What it buys is an end to
+ * re-probing rows that are provably dead.
+ *
+ * Every row gets a disposition — a keep is a reported reason, never a skipped
+ * iteration (INV-11).
+ */
+export async function tombstoneAbandonedRows(deps: TombstoneDeps, dryRun: boolean): Promise<TombstoneOutcome[]> {
+  const outcomes: TombstoneOutcome[] = []
+  for (const agent of deps.inventory()) outcomes.push(await decide(agent, deps, dryRun))
+  return outcomes
+}
+
+export function summarizeTombstones(outcomes: TombstoneOutcome[]): Array<[TombstoneDisposition, number]> {
+  const counts = new Map<TombstoneDisposition, number>()
+  for (const outcome of outcomes) counts.set(outcome.disposition, (counts.get(outcome.disposition) ?? 0) + 1)
+  return [...counts.entries()]
+}

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -25,6 +25,11 @@ export interface ManagedAgent {
   probeFailures?: number
   /** ISO instant before which the revival probe is suppressed for this row. */
   probeBackoffUntil?: string
+  /**
+   * ISO instant at which this row stopped being a revival candidate: its worktree
+   * is gone AND its scratchpad is archived. History, never deleted.
+   */
+  tombstonedAt?: string
 }
 
 export interface SpawnOptions {


### PR DESCRIPTION
## Problem

Row selection was **name-based**. Two rows called `feature` collapsed into one revival candidate even when they were different sessions, and one session that was renamed appeared as two. Moving to identity un-collapses those groups — which on a fleet with 100 inventory rows makes dormant rows visible to the sweep in a single merge.

## Solution

Selection goes: explicit id → recorded id → resolved id → canonical worktree → name. Ambiguity still dies, but names the competing **identities** rather than the shared name. Tombstoning ships in the same PR, per Kris's binding ruling: retire a row only when its worktree is gone **AND** its scratchpad is archived, and **never delete history** — a tombstoned row still reads back, still lists, and is still findable by explicit id. An `inaccessible` (403/404) scratchpad is never grounds, the same rule the reaper follows.

### The plan's stated mitigation does not hold, and I am not shipping the claim

The plan credits tombstoning as what makes the un-collapse safe. Measured against the real inventory it tombstones **nothing** — dormant scratchpads answer 403 — and it is *structurally* incapable of contributing: a tombstone's precondition (worktree gone AND archived) is a strict **subset** of `reviveAgent`'s refusal (`status !== "active"`), which returns at `commands.ts:551`/`:560`, **before** `restoreWorktree` at `:615`. Every row a tombstone could ever retire is already refused.

The safety comes from that gate. Tombstoning is inventory hygiene — it stops re-probing rows that are provably dead. The docstring and comments now say so. The residual case (worktree gone + scratchpad **active** → `git worktree add` on the recorded branch) is unmitigated **by design**: that is the intended revival behaviour.

Evidence rather than assertion: 281 real refs replayed through old and new `findAgentOrUndefined` — 91 differences, every one a ref that previously matched **nothing** (85 worktree paths) or **died** on a duplicate name (6), and **zero** cases where a ref that selected a row now selects a different one.

### Three defects found in review

- **Grouping keyed on identity alone**, so two rows recording one runtime session id for **different** directories collapsed and the loser was dropped with no log line. The live inventory still carries such a pair, left by the identity-inheritance bug fixed in `647a99978`. The key is now identity **and** canonical worktree.
- **The tombstone pass ran before the sweep**, holding the startup lock across one network request per worktree-gone row, serially, ignoring `probeBackoffUntil` — 61 rows currently carry a backoff with up to 27 consecutive failures. Worst case under rate limiting: tens of minutes of held lock before the first boot revival. It runs **after** the sweep now (nothing there depends on it) and skips suppressed rows, taking the probe count from **58 to 12**.
- **The resolved-identity rung had no test** — deleting it left all 277 green. It is the rung that distinguishes this from a recorded-id-plus-path lookup.

## Operator preview (live fleet)

```
harnessd tombstone --dry-run
100 rows, 42 kept worktree present, 46 kept probe suppressed, 12 kept scratchpad unreadable, 0 tombstoned
```

## Files

| File | Change |
| ---- | ------ |
| `src/inventory.ts` | `tombstoned_at` (additive migration + readonly projection); identity-based `findAgentOrUndefined` |
| `src/resume.ts` | `latestAgentsByIdentity`, keyed on identity **and** worktree |
| `src/tombstone.ts` | **new** — the ruling, dispositions, probe-suppression skip |
| `src/commands.ts` | `startupReconciliation` = backfill → sweep → tombstone; `tombstoneCommand`; `list` marker |
| `src/discovery.ts` | `defaultAgentIdentityResolver` (a `derived` answer counts as no identity) |

## Test plan

- [x] `bun test` — 282 pass / 0 fail (263 on base); typecheck clean; full pre-commit gates pass
- [x] Live `--dry-run` above; nothing written
- [x] Mutation-tested, restored byte-identical: resolved-identity rung deleted → 1 fail; grouping ignoring the worktree → 2; probe-suppressed rows re-probed → 1; plus the implementer's own 14
- [ ] No unattended restart against the live daemon — `startupReconciliation` is covered by injected deps

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/harnessd-profiles-9af997/ — chunk 5 of 6. §5's risk table needs the correction described above.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787917476&installation_model_id=20758&pr_number=1664&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1664&signature=c49c6101a54a0587d9d901a752606240d55a412725947a1c6df52a28d3c65262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->