### PR TITLE
feat: an Agent agenda page for follow-ups and delegations

### DIFF
--- a/apps/frontend/src/components/agent-outcomes/index.ts
+++ b/apps/frontend/src/components/agent-outcomes/index.ts
@@ -1,0 +1,3 @@
+export { OutcomesShell } from "./outcomes-shell"
+export { OutcomesList } from "./outcomes-list"
+export { OUTCOMES_PARAM, useOutcomesUrlState, type OutcomesFilters } from "./use-outcomes-url-state"

--- a/apps/frontend/src/components/agent-outcomes/outcomes-detail.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-detail.tsx
@@ -1,0 +1,120 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
+import { toast } from "sonner"
+import { agentFollowUpsApi } from "@/api/agent-follow-ups"
+import { delegationsApi } from "@/api/delegations"
+import { Button } from "@/components/ui/button"
+import { useAsyncAction } from "@/hooks/use-async-action"
+import { useFormattedDate } from "@/hooks"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { agentOutcomeKeys } from "@/hooks/use-agent-outcomes"
+import { OUTCOME_KIND_LABEL, type OutcomeItem } from "@/lib/agent-outcomes/items"
+import { cn } from "@/lib/utils"
+
+interface OutcomesDetailProps {
+  workspaceId: string
+  item: OutcomeItem | null
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="text-sm">{value}</div>
+    </div>
+  )
+}
+
+export function OutcomesDetail({ workspaceId, item }: OutcomesDetailProps) {
+  const { formatFull } = useFormattedDate()
+  const streamName = useStreamName(workspaceId, item?.streamId ?? "", "noun")
+  const queryClient = useQueryClient()
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: agentOutcomeKeys.all })
+
+  const cancel = useAsyncAction(
+    async () => {
+      if (!item) return
+      if (item.kind === "follow_up") {
+        const { cancelled } = await agentFollowUpsApi.cancel(workspaceId, item.id)
+        if (!cancelled) toast.info("This follow-up already ran or was cancelled")
+      } else {
+        const { cancelled } = await delegationsApi.cancel(workspaceId, item.id)
+        if (!cancelled) toast.info("This delegation already finished or was cancelled")
+      }
+      await invalidate()
+    },
+    { errorMessage: "Couldn't cancel" }
+  )
+
+  const markDone = useAsyncAction(
+    async () => {
+      if (!item) return
+      const { completed } = await delegationsApi.markDone(workspaceId, item.id)
+      if (!completed) toast.info("This delegation already finished or was cancelled")
+      await invalidate()
+    },
+    { errorMessage: "Couldn't mark it done" }
+  )
+
+  if (!item) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center text-xs text-muted-foreground">
+        Select a follow-up or delegation to see its detail.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto p-4" data-testid="outcomes-detail">
+      <div className="flex items-start gap-2">
+        <h2 className="min-w-0 flex-1 text-sm font-semibold">{item.title}</h2>
+        <span
+          className={cn(
+            "shrink-0 rounded px-1 py-px text-[10px] font-semibold uppercase tracking-wide",
+            item.statusPillClass
+          )}
+        >
+          {item.statusLabel}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        <Field label="Kind" value={OUTCOME_KIND_LABEL[item.kind]} />
+        <Field
+          label="Stream"
+          value={
+            <Link to={`/w/${workspaceId}/s/${item.streamId}`} className="underline-offset-2 hover:underline">
+              {streamName ?? "this stream"}
+            </Link>
+          }
+        />
+        {item.scheduledFor ? <Field label="Scheduled for" value={formatFull(new Date(item.scheduledFor))} /> : null}
+        <Field label="Created" value={formatFull(new Date(item.createdAt))} />
+        <Field label="Last change" value={formatFull(new Date(item.statusChangedAt))} />
+        {item.claimedByLabel ? <Field label="Claimed by" value={item.claimedByLabel} /> : null}
+        {item.statusNote ? <Field label="Note" value={item.statusNote} /> : null}
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        {item.anchorPath ? (
+          <Button asChild size="sm" variant="outline">
+            <Link to={item.anchorPath}>Open in stream</Link>
+          </Button>
+        ) : (
+          <span className="text-xs text-muted-foreground">No card to open — its source event is gone.</span>
+        )}
+        {item.canMarkDone ? (
+          <Button size="sm" variant="outline" onClick={markDone.run} disabled={markDone.pending}>
+            Mark done
+          </Button>
+        ) : null}
+        {item.canCancel ? (
+          <Button size="sm" variant="ghost" onClick={cancel.run} disabled={cancel.pending}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-empty.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-empty.tsx
@@ -1,0 +1,81 @@
+import { AlertCircle, Filter, Inbox } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { OutcomesFilters } from "./use-outcomes-url-state"
+
+type EmptyKind = "empty" | "filtered-empty" | "error"
+
+interface OutcomesEmptyProps {
+  kind: EmptyKind
+  filters: OutcomesFilters
+  onClearFilters?: () => void
+  onWidenScope?: () => void
+}
+
+const KIND_NOUN = { follow_up: "follow-ups", delegation: "delegations" } as const
+
+const CHROME: Record<EmptyKind, { icon: typeof Inbox; accent: string }> = {
+  empty: { icon: Inbox, accent: "bg-primary/10 text-primary" },
+  "filtered-empty": { icon: Filter, accent: "bg-muted text-muted-foreground" },
+  error: { icon: AlertCircle, accent: "bg-destructive/10 text-destructive" },
+}
+
+const FIXED_COPY: Record<"empty" | "error", { title: string; body: string }> = {
+  empty: {
+    title: "Nothing scheduled yet",
+    body: "Follow-ups your companion schedules and tasks it delegates show up here.",
+  },
+  error: {
+    title: "Couldn't load the agenda",
+    body: "Something went wrong loading this list. Try again in a moment.",
+  },
+}
+
+function filteredCopy(filters: OutcomesFilters): { title: string; body: string } {
+  const noun = filters.kind ? KIND_NOUN[filters.kind] : "follow-ups or delegations"
+  if (filters.queryText.trim()) {
+    return { title: "No matches", body: `No ${noun} match “${filters.queryText.trim()}” in this scope.` }
+  }
+  if (filters.state === "outstanding") {
+    return { title: "Nothing outstanding", body: `No ${noun} are still waiting to happen here.` }
+  }
+  if (filters.state === "settled") {
+    return { title: "Nothing settled yet", body: `No ${noun} have finished, fired, or been cancelled here.` }
+  }
+  return { title: "Nothing in this scope", body: `No ${noun} here yet. Try widening to the whole workspace.` }
+}
+
+export function OutcomesEmpty({ kind, filters, onClearFilters, onWidenScope }: OutcomesEmptyProps) {
+  const copy = kind === "filtered-empty" ? filteredCopy(filters) : FIXED_COPY[kind]
+  const { icon: Icon, accent } = CHROME[kind]
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center"
+      data-testid="outcomes-empty"
+    >
+      <div className={`flex h-12 w-12 items-center justify-center rounded-card ${accent}`}>
+        <Icon className="h-5 w-5" aria-hidden />
+      </div>
+      <div className="space-y-1">
+        <div className="text-sm font-medium">{copy.title}</div>
+        <p className="max-w-[30ch] text-xs text-muted-foreground">{copy.body}</p>
+      </div>
+      {kind === "filtered-empty" ? (
+        <div className="flex gap-2">
+          {onClearFilters ? (
+            <Button size="sm" variant="outline" onClick={onClearFilters}>
+              Clear filters
+            </Button>
+          ) : null}
+          {onWidenScope ? (
+            <Button size="sm" onClick={onWidenScope}>
+              Search the workspace
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-filters.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-filters.tsx
@@ -1,0 +1,107 @@
+import { Hash, X } from "lucide-react"
+import type { AgentOutcomeKind, AgentOutcomeState } from "@threa/types"
+import { Badge } from "@/components/ui/badge"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { cn } from "@/lib/utils"
+import type { OutcomesFilters as OutcomesFiltersValue } from "./use-outcomes-url-state"
+
+interface OutcomesFiltersProps {
+  workspaceId: string
+  filters: OutcomesFiltersValue
+  onUpdate: (next: Partial<OutcomesFiltersValue>) => void
+}
+
+/**
+ * Chips, not tabs: state and kind are independent narrowings of one interleaved
+ * list, so Outstanding has to be able to show a running delegation next to a
+ * follow-up firing tonight.
+ */
+const STATE_CHIPS: Array<{ value: AgentOutcomeState; label: string }> = [
+  { value: "outstanding", label: "Outstanding" },
+  { value: "settled", label: "Settled" },
+  { value: "all", label: "All" },
+]
+
+const KIND_CHIPS: Array<{ value: AgentOutcomeKind; label: string }> = [
+  { value: "follow_up", label: "Follow-ups" },
+  { value: "delegation", label: "Delegations" },
+]
+
+function ToggleChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+        active
+          ? "border-primary/40 bg-primary/10 text-primary"
+          : "border-transparent bg-muted text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ScopeChip({
+  workspaceId,
+  streamId,
+  onRemove,
+}: {
+  workspaceId: string
+  streamId: string
+  onRemove: () => void
+}) {
+  const name = useStreamName(workspaceId, streamId, "noun")
+
+  return (
+    <Badge variant="secondary" className="gap-1 pr-1">
+      <Hash className="h-3 w-3" />
+      <span className="max-w-[12rem] truncate">{name ?? "this stream"}</span>
+      <button
+        type="button"
+        className="rounded-full p-0.5 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        onClick={onRemove}
+        aria-label={`Remove ${name ?? "stream"} scope`}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </Badge>
+  )
+}
+
+export function OutcomesFilters({ workspaceId, filters, onUpdate }: OutcomesFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 px-3 py-2" data-testid="outcomes-chips">
+      {STATE_CHIPS.map((chip) => (
+        <ToggleChip
+          key={chip.value}
+          label={chip.label}
+          active={filters.state === chip.value}
+          onClick={() => onUpdate({ state: chip.value, selectedOutcomeId: null })}
+        />
+      ))}
+      <span className="mx-1 h-4 w-px bg-border" aria-hidden />
+      {KIND_CHIPS.map((chip) => (
+        <ToggleChip
+          key={chip.value}
+          label={chip.label}
+          active={filters.kind === chip.value}
+          onClick={() => onUpdate({ kind: filters.kind === chip.value ? null : chip.value, selectedOutcomeId: null })}
+        />
+      ))}
+      {filters.streamIds.map((streamId) => (
+        <ScopeChip
+          key={streamId}
+          workspaceId={workspaceId}
+          streamId={streamId}
+          onRemove={() =>
+            onUpdate({ streamIds: filters.streamIds.filter((id) => id !== streamId), selectedOutcomeId: null })
+          }
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-list.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-list.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useRef } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { groupOutcomesByDay } from "@/lib/agent-outcomes/grouping"
+import type { OutcomeItem } from "@/lib/agent-outcomes/items"
+import { OutcomesEmpty } from "./outcomes-empty"
+import { OutcomesRow } from "./outcomes-row"
+import type { OutcomesFilters } from "./use-outcomes-url-state"
+
+const NEXT_PAGE_PREFETCH_MARGIN = "200px"
+
+interface OutcomesListProps {
+  workspaceId: string
+  items: OutcomeItem[]
+  filters: OutcomesFilters
+  hasFilters: boolean
+  isLoading: boolean
+  isError: boolean
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  fetchNextPage: () => void
+  selectedId: string | null
+  onSelect: (id: string) => void
+  onClearFilters: () => void
+  onWidenScope: () => void
+}
+
+export function OutcomesList({
+  workspaceId,
+  items,
+  filters,
+  hasFilters,
+  isLoading,
+  isError,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  selectedId,
+  onSelect,
+  onClearFilters,
+  onWidenScope,
+}: OutcomesListProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) return
+    if (!hasNextPage || isFetchingNextPage) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) fetchNextPage()
+      },
+      { rootMargin: NEXT_PAGE_PREFETCH_MARGIN }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  const groups = useMemo(() => groupOutcomesByDay(items), [items])
+
+  if (isLoading && items.length === 0) {
+    return (
+      <div className="flex flex-col gap-0.5 px-2 pb-3 pt-1" data-testid="outcomes-skeleton">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 rounded-item px-3 py-2">
+            <Skeleton className="h-8 w-8 flex-none rounded-md" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-2.5 w-2/3" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return <OutcomesEmpty kind="error" filters={filters} />
+  }
+
+  if (items.length === 0) {
+    return (
+      <OutcomesEmpty
+        kind={hasFilters ? "filtered-empty" : "empty"}
+        filters={filters}
+        onClearFilters={hasFilters ? onClearFilters : undefined}
+        onWidenScope={filters.streamIds.length > 0 ? onWidenScope : undefined}
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 px-2 pb-3 pt-1" role="list" data-testid="outcomes-list">
+      {groups.map((group) => (
+        <section key={group.key} aria-label={group.label}>
+          <div className="sticky top-0 z-10 bg-background/95 px-3 pb-1 pt-2 text-xs font-medium text-muted-foreground backdrop-blur">
+            {group.label}
+          </div>
+          <div className="flex flex-col gap-0.5" role="presentation">
+            {group.items.map((item) => (
+              <div key={item.id} role="listitem">
+                <OutcomesRow
+                  workspaceId={workspaceId}
+                  item={item}
+                  isSelected={selectedId === item.id}
+                  onSelect={onSelect}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+      <div ref={sentinelRef} aria-hidden className="h-4" />
+      {isFetchingNextPage ? (
+        <div className="flex items-center justify-center py-2 text-xs text-muted-foreground">Loading more…</div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-row.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-row.tsx
@@ -1,0 +1,71 @@
+import { TerminalSquare, Timer } from "lucide-react"
+import { usePreferences } from "@/contexts"
+import { useFormattedDate } from "@/hooks"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { formatFutureTime } from "@/lib/dates"
+import { cn } from "@/lib/utils"
+import type { OutcomeItem } from "@/lib/agent-outcomes/items"
+
+interface OutcomesRowProps {
+  workspaceId: string
+  item: OutcomeItem
+  isSelected: boolean
+  onSelect: (id: string) => void
+}
+
+export function OutcomesRow({ workspaceId, item, isSelected, onSelect }: OutcomesRowProps) {
+  const { preferences } = usePreferences()
+  const { formatRelative } = useFormattedDate()
+  const streamName = useStreamName(workspaceId, item.streamId, "noun")
+
+  const occursAt = new Date(item.occursAt)
+  const now = new Date()
+  // Only the time format travels into a UI label; the timezone stays the
+  // device's (INV-42).
+  const timeLabel =
+    occursAt.getTime() > now.getTime()
+      ? formatFutureTime(occursAt, now, { timeFormat: preferences?.timeFormat })
+      : formatRelative(occursAt, now, { terse: true })
+
+  const Icon = item.kind === "follow_up" ? Timer : TerminalSquare
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      aria-current={isSelected}
+      data-outcome-id={item.id}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-item px-3 py-2 text-left transition-colors",
+        isSelected ? "bg-accent" : "hover:bg-muted/60"
+      )}
+    >
+      <div
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-md",
+          item.isSettled ? "bg-muted text-muted-foreground" : "bg-primary/10 text-primary"
+        )}
+      >
+        <Icon className="size-4" />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-sm">{item.title}</span>
+          <span
+            className={cn(
+              "shrink-0 rounded px-1 py-px text-[10px] font-semibold uppercase tracking-wide",
+              item.statusPillClass
+            )}
+          >
+            {item.statusLabel}
+          </span>
+        </div>
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <span className="min-w-0 truncate">{streamName ?? "this stream"}</span>
+          <span aria-hidden>·</span>
+          <span className="shrink-0">{timeLabel}</span>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
@@ -6,6 +6,8 @@ import { render, screen, userEvent, waitFor } from "@/test"
 import * as agentOutcomesApiModule from "@/api/agent-outcomes"
 import * as preferencesModule from "@/contexts/preferences-context"
 import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as mobileModule from "@/hooks/use-mobile"
+import { agentOutcomeKeys } from "@/hooks/use-agent-outcomes"
 import { OutcomesShell } from "./outcomes-shell"
 
 function makeFollowUp(overrides: Partial<AgentOutcomeSummary> = {}): AgentOutcomeSummary {
@@ -120,6 +122,82 @@ describe("OutcomesShell", () => {
     const detail = await screen.findByTestId("outcomes-detail")
     expect(detail).toHaveTextContent("Follow-up")
     expect(detail).toHaveTextContent("Scheduled")
+  })
+
+  it("the back arrow returns a deep-linked detail to the list, without closing the surface", async () => {
+    // The timeline's follow-up card links straight to ?aSelected=, so there is
+    // no list entry behind this view — popping history would leave the surface.
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda?aState=all&aSelected=fup_1")
+    await screen.findByTestId("outcomes-detail")
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Back to the agenda list" }))
+
+    await waitFor(() => {
+      const search = searchParams()
+      expect({
+        selected: search.get("aSelected"),
+        state: search.get("aState"),
+        list: !!screen.queryByTestId("outcomes-list"),
+      }).toEqual({ selected: null, state: "all", list: true })
+    })
+  })
+
+  it("shows one row when a page repeats an outcome the previous page already carried", async () => {
+    // `occurs_at` is a delegation's last transition, so a row that changes
+    // status between two fetches shifts past the cursor and comes back on the
+    // next page. Seeded as two pages because jsdom never fires the sentinel.
+    const repeated = makeFollowUp()
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([repeated]))
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    queryClient.setQueryData(agentOutcomeKeys.workspace("ws_1", { streamIds: [], state: "outstanding" }), {
+      pages: [
+        { items: [repeated], nextCursor: "c1", outstandingCount: 1 },
+        { items: [repeated], nextCursor: null, outstandingCount: 1 },
+      ],
+      pageParams: [null, "c1"],
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/w/ws_1/agenda"]}>
+          <LocationProbe />
+          <OutcomesShell workspaceId="ws_1" mode="page" enabled />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findAllByText("Check in on the migration")).toHaveLength(1)
+  })
+
+  it("fills the split layout's detail pane with the first row, and walks it with the arrow keys", async () => {
+    // Derived, not written: the default nobody picked stays out of the URL, so
+    // it cannot race a filter chip or leave a history entry behind.
+    vi.spyOn(mobileModule, "useIsSplitCapable").mockReturnValue(true)
+    const second = makeFollowUp({ id: "fup_2", title: "Chase the rollback" })
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp(), second]))
+
+    renderShell("/w/ws_1/agenda")
+
+    const detail = await screen.findByTestId("outcomes-detail")
+    expect({
+      detail: detail.textContent?.includes("Check in on the migration"),
+      url: searchParams().get("aSelected"),
+    }).toEqual({ detail: true, url: null })
+
+    // The arrows are scoped to this surface (they keep their default behaviour
+    // in the sidebar next to it), so the focus has to be on a row first.
+    const user = userEvent.setup()
+    await user.click(screen.getAllByText("Check in on the migration")[0]!)
+    await user.keyboard("{ArrowDown}")
+
+    await waitFor(() =>
+      expect({
+        detail: screen.getByTestId("outcomes-detail").textContent?.includes("Chase the rollback"),
+        url: searchParams().get("aSelected"),
+      }).toEqual({ detail: true, url: "fup_2" })
+    )
   })
 
   it("removing the scope chip widens to the whole workspace", async () => {

--- a/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
@@ -1,0 +1,164 @@
+import type { AgentOutcomeSummary, ListAgentOutcomesResponse } from "@threa/types"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, userEvent, waitFor } from "@/test"
+import * as agentOutcomesApiModule from "@/api/agent-outcomes"
+import * as preferencesModule from "@/contexts/preferences-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import { OutcomesShell } from "./outcomes-shell"
+
+function makeFollowUp(overrides: Partial<AgentOutcomeSummary> = {}): AgentOutcomeSummary {
+  return {
+    kind: "follow_up",
+    id: "fup_1",
+    streamId: "str_design",
+    title: "Check in on the migration",
+    status: "pending",
+    scheduledFor: "2026-08-01T18:00:00.000Z",
+    claimedByLabel: null,
+    statusNote: null,
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-07-28T09:00:00.000Z",
+    statusChangedAt: "2026-07-28T09:00:00.000Z",
+    occursAt: "2026-08-01T18:00:00.000Z",
+    anchorEventId: "event_1",
+    ...overrides,
+  } as AgentOutcomeSummary
+}
+
+function page(items: AgentOutcomeSummary[]): ListAgentOutcomesResponse {
+  return { items, nextCursor: null, outstandingCount: items.length }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="search">{location.search}</div>
+}
+
+function renderShell(initialEntry: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationProbe />
+        <OutcomesShell workspaceId="ws_1" mode="page" enabled />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function searchParams(): URLSearchParams {
+  return new URLSearchParams(screen.getByTestId("search").textContent ?? "")
+}
+
+describe("OutcomesShell", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([])
+    vi.spyOn(preferencesModule, "usePreferences").mockReturnValue({
+      preferences: { dateFormat: "YYYY-MM-DD", timeFormat: "24h", timezone: "UTC" } as never,
+    } as unknown as ReturnType<typeof preferencesModule.usePreferences>)
+  })
+
+  it("reads the default outstanding scope from the URL and issues a workspace-wide request", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda")
+
+    await waitFor(() => expect(listSpy).toHaveBeenCalled())
+    expect(listSpy.mock.calls[0]![1]).toMatchObject({ streamIds: [], state: "outstanding" })
+    expect(await screen.findByText("Check in on the migration")).toBeInTheDocument()
+  })
+
+  it("a state chip drives both the URL and the request", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda")
+    await waitFor(() => expect(listSpy).toHaveBeenCalled())
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Settled" }))
+
+    expect(searchParams().get("aState")).toBe("settled")
+    await waitFor(() => {
+      const last = listSpy.mock.calls[listSpy.mock.calls.length - 1]!
+      expect(last[1]).toMatchObject({ state: "settled" })
+    })
+  })
+
+  it("a kind chip narrows the request and toggles back off", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda")
+    await waitFor(() => expect(listSpy).toHaveBeenCalled())
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole("button", { name: "Delegations" }))
+    expect(searchParams().get("aKind")).toBe("delegation")
+    await waitFor(() => {
+      const last = listSpy.mock.calls[listSpy.mock.calls.length - 1]!
+      expect(last[1]).toMatchObject({ kind: "delegation" })
+    })
+
+    await user.click(screen.getByRole("button", { name: "Delegations" }))
+    expect(searchParams().has("aKind")).toBe(false)
+  })
+
+  it("selecting a row writes ?selected= and opens the detail", async () => {
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda")
+
+    const row = await screen.findByText("Check in on the migration")
+    await userEvent.setup().click(row)
+
+    expect(searchParams().get("aSelected")).toBe("fup_1")
+    const detail = await screen.findByTestId("outcomes-detail")
+    expect(detail).toHaveTextContent("Follow-up")
+    expect(detail).toHaveTextContent("Scheduled")
+  })
+
+  it("removing the scope chip widens to the whole workspace", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([makeFollowUp()]))
+
+    renderShell("/w/ws_1/agenda?aStreams=str_design")
+    await waitFor(() => expect(listSpy.mock.calls[0]![1]).toMatchObject({ streamIds: ["str_design"] }))
+
+    await userEvent.setup().click(screen.getByRole("button", { name: /Remove .* scope/ }))
+
+    expect(searchParams().has("aStreams")).toBe(false)
+    await waitFor(() => {
+      const last = listSpy.mock.calls[listSpy.mock.calls.length - 1]!
+      expect(last[1]).toMatchObject({ streamIds: [] })
+    })
+  })
+
+  it("shows the first-run copy on the bare route, with nothing to clear", async () => {
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([]))
+
+    renderShell("/w/ws_1/agenda")
+
+    const empty = await screen.findByTestId("outcomes-empty")
+    expect(empty).toHaveTextContent("Nothing scheduled yet")
+    expect(screen.queryByRole("button", { name: "Clear filters" })).not.toBeInTheDocument()
+  })
+
+  it("a filter that empties shows the filtered-empty state instead of stranding the view", async () => {
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockImplementation(async (_ws, filters) =>
+      page(filters?.kind === "delegation" ? [] : [makeFollowUp()])
+    )
+
+    renderShell("/w/ws_1/agenda")
+    await screen.findByText("Check in on the migration")
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Delegations" }))
+
+    const empty = await screen.findByTestId("outcomes-empty")
+    expect(empty).toHaveTextContent("Nothing outstanding")
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/agent-outcomes/outcomes-shell.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-shell.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+import { ArrowLeft, Search, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { PanelResizeHandle } from "@/components/layout/panel-resize-handle"
+import { useAgentOutcomes } from "@/hooks/use-agent-outcomes"
+import { useDebouncedUrlText } from "@/hooks/use-debounced-url-text"
+import { useIsMobile, useIsSplitCapable } from "@/hooks/use-mobile"
+import { useResizeDrag } from "@/hooks/use-resize-drag"
+import { toOutcomeItems } from "@/lib/agent-outcomes/items"
+import { OutcomesDetail } from "./outcomes-detail"
+import { OutcomesFilters } from "./outcomes-filters"
+import { OutcomesList } from "./outcomes-list"
+import { DEFAULT_OUTCOMES_STATE, useOutcomesUrlState } from "./use-outcomes-url-state"
+
+const DEFAULT_DETAIL_WIDTH = 400
+const MIN_DETAIL_WIDTH = 300
+const MIN_LIST_WIDTH = 320
+const QUERY_DEBOUNCE_MS = 200
+
+interface OutcomesShellProps {
+  workspaceId: string
+  /**
+   * "modal" hides the page chrome and shows a close button that strips the URL
+   * marker. "page" omits it — the host page owns its own navigation chrome and
+   * the surface never closes.
+   */
+  mode: "modal" | "page"
+  enabled: boolean
+}
+
+export function OutcomesShell({ workspaceId, mode, enabled }: OutcomesShellProps) {
+  const { filters, close, update } = useOutcomesUrlState()
+  const isMobile = useIsMobile()
+  // MIN_LIST_WIDTH + MIN_DETAIL_WIDTH is 620px before the docked sidebar, so
+  // the split needs SPLIT_VIEW_BREAKPOINT, not the phone breakpoint.
+  const isSplitCapable = useIsSplitCapable()
+
+  const query = useAgentOutcomes(
+    workspaceId,
+    {
+      streamIds: filters.streamIds,
+      state: filters.state,
+      ...(filters.kind ? { kind: filters.kind } : {}),
+      ...(filters.queryText.trim() ? { queryText: filters.queryText.trim() } : {}),
+    },
+    { enabled }
+  )
+
+  const items = useMemo(
+    () => toOutcomeItems(workspaceId, query.data?.pages.flatMap((page) => page.items) ?? []),
+    [workspaceId, query.data]
+  )
+
+  const { draft: queryDraft, setDraft: handleQueryChange } = useDebouncedUrlText({
+    value: filters.queryText,
+    onCommit: useCallback((next: string) => update({ queryText: next }), [update]),
+    delayMs: QUERY_DEBOUNCE_MS,
+  })
+
+  const selectedItem = useMemo(() => {
+    if (!filters.selectedOutcomeId) return null
+    return items.find((item) => item.id === filters.selectedOutcomeId) ?? null
+  }, [filters.selectedOutcomeId, items])
+
+  const hasFilters =
+    filters.streamIds.length > 0 ||
+    filters.kind !== null ||
+    filters.state !== DEFAULT_OUTCOMES_STATE ||
+    filters.queryText.trim().length > 0
+
+  const clearFilters = () => update({ streamIds: [], kind: null, state: "all", queryText: "" })
+  const widenScope = () => update({ streamIds: [] })
+
+  const showDetailOnly = !isSplitCapable && Boolean(selectedItem)
+
+  const splitContainerRef = useRef<HTMLDivElement | null>(null)
+  const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL_WIDTH)
+
+  const handleDetailWidthChange = useCallback((next: number) => {
+    const containerWidth = splitContainerRef.current?.offsetWidth ?? 0
+    const max = Math.max(MIN_DETAIL_WIDTH, containerWidth - MIN_LIST_WIDTH)
+    setDetailWidth(Math.max(MIN_DETAIL_WIDTH, Math.min(max, next)))
+  }, [])
+
+  const { isResizing, handleResizeStart, handleResizeMove, handleResizeEnd } = useResizeDrag({
+    width: detailWidth,
+    onWidthChange: handleDetailWidthChange,
+    direction: "left",
+  })
+
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const step = e.shiftKey ? 50 : 10
+      if (e.key === "ArrowLeft") {
+        e.preventDefault()
+        handleDetailWidthChange(detailWidth + step)
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault()
+        handleDetailWidthChange(detailWidth - step)
+      }
+    },
+    [detailWidth, handleDetailWidthChange]
+  )
+
+  const maxDetailWidth = Math.max(MIN_DETAIL_WIDTH, (splitContainerRef.current?.offsetWidth ?? 0) - MIN_LIST_WIDTH)
+
+  return (
+    <div className="flex h-full min-w-0 flex-col" data-testid="outcomes-shell">
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        {showDetailOnly ? (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={() => window.history.back()}
+            aria-label="Back to the agenda list"
+            className="h-7 w-7"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Search className="h-4 w-4 flex-none text-muted-foreground" aria-hidden />
+        )}
+        <Input
+          autoFocus={mode === "modal" && !isMobile}
+          value={queryDraft}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          placeholder="Search follow-ups and delegated tasks"
+          className="h-8 border-none px-1 shadow-none focus-visible:ring-0"
+          aria-label="Search the agenda"
+        />
+        {mode === "modal" ? (
+          <Button size="icon" variant="ghost" onClick={close} aria-label="Close" className="h-7 w-7">
+            <X className="h-4 w-4" />
+          </Button>
+        ) : null}
+      </div>
+
+      {showDetailOnly ? null : <OutcomesFilters workspaceId={workspaceId} filters={filters} onUpdate={update} />}
+
+      <div ref={splitContainerRef} className="flex min-w-0 flex-1 overflow-hidden border-t">
+        <div className={showDetailOnly ? "hidden" : "flex w-full min-w-0 flex-1 flex-col overflow-y-auto"}>
+          <OutcomesList
+            workspaceId={workspaceId}
+            items={items}
+            filters={filters}
+            hasFilters={hasFilters}
+            isLoading={query.isLoading}
+            isError={query.isError}
+            hasNextPage={query.hasNextPage}
+            isFetchingNextPage={query.isFetchingNextPage}
+            fetchNextPage={query.fetchNextPage}
+            selectedId={filters.selectedOutcomeId}
+            onSelect={(id) =>
+              update(
+                { selectedOutcomeId: id },
+                // Below the split breakpoint the detail replaces the list, so push history and
+                // hardware Back returns to the list instead of leaving the page.
+                { history: isSplitCapable ? "replace" : "push" }
+              )
+            }
+            onClearFilters={clearFilters}
+            onWidenScope={widenScope}
+          />
+        </div>
+        {!showDetailOnly && isSplitCapable && (
+          <PanelResizeHandle
+            isResizing={isResizing}
+            panelWidth={detailWidth}
+            minWidth={MIN_DETAIL_WIDTH}
+            maxWidth={maxDetailWidth}
+            onPointerDown={handleResizeStart}
+            onPointerMove={handleResizeMove}
+            onPointerEnd={handleResizeEnd}
+            onKeyDown={handleResizeKeyDown}
+            ariaLabel="Resize detail pane"
+          />
+        )}
+        <div
+          className={showDetailOnly ? "w-full min-w-0 flex-1" : "hidden min-w-0 flex-shrink-0 lg:block"}
+          style={!showDetailOnly && isSplitCapable ? { width: detailWidth } : undefined}
+          data-testid="outcomes-detail-pane"
+        >
+          <OutcomesDetail workspaceId={workspaceId} item={selectedItem} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/outcomes-shell.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-shell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ArrowLeft, Search, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -47,10 +47,19 @@ export function OutcomesShell({ workspaceId, mode, enabled }: OutcomesShellProps
     { enabled }
   )
 
-  const items = useMemo(
-    () => toOutcomeItems(workspaceId, query.data?.pages.flatMap((page) => page.items) ?? []),
-    [workspaceId, query.data]
-  )
+  // Deduped by id across pages: the keyset orders on `occurs_at`, which for a
+  // delegation IS its last transition — a row that changes status between two
+  // page fetches moves past the cursor and comes back on the next page. The
+  // list keys on id, so without this the reader sees the same outcome twice.
+  const items = useMemo(() => {
+    const seen = new Set<string>()
+    const rows = (query.data?.pages.flatMap((page) => page.items) ?? []).filter((row) => {
+      if (seen.has(row.id)) return false
+      seen.add(row.id)
+      return true
+    })
+    return toOutcomeItems(workspaceId, rows)
+  }, [workspaceId, query.data])
 
   const { draft: queryDraft, setDraft: handleQueryChange } = useDebouncedUrlText({
     value: filters.queryText,
@@ -58,10 +67,35 @@ export function OutcomesShell({ workspaceId, mode, enabled }: OutcomesShellProps
     delayMs: QUERY_DEBOUNCE_MS,
   })
 
+  // The detail pane never sits empty in the split layout — same affordance the
+  // explorer shell this copies has. The default is DERIVED, not written to the
+  // URL: a write here races every filter chip (both land in one tick, and the
+  // later one resolves against pre-click params), and a default nobody picked
+  // is not view state worth a history entry. Only the split layout defaults —
+  // below it the detail REPLACES the list, so a default would hide the list.
   const selectedItem = useMemo(() => {
-    if (!filters.selectedOutcomeId) return null
-    return items.find((item) => item.id === filters.selectedOutcomeId) ?? null
-  }, [filters.selectedOutcomeId, items])
+    if (filters.selectedOutcomeId) return items.find((item) => item.id === filters.selectedOutcomeId) ?? null
+    return isSplitCapable ? (items[0] ?? null) : null
+  }, [filters.selectedOutcomeId, isSplitCapable, items])
+
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+      const target = e.target instanceof HTMLElement ? e.target : null
+      // Scoped to this surface: on /agenda it shares the window with the
+      // sidebar, where the arrows keep their default behaviour.
+      if (!target || !shellRef.current?.contains(target)) return
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return
+      if (items.length === 0) return
+      const index = items.findIndex((item) => item.id === selectedItem?.id)
+      e.preventDefault()
+      const next = e.key === "ArrowDown" ? items[Math.min(index + 1, items.length - 1)] : items[Math.max(index - 1, 0)]
+      if (next) update({ selectedOutcomeId: next.id })
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [enabled, items, selectedItem, update])
 
   const hasFilters =
     filters.streamIds.length > 0 ||
@@ -72,8 +106,9 @@ export function OutcomesShell({ workspaceId, mode, enabled }: OutcomesShellProps
   const clearFilters = () => update({ streamIds: [], kind: null, state: "all", queryText: "" })
   const widenScope = () => update({ streamIds: [] })
 
-  const showDetailOnly = !isSplitCapable && Boolean(selectedItem)
+  const showDetailOnly = !isSplitCapable && Boolean(filters.selectedOutcomeId && selectedItem)
 
+  const shellRef = useRef<HTMLDivElement | null>(null)
   const splitContainerRef = useRef<HTMLDivElement | null>(null)
   const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL_WIDTH)
 
@@ -106,13 +141,17 @@ export function OutcomesShell({ workspaceId, mode, enabled }: OutcomesShellProps
   const maxDetailWidth = Math.max(MIN_DETAIL_WIDTH, (splitContainerRef.current?.offsetWidth ?? 0) - MIN_LIST_WIDTH)
 
   return (
-    <div className="flex h-full min-w-0 flex-col" data-testid="outcomes-shell">
+    <div ref={shellRef} className="flex h-full min-w-0 flex-col" data-testid="outcomes-shell">
       <div className="flex items-center gap-2 border-b px-3 py-2">
         {showDetailOnly ? (
           <Button
             size="icon"
             variant="ghost"
-            onClick={() => window.history.back()}
+            // Clears the selection rather than popping history: a deep link
+            // (the timeline's follow-up card) opens straight into the detail
+            // with no list entry behind it, and `history.back()` would close
+            // the whole surface — the one thing this arrow must not do.
+            onClick={() => update({ selectedOutcomeId: null })}
             aria-label="Back to the agenda list"
             className="h-7 w-7"
           >

--- a/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.test.ts
+++ b/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.test.ts
@@ -1,0 +1,191 @@
+import { createElement } from "react"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { useExplorerUrlState } from "@/components/attachment-explorer/use-explorer-url-state"
+import {
+  OUTCOMES_PARAM,
+  isOutcomesOpen,
+  readOutcomesFiltersFromParams,
+  useOutcomesUrlState,
+  writeOutcomesFiltersToParams,
+} from "./use-outcomes-url-state"
+
+describe("isOutcomesOpen", () => {
+  it("returns true when the marker param is present", () => {
+    expect(isOutcomesOpen(new URLSearchParams("agenda="))).toBe(true)
+    expect(isOutcomesOpen(new URLSearchParams("agenda=open"))).toBe(true)
+  })
+
+  it("returns false when the marker is absent", () => {
+    expect(isOutcomesOpen(new URLSearchParams(""))).toBe(false)
+    expect(isOutcomesOpen(new URLSearchParams("aStreams=str_1"))).toBe(false)
+  })
+})
+
+describe("readOutcomesFiltersFromParams", () => {
+  it("defaults to outstanding, both kinds, workspace-wide", () => {
+    expect(readOutcomesFiltersFromParams(new URLSearchParams(""))).toEqual({
+      streamIds: [],
+      state: "outstanding",
+      kind: null,
+      queryText: "",
+      selectedOutcomeId: null,
+    })
+  })
+
+  it("parses every param", () => {
+    const params = new URLSearchParams(
+      "agenda=&aStreams=str_design,str_strategy&aState=settled&aKind=delegation&aq=migration&aSelected=deleg_1"
+    )
+    expect(readOutcomesFiltersFromParams(params)).toEqual({
+      streamIds: ["str_design", "str_strategy"],
+      state: "settled",
+      kind: "delegation",
+      queryText: "migration",
+      selectedOutcomeId: "deleg_1",
+    })
+  })
+
+  it("falls back to the defaults for unknown state and kind values", () => {
+    const filters = readOutcomesFiltersFromParams(new URLSearchParams("aState=bogus&aKind=bogus"))
+    expect(filters.state).toBe("outstanding")
+    expect(filters.kind).toBe(null)
+  })
+
+  it("dedupes repeated stream IDs and drops empties", () => {
+    expect(readOutcomesFiltersFromParams(new URLSearchParams("aStreams=str_a,,str_b,str_a")).streamIds).toEqual([
+      "str_a",
+      "str_b",
+    ])
+  })
+
+  it("treats an absent streams param as workspace-wide", () => {
+    expect(readOutcomesFiltersFromParams(new URLSearchParams("agenda=")).streamIds).toEqual([])
+  })
+})
+
+describe("writeOutcomesFiltersToParams", () => {
+  it("round-trips a full filter object back through the parser", () => {
+    const written = writeOutcomesFiltersToParams(new URLSearchParams(), {
+      streamIds: ["str_design", "str_strategy"],
+      state: "all",
+      kind: "follow_up",
+      queryText: "migration",
+      selectedOutcomeId: "fup_1",
+    })
+    written.set(OUTCOMES_PARAM, "")
+
+    expect(readOutcomesFiltersFromParams(written)).toEqual({
+      streamIds: ["str_design", "str_strategy"],
+      state: "all",
+      kind: "follow_up",
+      queryText: "migration",
+      selectedOutcomeId: "fup_1",
+    })
+  })
+
+  it("clears params when filters are reset to their defaults", () => {
+    const initial = new URLSearchParams("aStreams=str_design&aState=all&aKind=delegation&aq=x&aSelected=deleg_1")
+    const cleared = writeOutcomesFiltersToParams(initial, {
+      streamIds: [],
+      state: "outstanding",
+      kind: null,
+      queryText: "",
+      selectedOutcomeId: null,
+    })
+    expect(cleared.toString()).toBe("")
+  })
+
+  it("preserves non-outcomes params when narrowing the scope", () => {
+    const initial = new URLSearchParams("panel=str_other&agenda=")
+    const updated = writeOutcomesFiltersToParams(initial, { streamIds: ["str_design"] })
+    expect(updated.get("panel")).toBe("str_other")
+    expect(updated.get("aStreams")).toBe("str_design")
+    expect(updated.has("agenda")).toBe(true)
+  })
+
+  it("widens to workspace scope by dropping the streams param", () => {
+    const initial = new URLSearchParams("agenda=&aStreams=str_design")
+    const widened = writeOutcomesFiltersToParams(initial, { streamIds: [] })
+    expect(widened.has("aStreams")).toBe(false)
+    expect(readOutcomesFiltersFromParams(widened).streamIds).toEqual([])
+  })
+})
+
+describe("useOutcomesUrlState", () => {
+  function renderUrlState(initialEntry: string) {
+    return renderHook(() => ({ state: useOutcomesUrlState(), location: useLocation() }), {
+      wrapper: ({ children }) => createElement(MemoryRouter, { initialEntries: [initialEntry] }, children),
+    })
+  }
+
+  it("close strips only the outcomes-owned keys", () => {
+    const { result } = renderUrlState(
+      "/w/ws_1?panel=str_other&m=msg_1&agenda=&aStreams=str_a&aState=all&aKind=delegation&aq=x&aSelected=deleg_1"
+    )
+
+    expect(result.current.state.isOpen).toBe(true)
+    act(() => result.current.state.close())
+
+    const params = new URLSearchParams(result.current.location.search)
+    expect(params.get("panel")).toBe("str_other")
+    expect(params.get("m")).toBe("msg_1")
+    expect([...params.keys()].sort()).toEqual(["m", "panel"])
+  })
+
+  it("update writes a filter into the URL and reads it back", () => {
+    const { result } = renderUrlState("/w/ws_1?agenda=")
+
+    act(() => result.current.state.update({ state: "settled", kind: "delegation" }))
+
+    expect(result.current.state.filters.state).toBe("settled")
+    expect(result.current.state.filters.kind).toBe("delegation")
+    expect(new URLSearchParams(result.current.location.search).has("agenda")).toBe(true)
+  })
+
+  it("survives the attachment explorer opening and closing on the same route", () => {
+    const { result } = renderHook(
+      () => ({
+        outcomes: useOutcomesUrlState(),
+        explorer: useExplorerUrlState(),
+      }),
+      {
+        wrapper: ({ children }) =>
+          createElement(
+            MemoryRouter,
+            { initialEntries: ["/w/ws_1/agenda?aStreams=str_design&aq=migration&aSelected=fup_7&aKind=follow_up"] },
+            children
+          ),
+      }
+    )
+
+    const before = result.current.outcomes.filters
+
+    act(() => result.current.explorer.open({ streamIds: [] }))
+    expect(result.current.explorer.isOpen).toBe(true)
+    expect(result.current.outcomes.filters).toEqual(before)
+
+    act(() => result.current.explorer.close())
+    expect(result.current.explorer.isOpen).toBe(false)
+    expect(result.current.outcomes.filters).toEqual(before)
+    expect(before).toEqual({
+      streamIds: ["str_design"],
+      state: "outstanding",
+      kind: "follow_up",
+      queryText: "migration",
+      selectedOutcomeId: "fup_7",
+    })
+  })
+
+  it("open marks the surface open without disturbing existing params", () => {
+    const { result } = renderUrlState("/w/ws_1?panel=str_other")
+
+    act(() => result.current.state.open({ streamIds: ["str_a"] }))
+
+    expect(result.current.state.isOpen).toBe(true)
+    const params = new URLSearchParams(result.current.location.search)
+    expect(params.get("panel")).toBe("str_other")
+    expect(params.get("aStreams")).toBe("str_a")
+  })
+})

--- a/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
+++ b/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
@@ -117,12 +117,16 @@ export function useOutcomesUrlState() {
     setSearchParams(next, { replace: true })
   }, [searchParams, setSearchParams])
 
+  // Applied to the CURRENT params, not the ones captured at render: two writes
+  // in the same tick both resolve against the snapshot, so the later one drops
+  // the earlier one's filter.
   const update = useCallback(
     (overrides: Partial<OutcomesFilters>, options: { history?: "push" | "replace" } = {}) => {
-      const next = writeOutcomesFiltersToParams(searchParams, overrides)
-      setSearchParams(next, { replace: options.history !== "push" })
+      setSearchParams((prev) => writeOutcomesFiltersToParams(prev, overrides), {
+        replace: options.history !== "push",
+      })
     },
-    [searchParams, setSearchParams]
+    [setSearchParams]
   )
 
   return { isOpen, filters, open, close, update }

--- a/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
+++ b/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
@@ -1,0 +1,129 @@
+import { useCallback, useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
+import { AGENT_OUTCOME_KINDS, AGENT_OUTCOME_STATES, type AgentOutcomeKind, type AgentOutcomeState } from "@threa/types"
+
+// Namespaced because the attachment explorer is mounted on every workspace
+// route, including this one, and claims the bare `streams` / `q` / `selected`.
+export const OUTCOMES_PARAM = "agenda"
+const STREAMS_PARAM = "aStreams"
+const STATE_PARAM = "aState"
+const KIND_PARAM = "aKind"
+const QUERY_PARAM = "aq"
+const SELECTED_PARAM = "aSelected"
+
+export const DEFAULT_OUTCOMES_STATE: AgentOutcomeState = "outstanding"
+
+export interface OutcomesFilters {
+  /**
+   * IDs of streams the user has scoped to. Empty means workspace-wide — the
+   * scope chip's remove action writes exactly this.
+   */
+  streamIds: string[]
+  state: AgentOutcomeState
+  /** null = both kinds interleaved. */
+  kind: AgentOutcomeKind | null
+  queryText: string
+  selectedOutcomeId: string | null
+}
+
+const STATE_SET = new Set<AgentOutcomeState>(AGENT_OUTCOME_STATES)
+const KIND_SET = new Set<AgentOutcomeKind>(AGENT_OUTCOME_KINDS)
+
+function parseStreamIds(raw: string | null): string[] {
+  if (!raw) return []
+  const ids = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean)
+  return Array.from(new Set(ids))
+}
+
+function parseState(raw: string | null): AgentOutcomeState {
+  return raw && STATE_SET.has(raw as AgentOutcomeState) ? (raw as AgentOutcomeState) : DEFAULT_OUTCOMES_STATE
+}
+
+function parseKind(raw: string | null): AgentOutcomeKind | null {
+  return raw && KIND_SET.has(raw as AgentOutcomeKind) ? (raw as AgentOutcomeKind) : null
+}
+
+export function readOutcomesFiltersFromParams(params: URLSearchParams): OutcomesFilters {
+  return {
+    streamIds: parseStreamIds(params.get(STREAMS_PARAM)),
+    state: parseState(params.get(STATE_PARAM)),
+    kind: parseKind(params.get(KIND_PARAM)),
+    queryText: params.get(QUERY_PARAM) ?? "",
+    selectedOutcomeId: params.get(SELECTED_PARAM) || null,
+  }
+}
+
+export function isOutcomesOpen(params: URLSearchParams): boolean {
+  return params.has(OUTCOMES_PARAM)
+}
+
+function applyFilter(params: URLSearchParams, key: string, value: string | null) {
+  if (value === null || value === "") {
+    params.delete(key)
+  } else {
+    params.set(key, value)
+  }
+}
+
+export function writeOutcomesFiltersToParams(params: URLSearchParams, next: Partial<OutcomesFilters>): URLSearchParams {
+  const updated = new URLSearchParams(params)
+
+  if ("streamIds" in next) {
+    const ids = next.streamIds ?? []
+    if (ids.length === 0) updated.delete(STREAMS_PARAM)
+    else updated.set(STREAMS_PARAM, Array.from(new Set(ids)).join(","))
+  }
+  if ("state" in next) {
+    if (!next.state || next.state === DEFAULT_OUTCOMES_STATE) updated.delete(STATE_PARAM)
+    else updated.set(STATE_PARAM, next.state)
+  }
+  if ("kind" in next) applyFilter(updated, KIND_PARAM, next.kind ?? null)
+  if ("queryText" in next) applyFilter(updated, QUERY_PARAM, next.queryText ?? null)
+  if ("selectedOutcomeId" in next) applyFilter(updated, SELECTED_PARAM, next.selectedOutcomeId ?? null)
+
+  return updated
+}
+
+const OUTCOMES_KEYS = [OUTCOMES_PARAM, STREAMS_PARAM, STATE_PARAM, KIND_PARAM, QUERY_PARAM, SELECTED_PARAM]
+
+/**
+ * Outcomes view state lives entirely in URL search params (INV-59) so refresh,
+ * back/forward, and a shared link all land on the same view. Mirrors
+ * `use-explorer-url-state` — same open/close/update contract, and `close` strips
+ * only the keys this surface owns so a host page's own params survive.
+ */
+export function useOutcomesUrlState() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const isOpen = isOutcomesOpen(searchParams)
+
+  const filters = useMemo(() => readOutcomesFiltersFromParams(searchParams), [searchParams])
+
+  const open = useCallback(
+    (overrides?: Partial<OutcomesFilters>) => {
+      const next = writeOutcomesFiltersToParams(searchParams, overrides ?? {})
+      next.set(OUTCOMES_PARAM, "")
+      setSearchParams(next, { replace: false })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const close = useCallback(() => {
+    const next = new URLSearchParams(searchParams)
+    for (const key of OUTCOMES_KEYS) next.delete(key)
+    setSearchParams(next, { replace: true })
+  }, [searchParams, setSearchParams])
+
+  const update = useCallback(
+    (overrides: Partial<OutcomesFilters>, options: { history?: "push" | "replace" } = {}) => {
+      const next = writeOutcomesFiltersToParams(searchParams, overrides)
+      setSearchParams(next, { replace: options.history !== "push" })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  return { isOpen, filters, open, close, update }
+}

--- a/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useResizeDrag } from "@/hooks/use-resize-drag"
+import { useDebouncedUrlText } from "@/hooks/use-debounced-url-text"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { PanelResizeHandle } from "@/components/layout/panel-resize-handle"
 import { useExplorerUrlState } from "./use-explorer-url-state"
@@ -36,57 +37,11 @@ export function ExplorerShell({ workspaceId, mode, enabled }: ExplorerShellProps
 
   const search = useAttachmentSearch(workspaceId, filters, { enabled })
 
-  // The query input is locally controlled and debounced into URL state.
-  // Driving `value` directly off `filters.queryText` (which comes from
-  // `useSearchParams`) makes the input lag a tick behind keystrokes, and
-  // mobile autocorrect — which replaces the misspelled word in two DOM
-  // steps — sees a stale value mid-replacement and concatenates the
-  // suggestion onto the original ("gurl" + "girl" -> "Guelirl") instead
-  // of substituting it.
-  const [queryDraft, setQueryDraft] = useState(filters.queryText)
-  const queryDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // The latest URL value we wrote ourselves. Lets the URL→draft sync
-  // distinguish our own debounced echo (skip — would clobber newer
-  // keystrokes typed during React Router's render delay) from external
-  // changes like Clear filters or back/forward (apply — cancel pending
-  // debounce so it can't resurrect stale typing).
-  const lastWrittenRef = useRef(filters.queryText)
-
-  // Always call the freshest `update` from the timer. Without this, a
-  // pending debounce captures an older `update` that closes over older
-  // searchParams; firing after another filter changed would write back
-  // a stale snapshot and revert that change.
-  const updateRef = useRef(update)
-  useEffect(() => {
-    updateRef.current = update
-  }, [update])
-
-  useEffect(() => {
-    if (filters.queryText === lastWrittenRef.current) return
-    if (queryDebounceRef.current) {
-      clearTimeout(queryDebounceRef.current)
-      queryDebounceRef.current = null
-    }
-    lastWrittenRef.current = filters.queryText
-    setQueryDraft(filters.queryText)
-  }, [filters.queryText])
-
-  useEffect(() => {
-    return () => {
-      if (queryDebounceRef.current) clearTimeout(queryDebounceRef.current)
-    }
-  }, [])
-
-  const handleQueryChange = useCallback((value: string) => {
-    setQueryDraft(value)
-    if (queryDebounceRef.current) clearTimeout(queryDebounceRef.current)
-    queryDebounceRef.current = setTimeout(() => {
-      queryDebounceRef.current = null
-      lastWrittenRef.current = value
-      updateRef.current({ queryText: value })
-    }, QUERY_DEBOUNCE_MS)
-  }, [])
+  const { draft: queryDraft, setDraft: handleQueryChange } = useDebouncedUrlText({
+    value: filters.queryText,
+    onCommit: useCallback((next: string) => update({ queryText: next }), [update]),
+    delayMs: QUERY_DEBOUNCE_MS,
+  })
 
   const parentStreamId = useMemo(() => {
     // Surface a single parent only when exactly one stream is filtered to —

--- a/apps/frontend/src/hooks/use-debounced-url-text.ts
+++ b/apps/frontend/src/hooks/use-debounced-url-text.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+interface DebouncedUrlTextOptions {
+  /** The committed value, read back from the URL. */
+  value: string
+  /** Called with the settled draft; must write `value` (directly or eventually). */
+  onCommit: (next: string) => void
+  delayMs?: number
+}
+
+const DEFAULT_DELAY_MS = 200
+
+/**
+ * A text input that is locally controlled and debounced into URL state.
+ *
+ * Driving `value` straight off `useSearchParams` makes the input lag a tick
+ * behind keystrokes, and mobile autocorrect — which replaces the misspelled word
+ * in two DOM steps — sees a stale value mid-replacement and concatenates the
+ * suggestion onto the original ("gurl" + "girl" -> "Guelirl") instead of
+ * substituting it.
+ *
+ * Two refs carry the rest of the contract: `lastWrittenRef` tells our own
+ * debounced echo (skip — it would clobber keystrokes typed during React Router's
+ * render delay) from an external change like Clear filters or back/forward
+ * (apply, and cancel the pending debounce so it can't resurrect stale typing);
+ * `commitRef` keeps the timer on the freshest callback, so a pending debounce
+ * can't write back a params snapshot taken before another filter changed.
+ */
+export function useDebouncedUrlText({ value, onCommit, delayMs = DEFAULT_DELAY_MS }: DebouncedUrlTextOptions) {
+  const [draft, setDraftState] = useState(value)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastWrittenRef = useRef(value)
+
+  const commitRef = useRef(onCommit)
+  useEffect(() => {
+    commitRef.current = onCommit
+  }, [onCommit])
+
+  useEffect(() => {
+    if (value === lastWrittenRef.current) return
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    lastWrittenRef.current = value
+    setDraftState(value)
+  }, [value])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const setDraft = useCallback(
+    (next: string) => {
+      setDraftState(next)
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        lastWrittenRef.current = next
+        commitRef.current(next)
+      }, delayMs)
+    },
+    [delayMs]
+  )
+
+  return { draft, setDraft }
+}

--- a/apps/frontend/src/lib/agent-outcomes/grouping.test.ts
+++ b/apps/frontend/src/lib/agent-outcomes/grouping.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { groupOutcomesByDay } from "./grouping"
+import type { OutcomeItem } from "./items"
+
+const NOW = new Date("2026-07-28T12:00:00")
+
+function item(overrides: Partial<OutcomeItem> & { id: string; occursAt: string }): OutcomeItem {
+  return {
+    kind: "follow_up",
+    streamId: "str_design",
+    title: "A follow-up",
+    statusLabel: "Scheduled",
+    statusPillClass: "",
+    isSettled: false,
+    scheduledFor: overrides.occursAt,
+    claimedByLabel: null,
+    statusNote: null,
+    createdAt: overrides.occursAt,
+    statusChangedAt: overrides.occursAt,
+    anchorPath: null,
+    canCancel: true,
+    canMarkDone: false,
+    ...overrides,
+  }
+}
+
+describe("groupOutcomesByDay", () => {
+  it("puts an overdue outstanding follow-up in Now, not in its calendar day", () => {
+    const groups = groupOutcomesByDay([item({ id: "fup_late", occursAt: "2026-07-26T09:00:00" })], NOW)
+    expect(groups.map((g) => g.label)).toEqual(["Now"])
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["fup_late"])
+  })
+
+  it("keeps a settled outcome in its calendar day even when it is in the past", () => {
+    const groups = groupOutcomesByDay([item({ id: "fup_done", occursAt: "2026-07-27T09:00:00", isSettled: true })], NOW)
+    expect(groups.map((g) => g.label)).toEqual(["Yesterday"])
+  })
+
+  it("interleaves both kinds inside Now", () => {
+    const groups = groupOutcomesByDay(
+      [
+        item({ id: "deleg_1", kind: "delegation", occursAt: "2026-07-28T10:30:00" }),
+        item({ id: "fup_late", occursAt: "2026-07-27T08:00:00" }),
+      ],
+      NOW
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["deleg_1", "fup_late"])
+  })
+
+  it("buckets later today, tomorrow, and beyond the horizon", () => {
+    const groups = groupOutcomesByDay(
+      [
+        item({ id: "far", occursAt: "2026-08-20T09:00:00" }),
+        item({ id: "tomorrow", occursAt: "2026-07-29T09:00:00" }),
+        item({ id: "tonight", occursAt: "2026-07-28T22:00:00" }),
+      ],
+      NOW
+    )
+    expect(groups.map((g) => [g.label, g.items.map((i) => i.id)])).toEqual([
+      ["Today", ["tonight"]],
+      ["Wednesday, July 29", ["tomorrow"]],
+      ["Later", ["far"]],
+    ])
+  })
+
+  it("leads with Now and trails with Later regardless of arrival order", () => {
+    const groups = groupOutcomesByDay(
+      [
+        item({ id: "far", occursAt: "2026-09-01T09:00:00" }),
+        item({ id: "tonight", occursAt: "2026-07-28T22:00:00" }),
+        item({ id: "overdue", occursAt: "2026-07-20T09:00:00" }),
+      ],
+      NOW
+    )
+    expect(groups.map((g) => g.label)).toEqual(["Now", "Today", "Later"])
+  })
+
+  it("orders the days between Today and Later chronologically from a DESC page", () => {
+    const groups = groupOutcomesByDay(
+      [
+        item({ id: "far", occursAt: "2026-09-01T09:00:00" }),
+        item({ id: "fri", occursAt: "2026-07-31T09:00:00" }),
+        item({ id: "thu", occursAt: "2026-07-30T09:00:00" }),
+        item({ id: "wed", occursAt: "2026-07-29T09:00:00" }),
+        item({ id: "tonight", occursAt: "2026-07-28T22:00:00" }),
+        item({ id: "overdue", occursAt: "2026-07-20T09:00:00" }),
+      ],
+      NOW
+    )
+    expect(groups.map((g) => [g.label, g.items.map((i) => i.id)])).toEqual([
+      ["Now", ["overdue"]],
+      ["Today", ["tonight"]],
+      ["Wednesday, July 29", ["wed"]],
+      ["Thursday, July 30", ["thu"]],
+      ["Friday, July 31", ["fri"]],
+      ["Later", ["far"]],
+    ])
+  })
+
+  it("returns no groups for an empty list", () => {
+    expect(groupOutcomesByDay([], NOW)).toEqual([])
+  })
+})

--- a/apps/frontend/src/lib/agent-outcomes/grouping.ts
+++ b/apps/frontend/src/lib/agent-outcomes/grouping.ts
@@ -1,0 +1,76 @@
+import { formatDayDivider, localStartOfDayMs } from "@/lib/dates"
+import type { OutcomeItem } from "./items"
+
+export interface OutcomeDayGroup {
+  /** Stable React key: `now`, `later`, or the local start-of-day in ms. */
+  key: string
+  label: string
+  items: OutcomeItem[]
+}
+
+/** Days ahead beyond which a scheduled outcome collapses into the "Later" bucket. */
+const LATER_HORIZON_DAYS = 6
+
+const NOW_KEY = "now"
+const LATER_KEY = "later"
+
+const INTERMEDIATE_RANK = 2
+
+function rankOf(key: string, todayKey: string): number {
+  if (key === NOW_KEY) return 0
+  if (key === todayKey) return 1
+  if (key === LATER_KEY) return 3
+  return INTERMEDIATE_RANK
+}
+
+function bucketFor(item: OutcomeItem, now: Date): { key: string; label: string } {
+  const occursAt = new Date(item.occursAt)
+
+  // Outstanding work whose moment has passed is the thing the user acts on
+  // first — an overdue follow-up and a delegation already moving belong side by
+  // side, not filed under their calendar days.
+  if (!item.isSettled && occursAt.getTime() <= now.getTime()) {
+    return { key: NOW_KEY, label: "Now" }
+  }
+
+  const dayMs = localStartOfDayMs(occursAt)
+  const daysAhead = Math.round((dayMs - localStartOfDayMs(now)) / 86_400_000)
+  if (daysAhead > LATER_HORIZON_DAYS) {
+    return { key: LATER_KEY, label: "Later" }
+  }
+
+  return { key: String(dayMs), label: formatDayDivider(occursAt, now) }
+}
+
+/**
+ * Day buckets for the outcomes list, in the device's local calendar (INV-42).
+ * `Now` leads and `Later` trails; the calendar days in between run
+ * chronologically regardless of the direction the server paged `occursAt` in.
+ */
+export function groupOutcomesByDay(items: OutcomeItem[], now: Date = new Date()): OutcomeDayGroup[] {
+  const byKey = new Map<string, OutcomeDayGroup>()
+  const order: string[] = []
+
+  for (const item of items) {
+    const { key, label } = bucketFor(item, now)
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.items.push(item)
+      continue
+    }
+    byKey.set(key, { key, label, items: [item] })
+    order.push(key)
+  }
+
+  const todayKey = String(localStartOfDayMs(now))
+  return order
+    .map((key, index) => ({ key, index, rank: rankOf(key, todayKey) }))
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank
+      // Intermediate buckets are keyed by their local start-of-day, so the page
+      // can arrive DESC and still read forwards.
+      if (a.rank === INTERMEDIATE_RANK) return Number(a.key) - Number(b.key)
+      return a.index - b.index
+    })
+    .map(({ key }) => byKey.get(key)!)
+}

--- a/apps/frontend/src/lib/agent-outcomes/items.test.ts
+++ b/apps/frontend/src/lib/agent-outcomes/items.test.ts
@@ -1,0 +1,104 @@
+import type { AgentOutcomeSummary } from "@threa/types"
+import { describe, expect, it } from "vitest"
+import { toOutcomeItem, toOutcomeItems } from "./items"
+
+function followUp(overrides: Partial<AgentOutcomeSummary> = {}): AgentOutcomeSummary {
+  return {
+    kind: "follow_up",
+    id: "fup_1",
+    streamId: "str_design",
+    title: "Check in on the migration",
+    status: "pending",
+    scheduledFor: "2026-08-01T18:00:00.000Z",
+    claimedByLabel: null,
+    statusNote: null,
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-07-28T09:00:00.000Z",
+    statusChangedAt: "2026-07-28T09:00:00.000Z",
+    occursAt: "2026-08-01T18:00:00.000Z",
+    anchorEventId: "event_1",
+    ...overrides,
+  } as AgentOutcomeSummary
+}
+
+function delegation(overrides: Partial<AgentOutcomeSummary> = {}): AgentOutcomeSummary {
+  return {
+    kind: "delegation",
+    id: "deleg_1",
+    streamId: "str_strategy",
+    title: "Run the schema migration locally",
+    status: "running",
+    scheduledFor: null,
+    claimedByLabel: "kris@laptop",
+    statusNote: "step 2 of 4",
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-07-28T09:00:00.000Z",
+    statusChangedAt: "2026-07-28T10:30:00.000Z",
+    occursAt: "2026-07-28T10:30:00.000Z",
+    anchorEventId: "event_2",
+    ...overrides,
+  } as AgentOutcomeSummary
+}
+
+describe("toOutcomeItem", () => {
+  it("maps a pending follow-up to its display shape", () => {
+    expect(toOutcomeItem("ws_1", followUp())).toEqual({
+      id: "fup_1",
+      kind: "follow_up",
+      streamId: "str_design",
+      title: "Check in on the migration",
+      statusLabel: "Scheduled",
+      statusPillClass: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+      isSettled: false,
+      occursAt: "2026-08-01T18:00:00.000Z",
+      scheduledFor: "2026-08-01T18:00:00.000Z",
+      claimedByLabel: null,
+      statusNote: null,
+      createdAt: "2026-07-28T09:00:00.000Z",
+      statusChangedAt: "2026-07-28T09:00:00.000Z",
+      anchorPath: "/w/ws_1/s/str_design?m=event_1",
+      canCancel: true,
+      canMarkDone: false,
+    })
+  })
+
+  it("maps a running delegation, which can be cancelled or marked done", () => {
+    expect(toOutcomeItem("ws_1", delegation())).toMatchObject({
+      kind: "delegation",
+      statusLabel: "Running",
+      isSettled: false,
+      claimedByLabel: "kris@laptop",
+      statusNote: "step 2 of 4",
+      anchorPath: "/w/ws_1/s/str_strategy?m=event_2",
+      canCancel: true,
+      canMarkDone: true,
+    })
+  })
+
+  it("marks terminal statuses settled and offers no actions", () => {
+    expect(toOutcomeItem("ws_1", followUp({ status: "fired" }))).toMatchObject({
+      statusLabel: "Ran",
+      isSettled: true,
+      canCancel: false,
+      canMarkDone: false,
+    })
+    expect(toOutcomeItem("ws_1", delegation({ status: "completed" }))).toMatchObject({
+      statusLabel: "Completed",
+      isSettled: true,
+      canCancel: false,
+      canMarkDone: false,
+    })
+  })
+
+  it("renders a null-anchor follow-up inert rather than as a dead link", () => {
+    expect(toOutcomeItem("ws_1", followUp({ anchorEventId: null })).anchorPath).toBe(null)
+  })
+
+  it("maps a mixed page in order", () => {
+    expect(toOutcomeItems("ws_1", [followUp(), delegation()]).map((i) => i.id)).toEqual(["fup_1", "deleg_1"])
+  })
+})

--- a/apps/frontend/src/lib/agent-outcomes/items.ts
+++ b/apps/frontend/src/lib/agent-outcomes/items.ts
@@ -1,0 +1,77 @@
+import type { AgentOutcomeKind, AgentOutcomeSummary } from "@threa/types"
+import { DELEGATION_STATUS_LABEL, DELEGATION_TERMINAL, delegationStatusPillClass } from "@/lib/delegation-display"
+import { FOLLOW_UP_STATUS_LABEL, FOLLOW_UP_TERMINAL, followUpStatusPillClass } from "@/lib/follow-up-display"
+
+/**
+ * The render shape both outcome kinds collapse to. The wire carries no display
+ * text (INV-46), so the labels and pill classes come from the two display
+ * modules the panel and the timeline cards already share.
+ */
+export interface OutcomeItem {
+  id: string
+  kind: AgentOutcomeKind
+  streamId: string
+  title: string
+  statusLabel: string
+  statusPillClass: string
+  /** Ended one way or another — drives the Outstanding/Settled split and the muted styling. */
+  isSettled: boolean
+  occursAt: string
+  scheduledFor: string | null
+  claimedByLabel: string | null
+  statusNote: string | null
+  createdAt: string
+  statusChangedAt: string
+  /**
+   * Router path to the anchoring timeline card, or null when the join came back
+   * empty. Null renders inert — the delegation precedent in `stream-context-row.tsx`
+   * (`cardTarget`): a focusable control whose click silently no-ops is worse than
+   * plain text.
+   */
+  anchorPath: string | null
+  canCancel: boolean
+  /** Only a delegation can be closed out by hand; a follow-up has no such affordance. */
+  canMarkDone: boolean
+}
+
+export const OUTCOME_KIND_LABEL: Record<AgentOutcomeKind, string> = {
+  follow_up: "Follow-up",
+  delegation: "Delegation",
+}
+
+export function outcomeAnchorPath(workspaceId: string, outcome: AgentOutcomeSummary): string | null {
+  if (!outcome.anchorEventId) return null
+  return `/w/${workspaceId}/s/${outcome.streamId}?m=${outcome.anchorEventId}`
+}
+
+export function toOutcomeItem(workspaceId: string, outcome: AgentOutcomeSummary): OutcomeItem {
+  const settled =
+    outcome.kind === "follow_up" ? FOLLOW_UP_TERMINAL.has(outcome.status) : DELEGATION_TERMINAL.has(outcome.status)
+
+  return {
+    id: outcome.id,
+    kind: outcome.kind,
+    streamId: outcome.streamId,
+    title: outcome.title,
+    statusLabel:
+      outcome.kind === "follow_up" ? FOLLOW_UP_STATUS_LABEL[outcome.status] : DELEGATION_STATUS_LABEL[outcome.status],
+    statusPillClass:
+      outcome.kind === "follow_up"
+        ? followUpStatusPillClass(outcome.status)
+        : delegationStatusPillClass(outcome.status),
+    isSettled: settled,
+    occursAt: outcome.occursAt,
+    scheduledFor: outcome.scheduledFor,
+    claimedByLabel: outcome.claimedByLabel,
+    statusNote: outcome.statusNote,
+    createdAt: outcome.createdAt,
+    statusChangedAt: outcome.statusChangedAt,
+    anchorPath: outcomeAnchorPath(workspaceId, outcome),
+    canCancel: !settled,
+    canMarkDone: outcome.kind === "delegation" && !settled,
+  }
+}
+
+export function toOutcomeItems(workspaceId: string, outcomes: AgentOutcomeSummary[]): OutcomeItem[] {
+  return outcomes.map((outcome) => toOutcomeItem(workspaceId, outcome))
+}

--- a/apps/frontend/src/pages/outcomes.tsx
+++ b/apps/frontend/src/pages/outcomes.tsx
@@ -1,0 +1,30 @@
+import { ArrowLeft, ListChecks } from "lucide-react"
+import { Link, useParams } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+import { SidebarToggle } from "@/components/layout"
+import { OutcomesShell } from "@/components/agent-outcomes/outcomes-shell"
+
+export function OutcomesPage() {
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+  if (!workspaceId) return null
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+        <SidebarToggle location="page" />
+        <Button asChild variant="ghost" size="icon" className="h-8 w-8">
+          <Link to={`/w/${workspaceId}`} aria-label="Back to workspace">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <ListChecks className="h-5 w-5 text-muted-foreground" />
+          <h1 className="font-semibold">Agent agenda</h1>
+        </div>
+      </header>
+      <main className="flex-1 overflow-hidden">
+        <OutcomesShell workspaceId={workspaceId} mode="page" enabled />
+      </main>
+    </div>
+  )
+}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -129,6 +129,11 @@ export const router = createBrowserRouter([
             lazy: async () => ({ Component: (await import("@/pages/files")).FilesPage }),
           },
           {
+            path: "agenda",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/outcomes")).OutcomesPage }),
+          },
+          {
             path: "memos/:memoId",
             element: <LegacyMemoRedirect />,
           },

--- a/tests/browser/agent-outcomes.spec.ts
+++ b/tests/browser/agent-outcomes.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * The outcomes page, asserted in a real browser.
+ *
+ * NOT end-to-end coverage: a real follow-up or delegation needs an agent turn,
+ * which this suite has no cheap way to drive, so the `agent-outcomes` response
+ * is stubbed with fixed fixtures. Everything else is real — real Chromium, real
+ * CSS, real component tree, real routing. These are layout claims, which jsdom
+ * cannot judge at all: it has no layout engine, so a unit test can only see that
+ * a class name is present, never that the result is legible.
+ */
+
+const STREAM_NAME_TITLE = "Check in on the migration once the read replica has caught up and the backfill has drained"
+
+function outcome(overrides: Record<string, unknown>) {
+  return {
+    kind: "follow_up",
+    id: "fup_1",
+    streamId: "str_seed",
+    title: "Check in on the migration",
+    status: "pending",
+    scheduledFor: "2030-01-01T18:00:00.000Z",
+    claimedByLabel: null,
+    statusNote: null,
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-07-28T09:00:00.000Z",
+    statusChangedAt: "2026-07-28T09:00:00.000Z",
+    occursAt: "2030-01-01T18:00:00.000Z",
+    anchorEventId: null,
+    ...overrides,
+  }
+}
+
+/** Enough rows, across enough days, that the list must scroll and group. */
+function fixtures() {
+  const items: Array<Record<string, unknown>> = [
+    outcome({ id: "fup_overdue", title: "Overdue check-in", occursAt: "2020-01-01T09:00:00.000Z" }),
+    outcome({
+      id: "deleg_running",
+      kind: "delegation",
+      title: "Run the schema migration locally",
+      status: "running",
+      scheduledFor: null,
+      claimedByLabel: "kris@laptop",
+      occursAt: "2020-01-02T09:00:00.000Z",
+    }),
+    outcome({ id: "fup_long", title: STREAM_NAME_TITLE, occursAt: "2030-01-01T18:00:00.000Z" }),
+  ]
+  for (let i = 0; i < 30; i++) {
+    items.push(
+      outcome({
+        id: `fup_bulk_${i}`,
+        title: `Scheduled follow-up number ${i}`,
+        occursAt: new Date(Date.UTC(2030, 0, 2 + i, 9)).toISOString(),
+      })
+    )
+  }
+  return items
+}
+
+async function stubOutcomes(page: Page) {
+  // Scoped to the API path on purpose: a bare `**/agent-outcomes*` also matches
+  // the dev server's module requests for `api/agent-outcomes.ts` and
+  // `hooks/use-agent-outcomes.ts`, which then arrive as JSON and blank the app.
+  await page.route("**/api/workspaces/*/agent-outcomes*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: fixtures(), nextCursor: null, outstandingCount: fixtures().length }),
+    })
+  })
+}
+
+async function openOutcomes(page: Page) {
+  const match = page.url().match(/\/w\/([^/?]+)/)
+  if (!match) throw new Error(`no workspace in URL: ${page.url()}`)
+  await stubOutcomes(page)
+  await page.goto(`/w/${match[1]}/agenda?aState=all`)
+  await expect(page.getByTestId("outcomes-list")).toBeVisible({ timeout: 15_000 })
+}
+
+/** The element that actually scrolls the rows — the list's own overflow box. */
+function listScroller(page: Page) {
+  return page.getByTestId("outcomes-list").locator("xpath=..")
+}
+
+test.describe("agent outcomes page", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAndCreateWorkspace(page, "outcomes")
+  })
+
+  test("the detail pane sits beside the list at 1440px and not at 390px", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await openOutcomes(page)
+
+    await page.getByRole("button", { name: /Overdue check-in/ }).click()
+
+    const listBox = await listScroller(page).boundingBox()
+    const detailBox = await page.getByTestId("outcomes-detail-pane").boundingBox()
+    if (!listBox || !detailBox) throw new Error("list or detail pane is not laid out")
+    expect(detailBox.x).toBeGreaterThanOrEqual(listBox.x + listBox.width - 1)
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    const sideBySide = await page.evaluate(() => {
+      const list = document.querySelector("[data-testid='outcomes-list']")
+      const detail = document.querySelector("[data-testid='outcomes-detail-pane']")
+      if (!list || !detail) return false
+      const l = list.getBoundingClientRect()
+      const d = detail.getBoundingClientRect()
+      return d.width > 0 && l.width > 0 && d.x >= l.x + l.width - 1
+    })
+    expect(sideBySide).toBe(false)
+
+    const bodyOverflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1
+    )
+    expect(bodyOverflows).toBe(false)
+  })
+
+  // A `fullPage` screenshot cannot see this: the page itself never scrolls, so
+  // the defect (rows scrolling the whole document and taking the header with
+  // them) looks identical in an image.
+  test("the list scrolls inside its own container while the header stays put", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 700 })
+    await openOutcomes(page)
+
+    const scroller = listScroller(page)
+    const scrollable = await scroller.evaluate((el) => el.scrollHeight > el.clientHeight + 1)
+    expect(scrollable).toBe(true)
+
+    const header = page.getByRole("heading", { name: "Agent agenda" })
+    const before = await header.boundingBox()
+    await scroller.evaluate((el) => {
+      el.scrollTop = 400
+    })
+    const scrolled = await scroller.evaluate((el) => el.scrollTop)
+    expect(scrolled).toBeGreaterThan(0)
+
+    const after = await header.boundingBox()
+    expect(after?.y).toBeCloseTo(before?.y ?? -1, 0)
+
+    const documentScrolled = await page.evaluate(() => document.documentElement.scrollTop)
+    expect(documentScrolled).toBe(0)
+  })
+
+  test("a long follow-up note truncates with the status pill still fully visible", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await openOutcomes(page)
+
+    const row = page.locator("[data-outcome-id='fup_long']")
+    await row.scrollIntoViewIfNeeded()
+
+    const title = row.locator("span").first()
+    const truncated = await title.evaluate((el) => el.scrollWidth > el.clientWidth + 1)
+    expect(truncated).toBe(true)
+
+    const pill = row.getByText("Scheduled", { exact: true })
+    const pillBox = await pill.boundingBox()
+    const rowBox = await row.boundingBox()
+    if (!pillBox || !rowBox) throw new Error("row or pill is not laid out")
+    expect(pillBox.width).toBeGreaterThan(0)
+    expect(pillBox.x + pillBox.width).toBeLessThanOrEqual(rowBox.x + rowBox.width + 1)
+    const pillClipped = await pill.evaluate((el) => el.scrollWidth > el.clientWidth + 1)
+    expect(pillClipped).toBe(false)
+  })
+
+  test("the chip row wraps rather than overflowing at 390px", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await openOutcomes(page)
+
+    const chips = page.getByTestId("outcomes-chips")
+    const overflows = await chips.evaluate((el) => el.scrollWidth > el.clientWidth + 1)
+    expect(overflows).toBe(false)
+
+    // Wrapped, not shrunk onto one clipped line: the chips occupy more than one
+    // row box.
+    const rows = await chips.evaluate((el) => {
+      const tops = Array.from(el.children).map((child) => Math.round(child.getBoundingClientRect().top))
+      return new Set(tops).size
+    })
+    expect(rows).toBeGreaterThan(1)
+  })
+
+  test("at 390px selecting a row replaces the list with the detail, and back returns", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await openOutcomes(page)
+
+    const list = page.getByTestId("outcomes-list")
+    const detail = page.getByTestId("outcomes-detail-pane")
+
+    await page.getByRole("button", { name: /Overdue check-in/ }).click()
+
+    await expect(list).toBeHidden()
+    await expect(detail).toBeVisible()
+    const detailBox = await detail.boundingBox()
+    expect(detailBox?.width ?? 0).toBeGreaterThan(300)
+
+    await page.getByRole("button", { name: "Back to the agenda list" }).click()
+
+    await expect(list).toBeVisible()
+    const detailWidth = await detail.evaluate((el) => el.getBoundingClientRect().width)
+    expect(detailWidth).toBe(0)
+  })
+
+  test("at 800px the layout is stacked, not a crushed split", async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 900 })
+    await openOutcomes(page)
+
+    const listWidth = await listScroller(page).evaluate((el) => el.getBoundingClientRect().width)
+    const detailWidthBefore = await page
+      .getByTestId("outcomes-detail-pane")
+      .evaluate((el) => el.getBoundingClientRect().width)
+    expect(detailWidthBefore).toBe(0)
+    expect(listWidth).toBeGreaterThan(400)
+
+    await page.getByRole("button", { name: /Overdue check-in/ }).click()
+
+    await expect(page.getByTestId("outcomes-list")).toBeHidden()
+    const detailWidthAfter = await page
+      .getByTestId("outcomes-detail-pane")
+      .evaluate((el) => el.getBoundingClientRect().width)
+    expect(detailWidthAfter).toBeGreaterThan(400)
+  })
+
+  test("day headers stay legible while the list is scrolled", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 700 })
+    await openOutcomes(page)
+
+    const scroller = listScroller(page)
+    await scroller.evaluate((el) => {
+      el.scrollTop = 600
+    })
+
+    const visibleHeader = await page.evaluate(() => {
+      const sections = Array.from(document.querySelectorAll("[data-testid='outcomes-list'] section > div:first-child"))
+      const scrollerEl = document.querySelector("[data-testid='outcomes-list']")?.parentElement
+      if (!scrollerEl) return null
+      const bounds = scrollerEl.getBoundingClientRect()
+      for (const section of sections) {
+        const rect = section.getBoundingClientRect()
+        if (rect.top >= bounds.top - 1 && rect.bottom <= bounds.bottom + 1 && rect.height > 0) {
+          return { text: (section.textContent ?? "").trim(), height: rect.height }
+        }
+      }
+      return null
+    })
+    expect(visibleHeader).not.toBeNull()
+    expect(visibleHeader!.text.length).toBeGreaterThan(0)
+    expect(visibleHeader!.height).toBeGreaterThan(8)
+  })
+})


