### PR TITLE
feat(harnessd): declare provisioning and cleanup per profile

### DIFF
--- a/extensions/bot-runtime-client/src/harness-links.test.ts
+++ b/extensions/bot-runtime-client/src/harness-links.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -153,4 +153,18 @@ describe("harness link registry", () => {
 
     expect(existsSync(join(harnessLinksDir(), "ccs-never-linked.json"))).toBe(false)
   })
+})
+
+test("an unreadable links directory throws rather than reading as no links", () => {
+  // `doctor` prints this count. "0 drift" from a scan that never ran is the
+  // unfalsifiable clean result the whole identity effort exists to remove.
+  const dir = mkdtempSync(join(tmpdir(), "harness-links-locked-"))
+  process.env.THREA_HARNESS_LINKS_DIR = dir
+  chmodSync(dir, 0o000)
+  try {
+    expect(() => readHarnessLinks()).toThrow(/could not read the harness link directory/)
+  } finally {
+    chmodSync(dir, 0o700)
+    rmSync(dir, { recursive: true, force: true })
+  }
 })

--- a/extensions/bot-runtime-client/src/harness-links.ts
+++ b/extensions/bot-runtime-client/src/harness-links.ts
@@ -147,8 +147,11 @@ export function readHarnessLinks(): HarnessLink[] {
   let entries: string[]
   try {
     entries = readdirSync(dir).filter((name) => name.endsWith(".json"))
-  } catch {
-    return []
+  } catch (error) {
+    // A scan that could not run must not read as a scan that found nothing:
+    // `doctor` prints the count, and "0 drift" from an unreadable directory is
+    // the unfalsifiable clean result this whole effort exists to remove.
+    throw new Error(`harnessd: could not read the harness link directory ${dir}: ${error}`)
   }
   for (const entry of entries) {
     try {

--- a/extensions/harness-daemon/src/adopt.test.ts
+++ b/extensions/harness-daemon/src/adopt.test.ts
@@ -840,3 +840,30 @@ describe("parseAdopt", () => {
     expect(parseAdopt([RUNTIME, "--root-stream-id", ROOT, "--no-yolo"])).toMatchObject({ noYolo: true })
   })
 })
+
+describe("adoptClaudeSession opposing evidence", () => {
+  test("a directory the identity store binds to another session is refused", async () => {
+    // Filtering identity records to the requested id before looking made the
+    // opposing one invisible, and the link record was then enough: the takeover
+    // resumed the newest transcript in a directory the store says is someone
+    // else's, under this scratchpad.
+    const dependencies = deps({
+      identities: () => [
+        {
+          runtimeSessionId: "ccs-someone-else",
+          instanceId: "cc-someone-else",
+          worktree: CWD,
+          runtimeKind: "claude-code-channel",
+          mintedAt: "2026-07-29T00:00:00.000Z",
+          source: "mint",
+        },
+      ],
+    })
+
+    const outcome = await adoptClaudeSessionUnlocked(options(), dependencies)
+
+    expect(outcome.status).toBe("refused identity mismatch")
+    expect(outcome.detail).toContain("ccs-someone-else")
+    expect(dependencies.launches).toEqual([])
+  })
+})

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -280,9 +280,19 @@ export async function adoptClaudeSessionUnlocked(options: AdoptOptions, deps: Ad
   // target NOTHING on this machine binds to this directory.
   const derived = resolveRuntimeIdentity(cwd, {}, config)
   const launch = pane ? parseClaudeChannelLaunch(pane.startCommand) : undefined
-  const minted = identityRecordsFor(cwd, identities, (path) => canonicalOrRaw(path, deps.disk.canonical)).filter(
-    (record) => record.runtimeSessionId === options.runtimeSessionId
-  )
+  const recorded = identityRecordsFor(cwd, identities, (path) => canonicalOrRaw(path, deps.disk.canonical))
+  // Filtering to the requested id BEFORE looking makes a record that binds this
+  // directory to a DIFFERENT session invisible, and a link record is then enough
+  // to take over: the takeover resumes the newest transcript in a directory the
+  // store says belongs to someone else, under this scratchpad.
+  const opposing = recorded.filter((record) => record.runtimeSessionId !== options.runtimeSessionId)
+  if (opposing.length > 0) {
+    return {
+      status: "refused identity mismatch",
+      detail: `${cwd} is recorded for ${opposing.map((record) => record.runtimeSessionId).join(", ")}, not ${options.runtimeSessionId}`,
+    }
+  }
+  const minted = recorded.filter((record) => record.runtimeSessionId === options.runtimeSessionId)
   const attestations: Array<{ source: string; instanceId?: string }> = []
   if (minted.length === 1) attestations.push({ source: "identity record", instanceId: minted[0]!.instanceId })
   if (link) attestations.push({ source: "harness link", instanceId: link.instanceId || undefined })

--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -667,8 +667,8 @@ async function launchTakeover(params: {
   if (!claudeBin) throw new Error("claude binary not found; set THREA_HARNESSD_CLAUDE_BIN or put claude on PATH")
   const channel = process.env.THREA_HARNESSD_CLAUDE_CHANNEL || "threa-channel"
   const channelEntry = prepareClaudeChannel()
-  const mcpConfig = mcpConfigPath(params.name)
-  if (!existsSync(mcpConfig)) writeChannelMcpConfig(params.name, channel, channelEntry)
+  const mcpConfig = mcpConfigPath(params.identity.runtimeSessionId)
+  if (!existsSync(mcpConfig)) writeChannelMcpConfig(params.identity.runtimeSessionId, channel, channelEntry)
   normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
 
   const session = params.tmux ?? tmuxSession({ runtime: "claude", name: params.name })

--- a/extensions/harness-daemon/src/archive-wind-down.test.ts
+++ b/extensions/harness-daemon/src/archive-wind-down.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
+import { DEFAULT_WIND_DOWN_POLICY, pushBranchAndRemoveWorktree } from "./archive-wind-down"
 
 const noLog = () => undefined
 
@@ -140,5 +140,94 @@ describe("pushBranchAndRemoveWorktree", () => {
     const report = pushBranchAndRemoveWorktree(dir, noLog)
     expect(report).toMatchObject({ committed: false, pushed: false, removed: false })
     expect(report.reason).toContain("not a git worktree")
+  })
+})
+
+/**
+ * The rung is an ordinal CEILING on the one fixed sequence, so a policy can only
+ * stop earlier. Every test above runs with no third argument — that is the
+ * regression guard proving the default is byte-identical to the pre-profile
+ * behaviour, and it is deliberately not restated here.
+ */
+describe("pushBranchAndRemoveWorktree under a preserve ceiling", () => {
+  test("the default policy is byte-identical to the pre-profile behaviour", () => {
+    const defaulted = makeFixture()
+    writeFileSync(join(defaulted.worktree, "wip.txt"), "unsaved work\n")
+    const explicit = makeFixture()
+    writeFileSync(join(explicit.worktree, "wip.txt"), "unsaved work\n")
+
+    expect(pushBranchAndRemoveWorktree(defaulted.worktree, noLog)).toEqual(
+      pushBranchAndRemoveWorktree(explicit.worktree, noLog, DEFAULT_WIND_DOWN_POLICY)
+    )
+    expect(existsSync(defaulted.worktree)).toBe(false)
+    expect(existsSync(explicit.worktree)).toBe(false)
+  })
+
+  test("preserve: none leaves the branch unpushed and the worktree on disk, with a reason", () => {
+    const { worktree, origin } = makeFixture()
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndRemoveWorktree(worktree, noLog, { preserve: "none", reclaim: false })
+
+    expect(report).toMatchObject({ committed: false, pushed: false, removed: false })
+    expect(report.reason).toContain("preserve 'none'")
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(false)
+    expect(existsSync(join(worktree, "wip.txt"))).toBe(true)
+  })
+
+  test("preserve: commit saves the dirty tree and stops before the push", () => {
+    const { worktree, origin } = makeFixture()
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndRemoveWorktree(worktree, noLog, { preserve: "commit", reclaim: false })
+
+    expect(report).toMatchObject({ committed: true, pushed: false, removed: false })
+    expect(sh(worktree, "git log -1 --format=%s")).toBe("wip: auto-commit — scratchpad archived")
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(false)
+    expect(existsSync(worktree)).toBe(true)
+  })
+
+  test("reclaim never runs without a successful push, whatever the rung", () => {
+    // {preserve: "commit", reclaim: true} is unrepresentable in a Profile and
+    // rejected at config time; the ladder is the second line of defence, and it
+    // returns before `push` ever runs, so the removal block is unreachable.
+    const { worktree, origin } = makeFixture()
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndRemoveWorktree(worktree, noLog, { preserve: "commit", reclaim: true })
+
+    expect(report).toMatchObject({ committed: true, pushed: false, removed: false })
+    expect(existsSync(join(worktree, "wip.txt"))).toBe(true)
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(false)
+  })
+
+  test("reclaim: false pushes and keeps the directory", () => {
+    const { worktree, origin } = makeFixture()
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndRemoveWorktree(worktree, noLog, { preserve: "commit+push", reclaim: false })
+
+    expect(report).toMatchObject({ committed: true, pushed: true, removed: false })
+    expect(report.reason).toContain("reclaim is off")
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(true)
+    expect(existsSync(worktree)).toBe(true)
+  })
+
+  test("a protected branch still refuses at the highest rung — the floor is not a policy input", () => {
+    const { main } = makeFixture()
+    const report = pushBranchAndRemoveWorktree(main, noLog, { preserve: "commit+push", reclaim: true })
+    expect(report).toMatchObject({ committed: false, pushed: false, removed: false })
+    expect(report.reason).toContain("protected")
+    expect(existsSync(main)).toBe(true)
+  })
+
+  test("the main checkout is never removed, whatever the policy", () => {
+    const { main, origin } = makeFixture()
+    sh(main, `git checkout -b feature/from-main`)
+    const report = pushBranchAndRemoveWorktree(main, noLog, { preserve: "commit+push", reclaim: true })
+    expect(report).toMatchObject({ pushed: true, removed: false })
+    expect(report.reason).toContain("main repository checkout")
+    expect(originHasBranch(origin, "feature/from-main")).toBe(true)
+    expect(existsSync(main)).toBe(true)
   })
 })

--- a/extensions/harness-daemon/src/archive-wind-down.ts
+++ b/extensions/harness-daemon/src/archive-wind-down.ts
@@ -35,6 +35,27 @@ export interface ArchiveCleanupReport {
   reason?: string
 }
 
+/**
+ * The ladder's rungs, in the only order they may run. A policy is an ordinal
+ * CEILING on this sequence, never a set of per-step toggles: a caller can stop
+ * earlier, and has no way to reorder, skip, or raise. The floors below —
+ * protected/detached branch, unreadable status, main-checkout-never-removed —
+ * live inside the function and are not policy inputs.
+ */
+export const PRESERVE_RUNGS = ["none", "commit", "commit+push"] as const
+export type PreserveRung = (typeof PRESERVE_RUNGS)[number]
+
+export interface WindDownPolicy {
+  preserve: PreserveRung
+  reclaim: boolean
+}
+
+export const DEFAULT_WIND_DOWN_POLICY: WindDownPolicy = { preserve: "commit+push", reclaim: true }
+
+function rung(preserve: PreserveRung): number {
+  return PRESERVE_RUNGS.indexOf(preserve)
+}
+
 const PROTECTED_BRANCHES = new Set(["main", "master", "HEAD"])
 const GIT_TIMEOUT_MS = 30_000
 // Staging + writing a commit for a large dirty tree is slower than a plain
@@ -54,7 +75,11 @@ function git(cwd: string, args: string[], timeoutMs = GIT_TIMEOUT_MS): { ok: boo
   }
 }
 
-export function pushBranchAndRemoveWorktree(cwd: string, log: (message: string) => void): ArchiveCleanupReport {
+export function pushBranchAndRemoveWorktree(
+  cwd: string,
+  log: (message: string) => void,
+  policy: WindDownPolicy = DEFAULT_WIND_DOWN_POLICY
+): ArchiveCleanupReport {
   const report: ArchiveCleanupReport = { committed: false, pushed: false, removed: false }
 
   if (!git(cwd, ["rev-parse", "--is-inside-work-tree"]).ok) {
@@ -64,6 +89,11 @@ export function pushBranchAndRemoveWorktree(cwd: string, log: (message: string) 
   const branch = git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout
   if (!branch || PROTECTED_BRANCHES.has(branch)) {
     report.reason = `branch '${branch || "?"}' is protected or detached — leaving everything as is`
+    return report
+  }
+
+  if (rung(policy.preserve) < rung("commit")) {
+    report.reason = `preserve '${policy.preserve}' — leaving the branch and the worktree exactly as they are`
     return report
   }
 
@@ -92,6 +122,11 @@ export function pushBranchAndRemoveWorktree(cwd: string, log: (message: string) 
     report.committed = true
   }
 
+  if (rung(policy.preserve) < rung("commit+push")) {
+    report.reason = `preserve '${policy.preserve}' — the work is committed locally and nothing is pushed or removed`
+    return report
+  }
+
   const push = git(cwd, ["push", "-u", "origin", `HEAD:${branch}`], PUSH_TIMEOUT_MS)
   if (!push.ok) {
     report.reason = "push failed — leaving the worktree so nothing is lost"
@@ -99,6 +134,11 @@ export function pushBranchAndRemoveWorktree(cwd: string, log: (message: string) 
   }
   report.pushed = true
   log(`pushed ${branch} to origin`)
+
+  if (!policy.reclaim) {
+    report.reason = "reclaim is off for this profile — the branch is pushed and the directory stays"
+    return report
+  }
 
   // Linked worktree ⇔ its .git dir differs from the repo's common dir. The
   // main checkout's dir IS the common dir, so this can never remove it.

--- a/extensions/harness-daemon/src/backfill.test.ts
+++ b/extensions/harness-daemon/src/backfill.test.ts
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { HarnessLink } from "@threa/bot-runtime-client"
-import { backfillIdentities, type BackfillDeps, type BackfillOutcome } from "./backfill"
+import { backfillIdentities, recordedProfile, type BackfillDeps, type BackfillOutcome } from "./backfill"
+import type { Profile } from "./profiles"
 import type { LocalTmuxPane } from "./discovery"
 import { writeMintedIdentity, type MintedIdentity, type WriteMintedIdentityResult } from "./identity-store"
 import type { ManagedAgent } from "./types"
@@ -94,6 +95,7 @@ function deps(overrides: Partial<BackfillDeps> = {}): { deps: BackfillDeps; writ
       },
       now: () => new Date("2026-07-29T00:00:00.000Z"),
       log: () => {},
+      profileFor: () => undefined,
       ...overrides,
     },
   }
@@ -295,4 +297,25 @@ test("a corroborated subject with no instance id is not counted as a single sour
 
   expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "refused no instance id" }])
   expect(context.written).toEqual([])
+})
+
+test("a row's recorded profile is carried onto the record the backfill writes", () => {
+  // A reap deletes the snapshot with the worktree, so a directory that comes
+  // back through an unarchive is re-recorded here. Without this it is
+  // re-recorded with NO profile, which resolves to the built-in default and
+  // silently stops running the teardown the operator declared.
+  const quiet: Profile = { name: "quiet", provision: "existing", preserve: "none", setup: [], teardown: [] }
+  const context = deps({ links: () => [link()], profileFor: () => quiet })
+
+  const outcomes = backfillIdentities(context.deps, false)
+
+  expect(pairs(outcomes)).toEqual([{ subject: WORKTREE, disposition: "recorded" }])
+  expect(context.written[0]?.profile).toEqual(quiet)
+})
+
+test("recordedProfile reads the profile off the row's own spawn command", () => {
+  expect(recordedProfile([agent({ command: ["threa-harnessd", "spawn", "claude", "--name", "x"] })])).toBeUndefined()
+  expect(
+    recordedProfile([agent({ command: ["threa-harnessd", "spawn", "claude", "--cwd", "/repo/x"] })])
+  ).toMatchObject({ provision: "existing", preserve: "none" })
 })

