### PR TITLE
chore: standardize small-model tasks on Luna

### DIFF
--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -96,7 +96,7 @@ Keep responses short and direct. Default to a few sentences unless the user asks
     avatarEmoji: null,
     avatarUrl: null,
     systemPrompt: "You are a minimal Threa agent. Follow system instructions and do not use tools.",
-    model: "openrouter:openai/gpt-5.4-mini",
+    model: "openrouter:openai/gpt-5.6-luna",
     escalationModel: null,
     temperature: 0,
     maxTokens: null,

--- a/apps/backend/src/features/agents/companion/config.ts
+++ b/apps/backend/src/features/agents/companion/config.ts
@@ -10,12 +10,7 @@ if (ariadneTemperature == null) {
 }
 export const COMPANION_TEMPERATURE = ariadneTemperature
 
-// Model for rolling long-context summaries of dropped history. Same tier as the
-// episode summary below and for the same reason — this is structured
-// condensation, and mini is both more capable and genuinely cheaper than
-// haiku-4.5 ($0.75/$4.50 against $1.00/$5.00; the $0.25/$1.25 that once made
-// haiku look like the cost-effective tier was a documentation error).
-export const COMPANION_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const COMPANION_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 // Lower temperature for deterministic summary updates
 export const COMPANION_SUMMARY_TEMPERATURE = 0.1
@@ -24,7 +19,7 @@ export const COMPANION_SUMMARY_TEMPERATURE = 0.1
 // the persona did and concluded in a session, stored on the session row and
 // replayed into later turns as "Previous sessions". Same small model the memo
 // classifier/memorizer runs (`MEMO_CLASSIFIER_MODEL_ID`).
-export const EPISODE_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const EPISODE_SUMMARY_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 export const EPISODE_SUMMARY_TEMPERATURE = 0.1
 export const EPISODE_SUMMARY_MAX_TOKENS = 256
 

--- a/apps/backend/src/features/agents/config.ts
+++ b/apps/backend/src/features/agents/config.ts
@@ -4,7 +4,7 @@ import { AgentToolNames, type AgentToolName } from "@threa/types"
  * Persona agent supersede rerun response validation config (INV-44).
  * Shared between production code and any future evals.
  */
-export const SUPERSEDE_RESPONSE_VALIDATOR_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const SUPERSEDE_RESPONSE_VALIDATOR_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 export const SUPERSEDE_RESPONSE_VALIDATOR_MAX_TOKENS = 180
 export const SUPERSEDE_RESPONSE_VALIDATOR_TEMPERATURE = 0
 
@@ -14,7 +14,7 @@ export const SUPERSEDE_RESPONSE_VALIDATOR_TEMPERATURE = 0
  * the shared component (`@threa/agent-runtime` turn-digest). The enclave uses
  * its own pinned turn model instead — it has exactly one egress-approved model.
  */
-export const TURN_DIGEST_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const TURN_DIGEST_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 /**
  * Follow-up scheduling bounds (`schedule_follow_up` tool, roadmap 1.1).

--- a/apps/backend/src/features/agents/context-bag/config.ts
+++ b/apps/backend/src/features/agents/context-bag/config.ts
@@ -7,7 +7,7 @@
 
 // Default model for the per-ref thread summarizer. Cheap + fast — the output
 // goes into the stable region of the prompt and is cached by inputs manifest.
-export const SUMMARIZER_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
+export const SUMMARIZER_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 // Lower temperature: summaries should be deterministic so the same thread
 // produces the same summary text, otherwise downstream cache thrash.

--- a/apps/backend/src/features/agents/episode-summary-service.test.ts
+++ b/apps/backend/src/features/agents/episode-summary-service.test.ts
@@ -6,7 +6,7 @@ import { MessageRepository } from "../messaging"
 import { AgentSessionRepository, SessionStatuses, type AgentSession } from "./session-repository"
 import { EpisodeSummaryService } from "./episode-summary-service"
 
-const MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+const MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 function makeSession(overrides?: Partial<AgentSession>): AgentSession {
   return {

--- a/apps/backend/src/features/agents/guardian/config.ts
+++ b/apps/backend/src/features/agents/guardian/config.ts
@@ -3,18 +3,6 @@
 import { z } from "zod"
 import { DELEGATION_BRIEF_MAX_CHARS } from "@threa/types"
 
-/**
- * Luna, not `gpt-5.4-mini`, and the reasoning is the same trade the memorizer
- * already makes: Luna costs ~33% more and runs ~40% slower, which is why mini
- * keeps the per-message components (boundary extraction, memo classifier). The
- * guardian is the opposite shape — it fires only on a tier-2 tool call, so a
- * turn either pays nothing or pays once. With volume that low, the quality
- * difference is the only term that matters, and the failure this component
- * exists to prevent is an unwanted write.
- *
- * `gpt-5.4-nano` was re-tested against the classification suites in July 2026
- * and rejected for systematically confident wrong answers.
- */
 export const TOOL_GUARDIAN_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 /** Low temperature: this is a classification, not a composition. */

