### PR TITLE
feat: index follow-ups into "In this stream", with an Agent filter

### DIFF
--- a/apps/backend/src/db/migrations/20260729120000_backfill_follow_up_context_index.sql
+++ b/apps/backend/src/db/migrations/20260729120000_backfill_follow_up_context_index.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- Backfill: "In this stream" projection rows for pre-existing follow-ups
+-- =============================================================================
+--
+-- The write path now projects a `follow_up` row at schedule time; every
+-- follow-up scheduled before it has none. Re-enqueue one `backfill.plan` job per
+-- workspace for the SAME `stream-context-index` definition — the plan now also
+-- fans out a `follow_ups` chunk per stream that has rows. A new name would throw
+-- `Unknown backfill` into the DLQ. Chunks are idempotent (`ON CONFLICT DO
+-- NOTHING` on the identity index), so re-running the whole definition rewrites
+-- nothing that already exists.
+--
+-- `process_after` is 15 minutes out (INV-67) so replicas still on the old code
+-- have cut over before a chunk job claims a chunk kind they don't handle.
+
+INSERT INTO queue_messages (
+    id,
+    queue_name,
+    workspace_id,
+    payload,
+    process_after,
+    inserted_at
+)
+SELECT
+    'queue_' || replace(gen_random_uuid()::text, '-', ''),
+    'backfill.plan',
+    w.id,
+    jsonb_build_object(
+        'workspaceId', w.id,
+        'backfillName', 'stream-context-index'
+    ),
+    NOW() + INTERVAL '15 minutes',
+    NOW()
+FROM workspaces w;

--- a/apps/backend/src/features/agents/follow-up-service.test.ts
+++ b/apps/backend/src/features/agents/follow-up-service.test.ts
@@ -5,7 +5,9 @@ import { AgentFollowUpService } from "./follow-up-service"
 import { AgentFollowUpRepository, type AgentFollowUp } from "./follow-up-repository"
 import { JobQueues, QueueRepository } from "../../lib/queue"
 import { OutboxRepository } from "../../lib/outbox"
-import { StreamEventRepository } from "../streams"
+import { logger } from "../../lib/logger"
+import { StreamEventRepository, StreamRepository } from "../streams"
+import { StreamContextRepository } from "../stream-context"
 import * as dbModule from "../../db"
 import { DEFAULT_MAX_PENDING_FOLLOW_UPS } from "./config"
 
@@ -18,6 +20,12 @@ function stubEventAppend() {
   const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({} as never)
   const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as never)
   return { insertEvent, insertOutbox }
+}
+
+/** Stub the stream lookup + "In this stream" projection write the schedule path performs. */
+function stubContextIndex(stream: Record<string, unknown> | null = { id: "stream_1", rootStreamId: null }) {
+  spyOn(StreamRepository, "findById").mockResolvedValue(stream as never)
+  return spyOn(StreamContextRepository, "insertMany").mockResolvedValue(0)
 }
 
 const NOW = new Date("2026-07-02T12:00:00.000Z")
@@ -71,6 +79,7 @@ describe("AgentFollowUpService.schedule", () => {
     spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
     const queueInsert = spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
     stubEventAppend()
+    stubContextIndex()
 
     const result = await makeService().schedule(scheduleParams)
 
@@ -94,6 +103,7 @@ describe("AgentFollowUpService.schedule", () => {
     spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
     spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
     const { insertEvent, insertOutbox } = stubEventAppend()
+    stubContextIndex()
 
     await makeService().schedule(scheduleParams)
 
@@ -142,12 +152,84 @@ describe("AgentFollowUpService.schedule", () => {
     spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
     spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
     stubEventAppend()
+    stubContextIndex()
 
     const result = await makeService(workspaceLimit).schedule(scheduleParams)
 
     expect(result).toMatchObject({ ok: true, limit: workspaceLimit })
     // The guarded insert enforces the resolved cap, not DEFAULT_MAX_PENDING_FOLLOW_UPS.
     expect(insertIfUnderCap.mock.calls[0]?.[2]).toBe(workspaceLimit)
+  })
+
+  it("projects the follow-up into the context index on the schedule transaction's client", async () => {
+    const client = { id: "the-tx-client" } as unknown as PoolClient
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn(client))
+    spyOn(AgentFollowUpRepository, "acquireStreamCapLock").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "insertIfUnderCap").mockResolvedValue(fakeFollowUp())
+    spyOn(AgentFollowUpRepository, "setQueueMessageId").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
+    spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
+    stubEventAppend()
+    const insertMany = stubContextIndex({ id: "stream_1", rootStreamId: "stream_root", e2eEnabled: false })
+
+    await makeService().schedule(scheduleParams)
+
+    expect(insertMany.mock.calls[0]?.[0]).toBe(client)
+    const [row] = insertMany.mock.calls[0]?.[1] ?? []
+    expect(row).toEqual(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        rootStreamId: "stream_root",
+        category: "follow_up",
+        refKind: "follow_up",
+        refId: "agfu_01",
+        groupKey: "agfu_01",
+        sourceMessageId: null,
+        authorId: null,
+        occurredAt: NOW,
+        sequence: null,
+        snippet: "check back on the deploy",
+        // Status and scheduledFor are mutable — joined live on read, never stored.
+        detail: { note: "check back on the deploy" },
+      })
+    )
+  })
+
+  it("writes no projection row for a sealed stream", async () => {
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+    spyOn(AgentFollowUpRepository, "acquireStreamCapLock").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "insertIfUnderCap").mockResolvedValue(fakeFollowUp())
+    spyOn(AgentFollowUpRepository, "setQueueMessageId").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
+    spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
+    stubEventAppend()
+    const insertMany = stubContextIndex({ id: "stream_1", rootStreamId: null, e2eEnabled: true })
+
+    const result = await makeService().schedule(scheduleParams)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(insertMany).not.toHaveBeenCalled()
+  })
+
+  it("logs and skips the projection when the stream row is missing, still scheduling", async () => {
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+    spyOn(AgentFollowUpRepository, "acquireStreamCapLock").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "insertIfUnderCap").mockResolvedValue(fakeFollowUp())
+    spyOn(AgentFollowUpRepository, "setQueueMessageId").mockResolvedValue(undefined)
+    spyOn(AgentFollowUpRepository, "countPending").mockResolvedValue(1)
+    spyOn(QueueRepository, "insert").mockResolvedValue({} as never)
+    stubEventAppend()
+    const insertMany = stubContextIndex(null)
+    const warn = spyOn(logger, "warn").mockImplementation(() => undefined as never)
+
+    const result = await makeService().schedule(scheduleParams)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(insertMany).not.toHaveBeenCalled()
+    expect(warn.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ workspaceId: "ws_1", streamId: "stream_1", followUpId: "agfu_01" })
+    )
   })
 })
 

--- a/apps/backend/src/features/agents/follow-up-service.ts
+++ b/apps/backend/src/features/agents/follow-up-service.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from "pg"
 import { withTransaction } from "../../db"
-import { agentFollowUpId, agentFollowUpQueueId, queueId, eventId } from "../../lib/id"
+import { agentFollowUpId, agentFollowUpQueueId, queueId, eventId, streamContextItemId } from "../../lib/id"
 import { JobQueues, QueueRepository, enqueueQueuedJob, type PersonaAgentJobData } from "../../lib/queue"
 import { OutboxRepository } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
@@ -11,7 +11,8 @@ import {
   type AgentFollowUpScheduledEventPayload,
   type AgentFollowUpCancelledEventPayload,
 } from "@threa/types"
-import { StreamEventRepository } from "../streams"
+import { StreamEventRepository, StreamRepository } from "../streams"
+import { StreamContextRepository, contextSnippet } from "../stream-context"
 import { AgentFollowUpRepository, type AgentFollowUp } from "./follow-up-repository"
 
 /** The outbox event type that carries each follow-up timeline event to the stream room. */
