### PR TITLE
perf(stream-context): stop rebuilding every date label on every render

### DIFF
--- a/apps/frontend/src/components/search/search-filter-menu.tsx
+++ b/apps/frontend/src/components/search/search-filter-menu.tsx
@@ -67,6 +67,14 @@ interface SearchFilterMenuProps {
    * narrow the menu rather than forking it. Defaults to every kind.
    */
   kinds?: readonly FilterKind[]
+  /**
+   * Restrict the `from:`/`with:`/`in:@` user picker to these workspace user ids.
+   * A stream-scoped surface offers only the people whose messages that scope can
+   * contain — a DM's context feed can never hold anything from a third party, so
+   * offering them is a filter that always returns nothing. Omit to offer every
+   * workspace user (the global search's scope).
+   */
+  userIds?: ReadonlySet<string>
 }
 
 /**
@@ -80,7 +88,14 @@ interface SearchFilterMenuProps {
  * `SearchableSelect`) — typing filter syntax on a touch keyboard is exactly
  * the flow this menu replaces. A mouse on a touchscreen laptop gets the popover.
  */
-export function SearchFilterMenu({ workspaceId, query, onQueryChange, className, kinds }: SearchFilterMenuProps) {
+export function SearchFilterMenu({
+  workspaceId,
+  query,
+  onQueryChange,
+  className,
+  kinds,
+  userIds,
+}: SearchFilterMenuProps) {
   const isTouch = useInputMode() === "touch"
   const [open, setOpen] = useState(false)
   const [step, setStep] = useState<FilterKind | null>(null)
@@ -123,7 +138,7 @@ export function SearchFilterMenu({ workspaceId, query, onQueryChange, className,
             <span className="text-xs font-medium">{activeKind.label}</span>
             <code className="ml-auto rounded bg-muted px-1 text-[10px] text-muted-foreground">{activeKind.syntax}</code>
           </div>
-          <FilterValuePicker workspaceId={workspaceId} kind={step} onCommit={commitFilter} />
+          <FilterValuePicker workspaceId={workspaceId} kind={step} onCommit={commitFilter} userIds={userIds} />
         </>
       )}
     </div>
@@ -201,18 +216,20 @@ function FilterValuePicker({
   workspaceId,
   kind,
   onCommit,
+  userIds,
 }: {
   workspaceId: string
   kind: FilterKind
   onCommit: (type: FilterType, value: string) => void
+  userIds?: ReadonlySet<string>
 }) {
   switch (kind) {
     case "from":
-      return <UserPicker onSelect={(slug) => onCommit("from", slug)} />
+      return <UserPicker userIds={userIds} onSelect={(slug) => onCommit("from", slug)} />
     case "with":
-      return <UserPicker onSelect={(slug) => onCommit("with", slug)} />
+      return <UserPicker userIds={userIds} onSelect={(slug) => onCommit("with", slug)} />
     case "in-dm":
-      return <UserPicker onSelect={(slug) => onCommit("in", slug)} />
+      return <UserPicker userIds={userIds} onSelect={(slug) => onCommit("in", slug)} />
     case "in-channel":
       return <ChannelPicker workspaceId={workspaceId} onSelect={(slug) => onCommit("in", `#${slug}`)} />
     case "type":
@@ -231,11 +248,14 @@ function FilterValuePicker({
  * personas/bots here would commit a chip whose filter silently never applies.
  * Keeps the "me" shortcut matching the current user.
  */
-function UserPicker({ onSelect }: { onSelect: (slug: string) => void }) {
+function UserPicker({ onSelect, userIds }: { onSelect: (slug: string) => void; userIds?: ReadonlySet<string> }) {
   const { mentionables } = useMentionables()
   const [search, setSearch] = useState("")
 
-  const filtered = useMemo(() => filterUsersOnly(mentionables, search), [mentionables, search])
+  const filtered = useMemo(() => {
+    const scoped = userIds ? mentionables.filter((item) => userIds.has(item.id)) : mentionables
+    return filterUsersOnly(scoped, search)
+  }, [mentionables, search, userIds])
 
   return (
     <Command shouldFilter={false}>

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { useSearchParams } from "react-router-dom"
 import { ChevronDown, PanelRight, Sparkles } from "lucide-react"
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { DateJumpMenu } from "@/components/timeline/date-jump-menu"
 import { StreamContextList } from "./stream-context-list"
+import { localStartOfDayMs } from "@/lib/dates"
 import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { CONTEXT_CATEGORIES, type ContextCategory, type ContextItem } from "@/lib/stream-context/types"
 import { cn } from "@/lib/utils"
@@ -49,6 +50,9 @@ export function useContextFilter(): [Filter, (value: Filter) => void] {
   const [searchParams, setSearchParams] = useSearchParams()
   const filter = parseFilter(searchParams.get("context"))
   const setFilter = (value: Filter) => {
+    // Re-tapping the active chip used to write the same param back, and the
+    // param lives on the route — so a no-op re-rendered the whole stream page.
+    if (value === filter) return
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
@@ -243,7 +247,14 @@ export function ContextTimeline({
   // virtua wraps every child in its own item element, so `:first-child` would
   // match every marker and collapse the gap between all day groups. The board's
   // feed carries the same `row.first` flag for the same reason.
-  const rows = groupItemsByDay(items, new Date()).flatMap((group, index) => [
+  // Memoized because grouping labels every item, and this component re-renders
+  // for reasons that never touch the list (a chip's active state, a fetch flag).
+  // Keyed on the local day rather than a captured `Date`: every label is a
+  // function of the calendar day alone, so this is the coarsest key that still
+  // lets a panel left open past midnight relabel "Today".
+  const today = localStartOfDayMs(new Date())
+  const groups = useMemo(() => groupItemsByDay(items, new Date(today)), [items, today])
+  const rows = groups.flatMap((group, index) => [
     <div key={`day:${group.items[0].key}`} className={index === 0 ? "pt-0" : "pt-3"}>
       {onJumpToDate ? (
         <DayMarkerJump label={group.label} day={new Date(group.items[0].createdAt)} onJumpToDate={onJumpToDate} />

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -63,7 +63,12 @@ export function StreamContextDerivedPanel({
   // link holds the requested view instead of flickering All → Delegations.
   const filterSettled = filter !== "delegation" || !delegationsPending
   const effectiveFilter: Filter = filter !== "all" && filterSettled && counts[filter] === 0 ? "all" : filter
-  const visible = effectiveFilter === "all" ? items : items.filter((i) => i.category === effectiveFilter)
+  // Memoized for its identity as much as its cost: the timeline's day grouping
+  // is keyed on this array, and a fresh one per render would miss that memo.
+  const visible = useMemo(
+    () => (effectiveFilter === "all" ? items : items.filter((i) => i.category === effectiveFilter)),
+    [items, effectiveFilter]
+  )
   const isLoading = events === undefined || (delegationsPending && visible.length === 0)
 
   const scrollerRef = useRef<HTMLDivElement | null>(null)

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import type { StreamBootstrap, StreamMember } from "@threa/types"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, Search, WifiOff, X } from "lucide-react"
 import { streamContextApi } from "@/api"
@@ -9,7 +11,9 @@ import { SearchFilterMenu } from "@/components/search/search-filter-menu"
 import { SEARCH_DEBOUNCE_MS } from "@/components/search/use-message-search"
 import { Input } from "@/components/ui/input"
 import { useFormattedDate } from "@/hooks"
+import { useCurrentWorkspaceUserId } from "@/hooks/use-current-workspace-user-id"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { streamKeys } from "@/hooks/use-streams"
 import { parseSearchQuery, type ParsedFilter } from "@/lib/search-query-parser"
 import { contextItemFromCached } from "@/lib/stream-context/from-cached"
 import { collapseContextRows, countByCategory, filterContextRows } from "@/lib/stream-context/filter"
@@ -129,6 +133,24 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
 
   const rows = useStreamContextRows(workspaceId, streamId, rootStreamId, "tree")
 
+  // Who `from:` can meaningfully name here: this stream's members, plus the
+  // viewer (a public root grants read without a membership row — INV-62 — so
+  // "things I shared" must stay reachable). A workspace-wide picker offers
+  // people this stream can hold nothing from — in a DM, everyone except the two
+  // participants — and every such choice is a filter that returns nothing.
+  //
+  // Threads inherit membership from their root (INV-62), so the root's roster is
+  // the answer for a thread too. `undefined` while no roster is cached: unscoped
+  // is honest about not knowing, where a roster of one would not be.
+  const currentUserId = useCurrentWorkspaceUserId(workspaceId)
+  const members = useCachedStreamMembers(workspaceId, rootStreamId, streamId)
+  const authorIds = useMemo(() => {
+    if (!members) return undefined
+    const ids = new Set(members.map((member) => member.memberId))
+    if (currentUserId) ids.add(currentUserId)
+    return ids
+  }, [members, currentUserId])
+
   // Phase 1 — narrow the cached window locally and render before the endpoint
   // answers. The server phase widens the same set through IDB, so there is no
   // second list to reconcile.
@@ -172,7 +194,17 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   // Jump the LIST to a date — navigation, not filtering: the feed stays one
   // continuous list and the view moves. The target is usually not mounted,
   // hence virtua's `scrollToIndex` over a DOM scroll.
-  const items = visibleRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null)
+  // The chip, the search box and the counts repaint on the tap; the list itself
+  // is allowed to arrive a frame later. Rebuilding and re-rendering a long list
+  // is the one part of this panel that can't be made free, so it yields instead
+  // of blocking the input that asked for it. Everything the list needs hangs off
+  // this one deferred value — the rows, their keys, and the jump's index into
+  // them — so nothing can index a list the user isn't looking at.
+  const renderedRows = useDeferredValue(visibleRows)
+  const items = useMemo(
+    () => renderedRows.map(contextItemFromCached).filter((item): item is ContextItem => item !== null),
+    [renderedRows]
+  )
 
   // Which jump is paging, not merely whether one is: an abandoned run must not
   // clear a skeleton the run that replaced it is still showing, and must not
@@ -268,8 +300,8 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
     )
   }
 
-  const isLoading = rows === undefined || (feed.isLoading && visibleRows.length === 0)
-  const itemsByKey = new Map(visibleRows.map((row) => [row.key, row]))
+  const isLoading = rows === undefined || (feed.isLoading && renderedRows.length === 0)
+  const itemsByKey = new Map(renderedRows.map((row) => [row.key, row]))
 
   // The cached window ends here and the next page can't be fetched — say so
   // rather than presenting a truncated list as the whole of it (INV-11).
@@ -367,6 +399,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
             query={query}
             onQueryChange={setQuery}
             kinds={["from", "after", "before"]}
+            userIds={authorIds}
           />
         </div>
         {unsupported.length > 0 && (
@@ -396,6 +429,34 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       </div>
     </div>
   )
+}
+
+/**
+ * The stream's member roster as the app already holds it. A cache-only observer
+ * (see `CLAUDE.md`): the stream page's own bootstrap owns this key, and a side
+ * panel must not open a second subscription just to populate a menu. Prefers the
+ * root's roster — a thread inherits its members (INV-62) — and falls back to the
+ * stream's own for a thread opened before its root was fetched.
+ */
+function useCachedStreamMembers(
+  workspaceId: string,
+  rootStreamId: string,
+  streamId: string
+): StreamMember[] | undefined {
+  const root = useCachedBootstrapMembers(workspaceId, rootStreamId)
+  const own = useCachedBootstrapMembers(workspaceId, streamId)
+  return root ?? own
+}
+
+function useCachedBootstrapMembers(workspaceId: string, streamId: string): StreamMember[] | undefined {
+  const { data } = useQuery({
+    queryKey: streamKeys.bootstrap(workspaceId, streamId),
+    queryFn: () => null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap: StreamBootstrap | null) => bootstrap?.members,
+  })
+  return data ?? undefined
 }
 
 /**

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { StreamBootstrap, StreamMember } from "@threa/types"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, Search, WifiOff, X } from "lucide-react"
@@ -449,9 +449,14 @@ function useCachedStreamMembers(
 }
 
 function useCachedBootstrapMembers(workspaceId: string, streamId: string): StreamMember[] | undefined {
+  const queryClient = useQueryClient()
+  const key = streamKeys.bootstrap(workspaceId, streamId)
   const { data } = useQuery({
-    queryKey: streamKeys.bootstrap(workspaceId, streamId),
-    queryFn: () => null,
+    queryKey: key,
+    // Returns what the cache already holds rather than a constant: this shares a
+    // key with the stream page's real bootstrap, and a `queryFn` that resolved
+    // to anything else would overwrite it if this observer were ever fetched.
+    queryFn: () => queryClient.getQueryData<StreamBootstrap>(key) ?? null,
     enabled: false,
     staleTime: Infinity,
     select: (bootstrap: StreamBootstrap | null) => bootstrap?.members,

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -1,15 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createElement, Fragment } from "react"
+import { createElement, Fragment, useRef } from "react"
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { MemoryRouter } from "react-router-dom"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { AuthContext } from "@/auth"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { streamContextApi } from "@/api"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real panel read path
 import { db, type CachedStreamContextItem } from "@/db"
 import * as hooks from "@/hooks"
 import * as connectionStatus from "@/components/layout/connection-status"
+import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import * as streamContextListModule from "@/components/stream-context/stream-context-list"
@@ -20,6 +22,7 @@ import { StreamContextPanel } from "./stream-context-panel"
 const WS = "ws_1"
 const STREAM = "stream_root"
 const THREAD = "stream_thread"
+const WORKOS_ME = "workos_me"
 
 const EMPTY_COUNTS = { link: 0, media: 0, file: 0, memo: 0, delegation: 0, thread: 0 }
 
@@ -67,29 +70,55 @@ function listResponse(overrides: Partial<ListStreamContextResponse> = {}): ListS
   return { items: [], counts: { ...EMPTY_COUNTS }, nextCursor: null, mode: "index", ...overrides }
 }
 
-function renderPanel(options: { flag?: "on" | "off"; entry?: string } = {}) {
+/** The panel's filter lives on the route, so history writes are observable. */
+function LocationProbe() {
+  const location = useLocation()
+  const seen = useRef(0)
+  seen.current += 1
+  return <span data-testid="location">{`${location.search}|${seen.current}`}</span>
+}
+
+function renderPanel(options: { flag?: "on" | "off"; entry?: string; memberIds?: string[] } = {}) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   queryClient.setQueryData(workspaceKeys.bootstrap(WS), {
     featureFlags: { workspace: { streamContextIndex: options.flag ?? "on" }, user: {} },
   })
+  if (options.memberIds) {
+    queryClient.setQueryData(streamKeys.bootstrap(WS, STREAM), {
+      members: options.memberIds.map((memberId) => ({ streamId: STREAM, memberId })),
+    })
+  }
   queryClient.setQueryData(delegationKeys.stream(WS, STREAM), { delegations: [] })
   const onJumpToMessage = vi.fn()
   const onOpenThread = vi.fn()
+  const panel = (
+    <>
+      <LocationProbe />
+      <StreamContextPanel
+        workspaceId={WS}
+        streamId={STREAM}
+        onClose={vi.fn()}
+        onJumpToMessage={onJumpToMessage}
+        onOpenThread={onOpenThread}
+        onOpenMemo={vi.fn()}
+        onOpenGallery={vi.fn()}
+      />
+    </>
+  )
   render(
-    <MemoryRouter initialEntries={[options.entry ?? "/s"]}>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <StreamContextPanel
-            workspaceId={WS}
-            streamId={STREAM}
-            onClose={vi.fn()}
-            onJumpToMessage={onJumpToMessage}
-            onOpenThread={onOpenThread}
-            onOpenMemo={vi.fn()}
-            onOpenGallery={vi.fn()}
-          />
-        </TooltipProvider>
-      </QueryClientProvider>
+    // A `:workspaceId` route segment, not a bare path: the filter menu's user
+    // picker reads the workspace off the route (`useMentionables`), so a
+    // param-less router silently offers nobody and makes a scoping test vacuous.
+    <MemoryRouter initialEntries={[`/w/${WS}${options.entry ?? "/s"}`]}>
+      <AuthContext.Provider value={{ user: { id: WORKOS_ME }, loading: false } as never}>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <Routes>
+              <Route path="/w/:workspaceId/*" element={panel} />
+            </Routes>
+          </TooltipProvider>
+        </QueryClientProvider>
+      </AuthContext.Provider>
     </MemoryRouter>
   )
   return { onJumpToMessage, onOpenThread }
@@ -331,6 +360,58 @@ describe("StreamContextPanel — flag on", () => {
     expect(await screen.findByLabelText("Remove filter @mara")).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText("Mine")).not.toBeInTheDocument())
     expect(screen.getByText("Hers")).toBeInTheDocument()
+  })
+
+  it("does not touch the route when the already-active chip is tapped", async () => {
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({ category: "link", refId: "https://a.example", detail: { url: "https://a.example", title: "A" } })
+      )
+    )
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(listResponse({ counts: { ...EMPTY_COUNTS, link: 1 } }))
+
+    renderPanel({ entry: "/s?context=all" })
+    expect(await screen.findByText("A")).toBeInTheDocument()
+    const before = screen.getByTestId("location").textContent
+
+    await userEvent.click(screen.getByRole("button", { name: /^All/ }))
+
+    // The filter is a route param, so writing it back unchanged re-renders the
+    // whole stream page — the timeline and composer included — for nothing.
+    expect(screen.getByTestId("location").textContent).toBe(before)
+  })
+
+  it("offers from: only this stream's members, plus the viewer", async () => {
+    await db.workspaceUsers.bulkPut([
+      { id: "usr_me", workspaceId: WS, workosUserId: WORKOS_ME, slug: "me", name: "Me" },
+      { id: "usr_2", workspaceId: WS, slug: "mara", name: "Mara" },
+      { id: "usr_3", workspaceId: WS, slug: "simon", name: "Simon" },
+    ] as never[])
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({
+          category: "link",
+          refId: "https://hers.example",
+          authorId: "usr_2",
+          detail: { url: "https://hers.example", title: "Hers" },
+        })
+      )
+    )
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(listResponse())
+
+    renderPanel({ memberIds: ["usr_2"] })
+    expect(await screen.findByText("Hers")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText("Add search filter"))
+    await userEvent.click(await screen.findByText("From user"))
+
+    expect(await screen.findByText("Mara")).toBeInTheDocument()
+    // The viewer reads this stream without a membership row (INV-62 grants read
+    // through a public root), and must still be able to find their own things.
+    expect(screen.getByText("Me")).toBeInTheDocument()
+    // Simon is in the workspace but not in this stream — nothing of his can ever
+    // be in this feed, so filtering by him could only ever return nothing.
+    expect(screen.queryByText("Simon")).not.toBeInTheDocument()
   })
 
   it("expands a multi-occurrence row into its occurrences, each with its own jump", async () => {

--- a/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react"
 import { useInfiniteQuery } from "@tanstack/react-query"
 import { streamContextApi, type ListStreamContextRequest } from "@/api"
 import { seedStreamContextItems } from "@/stores/stream-context-store"
@@ -27,10 +26,10 @@ export interface StreamContextFeed {
   /** `client` = sealed stream; the panel derives locally instead. */
   mode: ListStreamContextResponse["mode"] | null
   hasNextPage: boolean
-  /** Resolves when the page has landed and been seeded — a date jump pages in a
-   *  loop and must not re-read IDB before the rows are there. Its `hasNextPage`
-   *  is the post-fetch truth; the field above is a render-time snapshot and
-   *  stays stale inside such a loop. */
+  /** Resolves when the page has landed and been seeded (the query fn seeds
+   *  before it resolves) — a date jump pages in a loop and must not re-read IDB
+   *  before the rows are there. Its `hasNextPage` is the post-fetch truth; the
+   *  field above is a render-time snapshot and stays stale inside such a loop. */
   fetchNextPage: () => Promise<{ hasNextPage: boolean }>
   isFetchingNextPage: boolean
   isLoading: boolean
@@ -58,9 +57,18 @@ export function useStreamContextFeed(
 
   const query = useInfiniteQuery({
     queryKey: streamContextKeys.feed(workspaceId, streamId, { scope, category, q, from, before, after }),
-    queryFn: ({ pageParam }) => {
+    // Seeding here, not in an effect, is what makes "the page is in IDB by the
+    // time the fetch resolves" structural: `fetchNextPage` awaits this, so the
+    // date jump's paging loop can read IDB straight after. Once per page, too —
+    // the effect this replaces re-put every accumulated page on every change,
+    // costing O(pages²) writes, each waking the live query the panel renders
+    // from. A reconnect refetch re-runs this per page, so INV-53 catch-up still
+    // rewrites the whole window.
+    queryFn: async ({ pageParam }) => {
       const request: ListStreamContextRequest = { scope, category, q, from, before, after, cursor: pageParam }
-      return streamContextApi.list(workspaceId, streamId, request)
+      const page = await streamContextApi.list(workspaceId, streamId, request)
+      await seedStreamContextItems(workspaceId, rootStreamId, page.items)
+      return page
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
@@ -71,33 +79,12 @@ export function useStreamContextFeed(
     enabled: enabled && !!workspaceId && !!streamId,
   })
 
-  const { data } = query
-  useEffect(() => {
-    if (!data) return
-    void seedStreamContextItems(
-      workspaceId,
-      rootStreamId,
-      data.pages.flatMap((page) => page.items)
-    )
-  }, [data, workspaceId, rootStreamId])
-
-  const firstPage = data?.pages[0]
+  const firstPage = query.data?.pages[0]
   return {
     counts: firstPage?.counts ?? null,
     mode: firstPage?.mode ?? null,
     hasNextPage: query.hasNextPage,
-    // Seed before resolving. The effect above also seeds, but it runs a render
-    // later — a caller that awaits this and then reads IDB (the date jump) would
-    // race it and see the page missing.
-    fetchNextPage: async () => {
-      const result = await query.fetchNextPage()
-      await seedStreamContextItems(
-        workspaceId,
-        rootStreamId,
-        (result.data?.pages ?? []).flatMap((page) => page.items)
-      )
-      return { hasNextPage: result.hasNextPage }
-    },
+    fetchNextPage: async () => ({ hasNextPage: (await query.fetchNextPage()).hasNextPage }),
     isFetchingNextPage: query.isFetchingNextPage,
     isLoading: query.isLoading,
     isError: query.isError,

--- a/apps/frontend/src/lib/stream-context/grouping.ts
+++ b/apps/frontend/src/lib/stream-context/grouping.ts
@@ -4,6 +4,15 @@ function startOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate())
 }
 
+// `date.toLocaleDateString(undefined, opts)` builds a fresh `Intl.DateTimeFormat`
+// on every call — 0.024 ms in V8 against 0.0005 ms for a reused one. Labelling is
+// per item, so at 500 rows that was ~12 ms a pass, and this runs on every render
+// of both panels plus twice per date jump. Same locale resolution as the
+// `undefined` argument it replaces, so device-local (INV-42) is unchanged.
+const WEEKDAY = new Intl.DateTimeFormat(undefined, { weekday: "long" })
+const MONTH_DAY = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" })
+const MONTH_DAY_YEAR = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" })
+
 /**
  * A timeline milestone label for a date, relative to `now`, in device-local
  * time (INV-42): "Today", "Yesterday", a weekday within the last week, then a
@@ -13,12 +22,9 @@ export function dayBucketLabel(date: Date, now: Date): string {
   const diffDays = Math.round((startOfDay(now).getTime() - startOfDay(date).getTime()) / 86_400_000)
   if (diffDays <= 0) return "Today"
   if (diffDays === 1) return "Yesterday"
-  if (diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "long" })
+  if (diffDays < 7) return WEEKDAY.format(date)
   const sameYear = date.getFullYear() === now.getFullYear()
-  return date.toLocaleDateString(
-    undefined,
-    sameYear ? { month: "short", day: "numeric" } : { month: "short", day: "numeric", year: "numeric" }
-  )
+  return (sameYear ? MONTH_DAY : MONTH_DAY_YEAR).format(date)
 }
 
 export interface TimelineGroup {


### PR DESCRIPTION
## Problem

The "In this stream" panel blocked the main thread on every chip tap and keystroke. `dayBucketLabel` (`lib/stream-context/grouping.ts`) called `date.toLocaleDateString(locale, opts)` once per **item**, and that constructs a fresh `Intl.DateTimeFormat` on every call — ~11–14 ms per 500 labels against ~0.4 ms for a reused formatter, measured in both V8 and JSC. `groupItemsByDay` then ran unmemoized in `ContextTimeline`'s render body with `items` rebuilt inline, so it fired on all three renders a chip tap produces. The date jump paid it up to ten more times, once per paged round trip.

Separately, the `from:` picker offered every user in the workspace. In a DM with one person, every choice but two was a filter that could only ever return nothing.

Reported from a phone, where the symptoms were a visible freeze on each tap and the chip's colour transition stepping through its 150 ms instead of animating.

## Solution

Cache the formatters; memoize what feeds them.

- **`grouping.ts`** — three module-level `Intl.DateTimeFormat`s replace the per-call `toLocaleDateString(undefined, opts)`. Same locale resolution as the `undefined` argument it replaces, so device-local (INV-42) is unchanged. Fixes the derive panel and the date jump at the same time, since both go through this function.
- **`items` memoized on the rows; `groups` memoized in `ContextTimeline`** — keyed on the local day (`localStartOfDayMs`) rather than a captured `Date`, so a panel left open past midnight still relabels "Today". A captured `Date` would have frozen the labels; `new Date()` per render never hits the memo.
- **Pages seed once, inside `queryFn`.** The effect re-put every accumulated page on every `data` change and `fetchNextPage` seeded them again — O(pages²) IDB writes, each waking the `useLiveQuery` the panel renders from. Seeding in `queryFn` also makes "the page is in IDB when the fetch resolves" structural rather than incidental, which is what the jump's paging loop relies on. A reconnect refetch re-runs it per page, so INV-53 catch-up still rewrites the whole window.
- **Tapping the already-active chip no longer writes the filter back to the route** — the param lives on the route, so a no-op re-rendered the whole stream page.
- **`useDeferredValue` on the rows** — the chip, search box and counts repaint on the tap; the list follows. Rows, keys and the jump's index all hang off the one deferred value, so nothing can index a list the user isn't looking at.
- **`from:` bound to the stream's members plus the viewer**, via a new optional `userIds` on `SearchFilterMenu`. Members over "who has authored something in the feed" — Kris's call; authorship is the narrower set but membership is the one users can predict. The viewer is always included because INV-62 grants read through a public root without a membership row. Unscoped while no roster is cached: honest about not knowing, where a roster of one would not be.

Measured on the real component tree, 500 rows, three runs each: chip tap **109.6 ms → 69.6 ms** with the formatter and memo work. `useDeferredValue` then puts ~20 ms back onto total settle time (→ ~92 ms) in exchange for a first paint that doesn't wait on the list. That trade is deliberate and is the part I could not measure — jsdom flushes inside `act()`, so there is no first-paint number here, only the mechanism. Say the word and I drop it.

Not done here: `lib/dates.ts` has the same per-call formatter construction at nine sites. It is the app-wide date authority, but every consuming list is virtualized so the working set is 30–60 calls, not 500 — a few ms, not a freeze. Own PR.

## Files

| File | Change |
| ---- | ------ |
| `lib/stream-context/grouping.ts` | Module-level cached `Intl.DateTimeFormat`s |
| `stream-context/stream-context-chrome.tsx` | Memoized day grouping keyed on the local day; no-op guard on the active chip |
| `stream-context/stream-context-index-panel.tsx` | Memoized + deferred rows; member-scoped `from:` picker; cache-only roster reader |
| `stream-context/stream-context-derived-panel.tsx` | Memoized `visible` so the shared grouping memo can hit |
| `stream-context/use-stream-context-feed.ts` | Seed each page once in `queryFn`; drop the effect and the duplicate seed |
| `search/search-filter-menu.tsx` | Optional `userIds` scoping for the user picker |
| `stream-context/stream-context-panel.integration.test.tsx` | Auth + `:workspaceId` route in the harness; two new tests |

## Test plan

- [x] `bun scripts/test-silent.ts frontend` — 5278 pass, 0 fail
- [x] `bun run lint` — clean
- [x] Both new tests verified to fail when their fix is removed (member scoping, active-chip no-op)
- [ ] Browser/device profile — not run. The before/after numbers are from the jsdom harness driving the real components, which measures JS but not layout or paint. A Chrome trace at 4× CPU throttle is what would settle the absolute magnitude and the `useDeferredValue` trade.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934554&installation_model_id=20758&pr_number=1667&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1667&signature=6398d4ee07439642bddbc16db3e9e66cf7d1de48bb41b28dd76b51f2eba91e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->