--- a/apps/backend/src/features/agents/researcher/config.ts
+++ b/apps/backend/src/features/agents/researcher/config.ts
@@ -17,7 +17,7 @@
  * the highest-volume component we run (boundary extraction, ~1k calls/month) at
  * ~2s per call.
  */
-export const WORKSPACE_AGENT_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const WORKSPACE_AGENT_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 /** Lower temperature to reduce decision variance in retrieval planning */
 export const WORKSPACE_AGENT_TEMPERATURE = 0.1
 

--- a/apps/backend/src/features/ai-usage/budget-service.test.ts
+++ b/apps/backend/src/features/ai-usage/budget-service.test.ts
@@ -126,7 +126,7 @@ describe("AIBudgetService.checkBudget enforcement window", () => {
       reason: "soft_limit",
       currentUsageUsd: 60,
       budgetUsd: 50,
-      recommendedModel: "openrouter:openai/gpt-5.4-mini",
+      recommendedModel: "openrouter:openai/gpt-5.6-luna",
     })
     expect(captured.usagePeriod).toEqual(monthRangeInTimezone("Asia/Tokyo"))
   })

--- a/apps/backend/src/features/ai-usage/budget-service.ts
+++ b/apps/backend/src/features/ai-usage/budget-service.ts
@@ -14,27 +14,21 @@ const SOFT_LIMIT_THRESHOLD = 0.8 // 80% - start degrading models
  * Where an over-budget workspace's model requests land. Full model IDs with
  * provider prefix to match the format used in AI calls.
  *