@@ -145,6 +146,37 @@ export class AgentFollowUpService {
         actorId: params.personaId,
         actorType: AuthorTypes.PERSONA,
       })
+
+      // "In this stream" landmark. Sealed streams are never indexed. Status and
+      // `scheduledFor` are mutable, so they stay out of `detail` and are joined
+      // live on read — a stored copy would show a cancelled follow-up as pending.
+      const stream = await StreamRepository.findById(client, params.streamId)
+      if (!stream) {
+        logger.warn(
+          { workspaceId: params.workspaceId, streamId: params.streamId, followUpId: inserted.id },
+          "Follow-up scheduled against a missing stream row, skipping context landmark"
+        )
+      }
+      if (stream && stream.e2eEnabled !== true) {
+        await StreamContextRepository.insertMany(client, [
+          {
+            id: streamContextItemId(),
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            rootStreamId: stream.rootStreamId ?? stream.id,
+            category: "follow_up",
+            refKind: "follow_up",
+            refId: inserted.id,
+            groupKey: inserted.id,
+            sourceMessageId: null,
+            authorId: null,
+            occurredAt: inserted.createdAt,
+            sequence: null,
+            snippet: contextSnippet(inserted.note),
+            detail: { note: inserted.note },
+          },
+        ])
+      }
 
       const pendingCount = await AgentFollowUpRepository.countPending(client, params.workspaceId, params.streamId)
       return { ok: true, followUp: { ...inserted, queueMessageId }, pendingCount, limit }

--- a/apps/backend/src/features/stream-context/backfill.test.ts
+++ b/apps/backend/src/features/stream-context/backfill.test.ts
@@ -130,6 +130,29 @@ describe("stream-context backfill plan", () => {
     ])
   })
 