### PR DESCRIPTION
## Problem

Follow-ups and delegations were readable per stream after [#1668](https://github.com/threahq/threa/pull/1668) and [#1669](https://github.com/threahq/threa/pull/1669), but nothing answered "what has my companion got queued, across the workspace". Follow-ups still had no route of their own.

Chunk 3 of 5 (plan: https://seer.build/ws_vbyzjvdg6g/b/outcomes-plan-5544fa/, design: https://seer.build/ws_vbyzjvdg6g/b/outcomes-explorer-619bc7/).

## Solution

`OutcomesShell` with `mode: "modal" | "page"`, hosted at `/w/:workspaceId/outcomes`. Same shape as the attachment explorer, because that already solves the scope problem — one shell, two hosts, scope as a filter rather than as a second surface. Only the page host exists here; the modal arm and its entry points are chunks 4–5.

- **Chips, not tabs** (Outstanding / Settled / All · Follow-ups / Delegations · a removable scope chip). Outstanding has to interleave a running delegation with a follow-up firing tonight, which tabs can't express. Every filter round-trips through the URL (INV-59).
- **Namespaced URL params** — `oStreams`, `oState`, `oKind`, `oq`, `oSelected`. `<AttachmentExplorer>` mounts on **every** workspace route (`workspace-layout.tsx`) and claims `streams`, `q`, `selected`. Sharing them meant Cmd+K → "Browse files" from `/outcomes` deleted `streams` (the list silently widened to the whole workspace), the explorer opened pre-seeded with the outcomes search text and an outcome id as its `selected`, and Escape wiped both. Chunk 5 mounts the outcomes modal on that same layout, where it would have become bidirectional.
- **The split is gated on `useIsSplitCapable` (1024), not `useIsMobile` (640)**, with `lg:block` on the detail pane so the CSS and JS breakpoints agree. `MIN_LIST_WIDTH` + `MIN_DETAIL_WIDTH` is 620px of content before the sidebar, and `use-mobile.tsx` already documents why 1024 is the floor: *"phone-landscape (~667-850px) and small tablets land in that band; gating on MOBILE_BREAKPOINT alone would hand them the degenerate split."*
- **Day grouping** is `Now` (outstanding and already due) → `Today` → per-day → `Later`, local-time via `lib/dates` (INV-42). Intermediate days sort by day key, not by arrival order — the server pages in one direction and inheriting it put tomorrow's follow-up underneath next week's.
- **Detail pane** reuses the existing calls only: `agentFollowUpsApi.cancel`, `delegationsApi.cancel`, `delegationsApi.markDone`. No new mutations, no retry, no undo, no success toast (INV-63).
- **The explorer's debounced search input moved to `hooks/use-debounced-url-text.ts`** rather than being copied. It carries a mobile-autocorrect fix and two refs guarding against stale writes; a second copy would have drifted from them. The explorer was rewired to it and its own suite stayed green — that is the only edit outside this chunk's surface.

**`outcomes-row` does not wrap `StreamContextRow`**, which the plan suggested. That component navigates via `onJumpToMessage`/`onOpenThread` inside one stream, while an outcomes row selects into `?oSelected=` across streams; wrapping meant either editing `stream-context/**` or feeding it dummy callbacks. Reviewed for duplicated logic; there is none worth collapsing.

**Four review fixes, all shipped green first:** the day-group inversion above; the URL param collision above; the crushed split above; and `hasFilters` counting the *default* state as a filter, so a brand-new workspace got "Clear filters" having set none and the first-run copy was unreachable.

**Not here**: the modal host has no caller (chunk 5), no sidebar quick link (chunk 4), no backend or `packages/types` change.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/agent-outcomes/` | **new** — shell, filters, list, row, detail, empty, `use-outcomes-url-state` |
| `apps/frontend/src/lib/agent-outcomes/{items,grouping}.ts` | **new** — render shape for both kinds; the day buckets |
| `apps/frontend/src/pages/outcomes.tsx` | **new** — page host, mirrors `pages/files.tsx` |
| `apps/frontend/src/routes/index.tsx` | one lazy route beside `files` |
| `apps/frontend/src/hooks/use-debounced-url-text.ts` | **new** — extracted from `explorer-shell.tsx`, which now uses it |
| `tests/browser/agent-outcomes.spec.ts` | **new** — 7 layout claims in real Chromium |

## Test plan

- [x] `apps/frontend` vitest — 1001 pass / 0 fail across agent-outcomes, stream-context, attachment-explorer and hooks
- [x] **Playwright `agent-outcomes.spec.ts` — 7 pass / 0 fail** on the real stack (12/12 with `agent-effects.spec.ts`)
- [x] `bun run typecheck` exit 0 · `bun run lint` exit 0 · backend `test:unit` 3842/0, `test:integration` 743/0 (rebased tip)
- [x] **Mutation-checked, five times.** `overflow-y-auto`→`visible` reddens the scroll-container spec; reverting the split gate reddens the 800px spec at `expect(detailWidthBefore).toBe(0)` receiving 400 — the crushed split rendering exactly as reported; forcing `showDetailOnly` false reddens both mobile specs with the list still visible after a row click; reverting the param rename reddens 8 URL-state tests including the explorer round-trip; reverting `hasFilters` reddens the first-run test.
- [ ] The browser spec stubs `**/api/workspaces/*/agent-outcomes*` — a real follow-up needs an agent turn. It proves layout and component behaviour, not server data, and says so at the top.
- [ ] Infinite scroll is wired but every fixture returns `nextCursor: null`, so a second page has not been fetched in a test.
- [ ] Cancel / mark-done are wired but not driven by a test.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/outcomes-plan-5544fa/ — 5 chunks. This is C3.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787942445&installation_model_id=20758&pr_number=1672&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1672&signature=88a79282fb8745687dbb46040c05ab57c50ffd775f92877618d2c69df88012ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->