--- a/extensions/harness-daemon/src/backfill.ts
+++ b/extensions/harness-daemon/src/backfill.ts
@@ -19,6 +19,7 @@ import {
 import { readInventoryReadonly } from "./inventory"
 import { occupancyVeto } from "./mint"
 import type { ManagedAgent } from "./types"
+import { readProfiles, selectProfile, type Profile } from "./profiles"
 
 export type BackfillDisposition =
   | "recorded"
@@ -48,6 +49,8 @@ export interface BackfillDeps {
   write: (record: MintedIdentity) => WriteMintedIdentityResult
   now: () => Date
   log: (message: string) => void
+  /** The profile these rows were spawned under, from their recorded command. */
+  profileFor: (rows: ManagedAgent[]) => Profile | undefined
 }
 
 export function defaultBackfillDeps(): BackfillDeps {
@@ -62,6 +65,7 @@ export function defaultBackfillDeps(): BackfillDeps {
     write: writeMintedIdentity,
     now: () => new Date(),
     log: (message) => console.warn(message),
+    profileFor: recordedProfile,
   }
 }
 
@@ -95,6 +99,28 @@ function once<T>(read: () => T): () => T {
     if (thrown !== undefined) throw thrown
     return value
   }
+}
+
+/**
+ * The profile a row was spawned under, read back off its recorded command.
+ *
+ * Best-effort by design: a profile that has since been renamed away must not
+ * make the backfill die, and no profile is a truthful answer — it resolves to
+ * the built-in default, which is what a row with no `--profile` had anyway.
+ */
+export function recordedProfile(rows: ManagedAgent[]): Profile | undefined {
+  for (const row of rows) {
+    const at = row.command.indexOf("--profile")
+    const named = at >= 0 ? row.command[at + 1] : undefined
+    const cwd = row.command.includes("--cwd") ? "recorded" : undefined
+    if (!named && !cwd) continue
+    try {
+      return selectProfile({ profile: named, cwd }, readProfiles())
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
 }
 
 function subjectsOf(agents: ManagedAgent[], canonical: (path: string) => string): Map<string, ManagedAgent[]> {
@@ -227,6 +253,13 @@ function decide(
   }
   claimed.set(winner.runtimeSessionId, worktree)
 
+  // Carried forward from the row's own spawn command. A reap deletes the
+  // snapshot with the worktree, so a directory that comes back through an
+  // unarchive is re-recorded here — and without this it is re-recorded with NO
+  // profile, which resolves to the built-in default and silently stops running
+  // the teardown the operator declared.
+  const profile = deps.profileFor(rows)
+
   if (dryRun) {
     return { subject: worktree, disposition: "recorded", detail: `${winner.runtimeSessionId} via ${winner.attestor}` }
   }
@@ -238,6 +271,7 @@ function decide(
     mintedAt: deps.now().toISOString(),
     source: "backfill",
     attestedBy: winner.attestor,
+    ...(profile ? { profile } : {}),
   })
   if (written.status === "created") {
     return { subject: worktree, disposition: "recorded", detail: `${winner.runtimeSessionId} via ${winner.attestor}` }

--- a/extensions/harness-daemon/src/cli.test.ts
+++ b/extensions/harness-daemon/src/cli.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { resolve } from "node:path"
+import { parseSpawn } from "./cli"
+
+test("--cwd together with --repo, --branch or --base is refused at parse time", () => {
+  // --cwd provisions nothing, so there is nothing to create a branch off and
+  // nothing to create it in. Accepting both would silently ignore one.
+  for (const [flag, value] of [
+    ["--repo", "/somewhere"],
+    ["--branch", "feature/x"],
+    ["--base", "origin/main"],
+  ]) {
+    expect(() => parseSpawn(["claude", "--name", "a", "--cwd", "/tmp", flag!, value!])).toThrow(
+      new RegExp(`--cwd provisions nothing.*\\${flag}`)
+    )
+  }
+})
+
+test("--cwd is resolved and records no repo", () => {
+  const options = parseSpawn(["claude", "--name", "orchestrator", "--cwd", "."])
+  expect(options.cwd).toBe(resolve("."))
+  expect(options.repo).toBeUndefined()
+})
+
+test("--profile is carried through, and its absence is not a name", () => {
+  expect(parseSpawn(["claude", "--name", "a", "--profile", "pi-orchestrator"]).profile).toBe("pi-orchestrator")
+  expect(parseSpawn(["claude", "--name", "a"]).profile).toBeUndefined()
+})
+
+test("without --cwd the repo still defaults, exactly as before", () => {
+  expect(parseSpawn(["claude", "--name", "a"]).repo).toBeTruthy()
+})

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -9,6 +9,7 @@ export function usage(): never {
 
 Usage:
   threa-harnessd spawn <pi|claude> --name <name> [--branch <ref>] [--repo <path>] [--tmux <session>] [--skip-setup]
+      [--cwd <path>] [--profile <name>]   (--cwd uses an existing folder and provisions nothing)
   threa-harnessd do <natural language command>
   threa-harnessd list
   threa-harnessd up [--tmux <session>] [--dry-run] [--recreate-worktree]
@@ -208,12 +209,22 @@ export function parseSpawn(args: string[]): SpawnOptions {
   const flags = parseFlags(args)
   const name = stringFlag(flags, "name")
   if (!name) die("spawn requires --name")
+  const cwd = stringFlag(flags, "cwd")
+  if (cwd !== undefined) {
+    // --cwd means "use this folder": there is nothing to create a branch off,
+    // and nothing to create it in. Accepting both would silently ignore one.
+    const conflicting = (["repo", "branch", "base"] as const).filter((flag) => flags[flag] !== undefined)
+    if (conflicting.length > 0) {
+      die(`--cwd provisions nothing, so it cannot be combined with ${conflicting.map((f) => `--${f}`).join(", ")}`)
+    }
+  }
   return {
     runtime,
     name: normalizeName(name),
     branch: stringFlag(flags, "branch"),
     base: stringFlag(flags, "base"),
-    repo: resolve(stringFlag(flags, "repo") ?? defaultRepo()),
+    ...(cwd !== undefined ? { cwd: resolve(cwd) } : { repo: resolve(stringFlag(flags, "repo") ?? defaultRepo()) }),
+    profile: stringFlag(flags, "profile"),
     tmux: stringFlag(flags, "tmux"),
     skipSetup: boolFlag(flags, "skip-setup"),
     noRemote: boolFlag(flags, "no-remote"),

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -19,6 +19,7 @@ import {
   type ManagedAgentPane,
   type ResolvedRuntimeIdentity,
 } from "./discovery"
+import { profileForWorktree } from "./identity-store"
 import { die } from "./errors"
 import { identityConsistency, identityVerdict } from "./identity"
 import {
@@ -30,6 +31,7 @@ import {
   upsertAgent,
 } from "./inventory"
 import { acquireProcessLock, resumeActiveLockPath } from "./lock"
+import { inspectProfiles, DEFAULT_PROFILE } from "./profiles"
 import { commandExists, commandPath, output } from "./shell"
 import {
   ClaudeRuntimeSpawner,
@@ -79,6 +81,8 @@ function spawnCommand(options: SpawnOptions): string[] {
   if (options.branch) command.push("--branch", options.branch)
   if (options.base) command.push("--base", options.base)
   if (options.repo) command.push("--repo", options.repo)
+  if (options.cwd) command.push("--cwd", options.cwd)
+  if (options.profile) command.push("--profile", options.profile)
   if (options.tmux) command.push("--tmux", options.tmux)
   if (options.skipSetup) command.push("--skip-setup")
   if (options.noRemote) command.push("--no-remote")
@@ -464,7 +468,11 @@ export function defaultReviveDeps(): ReviveDeps {
     pathExists: existsSync,
     scratchpadStatus: fetchScratchpadStatus,
     preflight: preflightRuntimeSession,
-    restoreWorktree: restoreManagedWorktree,
+    // The profile the worktree was provisioned under, not the built-in default:
+    // a row whose profile declares its own setup would otherwise silently run
+    // `bun run setup:worktree` on revival instead.
+    restoreWorktree: (agent) =>
+      restoreManagedWorktree(agent, agent.worktree ? profileForWorktree(agent.worktree) : DEFAULT_PROFILE),
     restorableWorktree: restorableWorktreeSource,
     piLink: readPiRemoteSession,
     claudeIdentity: claudeAgentIdentity,
@@ -932,6 +940,15 @@ export function doctor(): void {
     }
     console.log(
       `${count === 0 ? "ok" : "drift"}\t${name}\t${count} carry an identity today's derivation cannot reproduce`
+    )
+  }
+  const profiles = inspectProfiles()
+  if (profiles.status === "invalid") {
+    console.log(`broken\tprofiles\t${profiles.path}: ${profiles.errors.join("; ")}`)
+  } else {
+    const names = Object.keys(profiles.profiles)
+    console.log(
+      `ok\tprofiles\t${profiles.path}${profiles.present ? ` parses; ${names.length} defined${names.length > 0 ? ` (${names.join(", ")})` : ""}` : " (absent; the built-in default applies)"}`
     )
   }
   console.log(`inventory\t${inventoryPath()}`)

--- a/extensions/harness-daemon/src/identity-store.test.ts
+++ b/extensions/harness-daemon/src/identity-store.test.ts
@@ -8,7 +8,11 @@ import {
   readMintedIdentity,
   writeMintedIdentity,
   type MintedIdentity,
+  identityRecordsFor,
+  profileForWorktree,
+  recordProfileSnapshot,
 } from "./identity-store"
+import { DEFAULT_PROFILE, UNKNOWN_PROFILE, type Profile } from "./profiles"
 
 let dir: string
 const previous = process.env.THREA_HARNESSD_IDENTITIES_DIR
@@ -79,4 +83,53 @@ test("the store honours THREA_HARNESSD_IDENTITIES_DIR and defaults under ~/.thre
   delete process.env.THREA_HARNESSD_IDENTITIES_DIR
   expect(identityStoreDir()).toBe(join(homedir(), ".threa", "harnessd", "identities"))
   process.env.THREA_HARNESSD_IDENTITIES_DIR = dir
+})
+
+test("an ambiguous or unreadable profile resolves to nothing-destructive, never to the default", () => {
+  // The default commits, pushes and reclaims, so failing open to it escalates
+  // "I do not know" into the most destructive policy there is.
+  const base = {
+    instanceId: "cc-a",
+    worktree: "/repo/threa.x",
+    runtimeKind: "claude-code-channel",
+    mintedAt: "2026-07-29T00:00:00.000Z",
+    source: "mint" as const,
+  }
+  const quiet: Profile = { name: "quiet", provision: "existing", preserve: "none", setup: [], teardown: [] }
+
+  expect(profileForWorktree("/repo/threa.x", [], (path) => path)).toEqual(DEFAULT_PROFILE)
+  expect(
+    profileForWorktree("/repo/threa.x", [{ ...base, runtimeSessionId: "ccs-a", profile: quiet }], (p) => p)
+  ).toEqual(quiet)
+  expect(
+    profileForWorktree(
+      "/repo/threa.x",
+      [
+        { ...base, runtimeSessionId: "ccs-a", profile: quiet },
+        { ...base, runtimeSessionId: "ccs-b", profile: quiet },
+      ],
+      (path) => path
+    )
+  ).toEqual(UNKNOWN_PROFILE)
+  expect(
+    profileForWorktree("/repo/threa.x", [{ ...base, runtimeSessionId: "ccs-a", profileUnreadable: true }], (p) => p)
+  ).toEqual(UNKNOWN_PROFILE)
+})
+
+test("a respawn supersedes the directory's record instead of adding a second", () => {
+  recordProfileSnapshot({
+    worktree: "/repo/threa.y",
+    runtimeSessionId: "pi-one",
+    runtimeKind: "pi-local",
+    profile: { name: "q", provision: "existing", preserve: "none", setup: [], teardown: [] },
+  })
+  recordProfileSnapshot({
+    worktree: "/repo/threa.y",
+    runtimeSessionId: "pi-two",
+    runtimeKind: "pi-local",
+    profile: { name: "q", provision: "existing", preserve: "none", setup: [], teardown: [] },
+  })
+
+  expect(identityRecordsFor("/repo/threa.y").map((record) => record.runtimeSessionId)).toEqual(["pi-two"])
+  expect(profileForWorktree("/repo/threa.y").preserve).toBe("none")
 })

--- a/extensions/harness-daemon/src/identity-store.ts
+++ b/extensions/harness-daemon/src/identity-store.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { isSafeSessionFileName } from "@threa/bot-runtime-client"
 import { canonicalOrRaw } from "./discovery"
-import { DEFAULT_PROFILE, parseProfileSnapshot, type Profile } from "./profiles"
+import { DEFAULT_PROFILE, parseProfileSnapshot, type Profile, UNKNOWN_PROFILE } from "./profiles"
 
 /**
  * Where a runtime session's identity is RECORDED, so nothing has to recompute
@@ -21,6 +21,8 @@ export interface MintedIdentity {
   runtimeKind: string
   mintedAt: string
   source: "mint" | "backfill"
+  /** Set when a snapshot was present but would not re-read: the caller must not guess. */
+  profileUnreadable?: boolean
   attestedBy?: "ledger" | "inventory" | "launch"
   /**
    * The RESOLVED profile this workspace was provisioned under, snapshotted — not
@@ -59,12 +61,14 @@ function parseRecord(text: string): MintedIdentity | undefined {
   ) {
     return undefined
   }
-  // A snapshot that cannot be re-read is not a record with no snapshot: reading
-  // it as "no profile" would silently wind the directory down under the default,
-  // which reclaims. An unreadable record is skipped instead, and the reaper's
-  // own default-profile fallback then applies knowingly.
+  // A snapshot that cannot be re-read is NOT a record with no snapshot. Dropping
+  // the whole record made it invisible to `identityRecordsFor`, so the reaper
+  // found nothing and applied the default — escalating a corrupt `preserve:
+  // "none"` into commit+push+reclaim. The record is kept and the unreadable
+  // snapshot is marked, so the caller can tell "never had one" from "cannot
+  // read it" and refuse to guess.
   const profile = parsed.profile === undefined ? undefined : parseProfileSnapshot(parsed.profile)
-  if (parsed.profile !== undefined && !profile) return undefined
+  const profileUnreadable = parsed.profile !== undefined && !profile
   return {
     runtimeSessionId: parsed.runtimeSessionId,
     instanceId: parsed.instanceId,
@@ -76,13 +80,18 @@ function parseRecord(text: string): MintedIdentity | undefined {
       ? { attestedBy: parsed.attestedBy }
       : {}),
     ...(profile ? { profile } : {}),
+    ...(profileUnreadable ? { profileUnreadable: true } : {}),
   }
 }
 
 /**
- * The profile a worktree is cleaned up under. No mint record — or more than one,
- * which is already refused elsewhere — means the pre-profile fleet, so the
- * built-in default applies and nothing about today's behaviour changes.
+ * The profile a worktree is cleaned up under.
+ *
+ * NO record means the pre-profile fleet: the built-in default applies and
+ * nothing about today's behaviour changes. Anything else that leaves the answer
+ * in doubt — two records naming one directory, or a snapshot that will not
+ * re-read — resolves to {@link UNKNOWN_PROFILE}, never to the default. Failing
+ * open here escalates "I do not know" into commit, push and reclaim.
  */
 export function profileForWorktree(
   worktree: string,
@@ -90,7 +99,9 @@ export function profileForWorktree(
   canonical: (path: string) => string = canonicalOrRaw
 ): Profile {
   const found = identityRecordsFor(worktree, records, canonical)
-  return found.length === 1 ? (found[0]!.profile ?? DEFAULT_PROFILE) : DEFAULT_PROFILE
+  if (found.length === 0) return DEFAULT_PROFILE
+  if (found.length > 1 || found[0]!.profileUnreadable) return UNKNOWN_PROFILE
+  return found[0]!.profile ?? DEFAULT_PROFILE
 }
 
 /**
@@ -107,7 +118,22 @@ export function recordProfileSnapshot(params: {
   profile: Profile
   instanceId?: string
 }): void {
-  writeMintedIdentity({
+  const worktree = canonicalOrRaw(params.worktree)
+  const existing = identityRecordsFor(worktree)
+  // Never a SECOND record for one directory. `profileForWorktree` cannot honour
+  // an ambiguous answer, so a respawn that simply appended would turn a
+  // `preserve: "none"` directory into one the reaper treats as unknown — and
+  // before that fallback was made safe, into one it committed, pushed and
+  // reclaimed. Supersede by worktree, exactly as `recordHarnessLink` does.
+  const foreign = existing.filter((record) => record.runtimeKind !== params.runtimeKind)
+  if (foreign.length > 0) {
+    console.warn(
+      `harnessd: not recording a ${params.runtimeKind} profile for ${worktree}: ${foreign.map((record) => `${record.runtimeSessionId} (${record.runtimeKind})`).join(", ")} already claims it`
+    )
+    return
+  }
+  for (const record of existing) clearMintedIdentity(record.runtimeSessionId)
+  const written = writeMintedIdentity({
     runtimeSessionId: params.runtimeSessionId,
     instanceId: params.instanceId ?? params.runtimeSessionId,
     worktree: canonicalOrRaw(params.worktree),
@@ -116,6 +142,12 @@ export function recordProfileSnapshot(params: {
     source: "mint",
     profile: params.profile,
   })
+  // Reported, not discarded: without the snapshot the reaper falls back, and the
+  // operator should learn that here rather than from a directory that was
+  // cleaned up under a policy they did not declare.
+  if (written.status !== "created") {
+    console.warn(`harnessd: could not record the profile for ${worktree}: ${JSON.stringify(written)}`)
+  }
 }
 
 /** Every recorded identity. Unreadable or malformed files are skipped, not fatal. */
@@ -174,6 +206,17 @@ export function identityRecordsFor(
  * resolves to the same path, finds the dead session's record, and launches under
  * a `runtimeSessionId` the server already knows as wound down.
  */
+export function clearMintedIdentity(runtimeSessionId: string): void {
+  const path = identityPath(runtimeSessionId)
+  if (!path) return
+  try {
+    rmSync(path, { force: true })
+  } catch {
+    // A leftover record only costs the next lookup its precision; it must never
+    // abort the caller.
+  }
+}
+
 export function forgetMintedIdentitiesFor(worktree: string): string[] {
   const retired: string[] = []
   for (const record of identityRecordsFor(worktree)) {

--- a/extensions/harness-daemon/src/identity-store.ts
+++ b/extensions/harness-daemon/src/identity-store.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { isSafeSessionFileName } from "@threa/bot-runtime-client"
 import { canonicalOrRaw } from "./discovery"
+import { DEFAULT_PROFILE, parseProfileSnapshot, type Profile } from "./profiles"
 
 /**
  * Where a runtime session's identity is RECORDED, so nothing has to recompute
@@ -21,6 +22,14 @@ export interface MintedIdentity {
   mintedAt: string
   source: "mint" | "backfill"
   attestedBy?: "ledger" | "inventory" | "launch"
+  /**
+   * The RESOLVED profile this workspace was provisioned under, snapshotted — not
+   * a name. Editing a profile later must not retroactively change how a
+   * directory created under the old one is cleaned up. Absent on every record
+   * written before profiles existed, which is why the reader falls back to
+   * {@link DEFAULT_PROFILE}: today's fleet is wound down exactly as it is now.
+   */
+  profile?: Profile
 }
 
 export type WriteMintedIdentityResult =
@@ -50,6 +59,12 @@ function parseRecord(text: string): MintedIdentity | undefined {
   ) {
     return undefined
   }
+  // A snapshot that cannot be re-read is not a record with no snapshot: reading
+  // it as "no profile" would silently wind the directory down under the default,
+  // which reclaims. An unreadable record is skipped instead, and the reaper's
+  // own default-profile fallback then applies knowingly.
+  const profile = parsed.profile === undefined ? undefined : parseProfileSnapshot(parsed.profile)
+  if (parsed.profile !== undefined && !profile) return undefined
   return {
     runtimeSessionId: parsed.runtimeSessionId,
     instanceId: parsed.instanceId,
@@ -60,7 +75,47 @@ function parseRecord(text: string): MintedIdentity | undefined {
     ...(parsed.attestedBy === "ledger" || parsed.attestedBy === "inventory" || parsed.attestedBy === "launch"
       ? { attestedBy: parsed.attestedBy }
       : {}),
+    ...(profile ? { profile } : {}),
   }
+}
+
+/**
+ * The profile a worktree is cleaned up under. No mint record — or more than one,
+ * which is already refused elsewhere — means the pre-profile fleet, so the
+ * built-in default applies and nothing about today's behaviour changes.
+ */
+export function profileForWorktree(
+  worktree: string,
+  records: MintedIdentity[] = readMintedIdentities(),
+  canonical: (path: string) => string = canonicalOrRaw
+): Profile {
+  const found = identityRecordsFor(worktree, records, canonical)
+  return found.length === 1 ? (found[0]!.profile ?? DEFAULT_PROFILE) : DEFAULT_PROFILE
+}
+
+/**
+ * Bind a profile to a directory for a runtime that does not mint.
+ *
+ * Best-effort: a spawn must not fail because bookkeeping could not be written.
+ * A missing snapshot only costs the reaper its declared policy — which is why
+ * the caller records it BEFORE the session starts, not after.
+ */
+export function recordProfileSnapshot(params: {
+  worktree: string
+  runtimeSessionId: string
+  runtimeKind: string
+  profile: Profile
+  instanceId?: string
+}): void {
+  writeMintedIdentity({
+    runtimeSessionId: params.runtimeSessionId,
+    instanceId: params.instanceId ?? params.runtimeSessionId,
+    worktree: canonicalOrRaw(params.worktree),
+    runtimeKind: params.runtimeKind,
+    mintedAt: new Date().toISOString(),
+    source: "mint",
+    profile: params.profile,
+  })
 }
 
 /** Every recorded identity. Unreadable or malformed files are skipped, not fatal. */

--- a/extensions/harness-daemon/src/lock.test.ts
+++ b/extensions/harness-daemon/src/lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { acquireProcessLock } from "./lock"
@@ -54,4 +54,68 @@ describe("acquireProcessLock", () => {
 
     expect(readFileSync(path, "utf8")).toBe("999")
   })
+})
+
+const dir = mkdtempSync(join(tmpdir(), "harnessd-lock-race-"))
+
+test("two waiters observing one dead holder cannot both take the lock", async () => {
+  // The interleaving the old re-read did not prevent: both read the dead holder
+  // and are authorised, the first unlinks and takes the lock, and the second's
+  // already-authorised unlink deletes that fresh lock and takes its own.
+  const path = join(dir, "contended.lock")
+  writeFileSync(path, "111")
+  const dead = (pid: number) => pid !== 111
+
+  const first = await acquireProcessLock(path, { pid: 222, isAlive: dead, pollMs: 1, timeoutMs: 2_000 })
+
+  // 333 arrives while 222 holds it. 222 is alive, so 333 must wait, not steal.
+  let taken = false
+  const second = acquireProcessLock(path, { pid: 333, isAlive: () => true, pollMs: 1, timeoutMs: 2_000 }).then(
+    (release) => {
+      taken = true
+      return release
+    }
+  )
+  await Bun.sleep(50)
+
+  expect(taken).toBe(false)
+  expect(readFileSync(path, "utf8")).toBe("222")
+
+  first()
+  ;(await second)()
+  expect(existsSync(path)).toBe(false)
+})
+
+test("a stealer that died mid-steal does not wedge every later waiter", async () => {
+  const path = join(dir, "wedged.lock")
+  writeFileSync(path, "111")
+  writeFileSync(`${path}.steal`, "222")
+
+  const release = await acquireProcessLock(path, {
+    pid: 333,
+    isAlive: (pid) => pid === 333,
+    pollMs: 1,
+    timeoutMs: 2_000,
+  })
+
+  expect(readFileSync(path, "utf8")).toBe("333")
+  expect(existsSync(`${path}.steal`)).toBe(false)
+  release()
+})
+
+test("only one waiter at a time may remove a dead holder's lock", async () => {
+  // The serialisation itself: with another stealer live, a waiter that has
+  // already seen the dead holder must NOT reach the unlink — otherwise its
+  // authorisation outlives the state it was granted for and it deletes the lock
+  // the first stealer has since taken.
+  const path = join(dir, "serialised.lock")
+  writeFileSync(path, "111")
+  writeFileSync(`${path}.steal`, "222")
+
+  await expect(
+    acquireProcessLock(path, { pid: 333, isAlive: (pid) => pid !== 111, pollMs: 1, timeoutMs: 150 })
+  ).rejects.toThrow(/held by pid 111/)
+
+  expect(readFileSync(path, "utf8")).toBe("111")
+  expect(readFileSync(`${path}.steal`, "utf8")).toBe("222")
 })

--- a/extensions/harness-daemon/src/lock.ts
+++ b/extensions/harness-daemon/src/lock.ts
@@ -25,6 +25,51 @@ export function processAlive(pid: number): boolean {
 }
 
 /**
+ * Remove a lock whose owner is gone — but only one waiter at a time.
+ *
+ * Re-reading the file immediately before unlinking is NOT enough, and the
+ * comment that used to claim it was is why this looked safe. Two waiters can
+ * both read the dead holder and both be authorised; the first unlinks and takes
+ * the lock, and the second's already-authorised `unlink` then deletes that fresh
+ * lock and takes its own. Both return believing they hold it, and a revive runs
+ * concurrently with a reap that force-removes worktrees.
+ *
+ * The steal marker closes it: a waiter can only reach the unlink while holding
+ * an exclusive marker, so by the time the second waiter gets there its re-read
+ * shows the NEW owner rather than the dead one, and it declines. The marker is
+ * itself stale-recoverable, or a stealer dying mid-steal would wedge everyone.
+ */
+function stealStaleLock(path: string, holder: number, pid: number, isAlive: (pid: number) => boolean): boolean {
+  const markerPath = `${path}.steal`
+  try {
+    writeFileSync(markerPath, String(pid), { flag: "wx" })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+    try {
+      const owner = Number(readFileSync(markerPath, "utf8")) || undefined
+      if (owner !== undefined && owner !== pid && !isAlive(owner)) unlinkSync(markerPath)
+    } catch {
+      // The marker went away on its own; the next pass re-reads the lock.
+    }
+    return false
+  }
+  try {
+    if (Number(readFileSync(path, "utf8")) !== holder || isAlive(holder)) return false
+    unlinkSync(path)
+    return true
+  } catch {
+    // Already gone, or taken by the waiter that stole it before us.
+    return false
+  } finally {
+    try {
+      unlinkSync(markerPath)
+    } catch {
+      // Losing the marker only costs the next stealer one poll.
+    }
+  }
+}
+
+/**
  * Cross-process mutex with owner-pid staleness recovery: a crashed holder's
  * lock is stolen instead of wedging every later pass (the previous tmux
  * wait-for lock survived its owner until the tmux server restarted).
@@ -56,19 +101,24 @@ export async function acquireProcessLock(path: string, options: LockOptions = {}
     } catch {
       continue
     }
+    // Retry at once only when the steal actually freed the lock. Falling through
+    // otherwise is what keeps a contested steal — another waiter holding the
+    // marker — from spinning past the deadline instead of timing out.
     if (holder !== undefined && holder !== pid && !isAlive(holder)) {
-      // Re-read immediately before removing: two waiters can observe the same
-      // dead holder, and an unconditional unlink lets the second delete the
-      // FIRST one's freshly taken lock, leaving both convinced they hold it.
-      // Only the file still naming the dead pid may be removed.
-      try {
-        if (Number(readFileSync(path, "utf8")) === holder) unlinkSync(path)
-      } catch {}
-      continue
+      if (stealStaleLock(path, holder, pid, isAlive)) continue
     }
     if (Date.now() >= deadline) {
+      // Re-read: `holder` was captured before the steal attempt, and naming the
+      // pid we gave up on rather than the one actually holding it sends whoever
+      // reads this at a process that is already gone.
+      let current: number | undefined
+      try {
+        current = Number(readFileSync(path, "utf8")) || undefined
+      } catch {
+        current = holder
+      }
       throw new Error(
-        `lock ${path} held by pid ${holder ?? "unknown"} for over ${Math.round(timeoutMs / 1000)}s; ` +
+        `lock ${path} held by pid ${current ?? holder ?? "unknown"} for over ${Math.round(timeoutMs / 1000)}s; ` +
           "another revival pass appears stuck"
       )
     }

--- a/extensions/harness-daemon/src/mint.test.ts
+++ b/extensions/harness-daemon/src/mint.test.ts
@@ -316,3 +316,35 @@ test("no tmux server does not block a cold-start mint, but is reported", async (
   expect(warnings).toHaveLength(1)
   expect(warnings[0]).toContain("process table only")
 })
+
+test("a spawn refuses a directory a live Claude already occupies, even an identified one", async () => {
+  // The reuse rungs answer "what identity does this directory have", which is
+  // right for a backfill and wrong for a launch: reusing an identified live
+  // session's id starts a SECOND runtime under it.
+  const { deps: mintDeps, written } = deps({
+    identities: () => [identity()],
+    claudeProcessesIn: () => [4242],
+  })
+
+  const outcome = await mintRuntimeIdentity(
+    { worktree: WORKTREE, runtimeKind: "claude-code-channel", requireVacant: true },
+    mintDeps
+  )
+
+  expect(outcome.status).toBe("refused")
+  expect(outcome.status === "refused" && outcome.reason).toContain("4242")
+  expect(written).toEqual([])
+})
+
+test("a record for another runtime is never reused as this one's identity", async () => {
+  const { deps: mintDeps } = deps({
+    identities: () => [identity({ runtimeSessionId: "pi-uuid", instanceId: "pi-uuid", runtimeKind: "pi-local" })],
+  })
+
+  const outcome = await mintRuntimeIdentity({ worktree: WORKTREE, runtimeKind: "claude-code-channel" }, mintDeps)
+
+  expect(outcome).toEqual({
+    status: "refused",
+    reason: `${WORKTREE} is recorded for pi-uuid (pi-local), not claude-code-channel`,
+  })
+})

--- a/extensions/harness-daemon/src/mint.ts
+++ b/extensions/harness-daemon/src/mint.ts
@@ -17,6 +17,7 @@ import {
   type WriteMintedIdentityResult,
 } from "./identity-store"
 import { acquireProcessLock, resumeActiveLockPath } from "./lock"
+import { DEFAULT_PROFILE, type Profile } from "./profiles"
 import { CLAUDE_INSTANCE_ID_PREFIX, CLAUDE_RUNTIME_SESSION_ID_PREFIX } from "./spawners"
 
 export interface MintRequest {
@@ -24,6 +25,8 @@ export interface MintRequest {
   runtimeKind: string
   /** Ids declared in ~/.claude/threa-channel/config.json: recorded as the mint rather than generated. */
   declared?: { instanceId?: string; runtimeSessionId?: string }
+  /** Snapshotted onto the record: a later edit to the profiles file must not change how this directory is reaped. */
+  profile?: Profile
 }
 
 export interface MintDeps {
@@ -171,6 +174,7 @@ function mintRuntimeIdentityUnlocked(request: MintRequest, deps: MintDeps): Mint
     runtimeKind: request.runtimeKind,
     mintedAt: deps.now().toISOString(),
     source: "mint",
+    profile: request.profile ?? DEFAULT_PROFILE,
   }
   const written = deps.write(record)
   if (written.status === "exists") {

--- a/extensions/harness-daemon/src/mint.ts
+++ b/extensions/harness-daemon/src/mint.ts
@@ -23,6 +23,15 @@ import { CLAUDE_INSTANCE_ID_PREFIX, CLAUDE_RUNTIME_SESSION_ID_PREFIX } from "./s
 export interface MintRequest {
   worktree: string
   runtimeKind: string
+  /**
+   * Set by a spawn: refuse ANY live occupant, identified or not.
+   *
+   * The reuse rungs answer "what identity does this directory have", which is
+   * right for a backfill and wrong for a launch — reusing an identified live
+   * session's id starts a SECOND runtime under it, which is the duplicate-session
+   * failure this whole effort exists to remove.
+   */
+  requireVacant?: boolean
   /** Ids declared in ~/.claude/threa-channel/config.json: recorded as the mint rather than generated. */
   declared?: { instanceId?: string; runtimeSessionId?: string }
   /** Snapshotted onto the record: a later edit to the profiles file must not change how this directory is reaped. */
@@ -124,9 +133,21 @@ function mintRuntimeIdentityUnlocked(request: MintRequest, deps: MintDeps): Mint
   const worktree = deps.canonicalPath(request.worktree)
 
   const records = deps.identities()
+  if (request.requireVacant) {
+    const occupied = occupancyVeto(worktree, deps, new Set())
+    if (occupied) return { status: "refused", reason: occupied }
+  }
   const recorded = identityRecordsFor(worktree, records, deps.canonicalPath)
   if (recorded.length === 1) {
     const record = recorded[0]!
+    // Reusing across runtimes hands a Claude the live Pi's session id, and both
+    // pane finders then match it.
+    if (record.runtimeKind !== request.runtimeKind) {
+      return {
+        status: "refused",
+        reason: `${worktree} is recorded for ${record.runtimeSessionId} (${record.runtimeKind}), not ${request.runtimeKind}`,
+      }
+    }
     return {
       status: "reused",
       runtimeSessionId: record.runtimeSessionId,

--- a/extensions/harness-daemon/src/profiles.test.ts
+++ b/extensions/harness-daemon/src/profiles.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  CWD_PROFILE,
+  DEFAULT_PROFILE,
+  parseProfiles,
+  profilesPath,
+  readProfiles,
+  selectProfile,
+  windDownPolicyFor,
+  type Profile,
+} from "./profiles"
+
+let root: string
+let savedProfilesEnv: string | undefined
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-profiles-"))
+  savedProfilesEnv = process.env.THREA_HARNESSD_PROFILES
+  process.env.THREA_HARNESSD_PROFILES = join(root, "profiles.json")
+})
+
+afterEach(() => {
+  if (savedProfilesEnv === undefined) delete process.env.THREA_HARNESSD_PROFILES
+  else process.env.THREA_HARNESSD_PROFILES = savedProfilesEnv
+  rmSync(root, { recursive: true, force: true })
+})
+
+function errorsFor(value: unknown): string[] {
+  const result = parseProfiles(value)
+  if (result.status === "ok") throw new Error(`expected invalid, got ${JSON.stringify(result.profiles)}`)
+  return result.errors
+}
+
+function okProfiles(value: unknown): Record<string, Profile> {
+  const result = parseProfiles(value)
+  if (result.status === "invalid") throw new Error(`expected ok, got ${result.errors.join("; ")}`)
+  return result.profiles
+}
+
+describe("parseProfiles", () => {
+  test("reclaim under provision: existing is rejected at config time with a named error", () => {
+    const errors = errorsFor({ pi: { provision: "existing", preserve: "commit+push", reclaim: true } })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("profile 'pi'")
+    expect(errors[0]).toContain("reclaim is not available under provision 'existing'")
+    expect(errors[0]).toContain("cleanup may only destroy what setup created")
+  })
+
+  test("reclaim: false under provision: existing is rejected too — not offered is not defaulted to false", () => {
+    const errors = errorsFor({ pi: { provision: "existing", preserve: "commit+push", reclaim: false } })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("reclaim is not available under provision 'existing'")
+  })
+
+  test("reclaim: true below the commit+push rung is rejected", () => {
+    // The shape two adversarial reviewers found: it satisfies "no removal
+    // without a successful push" while destroying the uncommitted work.
+    const errors = errorsFor({
+      wt: { provision: "worktree", layout: "threa.${name}", base: "origin/main", preserve: "commit", reclaim: true },
+    })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("reclaim is not available below the 'commit+push' rung")
+  })
+
+  test("an unknown preserve rung is rejected, never coerced", () => {
+    const errors = errorsFor({
+      wt: { provision: "worktree", layout: "threa.${name}", base: "origin/main", preserve: "push" },
+    })
+    expect(errors[0]).toContain("preserve must be one of none, commit, commit+push")
+  })
+
+  test("a worktree profile missing layout or base is rejected", () => {
+    expect(errorsFor({ a: { provision: "worktree", base: "origin/main", preserve: "none" } })[0]).toContain(
+      "requires a layout template"
+    )
+    expect(errorsFor({ a: { provision: "worktree", layout: "x.${name}", preserve: "none" } })[0]).toContain(
+      "requires a base ref"
+    )
+  })
+
+  test("a layout escaping the repo's parent directory is rejected", () => {
+    const errors = errorsFor({
+      esc: { provision: "worktree", layout: "../../${name}", base: "origin/main", preserve: "none" },
+    })
+    expect(errors[0]).toContain("resolves outside the repo's parent directory")
+    expect(
+      errorsFor({ abs: { provision: "worktree", layout: "/tmp/${name}", base: "origin/main", preserve: "none" } })[0]
+    ).toContain("resolves outside")
+  })
+
+  test("an invalid profiles file dies with every error, not the first", () => {
+    const errors = errorsFor({
+      one: { provision: "existing", preserve: "commit+push", reclaim: true },
+      two: { provision: "worktree", layout: "x.${name}", base: "origin/main", preserve: "commit", reclaim: true },
+      three: { provision: "nonsense" },
+    })
+    expect(errors).toHaveLength(3)
+    expect(errors.map((error) => error.split(":")[0])).toEqual(["profile 'one'", "profile 'two'", "profile 'three'"])
+  })
+
+  test("setup and teardown accept arbitrary commands", () => {
+    const profiles = okProfiles({
+      dev: {
+        provision: "existing",
+        preserve: "none",
+        setup: ["docker compose up -d", "bun install"],
+        teardown: ["docker compose down"],
+      },
+    })
+    expect(profiles.dev).toEqual({
+      name: "dev",
+      provision: "existing",
+      preserve: "none",
+      setup: ["docker compose up -d", "bun install"],
+      teardown: ["docker compose down"],
+    })
+  })
+})
+
+describe("the built-in default", () => {
+  test("reproduces today's layout, base and setup", () => {
+    expect(DEFAULT_PROFILE).toEqual({
+      name: "default",
+      provision: "worktree",
+      layout: "threa.${name}",
+      base: "origin/main",
+      setup: ["bun run setup:worktree"],
+      teardown: [],
+      preserve: "commit+push",
+      reclaim: true,
+    })
+    expect(windDownPolicyFor(DEFAULT_PROFILE)).toEqual({ preserve: "commit+push", reclaim: true })
+  })
+})
+
+describe("windDownPolicyFor", () => {
+  test("every existing profile yields a policy that cannot reclaim", () => {
+    const profiles = okProfiles({
+      a: { provision: "existing", preserve: "none" },
+      b: { provision: "existing", preserve: "commit" },
+      c: { provision: "existing", preserve: "commit+push" },
+    })
+    for (const profile of [...Object.values(profiles), CWD_PROFILE]) {
+      expect(windDownPolicyFor(profile).reclaim).toBe(false)
+    }
+  })
+
+  test("a worktree profile below commit+push cannot reclaim either", () => {
+    const profiles = okProfiles({
+      keep: { provision: "worktree", layout: "x.${name}", base: "origin/main", preserve: "commit" },
+    })
+    expect(windDownPolicyFor(profiles.keep!)).toEqual({ preserve: "commit", reclaim: false })
+  })
+})
+
+describe("readProfiles", () => {
+  test("an absent file is no profiles, not an error", () => {
+    expect(readProfiles()).toEqual({})
+  })
+
+  test("an invalid file dies with the whole error list rather than falling back to none", () => {
+    writeFileSync(
+      profilesPath(),
+      JSON.stringify({
+        one: { provision: "existing", preserve: "commit+push", reclaim: true },
+        two: { provision: "worktree", layout: "x.${name}", base: "origin/main", preserve: "commit", reclaim: true },
+      })
+    )
+    expect(() => readProfiles()).toThrow(/reclaim is not available under provision 'existing'/)
+    expect(() => readProfiles()).toThrow(/reclaim is not available below the 'commit\+push' rung/)
+  })
+
+  test("unparseable JSON dies rather than reading as an empty fleet", () => {
+    writeFileSync(profilesPath(), "{ not json")
+    expect(() => readProfiles()).toThrow(/could not read/)
+  })
+})
+
+describe("selectProfile", () => {
+  test("a named-but-missing profile dies rather than silently falling back", () => {
+    expect(() => selectProfile({ profile: "nope" }, {})).toThrow(/no profile named 'nope'/)
+  })
+
+  test("a named profile is selected", () => {
+    const profiles = okProfiles({ pi: { provision: "existing", preserve: "none" } })
+    expect(selectProfile({ profile: "pi" }, profiles)).toBe(profiles.pi!)
+  })
+
+  test("no name falls back to the built-in default, and --cwd to the existing-directory profile", () => {
+    expect(selectProfile({}, {})).toBe(DEFAULT_PROFILE)
+    expect(selectProfile({ cwd: "/some/dir" }, {})).toBe(CWD_PROFILE)
+  })
+})
+
+test("a bare --cwd session preserves nothing, not just reclaims nothing", () => {
+  // commit+push here would `git add -A`, wip-commit and push a checkout harnessd
+  // did not create. PROTECTED_BRANCHES covers only main/master/HEAD, so every
+  // feature branch in a main working tree would be exposed.
+  expect(selectProfile({ cwd: "/repo" }, {})).toMatchObject({ provision: "existing", preserve: "none" })
+  expect(windDownPolicyFor(selectProfile({ cwd: "/repo" }, {}))).toEqual({ preserve: "none", reclaim: false })
+})
+
+test("--cwd against a profile that provisions a worktree is refused before anything is minted", () => {
+  expect(() => selectProfile({ cwd: "/repo", profile: "wt" }, { wt: DEFAULT_PROFILE })).toThrow(/cannot apply/)
+})

--- a/extensions/harness-daemon/src/profiles.ts
+++ b/extensions/harness-daemon/src/profiles.ts
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve, sep } from "node:path"
+import { DEFAULT_WIND_DOWN_POLICY, PRESERVE_RUNGS, type PreserveRung, type WindDownPolicy } from "./archive-wind-down"
+import { die } from "./errors"
+
+export { PRESERVE_RUNGS, type PreserveRung, type WindDownPolicy }
+
+interface ProfileCommon {
+  name: string
+  setup: string[]
+  teardown: string[]
+  displayName?: string
+}
+
+/**
+ * `reclaim` exists only on the rung a successful push can precede. Cleanup may
+ * only destroy what setup created, so the two shapes that cannot have created a
+ * directory — and the rungs that stop before the push — carry no field to read.
+ */
+type WorktreeCleanup = { preserve: "commit+push"; reclaim: boolean } | { preserve: "none" | "commit" }
+
+export type Profile =
+  | (ProfileCommon & { provision: "existing"; preserve: PreserveRung })
+  | (ProfileCommon & { provision: "worktree"; layout: string; base: string } & WorktreeCleanup)
+
+export const DEFAULT_PROFILE: Profile = {
+  name: "default",
+  provision: "worktree",
+  layout: "threa.${name}",
+  base: "origin/main",
+  setup: ["bun run setup:worktree"],
+  teardown: [],
+  preserve: "commit+push",
+  reclaim: true,
+}
+
+/**
+ * `--cwd` with no named profile: use the folder and touch nothing.
+ *
+ * `commit+push` here would `git add -A`, wip-commit and push a checkout harnessd
+ * did not create — PROTECTED_BRANCHES only covers main/master/HEAD, so every
+ * feature branch in a main working tree is exposed. The user's requirement was
+ * the opposite: no cleanup in the repo main checkouts or the orchestrator
+ * directory. Someone who does want that declares a named profile and says so.
+ */
+export const CWD_PROFILE: Profile = {
+  name: "cwd",
+  provision: "existing",
+  preserve: "none",
+  setup: [],
+  teardown: [],
+}
+
+export function windDownPolicyFor(profile: Profile): WindDownPolicy {
+  if (profile.provision === "worktree" && profile.preserve === "commit+push") {
+    return { preserve: "commit+push", reclaim: profile.reclaim }
+  }
+  return { preserve: profile.preserve, reclaim: false }
+}
+
+export function profilesPath(): string {
+  return process.env.THREA_HARNESSD_PROFILES || join(homedir(), ".threa", "harnessd", "profiles.json")
+}
+
+export type ParseProfilesResult =
+  | { status: "ok"; profiles: Record<string, Profile> }
+  | { status: "invalid"; errors: string[] }
+
+const RULE = "cleanup may only destroy what setup created"
+const PROVISIONS = new Set(["existing", "worktree"])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function commandList(raw: unknown, field: string, name: string, errors: string[]): string[] {
+  if (raw === undefined) return []
+  if (!Array.isArray(raw) || raw.some((entry) => typeof entry !== "string")) {
+    errors.push(`profile '${name}': ${field} must be an array of command strings`)
+    return []
+  }
+  return raw as string[]
+}
+
+/**
+ * The layout is a template, so it cannot be resolved against a real repo here.
+ * It is resolved against a probe parent instead: a template that escapes the
+ * probe escapes every parent, and one that does not escapes none.
+ */
+export function layoutEscapesParent(layout: string): boolean {
+  if (isAbsolute(layout)) return true
+  const parent = resolve(sep, "harnessd-layout-probe")
+  const resolved = resolve(parent, expandLayout(layout, { name: "a", repo: "b" }))
+  return resolved !== parent && !resolved.startsWith(parent + sep)
+}
+
+export function expandLayout(layout: string, values: { name: string; repo: string }): string {
+  return layout.replaceAll("${name}", values.name).replaceAll("${repo}", values.repo)
+}
+
+function parseProfile(name: string, raw: unknown, errors: string[]): Profile | undefined {
+  if (!isRecord(raw)) {
+    errors.push(`profile '${name}': must be an object`)
+    return undefined
+  }
+  const before = errors.length
+  const provision = raw.provision
+  if (typeof provision !== "string" || !PROVISIONS.has(provision)) {
+    errors.push(`profile '${name}': provision must be 'existing' or 'worktree'`)
+    return undefined
+  }
+  const preserve = raw.preserve
+  if (typeof preserve !== "string" || !(PRESERVE_RUNGS as readonly string[]).includes(preserve)) {
+    errors.push(`profile '${name}': preserve must be one of ${PRESERVE_RUNGS.join(", ")}`)
+  }
+  if (raw.displayName !== undefined && typeof raw.displayName !== "string") {
+    errors.push(`profile '${name}': displayName must be a string`)
+  }
+  const setup = commandList(raw.setup, "setup", name, errors)
+  const teardown = commandList(raw.teardown, "teardown", name, errors)
+  const common: ProfileCommon = {
+    name,
+    setup,
+    teardown,
+    ...(typeof raw.displayName === "string" ? { displayName: raw.displayName } : {}),
+  }
+
+  if (provision === "existing") {
+    if ("reclaim" in raw) {
+      errors.push(
+        `profile '${name}': reclaim is not available under provision 'existing' — ${RULE}, and this profile creates nothing`
+      )
+    }
+    for (const field of ["layout", "base"] as const) {
+      if (field in raw) {
+        errors.push(`profile '${name}': ${field} is not available under provision 'existing' — nothing is created`)
+      }
+    }
+    if (errors.length > before) return undefined
+    return { ...common, provision: "existing", preserve: preserve as PreserveRung }
+  }
+
+  if (typeof raw.layout !== "string" || !raw.layout) {
+    errors.push(`profile '${name}': provision 'worktree' requires a layout template`)
+  } else if (layoutEscapesParent(raw.layout)) {
+    errors.push(`profile '${name}': layout '${raw.layout}' resolves outside the repo's parent directory`)
+  }
+  if (typeof raw.base !== "string" || !raw.base) {
+    errors.push(`profile '${name}': provision 'worktree' requires a base ref`)
+  }
+  if (preserve === "commit+push") {
+    if (typeof raw.reclaim !== "boolean") {
+      errors.push(`profile '${name}': reclaim must be stated as true or false at the 'commit+push' rung`)
+    }
+  } else if ("reclaim" in raw) {
+    errors.push(
+      `profile '${name}': reclaim is not available below the 'commit+push' rung — ${RULE}, and nothing below it pushes`
+    )
+  }
+  if (errors.length > before) return undefined
+
+  const worktree = { ...common, provision: "worktree" as const, layout: raw.layout as string, base: raw.base as string }
+  return preserve === "commit+push"
+    ? { ...worktree, preserve: "commit+push", reclaim: raw.reclaim as boolean }
+    : { ...worktree, preserve: preserve as "none" | "commit" }
+}
+
+/** A single profile value, keyed by its own recorded `name`. Used to re-read a snapshot. */
+export function parseProfileSnapshot(raw: unknown): Profile | undefined {
+  if (!isRecord(raw) || typeof raw.name !== "string" || !raw.name) return undefined
+  const errors: string[] = []
+  const profile = parseProfile(raw.name, raw, errors)
+  return errors.length === 0 ? profile : undefined
+}
+
+/** Every error, never the first: a config fixed one line at a time is fixed by guesswork. */
+export function parseProfiles(value: unknown): ParseProfilesResult {
+  if (!isRecord(value)) return { status: "invalid", errors: ["profiles must be a JSON object of name -> profile"] }
+  const errors: string[] = []
+  const profiles: Record<string, Profile> = {}
+  for (const [name, raw] of Object.entries(value)) {
+    const profile = parseProfile(name, raw, errors)
+    if (profile) profiles[name] = profile
+  }
+  return errors.length > 0 ? { status: "invalid", errors } : { status: "ok", profiles }
+}
+
+export type ReadProfilesResult =
+  | { status: "ok"; path: string; profiles: Record<string, Profile>; present: boolean }
+  | { status: "invalid"; path: string; errors: string[] }
+
+/** Reports rather than throws, so `doctor` can show a broken file before anything needs it. */
+export function inspectProfiles(path = profilesPath()): ReadProfilesResult {
+  if (!existsSync(path)) return { status: "ok", path, profiles: {}, present: false }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"))
+  } catch (error) {
+    return { status: "invalid", path, errors: [`could not read ${path}: ${error}`] }
+  }
+  const result = parseProfiles(parsed)
+  return result.status === "ok"
+    ? { status: "ok", path, profiles: result.profiles, present: true }
+    : { status: "invalid", path, errors: result.errors }
+}
+
+/** Dies with the full error list. A profiles file that failed to parse is never an empty fleet. */
+export function readProfiles(path = profilesPath()): Record<string, Profile> {
+  const result = inspectProfiles(path)
+  if (result.status === "invalid") {
+    die(`harnessd: invalid profiles in ${result.path}:\n  ${result.errors.join("\n  ")}`)
+  }
+  return result.profiles
+}
+
+/**
+ * A named-but-missing profile dies: silently provisioning the default under a
+ * name the user chose is the no-op this feature exists to remove.
+ */
+export function selectProfile(
+  options: { profile?: string; cwd?: string },
+  profiles: Record<string, Profile> = readProfiles()
+): Profile {
+  if (options.profile) {
+    const found = profiles[options.profile]
+    if (!found) {
+      const known = Object.keys(profiles)
+      die(
+        `harnessd: no profile named '${options.profile}' in ${profilesPath()}${known.length > 0 ? ` (known: ${known.join(", ")})` : ""}`
+      )
+    }
+    // Before the mint, not inside the provisioner: `plannedWorktreePath` would
+    // otherwise fall back to the daemon's own cwd for a worktree profile with no
+    // --repo, and mint a durable identity for an unrelated directory on the way
+    // to dying.
+    if (options.cwd && found.provision === "worktree") {
+      die(`harnessd: profile '${options.profile}' provisions a worktree; --cwd cannot apply to it`)
+    }
+    return found
+  }
+  return options.cwd ? CWD_PROFILE : DEFAULT_PROFILE
+}
+
+export { DEFAULT_WIND_DOWN_POLICY }

--- a/extensions/harness-daemon/src/profiles.ts
+++ b/extensions/harness-daemon/src/profiles.ts
@@ -36,6 +36,22 @@ export const DEFAULT_PROFILE: Profile = {
 }
 
 /**
+ * What a directory is cleaned up under when the evidence does not say.
+ *
+ * Deliberately NOT the built-in default: the default commits, pushes and
+ * reclaims, so failing open to it escalates an unreadable or contradictory
+ * snapshot into the most destructive policy there is. Nothing is the only safe
+ * answer to "I do not know".
+ */
+export const UNKNOWN_PROFILE: Profile = {
+  name: "unknown",
+  provision: "existing",
+  preserve: "none",
+  setup: [],
+  teardown: [],
+}
+
+/**
  * `--cwd` with no named profile: use the folder and touch nothing.
  *
  * `commit+push` here would `git add -A`, wip-commit and push a checkout harnessd

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -490,9 +490,12 @@ test("an occupied worktree two link records disagree about is never reaped", asy
   expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [], retired: [] })
 })
 
-test("disagreeing records do not wedge an EMPTY worktree out of reaping", async () => {
-  // reapLink is the only thing that clears a record, so refusing here would
-  // strand the directory forever — and nothing is at risk when nothing is in it.
+test("disagreeing records on an EMPTY worktree are drained, and the directory is left alone", async () => {
+  // Empty means no PROCESS, not no owner: the other record may belong to a
+  // scratchpad that is still active and a worktree that is merely dormant, so
+  // pushing and force-removing it on THIS record's archived word destroys a live
+  // session's work. The record is still dropped — reapLink is the only thing
+  // that clears one — but nothing is destroyed while ownership is in doubt.
   const { deps, recorded } = makeDeps({
     links: () => [link({ runtimeSessionId: "ccs-abc" }), link({ runtimeSessionId: "ccs-xyz" })],
     panes: () => [],
@@ -500,8 +503,10 @@ test("disagreeing records do not wedge an EMPTY worktree out of reaping", async 
 
   const outcomes = await reapArchivedWorktrees(deps)
 
-  expect(outcomes.map((outcome) => outcome.status)).toEqual(["reaped", "reaped"])
+  expect(outcomes.map((outcome) => outcome.status)).toEqual(["drained contested record", "drained contested record"])
   expect(recorded.forgotten).toEqual(["ccs-abc", "ccs-xyz"])
+  expect(recorded.woundDown).toEqual([])
+  expect(recorded.retired).toEqual([])
 })
 
 test("a minted record naming the worktree a different session claims blocks the reap", async () => {

--- a/extensions/harness-daemon/src/reap.test.ts
+++ b/extensions/harness-daemon/src/reap.test.ts
@@ -5,6 +5,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { LocalTmuxPane } from "./discovery"
+import { DEFAULT_PROFILE, type Profile, type WindDownPolicy } from "./profiles"
+import { profileForWorktree, type MintedIdentity } from "./identity-store"
 
 // Every dep is injected, but a defaulted one would silently read the developer's
 // real stores — which is how a green test can depend on what happens to be in
@@ -82,6 +84,8 @@ function makeDeps(overrides: Partial<ReapDeps> = {}): { deps: ReapDeps; recorded
       recorded.woundDown.push(cwd)
       return { pushed: true, removed: true }
     },
+    profileFor: () => DEFAULT_PROFILE,
+    teardown: () => ({ ok: true }),
     killWindow: (windowId) => void recorded.killed.push(windowId),
     awaitExit: async (pid) => void recorded.awaited.push(pid),
     forgetLink: (id) => void recorded.forgotten.push(id),
@@ -555,4 +559,130 @@ test("only the injected identity store reaches the destructive decision", async 
   } finally {
     rmSync(join(dir, "ccs-ondisk.json"), { force: true })
   }
+})
+
+describe("profile teardown and wind-down policy", () => {
+  function existingProfile(overrides: Partial<Profile> = {}): Profile {
+    return {
+      name: "pi",
+      provision: "existing",
+      preserve: "commit+push",
+      setup: [],
+      teardown: [],
+      ...overrides,
+    } as Profile
+  }
+
+  test("teardown runs before the window is killed and before the wind-down", async () => {
+    const order: string[] = []
+    const { deps } = makeDeps({
+      profileFor: () => existingProfile({ teardown: ["docker compose down"] }),
+      teardown: (_cwd, commands) => {
+        order.push(`teardown:${commands.join("|")}`)
+        return { ok: true }
+      },
+      killWindow: () => void order.push("kill"),
+      windDown: () => {
+        order.push("windDown")
+        return { pushed: true, removed: false }
+      },
+    })
+
+    await reapArchivedWorktrees(deps)
+
+    expect(order).toEqual(["teardown:docker compose down", "kill", "windDown"])
+  })
+
+  test("a failing teardown refuses the wind-down and leaves everything on disk", async () => {
+    const { deps, recorded } = makeDeps({
+      profileFor: () => existingProfile({ teardown: ["false"] }),
+      teardown: () => ({ ok: false, reason: "teardown command 'false' exit code 1" }),
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome).toMatchObject({ status: "skipped teardown failed" })
+    expect(outcome!.detail).toContain("exit code 1")
+    expect(recorded).toEqual({ woundDown: [], killed: [], forgotten: [], awaited: [], retired: [] })
+  })
+
+  test("a hanging teardown is bounded and reported, not a wedge", async () => {
+    const { deps, recorded } = makeDeps({
+      profileFor: () => existingProfile({ teardown: ["sleep 999"] }),
+      teardown: () => ({ ok: false, reason: "teardown command 'sleep 999' timed out or was killed (SIGTERM)" }),
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(outcome!.status).toBe("skipped teardown failed")
+    expect(outcome!.detail).toContain("timed out")
+    expect(recorded.killed).toEqual([])
+  })
+
+  test("a worktree with no mint record is wound down under the default profile", async () => {
+    // Today's fleet carries no profile snapshot; nothing about its cleanup changes.
+    const policies: WindDownPolicy[] = []
+    const { deps } = makeDeps({
+      identities: () => [],
+      profileFor: (worktree) => profileForWorktree(worktree, []),
+      windDown: (_cwd, _log, policy) => {
+        policies.push(policy)
+        return { pushed: true, removed: true }
+      },
+    })
+
+    await reapArchivedWorktrees(deps)
+
+    expect(policies).toEqual([{ preserve: "commit+push", reclaim: true }])
+  })
+
+  test("a worktree whose mint record pins preserve: commit is not removed", async () => {
+    const record: MintedIdentity = {
+      runtimeSessionId: "ccs-abc",
+      instanceId: "cc-abc",
+      worktree: WORKTREE,
+      runtimeKind: "claude-code-channel",
+      mintedAt: "2026-07-27T09:00:00.000Z",
+      source: "mint",
+      profile: {
+        name: "keep",
+        provision: "worktree",
+        layout: "threa.${name}",
+        base: "origin/main",
+        setup: [],
+        teardown: [],
+        preserve: "commit",
+      },
+    }
+    const policies: WindDownPolicy[] = []
+    const { deps, recorded } = makeDeps({
+      identities: () => [record],
+      profileFor: (worktree) => profileForWorktree(worktree, [record], (path) => path),
+      windDown: (_cwd, _log, policy) => {
+        policies.push(policy)
+        return { pushed: false, removed: false, reason: "preserve 'commit'" }
+      },
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps)
+
+    expect(policies).toEqual([{ preserve: "commit", reclaim: false }])
+    expect(outcome!.status).toBe("reaped, worktree left")
+    // The directory survived, so the identity binding must survive with it.
+    expect(recorded.retired).toEqual([])
+  })
+
+  test("a dry run neither tears down nor winds down", async () => {
+    const { deps, recorded } = makeDeps({
+      profileFor: () => existingProfile({ teardown: ["docker compose down"] }),
+      teardown: () => {
+        throw new Error("teardown must not run in a dry run")
+      },
+    })
+
+    const [outcome] = await reapArchivedWorktrees(deps, true)
+
+    expect(outcome!.status).toBe("would reap")
+    expect(recorded.woundDown).toEqual([])
+  })
 })

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -8,7 +8,14 @@ import {
 import { existsSync } from "node:fs"
 import { pushBranchAndRemoveWorktree } from "./archive-wind-down"
 import { liveClaudePidsIn } from "./claude-registry"
-import { forgetMintedIdentitiesFor, readMintedIdentities, type MintedIdentity } from "./identity-store"
+import {
+  forgetMintedIdentitiesFor,
+  profileForWorktree,
+  readMintedIdentities,
+  type MintedIdentity,
+} from "./identity-store"
+import { windDownPolicyFor, type Profile, type WindDownPolicy } from "./profiles"
+import { runTeardownCommands } from "./worktree"
 import {
   attestedRuntimes,
   canonicalOrRaw,
@@ -69,6 +76,8 @@ export type ReapStatus =
   | "skipped observer too young"
   | "skipped inaccessible"
   | "skipped unavailable"
+  /** The profile's teardown commands failed or timed out; nothing destructive ran. */
+  | "skipped teardown failed"
 
 export interface ReapOutcome {
   runtimeSessionId: string
@@ -89,7 +98,15 @@ export interface ReapDeps {
   scratchpadStatus: (streamId: string) => Promise<ScratchpadStatus>
   archivedAt: (streamId: string) => Promise<string | undefined>
   pathExists: (path: string) => boolean
-  windDown: (cwd: string, log: (message: string) => void) => { pushed: boolean; removed: boolean; reason?: string }
+  windDown: (
+    cwd: string,
+    log: (message: string) => void,
+    policy: WindDownPolicy
+  ) => { pushed: boolean; removed: boolean; reason?: string }
+  /** The profile this worktree was provisioned under; no mint record ⇒ the built-in default profile. */
+  profileFor: (worktree: string) => Profile
+  /** The profile's teardown commands, bounded. Runs before anything destructive. */
+  teardown: (cwd: string, commands: string[]) => { ok: boolean; reason?: string }
   killWindow: (windowId: string) => void
   /** Resolves once the killed pane's process is gone, or after a bounded wait. */
   awaitExit: (pid: number) => Promise<void>
@@ -111,6 +128,8 @@ export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; 
     archivedAt: (streamId) => fetchScratchpadArchivedAt({ ...target, streamId }),
     pathExists: existsSync,
     windDown: pushBranchAndRemoveWorktree,
+    profileFor: (worktree) => profileForWorktree(worktree),
+    teardown: runTeardownCommands,
     killWindow: (windowId) => {
       output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
     },
@@ -287,11 +306,25 @@ export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolea
   // process is gone. Removing the directory in that gap deletes the cwd of a
   // Claude still flushing its transcript, so wait for the pane to actually
   // exit — the grace the old detached `sleep 5` provided by accident.
+  // Teardown is arbitrary user commands, so it is NOT a rung on the ladder — it
+  // runs one level up, before the window is killed and before anything is
+  // pushed or removed. A failure refuses the whole wind-down: a teardown that
+  // did not run is not a teardown with nothing to do.
+  const profile = deps.profileFor(link.worktree)
+  const teardown = deps.teardown(link.worktree, profile.teardown)
+  if (!teardown.ok) {
+    return { ...base, status: "skipped teardown failed", detail: teardown.reason ?? "teardown failed" }
+  }
+
   if (window.kind === "kill") {
     deps.killWindow(window.pane.windowId)
     await deps.awaitExit(window.pane.panePid)
   }
-  const report = deps.windDown(link.worktree, (message) => deps.log(`${link.worktree}: ${message}`))
+  const report = deps.windDown(
+    link.worktree,
+    (message) => deps.log(`${link.worktree}: ${message}`),
+    windDownPolicyFor(profile)
+  )
   // Forgotten either way, matching the pre-existing contract for a refused
   // wind-down: the branch is the thing that had to survive, and a directory
   // left behind is for a human. What must not happen is reporting it gone.

--- a/extensions/harness-daemon/src/reap.ts
+++ b/extensions/harness-daemon/src/reap.ts
@@ -72,6 +72,8 @@ export type ReapStatus =
   | "skipped grace"
   | "skipped worktree missing"
   | "skipped ambiguous"
+  /** Record forgotten, directory untouched: two records name it and one may still be live. */
+  | "drained contested record"
   | "skipped occupied"
   | "skipped observer too young"
   | "skipped inaccessible"
@@ -145,8 +147,14 @@ export function defaultReapDeps(target: { baseUrl: string; workspaceId: string; 
   }
 }
 
+function conflictReason(link: HarnessLink, conflict: string[]): string {
+  return `identity evidence for ${link.worktree} disagrees: ${conflict.join(", ")}`
+}
+
 type WindowDecision =
   | { kind: "none" }
+  /** Forget the record, destroy nothing: the directory's ownership is in doubt. */
+  | { kind: "drain"; reason: string }
   | { kind: "kill"; pane: LocalTmuxPane }
   | { kind: "refuse"; status: ReapStatus; reason: string }
 
@@ -176,10 +184,26 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
   const occupants = panes.filter((pane) => deps.canonicalPath(pane.cwd) === worktree)
   const livePids = deps.claudeProcessesIn(link.worktree)
 
+  const conflict = conflictingAttestations(
+    link.worktree,
+    attestedRuntimes(deps.links(), deps.canonicalPath),
+    deps.identities(),
+    deps.canonicalPath
+  )
+
   if (occupants.length === 0) {
     // Nobody is in the worktree: the offline case this reaper exists for —
     // unless a paneless Claude is still running there.
-    if (livePids.length === 0) return { kind: "none" }
+    //
+    // Empty means no PROCESS, not no owner. When two records name this directory
+    // the other one may belong to a scratchpad that is still active, and its
+    // worktree is merely dormant — pushing and force-removing it on THIS
+    // record's archived word destroys a live session's work. So the record is
+    // still drained (or the duplication wedges the directory forever), but
+    // nothing is destroyed while it is in doubt.
+    if (livePids.length === 0) {
+      return conflict.length > 0 ? { kind: "drain", reason: conflictReason(link, conflict) } : { kind: "none" }
+    }
     return {
       kind: "refuse",
       status: "skipped occupied",
@@ -200,18 +224,8 @@ function decideWindow(link: HarnessLink, panes: LocalTmuxPane[], deps: ReapDeps)
   // EMPTY worktree would wedge it out of reaping forever, because `reapLink` is
   // the only thing that clears a record. Nothing is at risk when nothing is
   // there, and reaping one record per pass is what resolves the duplication.
-  const conflict = conflictingAttestations(
-    link.worktree,
-    attestedRuntimes(deps.links(), deps.canonicalPath),
-    deps.identities(),
-    deps.canonicalPath
-  )
   if (conflict.length > 0) {
-    return {
-      kind: "refuse",
-      status: "skipped ambiguous",
-      reason: `identity evidence for ${link.worktree} disagrees: ${conflict.join(", ")}`,
-    }
+    return { kind: "refuse", status: "skipped ambiguous", reason: conflictReason(link, conflict) }
   }
 
   const resolved = resolveManagedAgentPane(
@@ -284,6 +298,13 @@ export async function reapLink(link: HarnessLink, deps: ReapDeps, dryRun: boolea
 
   const window = decideWindow(link, deps.panes(), deps)
   if (window.kind === "refuse") return { ...base, status: window.status, detail: window.reason }
+
+  // Drop the record, touch nothing else. Leaving it would wedge the directory
+  // out of reaping forever, since this is the only pass that clears a record.
+  if (window.kind === "drain") {
+    if (!dryRun) deps.forgetLink(link.runtimeSessionId)
+    return { ...base, status: "drained contested record", detail: window.reason }
+  }
 
   if (!deps.pathExists(link.worktree)) {
     // Already gone — the records are the only leftover.

--- a/extensions/harness-daemon/src/spawners.test.ts
+++ b/extensions/harness-daemon/src/spawners.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { mcpConfigDir, mcpConfigPath, writeChannelMcpConfig } from "./spawners"
+import { profileForWorktree, recordProfileSnapshot } from "./identity-store"
+import { windDownPolicyFor, type Profile } from "./profiles"
+
+let root: string
+let savedDir: string | undefined
+let savedIdentities: string | undefined
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "harnessd-mcp-"))
+  savedDir = process.env.THREA_HARNESSD_MCP_DIR
+  process.env.THREA_HARNESSD_MCP_DIR = join(root, "mcp")
+  savedIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
+  process.env.THREA_HARNESSD_IDENTITIES_DIR = join(root, "identities")
+})
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.THREA_HARNESSD_MCP_DIR
+  else process.env.THREA_HARNESSD_MCP_DIR = savedDir
+  if (savedIdentities === undefined) delete process.env.THREA_HARNESSD_IDENTITIES_DIR
+  else process.env.THREA_HARNESSD_IDENTITIES_DIR = savedIdentities
+  rmSync(root, { recursive: true, force: true })
+})
+
+/** A test that silently wrote the developer's real ~/.threa/harnessd would be worse than red. */
+function guardDir(): void {
+  if (!mcpConfigDir().startsWith(root)) throw new Error(`MCP dir override did not take: ${mcpConfigDir()}`)
+}
+
+test("the MCP config path is keyed by runtime session id, not the agent name", () => {
+  guardDir()
+  expect(mcpConfigPath("ccs-abc123")).toBe(join(root, "mcp", "ccs-abc123.json"))
+})
+
+test("two agents sharing a name get separate MCP configs", () => {
+  // One file per name meant the second spawn of a name silently repointed the
+  // first session's channel at its own entry.
+  guardDir()
+  const first = writeChannelMcpConfig("ccs-one", "threa-channel", "/entry/one.ts")
+  const second = writeChannelMcpConfig("ccs-two", "threa-channel", "/entry/two.ts")
+
+  expect(first).not.toBe(second)
+  expect(JSON.parse(readFileSync(first, "utf8"))).toMatchObject({
+    mcpServers: { "threa-channel": { args: ["/entry/one.ts"] } },
+  })
+  expect(JSON.parse(readFileSync(second, "utf8"))).toMatchObject({
+    mcpServers: { "threa-channel": { args: ["/entry/two.ts"] } },
+  })
+})
+
+test("a resume writes the new key and leaves the old name-keyed file in place", () => {
+  // `reconnect` validates that the path in a live pane's recorded launch command
+  // still exists, so deleting the old file would break a running session.
+  guardDir()
+  const legacy = mcpConfigPath("fix-sidebar")
+  mkdirSync(mcpConfigDir(), { recursive: true })
+  writeFileSync(legacy, JSON.stringify({ mcpServers: { "threa-channel": { args: ["/old/entry.ts"] } } }))
+
+  const written = writeChannelMcpConfig("ccs-sidebar", "threa-channel", "/new/entry.ts")
+
+  expect(written).toBe(mcpConfigPath("ccs-sidebar"))
+  expect(existsSync(legacy)).toBe(true)
+  expect(JSON.parse(readFileSync(legacy, "utf8"))).toMatchObject({
+    mcpServers: { "threa-channel": { args: ["/old/entry.ts"] } },
+  })
+})
+
+test("a Pi spawn records the profile its directory was provisioned under", () => {
+  // Pi does not mint, but `pi-local` links ARE reaped and the reaper reads the
+  // profile by worktree. With no snapshot it falls back to the built-in default,
+  // which commits, pushes and reclaims a directory the operator owns.
+  const profile: Profile = {
+    name: "orchestrator",
+    provision: "existing",
+    preserve: "none",
+    setup: [],
+    teardown: ["echo bye"],
+  }
+  recordProfileSnapshot({
+    worktree: "/repo/orchestrator",
+    runtimeSessionId: "pi-abc",
+    runtimeKind: "pi-local",
+    profile,
+  })
+
+  expect(profileForWorktree("/repo/orchestrator")).toEqual(profile)
+  expect(windDownPolicyFor(profileForWorktree("/repo/orchestrator"))).toEqual({ preserve: "none", reclaim: false })
+})

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -9,12 +9,24 @@ import { commandExists, commandPath, run, shellQuote } from "./shell"
 import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
 import { recordedNoYolo } from "./resume"
+import { recordProfileSnapshot } from "./identity-store"
 import { mintRuntimeIdentity } from "./mint"
-import { ensureWorktree, plannedWorktreePath } from "./worktree"
+import { plannedWorktreePath, provisionWorkspace } from "./worktree"
+import { selectProfile, type Profile } from "./profiles"
 import { runtimeIdentityFor, type ResolvedRuntimeIdentity } from "./discovery"
 
-export function mcpConfigPath(name: string): string {
-  return join(homedir(), ".threa", "harnessd", "mcp", `${name}.json`)
+/**
+ * Keyed by runtime session id, not the agent name: two agents that share a name
+ * shared one config file, so the second silently repointed the first's channel.
+ * Old name-keyed files are written past, never deleted — a live pane's recorded
+ * launch command still names one, and `reconnect` validates that it exists.
+ */
+export function mcpConfigDir(): string {
+  return process.env.THREA_HARNESSD_MCP_DIR || join(homedir(), ".threa", "harnessd", "mcp")
+}
+
+export function mcpConfigPath(runtimeSessionId: string): string {
+  return join(mcpConfigDir(), `${runtimeSessionId}.json`)
 }
 
 export function configuredThreaBaseUrl(config: ThreaChannelConfig): string {
@@ -76,8 +88,8 @@ export function claudeLaunchArgs(params: {
  * channel implementation and leaves global config untouched. This also keeps
  * revived feature branches from loading an obsolete connector.
  */
-export function writeChannelMcpConfig(name: string, channel: string, channelEntry: string): string {
-  const path = mcpConfigPath(name)
+export function writeChannelMcpConfig(runtimeSessionId: string, channel: string, channelEntry: string): string {
+  const path = mcpConfigPath(runtimeSessionId)
   mkdirSync(dirname(path), { recursive: true })
   writeFileSync(
     path,
@@ -183,8 +195,12 @@ export class RuntimeSpawnError extends Error {
 abstract class RuntimeSpawner {
   abstract spawn(options: SpawnOptions): Promise<SpawnResult>
 
-  protected createWorktree(options: SpawnOptions): { worktree: string; branch: string } {
-    return ensureWorktree(options)
+  protected profileFor(options: SpawnOptions): Profile {
+    return selectProfile(options)
+  }
+
+  protected createWorktree(options: SpawnOptions, profile: Profile): { worktree: string; branch: string } {
+    return provisionWorkspace(options, profile)
   }
 }
 
@@ -199,8 +215,15 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
     const session = tmuxSession(options)
     ensureTmuxSession(session)
     ensurePiDefaultLabel()
-    const { worktree, branch } = this.createWorktree(options)
+    const profile = this.profileFor(options)
+    const { worktree, branch } = this.createWorktree(options, profile)
     const runtimeSessionId = randomUUID()
+    // Pi does not mint, but the mint record is where the profile snapshot lives
+    // and the reaper reads it by worktree — `pi-local` links are reaped too. With
+    // no snapshot the reaper falls back to the built-in default, which commits,
+    // pushes and reclaims: exactly the wrong answer for a `--cwd` directory the
+    // operator owns, and it would drop the declared teardown silently.
+    recordProfileSnapshot({ worktree, runtimeSessionId, runtimeKind: "pi-local", profile })
     const partial: Partial<SpawnResult> = { worktree, branch, tmuxSession: session, runtimeSessionId }
     try {
       const window = pickTmuxWindow(session, options.name)
@@ -296,6 +319,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     if (!claudeBin) die("claude binary not found; set THREA_HARNESSD_CLAUDE_BIN or put claude on PATH")
 
     const config = readThreaChannelConfig()
+    const profile = this.profileFor(options)
     // Minted against the path the worktree WILL occupy, before anything exists.
     // Minting after `git worktree add` meant a refusal — or the lock timing out
     // behind a long revival sweep — stranded a directory and a branch that no
@@ -303,16 +327,17 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     // leftover. It is also the only ordering under which the occupancy veto can
     // see a live Claude already squatting the target.
     const minted = await mintRuntimeIdentity({
-      worktree: plannedWorktreePath(options),
+      worktree: plannedWorktreePath(options, profile),
       runtimeKind: "claude-code-channel",
       declared: { instanceId: config.instanceId, runtimeSessionId: config.runtimeSessionId },
+      profile,
     })
     if (minted.status === "refused") die(`harnessd: refusing to spawn — ${minted.reason}`)
     const identity = { instanceId: minted.instanceId, runtimeSessionId: minted.runtimeSessionId }
 
     const session = tmuxSession(options)
     ensureTmuxSession(session)
-    const { worktree, branch } = this.createWorktree(options)
+    const { worktree, branch } = this.createWorktree(options, profile)
     const partial: Partial<SpawnResult> = {
       worktree,
       branch,
@@ -333,7 +358,9 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
         claudeBin,
         name: options.name,
         channel,
-        mcpConfig: options.noRegister ? undefined : this.writeMcpConfig(options.name, channel, channelEntry),
+        mcpConfig: options.noRegister
+          ? undefined
+          : this.writeMcpConfig(identity.runtimeSessionId, channel, channelEntry),
         noYolo: options.noYolo,
       })
 
@@ -370,11 +397,11 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
 
     const channel = process.env.THREA_HARNESSD_CLAUDE_CHANNEL || "threa-channel"
     const channelEntry = prepareClaudeChannel()
-    const mcpConfig = mcpConfigPath(agent.name)
-    if (!existsSync(mcpConfig)) this.writeMcpConfig(agent.name, channel, channelEntry)
-    normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
     const config = readThreaChannelConfig()
     const identity = claudeAgentIdentity(agent, config)
+    const mcpConfig = mcpConfigPath(identity.runtimeSessionId)
+    if (!existsSync(mcpConfig)) this.writeMcpConfig(identity.runtimeSessionId, channel, channelEntry)
+    normalizeChannelMcpConfig(mcpConfig, channel, channelEntry)
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "claude", name: agent.name })
     ensureTmuxSession(session, true)
     const noYolo = recordedNoYolo(agent)
@@ -441,8 +468,8 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     }
   }
 
-  private writeMcpConfig(name: string, channel: string, channelEntry: string): string {
-    return writeChannelMcpConfig(name, channel, channelEntry)
+  private writeMcpConfig(runtimeSessionId: string, channel: string, channelEntry: string): string {
+    return writeChannelMcpConfig(runtimeSessionId, channel, channelEntry)
   }
 
   private async prelinkScratchpad(

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -329,6 +329,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     const minted = await mintRuntimeIdentity({
       worktree: plannedWorktreePath(options, profile),
       runtimeKind: "claude-code-channel",
+      requireVacant: true,
       declared: { instanceId: config.instanceId, runtimeSessionId: config.runtimeSessionId },
       profile,
     })

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -38,6 +38,10 @@ export interface SpawnOptions {
   branch?: string
   base?: string
   repo?: string
+  /** Use this directory as-is; provisions nothing, and cleanup may reclaim nothing. */
+  cwd?: string
+  /** Name of a profile in the profiles file; missing names die rather than falling back. */
+  profile?: string
   tmux?: string
   skipSetup?: boolean
   noRemote?: boolean

--- a/extensions/harness-daemon/src/worktree.test.ts
+++ b/extensions/harness-daemon/src/worktree.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { realpathSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { plannedWorktreePath } from "./worktree"
+import { plannedWorktreePath, provisionWorkspace, runTeardownCommands } from "./worktree"
+import { DEFAULT_PROFILE, type Profile } from "./profiles"
 
 let root: string
 
@@ -36,4 +37,129 @@ test("a repo reached through a symlink plans the resolved path, not the link pat
   expect(plannedWorktreePath({ runtime: "claude", name: "feature", repo: join(root, "link", "threa") })).toBe(
     join(root, "real", "threa.feature")
   )
+})
+
+function repoAt(path: string): void {
+  mkdirSync(path, { recursive: true })
+  const origin = `${path}.origin.git`
+  Bun.spawnSync(["git", "init", "--bare", origin], { stdout: "pipe", stderr: "pipe" })
+  for (const command of ["git init -b main .", "git config user.email t@t", "git config user.name t"]) {
+    const result = Bun.spawnSync(["sh", "-c", command], { cwd: path, stdout: "pipe", stderr: "pipe" })
+    if (result.exitCode !== 0) throw new Error(`${command}: ${result.stderr.toString()}`)
+  }
+  writeFileSync(join(path, "a.txt"), "a\n")
+  for (const command of [
+    "git add -A && git commit -m init",
+    `git remote add origin ${origin}`,
+    "git push -u origin main",
+  ]) {
+    const result = Bun.spawnSync(["sh", "-c", command], { cwd: path, stdout: "pipe", stderr: "pipe" })
+    if (result.exitCode !== 0) throw new Error(`${command}: ${result.stderr.toString()}`)
+  }
+}
+
+const EXISTING: Profile = {
+  name: "here",
+  provision: "existing",
+  preserve: "commit+push",
+  setup: [],
+  teardown: [],
+}
+
+test("the existing provisioner uses the given directory and creates nothing", () => {
+  const dir = join(root, "orchestrator")
+  mkdirSync(dir, { recursive: true })
+
+  const result = provisionWorkspace({ runtime: "pi", name: "orchestrator", cwd: dir }, EXISTING)
+
+  expect(result.worktree).toBe(dir)
+  expect(readdirSync(root).sort()).toEqual(["orchestrator"])
+})
+
+test("the existing provisioner refuses a directory that does not exist", () => {
+  expect(() => provisionWorkspace({ runtime: "pi", name: "gone", cwd: join(root, "nope") }, EXISTING)).toThrow(
+    /directory not found/
+  )
+})
+
+test("the existing provisioner names a branch for a directory that is not a repo", () => {
+  // The Pi orchestrator directory is not a git repo, and SpawnResult.branch is required.
+  const dir = join(root, "orchestrator")
+  mkdirSync(dir, { recursive: true })
+  expect(provisionWorkspace({ runtime: "pi", name: "orchestrator", cwd: dir }, EXISTING).branch).toBe("orchestrator")
+})
+
+test("the existing provisioner takes the checked-out branch when the directory is a repo", () => {
+  const dir = join(root, "repo")
+  repoAt(dir)
+  expect(provisionWorkspace({ runtime: "pi", name: "anything", cwd: dir }, EXISTING).branch).toBe("main")
+})
+
+test("a worktree profile cannot be pointed at an existing directory", () => {
+  expect(() => provisionWorkspace({ runtime: "claude", name: "f", cwd: join(root, "x") }, DEFAULT_PROFILE)).toThrow(
+    /--cwd cannot apply/
+  )
+})
+
+test("the worktree provisioner honours a profile's layout and base", () => {
+  const repo = join(root, "threa")
+  repoAt(repo)
+  const profile: Profile = {
+    name: "custom",
+    provision: "worktree",
+    layout: "wt-${repo}-${name}",
+    base: "main",
+    setup: [],
+    teardown: [],
+    preserve: "commit+push",
+    reclaim: true,
+  }
+
+  const planned = plannedWorktreePath({ runtime: "claude", name: "feature", repo }, profile)
+
+  expect(planned).toBe(join(root, "wt-threa-feature"))
+  const result = provisionWorkspace({ runtime: "claude", name: "feature", repo, branch: "feature/x" }, profile)
+  expect(result).toEqual({ worktree: planned, branch: "feature/x" })
+  expect(existsSync(join(planned, "a.txt"))).toBe(true)
+})
+
+test("a layout that escapes the repo's parent is refused before anything is created", () => {
+  const repo = join(root, "threa")
+  repoAt(repo)
+  const escaping = {
+    name: "bad",
+    provision: "worktree",
+    layout: "../../${name}",
+    base: "main",
+    setup: [],
+    teardown: [],
+    preserve: "commit+push",
+    reclaim: true,
+  } as Profile
+
+  expect(() => plannedWorktreePath({ runtime: "claude", name: "f", repo }, escaping)).toThrow(/resolves outside/)
+})
+
+test("teardown commands are bounded and a failure is reported rather than swallowed", () => {
+  const dir = join(root, "td")
+  mkdirSync(dir, { recursive: true })
+  expect(runTeardownCommands(dir, [])).toEqual({ ok: true })
+  expect(runTeardownCommands(dir, ["true"])).toEqual({ ok: true })
+  const failed = runTeardownCommands(dir, ["exit 3"])
+  expect(failed.ok).toBe(false)
+  expect(failed.reason).toContain("exit code 3")
+})
+
+test("a teardown that ignores SIGTERM is still killed, and reported", () => {
+  // spawnSync's timeout signals but does not escalate, so without killSignal a
+  // command that traps TERM holds `resume-active.lock` for as long as it likes.
+  const dir = join(root, "trap")
+  mkdirSync(dir, { recursive: true })
+
+  const startedAt = Date.now()
+  const result = runTeardownCommands(dir, ["trap '' TERM; sleep 30"], 500)
+
+  expect(result.ok).toBe(false)
+  expect(result.reason).toMatch(/timed out or was killed|ETIMEDOUT/)
+  expect(Date.now() - startedAt).toBeLessThan(10_000)
 })

--- a/extensions/harness-daemon/src/worktree.ts
+++ b/extensions/harness-daemon/src/worktree.ts
@@ -1,38 +1,73 @@
-import { existsSync } from "node:fs"
-import { dirname, join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
+import { basename, dirname, resolve, sep } from "node:path"
 import { canonicalOrRaw } from "./discovery"
 import { die } from "./errors"
+import { DEFAULT_PROFILE, expandLayout, type Profile } from "./profiles"
 import { output, run } from "./shell"
 import type { ManagedAgent, SpawnOptions } from "./types"
 
 /**
- * Where {@link ensureWorktree} will put this agent, without creating anything —
- * and the single definition of that path, so a caller that has to name the
- * directory before it exists cannot drift from the one that creates it.
+ * Setup can be a full monorepo install; teardown runs while `resume-active.lock`
+ * is held, so a hang there blocks every revive — the same reasoning as
+ * `REMOVE_TIMEOUT_MS` in `archive-wind-down.ts`.
+ */
+const SETUP_TIMEOUT_MS = 600_000
+const TEARDOWN_TIMEOUT_MS = 120_000
+
+/**
+ * Where {@link provisionWorkspace} will put this agent, without creating
+ * anything — and the single definition of that path, so a caller that has to
+ * name the directory before it exists cannot drift from the one that creates it.
  *
  * The parent is canonicalized and the leaf appended, rather than canonicalizing
  * the whole path: the leaf does not exist yet, so `realpathSync` would throw and
  * fall back to the raw path — which then fails to match the resolved path every
  * later reader sees once the directory does exist.
  */
-export function plannedWorktreePath(options: SpawnOptions): string {
+export function plannedWorktreePath(options: SpawnOptions, profile: Profile = DEFAULT_PROFILE): string {
+  if (profile.provision === "existing") {
+    return canonicalOrRaw(resolve(options.cwd ?? die("this profile provisions no directory; pass --cwd")))
+  }
   const repo = resolve(options.repo ?? process.cwd())
-  return join(canonicalOrRaw(dirname(repo)), `threa.${options.name}`)
+  const parent = canonicalOrRaw(dirname(repo))
+  const leaf = expandLayout(profile.layout, { name: options.name, repo: basename(repo) })
+  const path = resolve(parent, leaf)
+  if (path !== parent && !path.startsWith(parent + sep)) {
+    die(`profile '${profile.name}': layout '${profile.layout}' resolves outside ${parent}`)
+  }
+  return path
 }
 
 function branchFor(options: SpawnOptions): string {
   return options.branch ?? options.name
 }
 
-function baseFor(options: SpawnOptions): string {
-  return options.base ?? "origin/main"
+export function provisionWorkspace(
+  options: SpawnOptions,
+  profile: Profile = DEFAULT_PROFILE
+): { worktree: string; branch: string } {
+  return profile.provision === "existing" ? useExistingDirectory(options, profile) : createWorktree(options, profile)
 }
 
-export function ensureWorktree(options: SpawnOptions): { worktree: string; branch: string } {
+function useExistingDirectory(options: SpawnOptions, profile: Profile): { worktree: string; branch: string } {
+  if (options.cwd === undefined) die(`profile '${profile.name}' provisions nothing; pass --cwd <path>`)
+  const dir = plannedWorktreePath(options, profile)
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) die(`directory not found: ${dir}`)
+  console.log(`harnessd: using existing directory ${dir} (profile '${profile.name}')`)
+  runSetupCommands(dir, profile.setup, options.skipSetup === true)
+  return { worktree: dir, branch: options.branch ?? currentBranch(dir) ?? options.name }
+}
+
+function createWorktree(
+  options: SpawnOptions,
+  profile: Profile & { provision: "worktree" }
+): { worktree: string; branch: string } {
+  if (options.cwd !== undefined) die(`profile '${profile.name}' creates a worktree; --cwd cannot apply to it`)
   const repo = resolve(options.repo ?? process.cwd())
   const branch = branchFor(options)
-  const base = baseFor(options)
-  const worktree = plannedWorktreePath(options)
+  const base = options.base ?? profile.base
+  const worktree = plannedWorktreePath(options, profile)
   if (!existsSync(repo)) die(`repo not found: ${repo}`)
   if (existsSync(worktree)) die(`worktree dir already exists: ${worktree}`)
 
@@ -40,8 +75,16 @@ export function ensureWorktree(options: SpawnOptions): { worktree: string; branc
   run(["git", "-C", repo, "fetch", "origin", base.replace(/^origin\//, "")])
   console.log(`harnessd: creating worktree ${worktree} (${branch} off ${base})`)
   run(["git", "-C", repo, "worktree", "add", "-b", branch, worktree, base])
-  maybeSetupWorktree(worktree, options.skipSetup === true)
+  runSetupCommands(worktree, profile.setup, options.skipSetup === true)
   return { worktree, branch }
+}
+
+/** The Pi orchestrator directory is not a repo, and `SpawnResult.branch` is required. */
+function currentBranch(dir: string): string | undefined {
+  const result = output(["git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD"], { allowFailure: true })
+  if (result.exitCode !== 0) return undefined
+  const branch = result.stdout.trim()
+  return branch && branch !== "HEAD" ? branch : undefined
 }
 
 export function restorableWorktreeSource(
@@ -56,7 +99,10 @@ export function restorableWorktreeSource(
   return { repo, worktree: agent.worktree, branch: agent.branch }
 }
 
-export function restoreManagedWorktree(agent: ManagedAgent): { restored: boolean; reason?: string } {
+export function restoreManagedWorktree(
+  agent: ManagedAgent,
+  profile: Profile = DEFAULT_PROFILE
+): { restored: boolean; reason?: string } {
   if (agent.worktree && existsSync(agent.worktree)) return { restored: false }
   const source = restorableWorktreeSource(agent)
   if ("reason" in source) return { restored: false, reason: source.reason }
@@ -68,21 +114,58 @@ export function restoreManagedWorktree(agent: ManagedAgent): { restored: boolean
   if (result.exitCode !== 0) {
     return { restored: false, reason: result.stderr.trim() || `could not restore ${source.branch}` }
   }
-  maybeSetupWorktree(source.worktree, agent.command.includes("--skip-setup"))
+  runSetupCommands(source.worktree, profile.setup, agent.command.includes("--skip-setup"))
   return { restored: true }
 }
 
-function maybeSetupWorktree(worktree: string, skipSetup: boolean): void {
-  if (skipSetup) {
-    console.warn("harnessd: --skip-setup: skipping bun run setup:worktree")
-    return
+function runProfileCommands(
+  cwd: string,
+  commands: string[],
+  label: string,
+  timeoutMs: number,
+  skip = false
+): { ok: boolean; reason?: string } {
+  if (commands.length === 0) return { ok: true }
+  if (skip) {
+    console.warn(`harnessd: --skip-setup: skipping ${commands.length} ${label} command(s)`)
+    return { ok: true }
   }
-  const docker = output(["docker", "ps", "--format", "{{.Names}}"], { allowFailure: true })
-  if (docker.exitCode !== 0 || !docker.stdout.split("\n").includes("threa-postgres")) {
-    console.warn("harnessd: threa-postgres container not running; skipping setup:worktree")
-    return
+  for (const command of commands) {
+    console.log(`harnessd: running ${label}: ${command}`)
+    // killSignal: spawnSync's timeout signals but never escalates, so a command
+    // that traps SIGTERM blocks the reap sweep — and everything waiting on the
+    // lock it holds — for as long as it likes.
+    const result = spawnSync("sh", ["-c", command], {
+      cwd,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      killSignal: "SIGKILL",
+      stdio: "inherit",
+    })
+    if (result.error || result.signal !== null || result.status !== 0) {
+      const detail = result.signal
+        ? `timed out or was killed (${result.signal}) after ${timeoutMs}ms`
+        : (result.error?.message ?? `exit code ${result.status}`)
+      return { ok: false, reason: `${label} command '${command}' ${detail}` }
+    }
   }
-  console.log("harnessd: running bun run setup:worktree")
-  const result = run(["bun", "run", "setup:worktree"], { cwd: worktree, allowFailure: true })
-  if (result.exitCode !== 0) console.warn("harnessd: setup:worktree reported errors; continuing")
+  return { ok: true }
+}
+
+/**
+ * Setup failures warn and continue, as they always have. Teardown failures do
+ * not: {@link reapLink} is about to destroy the directory, and a teardown that
+ * did not run is not a teardown that had nothing to do.
+ */
+export function runSetupCommands(cwd: string, commands: string[], skip = false): void {
+  const result = runProfileCommands(cwd, commands, "setup", SETUP_TIMEOUT_MS, skip)
+  if (!result.ok) console.warn(`harnessd: ${result.reason}; continuing`)
+}
+
+export function runTeardownCommands(
+  cwd: string,
+  commands: string[],
+  timeoutMs = TEARDOWN_TIMEOUT_MS
+): { ok: boolean; reason?: string } {
+  return runProfileCommands(cwd, commands, "teardown", timeoutMs)
 }


### PR DESCRIPTION
## Problem

`worktree.ts` hardcoded everything: the layout `threa.${name}`, the base `origin/main`, the setup command `bun run setup:worktree`. There was no way to say *"just use this folder"* and no way to say *"never clean this one up"* — which is exactly what the repo main checkouts and the non-git orchestrator directory need.

> "I explicitly want to not need to create branches or directories, sometimes I just want a session in an existing folder." … "When I'm in a non-git folder I don't want cleanup, likewise when in the main worktree of a repo, whereas the thread worktrees I do want cleaned up afterwards."

## Solution

```
provision: existing | worktree { layout, base }
setup:    [commands]        teardown: [commands]      # arbitrary, pluggable
preserve: none | commit | commit+push                 # a rung, not a script
reclaim:  true | false                                # only where it can exist
```

**Cleanup may only destroy what setup created, and the type carries the rule** — not a validator:

```ts
type WorktreeCleanup = { preserve: "commit+push"; reclaim: boolean } | { preserve: "none" | "commit" }
export type Profile =
  | (ProfileCommon & { provision: "existing"; preserve: PreserveRung })
  | (ProfileCommon & { provision: "worktree"; layout: string; base: string } & WorktreeCleanup)
```

`{provision:"worktree", preserve:"commit", reclaim:true}` — which satisfies "no removal without a successful push" *while destroying the uncommitted work*, and which two adversarial reviewers found independently — **does not compile**. Nor does `reclaim` under `existing`, in either direction (not offered ≠ defaulted to false). Verified by compiling each hostile shape, not by reading a test.

**The ladder is not forked.** `pushBranchAndRemoveWorktree` gains one appended, defaulted ordinal ceiling. A caller can stop earlier; it cannot reorder, raise, or skip. The floors — inside a work tree, protected/detached branch, unreadable status, main-checkout-never-removed — stay inside and take no policy input. All pre-existing `archive-wind-down` tests pass untouched: that is the byte-identical guard.

### Two blockers found in review, both against the user's own directories

- **A bare `--cwd` preserved at `commit+push`.** It would `git add -A`, wip-commit and `git push` a checkout harnessd did not create — and `PROTECTED_BRANCHES` covers only main/master/HEAD, so every feature branch in a working tree was exposed. Now `preserve: "none"`: use the folder, touch nothing. Mutation-confirmed the old value was unpinned (329/329 green with it wrong).
- **Pi never recorded a profile snapshot.** Pi doesn't mint, and the snapshot lives on the mint record — but `pi-local` links *are* reaped, so `profileFor` fell back to the built-in default and would commit, push and reclaim a directory the operator owns, dropping the declared teardown silently. The entire safety derivation was bypassed because the `existing` profile never reached `windDownPolicyFor`. Pi records it now.

Plus: `--cwd` against a worktree profile is refused at selection, before `plannedWorktreePath` falls back to the *daemon's own cwd* and mints a durable identity for an unrelated directory on its way to dying. Teardown is killed with `SIGKILL` — `spawnSync`'s timeout signals without escalating, so a command trapping SIGTERM held `resume-active.lock` indefinitely (measured: 4014ms against an 800ms timeout). And `restoreManagedWorktree` now receives the worktree's own profile instead of carrying a dead parameter.

**Behaviour change:** the `threa-postgres` precondition inside setup is gone — setup is arbitrary commands now and that precondition belongs in the command.

## Test plan

- [x] `bun test` — 333 pass / 0 fail (284 on base); typecheck clean; full pre-commit gates pass
- [x] Every hostile `reclaim` shape compile-checked as a TS error; the legal one compiles
- [x] Mutation-tested: `CWD_PROFILE` back to commit+push → 1 fail; `--cwd`+worktree profile allowed → 1; teardown kill not escalating → 1; plus the implementer's own 10
- [ ] **The Pi spawn wiring itself is not unit-covered** — no test performs a live spawn. The behaviour it feeds (snapshot → `windDownPolicyFor`) is covered; the call site is not
- [ ] No live `spawn --cwd` against the real fleet

## Known follow-up

`restoreManagedWorktree` is reached from the revive path, which resolves the profile by worktree — a row whose directory is already gone falls back to the default's setup.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/harnessd-profiles-9af997/ — chunk 6 of 6.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787919866&installation_model_id=20758&pr_number=1665&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1665&signature=2108c5adbbdf86a2edd8543742fe78d942621573791b047028f3bda9bed6a13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->