+  it("plans one follow_ups chunk per stream with rows, and none for a sealed stream", async () => {
+    const { ctx } = fakePool([
+      // `stream_sealed` is absent from the plan query's result — sealed streams
+      // are excluded there — so its follow-ups are never asked for either.
+      {
+        match: /FROM streams s/,
+        rows: [
+          { id: "stream_a", root_stream_id: "stream_a" },
+          { id: "stream_b", root_stream_id: "stream_a" },
+        ],
+      },
+      { match: /SELECT id, stream_id FROM messages/, rows: [] },
+      { match: /FROM memos mo/, rows: [] },
+      { match: /FROM delegated_tasks/, rows: [] },
+      { match: /FROM agent_follow_ups/, rows: [{ stream_id: "stream_b" }] },
+      { match: /SELECT DISTINCT parent_stream_id/, rows: [] },
+    ])
+
+    const chunks = await plan(ctx, "ws_1")
+
+    expect(chunks).toEqual([{ kind: "follow_ups", streamId: "stream_b", rootStreamId: "stream_a" }])
+  })
+
   it("plans nothing when the workspace has no indexable stream", async () => {
     const { ctx } = fakePool([{ match: /FROM streams s/, rows: [] }])
 
@@ -529,6 +552,58 @@ describe("stream-context backfill — memos, delegations, threads", () => {
       detail: { title: "Ship it" },
       snippet: "Ship it",
     })
+  })
+
+  it("indexes follow-ups at their created_at under the write path's identity key", async () => {
+    const { ctx, inserted } = fakePool([
+      {
+        match: /FROM agent_follow_ups/,
+        rows: [{ id: "agfu_1", note: "check the deploy", created_at: new Date("2026-07-20T12:00:00.000Z") }],
+      },
+    ])
+    const captured: any[] = []
+    const originalQuery = (ctx.pool as any).query.bind(ctx.pool)
+    ;(ctx.pool as any).query = async (config: any) => {
+      if (typeof config !== "string" && config.text.includes("INSERT INTO stream_context_items")) {
+        captured.push(config.values)
+      }
+      return originalQuery(config)
+    }
+
+    await processChunk(ctx, "ws_1", { kind: "follow_ups", streamId: "stream_a", rootStreamId: "stream_root" })
+
+    const [values] = captured
+    expect({
+      rootStreamId: values[3][0],
+      category: values[4][0],
+      refKind: values[5][0],
+      refId: values[6][0],
+      groupKey: values[7][0],
+      sourceMessageId: values[8][0],
+      authorId: values[9][0],
+      occurredAt: values[10][0],
+      sequence: values[11][0],
+      snippet: values[12][0],
+      detail: JSON.parse(values[13][0]),
+    }).toEqual({
+      rootStreamId: "stream_root",
+      category: "follow_up",
+      refKind: "follow_up",
+      refId: "agfu_1",
+      groupKey: "agfu_1",
+      sourceMessageId: null,
+      authorId: null,
+      occurredAt: new Date("2026-07-20T12:00:00.000Z"),
+      sequence: null,
+      snippet: "check the deploy",
+      // Status and scheduled_for are joined live on read, never stored.
+      detail: { note: "check the deploy" },
+    })
+    // The identity key the write path produces: (stream, category, ref, "").
+    expect([...inserted.keys()]).toEqual(["stream_a:follow_up:agfu_1:"])
+
+    await processChunk(ctx, "ws_1", { kind: "follow_ups", streamId: "stream_a", rootStreamId: "stream_root" })
+    expect([...inserted.keys()]).toEqual(["stream_a:follow_up:agfu_1:"])
   })
 
   it("places a thread row on the parent stream at its anchor message", async () => {

--- a/apps/backend/src/features/stream-context/backfill.ts
+++ b/apps/backend/src/features/stream-context/backfill.ts
@@ -23,6 +23,7 @@ export type StreamContextChunk =
   | ({ kind: "messages"; ids: string[] } & StreamRef)
   | ({ kind: "memos" } & StreamRef)
   | ({ kind: "delegations" } & StreamRef)
+  | ({ kind: "follow_ups" } & StreamRef)
   | ({ kind: "threads" } & StreamRef)
 
 interface MessageRow {
@@ -54,6 +55,12 @@ interface DelegationRow {
   title: string
   created_by_kind: string
   created_by_id: string
+  created_at: Date
+}
+
+interface FollowUpRow {
+  id: string
+  note: string
   created_at: Date
 }
 
@@ -131,6 +138,10 @@ export async function plan(ctx: BackfillContext, workspaceId: string): Promise<S
     SELECT DISTINCT stream_id FROM delegated_tasks
     WHERE workspace_id = ${workspaceId} AND stream_id = ANY(${streamIds})
   `)
+  const followUpStreams = await ctx.pool.query<{ stream_id: string }>(sql`
+    SELECT DISTINCT stream_id FROM agent_follow_ups
+    WHERE workspace_id = ${workspaceId} AND stream_id = ANY(${streamIds})
+  `)
   const threadParents = await ctx.pool.query<{ parent_stream_id: string }>(sql`
     SELECT DISTINCT parent_stream_id FROM streams
     WHERE workspace_id = ${workspaceId}
@@ -152,6 +163,9 @@ export async function plan(ctx: BackfillContext, workspaceId: string): Promise<S
   }
   for (const row of delegationStreams.rows) {
     chunks.push({ kind: "delegations", streamId: row.stream_id, rootStreamId: rootByStream.get(row.stream_id)! })
+  }
+  for (const row of followUpStreams.rows) {
+    chunks.push({ kind: "follow_ups", streamId: row.stream_id, rootStreamId: rootByStream.get(row.stream_id)! })
   }
   for (const row of threadParents.rows) {
     chunks.push({
@@ -258,6 +272,35 @@ function delegationChunkRows(
     sequence: null,
     snippet: contextSnippet(task.title),
     detail: { title: task.title },
+  }))
+}
+
+/**
+ * Same identity key `AgentFollowUpService.schedule` writes — same category,
+ * `ref_id` and null `source_message_id` — so a re-run collides on
+ * `stream_context_items_identity` instead of duplicating. Status and
+ * `scheduled_for` are joined live on read, never stored.
+ */
+function followUpChunkRows(
+  chunk: StreamContextChunk & { kind: "follow_ups" },
+  workspaceId: string,
+  followUps: FollowUpRow[]
+): NewStreamContextItem[] {
+  return followUps.map((followUp) => ({
+    id: streamContextItemId(),
+    workspaceId,
+    streamId: chunk.streamId,
+    rootStreamId: chunk.rootStreamId,
+    category: "follow_up" as const,
+    refKind: "follow_up" as const,
+    refId: followUp.id,
+    groupKey: followUp.id,
+    sourceMessageId: null,
+    authorId: null,
+    occurredAt: followUp.created_at,
+    sequence: null,
+    snippet: contextSnippet(followUp.note),
+    detail: { note: followUp.note },
   }))
 }
 
@@ -455,6 +498,20 @@ async function processDelegationsChunk(
   return delegationChunkRows(chunk, workspaceId, delegations.rows)
 }
 
+async function processFollowUpsChunk(
+  ctx: BackfillContext,
+  workspaceId: string,
+  chunk: StreamContextChunk & { kind: "follow_ups" }
+): Promise<NewStreamContextItem[]> {
+  const followUps = await ctx.pool.query<FollowUpRow>(sql`
+    SELECT id, note, created_at
+    FROM agent_follow_ups
+    WHERE workspace_id = ${workspaceId} AND stream_id = ${chunk.streamId}
+    ORDER BY id
+  `)
+  return followUpChunkRows(chunk, workspaceId, followUps.rows)
+}
+
 async function processThreadsChunk(
   ctx: BackfillContext,
   workspaceId: string,
@@ -500,6 +557,9 @@ export async function processChunk(
       break
     case "delegations":
       rows = await processDelegationsChunk(ctx, workspaceId, chunk)
+      break
+    case "follow_ups":
+      rows = await processFollowUpsChunk(ctx, workspaceId, chunk)
       break
     case "threads":
       rows = await processThreadsChunk(ctx, workspaceId, chunk)

--- a/apps/backend/src/features/stream-context/handlers.ts
+++ b/apps/backend/src/features/stream-context/handlers.ts
@@ -26,6 +26,13 @@ const filterQuerySchema = z.object({
 
 const listQuerySchema = baseQuerySchema.merge(filterQuerySchema).extend({
   category: z.enum(CONTEXT_CATEGORIES).optional(),
+  /** Comma-separated, for a chip that stands for more than one category. */
+  categories: z
+    .string()
+    .min(1)
+    .transform((raw) => raw.split(","))
+    .pipe(z.array(z.enum(CONTEXT_CATEGORIES)).min(1))
+    .optional(),
 })
 
 const occurrencesQuerySchema = baseQuerySchema.merge(filterQuerySchema).extend({
@@ -47,6 +54,7 @@ export function createStreamContextHandlers({ streamContextService }: Dependenci
         streamId: req.params.streamId!,
         scope: query.scope,
         category: query.category,
+        categories: query.categories,
         queryText: query.q,
         authorId: query.from,
         before: query.before ? new Date(query.before) : undefined,

--- a/apps/backend/src/features/stream-context/read-repository.ts
+++ b/apps/backend/src/features/stream-context/read-repository.ts
@@ -19,6 +19,10 @@ export interface StreamContextFeedFilters {
   streamId: string
   scope: StreamContextScope
   category?: ContextCategory
+  /** Multi-category narrowing (the Agent chip's two categories). Applied on top
+   *  of `category`, which stays the single-category form the occurrences read
+   *  requires. */
+  categories?: ContextCategory[]
   queryText?: string
   authorId?: string
   /** Exclusive upper bound on `occurred_at`. */
@@ -83,6 +87,10 @@ interface DbRow {
   task_status_note: string | null
   task_result_message_id: string | null
   delegation_event_id: string | null
+  follow_up_note: string | null
+  follow_up_status: string | null
+  follow_up_scheduled_for: Date | null
+  follow_up_event_id: string | null
   thread_name: string | null
   thread_reply_count: number | null
   thread_last_reply_at: Date | null
@@ -136,9 +144,9 @@ function detailFor(row: DbRow): StreamContextItemDetail {
       }
     case "follow_up":
       return {
-        note: stringOrNull(row.detail.note) ?? row.snippet,
-        status: (stringOrNull(row.detail.status) ?? "pending") as FollowUpStatus,
-        scheduledFor: stringOrNull(row.detail.scheduledFor),
+        note: row.follow_up_note ?? stringOrNull(row.detail.note) ?? row.snippet,
+        status: (row.follow_up_status ?? "pending") as FollowUpStatus,
+        scheduledFor: row.follow_up_scheduled_for?.toISOString() ?? null,
       }
     case "thread":
       return {
@@ -152,11 +160,13 @@ function detailFor(row: DbRow): StreamContextItemDetail {
 
 /**
  * The event a row deep-links to when it has no source message: the delegation's
- * created card, or the anchor a card-anchored thread hangs under. Null for every
+ * created card, the follow-up's scheduled card, or the anchor a card-anchored
+ * thread hangs under. Null for every
  * artifact that lives in a message — those jump by `sourceMessageId`.
  */
 function anchorEventIdFor(row: DbRow): string | null {
   if (row.category === "delegation") return row.delegation_event_id
+  if (row.category === "follow_up") return row.follow_up_event_id
   if (row.category === "thread") {
     const anchor = stringOrNull(row.detail.anchorEventId) ?? row.thread_anchor_event_id
     return anchor?.startsWith("event_") ? anchor : null
@@ -239,6 +249,10 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
       dt.status_note AS task_status_note,
       dt.result_message_id AS task_result_message_id,
       de.id AS delegation_event_id,
+      afu.note AS follow_up_note,
+      afu.status AS follow_up_status,
+      afu.scheduled_for AS follow_up_scheduled_for,
+      fue.id AS follow_up_event_id,
       th.display_name AS thread_name,
       th.reply_count AS thread_reply_count,
       th.last_reply_at AS thread_last_reply_at,
@@ -265,6 +279,15 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
      AND de.stream_id = sci.stream_id
      AND de.event_type = 'delegation:created'
      AND de.payload->>'delegationId' = sci.ref_id
+    LEFT JOIN agent_follow_ups afu
+      ON sci.category = 'follow_up'
+     AND afu.workspace_id = sci.workspace_id
+     AND afu.id = sci.ref_id
+    LEFT JOIN stream_events fue
+      ON sci.category = 'follow_up'
+     AND fue.stream_id = sci.stream_id
+     AND fue.event_type = 'agent:follow_up_scheduled'
+     AND fue.payload->>'followUpId' = sci.ref_id
     LEFT JOIN streams th
       ON sci.category = 'thread'
      AND th.workspace_id = sci.workspace_id
@@ -275,6 +298,7 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
         OR (${!isTree} AND sci.stream_id = ${filters.streamId})
       )
       AND (${filters.category === undefined} OR sci.category = ${filters.category ?? ""})
+      AND (${filters.categories === undefined} OR sci.category = ANY(${filters.categories ?? [""]}))
       AND (${extra?.groupKey === undefined} OR sci.group_key = ${extra?.groupKey ?? ""})
       AND (${filters.authorId === undefined} OR sci.author_id = ${filters.authorId ?? ""})
       AND (${filters.before === undefined} OR sci.occurred_at < ${filters.before ?? EPOCH}::timestamptz)
@@ -288,6 +312,7 @@ function scopedSql(filters: StreamContextFeedFilters, extra?: { groupKey?: strin
         OR att.filename ILIKE ${likePattern}
         OR mem.title ILIKE ${likePattern}
         OR dt.title ILIKE ${likePattern}
+        OR afu.note ILIKE ${likePattern}
         OR th.display_name ILIKE ${likePattern}
       )
   `

--- a/apps/backend/src/features/stream-context/service.ts
+++ b/apps/backend/src/features/stream-context/service.ts
@@ -23,6 +23,7 @@ export interface ListStreamContextParams {
   streamId: string
   scope: StreamContextScope
   category?: ContextCategory
+  categories?: ContextCategory[]
   queryText?: string
   authorId?: string
   before?: Date
@@ -98,6 +99,7 @@ export function createStreamContextService({ pool }: Dependencies) {
         streamId: params.streamId,
         scope: params.scope,
         category: params.category,
+        categories: params.categories,
         queryText: params.queryText,
         authorId: params.authorId,
         before: params.before,
@@ -109,7 +111,11 @@ export function createStreamContextService({ pool }: Dependencies) {
       // selector must not narrow them — every other chip would read 0.
       const counts = cursor
         ? null
-        : await StreamContextReadRepository.countsByCategory(pool, { ...filters, category: undefined })
+        : await StreamContextReadRepository.countsByCategory(pool, {
+            ...filters,
+            category: undefined,
+            categories: undefined,
+          })
       return { ...page(rows, params.limit), counts, mode: "index" }
     },
 

--- a/apps/backend/tests/integration/follow-up-context-index.test.ts
+++ b/apps/backend/tests/integration/follow-up-context-index.test.ts
@@ -28,7 +28,10 @@ describe("follow-up context index against the real schema", () => {
   let contextService: ReturnType<typeof createStreamContextService>
 
   const wsId = workspaceId()
-  const scheduledFor = new Date("2026-08-01T09:00:00.000Z")
+  // Relative, not a literal: a fixed instant goes stale the day it passes, and
+  // then the firing worker fires this row before the cancel test reaches it —
+  // `cancel` no-ops on a fired follow-up and the suite starts failing on a date.
+  const scheduledFor = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
   let ownerId: string
   let channelId: string
   let followUpId: string

--- a/apps/backend/tests/integration/follow-up-context-index.test.ts
+++ b/apps/backend/tests/integration/follow-up-context-index.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The `follow_up` arm of the "In this stream" index, against a real schema.
+ *
+ * The row's status and scheduled time are NOT stored on the projection — they
+ * are joined live from `agent_follow_ups` — and its deep link comes from a
+ * payload-key join on `stream_events`. A fake Querier cannot tell either join
+ * from a column that does not exist (INV-68), and the failure it would hide is
+ * the one this whole arm exists to avoid: a cancelled follow-up still reading
+ * `pending` in the panel.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService } from "../../src/features/streams"
+import { AgentFollowUpService } from "../../src/features/agents"
+import { createStreamContextService, StreamContextRepository } from "../../src/features/stream-context"
+import { plan, processChunk } from "../../src/features/stream-context/backfill"
+import { DelegationService } from "../../src/features/delegations"
+import { streamContextItemId, workspaceId } from "../../src/lib/id"
+import { sql } from "../../src/db"
+import { AuthorTypes, StreamTypes, Visibilities, type StreamContextFollowUpDetail } from "@threa/types"
+
+describe("follow-up context index against the real schema", () => {
+  let pool: Pool
+  let followUpService: AgentFollowUpService
+  let contextService: ReturnType<typeof createStreamContextService>
+
+  const wsId = workspaceId()
+  const scheduledFor = new Date("2026-08-01T09:00:00.000Z")
+  let ownerId: string
+  let channelId: string
+  let followUpId: string
+  let delegationRefId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    followUpService = new AgentFollowUpService({
+      pool,
+      workspaceSettingsService: { getSettings: async () => ({ maxPendingFollowUps: 10 }) },
+    })
+    contextService = createStreamContextService({ pool })
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Follow-up WS",
+        slug: `follow-up-ws-${wsId}`,
+        createdBy: wsId,
+      })
+      ownerId = (await addTestMember(client, wsId, `owner-${wsId.slice(-8)}`)).id
+    })
+
+    const channel = await new StreamService(pool).create({
+      workspaceId: wsId,
+      type: StreamTypes.CHANNEL,
+      name: "follow-up-channel",
+      slug: `follow-up-channel-${wsId.slice(-8)}`,
+      visibility: Visibilities.PUBLIC,
+      createdBy: ownerId,
+    })
+    channelId = channel.id
+
+    const scheduled = await followUpService.schedule({
+      workspaceId: wsId,
+      streamId: channelId,
+      personaId: "persona_system_ariadne",
+      sessionId: "session_1",
+      sourceConversationId: null,
+      note: "check back on the deploy",
+      scheduledFor,
+    })
+    if (!scheduled.ok) throw new Error("follow-up schedule hit the cap")
+    followUpId = scheduled.followUp.id
+
+    const delegation = await new DelegationService({ pool }).create({
+      workspaceId: wsId,
+      streamId: channelId,
+      sessionId: null,
+      sourceConversationId: null,
+      createdByKind: AuthorTypes.PERSONA,
+      createdById: "persona_system_ariadne",
+      title: "walk the release checklist",
+      brief: "confirm every step is signed off",
+      contextRefs: [],
+    })
+    delegationRefId = delegation.id
+
+    // A third category, so `categories` has something to exclude.
+    await StreamContextRepository.insertMany(pool, [
+      {
+        id: streamContextItemId(),
+        workspaceId: wsId,
+        streamId: channelId,
+        rootStreamId: channelId,
+        category: "link",
+        refKind: "url",
+        refId: "https://example.test/release",
+        groupKey: "https://example.test/release",
+        sourceMessageId: null,
+        authorId: ownerId,
+        occurredAt: new Date("2026-07-29T09:00:00.000Z"),
+        sequence: null,
+        snippet: "release notes",
+        detail: { url: "https://example.test/release" },
+      },
+    ])
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function readFollowUpRow() {
+    const response = await contextService.list({
+      workspaceId: wsId,
+      userId: ownerId,
+      streamId: channelId,
+      scope: "tree",
+      limit: 20,
+    })
+    return response
+  }
+
+  test("scheduling projects one indexed row carrying the live pending status", async () => {
+    const response = await readFollowUpRow()
+    const item = response.items.find((row) => row.category === "follow_up")
+
+    expect({
+      refId: item?.refId,
+      snippet: item?.snippet,
+      detail: item?.detail as StreamContextFollowUpDetail,
+      followUpCount: response.counts?.follow_up,
+    }).toEqual({
+      refId: followUpId,
+      snippet: "check back on the deploy",
+      detail: {
+        note: "check back on the deploy",
+        status: "pending",
+        scheduledFor: scheduledFor.toISOString(),
+      },
+      followUpCount: 1,
+    })
+  })
+
+  test("the row deep-links to its agent:follow_up_scheduled event", async () => {
+    const response = await readFollowUpRow()
+    const item = response.items.find((row) => row.category === "follow_up")
+    const event = await pool.query<{ id: string }>(sql`
+      SELECT id FROM stream_events
+      WHERE stream_id = ${channelId}
+        AND event_type = 'agent:follow_up_scheduled'
+        AND payload->>'followUpId' = ${followUpId}
+    `)
+
+    expect(item?.anchorEventId).toBe(event.rows[0]!.id)
+  })
+
+  test("the free-text predicate reaches the joined note", async () => {
+    const response = await contextService.list({
+      workspaceId: wsId,
+      userId: ownerId,
+      streamId: channelId,
+      scope: "tree",
+      queryText: "the deploy",
+      limit: 20,
+    })
+
+    expect(response.items.map((row) => row.refId)).toEqual([followUpId])
+  })
+
+  test("the categories filter returns both agent categories and nothing else", async () => {
+    // Three categories have to be present for this to discriminate: with only
+    // the follow-up in the stream the assertion holds even if `categories` is
+    // ignored outright, or honours just its first element.
+    const response = await contextService.list({
+      workspaceId: wsId,
+      userId: ownerId,
+      streamId: channelId,
+      scope: "tree",
+      categories: ["follow_up", "delegation"],
+      limit: 20,
+    })
+
+    expect({
+      categories: [...new Set(response.items.map((row) => row.category))].sort(),
+      refIds: response.items.map((row) => row.refId).sort(),
+    }).toEqual({
+      categories: ["delegation", "follow_up"],
+      refIds: [delegationRefId, followUpId].sort(),
+    })
+  })
+
+  test("cancelling flips the indexed row's status — the stored detail cannot show pending", async () => {
+    const cancelled = await followUpService.cancel({ workspaceId: wsId, id: followUpId })
+    expect(cancelled?.status).toBe("cancelled")
+
+    const stored = await pool.query<{ detail: Record<string, unknown> }>(sql`
+      SELECT detail FROM stream_context_items
+      WHERE workspace_id = ${wsId} AND category = 'follow_up' AND ref_id = ${followUpId}
+    `)
+    const response = await readFollowUpRow()
+    const item = response.items.find((row) => row.category === "follow_up")
+
+    expect({
+      storedDetail: stored.rows[0]?.detail,
+      readStatus: (item?.detail as StreamContextFollowUpDetail).status,
+    }).toEqual({
+      storedDetail: { note: "check back on the deploy" },
+      readStatus: "cancelled",
+    })
+  })
+
+  test("the follow_ups backfill chunk is idempotent against the live row", async () => {
+    const chunks = (await plan({ pool } as never, wsId)).filter((chunk) => chunk.kind === "follow_ups")
+    expect(chunks).toEqual([{ kind: "follow_ups", streamId: channelId, rootStreamId: channelId }])
+
+    const counts: number[] = []
+    for (let run = 0; run < 2; run += 1) {
+      for (const chunk of chunks) await processChunk({ pool } as never, wsId, chunk)
+      const rows = await pool.query<{ count: string }>(sql`
+        SELECT count(*)::text AS count FROM stream_context_items
+        WHERE workspace_id = ${wsId} AND category = 'follow_up'
+      `)
+      counts.push(Number(rows.rows[0]!.count))
+    }
+
+    expect(counts).toEqual([1, 1])
+  })
+})

--- a/apps/frontend/src/api/stream-context.ts
+++ b/apps/frontend/src/api/stream-context.ts
@@ -20,6 +20,8 @@ export interface StreamContextFilters {
 export interface ListStreamContextRequest extends StreamContextFilters {
   scope?: StreamContextScope
   category?: ContextCategory
+  /** Serialized comma-separated; for a chip standing for more than one category. */
+  categories?: ContextCategory[]
   cursor?: string
   limit?: number
 }
@@ -32,10 +34,14 @@ export interface ListStreamContextOccurrencesRequest extends StreamContextFilter
   limit?: number
 }
 
-function toQueryString(params: Record<string, string | number | undefined>): string {
+function toQueryString(params: Record<string, string | number | string[] | undefined>): string {
   const search = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === "") continue
+    if (Array.isArray(value)) {
+      if (value.length > 0) search.set(key, value.join(","))
+      continue
+    }
     search.set(key, String(value))
   }
   const serialized = search.toString()

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { createElement, Fragment, createRef } from "react"
 import { render, screen } from "@testing-library/react"
 import * as streamContextListModule from "./stream-context-list"
-import { ContextTimeline } from "./stream-context-chrome"
+import { chipsFromCounts, ContextTimeline, filterCategories, filterCount, parseFilter } from "./stream-context-chrome"
 import type { ContextItem } from "@/lib/stream-context/types"
 
 /**
@@ -79,5 +79,41 @@ describe("ContextTimeline virtualization wiring", () => {
 
     expect(seam).not.toHaveBeenCalled()
     expect(screen.getByText("a")).toBeInTheDocument()
+  })
+})
+
+describe("the Agent chip", () => {
+  const counts = { link: 3, media: 0, file: 0, memo: 0, delegation: 2, follow_up: 4, thread: 0 }
+
+  it("stands for both agent categories: one chip, their summed count, ahead of the per-category chips", () => {
+    expect(chipsFromCounts(counts, 9)).toEqual([
+      { value: "all", label: "All", count: 9 },
+      { value: "agent", label: "Agent", count: 6 },
+      { value: "link", label: "Links", count: 3 },
+      { value: "delegation", label: "Delegations", count: 2 },
+      { value: "follow_up", label: "Follow-ups", count: 4 },
+    ])
+  })
+
+  it("is absent when neither agent category has rows", () => {
+    const empty = { ...counts, delegation: 0, follow_up: 0 }
+
+    expect(chipsFromCounts(empty, 3).map((chip) => chip.value)).toEqual(["all", "link"])
+  })
+
+  it("is addressable as ?context=agent and narrows to both categories", () => {
+    expect({
+      parsed: parseFilter("agent"),
+      categories: filterCategories("agent"),
+      singleCategory: filterCategories("follow_up"),
+      all: filterCategories("all"),
+      count: filterCount(counts, "agent", 9),
+    }).toEqual({
+      parsed: "agent",
+      categories: ["follow_up", "delegation"],
+      singleCategory: ["follow_up"],
+      all: undefined,
+      count: 6,
+    })
   })
 })

--- a/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-chrome.tsx
@@ -12,7 +12,25 @@ import { groupItemsByDay } from "@/lib/stream-context/grouping"
 import { CONTEXT_CATEGORIES, type ContextCategory, type ContextItem } from "@/lib/stream-context/types"
 import { cn } from "@/lib/utils"
 
-export type Filter = "all" | ContextCategory
+/** `agent` stands for both agent-outcome categories at once — see {@link AGENT_FILTER_CATEGORIES}. */
+export type Filter = "all" | ContextCategory | "agent"
+
+/** The two categories the Agent chip selects, and whose counts it sums. */
+export const AGENT_FILTER_CATEGORIES = ["follow_up", "delegation"] as const satisfies readonly ContextCategory[]
+
+/** The categories a filter narrows to, or `undefined` for the whole scope. */
+export function filterCategories(filter: Filter): ContextCategory[] | undefined {
+  if (filter === "all") return undefined
+  if (filter === "agent") return [...AGENT_FILTER_CATEGORIES]
+  return [filter]
+}
+
+/** The count a chip shows — the Agent chip sums the categories it stands for. */
+export function filterCount(counts: Record<ContextCategory, number>, filter: Filter, total: number): number {
+  if (filter === "all") return total
+  if (filter === "agent") return AGENT_FILTER_CATEGORIES.reduce((sum, c) => sum + counts[c], 0)
+  return counts[filter]
+}
 
 /** The props both panel implementations take; the index panel owns the choice. */
 export interface StreamContextPanelProps {
@@ -37,6 +55,7 @@ export const CATEGORY_LABELS: Record<ContextCategory, string> = {
 
 export function parseFilter(raw: string | null): Filter {
   if (raw === "all") return "all"
+  if (raw === "agent") return "agent"
   if (raw && (CONTEXT_CATEGORIES as string[]).includes(raw)) return raw as ContextCategory
   return "all"
 }
@@ -74,8 +93,10 @@ export interface ContextChip {
 
 /** Build the chip row from per-category counts, dropping empty categories. */
 export function chipsFromCounts(counts: Record<ContextCategory, number>, total: number): ContextChip[] {
+  const agentCount = filterCount(counts, "agent", total)
   return [
     { value: "all", label: "All", count: total },
+    ...(agentCount > 0 ? [{ value: "agent" as Filter, label: "Agent", count: agentCount }] : []),
     ...CONTEXT_CATEGORIES.filter((c) => counts[c] > 0).map((c) => ({
       value: c as Filter,
       label: CATEGORY_LABELS[c],

--- a/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-derived-panel.tsx
@@ -10,8 +10,10 @@ import { delegationContextItems, withDelegations } from "@/lib/stream-context/de
 import { followUpContextItems, withFollowUps } from "@/lib/stream-context/follow-ups"
 import { StreamContextRow } from "./stream-context-row"
 import {
+  AGENT_FILTER_CATEGORIES,
   chipsFromCounts,
   ContextChipRow,
+  filterCount,
   ContextEmpty,
   ContextPanelHeader,
   ContextSkeleton,
@@ -72,15 +74,25 @@ export function StreamContextDerivedPanel({
   // "all" so the body never strands the user on an empty filter. The delegation
   // count isn't known until its query settles, so a `?context=delegation` deep
   // link holds the requested view instead of flickering All → Delegations.
+  // The Agent chip stands for both agent categories, so it only settles once
+  // both of their queries have.
+  const agentPending = delegationsPending || outcomesQuery.isPending
   const filterSettled =
-    (filter !== "delegation" || !delegationsPending) && (filter !== "follow_up" || !outcomesQuery.isPending)
-  const effectiveFilter: Filter = filter !== "all" && filterSettled && counts[filter] === 0 ? "all" : filter
+    (filter !== "delegation" || !delegationsPending) &&
+    (filter !== "follow_up" || !outcomesQuery.isPending) &&
+    (filter !== "agent" || !agentPending)
+  const effectiveFilter: Filter =
+    filter !== "all" && filterSettled && filterCount(counts, filter, total) === 0 ? "all" : filter
   // Memoized for its identity as much as its cost: the timeline's day grouping
   // is keyed on this array, and a fresh one per render would miss that memo.
-  const visible = useMemo(
-    () => (effectiveFilter === "all" ? items : items.filter((i) => i.category === effectiveFilter)),
-    [items, effectiveFilter]
-  )
+  const visible = useMemo(() => {
+    if (effectiveFilter === "agent") {
+      const agentCategories: readonly string[] = AGENT_FILTER_CATEGORIES
+      return items.filter((i) => agentCategories.includes(i.category))
+    }
+    if (effectiveFilter !== "all") return items.filter((i) => i.category === effectiveFilter)
+    return items
+  }, [items, effectiveFilter])
   const isLoading = events === undefined || ((delegationsPending || outcomesQuery.isPending) && visible.length === 0)
 
   const scrollerRef = useRef<HTMLDivElement | null>(null)

--- a/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-index-panel.tsx
@@ -36,6 +36,8 @@ import { useStreamContextFeed } from "./use-stream-context-feed"
 import {
   chipsFromCounts,
   ContextChipRow,
+  filterCategories,
+  filterCount,
   ContextEmpty,
   ContextPanelHeader,
   ContextSkeleton,
@@ -118,12 +120,16 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   // out) must not strand the panel on a filter the scope has nothing for — fall
   // back to "all" once the server-owned counts say so, for the query and the
   // chip row alike.
-  const effectiveFilter: Filter = filter !== "all" && serverCounts?.[filter] === 0 ? "all" : filter
+  // `filterCount` reads the Agent chip as the SUM of its two categories, so a
+  // `?context=agent` link survives once counts land as long as either has rows —
+  // `counts["agent"]` is not a key and indexing for it would read `undefined`.
+  const effectiveFilter: Filter =
+    filter !== "all" && serverCounts !== null && filterCount(serverCounts, filter, 0) === 0 ? "all" : filter
 
-  const category: ContextCategory | undefined = effectiveFilter === "all" ? undefined : effectiveFilter
+  const categories = useMemo(() => filterCategories(effectiveFilter), [effectiveFilter])
   const feed = useStreamContextFeed(workspaceId, streamId, rootStreamId, {
     scope: "tree",
-    category,
+    categories,
     q: debounced.parsed.text || undefined,
     from: debounced.authorId ?? undefined,
     before: debounced.before,
@@ -158,14 +164,14 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
     () =>
       collapseContextRows(
         filterContextRows(rows ?? [], {
-          category,
+          categories,
           terms: searchTerms,
           authorId: authorId ?? undefined,
           before,
           after,
         })
       ),
-    [rows, category, searchTerms, authorId, before, after]
+    [rows, categories, searchTerms, authorId, before, after]
   )
   // Counts are whole-scope facts the server owns; the local tally is the
   // offline/first-paint fallback: computed over the same search/author/date
@@ -222,7 +228,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
   const jumpGeneration = useRef(0)
   useEffect(() => {
     jumpGeneration.current += 1
-  }, [category, searchTerms, authorId, before, after])
+  }, [categories, searchTerms, authorId, before, after])
   const jumpToDate = useCallback(
     async (date: Date) => {
       const generation = (jumpGeneration.current += 1)
@@ -245,7 +251,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
         const fresh = await readStreamContextRows(workspaceId, streamId, rootStreamId, "tree")
         const rebuilt = collapseContextRows(
           filterContextRows(fresh, {
-            category,
+            categories,
             terms: searchTerms,
             authorId: authorId ?? undefined,
             before,
@@ -272,7 +278,7 @@ export function StreamContextIndexPanel(props: StreamContextPanelProps) {
       // keep tabbing from where they landed.
       scrollerRef.current?.focus({ preventScroll: true })
     },
-    [items, feed, workspaceId, streamId, rootStreamId, category, searchTerms, authorId, before, after]
+    [items, feed, workspaceId, streamId, rootStreamId, categories, searchTerms, authorId, before, after]
   )
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = feed
   useEffect(() => {

--- a/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.integration.test.tsx
@@ -19,6 +19,7 @@ import * as storeModule from "@/stores/stream-context-store"
 import {
   streamContextItemKey,
   type AgentOutcomeSummary,
+  type DelegationSummary,
   type ListStreamContextResponse,
   type StreamContextItem,
 } from "@threa/types"
@@ -83,14 +84,21 @@ function LocationProbe() {
   return <span data-testid="location">{`${location.search}|${seen.current}`}</span>
 }
 
-function renderPanel(options: { entry?: string; memberIds?: string[]; outcomes?: AgentOutcomeSummary[] } = {}) {
+function renderPanel(
+  options: {
+    entry?: string
+    memberIds?: string[]
+    outcomes?: AgentOutcomeSummary[]
+    delegations?: DelegationSummary[]
+  } = {}
+) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   if (options.memberIds) {
     queryClient.setQueryData(streamKeys.bootstrap(WS, STREAM), {
       members: options.memberIds.map((memberId) => ({ streamId: STREAM, memberId })),
     })
   }
-  queryClient.setQueryData(delegationKeys.stream(WS, STREAM), { delegations: [] })
+  queryClient.setQueryData(delegationKeys.stream(WS, STREAM), { delegations: options.delegations ?? [] })
   queryClient.setQueryData(agentOutcomeKeys.stream(WS, STREAM), {
     items: options.outcomes ?? [],
     nextCursor: null,
@@ -205,7 +213,6 @@ describe("StreamContextPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "Go to follow-up Check the staging deploy" }))
     expect(onJumpToMessage).toHaveBeenCalledWith("event_followup")
   })
-
 
   it("renders rows from IDB and appends the next page when the sentinel intersects", async () => {
     await db.streamContextItems.bulkPut([
@@ -925,5 +932,157 @@ describe("StreamContextPanel", () => {
     expect(await screen.findByText("Cached")).toBeInTheDocument()
     const boundary = await screen.findByText(/Offline — showing what's cached/)
     expect(within(boundary.parentElement!).getByText(/reconnect/)).toBeInTheDocument()
+  })
+})
+
+/**
+ * The Agent chip is one control over TWO categories, and a sealed stream renders
+ * it from the derive path instead of the index, so both paths are exercised —
+ * one proves nothing about the other.
+ */
+describe("StreamContextPanel — the Agent chip", () => {
+  const followUp: AgentOutcomeSummary = {
+    id: "afu_1",
+    kind: "follow_up",
+    streamId: STREAM,
+    title: "Check the staging deploy",
+    status: "pending",
+    scheduledFor: "2026-06-25T09:00:00.000Z",
+    claimedByLabel: null,
+    statusNote: null,
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-06-24T10:00:00.000Z",
+    statusChangedAt: "2026-06-24T10:00:00.000Z",
+    occursAt: "2026-06-25T09:00:00.000Z",
+    anchorEventId: "event_followup",
+  }
+  const delegation: DelegationSummary = {
+    id: "deleg_1",
+    streamId: STREAM,
+    title: "Run the migration locally",
+    status: "open",
+    claimedByLabel: null,
+    resultMessageId: null,
+    statusNote: null,
+    createdEventId: "event_delegation",
+    createdAt: "2026-06-24T11:00:00.000Z",
+    statusChangedAt: "2026-06-24T11:00:00.000Z",
+  }
+
+  it("derived panel: sums both categories and shows both when selected", async () => {
+    await db.streams.put({ id: STREAM, workspaceId: WS, rootStreamId: null, e2eEnabled: true } as never)
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(listResponse({ counts: null, mode: "client" }))
+
+    renderPanel({ outcomes: [followUp], delegations: [delegation] })
+
+    const chip = await screen.findByRole("button", { name: /^Agent/ })
+    expect(chip.textContent).toBe("Agent2")
+
+    await userEvent.click(chip)
+
+    expect(await screen.findByText("Check the staging deploy")).toBeInTheDocument()
+    expect(screen.getByText("Run the migration locally")).toBeInTheDocument()
+    expect(chip).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("indexed panel: selects both categories on one request and shows both rows", async () => {
+    await db.streamContextItems.bulkPut([
+      cachedRow(
+        serverItem({
+          category: "follow_up",
+          refKind: "follow_up",
+          refId: "afu_1",
+          sourceMessageId: null,
+          anchorEventId: "event_followup",
+          snippet: "Check the staging deploy",
+          detail: { note: "Check the staging deploy", status: "pending", scheduledFor: "2026-06-25T09:00:00.000Z" },
+        })
+      ),
+      cachedRow(
+        serverItem({
+          category: "delegation",
+          refKind: "delegation",
+          refId: "deleg_1",
+          sourceMessageId: null,
+          anchorEventId: "event_delegation",
+          detail: { title: "Run the migration locally", status: "open" },
+        })
+      ),
+      cachedRow(
+        serverItem({
+          category: "link",
+          refId: "https://a.example",
+          detail: { url: "https://a.example", title: "Alpha" },
+        })
+      ),
+    ])
+    const list = vi
+      .spyOn(streamContextApi, "list")
+      .mockResolvedValue(listResponse({ counts: { ...EMPTY_COUNTS, link: 1, delegation: 1, follow_up: 1 } }))
+
+    renderPanel()
+
+    const chip = await screen.findByRole("button", { name: /^Agent/ })
+    expect(chip.textContent).toBe("Agent2")
+
+    await userEvent.click(chip)
+
+    expect(screen.getByText("Check the staging deploy")).toBeInTheDocument()
+    expect(screen.getByText("Run the migration locally")).toBeInTheDocument()
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument()
+    await waitFor(() => expect(list.mock.calls.at(-1)?.[2]).toMatchObject({ categories: ["follow_up", "delegation"] }))
+  })
+
+  it("indexed panel: a ?context=follow_up deep link survives the arrival of server counts", async () => {
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({
+          category: "follow_up",
+          refKind: "follow_up",
+          refId: "afu_1",
+          sourceMessageId: null,
+          anchorEventId: "event_followup",
+          snippet: "Check the staging deploy",
+          detail: { note: "Check the staging deploy", status: "pending", scheduledFor: "2026-06-25T09:00:00.000Z" },
+        })
+      )
+    )
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(
+      listResponse({ counts: { ...EMPTY_COUNTS, link: 4, follow_up: 1 } })
+    )
+
+    renderPanel({ entry: "/s?context=follow_up" })
+
+    expect(await screen.findByText("Check the staging deploy")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Follow-ups/ })).toHaveAttribute("aria-pressed", "true")
+    )
+    expect(screen.getByRole("button", { name: /^All/ })).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("indexed panel: a ?context=agent deep link survives the arrival of server counts", async () => {
+    await db.streamContextItems.put(
+      cachedRow(
+        serverItem({
+          category: "follow_up",
+          refKind: "follow_up",
+          refId: "afu_1",
+          sourceMessageId: null,
+          anchorEventId: "event_followup",
+          snippet: "Check the staging deploy",
+          detail: { note: "Check the staging deploy", status: "pending", scheduledFor: "2026-06-25T09:00:00.000Z" },
+        })
+      )
+    )
+    vi.spyOn(streamContextApi, "list").mockResolvedValue(
+      listResponse({ counts: { ...EMPTY_COUNTS, link: 4, follow_up: 1 } })
+    )
+
+    renderPanel({ entry: "/s?context=agent" })
+
+    expect(await screen.findByText("Check the staging deploy")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole("button", { name: /^Agent/ })).toHaveAttribute("aria-pressed", "true"))
   })
 })

--- a/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-context-feed.ts
@@ -12,6 +12,8 @@ export const streamContextKeys = {
 export interface UseStreamContextFeedOptions {
   scope?: StreamContextScope
   category?: ContextCategory
+  /** Two-or-more-category narrowing (the Agent chip). */
+  categories?: ContextCategory[]
   /** Free text; already debounced by the caller. */
   q?: string
   /** Author **id** (the panel resolves `from:@slug` before calling). */
@@ -53,10 +55,19 @@ export function useStreamContextFeed(
   rootStreamId: string,
   options: UseStreamContextFeedOptions = {}
 ): StreamContextFeed {
-  const { scope = "tree", category, q, from, before, after, enabled = true } = options
+  const { scope = "tree", category, categories, q, from, before, after, enabled = true } = options
+  const categoriesKey = categories?.join(",")
 
   const query = useInfiniteQuery({
-    queryKey: streamContextKeys.feed(workspaceId, streamId, { scope, category, q, from, before, after }),
+    queryKey: streamContextKeys.feed(workspaceId, streamId, {
+      scope,
+      category,
+      categories: categoriesKey,
+      q,
+      from,
+      before,
+      after,
+    }),
     // Seeding here, not in an effect, is what makes "the page is in IDB by the
     // time the fetch resolves" structural: `fetchNextPage` awaits this, so the
     // date jump's paging loop can read IDB straight after. Once per page, too —
@@ -65,7 +76,16 @@ export function useStreamContextFeed(
     // from. A reconnect refetch re-runs this per page, so INV-53 catch-up still
     // rewrites the whole window.
     queryFn: async ({ pageParam }) => {
-      const request: ListStreamContextRequest = { scope, category, q, from, before, after, cursor: pageParam }
+      const request: ListStreamContextRequest = {
+        scope,
+        category,
+        categories,
+        q,
+        from,
+        before,
+        after,
+        cursor: pageParam,
+      }
       const page = await streamContextApi.list(workspaceId, streamId, request)
       await seedStreamContextItems(workspaceId, rootStreamId, page.items)
       return page

--- a/apps/frontend/src/lib/stream-context/filter.test.ts
+++ b/apps/frontend/src/lib/stream-context/filter.test.ts
@@ -39,6 +39,22 @@ describe("filterContextRows date bounds", () => {
   })
 })
 
+describe("filterContextRows free text", () => {
+  // A follow-up's display text is `detail.note`, and the endpoint searches
+  // `afu.note`. Phase 1 dropping what phase 2 returns leaves the chip row
+  // claiming a match the list cannot show.
+  it("matches a follow-up on its note, the term a user actually types", () => {
+    const followUp = row({
+      category: "follow_up",
+      groupKey: "agfu_1",
+      refKind: "follow_up",
+      detail: { note: "check back on the deploy", status: "pending", scheduledFor: null },
+    })
+
+    expect(filterContextRows([followUp], { terms: ["deploy"] })).toEqual([followUp])
+  })
+})
+
 describe("collapseContextRows", () => {
   it("keeps one row per group, represented by its newest occurrence", () => {
     const older = row({ sourceMessageId: "msg_a", occurredAt: "2026-06-20T10:00:00.000Z", snippet: "first" })

--- a/apps/frontend/src/lib/stream-context/filter.ts
+++ b/apps/frontend/src/lib/stream-context/filter.ts
@@ -3,6 +3,8 @@ import type { CachedStreamContextItem } from "@/db"
 
 export interface ContextRowFilters {
   category?: ContextCategory
+  /** Multi-category narrowing, mirroring the endpoint's `categories`. */
+  categories?: ContextCategory[]
   /** Free-text terms; a row must contain every one (case-insensitive). */
   terms?: string[]
   /** Author id. */
@@ -26,7 +28,17 @@ export interface ContextRowFilters {
 export function contextRowText(row: CachedStreamContextItem): string {
   const detail = row.detail as unknown as Record<string, unknown>
   const parts = [row.refId]
-  for (const field of ["url", "title", "siteName", "description", "filename", "giphyTitle", "name", "statusNote"]) {
+  for (const field of [
+    "url",
+    "title",
+    "siteName",
+    "description",
+    "filename",
+    "giphyTitle",
+    "name",
+    "note",
+    "statusNote",
+  ]) {
     const value = detail?.[field]
     if (typeof value === "string") parts.push(value)
   }
@@ -45,6 +57,7 @@ export function filterContextRows(
   const terms = (filters.terms ?? []).map((t) => t.toLowerCase()).filter(Boolean)
   return rows.filter((row) => {
     if (filters.category && row.category !== filters.category) return false
+    if (filters.categories && !filters.categories.includes(row.category)) return false
     if (filters.authorId && row.authorId !== filters.authorId) return false
     if (filters.before && row.occurredAt >= filters.before) return false
     if (filters.after && row.occurredAt < filters.after) return false


### PR DESCRIPTION
## Problem

[#1668](https://github.com/threahq/threa/pull/1668) made follow-ups readable, but only on the **derived** "In this stream" panel, which fetches them live. `streamContextIndex` picks between two panel implementations (`stream-context-panel.tsx:14`), and the **indexed** one counts what the server projected — nothing writes a `follow_up` row into `stream_context_items`. With the flag on, the category can't be addressed at all: `chipsFromCounts` drops a zero-count category, and `effectiveFilter` (`stream-context-index-panel.tsx:117`) resets `?context=follow_up` back to All.

Chunk 2 of 5 (plan: https://seer.build/ws_vbyzjvdg6g/b/outcomes-plan-5544fa/).

## Solution

`AgentFollowUpService.schedule` writes the projection row inside the **same transaction** as the follow-up row, its fire job and its `agent:follow_up_scheduled` outbox event (INV-4/7), skipped when `stream.e2eEnabled` — mirroring `delegations/service.ts:105`. A missing stream row logs and skips rather than throwing, same as the delegation path.

- **Status and `scheduledFor` are deliberately not stored on the projection.** They're joined live from `agent_follow_ups` at read time. A cancelled or rescheduled follow-up reading `pending` out of a stale row is exactly the failure this arm exists to avoid; the stored `detail` carries only the note, as the fallback for a row whose source is gone. The anchor is a constant-keyed join on `payload->>'followUpId'`, matching the delegation join rather than a computed key.
- **Backfill**: existing follow-ups have no rows, and a registered backfill is inert until enqueued (INV-67). A `follow_ups` chunk joins the existing `stream-context-index` definition — **not** a new name, which would dead-letter as `Unknown backfill` — and `20260729120000_backfill_follow_up_context_index.sql` enqueues it at `NOW() + 15 minutes` so old replicas cut over first. `followUpChunkRows` produces the write path's exact identity key, so a re-run collides on `stream_context_items_identity` instead of duplicating.
- **The Agent chip** unions follow-ups and delegations on both panels. `Filter` becomes `"all" | ContextCategory | "agent"`; `filterCategories`/`filterCount` mean no caller ever indexes a `Record<ContextCategory, number>` with `"agent"`.
- **`categories` array on the endpoint over client-filtering the `all` feed** — the feed pages 40 rows of *every* category, so in a link-heavy stream the Agent view would render near-empty and walk the sentinel through many round trips to surface a handful of rows, with `occurrenceCount` and the keyset computed over a set the user isn't looking at. Cost is one predicate, one Zod field and a query-key term; counts stay category-independent and whole-scope.

**Two fixes from review, both of which shipped green:**

- `contextRowText` (`lib/stream-context/filter.ts:31`) searched `url, title, siteName, description, filename, giphyTitle, name, statusNote` — a follow-up's detail is `{ note, status, scheduledFor }`, so every row reduced to its `agfu_…` id and any text search dropped it. Since the server half now matches `afu.note`, the chip read `Follow-ups 1` next to "No matches in this stream". The function's own docstring names the contract it broke: *"Mirrors the endpoint's predicate; the two must agree."* It had no test at all.
- The `categories` integration test ran against a stream holding exactly one item, so `["follow_up"]` was the right answer whether the parameter was honoured, ignored outright, or truncated to its first element. It now seeds a real delegation and a link row and asserts by refId across three categories.

**Not here**: no `fired`/`failed` outbox event (INV-36), no `stream_events` index, no Outcomes page/shell/modal, no sidebar link, no owner filter, no changes to the timeline cards.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/follow-up-service.ts` | projection insert on the schedule transaction; sealed streams skipped |
| `apps/backend/src/features/stream-context/read-repository.ts` | live `agent_follow_ups` join, constant-keyed anchor join, `afu.note` in free text, `categories` predicate |
| `apps/backend/src/features/stream-context/{service,handlers}.ts` | `categories` threaded through; counts still strip it |
| `apps/backend/src/features/stream-context/backfill.ts` | `follow_ups` chunk kind, `followUpChunkRows`, plan branch, processChunk arm |
| `apps/backend/src/db/migrations/20260729120000_backfill_follow_up_context_index.sql` | **new** — enqueue under `stream-context-index`, +15 min |
| `apps/frontend/src/components/stream-context/stream-context-chrome.tsx` | `"agent"` filter, `filterCategories`, `filterCount`, the chip |
| `apps/frontend/src/components/stream-context/stream-context-{index,derived}-panel.tsx` | the chip and its filter on both panels |
| `apps/frontend/src/lib/stream-context/filter.ts` | `note` in the searchable field list (review fix) |
| `apps/frontend/src/{api/stream-context.ts,components/stream-context/use-stream-context-feed.ts}` | `categories` on the wire |

## Test plan

- [x] `apps/backend` `test:unit` — 3842 pass / 0 fail
- [x] `apps/backend` `test:integration` — 741 pass / 0 fail, incl. 6 new in `follow-up-context-index.test.ts` against the real schema (INV-68)
- [x] `apps/frontend` vitest (stream-context) — 93 pass / 0 fail, Agent chip covered on **both** panels
- [x] `bun run typecheck` — exit 0 · `bun run lint` — exit 0, 248 migrations clean
- [x] **Mutation-checked, both review fixes.** Collapsing the service to `categories: [params.categories[0]]` turns the categories test red (5/1); restored 6/6. Removing `"note"` from the field list turns "matches a follow-up on its note" red; restored 93/0.
- [ ] The backfill's enqueue was not run end-to-end through the queue; the "old replicas cut over first" property rests on the 15-minute delay and `check:migrations`, not on an observation.
- [ ] No browser/layout check of the Agent chip — jsdom is blind to layout; the Outcomes surfaces get a Playwright pass in chunk 3.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/outcomes-plan-5544fa/ — 5 chunks. This is C2.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787938601&installation_model_id=20758&pr_number=1669&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1669&signature=1a279c1da6c220a1b9d4e742bad2495a6b1776e3d9e9c5c4885fb191a11375ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->