- * Every target is `gpt-5.4-mini` — the cheapest current-generation model that
- * still holds up on the agentic tool use a degraded persona turn has to keep
- * doing. The previous targets were picked against the price table in
- * `docs/model-reference.md`, which listed `claude-haiku-4.5` at $0.25/$1.25;
- * it bills $1.00/$5.00, so the valve that fires when a workspace has just blown
- * its budget was switching to a model 33% dearer per input token than mini. The
- * OpenAI targets were worse: `gpt-4o-mini` and `gpt-5-mini` are both deprecated
- * (INV-16).
+ * Every target is Luna: the cheapest current-generation model that still
+ * holds up on the agentic tool use a degraded persona turn must retain (INV-16).
  */
 const MODEL_DEGRADATION_MAP: Record<string, string> = {
-  "openrouter:anthropic/claude-opus-4.8": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-sonnet-5": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-sonnet-4.6": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-sonnet-4.5": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-sonnet-4": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:anthropic/claude-haiku-4.5": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:anthropic/claude-opus-4.8": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-sonnet-5": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-sonnet-4.6": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-sonnet-4.5": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-sonnet-4": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:anthropic/claude-haiku-4.5": "openrouter:openai/gpt-5.6-luna",
 
-  "openrouter:openai/gpt-4o": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:openai/gpt-5": "openrouter:openai/gpt-5.4-mini",
-  "openrouter:openai/gpt-5-turbo": "openrouter:openai/gpt-5.4-mini",
+  "openrouter:openai/gpt-4o": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:openai/gpt-5": "openrouter:openai/gpt-5.6-luna",
+  "openrouter:openai/gpt-5-turbo": "openrouter:openai/gpt-5.6-luna",
 }
 
 export interface BudgetStatus {

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -3,11 +3,7 @@
 import { z } from "zod"
 import { CONVERSATION_STATUSES } from "@threa/types"
 
-// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
-// was fixed) showed nano failing systematically — sandwich-split and
-// gap-resume cases in every round (30-33/35 vs mini's 33-35/35). See
-// docs/model-reference.md.
-export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
+export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 /** Low temperature for classification consistency. */
 export const BOUNDARY_EXTRACTION_TEMPERATURE = 0.2

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -20,17 +20,7 @@ import { formatDate } from "../../lib/temporal"
 // handlers import (source of truth is @threa/types — INV-33).
 export { MEMO_ABSTRACT_MAX_CHARS, MEMO_KEY_POINTS_MAX, MEMO_TAGS_MAX, MEMO_TITLE_MAX_CHARS }
 
-// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
-// was fixed) showed nano classifying real knowledge as not-worthy in every
-// round (6/9 with the same three misses) — silent knowledge loss, the worst
-// GAM failure mode. See docs/model-reference.md.
-export const MEMO_CLASSIFIER_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
-
-// Luna over mini for memorization (July 2026, 6-run tallies): Luna passed all
-// 10 memorizer cases every round where mini still leaked the anti-gossip
-// residuals (news-facts 1/6, transient-status 2/6) and had inverted a decision
-// direction in prod. +33% price on the lowest-volume component (settle-gated,
-// one capture per settled conversation). See docs/model-reference.md.
+export const MEMO_CLASSIFIER_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 export const MEMO_MEMORIZER_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 export const MEMO_TEMPERATURES = {
@@ -171,7 +161,7 @@ export const MEMO_BOOST_DEFAULT = 1.0
  * ranking (INV-16); rerank is a best-effort enhancer only — fixed
  * timeout, fail-open on every failure reason, never a dependency.
  */
-export const MEMO_RERANKER_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
+export const MEMO_RERANKER_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 export const MEMO_RERANKER_TEMPERATURE = 0
 export const MEMO_RERANKER_TIMEOUT_MS = 4000
 /** Top-K window handed to the reranker; the un-reranked tail is appended (recall protection). */

--- a/apps/backend/src/features/saved-suggestions/config.ts
+++ b/apps/backend/src/features/saved-suggestions/config.ts
@@ -7,12 +7,7 @@
 import { z } from "zod"
 import { formatDate } from "../../lib/temporal"
 
-/**
- * Model for to-do extraction. Same nano-class model as the memo pipeline the
- * extractor rides on — extraction is structured-output classification work,
- * which is exactly what this tier is priced for.
- */
-export const SUGGESTION_EXTRACTOR_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
+export const SUGGESTION_EXTRACTOR_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 export const SUGGESTION_EXTRACTOR_TEMPERATURE = 0.1
 

--- a/apps/backend/src/features/streams/naming-config.ts
+++ b/apps/backend/src/features/streams/naming-config.ts
@@ -1,6 +1,6 @@
 // Co-located config (INV-43): both production and evals import from here.
 
-export const STREAM_NAMING_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
+export const STREAM_NAMING_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 
 // Low for consistent naming across runs
 export const STREAM_NAMING_TEMPERATURE = 0.3

--- a/apps/backend/src/features/voice-transcription/config.ts
+++ b/apps/backend/src/features/voice-transcription/config.ts
@@ -67,7 +67,7 @@ export const voiceConfig = {
 
 // Voice-transcript polish config (INV-44: colocated with the feature, shared
 // by production and evals).
-export const POLISH_MODEL = "openrouter:openai/gpt-5.4-nano"
+export const POLISH_MODEL = "openrouter:openai/gpt-5.6-luna"
 export const POLISH_TIMEOUT_MS = 4500
 export const POLISH_MAX_TOKENS = 2048
 

--- a/apps/backend/src/lib/ai/config-resolver.test.ts
+++ b/apps/backend/src/lib/ai/config-resolver.test.ts
@@ -7,16 +7,16 @@ describe("StaticConfigResolver", () => {
     const resolver = createStaticConfigResolver()
 
     const boundaryConfig = await resolver.resolve(COMPONENT_PATHS.BOUNDARY_EXTRACTION)
-    expect(boundaryConfig.modelId).toBe("openrouter:openai/gpt-5.4-mini")
+    expect(boundaryConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
     expect(boundaryConfig.temperature).toBe(0.2)
     expect(boundaryConfig.systemPrompt).toBeDefined()
 
     const streamNamingConfig = await resolver.resolve(COMPONENT_PATHS.STREAM_NAMING)
-    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.4-nano")
+    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
     expect(streamNamingConfig.temperature).toBe(0.3)
 
     const memoClassifierConfig = await resolver.resolve(COMPONENT_PATHS.MEMO_CLASSIFIER)
-    expect(memoClassifierConfig.modelId).toBe("openrouter:openai/gpt-5.4-mini")
+    expect(memoClassifierConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
     expect(memoClassifierConfig.temperature).toBe(0.1)
 
     const memoMemorizerConfig = await resolver.resolve(COMPONENT_PATHS.MEMO_MEMORIZER)
@@ -28,7 +28,7 @@ describe("StaticConfigResolver", () => {
     expect(companionConfig.temperature).toBe(0.7)
 
     const researcherConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_RESEARCHER)
-    expect(researcherConfig.modelId).toBe("openrouter:openai/gpt-5.4-mini")
+    expect(researcherConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
     expect(researcherConfig.temperature).toBe(0.1)
 
     const embeddingConfig = await resolver.resolve(COMPONENT_PATHS.EMBEDDING)
@@ -71,6 +71,6 @@ describe("StaticConfigResolver", () => {
 
     // Non-overridden path should have default
     const streamNamingConfig = await resolver.resolve(COMPONENT_PATHS.STREAM_NAMING)
-    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.4-nano")
+    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
   })
 })

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -197,8 +197,8 @@ export function loadConfig(): Config {
       tavilyApiKey: process.env.TAVILY_API_KEY || "",
       elevenLabsApiKey: process.env.ELEVENLABS_API_KEY || "",
       deepgramApiKey: process.env.DEEPGRAM_API_KEY || "",
-      namingModel: process.env.AI_NAMING_MODEL || "openrouter:openai/gpt-5-mini",
-      extractionModel: process.env.AI_EXTRACTION_MODEL || "openrouter:openai/gpt-5-mini",
+      namingModel: process.env.AI_NAMING_MODEL || "openrouter:openai/gpt-5.6-luna",
+      extractionModel: process.env.AI_EXTRACTION_MODEL || "openrouter:openai/gpt-5.6-luna",
     },
     s3: {
       bucket: process.env.S3_BUCKET || "threa-uploads",

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -1,12 +1,12 @@
 # AI Model Reference
 
-**Last updated:** 2026-07-27
+**Last updated:** 2026-07-30
 
 This document provides a comprehensive reference for AI models including capabilities, pricing, and usage guidelines. Always verify against this file when working with AI integration.
 
 ## Price table
 
-All figures per 1M tokens, verified against the live OpenRouter models endpoint on 2026-07-27. **Verify before making a model-choice argument** — this table was wrong about `claude-haiku-4.5` by 4× for months, and five components were pinned to it on the strength of that number:
+All figures per 1M tokens, verified on 2026-07-30. Temporary OpenRouter discounts are excluded; Luna's listed discounted rates were normalized to its standard rates. **Verify before making a model-choice argument** — this table was wrong about `claude-haiku-4.5` by 4× for months, and five components were pinned to it on the strength of that number:
 
 ```bash
 curl -s https://openrouter.ai/api/v1/models -H "Authorization: Bearer $OPENROUTER_API_KEY" \
@@ -17,7 +17,7 @@ curl -s https://openrouter.ai/api/v1/models -H "Authorization: Bearer $OPENROUTE
 | ------------------------------- | ----- | ------ | ---------- | ----------- | ------- |
 | `openai/gpt-5.4-nano`           | $0.20 | $1.25  | $0.02      | free        | 400K    |
 | `openai/gpt-5.4-mini`           | $0.75 | $4.50  | $0.075     | free        | 400K    |
-| `openai/gpt-5.6-luna`           | $1.00 | $6.00  | $0.107     | **$1.25**   | 1.05M   |
+| `openai/gpt-5.6-luna`           | $0.20 | $1.20  | $0.02      | **$0.25**   | 1.05M   |
 | `openai/gpt-5.6-terra`          | $2.50 | $15.00 | $0.25      | $3.125      | 1.05M   |
 | `openai/gpt-5.6-sol`            | $5.00 | $30.00 | $0.50      | $6.25       | 1.05M   |
 | `anthropic/claude-haiku-4.5`    | $1.00 | $5.00  | $0.10      | $1.25       | 200K    |
@@ -36,7 +36,7 @@ Anthropic, Google and OpenAI only. That is a deliberate constraint, not an accid
 **Cache columns are not a footnote — they change which model is cheapest.**
 
 - **Free writes (OpenAI family).** Caching is automatic and costs nothing to attempt, so a stable ≥1024-token prefix is pure upside. A cache miss bills the normal input rate.
-- **Paid writes (Anthropic, Google, and `gpt-5.6-luna`).** A miss on a cacheable-size prompt bills the **write** rate, not the input rate. This is a bet that the prefix will be read back; below roughly 1.4 reads per write it loses money. `gpt-5.6-luna`'s listed $1.00 input is therefore the rate that never applies — in production it bills $1.25 on a miss or $0.107 on a hit.
+- **Paid writes (Anthropic, Google, and `gpt-5.6-luna`).** A miss on a cacheable-size prompt bills the **write** rate, not the input rate. Luna bills $0.25 on a miss or $0.02 on a hit; its $0.20 headline input rate applies below the cache floor. Prompts above 272K tokens use the long-context rate ($0.40 input, $1.80 output, $0.04 cache read, $0.50 cache write).
 - **Anthropic and Google need an explicit breakpoint** (`applyCacheBreakpoints`, `packages/agent-runtime/src/ai/ai.ts`); the OpenAI family needs only prefix stability.
 - **A prefix only caches if it is genuinely a prefix.** Interpolating a date, a language rule, or a message list _above_ the static block truncates the cacheable span to whatever precedes the first variable — commonly a few dozen tokens, under the 1024-token floor, so nothing caches at all.
 
@@ -127,9 +127,9 @@ model picker. The two lists are meant to stay identical — an entry is an offer
 
 **When to use:** nothing. No production component selects it.
 
-This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On the strength of that number five components were pinned to haiku "for cost" (companion summary, workspace-agent plan/eval, turn digest, supersede validator, the Empty Agent shell) and the over-budget degradation map degraded Sonnet _to_ it, buying 2× where `gpt-5.4-mini` buys 2.7× and `gpt-5.4-nano` buys 10×. All six now target mini. Left in the registry so a persona deliberately pinned to it keeps resolving.
+This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On the strength of that number five components were pinned to haiku "for cost" (companion summary, workspace-agent plan/eval, turn digest, supersede validator, the Empty Agent shell) and the over-budget degradation map degraded Sonnet _to_ it, buying 2× where `gpt-5.4-mini` buys 2.7× and `gpt-5.4-nano` buys 10×. All six now target Luna. Left in the registry so a persona deliberately pinned to it keeps resolving.
 
-**Use instead:** `gpt-5.4-mini` for structured condensation and extraction, `gpt-5.4-nano` for classification and ranking.
+**Use instead:** `gpt-5.6-luna`.
 
 ---
 
@@ -141,10 +141,7 @@ This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On 
 
 **Typical cost:** ~$0.20 / ~$1.25 per 1M (cache read $0.02, writes free)
 
-**When to use:**
-
-- Saved-suggestion extraction and voice-transcript polish (production choices)
-- High-volume classification and ranking
+**When to use:** nothing new. Luna is cheaper at its undiscounted price and stronger on the evaluated classification suites.
 
 **Caution:** re-tested July 2026 on the memo-classifier and boundary-extraction suites and rejected for both — it classified real knowledge as not-worthy 6/9 with the same three misses every round (silent knowledge loss) and failed sandwich-split/gap-resume every round (30–33/35 against mini's 33–35/35). Cheap, but not for anything where a miss is invisible.
 
@@ -158,12 +155,7 @@ This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On 
 
 **Typical cost:** ~$0.75 / ~$4.50 per 1M (cache read $0.075, writes free)
 
-**When to use:**
-
-- Boundary extraction and memo classification (highest-volume components we run)
-- Companion summary, workspace-agent plan/eval, turn digest, supersede validation, episode summaries
-- The over-budget degradation target
-- Default choice when a component needs structured output and has no eval suite to justify anything more specific
+**When to use:** nothing new. Production text components moved to Luna after its July 2026 price cut.
 
 ---
 
@@ -173,14 +165,15 @@ This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On 
 
 **Description:** Fast, high-volume tier of the GPT-5.6 series. 1.05M context. Available EU-pinned. A `gpt-5.6-luna-pro` variant (same price) serves the same weights with `reasoning.mode: pro`.
 
-**Typical cost:** ~$1.25 / ~$6.00 per 1M **on a cache miss**, ~$0.107 per 1M on a hit. The $1.00 headline input rate applies only below the 1024-token cache floor — every real prompt is a write or a read.
+**Typical cost:** ~$0.25 / ~$1.20 per 1M **on a cache miss**, ~$0.02 per 1M on a hit. The $0.20 headline input rate applies below the 1024-token cache floor. Long-context pricing begins at 272K tokens ($0.40/$1.80). Prices exclude temporary OpenRouter discounts.
 
 **When to use:**
 
-- Memo memorization (production choice since July 2026)
-- Extraction and summarization where a small model's conclusion errors are costly
+- Classification, extraction, ranking, naming, transcript polish, and summarization
+- Memo memorization and tool-call guarding
+- Over-budget model degradation
 
-**Eval history (July 2026, 6-run tallies vs `gpt-5.4-mini`):** memorizer 10/10 cases perfect against mini's 8/10 — Luna never leaked the anti-gossip residuals and never inverted a decision direction; boundary-extraction effectively tied (0.996 vs 0.992); memo-classifier tied (11/11 both). ~40% slower per call, so mini keeps the high-volume per-message components and Luna runs the memorizer, where quality dominates and the settle gate keeps volume low.
+**Eval history (July 2026, 6-run tallies vs `gpt-5.4-mini`):** memorizer 10/10 cases perfect against mini's 8/10 — Luna never leaked the anti-gossip residuals and never inverted a decision direction; boundary-extraction effectively tied (0.996 vs 0.992); memo-classifier tied (11/11 both). Luna was ~40% slower per call, but the price cut makes it cheaper than both 5.4 tiers, so every production task previously on a GPT-5.4 tier now uses Luna.
 
 ---
 


### PR DESCRIPTION
## Problem

GPT-5.6 Luna’s standard price dropped below both GPT-5.4 Mini and Nano while matching Mini on the memo-classifier and boundary-extraction evals. Backend small-model tasks still selected the older, more expensive tiers, and `docs/model-reference.md` retained Luna’s previous pricing.

## Solution

- Move every backend production task previously pinned to GPT-5.4 Mini or Nano to `openrouter:openai/gpt-5.6-luna`: classification, extraction, ranking, naming, summarization, transcript polish, and budget degradation.
- Keep multimodal Gemini and full persona/research models unchanged.
- Record Luna’s undiscounted $0.20/$1.20 base price, cache pricing, and long-context rates; explicitly exclude temporary OpenRouter discounts.
- Update model-selection assertions and remove obsolete cost comments.

## Test plan

- [x] Targeted backend tests — 19 pass
- [x] Monorepo typecheck
- [x] Pre-commit lint, Dockerfile checks, migration checks, typecheck, and OpenAPI check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788039239&installation_model_id=20758&pr_number=1674&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1674&signature=b805d75b6f85a97a991b7260e3b75ec8dacbe2622aeaf2c313a70a4ad11e142a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->