### PR TITLE
fix: stream a turn's writes as they land, and open memos in place

### DIFF
--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -81,9 +81,12 @@ const STUB_EFFECTS: AgentToolEffect[] = [
   { kind: "settings", target: "timezone", before: "Europe/Stockholm", after: "Europe/Copenhagen" },
   { kind: "delegation", label: "Plan out how to set up and use Threa", target: "dlg_stub" },
   { kind: "follow_up", label: "Check in on how things are going", target: "fu_stub" },
+  // A memo opens a dialog rather than navigating, so the browser suite needs one
+  // to check that the overlay actually lands on top of the stream.
+  { kind: "memo", label: "User test run: settings, delegation, follow-up", target: "memo_stub" },
 ]
 
-const STUB_EFFECTS_CONTENT = "update_user_settings, delegate_task, schedule_follow_up"
+const STUB_EFFECTS_CONTENT = "update_user_settings, delegate_task, schedule_follow_up, save_memo"
 
 export interface PersonaAgentDeps {
   pool: Pool

--- a/apps/frontend/src/components/board/board-row-item.effects.test.tsx
+++ b/apps/frontend/src/components/board/board-row-item.effects.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { StreamEvent } from "@threa/types"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import * as contextsModule from "@/contexts"
@@ -40,7 +41,7 @@ describe("BoardEventRowItem session effects", () => {
     vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation(() => <span>just now</span>)
   })
 
-  it("renders the effect grid without nesting an anchor in the card link", () => {
+  it("renders the effect grid without nesting an interactive element in the card link", () => {
     const row = {
       kind: "session",
       key: "session:session_fx",
@@ -66,16 +67,21 @@ describe("BoardEventRowItem session effects", () => {
     } as unknown as BoardEventRow
 
     const { container } = render(
-      <MemoryRouter initialEntries={["/w/ws_1/board"]}>
-        <Routes>
-          <Route path="/w/:workspaceId/board" element={<BoardEventRowItem row={row} workspaceId="ws_1" />} />
-        </Routes>
-      </MemoryRouter>
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={["/w/ws_1/board"]}>
+          <Routes>
+            <Route path="/w/:workspaceId/board" element={<BoardEventRowItem row={row} workspaceId="ws_1" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
 
     const cardLink = container.querySelector('a[href="/trace/session_fx"]')!
     expect(cardLink.querySelectorAll("a")).toHaveLength(0)
-    expect(screen.getByRole("link", { name: /Saved a memo/ })).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_1")
+    // The memo row is a dialog button, and it must not be nested in the card
+    // link either.
+    expect(cardLink.querySelectorAll("button")).toHaveLength(0)
+    expect(screen.getByRole("button", { name: /Saved a memo/ })).toBeInTheDocument()
   })
 })
 
@@ -112,14 +118,19 @@ describe("BoardEventRowItem running session", () => {
 
   function mount(onRedirectSession?: () => void) {
     return render(
-      <MemoryRouter initialEntries={["/w/ws_1/board"]}>
-        <Routes>
-          <Route
-            path="/w/:workspaceId/board"
-            element={<BoardEventRowItem row={row} workspaceId="ws_1" onRedirectSession={onRedirectSession} />}
-          />
-        </Routes>
-      </MemoryRouter>
+      // A running card mounts the live effect grid, which subscribes through
+      // `useAgentTrace` — so this harness needs the query client the board sits
+      // under in the app.
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={["/w/ws_1/board"]}>
+          <Routes>
+            <Route
+              path="/w/:workspaceId/board"
+              element={<BoardEventRowItem row={row} workspaceId="ws_1" onRedirectSession={onRedirectSession} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
 

--- a/apps/frontend/src/components/timeline/agent-session-event.test.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.test.tsx
@@ -5,6 +5,9 @@ import type { StreamEvent } from "@threa/types"
 import * as contextsModule from "@/contexts"
 import * as hooksModule from "@/hooks"
 import * as relativeTimeModule from "@/components/relative-time"
+import * as agentTraceModule from "@/hooks/use-agent-trace"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { AgentSessionStep } from "@threa/types"
 import { AgentSessionEvent } from "./agent-session-event"
 
 beforeEach(() => {
@@ -358,15 +361,52 @@ describe("AgentSessionEvent effects", () => {
     })
   }
 
+  // The memo row mounts a `MemoPreviewDialog`, which reads the memo cache, and
+  // a running card subscribes through `useAgentTrace` — both need a client.
   function renderInWorkspace(events: StreamEvent[]) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     return render(
-      <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
-        <Routes>
-          <Route path="/w/:workspaceId/s/:streamId" element={<AgentSessionEvent events={events} />} />
-        </Routes>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
+          <Routes>
+            <Route path="/w/:workspaceId/s/:streamId" element={<AgentSessionEvent events={events} />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
+
+  function traceResult(steps: AgentSessionStep[]): ReturnType<typeof agentTraceModule.useAgentTrace> {
+    return {
+      steps,
+      streamingContent: {},
+      streamingSubsteps: {},
+      session: null,
+      relatedSessions: [],
+      persona: null,
+      status: "running",
+      isLoading: false,
+      error: null,
+    }
+  }
+
+  function toolStep(
+    stepNumber: number,
+    step: Partial<AgentSessionStep> & Pick<AgentSessionStep, "effects">
+  ): AgentSessionStep {
+    return {
+      id: `step_${stepNumber}`,
+      sessionId: "session_fx",
+      stepNumber,
+      stepType: "tool_call",
+      startedAt: "2026-02-19T18:00:00.000Z",
+      ...step,
+    } as AgentSessionStep
+  }
+
+  beforeEach(() => {
+    vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(traceResult([]))
+  })
 
   it("renders one row per labelled effect", () => {
     renderInWorkspace([
@@ -389,8 +429,10 @@ describe("AgentSessionEvent effects", () => {
 
     const cardLink = container.querySelector('a[href="/trace/session_fx"]')!
     expect(cardLink.querySelectorAll("a")).toHaveLength(0)
-    // ...and the effect link is still a real link, just outside the card.
-    expect(screen.getByRole("link", { name: /Saved a memo/ })).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_1")
+    // A memo opens in place, so its row is a button — which must not be nested
+    // in the card's <a> either.
+    expect(cardLink.querySelectorAll("button")).toHaveLength(0)
+    expect(screen.getByRole("button", { name: /Saved a memo/ })).toBeInTheDocument()
   })
 
   it("spans the last line across both columns on an odd count", () => {
@@ -403,8 +445,8 @@ describe("AgentSessionEvent effects", () => {
       ]),
     ])
 
-    expect(screen.getByRole("link", { name: /Memo C/ }).className).toContain("effect-grid-span")
-    expect(screen.getByRole("link", { name: /Memo A/ }).className).not.toContain("effect-grid-span")
+    expect(screen.getByRole("button", { name: /Memo C/ }).className).toContain("effect-grid-span")
+    expect(screen.getByRole("button", { name: /Memo A/ }).className).not.toContain("effect-grid-span")
   })
 
   it("renders a routeless effect as inert text that cannot be focused", () => {
@@ -419,11 +461,120 @@ describe("AgentSessionEvent effects", () => {
     expect(screen.queryByRole("link", { name: /Reminder on Friday/ })).not.toBeInTheDocument()
   })
 
-  it("renders no grid while the session is still running", () => {
+  it("renders no grid while a running session has written nothing yet", () => {
     renderInWorkspace([startedEvent()])
 
     expect(screen.queryByText("Saved a memo")).not.toBeInTheDocument()
     expect(screen.getByText(/is working/)).toBeInTheDocument()
+  })
+
+  it("renders a running turn's write as soon as its step carries it", async () => {
+    vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(
+      traceResult([toolStep(1, { effects: [{ kind: "settings", target: "theme", before: "light", after: "dark" }] })])
+    )
+
+    renderInWorkspace([startedEvent()])
+
+    expect(await screen.findByText(/dark/)).toBeInTheDocument()
+    expect(screen.getByText(/is working/)).toBeInTheDocument()
+  })
+
+  it("drops the effects of a step the guardian denied", async () => {
+    vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(
+      traceResult([
+        toolStep(1, { effects: [{ kind: "memo", label: "Allowed memo", target: "memo_1" }] }),
+        toolStep(2, {
+          effects: [{ kind: "memo", label: "Denied memo", target: "memo_2" }],
+          verification: { status: "denied", reason: "no" },
+        } as Partial<AgentSessionStep> & Pick<AgentSessionStep, "effects">),
+      ])
+    )
+
+    renderInWorkspace([startedEvent()])
+
+    expect(await screen.findByText("Allowed memo")).toBeInTheDocument()
+    expect(screen.queryByText("Denied memo")).not.toBeInTheDocument()
+  })
+
+  // The row on screen may not move when the next one lands (INV-21), and it may
+  // not survive into the terminal grid twice.
+  it("appends live rows without reordering or dropping the ones already shown", async () => {
+    const first = toolStep(1, { effects: [{ kind: "memo", label: "Memo A", target: "memo_1" }] })
+    const second = toolStep(2, { effects: [{ kind: "memo", label: "Memo B", target: "memo_2" }] })
+    const trace = vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(traceResult([first]))
+
+    const { rerender } = renderInWorkspace([startedEvent()])
+    const rowA = await screen.findByRole("button", { name: /Memo A/ })
+
+    // A reconnect empties the realtime map before the refetch lands; the rendered
+    // rows must not follow it out.
+    trace.mockReturnValue(traceResult([]))
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
+          <Routes>
+            <Route path="/w/:workspaceId/s/:streamId" element={<AgentSessionEvent events={[startedEvent()]} />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    expect(screen.getByRole("button", { name: /Memo A/ })).toBe(rowA)
+
+    trace.mockReturnValue(traceResult([first, second]))
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
+          <Routes>
+            <Route path="/w/:workspaceId/s/:streamId" element={<AgentSessionEvent events={[startedEvent()]} />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    const rows = await screen.findAllByRole("button", { name: /Memo [AB]/ })
+    expect(rows.map((r) => r.textContent)).toEqual(["Memo A›", "Memo B›"])
+    expect(rows[0]).toBe(rowA)
+  })
+
+  // `retrying` is started + interrupted with no terminal event — an attempt is
+  // running RIGHT NOW, so it has to stream too. The earlier attempt's writes only
+  // survive on the interrupted payload (the retry's `upsertStep` resets the step's
+  // effects), so they seed the grid and the new attempt appends to them.
+  it("keeps an interrupted attempt's writes and streams the retry's onto the end", async () => {
+    const interrupted = createSessionEvent("agent_session:interrupted", {
+      sessionId: "session_fx",
+      stepCount: 2,
+      attempt: 0,
+      maxAttempts: 5,
+      error: "Error: boom",
+      interruptedAt: "2026-02-19T18:00:05.000Z",
+      effects: [{ kind: "memo", label: "Memo A", target: "memo_1" }],
+    })
+    // The retry re-runs the same tool (same descriptor, so it must NOT double) and
+    // then writes something new.
+    vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(
+      traceResult([
+        toolStep(1, { effects: [{ kind: "memo", label: "Memo A", target: "memo_1" }] }),
+        toolStep(2, { effects: [{ kind: "memo", label: "Memo B", target: "memo_2" }] }),
+      ])
+    )
+
+    renderInWorkspace([startedEvent(), interrupted])
+
+    const rows = await screen.findAllByRole("button", { name: /Memo [AB]/ })
+    expect(rows.map((r) => r.textContent)).toEqual(["Memo A›", "Memo B›"])
+  })
+
+  // The live path is for the in-flight turn only: once the session is terminal
+  // the lifecycle payloads take over, and the row must not appear twice.
+  it("hands over to the payload union on completion without duplicating a row", async () => {
+    vi.spyOn(agentTraceModule, "useAgentTrace").mockReturnValue(
+      traceResult([toolStep(1, { effects: [{ kind: "memo", label: "Saved a memo", target: "memo_1" }] })])
+    )
+
+    renderInWorkspace([startedEvent(), completedEvent([{ kind: "memo", label: "Saved a memo", target: "memo_1" }])])
+
+    expect(await screen.findAllByRole("button", { name: /Saved a memo/ })).toHaveLength(1)
   })
 
   // Only a bare `{ kind }` is a layer-0 marker — a mutating tool that declared

--- a/apps/frontend/src/components/timeline/agent-session-event.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Link } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 import { Check, X, Loader2 } from "lucide-react"
 import type {
   AgentToolEffect,
@@ -17,7 +17,8 @@ import { formatDuration } from "@/lib/dates"
 import { findVisibleZoneEditor, focusAtEnd } from "@/hooks"
 import { StopSessionButton, RedirectSessionButton } from "@/components/trace/session-action-buttons"
 import { SessionEffectGrid } from "./session-effect-grid"
-import { unionSessionEffects } from "@/lib/effect-links"
+import { LiveSessionEffectGrid } from "./live-session-effect-grid"
+import { isDescribedEffect, unionSessionEffects } from "@/lib/effect-links"
 
 /** How long the Redirect hint replaces the subtitle line after a click. */
 const REDIRECT_HINT_MS = 5000
@@ -344,6 +345,7 @@ export function AgentSessionEvent({
   onSteerSession,
 }: AgentSessionEventProps) {
   const { getTraceUrl } = useTrace()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
   const {
     status,
     sessionId,
@@ -355,16 +357,14 @@ export function AgentSessionEvent({
     deletedPayload,
   } = deriveStatus(events)
 
-  // A RUNNING card never grows a grid: the effects arrive as part of a status
-  // transition that already swaps the card's title, icon and colours, so
-  // nothing pops in mid-turn (INV-21).
+  // A running turn streams its writes onto the card as each tool returns
+  // (`LiveSessionEffectGrid` below) — rows only ever append, so nothing already
+  // on screen moves (INV-21).
   //
-  // `retrying` is included deliberately, and it is not terminal. An attempt
-  // that wrote something before it was interrupted has already changed the
-  // user's state, and the retry can take minutes; hiding that until the turn
-  // finally settles would leave a real write invisible for the whole window.
-  // The grid can gain rows again at the terminal transition, which is the same
-  // kind of shift as the transition itself rather than a spontaneous one.
+  // Once the session is terminal — and while `retrying`, which is not — the
+  // lifecycle payloads take over as the authority: they survive a reload, and
+  // they carry each retry attempt's writes, which the step rows do not
+  // (`upsertStep`'s ON CONFLICT resets `effects` on a retry).
   const sessionEffects: AgentToolEffect[] =
     status === "completed" || status === "failed" || status === "retrying"
       ? unionSessionEffects(...interruptedPayloads, completedPayload, failedPayload)
@@ -377,13 +377,7 @@ export function AgentSessionEvent({
   // `update_stream_brief` and `cancel_follow_up` all describe themselves through
   // `target`/`before`/`after` and set no label at all, and the settings write is
   // the case this whole feature exists for.
-  const describedEffects = sessionEffects.filter(
-    (effect) =>
-      effect.label !== undefined ||
-      effect.target !== undefined ||
-      effect.before !== undefined ||
-      effect.after !== undefined
-  )
+  const describedEffects = sessionEffects.filter(isDescribedEffect)
 
   const config = buildStatusConfig(
     status,
@@ -433,6 +427,15 @@ export function AgentSessionEvent({
   // active — the backend aborts the whole session gracefully regardless
   // (roadmap 2.1), so the buttons stay stable for the entire run (INV-21).
   const showSessionActions = status === "running"
+  // Live rows need a session room to subscribe to, which needs the workspace the
+  // route is on. Outside a workspace route there is nothing to subscribe with.
+  //
+  // `retrying` counts: it means started + interrupted with no terminal event, so
+  // an attempt is running right now. Its earlier attempts' writes ride the
+  // `interrupted` payloads (a retry's `upsertStep` resets the step's effects),
+  // and go in as `priorEffects` so the grid keeps them while the new attempt
+  // streams onto the end. Same reason the live substep shows while retrying.
+  const inFlight = status === "running" || status === "retrying"
   const showRedirectHint = showSessionActions && redirectHintVisible
   // Substep also shows while retrying — a resumed attempt streams its live phase
   // text, which is what keeps the amber "Interrupted, retrying…" card from reading
@@ -546,7 +549,16 @@ export function AgentSessionEvent({
         )}
       </Link>
       {/* Sibling of the card link, never a child: the card is an <a>. */}
-      <SessionEffectGrid effects={describedEffects} />
+      {inFlight && workspaceId ? (
+        <LiveSessionEffectGrid
+          key={sessionId}
+          workspaceId={workspaceId}
+          sessionId={sessionId}
+          priorEffects={describedEffects}
+        />
+      ) : (
+        <SessionEffectGrid effects={describedEffects} />
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/live-session-effect-grid.tsx
+++ b/apps/frontend/src/components/timeline/live-session-effect-grid.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react"
+import {
+  EFFECTS_PER_SESSION_MAX,
+  ToolVerificationStatuses,
+  type AgentSessionStep,
+  type AgentToolEffect,
+} from "@threa/types"
+import { useAgentTrace } from "@/hooks/use-agent-trace"
+import { isDescribedEffect } from "@/lib/effect-links"
+import { SessionEffectGrid } from "./session-effect-grid"
+
+interface KeyedEffect {
+  key: string
+  effect: AgentToolEffect
+}
+
+/** Identity of the write itself, independent of which step reported it. */
+function descriptorKey(effect: AgentToolEffect): string {
+  return JSON.stringify([effect.kind, effect.label, effect.target, effect.before, effect.after])
+}
+
+/**
+ * Every write a step has declared so far, in step order, keyed by where it came
+ * from. The key is the step id plus the effect's index on that step, so the same
+ * descriptor written by two different steps stays two rows while a re-delivery of
+ * one step (bootstrap refetch, reconnect) collapses onto the row already shown.
+ *
+ * A denied guardian verdict contributes nothing: the call never ran, so it wrote
+ * nothing (same rule as `trace-step.tsx`).
+ */
+function keyedStepEffects(steps: AgentSessionStep[]): KeyedEffect[] {
+  const out: KeyedEffect[] = []
+  for (const step of steps) {
+    if (step.verification?.status === ToolVerificationStatuses.DENIED) continue
+    for (const [index, effect] of (step.effects ?? []).entries()) {
+      if (!isDescribedEffect(effect)) continue
+      out.push({ key: `${step.id}:${index}`, effect })
+    }
+  }
+  return out
+}
+
+/**
+ * What the running turn has written so far, streamed onto the session card as
+ * each tool returns rather than held back until the turn settles.
+ *
+ * The rows are APPEND-ONLY for the life of the turn (INV-21). The rendered list
+ * is accumulated here rather than derived from the current step set, so nothing
+ * already on screen can move or vanish when the upstream steps change: a
+ * reconnect wipes `useAgentTrace`'s realtime map before the refetch lands, and a
+ * late verdict can turn a step denied. Either would otherwise pull a row back
+ * out from under the reader. The cap trims the tail, never the head.
+ *
+ * A separate component so the subscription can be conditional on the session
+ * still running — the caller mounts it only then (INV-18).
+ */
+export function LiveSessionEffectGrid({
+  workspaceId,
+  sessionId,
+  priorEffects,
+}: {
+  workspaceId: string
+  sessionId: string
+  /**
+   * What earlier attempts of this session already wrote, from their `interrupted`
+   * payloads. A retry is in flight — not terminal — so its writes have to stream
+   * too, but `upsertStep` resets a step's effects on the retry, which makes those
+   * earlier writes recoverable only from the payloads.
+   */
+  priorEffects?: AgentToolEffect[]
+}) {
+  const { steps } = useAgentTrace(workspaceId, sessionId)
+  const shownKeys = useRef<Set<string>>(new Set())
+  // Descriptors an earlier attempt already showed, as a multiset. A retry that
+  // re-runs the same tool must not draw the same row twice, but a turn that
+  // genuinely writes the same thing twice must still draw two — so a match is
+  // consumed rather than remembered (the rule `unionSessionEffects` follows:
+  // dedupe across attempts, never within one).
+  const unclaimedPrior = useRef<Map<string, number> | null>(null)
+  if (unclaimedPrior.current === null) {
+    unclaimedPrior.current = new Map()
+    for (const effect of priorEffects ?? []) {
+      const key = descriptorKey(effect)
+      unclaimedPrior.current.set(key, (unclaimedPrior.current.get(key) ?? 0) + 1)
+    }
+  }
+  const [effects, setEffects] = useState<AgentToolEffect[]>(() => priorEffects ?? [])
+
+  useEffect(() => {
+    const additions: AgentToolEffect[] = []
+    for (const entry of keyedStepEffects(steps)) {
+      if (shownKeys.current.has(entry.key)) continue
+      shownKeys.current.add(entry.key)
+      const key = descriptorKey(entry.effect)
+      const outstanding = unclaimedPrior.current?.get(key) ?? 0
+      if (outstanding > 0) {
+        unclaimedPrior.current?.set(key, outstanding - 1)
+        continue
+      }
+      additions.push(entry.effect)
+    }
+    if (additions.length === 0) return
+    setEffects((prev) => [...prev, ...additions].slice(0, EFFECTS_PER_SESSION_MAX))
+  }, [steps])
+
+  return <SessionEffectGrid effects={effects} />
+}

--- a/apps/frontend/src/components/timeline/session-effect-grid.tsx
+++ b/apps/frontend/src/components/timeline/session-effect-grid.tsx
@@ -1,19 +1,18 @@
-import { Link, useParams } from "react-router-dom"
+import { useParams } from "react-router-dom"
 import type { AgentToolEffect } from "@threa/types"
 import { useOptionalSettings } from "@/contexts"
-import { EffectRowContent, resolveEffectPath } from "@/lib/effect-links"
-import { cn } from "@/lib/utils"
+import { EffectRow } from "@/lib/effect-links"
 
 /**
- * What a finished turn wrote, one line per effect, under the session card.
+ * What a turn wrote, one line per effect, under the session card.
  *
  * Rendered as a SIBLING of the card's `<Link>`, never inside it: the card is an
- * `<a>`, and a nested `<a>` is invalid HTML and a screen-reader trap. That
- * placement is the whole reason the lines can be links at all.
+ * `<a>`, and a nested interactive element inside it is invalid HTML and a
+ * screen-reader trap. That placement is the whole reason the lines can be links
+ * and dialog buttons at all.
  *
- * The caller only passes effects for terminal sessions, so the grid appears as
- * part of the same status transition that already swaps the card's title, icon
- * and colours — nothing pops in mid-turn (INV-21).
+ * Rows only ever append while a turn is in flight (INV-21) — see
+ * `live-session-effect-grid.tsx`, which owns that guarantee.
  */
 export function SessionEffectGrid({ effects }: { effects: AgentToolEffect[] }) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
@@ -26,58 +25,19 @@ export function SessionEffectGrid({ effects }: { effects: AgentToolEffect[] }) {
   return (
     <div className="effect-grid-host mt-1 px-3.5 text-[11px]">
       <div className="effect-grid gap-x-4">
-        {effects.map((effect, index) => {
-          const path = resolveEffectPath(effect, { workspaceId, getSettingsUrl: settings?.getSettingsUrl })
-          // An odd count would otherwise leave a hole in the last row that reads
-          // as a missing item; the tail spans instead.
-          const spanClass = lastSpansBoth && index === effects.length - 1 ? "effect-grid-span" : undefined
-          return (
-            <EffectLine
-              key={`${effect.kind}-${effect.target ?? ""}-${index}`}
-              effect={effect}
-              path={path}
-              className={spanClass}
-            />
-          )
-        })}
+        {effects.map((effect, index) => (
+          <EffectRow
+            key={`${effect.kind}-${effect.target ?? ""}-${index}`}
+            effect={effect}
+            workspaceId={workspaceId}
+            getSettingsUrl={settings?.getSettingsUrl}
+            variant="grid"
+            // An odd count would otherwise leave a hole in the last row that
+            // reads as a missing item; the tail spans instead.
+            className={lastSpansBoth && index === effects.length - 1 ? "effect-grid-span" : undefined}
+          />
+        ))}
       </div>
     </div>
-  )
-}
-
-function EffectLine({ effect, path, className }: { effect: AgentToolEffect; path: string | null; className?: string }) {
-  const body = (
-    <EffectRowContent
-      effect={effect}
-      trailing={
-        path ? (
-          <span aria-hidden className="ml-auto shrink-0 text-muted-foreground/50">
-            ›
-          </span>
-        ) : null
-      }
-    />
-  )
-
-  // No route means no destination — a greyed, non-focusable span, never a link
-  // with nowhere to go. Follow-ups and briefs have no route anywhere in the app.
-  if (!path) {
-    return (
-      <span className={cn("flex min-w-0 items-center gap-1.5 py-[3px] text-muted-foreground/60", className)}>
-        {body}
-      </span>
-    )
-  }
-
-  return (
-    <Link
-      to={path}
-      className={cn(
-        "flex min-w-0 items-center gap-1.5 py-[3px] text-muted-foreground no-underline transition-colors hover:text-primary",
-        className
-      )}
-    >
-      {body}
-    </Link>
   )
 }

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   AgentReconsiderationDecisions,
   PI_TOOL_TRACE_FORMAT,
@@ -761,11 +762,14 @@ describe("TraceStep effects", () => {
     )) as unknown as typeof relativeTimeModule.RelativeTime)
   })
 
+  // A memo row mounts a `MemoPreviewDialog`, which reads the memo cache.
   function renderStep(step: AgentSessionStep) {
     return render(
-      <MemoryRouter>
-        <TraceStep step={step} workspaceId="ws_1" streamId="stream_1" />
-      </MemoryRouter>
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <TraceStep step={step} workspaceId="ws_1" streamId="stream_1" />
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
 
@@ -814,11 +818,29 @@ describe("TraceStep effects", () => {
       createStep({
         stepType: "tool_call",
         content: "",
+        effects: [{ kind: "delegation", label: "Delegated the audit", target: "dlg_1" }],
+      })
+    )
+
+    expect(screen.getByRole("link", { name: /Delegated the audit/ })).toHaveAttribute(
+      "href",
+      "/w/ws_1/delegations/dlg_1"
+    )
+  })
+
+  // A memo opens in place rather than navigating to the memory explorer, so its
+  // row is a dialog button on this surface too.
+  it("opens a memo effect in place instead of linking to the explorer", () => {
+    renderStep(
+      createStep({
+        stepType: "tool_call",
+        content: "",
         effects: [{ kind: "memo", label: "Saved a memo", target: "memo_1" }],
       })
     )
 
-    expect(screen.getByRole("link", { name: /Saved a memo/ })).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_1")
+    expect(screen.queryByRole("link", { name: /Saved a memo/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Saved a memo/ })).toBeInTheDocument()
   })
 
   it("renders a routeless follow-up effect as text, never a link", () => {

--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -38,7 +38,7 @@ import { buildContextRefSourceHref } from "@/lib/context-bag/source-link"
 import { stripMarkdownToInline } from "@/lib/markdown/strip"
 import { useDecryptedStepContent } from "@/hooks/use-decrypted-step-content"
 import { useOptionalSettings } from "@/contexts"
-import { EffectRowContent, resolveEffectPath } from "@/lib/effect-links"
+import { EffectRow } from "@/lib/effect-links"
 import { RedirectSessionButton, StopSessionButton } from "./session-action-buttons"
 
 interface TraceStepProps {
@@ -246,23 +246,15 @@ function StepEffectList({ effects, workspaceId }: { effects: AgentToolEffect[]; 
 
   return (
     <div className="mt-3 space-y-1 text-[12px]">
-      {effects.map((effect, index) => {
-        const path = resolveEffectPath(effect, { workspaceId, getSettingsUrl: settings?.getSettingsUrl })
-        const body = <EffectRowContent effect={effect} />
-        const key = `${effect.kind}-${effect.target ?? ""}-${index}`
-        return path ? (
-          <Link key={key} to={path} className="flex min-w-0 items-center gap-1.5 text-primary hover:underline">
-            {body}
-            <span aria-hidden className="shrink-0 text-muted-foreground/60">
-              ›
-            </span>
-          </Link>
-        ) : (
-          <div key={key} className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
-            {body}
-          </div>
-        )
-      })}
+      {effects.map((effect, index) => (
+        <EffectRow
+          key={`${effect.kind}-${effect.target ?? ""}-${index}`}
+          effect={effect}
+          workspaceId={workspaceId}
+          getSettingsUrl={settings?.getSettingsUrl}
+          variant="list"
+        />
+      ))}
     </div>
   )
 }

--- a/apps/frontend/src/lib/effect-links.test.tsx
+++ b/apps/frontend/src/lib/effect-links.test.tsx
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import * as memosModule from "@/hooks/use-memos"
 import { AGENT_SETTABLE_PREFERENCE_KEYS, TOOL_EFFECT_KINDS, type AgentToolEffect } from "@threa/types"
 import {
   SETTINGS_TAB_BY_PREFERENCE_KEY,
@@ -7,6 +12,7 @@ import {
   kindNoun,
   resolveEffectPath,
   unionSessionEffects,
+  EffectRow,
 } from "./effect-links"
 
 const ctx = {
@@ -26,7 +32,8 @@ describe("resolveEffectPath", () => {
     expect(Object.fromEntries(TOOL_EFFECT_KINDS.map((kind, i) => [kind, resolved[i]]))).toEqual({
       settings: "?settings=appearance",
       delegation: "/w/ws_1/delegations/id_1",
-      memo: "/w/ws_1/memory?memo=id_1",
+      // A memo opens in place, so it has no route at all.
+      memo: null,
       follow_up: null,
       brief: null,
       other: null,
@@ -34,11 +41,11 @@ describe("resolveEffectPath", () => {
   })
 
   it("is inert without a target", () => {
-    expect(resolveEffectPath(effect({ kind: "memo" }), ctx)).toBeNull()
+    expect(resolveEffectPath(effect({ kind: "delegation" }), ctx)).toBeNull()
   })
 
   it("is inert without a workspace id", () => {
-    expect(resolveEffectPath(effect({ kind: "memo", target: "memo_1" }), { ...ctx, workspaceId: null })).toBeNull()
+    expect(resolveEffectPath(effect({ kind: "delegation", target: "dlg_1" }), { ...ctx, workspaceId: null })).toBeNull()
   })
 
   it("is inert for a settings key no tab renders", () => {
@@ -100,5 +107,62 @@ describe("unionSessionEffects", () => {
       effect({ kind: "settings", label: "Theme", target: "theme" }),
       effect({ kind: "delegation", label: "Task", target: "dlg_1" }),
     ])
+  })
+})
+
+describe("EffectRow", () => {
+  function renderRow(e: AgentToolEffect, workspaceId: string | null = "ws_1") {
+    return render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <EffectRow effect={e} workspaceId={workspaceId} getSettingsUrl={ctx.getSettingsUrl} variant="grid" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+
+  it("opens a memo in place rather than navigating to the explorer", async () => {
+    const detail = vi.spyOn(memosModule, "useMemoDetail").mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof memosModule.useMemoDetail>)
+
+    renderRow(effect({ kind: "memo", label: "Saved a memo", target: "memo_1" }))
+
+    const trigger = screen.getByRole("button", { name: /Saved a memo/ })
+    expect(screen.queryByRole("link", { name: /Saved a memo/ })).not.toBeInTheDocument()
+    // Closed: the memo is not fetched until the row is clicked.
+    expect(detail).toHaveBeenCalledWith("ws_1", null)
+
+    await userEvent.click(trigger)
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(detail).toHaveBeenLastCalledWith("ws_1", "memo_1")
+    // The row's own label carries the dialog until the memo resolves.
+    expect(screen.getByRole("dialog")).toHaveTextContent("Saved a memo")
+  })
+
+  it("renders a delegation as a link", () => {
+    renderRow(effect({ kind: "delegation", label: "Delegated the audit", target: "dlg_1" }))
+
+    expect(screen.getByRole("link", { name: /Delegated the audit/ })).toHaveAttribute(
+      "href",
+      "/w/ws_1/delegations/dlg_1"
+    )
+  })
+
+  it("renders a routeless effect as inert text", () => {
+    renderRow(effect({ kind: "follow_up", label: "Reminder on Friday", target: "fu_1" }))
+
+    const text = screen.getByText("Reminder on Friday")
+    expect(text.closest("a")).toBeNull()
+    expect(text.closest("button")).toBeNull()
+  })
+
+  it("renders a memo with no workspace as inert text", () => {
+    renderRow(effect({ kind: "memo", label: "Saved a memo", target: "memo_1" }), null)
+
+    expect(screen.queryByRole("button", { name: /Saved a memo/ })).not.toBeInTheDocument()
+    expect(screen.getByText("Saved a memo")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/lib/effect-links.tsx
+++ b/apps/frontend/src/lib/effect-links.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react"
+import { useState, type ReactNode } from "react"
+import { Link } from "react-router-dom"
 import {
   AGENT_SETTABLE_PREFERENCE_KEYS,
   EFFECTS_PER_SESSION_MAX,
@@ -10,6 +11,7 @@ import {
 import { Clock, FileText, PenLine, SlidersHorizontal, Sparkles, TerminalSquare, type LucideIcon } from "lucide-react"
 import { buildDelegationPath } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
+import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 
 /** How a label-less effect names itself. The backend sends no display text (INV-46). */
 const EFFECT_KIND_NOUNS = {
@@ -87,9 +89,12 @@ type EffectResolver = (target: string, workspaceId: string, ctx: EffectRouteCont
  * Exhaustive over `ToolEffectKind` so a new kind cannot ship without an answer.
  * `null` is a legitimate answer — a routeless effect renders inert rather than
  * as a dead link. Follow-ups and briefs have no route anywhere in the app.
+ *
+ * A memo has no route either: it opens in place, in `MemoPreviewDialog`, so
+ * reading it never navigates away from the conversation that produced it.
  */
 const EFFECT_ROUTE_RESOLVERS = {
-  memo: (target, workspaceId) => `/w/${workspaceId}/memory?memo=${encodeURIComponent(target)}`,
+  memo: () => null,
   delegation: (target, workspaceId) => buildDelegationPath(workspaceId, encodeURIComponent(target)),
   settings: (target, _workspaceId, ctx) => {
     const tab = settingsTabFor(target)
@@ -118,6 +123,20 @@ export function resolveEffectPath(effect: AgentToolEffect, ctx: EffectRouteConte
 export function effectDiff(effect: AgentToolEffect): { before?: string; after: string } | null {
   if (effect.after === undefined) return null
   return { ...(effect.before !== undefined ? { before: effect.before } : {}), after: effect.after }
+}
+
+/**
+ * Whether an effect has anything to say. A layer-0 marker is a bare `{ kind }`
+ * — a mutating tool declared nothing, so there is nothing to name, diff or
+ * link and it only earns a counter on the meta line.
+ */
+export function isDescribedEffect(effect: AgentToolEffect): boolean {
+  return (
+    effect.label !== undefined ||
+    effect.target !== undefined ||
+    effect.before !== undefined ||
+    effect.after !== undefined
+  )
 }
 
 /**
@@ -173,5 +192,95 @@ export function EffectRowContent({ effect, trailing }: { effect: AgentToolEffect
       )}
       {trailing}
     </>
+  )
+}
+
+/**
+ * Per-surface styling for a row. The affordance logic below is shared; only
+ * these class names differ between the in-stream grid and the trace step list,
+ * so the two cannot drift again (INV-29, INV-35).
+ */
+const EFFECT_ROW_VARIANTS = {
+  grid: {
+    interactive:
+      "flex min-w-0 items-center gap-1.5 py-[3px] text-left text-muted-foreground no-underline transition-colors hover:text-primary",
+    inert: "flex min-w-0 items-center gap-1.5 py-[3px] text-muted-foreground/60",
+    chevron: "ml-auto shrink-0 text-muted-foreground/50",
+  },
+  list: {
+    interactive: "flex min-w-0 items-center gap-1.5 text-left text-primary hover:underline",
+    inert: "flex min-w-0 items-center gap-1.5 text-muted-foreground",
+    chevron: "shrink-0 text-muted-foreground/60",
+  },
+} as const
+
+export type EffectRowVariant = keyof typeof EFFECT_ROW_VARIANTS
+
+/**
+ * One effect's row, affordance included — the single place that decides
+ * between a dialog button, a link, and inert text.
+ *
+ * A memo opens IN PLACE (`MemoPreviewDialog`), never as navigation to the
+ * memory explorer: the same rule `memo-captured-event.tsx` follows, because
+ * being thrown out of the conversation to read what was just saved is what
+ * made the explorer route wrong. Everything with a resolvable path is a
+ * `<Link>` (INV-40); everything else is a non-focusable span.
+ */
+export function EffectRow({
+  effect,
+  workspaceId,
+  getSettingsUrl,
+  variant,
+  className,
+}: {
+  effect: AgentToolEffect
+  workspaceId: string | null | undefined
+  getSettingsUrl?: (tab?: SettingsTab) => string
+  variant: EffectRowVariant
+  className?: string
+}) {
+  const [memoOpen, setMemoOpen] = useState(false)
+  const styles = EFFECT_ROW_VARIANTS[variant]
+  const chevron = (
+    <span aria-hidden className={styles.chevron}>
+      ›
+    </span>
+  )
+
+  if (effect.kind === "memo" && effect.target && workspaceId) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setMemoOpen(true)}
+          aria-haspopup="dialog"
+          className={cn(styles.interactive, className)}
+        >
+          <EffectRowContent effect={effect} trailing={chevron} />
+        </button>
+        <MemoPreviewDialog
+          open={memoOpen}
+          onOpenChange={setMemoOpen}
+          workspaceId={workspaceId}
+          memoId={effect.target}
+          fallbackTitle={effectLabel(effect)}
+        />
+      </>
+    )
+  }
+
+  const path = resolveEffectPath(effect, { workspaceId, getSettingsUrl })
+  if (!path) {
+    return (
+      <span className={cn(styles.inert, className)}>
+        <EffectRowContent effect={effect} />
+      </span>
+    )
+  }
+
+  return (
+    <Link to={path} className={cn(styles.interactive, className)}>
+      <EffectRowContent effect={effect} trailing={chevron} />
+    </Link>
   )
 }

--- a/tests/browser/agent-effects.spec.ts
+++ b/tests/browser/agent-effects.spec.ts
@@ -140,13 +140,38 @@ test.describe("agent effect surfaces", () => {
   // session card's own <a>. That is the structural claim the whole in-stream
   // design rests on, and invalid nesting renders fine while breaking keyboard
   // and screen-reader navigation.
-  test("no effect row is nested inside another anchor", async ({ page }) => {
+  test("no effect row is nested inside another anchor or button", async ({ page }) => {
     await runCompanionTurn(page)
 
+    // The memo row is a <button>, so the card link can trap that too.
     const nested = await page.evaluate(
-      () => Array.from(document.querySelectorAll("a")).filter((a) => a.querySelector("a")).length
+      () => Array.from(document.querySelectorAll("a")).filter((a) => a.querySelector("a, button")).length
     )
     expect(nested).toBe(0)
+  })
+
+  // A memo has to open ON TOP of the stream, not navigate to the memory
+  // explorer — the rule `memo-captured-event.tsx` already follows. Route and
+  // stacking are both things only a real browser can settle.
+  test("a memo effect opens over the stream instead of navigating away", async ({ page }) => {
+    await runCompanionTurn(page)
+    const before = page.url()
+
+    await effectGrid(page)
+      .getByRole("button", { name: /User test run/ })
+      .click()
+
+    const dialog = page.getByRole("dialog").first()
+    await expect(dialog).toBeVisible()
+    expect(page.url()).toBe(before)
+
+    // On top of the timeline, not tucked behind it.
+    const overTimeline = await dialog.evaluate((el) => {
+      const box = el.getBoundingClientRect()
+      const hit = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2)
+      return el.contains(hit)
+    })
+    expect(overTimeline).toBe(true)
   })
 
   // A follow-up has no route anywhere in the app, so its row must be inert


### PR DESCRIPTION
## Problem

Two defects found testing staging, both on the effect-grid work from [#1656](https://github.com/threahq/threa/pull/1656).

**Writes only appeared once the turn ended.** The grid was gated on terminal status because effects ride the session lifecycle payloads. That was a deliberate call — nothing pops in mid-turn — but watching a turn actually run, the delay reads as the card being stale.

**A memo effect navigated to the memory explorer.** `memo-captured-event.tsx` opens a memo in a `MemoPreviewDialog` over the stream, and its own doc comment says why: navigating away was the wrong behaviour. `EFFECT_ROUTE_RESOLVERS.memo` built exactly that route.

## Solution

**Live rows.** Nothing was missing server-side: `trace-emitter.ts`'s `ActiveStep.complete` already serializes `effects` onto the step it broadcasts, and `StepCompletedPayload.step` is a full `AgentSessionStep` — every write has been on the wire the moment its tool returned. `LiveSessionEffectGrid` is mounted only while the session is in flight and subscribes through the existing `useAgentTrace`.

- **Rows are accumulated, not derived.** Deriving from the current step set has two real disappearance paths: a reconnect wipes `useAgentTrace`'s realtime map before the refetch lands, and a late `step:verification` can flip a step to `denied` after its writes are on screen. Either pulls a row back out from under the reader. Keyed on `stepId:index`, so a re-delivered step collapses onto the row it already drew, two different steps writing the same descriptor stay two rows, and the list only ever grows (INV-21). The cap trims the tail.
- **`retrying` counts as in flight** — it is `started + interrupted` with no terminal event, so an attempt is running right now. Its earlier attempts' writes survive only on the `interrupted` payloads (a retry's `upsertStep` resets the step's `effects`), so they seed the grid and the new attempt appends. A re-run of the same tool **consumes** its match rather than drawing a second row, while two genuinely identical writes inside one attempt still draw two — the rule `unionSessionEffects` already follows: dedupe across attempts, never within one.
- Terminal statuses still take the payload union verbatim; it survives a reload and the step rows do not.

**Memo opens in place.** The memo row is a `<button>` mounting `MemoPreviewDialog` (centred modal on desktop, drawer on mobile), with the row's label as `fallbackTitle`. The route resolver returns `null` for `memo` — the record is exhaustive over `ToolEffectKind`, so the entry stays but builds nothing.

**One `EffectRow`.** The link-vs-button-vs-inert decision lived in `session-effect-grid.tsx` and `trace-step.tsx`, the same two files that had already drifted into byte-identical copies once (which is why `EffectRowContent` exists). One component owns it now; only the per-surface class sets differ (INV-29/35).

The grid stays a **sibling** of the session card's `<Link>` — a `<button>` nested in an `<a>` is the same trap as a nested `<a>`, so the browser assertion was widened to catch both.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/live-session-effect-grid.tsx` | **new** — the in-flight subscription and the append-only accumulator |
| `apps/frontend/src/lib/effect-links.tsx` | `EffectRow` (the shared affordance), `isDescribedEffect`, memo resolver → `null` |
| `apps/frontend/src/components/timeline/agent-session-event.tsx` | mounts the live grid while `running` or `retrying`, seeded with prior attempts' writes |
| `apps/frontend/src/components/timeline/session-effect-grid.tsx` · `components/trace/trace-step.tsx` | both render `EffectRow`; local copies deleted |
| `apps/backend/src/features/agents/persona-agent.ts` | a memo in `STUB_EFFECTS`, so the browser suite can exercise the dialog |
| `tests/browser/agent-effects.spec.ts` | nested-`button` assertion; the memo-opens-over-the-stream case |

## Test plan

- [x] `apps/frontend` vitest — **5407 pass / 0 fail** (whole suite)
- [x] `apps/backend` `test:unit` — 3819 pass / 0 fail · `bun run typecheck` exit 0 · `bun run lint` exit 0
- [x] **Playwright `agent-effects.spec.ts` — 6 pass / 0 fail** on the real stack, including the new memo case
- [x] **Mutation-checked.** Restoring the memo route (and skipping the memo branch) turns "a memo effect opens over the stream instead of navigating away" red; restored, 6/6. Dropping `retrying` from the in-flight test turns the retry case red. Removing the prior-attempt consumption turns it red the other way, by drawing the re-run row twice. Replacing the accumulator with a straight derivation turns the append-only case red.
- [ ] The mid-turn timing itself is asserted in jsdom, not in a browser: the stub companion completes in well under a second, so there is no observable in-flight window for Playwright to catch. The wiring is covered; the feel needs a look on staging.
- [ ] One browser run failed all six with "agent never opened a thread" and passed on replay — the harness's own flake after back-to-back full-stack boots, unrelated to this diff. Re-ran clean twice.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788000735&installation_model_id=20758&pr_number=1673&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1673&signature=a9ce8e7074dec02c5ddde1ec88b80879f8f20342a487240ac7debf570f6d685d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->