### PR TITLE
feat(board): drop classifier status/completeness surfaces

### DIFF
--- a/apps/backend/src/features/board-views/repository.ts
+++ b/apps/backend/src/features/board-views/repository.ts
@@ -1,6 +1,6 @@
 import { sql, type Querier } from "../../db"
 import { boardViewId } from "../../lib/id"
-import type { BoardView, BoardLens, BoardScopeStreamType } from "@threa/types"
+import { BOARD_LENSES, type BoardView, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 
 interface BoardViewRow {
   id: string
@@ -18,11 +18,18 @@ interface BoardViewRow {
 const SELECT =
   "id, name, base_lens, scope_stream_ids, scope_stream_types, scope_label_ids, exclude_stream_ids, exclude_stream_types, exclude_label_ids, sort_order"
 
+/** A row written under a since-retired lens degrades to the widest lens here, at
+ *  the single read boundary, so every consumer of a saved view (href,
+ *  active-match, summary) sees a live lens. Mirrors `parseLensParam`. */
+function normalizeLens(value: string): BoardLens {
+  return (BOARD_LENSES as readonly string[]).includes(value) ? (value as BoardLens) : "all"
+}
+
 function mapRow(row: BoardViewRow): BoardView {
   return {
     id: row.id,
     name: row.name,
-    baseLens: row.base_lens as BoardLens,
+    baseLens: normalizeLens(row.base_lens),
     scopeStreamIds: row.scope_stream_ids,
     scopeStreamTypes: row.scope_stream_types as BoardScopeStreamType[],
     scopeLabelIds: row.scope_label_ids,

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -156,12 +156,8 @@ describe("Conversation Handlers", () => {
     })
 
     test("threads the validated lens through to the service", async () => {
-      await handlers.listByWorkspace(mockReq({ query: { lens: "needs-resolution" } }), mockRes())
-      expect(mockListByWorkspace).toHaveBeenCalledWith(
-        "ws_1",
-        "usr_1",
-        expect.objectContaining({ lens: "needs-resolution" })
-      )
+      await handlers.listByWorkspace(mockReq({ query: { lens: "decisions" } }), mockRes())
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: "decisions" }))
     })
 
     test("accepts the all lens as an explicit no-op filter", async () => {
@@ -169,10 +165,9 @@ describe("Conversation Handlers", () => {
       expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: "all" }))
     })
 
-    test("rejects an unknown lens with a 400", async () => {
-      await expect(handlers.listByWorkspace(mockReq({ query: { lens: "bogus" } }), mockRes())).rejects.toMatchObject({
-        status: 400,
-      })
+    test("degrades a retired lens to no lens condition instead of a 400", async () => {
+      await handlers.listByWorkspace(mockReq({ query: { lens: "needs-resolution" } }), mockRes())
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: undefined }))
     })
 
     test("splits the comma-separated streams scope into scopeStreamIds", async () => {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -51,7 +51,17 @@ const csvTypeListSchema = z
 // `excludeTypes` (root-stream grains), and `labels` + `excludeLabels` (the
 // viewer's own label assignments on the anchor/root stream).
 const listWorkspaceConversationsSchema = listConversationsSchema.extend({
-  lens: z.enum(BOARD_LENSES).optional(),
+  // A retired lens degrades to "no lens condition" instead of a 400: the
+  // frontend deploys before the backend and SW-cached bundles linger, so old
+  // bundles still send retired values and must get the board, not an error.
+  lens: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value !== undefined && (BOARD_LENSES as readonly string[]).includes(value)
+        ? (value as (typeof BOARD_LENSES)[number])
+        : undefined
+    ),
   streams: csvIdListSchema(MAX_BOARD_SCOPE_STREAMS, "streams").optional(),
   excludeStreams: csvIdListSchema(MAX_BOARD_SCOPE_STREAMS, "excludeStreams").optional(),
   types: csvTypeListSchema.optional(),

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -6,21 +6,16 @@ import {
   LabelableResourceTypes,
   type ConversationStatus,
   type BoardLens,
-  BOARD_LENS_STALE_HOURS,
-  BOARD_LENS_MAX_COMPLETENESS,
 } from "@threa/types"
 
 /**
  * The board-lens WHERE fragment — the SQL half of the seed/pagination filter,
  * kept in lockstep with `matchesBoardLens` (the client's read-side predicate) so
- * a page can't return rows the client then hides. Reads the same signals and the
- * same `BOARD_LENS_*` thresholds. `all` (and absent) adds nothing — the default
- * home shows everything.
+ * a page can't return rows the client then hides. `all`, absent, and any retired
+ * lens value still stored on a saved view add nothing — the fragment degrades to
+ * the default home, which shows everything.
  */
 function boardLensCondSql(lens: BoardLens | undefined, userId: string) {
-  if (lens === "active") {
-    return composeSql`AND status = ${ConversationStatuses.ACTIVE}`
-  }
   if (lens === "mine") {
     // The viewer's own conversations: authored/participating (`participant_ids`,
     // GIN-indexed) OR `@`-mentioned on a primary message (`user_activity`,
@@ -36,19 +31,6 @@ function boardLensCondSql(lens: BoardLens | undefined, userId: string) {
           AND ua.user_id = ${userId}
           AND ua.activity_type = ${ActivityTypes.MENTION}
           AND ua.message_id = ANY(conversations.message_ids)
-      )
-    )`
-  }
-  if (lens === "needs-resolution") {
-    // A `resolved` conversation is done — never a loose end — even if its LLM
-    // completeness score was never bumped up on resolution, so exclude it from the
-    // idle branch (the `stalled` branch can't match a resolved row anyway).
-    return composeSql`AND (
-      status = ${ConversationStatuses.STALLED}
-      OR (
-        status <> ${ConversationStatuses.RESOLVED}
-        AND last_activity_at < NOW() - make_interval(hours => ${BOARD_LENS_STALE_HOURS})
-        AND completeness_score < ${BOARD_LENS_MAX_COMPLETENESS}
       )
     )`
   }

--- a/apps/backend/tests/integration/board-view-repository.test.ts
+++ b/apps/backend/tests/integration/board-view-repository.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, addTestMember, setupTestDatabase } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { BoardViewRepository } from "../../src/features/board-views"
+import { sql } from "../../src/db"
+import { userId, workspaceId, boardViewId } from "../../src/lib/id"
+
+describe("BoardViewRepository", () => {
+  let pool: Pool
+  let testUserId: string
+  let testWorkspaceId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Test Workspace",
+        slug: `test-ws-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("degrades a retired stored base_lens to 'all' on read", async () => {
+    const id = boardViewId()
+    await pool.query(sql`
+      INSERT INTO board_views
+        (id, workspace_id, user_id, name, base_lens, scope_stream_ids, scope_stream_types,
+         scope_label_ids, exclude_stream_ids, exclude_stream_types, exclude_label_ids, sort_order)
+      VALUES (${id}, ${testWorkspaceId}, ${testUserId}, 'Legacy view', 'needs-resolution',
+        '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], 0)
+    `)
+
+    const views = await BoardViewRepository.listForUser(pool, testWorkspaceId, testUserId)
+
+    expect(views.find((v) => v.id === id)?.baseLens).toBe("all")
+  })
+
+  test("keeps a live lens unchanged", async () => {
+    const view = await BoardViewRepository.create(pool, {
+      workspaceId: testWorkspaceId,
+      userId: testUserId,
+      name: "Mine",
+      baseLens: "mine",
+      scopeStreamIds: [],
+      scopeStreamTypes: [],
+      scopeLabelIds: [],
+      excludeStreamIds: [],
+      excludeStreamTypes: [],
+      excludeLabelIds: [],
+    })
+
+    expect(view.baseLens).toBe("mine")
+  })
+})

--- a/apps/backend/tests/integration/conversation-repository.test.ts
+++ b/apps/backend/tests/integration/conversation-repository.test.ts
@@ -19,7 +19,7 @@ import { MemoRepository } from "../../src/features/memos"
 import { sql } from "../../src/db"
 import { setupTestDatabase, testMessageContent } from "./setup"
 import { userId, workspaceId, streamId, messageId, conversationId, memoId } from "../../src/lib/id"
-import { ConversationStatuses } from "@threa/types"
+import { ConversationStatuses, type BoardLens } from "@threa/types"
 
 describe("ConversationRepository", () => {
   let pool: Pool
@@ -457,36 +457,67 @@ describe("ConversationRepository", () => {
           limit: 100,
         })
         const ids = new Set(rows.map((r) => r.id))
-        for (const id of [activeConv, stalledConv, idleIncompleteConv, resolvedIdleConv, decisionConv]) {
+        for (const id of [
+          activeConv,
+          stalledConv,
+          idleIncompleteConv,
+          idleCompleteConv,
+          resolvedIdleConv,
+          decisionConv,
+        ]) {
           expect(ids.has(id)).toBe(true)
         }
       }
     })
 
-    test("active lens keeps only status-active conversations", async () => {
-      const rows = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
-        lens: "active",
+    // A saved board view created before the status lenses were retired still holds
+    // `base_lens = 'active'` / `'needs-resolution'`. Those must degrade to `all`
+    // (same rows, no filter, no throw), never to an empty board.
+    test("a retired lens value still stored on a saved view returns exactly the `all` rows", async () => {
+      const all = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
+        lens: "all",
         limit: 100,
       })
-      const ids = new Set(rows.map((r) => r.id))
-      expect(ids.has(activeConv)).toBe(true)
-      expect(ids.has(idleIncompleteConv)).toBe(true)
-      expect(ids.has(stalledConv)).toBe(false)
-      expect(ids.has(resolvedIdleConv)).toBe(false)
+      for (const retired of ["active", "needs-resolution"] as unknown as BoardLens[]) {
+        const rows = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
+          lens: retired,
+          limit: 100,
+        })
+        expect(rows.map((r) => r.id)).toEqual(all.map((r) => r.id))
+      }
     })
 
-    test("needs-resolution lens keeps stalled and long-idle-incomplete, drops fresh and near-complete", async () => {
+    test("mine lens keeps only the viewer's own conversations", async () => {
+      const all = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
+        lens: "all",
+        limit: 100,
+      })
       const rows = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
-        lens: "needs-resolution",
+        lens: "mine",
         limit: 100,
       })
       const ids = new Set(rows.map((r) => r.id))
-      expect(ids.has(stalledConv)).toBe(true)
-      expect(ids.has(idleIncompleteConv)).toBe(true)
-      expect(ids.has(activeConv)).toBe(false)
-      expect(ids.has(idleCompleteConv)).toBe(false)
-      // Resolved is done — excluded even when idle + low-score.
-      expect(ids.has(resolvedIdleConv)).toBe(false)
+      // Every seeded conversation lists the test user as a participant.
+      for (const id of [activeConv, stalledConv, decisionConv]) expect(ids.has(id)).toBe(true)
+
+      const stranger = await ConversationRepository.findByWorkspaceForViewer(
+        pool,
+        testWorkspaceId,
+        "usr_not_a_member",
+        {
+          lens: "mine",
+          limit: 100,
+        }
+      )
+      expect(stranger.map((r) => r.id)).toEqual([])
+      // The stranger CAN read the public channel — `mine` is what empties it, not access.
+      const strangerAll = await ConversationRepository.findByWorkspaceForViewer(
+        pool,
+        testWorkspaceId,
+        "usr_not_a_member",
+        { lens: "all", limit: 100 }
+      )
+      expect(strangerAll.map((r) => r.id)).toEqual(all.map((r) => r.id))
     })
 
     test("decisions lens keeps only conversations with an active captured memo", async () => {

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -76,9 +76,11 @@ export const BOARD_FILTER_PARAMS = [
   BOARD_UNREAD_PARAM,
 ] as const
 
-/** Parse `?lens=`: a valid lens, anything else (absent, unknown) degrades to
- *  the default `all` — a hand-built URL renders the widest view rather than
- *  erroring. */
+/** Parse a stored or URL-supplied lens value: a valid lens, anything else
+ *  (absent, unknown, a lens retired since the value was written) degrades to the
+ *  default `all` — a hand-built URL, a stale saved view, or a stale home
+ *  preference renders the widest view rather than erroring or landing nowhere.
+ *  The single degrade authority; `matchesBoardLens` mirrors it read-side. */
 export function parseLensParam(value: string | null): BoardLens {
   return value && (BOARD_LENSES as readonly string[]).includes(value) ? (value as BoardLens) : DEFAULT_BOARD_LENS
 }

--- a/apps/frontend/src/components/board/board-home-redirect.test.ts
+++ b/apps/frontend/src/components/board/board-home-redirect.test.ts
@@ -7,8 +7,8 @@ const WS = "ws_1"
 function view(overrides: Partial<BoardView> = {}): BoardView {
   return {
     id: "bview_1",
-    name: "Channels, active",
-    baseLens: "active",
+    name: "Channels, mine",
+    baseLens: "mine",
     scopeStreamIds: [],
     scopeStreamTypes: ["channel"],
     scopeLabelIds: [],
@@ -22,7 +22,7 @@ function view(overrides: Partial<BoardView> = {}): BoardView {
 
 describe("boardHomeHref", () => {
   it("expands the default view to its canonical query URL", () => {
-    expect(boardHomeHref(WS, "bview_1", [view()], "all")).toBe(`/w/${WS}/board?lens=active&is=channel`)
+    expect(boardHomeHref(WS, "bview_1", [view()], "all")).toBe(`/w/${WS}/board?lens=mine&is=channel`)
   })
 
   it("targets the home lens when no default view is set", () => {
@@ -31,6 +31,14 @@ describe("boardHomeHref", () => {
 
   it("falls back to the home lens when the default id no longer resolves", () => {
     expect(boardHomeHref(WS, "bview_gone", [view()], "all")).toBe(`/w/${WS}/board?lens=all`)
+  })
+
+  it("targets `all` for a view stored under a retired lens — the API normalizes it at the read boundary", () => {
+    // A row written with a since-retired lens can no longer reach the client as
+    // that value: BoardViewRepository's row mapper degrades it to `all`, so the
+    // view this helper sees is already normalized.
+    const legacy = view({ id: "bview_legacy", baseLens: "all", scopeStreamTypes: [] })
+    expect(boardHomeHref(WS, "bview_legacy", [legacy], "all")).toBe(`/w/${WS}/board?lens=all`)
   })
 
   it("never emits the bare entry alias, even for an unfiltered all-lens view", () => {

--- a/apps/frontend/src/components/conversations/conversation-item.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.test.tsx
@@ -57,8 +57,9 @@ describe("ConversationItem", () => {
     for (const label of ["Active", "Stalled", "Resolved"]) {
       expect(screen.queryByText(label)).not.toBeInTheDocument()
     }
-    // The completeness meter rendered seven fixed-size segments; none may remain.
-    expect(container.querySelectorAll("div.w-1\\.5.h-3").length).toBe(0)
+    // The completeness meter carried a tooltip naming the score; none may remain.
+    expect(container.querySelector("[aria-label^='Completeness']")).toBeNull()
+    expect(screen.queryByText(/Completeness/)).not.toBeInTheDocument()
   })
 
   it("does not dim a temporally stale conversation — staleness no longer drives the row", () => {

--- a/apps/frontend/src/components/conversations/conversation-item.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type { ConversationWithStaleness } from "@threa/types"
+import { ConversationItem } from "./conversation-item"
+import { PanelProvider } from "@/contexts"
+import * as contextsModule from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+function conversation(overrides: Partial<ConversationWithStaleness> = {}): ConversationWithStaleness {
+  return {
+    id: "conv_1",
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    topicSummary: "Pricing for the new tier",
+    messageIds: ["msg_1", "msg_2"],
+    participantIds: ["usr_1"],
+    status: "stalled",
+    completenessScore: 2,
+    effectiveCompleteness: 2,
+    temporalStaleness: 5,
+    lastActivityAt: "2026-07-20T10:00:00.000Z",
+    createdAt: "2026-07-20T09:00:00.000Z",
+    updatedAt: "2026-07-20T10:00:00.000Z",
+    ...overrides,
+  } as unknown as ConversationWithStaleness
+}
+
+function renderItem(conv: ConversationWithStaleness) {
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <PanelProvider>
+          <ConversationItem workspaceId="ws_1" conversation={conv} isExpanded={false} onToggle={() => {}} />
+        </PanelProvider>
+      </TooltipProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("ConversationItem", () => {
+  beforeEach(() => {
+    vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+      preferences: { timezone: "UTC", locale: "en-US" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it("shows the topic and message count", () => {
+    renderItem(conversation())
+    expect(screen.getByText("Pricing for the new tier")).toBeInTheDocument()
+    expect(screen.getByText("2 messages")).toBeInTheDocument()
+  })
+
+  it("renders no classifier-judgment surfaces — no status badge, no completeness segments", () => {
+    const { container } = renderItem(conversation({ status: "stalled" } as Partial<ConversationWithStaleness>))
+    for (const label of ["Active", "Stalled", "Resolved"]) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument()
+    }
+    // The completeness meter rendered seven fixed-size segments; none may remain.
+    expect(container.querySelectorAll("div.w-1\\.5.h-3").length).toBe(0)
+  })
+
+  it("does not dim a temporally stale conversation — staleness no longer drives the row", () => {
+    const { container } = renderItem(conversation({ temporalStaleness: 6 } as Partial<ConversationWithStaleness>))
+    expect(container.querySelector(".opacity-60")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -2,11 +2,10 @@ import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
 import { ChevronDown, ChevronRight, PanelRight } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { RelativeTime } from "@/components/relative-time"
 import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { useActors } from "@/hooks"
@@ -30,14 +29,12 @@ export function ConversationItem({
   onMessageClick,
   className,
 }: ConversationItemProps) {
-  const { topicSummary, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } = conversation
+  const { topicSummary, messageIds, lastActivityAt } = conversation
   const { openPanel } = usePanel()
 
   return (
     <Collapsible open={isExpanded} onOpenChange={onToggle}>
-      <div
-        className={cn("rounded-lg border bg-card transition-colors", temporalStaleness >= 3 && "opacity-60", className)}
-      >
+      <div className={cn("rounded-lg border bg-card transition-colors", className)}>
         {/* Header row: the inline-expand trigger fills the row, the panel-open
             button sits beside it (outside the trigger so it isn't a nested button). */}
         <div className="flex items-stretch">
@@ -55,16 +52,12 @@ export function ConversationItem({
                   )}
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate">{topicSummary || "Untitled conversation"}</p>
-                    <div className="flex items-center gap-2 mt-1">
-                      <span className="text-xs text-muted-foreground">
-                        {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
-                      </span>
-                      <StatusBadge status={status} />
-                    </div>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
+                    </span>
                   </div>
                 </div>
                 <div className="flex flex-col items-end gap-1 flex-shrink-0">
-                  <CompletenessIndicator score={effectiveCompleteness} />
                   <RelativeTime date={lastActivityAt} className="text-xs text-muted-foreground" />
                 </div>
               </div>
@@ -188,63 +181,5 @@ function MessagePreview({ message, workspaceId, getActorName, onMessageClick }: 
       </div>
       <p className="text-foreground/80 whitespace-pre-wrap break-words">{truncatedContent}</p>
     </Link>
-  )
-}
-
-export function StatusBadge({ status }: { status: string }) {
-  switch (status) {
-    case "active":
-      return (
-        <Badge variant="outline" className="text-xs py-0 px-1.5 h-5 bg-green-500/10 text-green-600 border-green-500/20">
-          Active
-        </Badge>
-      )
-    case "stalled":
-      return (
-        <Badge
-          variant="outline"
-          className="text-xs py-0 px-1.5 h-5 bg-yellow-500/10 text-yellow-600 border-yellow-500/20"
-        >
-          Stalled
-        </Badge>
-      )
-    case "resolved":
-      return (
-        <Badge variant="outline" className="text-xs py-0 px-1.5 h-5 bg-blue-500/10 text-blue-600 border-blue-500/20">
-          Resolved
-        </Badge>
-      )
-    default:
-      return null
-  }
-}
-
-export function CompletenessIndicator({ score }: { score: number }) {
-  const clampedScore = Math.max(1, Math.min(7, score))
-  const segments = 7
-
-  const getDescription = (s: number): string => {
-    if (s <= 2) return "Just started - conversation has recently begun"
-    if (s <= 4) return "In progress - ongoing discussion"
-    if (s <= 6) return "Mostly complete - wrapping up"
-    return "Complete - conversation appears resolved"
-  }
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex gap-0.5 cursor-help">
-            {Array.from({ length: segments }).map((_, i) => (
-              <div key={i} className={cn("w-1.5 h-3 rounded-sm", i < clampedScore ? "bg-primary" : "bg-muted")} />
-            ))}
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="left">
-          <p className="font-medium">Completeness: {clampedScore}/7</p>
-          <p className="text-xs text-muted-foreground">{getDescription(clampedScore)}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   )
 }

--- a/apps/frontend/src/components/conversations/conversation-list.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-list.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type { ConversationWithStaleness } from "@threa/types"
+import { ConversationList } from "./conversation-list"
+import { PanelProvider } from "@/contexts"
+import * as contextsModule from "@/contexts"
+import * as hooksModule from "@/hooks"
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+function conversation(overrides: Partial<ConversationWithStaleness> = {}): ConversationWithStaleness {
+  return {
+    id: "conv_1",
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    topicSummary: "Topic",
+    messageIds: ["msg_1"],
+    participantIds: ["usr_1"],
+    status: "active",
+    completenessScore: 2,
+    effectiveCompleteness: 2,
+    temporalStaleness: 0,
+    lastActivityAt: "2026-07-20T10:00:00.000Z",
+    createdAt: "2026-07-20T09:00:00.000Z",
+    updatedAt: "2026-07-20T10:00:00.000Z",
+    ...overrides,
+  } as unknown as ConversationWithStaleness
+}
+
+function renderList(conversations: ConversationWithStaleness[]) {
+  vi.spyOn(hooksModule, "useConversations").mockReturnValue({
+    conversations,
+    isLoading: false,
+    error: null,
+  } as unknown as ReturnType<typeof hooksModule.useConversations>)
+
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <PanelProvider>
+          <ConversationList workspaceId="ws_1" streamId="stream_1" />
+        </PanelProvider>
+      </TooltipProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("ConversationList", () => {
+  beforeEach(() => {
+    vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+      preferences: { timezone: "UTC", locale: "en-US" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  const rows = [
+    conversation({ id: "conv_old", topicSummary: "Oldest", lastActivityAt: "2026-07-18T10:00:00.000Z" }),
+    conversation({ id: "conv_new", topicSummary: "Newest", lastActivityAt: "2026-07-22T10:00:00.000Z" }),
+    conversation({
+      id: "conv_mid",
+      topicSummary: "Middle",
+      status: "resolved",
+      lastActivityAt: "2026-07-20T10:00:00.000Z",
+    }),
+  ]
+
+  it("renders one flat list ordered by lastActivityAt desc, ignoring status", () => {
+    renderList(rows)
+    const topics = screen.getAllByText(/Oldest|Newest|Middle/).map((el) => el.textContent)
+    expect(topics).toEqual(["Newest", "Middle", "Oldest"])
+  })
+
+  it("renders no classifier status sections", () => {
+    renderList(rows)
+    for (const heading of ["Active", "Stalled", "Resolved"]) {
+      expect(screen.queryByText(new RegExp(`^${heading}( \\(\\d+\\))?$`))).not.toBeInTheDocument()
+    }
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-list.tsx
+++ b/apps/frontend/src/components/conversations/conversation-list.tsx
@@ -3,7 +3,6 @@ import { cn } from "@/lib/utils"
 import { useConversations } from "@/hooks"
 import { ConversationItem } from "./conversation-item"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { ConversationWithStaleness } from "@threa/types"
 
 interface ConversationListProps {
   workspaceId: string
@@ -48,80 +47,22 @@ export function ConversationList({ workspaceId, streamId, className, onMessageCl
     return <div className={cn("p-4 text-sm text-muted-foreground text-center", className)}>No conversations yet</div>
   }
 
-  const activeConversations = conversations.filter((c) => c.status === "active")
-  const stalledConversations = conversations.filter((c) => c.status === "stalled")
-  const resolvedConversations = conversations.filter((c) => c.status === "resolved")
-
-  return (
-    <div className={cn("space-y-4 p-2", className)}>
-      {activeConversations.length > 0 && (
-        <ConversationSection
-          title="Active"
-          workspaceId={workspaceId}
-          conversations={activeConversations}
-          expandedConversationId={expandedConversationId}
-          onToggle={handleToggle}
-          onMessageClick={onMessageClick}
-        />
-      )}
-      {stalledConversations.length > 0 && (
-        <ConversationSection
-          title="Stalled"
-          workspaceId={workspaceId}
-          conversations={stalledConversations}
-          expandedConversationId={expandedConversationId}
-          onToggle={handleToggle}
-          onMessageClick={onMessageClick}
-        />
-      )}
-      {resolvedConversations.length > 0 && (
-        <ConversationSection
-          title="Resolved"
-          workspaceId={workspaceId}
-          conversations={resolvedConversations}
-          expandedConversationId={expandedConversationId}
-          onToggle={handleToggle}
-          onMessageClick={onMessageClick}
-        />
-      )}
-    </div>
+  const ordered = [...conversations].sort(
+    (a, b) => new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime()
   )
-}
 
-interface ConversationSectionProps {
-  title: string
-  workspaceId: string
-  conversations: ConversationWithStaleness[]
-  expandedConversationId: string | null
-  onToggle: (conversationId: string) => void
-  onMessageClick?: () => void
-}
-
-function ConversationSection({
-  title,
-  workspaceId,
-  conversations,
-  expandedConversationId,
-  onToggle,
-  onMessageClick,
-}: ConversationSectionProps) {
   return (
-    <div>
-      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-1 mb-2">
-        {title} ({conversations.length})
-      </h3>
-      <div className="space-y-1">
-        {conversations.map((conversation) => (
-          <ConversationItem
-            key={conversation.id}
-            workspaceId={workspaceId}
-            conversation={conversation}
-            isExpanded={expandedConversationId === conversation.id}
-            onToggle={() => onToggle(conversation.id)}
-            onMessageClick={onMessageClick}
-          />
-        ))}
-      </div>
+    <div className={cn("space-y-1 p-2", className)}>
+      {ordered.map((conversation) => (
+        <ConversationItem
+          key={conversation.id}
+          workspaceId={workspaceId}
+          conversation={conversation}
+          isExpanded={expandedConversationId === conversation.id}
+          onToggle={() => handleToggle(conversation.id)}
+          onMessageClick={onMessageClick}
+        />
+      ))}
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -121,7 +121,7 @@ describe("BoardModeBlock", () => {
     mountAt(`/w/${WS}/board`)
 
     expect(screen.getByText("Lenses")).toBeInTheDocument()
-    for (const label of ["All", "Active", "Needs resolution", "Decisions", "Mine"]) {
+    for (const label of ["All", "Decisions", "Mine"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument()
     }
   })
@@ -135,7 +135,7 @@ describe("BoardModeBlock", () => {
 
   it("carries the current filters across every lens link", () => {
     stub()
-    mountAt(`/w/${WS}/board?lens=active&in=stream_1&label=label_a`)
+    mountAt(`/w/${WS}/board?lens=mine&in=stream_1&label=label_a`)
 
     const all = new URL(hrefOf("All"), "http://x")
     expect(all.searchParams.get("lens")).toBe("all")
@@ -155,15 +155,15 @@ describe("BoardModeBlock", () => {
     const all = new URL(hrefOf("All"), "http://x")
     expect(all.pathname).toBe(`/w/${WS}/board`)
     expect(all.searchParams.get("lens")).toBe("all")
-    const active = new URL(hrefOf("Active"), "http://x")
-    expect(active.searchParams.get("lens")).toBe("active")
+    const mine = new URL(hrefOf("Mine"), "http://x")
+    expect(mine.searchParams.get("lens")).toBe("mine")
   })
 
   it("marks the current lens active", () => {
     stub()
-    mountAt(`/w/${WS}/board?lens=active`)
+    mountAt(`/w/${WS}/board?lens=mine`)
 
-    expect(screen.getByRole("link", { name: "Active" })).toHaveAttribute("aria-current", "true")
+    expect(screen.getByRole("link", { name: "Mine" })).toHaveAttribute("aria-current", "true")
     expect(screen.getByRole("link", { name: "All" })).not.toHaveAttribute("aria-current")
   })
 
@@ -203,7 +203,7 @@ describe("BoardModeBlock", () => {
   it("renders per-lens counts from lensTotals, right-aligned inside each lens row", () => {
     stub()
     mountAt(`/w/${WS}/board`, {
-      lensTotals: { all: 14, active: 6, "needs-resolution": 2, decisions: 3, mine: 0 },
+      lensTotals: { all: 14, decisions: 3, mine: 0 },
     })
 
     const all = screen.getByRole("link", { name: "All" })
@@ -216,7 +216,7 @@ describe("BoardModeBlock", () => {
     stub()
     mountAt(`/w/${WS}/board`, { lensTotals: null })
 
-    expect(screen.getByRole("link", { name: "Active" })).toHaveTextContent(/^Active$/)
+    expect(screen.getByRole("link", { name: "Decisions" })).toHaveTextContent(/^Decisions$/)
   })
 
   it("renders the Filters group with the stream and type pickers", () => {
@@ -263,8 +263,8 @@ describe("BoardModeBlock", () => {
     const { updatePreferences } = stub({ boardDefaultLens: "all" })
     mountAt(`/w/${WS}/board?lens=all`)
 
-    await user.click(screen.getByRole("button", { name: "Set Active as board home" }))
-    expect(updatePreferences).toHaveBeenCalledWith({ boardDefaultLens: "active", boardDefaultViewId: null })
+    await user.click(screen.getByRole("button", { name: "Set Mine as board home" }))
+    expect(updatePreferences).toHaveBeenCalledWith({ boardDefaultLens: "mine", boardDefaultViewId: null })
   })
 
   it("pinning a saved view writes the home-view preference", async () => {

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { Link, useLocation, useSearchParams } from "react-router-dom"
 import { Archive, Bookmark, Check, CircleDot, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
-import { BOARD_LENSES, DEFAULT_BOARD_LENS, type BoardLens, type BoardScopeStreamType } from "@threa/types"
+import { BOARD_LENSES, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { useBoardHome, useBoardViews, useDeleteBoardView, useUpdateBoardView } from "@/hooks/use-board-views"
@@ -33,6 +33,7 @@ import {
   BOARD_TYPE_PARAM,
   BOARD_UNREAD_ON,
   BOARD_UNREAD_PARAM,
+  parseLensParam,
 } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
@@ -90,7 +91,7 @@ export function BoardModeBlock({ workspaceId, lensTotals }: BoardModeBlockProps)
     selection.excludeLabelIds.length > 0
 
   // No lens reads as home while a saved-view home resolves (the view's pin is home).
-  const homeLens = prefs?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const homeLens = parseLensParam(prefs?.preferences?.boardDefaultLens ?? null)
   const homeViewActive = homeView != null
 
   return (

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -577,26 +577,20 @@ describe("StreamItem — board mode", () => {
 
   it("shows the topic stats line in place of the message preview", () => {
     const stream = createStream()
-    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 14, active: 6, needsResolution: 2 }) }))
-    expect(screen.getByText("14 topics · 6 active · 2 need resolution")).toBeInTheDocument()
+    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 14 }) }))
+    expect(screen.getByText("14 topics")).toBeInTheDocument()
     expect(screen.queryByText("Latest update from the stream")).not.toBeInTheDocument()
   })
 
-  it("uses singular grammar for a lone topic and resolution", () => {
+  it("uses singular grammar for a lone topic", () => {
     const stream = createStream()
-    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 1, active: 1, needsResolution: 1 }) }))
-    expect(screen.getByText("1 topic · 1 active · 1 needs resolution")).toBeInTheDocument()
-  })
-
-  it("omits the resolution clause when nothing needs resolution", () => {
-    const stream = createStream()
-    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 3, active: 3, needsResolution: 0 }) }))
-    expect(screen.getByText("3 topics · 3 active")).toBeInTheDocument()
+    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 1 }) }))
+    expect(screen.getByText("1 topic")).toBeInTheDocument()
   })
 
   it("renders 'No topics yet' at zero topics", () => {
     const stream = createStream()
-    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 0, active: 0, needsResolution: 0 }) }))
+    renderBoardRow(stream, makeBoardMode({ statsForStream: () => ({ topics: 0 }) }))
     expect(screen.getByText("No topics yet")).toBeInTheDocument()
   })
 
@@ -606,7 +600,7 @@ describe("StreamItem — board mode", () => {
       stream,
       makeBoardMode({
         mutedStreamIds: new Set(["stream_general"]),
-        statsForStream: () => ({ topics: 14, active: 6, needsResolution: 2 }),
+        statsForStream: () => ({ topics: 14 }),
       })
     )
     expect(screen.getByText("Muted on the board")).toBeInTheDocument()
@@ -620,13 +614,13 @@ describe("StreamItem — board mode", () => {
       makeBoardMode({
         includedStreamIds: new Set(["stream_general"]),
         mutedStreamIds: new Set(["stream_general"]),
-        statsForStream: () => ({ topics: 14, active: 6, needsResolution: 2 }),
+        statsForStream: () => ({ topics: 14 }),
       })
     )
     // ?in= overrides the board mute server-side, so the row must read as on the
     // board: stats line instead of the muted status, no dim.
     expect(screen.queryByText("Muted on the board")).not.toBeInTheDocument()
-    expect(screen.getByText("14 topics · 6 active · 2 need resolution")).toBeInTheDocument()
+    expect(screen.getByText("14 topics")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: /general/i })).not.toHaveClass("opacity-50")
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -107,20 +107,21 @@ export function BoardTileToggle({
 
 /**
  * The board-mode row preview line: the stream's topic tally in place of the last
- * message ("14 topics · 6 active", "· 2 need resolution" only when > 0, "No
- * topics yet" at zero). Same size/truncation as the message preview it replaces
- * so swapping in board mode shifts nothing (INV-21). `null` stats = the single
- * aggregation hasn't resolved yet; render nothing rather than flash "No topics".
+ * message ("14 topics", "No topics yet" at zero). Same size/truncation as the
+ * message preview it replaces so swapping in board mode shifts nothing (INV-21).
+ * `null` stats = the single aggregation hasn't resolved yet; render nothing
+ * rather than flash "No topics".
  */
 export function BoardStatsLine({ stats }: { stats: BoardStreamStats | null }) {
   if (!stats) return null
   if (stats.topics === 0) {
     return <div className="truncate text-xs text-muted-foreground">No topics yet</div>
   }
-  const parts = [`${stats.topics} ${stats.topics === 1 ? "topic" : "topics"}`, `${stats.active} active`]
-  if (stats.needsResolution > 0)
-    parts.push(`${stats.needsResolution} ${stats.needsResolution === 1 ? "needs" : "need"} resolution`)
-  return <div className="truncate text-xs text-muted-foreground">{parts.join(" · ")}</div>
+  return (
+    <div className="truncate text-xs text-muted-foreground">
+      {stats.topics} {stats.topics === 1 ? "topic" : "topics"}
+    </div>
+  )
 }
 
 export function UrgencyStrip({ urgency }: { urgency: UrgencyLevel }) {

--- a/apps/frontend/src/components/settings/appearance-settings.board-home.test.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.board-home.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { AppearanceSettings } from "./appearance-settings"
+import * as contextsModule from "@/contexts"
+import * as boardViewsModule from "@/hooks/use-board-views"
+
+const WS = "ws_1"
+
+function mount(boardDefaultLens: string) {
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { boardDefaultLens, accessibility: {} },
+    updatePreference: vi.fn(),
+    updatePreferences: vi.fn(),
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(boardViewsModule, "useBoardViews").mockReturnValue({ data: [] } as unknown as ReturnType<
+    typeof boardViewsModule.useBoardViews
+  >)
+  vi.spyOn(boardViewsModule, "useBoardHome").mockReturnValue({ view: null } as unknown as ReturnType<
+    typeof boardViewsModule.useBoardHome
+  >)
+  render(
+    <MemoryRouter initialEntries={[`/w/${WS}/settings`]}>
+      <Routes>
+        <Route path="/w/:workspaceId/settings" element={<AppearanceSettings />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("AppearanceSettings — board home", () => {
+  beforeEach(() => vi.restoreAllMocks())
+  afterEach(() => vi.restoreAllMocks())
+
+  it("offers exactly the three board lenses", () => {
+    mount("all")
+    const options = screen.getAllByRole("radio").filter((el) => el.id.startsWith("board-home-lens-"))
+    expect(options.map((el) => el.id)).toEqual([
+      "board-home-lens-all",
+      "board-home-lens-decisions",
+      "board-home-lens-mine",
+    ])
+  })
+
+  it("degrades a retired stored home lens to the default rather than selecting nothing", () => {
+    // A preference blob written before the status lenses were dropped still says
+    // `needs-resolution`. It must land on All, not blank the section or throw.
+    mount("needs-resolution")
+    expect(screen.getByText("Board home")).toBeInTheDocument()
+    expect(document.getElementById("board-home-lens-all")).toHaveAttribute("data-state", "checked")
+  })
+})

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
 import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
 import { summarizeBoardView } from "@/components/board/board-saved-views"
+import { parseLensParam } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
   THEME_OPTIONS,
@@ -33,7 +34,6 @@ import {
   BOARD_CARD_COLLAPSE_TO_HEIGHT_MAX,
   DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT,
   BOARD_LENSES,
-  DEFAULT_BOARD_LENS,
   type Theme,
   type MessageDisplay,
   type UnreadOpenPosition,
@@ -89,7 +89,7 @@ function BoardHomeSection({ workspaceId }: { workspaceId: string }) {
   const { preferences, updatePreferences } = usePreferences()
   const { data: views } = useBoardViews(workspaceId)
   const savedViews = views ?? []
-  const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const boardDefaultLens = parseLensParam(preferences?.boardDefaultLens ?? null)
   // The resolved home view's id, or null when the home is a lens (or the stored id
   // no longer resolves) — land on the lens then.
   const activeViewId = useBoardHome(workspaceId).view?.id ?? null

--- a/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
+++ b/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
@@ -45,72 +45,61 @@ function post(id: string, opts: PostOpts): CachedBoardPost {
 }
 
 describe("aggregateBoardSidebarStats", () => {
-  it("tallies topics/active/needsResolution per effective root stream", () => {
-    const { byStream } = aggregateBoardSidebarStats(
-      [
-        post("c1", { streamId: "chan_a", status: "active" }),
-        post("c2", { streamId: "chan_a", status: "stalled" }),
-        post("c3", { streamId: "chan_a", status: "resolved" }),
-        post("c4", { streamId: "chan_b", status: "active" }),
-      ],
-      NOW
-    )
-    expect(byStream.get("chan_a")).toEqual({ topics: 3, active: 1, needsResolution: 1 })
-    expect(byStream.get("chan_b")).toEqual({ topics: 1, active: 1, needsResolution: 0 })
+  it("tallies topics per effective root stream, whatever the conversation status", () => {
+    const { byStream } = aggregateBoardSidebarStats([
+      post("c1", { streamId: "chan_a", status: "active" }),
+      post("c2", { streamId: "chan_a", status: "stalled" }),
+      post("c3", { streamId: "chan_a", status: "resolved" }),
+      post("c4", { streamId: "chan_b", status: "active" }),
+    ])
+    expect(byStream.get("chan_a")).toEqual({ topics: 3 })
+    expect(byStream.get("chan_b")).toEqual({ topics: 1 })
   })
 
   it("resolves a thread-anchored conversation to its rootStreamId, not its anchor", () => {
-    const { byStream } = aggregateBoardSidebarStats(
-      [post("c1", { streamId: "thread_x", rootStreamId: "chan_a" }), post("c2", { streamId: "chan_a" })],
-      NOW
-    )
+    const { byStream } = aggregateBoardSidebarStats([
+      post("c1", { streamId: "thread_x", rootStreamId: "chan_a" }),
+      post("c2", { streamId: "chan_a" }),
+    ])
     expect(byStream.get("chan_a")?.topics).toBe(2)
     expect(byStream.has("thread_x")).toBe(false)
   })
 
   it("falls back to the anchor streamId when rootStreamId is absent (pre-field row)", () => {
-    const { byStream } = aggregateBoardSidebarStats([post("c1", { streamId: "chan_a" })], NOW)
+    const { byStream } = aggregateBoardSidebarStats([post("c1", { streamId: "chan_a" })])
     expect(byStream.get("chan_a")?.topics).toBe(1)
   })
 
   it("excludes emptied-shell conversations (no messages) — mirrors the board feed", () => {
-    const { byStream, lensTotals } = aggregateBoardSidebarStats(
-      [post("c1", { streamId: "chan_a", messageIds: [] }), post("c2", { streamId: "chan_a", messageIds: ["m"] })],
-      NOW
-    )
+    const { byStream, lensTotals } = aggregateBoardSidebarStats([
+      post("c1", { streamId: "chan_a", messageIds: [] }),
+      post("c2", { streamId: "chan_a", messageIds: ["m"] }),
+    ])
     expect(byStream.get("chan_a")?.topics).toBe(1)
     expect(lensTotals.all).toBe(1)
   })
 
   it("excludes conversations whose root is archived", () => {
-    const { byStream } = aggregateBoardSidebarStats(
-      [post("c1", { streamId: "chan_a", rootArchived: true }), post("c2", { streamId: "chan_a" })],
-      NOW
-    )
+    const { byStream } = aggregateBoardSidebarStats([
+      post("c1", { streamId: "chan_a", rootArchived: true }),
+      post("c2", { streamId: "chan_a" }),
+    ])
     expect(byStream.get("chan_a")?.topics).toBe(1)
   })
 
-  it("computes per-lens totals via matchesBoardLens (all five lenses)", () => {
-    const { lensTotals } = aggregateBoardSidebarStats(
-      [
-        post("c1", { streamId: "chan_a", status: "active", isMine: true }),
-        post("c2", { streamId: "chan_a", status: "stalled", completenessScore: 1, idleHours: 0 }),
-        post("c3", { streamId: "chan_a", status: "resolved", hasCapturedMemo: true }),
-        // Idle + incomplete → needs-resolution even though status is active.
-        post("c4", { streamId: "chan_b", status: "active", idleHours: 100, completenessScore: 1 }),
-      ],
-      NOW
-    )
-    expect(lensTotals.all).toBe(4)
-    expect(lensTotals.active).toBe(2) // c1, c4
-    expect(lensTotals["needs-resolution"]).toBe(2) // c2 (stalled), c4 (idle+incomplete)
-    expect(lensTotals.decisions).toBe(1) // c3
-    expect(lensTotals.mine).toBe(1) // c1
+  it("computes per-lens totals via matchesBoardLens, keyed by exactly the three lenses", () => {
+    const { lensTotals } = aggregateBoardSidebarStats([
+      post("c1", { streamId: "chan_a", status: "active", isMine: true }),
+      post("c2", { streamId: "chan_a", status: "stalled", completenessScore: 1, idleHours: 0 }),
+      post("c3", { streamId: "chan_a", status: "resolved", hasCapturedMemo: true }),
+      post("c4", { streamId: "chan_b", status: "active", idleHours: 100, completenessScore: 1 }),
+    ])
+    expect(lensTotals).toEqual({ all: 4, decisions: 1, mine: 1 })
   })
 
   it("returns empty tallies for an empty feed", () => {
-    const { byStream, lensTotals } = aggregateBoardSidebarStats([], NOW)
+    const { byStream, lensTotals } = aggregateBoardSidebarStats([])
     expect(byStream.size).toBe(0)
-    expect(lensTotals).toEqual({ all: 0, active: 0, "needs-resolution": 0, decisions: 0, mine: 0 })
+    expect(lensTotals).toEqual({ all: 0, decisions: 0, mine: 0 })
   })
 })

--- a/apps/frontend/src/hooks/use-board-sidebar-stats.ts
+++ b/apps/frontend/src/hooks/use-board-sidebar-stats.ts
@@ -5,9 +5,8 @@ import { BOARD_LENSES, matchesBoardLens, type BoardLens } from "@threa/types"
 import { db, type CachedBoardPost } from "@/db"
 
 /** Per-root-stream topic tally shown on a board-mode sidebar row. `topics` counts
- *  the visible conversations whose effective root is that stream; `active` and
- *  `needsResolution` split them by conversation status. No `unread`: the design
- *  doc's "N unread" needs per-conversation read truth (per-message watermarks via
+ *  the visible conversations whose effective root is that stream. No `unread`: the
+ *  design doc's "N unread" needs per-conversation read truth (per-message watermarks via
  *  the sparse-read overlay, as board cards compute it), which this single pass
  *  over `db.conversations` can't derive without breaking the one-subscription
  *  perf contract — so unread is deliberately left off the stats line.
@@ -20,8 +19,6 @@ import { db, type CachedBoardPost } from "@/db"
  *  would need the full projection per stream, breaking the single pass. */
 export interface BoardStreamStats {
   topics: number
-  active: number
-  needsResolution: number
 }
 
 /** The single aggregation the board sidebar reads: per-root-stream tallies plus
@@ -33,7 +30,7 @@ export interface BoardSidebarStats {
 
 /** Shared zero tally for a stream the aggregation resolved but never counted (no
  *  topics) — a constant so the per-row lookup allocates nothing. */
-export const ZERO_BOARD_STREAM_STATS: BoardStreamStats = { topics: 0, active: 0, needsResolution: 0 }
+export const ZERO_BOARD_STREAM_STATS: BoardStreamStats = { topics: 0 }
 
 /**
  * Fold the cached board feed into the sidebar's per-stream + per-lens counts in a
@@ -43,25 +40,22 @@ export const ZERO_BOARD_STREAM_STATS: BoardStreamStats = { topics: 0, active: 0,
  * `cardinality(message_ids) > 0` board filter and `mergeBoardConversation`'s
  * delete-on-empty) or its root is archived (hidden on the board by default). Lens
  * totals reuse `matchesBoardLens`, the same read-side lens authority the board
- * card filters with, so the two surfaces can't drift. `nowMs` is passed so the
- * function stays pure/testable; the hook samples it per feed change.
+ * card filters with, so the two surfaces can't drift.
  */
-export function aggregateBoardSidebarStats(posts: CachedBoardPost[], nowMs: number): BoardSidebarStats {
+export function aggregateBoardSidebarStats(posts: CachedBoardPost[]): BoardSidebarStats {
   const byStream = new Map<string, BoardStreamStats>()
-  const lensTotals: Record<BoardLens, number> = { all: 0, active: 0, "needs-resolution": 0, decisions: 0, mine: 0 }
+  const lensTotals = Object.fromEntries(BOARD_LENSES.map((lens) => [lens, 0])) as Record<BoardLens, number>
   for (const post of posts) {
     if (post.conversation.messageIds.length === 0) continue
     if (post.rootArchived === true) continue
     const rootId = post.rootStreamId ?? post.conversation.streamId
     let entry = byStream.get(rootId)
     if (!entry) {
-      entry = { topics: 0, active: 0, needsResolution: 0 }
+      entry = { topics: 0 }
       byStream.set(rootId, entry)
     }
     entry.topics += 1
-    if (post.conversation.status === "active") entry.active += 1
-    else if (post.conversation.status === "stalled") entry.needsResolution += 1
-    for (const lens of BOARD_LENSES) if (matchesBoardLens(post, lens, nowMs)) lensTotals[lens] += 1
+    for (const lens of BOARD_LENSES) if (matchesBoardLens(post, lens)) lensTotals[lens] += 1
   }
   return { byStream, lensTotals }
 }
@@ -89,5 +83,5 @@ export function useBoardSidebarStats(workspaceId: string, enabled: boolean): Boa
       .between([workspaceId, Dexie.minKey], [workspaceId, Dexie.maxKey])
       .toArray()
   }, [enabled, workspaceId])
-  return useMemo(() => (posts ? aggregateBoardSidebarStats(posts, Date.now()) : null), [posts])
+  return useMemo(() => (posts ? aggregateBoardSidebarStats(posts) : null), [posts])
 }

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -53,7 +53,10 @@ describe("useLastLocation — stream arm", () => {
 
   it("never falls back into an archived stream, even when it is the most recent", () => {
     // Archiving bumps updated_at, so an unfiltered fallback would pick it.
-    const archived = { ...stream("stream_archived", "2026-03-01T00:00:00.000Z"), archivedAt: "2026-03-01T00:00:00.000Z" } as CachedStream
+    const archived = {
+      ...stream("stream_archived", "2026-03-01T00:00:00.000Z"),
+      archivedAt: "2026-03-01T00:00:00.000Z",
+    } as CachedStream
     setup({ streams: [archived, stream("stream_active", "2026-01-01T00:00:00.000Z")] })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current.redirectStreamId).toBe("stream_active")
@@ -81,11 +84,11 @@ describe("useLastLocation — board arm", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: "stream_a",
-      board: { search: "?lens=active&in=stream_a,stream_gone" },
+      board: { search: "?lens=mine&in=stream_a,stream_gone" },
     })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({
-      boardHref: "/w/ws_1/board?lens=active&in=stream_a",
+      boardHref: "/w/ws_1/board?lens=mine&in=stream_a",
       redirectStreamId: null,
     })
   })
@@ -105,12 +108,12 @@ describe("usePersistLastLocation", () => {
   it("retains the prior stream id when writing a board surface", () => {
     setLastLocation(USER, WS, { surface: "stream", streamId: "stream_prior", board: null })
     renderHook(() => usePersistLastLocation(WS), {
-      wrapper: routerAt("/w/ws_1/board?lens=active&in=stream_x&panel=stream_z"),
+      wrapper: routerAt("/w/ws_1/board?lens=mine&in=stream_x&panel=stream_z"),
     })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "board",
       streamId: "stream_prior",
-      board: { search: "?lens=active&in=stream_x" },
+      board: { search: "?lens=mine&in=stream_x" },
     })
   })
 
@@ -118,13 +121,13 @@ describe("usePersistLastLocation", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: null,
-      board: { search: "?lens=active&in=stream_a" },
+      board: { search: "?lens=mine&in=stream_a" },
     })
     renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_new") })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "stream",
       streamId: "stream_new",
-      board: { search: "?lens=active&in=stream_a" },
+      board: { search: "?lens=mine&in=stream_a" },
     })
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -69,12 +69,18 @@ function pendingPost(id: string, activityMs: number): CachedBoardPost {
 function lensPost(
   id: string,
   activityMs: number,
-  opts: { status?: "active" | "stalled" | "resolved"; completenessScore?: number; hasCapturedMemo?: boolean }
+  opts: {
+    status?: "active" | "stalled" | "resolved"
+    completenessScore?: number
+    hasCapturedMemo?: boolean
+    isMine?: boolean
+  }
 ): CachedBoardPost {
   const base = post(id, activityMs)
   return {
     ...base,
     hasCapturedMemo: opts.hasCapturedMemo ?? false,
+    isMine: opts.isMine ?? false,
     conversation: {
       ...base.conversation,
       status: opts.status ?? "active",
@@ -273,15 +279,15 @@ describe("useStableBoardView", () => {
   it("commits the new lens's feed wholesale across disjoint subsets — no stranding behind the pill", () => {
     // The bug this guards: switching between two lenses with disjoint subsets where
     // a fresh card of the new lens sits ABOVE the old lens's committed floor. `s`
-    // is the only Needs-resolution card (floor 300); `d` is a Decisions card above
-    // it (400) that isn't a Needs-resolution card. Reconciling `d` against the
-    // stale `{s}` committed strands it behind an empty "N new" pill; folding the
-    // reset into the reconcile input commits `d` immediately instead.
-    const stalled = lensPost("s", 300, { status: "stalled" })
+    // is the only Mine card (floor 300); `d` is a Decisions card above it (400)
+    // that isn't a Mine card. Reconciling `d` against the stale `{s}` committed
+    // strands it behind an empty "N new" pill; folding the reset into the
+    // reconcile input commits `d` immediately instead.
+    const mine = lensPost("s", 300, { isMine: true })
     const decision = lensPost("d", 400, { hasCapturedMemo: true })
-    mockLive(feed(stalled, decision))
+    mockLive(feed(mine, decision))
     const { result, rerender } = renderHook(({ lens }) => useStableBoardView("ws_1", lensFilter(lens)), {
-      initialProps: { lens: "needs-resolution" as BoardLens },
+      initialProps: { lens: "mine" as BoardLens },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
     rerender({ lens: "decisions" })
@@ -297,11 +303,11 @@ describe("useStableBoardView", () => {
     // new lens (classified "already committed"), so its fresh arrival never shows
     // behind the "N new" pill. Feeding the reset (EMPTY_VIEW) into the reconcile
     // leaves no phantom, so the later arrival buffers. Fails on the pre-fix code.
-    const stalled = lensPost("s", 300, { status: "stalled" }) // needs-resolution only
+    const mine = lensPost("s", 300, { isMine: true }) // mine only
     const decisionLow = lensPost("x", 200, { hasCapturedMemo: true }) // decisions, below s's floor
-    mockLive(feed(stalled, decisionLow))
+    mockLive(feed(mine, decisionLow))
     const { result, rerender } = renderHook(({ lens }) => useStableBoardView("ws_1", lensFilter(lens)), {
-      initialProps: { lens: "needs-resolution" as BoardLens },
+      initialProps: { lens: "mine" as BoardLens },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
@@ -309,8 +315,8 @@ describe("useStableBoardView", () => {
     expect(result.current.posts.map((p) => p.id)).toEqual(["x"])
 
     // `s` gains a memo with fresh activity — a genuine new arrival on decisions.
-    const stalledWithMemo = lensPost("s", 500, { status: "stalled", hasCapturedMemo: true })
-    act(() => mockLive(feed(stalledWithMemo, decisionLow)))
+    const mineWithMemo = lensPost("s", 500, { isMine: true, hasCapturedMemo: true })
+    act(() => mockLive(feed(mineWithMemo, decisionLow)))
     rerender({ lens: "decisions" })
     // The fresh `s` waits behind the pill; it is not absorbed in-place.
     expect(result.current.newCount).toBe(1)
@@ -318,19 +324,18 @@ describe("useStableBoardView", () => {
   })
 
   it("keeps an acted-on card in place when it stops matching the lens (never yanked)", () => {
-    // The steer this encodes: replying to a Needs-resolution card makes it fresh,
-    // so it stops MATCHING the lens — but a filter must never yank what's on
-    // screen. The committed card keeps rendering (retained) until the viewer
-    // commits a fresh view themselves.
-    const stalled = lensPost("s", 300, { status: "stalled" })
-    const idle = lensPost("i", 200, { status: "stalled" })
-    mockLive(feed(stalled, idle))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", lensFilter("needs-resolution")))
+    // The steer this encodes: a card can stop MATCHING the lens after an update
+    // (here its memo is archived, so it leaves Decisions) — but a filter must
+    // never yank what's on screen. The committed card keeps rendering (retained)
+    // until the viewer commits a fresh view themselves.
+    const decision = lensPost("s", 300, { hasCapturedMemo: true })
+    const idle = lensPost("i", 200, { hasCapturedMemo: true })
+    mockLive(feed(decision, idle))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", lensFilter("decisions")))
     expect(result.current.posts.map((p) => p.id)).toEqual(["s", "i"])
 
-    // The viewer replies to `s`: fresh activity, status back to active — it no
-    // longer matches the lens.
-    act(() => mockLive(feed(lensPost("s", 900, { status: "active" }), idle)))
+    // `s`'s memo is archived with fresh activity — it no longer matches the lens.
+    act(() => mockLive(feed(lensPost("s", 900, { hasCapturedMemo: false }), idle)))
     rerender()
     // Still rendered in place, and not counted as "new".
     expect(result.current.posts.map((p) => p.id)).toEqual(["s", "i"])
@@ -345,16 +350,16 @@ describe("useStableBoardView", () => {
     // Posting from a filtered board navigates back to the All home (the new post
     // might not match the filter); the pending optimistic card reveals itself at
     // top there via reconcile, no arm to carry across the reset.
-    const stalled = lensPost("s", 300, { status: "stalled" })
-    mockLive(feed(stalled))
+    const decision = lensPost("s", 300, { hasCapturedMemo: true })
+    mockLive(feed(decision))
     const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter), {
-      initialProps: { filter: lensFilter("needs-resolution") },
+      initialProps: { filter: lensFilter("decisions") },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
     // Navigate to All, then the authored card lands after the fresh view's commit.
     rerender({ filter: ALL })
-    act(() => mockLive(feed(pendingPost("mine", 900), stalled)))
+    act(() => mockLive(feed(pendingPost("mine", 900), decision)))
     rerender({ filter: ALL })
     expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "s"])
     expect(result.current.newCount).toBe(0)

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -365,9 +365,7 @@ export function useStableBoardView(
   // whose parent survives the same filters is suppressed and bumps the parent's
   // effective activity; a child whose parent is filtered out stays standalone). The
   // fold runs BEFORE reconcile, so the committed-view machinery only ever sees the
-  // projected list. Recomputed when the feed or filter changes; `Date.now()` is
-  // sampled then (the staleness signal for `needs-resolution` only needs to be
-  // fresh at feed-change granularity, which is frequent on a live board).
+  // projected list. Recomputed when the feed or filter changes.
   const live = useMemo(
     () =>
       rawLive === undefined || graph === null
@@ -375,7 +373,7 @@ export function useStableBoardView(
         : projectNestedBoardView(
             rawLive.filter(
               (post) =>
-                matchesBoardLens(post, lens, Date.now()) &&
+                matchesBoardLens(post, lens) &&
                 matchesScope(post, scope) &&
                 matchesTypeScope(post, types) &&
                 matchesExcludedStreams(post, excludeStreams) &&

--- a/apps/frontend/src/lib/board/lens-defs.ts
+++ b/apps/frontend/src/lib/board/lens-defs.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react"
-import { BookMarked, CircleDashed, LayoutGrid, User, Zap } from "lucide-react"
+import { BookMarked, LayoutGrid, User } from "lucide-react"
 import { type BoardLens } from "@threa/types"
 
 export interface BoardLensDef {
@@ -17,13 +17,6 @@ export interface BoardLensDef {
  */
 export const BOARD_LENS_DEFS: Record<BoardLens, BoardLensDef> = {
   all: { value: "all", label: "All", description: "Everything, newest activity first", icon: LayoutGrid },
-  active: { value: "active", label: "Active", description: "Still in motion — not stalled or resolved", icon: Zap },
-  "needs-resolution": {
-    value: "needs-resolution",
-    label: "Needs resolution",
-    description: "Stalled or gone quiet while unresolved",
-    icon: CircleDashed,
-  },
   decisions: {
     value: "decisions",
     label: "Decisions",

--- a/apps/frontend/src/lib/last-location.test.ts
+++ b/apps/frontend/src/lib/last-location.test.ts
@@ -21,10 +21,10 @@ describe("sanitizeBoardSearch", () => {
     // percent-encodes the comma, matching savedViewHref's own output), so
     // compare by parsed params rather than raw string.
     const search =
-      "?lens=active&in=stream_a,stream_b&not-in=stream_c&is=dm&not-is=channel&label=lbl_1&not-label=lbl_2&archived=true"
+      "?lens=mine&in=stream_a,stream_b&not-in=stream_c&is=dm&not-is=channel&label=lbl_1&not-label=lbl_2&archived=true"
     const out = new URLSearchParams(sanitizeBoardSearch(search))
     expect(Object.fromEntries(out)).toEqual({
-      lens: "active",
+      lens: "mine",
       in: "stream_a,stream_b",
       "not-in": "stream_c",
       is: "dm",
@@ -39,6 +39,10 @@ describe("sanitizeBoardSearch", () => {
     expect(sanitizeBoardSearch("?lens=bogus&in=stream_a")).toBe("?lens=all&in=stream_a")
   })
 
+  it("degrades a retired lens value in a persisted last-location to `all`", () => {
+    expect(sanitizeBoardSearch("?lens=needs-resolution&in=stream_a")).toBe("?lens=all&in=stream_a")
+  })
+
   it("strips panel, m, and unrelated params", () => {
     expect(sanitizeBoardSearch("?in=stream_a&panel=stream_z&m=evt_1&q=hi")).toBe("?in=stream_a")
   })
@@ -51,7 +55,7 @@ describe("sanitizeBoardSearch", () => {
 
 describe("buildBoardHref", () => {
   it("carries the lens in the query", () => {
-    expect(buildBoardHref(WS, { search: "?lens=active" }, [])).toBe("/w/ws_1/board?lens=active")
+    expect(buildBoardHref(WS, { search: "?lens=mine" }, [])).toBe("/w/ws_1/board?lens=mine")
   })
 
   it("restores the bare entry alias for a record captured there", () => {
@@ -95,12 +99,12 @@ describe("getLastLocation / setLastLocation round-trip", () => {
     setLastLocation(USER, WS, {
       surface: "board",
       streamId: "stream_a",
-      board: { search: "?lens=active&in=stream_a&panel=stream_z" },
+      board: { search: "?lens=mine&in=stream_a&panel=stream_z" },
     })
     expect(getLastLocation(USER, WS)).toEqual({
       surface: "board",
       streamId: "stream_a",
-      board: { search: "?lens=active&in=stream_a" },
+      board: { search: "?lens=mine&in=stream_a" },
     })
   })
 

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -95,8 +95,8 @@ function makePost(
 function makeBoardView(overrides: Partial<BoardView> = {}): BoardView {
   return {
     id: "boardview_1",
-    name: "Channels, active",
-    baseLens: "active",
+    name: "Channels, mine",
+    baseLens: "mine",
     scopeStreamIds: [],
     scopeStreamTypes: ["channel"],
     scopeLabelIds: [],
@@ -265,7 +265,7 @@ describe("BoardPage", () => {
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     mountBoard([], { boardViews: [makeBoardView()] })
     const probe = await screen.findByTestId("location")
-    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board?lens=active&is=channel`))
+    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board?lens=mine&is=channel`))
   })
 
   it("offers 'Show everything' on the viewer's own empty saved-view home (its filters are clearable)", async () => {
@@ -279,7 +279,7 @@ describe("BoardPage", () => {
       preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
     } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
     // The saved view's own URL (`makeBoardView` → active + `?is=channel`).
-    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board?lens=active&is=channel` })
+    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board?lens=mine&is=channel` })
     expect(await screen.findByText("Nothing here right now")).toBeTruthy()
     const cta = await screen.findByRole("link", { name: "Show everything" })
     expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board?lens=all`)

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -60,7 +60,6 @@ import {
 } from "@/components/board/board-filter-params"
 import { cn } from "@/lib/utils"
 import {
-  DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   type BoardLens,
@@ -68,9 +67,9 @@ import {
 } from "@threa/types"
 
 /** Lenses that always contain the viewer's own fresh post: `all` (everything)
- *  and `mine` (a self-authored conversation is `isMine`). The status/memo lenses
- *  gate on classification a brand-new post may not have yet, so posting from
- *  those routes back to All so the author's card always surfaces. */
+ *  and `mine` (a self-authored conversation is `isMine`). `decisions` gates on a
+ *  memo a brand-new post doesn't have yet, so posting from it routes back to All
+ *  so the author's card always surfaces. */
 const SELF_POST_VISIBLE_LENSES = new Set<BoardLens>(["all", "mine"])
 
 /** How many leading cards' rails the reveal gate pre-warms before first paint.
@@ -84,14 +83,6 @@ const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {
   all: {
     title: "Nothing on the board yet",
     body: "As your conversations build up, the topics worth returning to surface here, newest activity first.",
-  },
-  active: {
-    title: "Nothing in motion",
-    body: "Conversations that are still being worked — not stalled, not resolved — show up here.",
-  },
-  "needs-resolution": {
-    title: "No loose ends",
-    body: "Conversations that stall or go quiet while unresolved show up here. Nothing needs picking back up right now.",
   },
   decisions: {
     title: "No decisions captured yet",
@@ -156,7 +147,7 @@ function groupByRecency(posts: BoardViewPost[], activityById: Map<string, number
  * message-led post) ordered by recent activity, grouped into recency sections.
  *
  * Route is `/w/:workspaceId/board`; the whole view is query state (INV-59). The
- * lens rides `?lens=` (`all`, `active`, `needs-resolution`, `decisions`, `mine`
+ * lens rides `?lens=` (`all`, `decisions`, `mine`
  * — board-view-design.md § "Lenses"; absent or unknown degrades to `all`), the
  * stream scope rides `?in=`, and every rendered board URL carries an explicit
  * `?lens=`. The bare query-less `/board` is only an entry alias: it redirects
@@ -169,7 +160,7 @@ export function BoardPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const location = useLocation()
   const preferences = usePreferencesOptional()
-  const homeLens = preferences?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const homeLens = parseLensParam(preferences?.preferences?.boardDefaultLens ?? null)
   const defaultViewId = preferences?.preferences?.boardDefaultViewId ?? null
   // Already mounted deeper (the lens menu), so this adds no fetch — it just lets
   // the entry alias resolve a saved-view home.

--- a/packages/types/src/board-lens.test.ts
+++ b/packages/types/src/board-lens.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { matchesBoardLens } from "./board-lens"
-import { BOARD_LENS_STALE_HOURS } from "./constants"
+import type { BoardLens } from "./constants"
 import type { BoardPost } from "./domain"
 
 const NOW = Date.parse("2026-07-04T12:00:00.000Z")
@@ -27,59 +27,28 @@ function post(overrides: {
 
 describe("matchesBoardLens", () => {
   it("all accepts everything — the default home never hides", () => {
-    expect(matchesBoardLens(post({ status: "resolved", hasCapturedMemo: false }), "all", NOW)).toBe(true)
-    expect(matchesBoardLens(post({ status: "stalled" }), "all", NOW)).toBe(true)
-    expect(matchesBoardLens(post({ hoursIdle: 0 }), "all", NOW)).toBe(true)
-  })
-
-  it("active accepts only conversations still in motion", () => {
-    expect(matchesBoardLens(post({ status: "active" }), "active", NOW)).toBe(true)
-    expect(matchesBoardLens(post({ status: "stalled" }), "active", NOW)).toBe(false)
-    expect(matchesBoardLens(post({ status: "resolved" }), "active", NOW)).toBe(false)
+    expect(matchesBoardLens(post({ status: "resolved", hasCapturedMemo: false }), "all")).toBe(true)
+    expect(matchesBoardLens(post({ status: "stalled" }), "all")).toBe(true)
+    expect(matchesBoardLens(post({ hoursIdle: 0 }), "all")).toBe(true)
   })
 
   it("decisions accepts only captured-memo posts", () => {
-    expect(matchesBoardLens(post({ hasCapturedMemo: true }), "decisions", NOW)).toBe(true)
-    expect(matchesBoardLens(post({ hasCapturedMemo: false }), "decisions", NOW)).toBe(false)
+    expect(matchesBoardLens(post({ hasCapturedMemo: true }), "decisions")).toBe(true)
+    expect(matchesBoardLens(post({ hasCapturedMemo: false }), "decisions")).toBe(false)
   })
 
   it("mine accepts only the viewer's own posts (server-precomputed isMine)", () => {
-    expect(matchesBoardLens(post({ isMine: true }), "mine", NOW)).toBe(true)
-    expect(matchesBoardLens(post({ isMine: false }), "mine", NOW)).toBe(false)
+    expect(matchesBoardLens(post({ isMine: true }), "mine")).toBe(true)
+    expect(matchesBoardLens(post({ isMine: false }), "mine")).toBe(false)
     // Mine narrows; it must not leak into the default home — `all` still takes an
     // isMine:false post.
-    expect(matchesBoardLens(post({ isMine: false }), "all", NOW)).toBe(true)
+    expect(matchesBoardLens(post({ isMine: false }), "all")).toBe(true)
   })
 
-  it("needs-resolution accepts an explicitly stalled conversation regardless of age", () => {
-    expect(
-      matchesBoardLens(post({ status: "stalled", hoursIdle: 0, completenessScore: 7 }), "needs-resolution", NOW)
-    ).toBe(true)
-  })
-
-  it("needs-resolution accepts a long-idle, still-incomplete conversation", () => {
-    expect(
-      matchesBoardLens(post({ hoursIdle: BOARD_LENS_STALE_HOURS + 1, completenessScore: 2 }), "needs-resolution", NOW)
-    ).toBe(true)
-  })
-
-  it("needs-resolution rejects a fresh conversation even if incomplete", () => {
-    expect(matchesBoardLens(post({ hoursIdle: 1, completenessScore: 1 }), "needs-resolution", NOW)).toBe(false)
-  })
-
-  it("needs-resolution rejects a long-idle but near-complete conversation", () => {
-    expect(
-      matchesBoardLens(post({ hoursIdle: BOARD_LENS_STALE_HOURS + 10, completenessScore: 7 }), "needs-resolution", NOW)
-    ).toBe(false)
-  })
-
-  it("needs-resolution rejects a resolved conversation even when idle and incomplete", () => {
-    expect(
-      matchesBoardLens(
-        post({ status: "resolved", hoursIdle: BOARD_LENS_STALE_HOURS + 5, completenessScore: 2 }),
-        "needs-resolution",
-        NOW
-      )
-    ).toBe(false)
+  it("a retired lens value still stored on a saved view degrades to `all`, never hides or throws", () => {
+    for (const retired of ["active", "needs-resolution", "nonsense"] as unknown as BoardLens[]) {
+      expect(matchesBoardLens(post({ status: "resolved", hasCapturedMemo: false, isMine: false }), retired)).toBe(true)
+      expect(matchesBoardLens(post({ status: "stalled", hoursIdle: 99, completenessScore: 7 }), retired)).toBe(true)
+    }
   })
 })

--- a/packages/types/src/board-lens.ts
+++ b/packages/types/src/board-lens.ts
@@ -1,44 +1,29 @@
-import { BOARD_LENS_MAX_COMPLETENESS, BOARD_LENS_STALE_HOURS, type BoardLens } from "./constants"
+import type { BoardLens } from "./constants"
 import type { BoardPost } from "./domain"
 
 /**
  * Whether a board post belongs on a lens — the read-side authority the board
  * card filters the live IDB feed with, kept in lockstep with the backend's
  * seed/pagination SQL (`findByWorkspaceForViewer`) so a card can't seed onto a
- * lens the client then hides, or vice versa. Both sides read the same signals
- * and the same thresholds (`BOARD_LENS_*`); this is the JS half, the WHERE
- * clause is the SQL half.
+ * lens the client then hides, or vice versa.
  *
  *  - `all` — everything, by recency. The default home; never hides anything.
- *  - `active` — status `active`: still in motion, not stalled or resolved.
- *  - `needs-resolution` — explicitly stalled, or gone quiet (≥ stale hours) while
- *    still incomplete (< max completeness). Loose ends.
  *  - `decisions` — produced a captured memo (`hasCapturedMemo`). What got settled.
  *  - `mine` — the viewer authored/participates in it or was `@`-mentioned
  *    (`isMine`, precomputed server-side like `hasCapturedMemo`). For you.
  *
- * `nowMs` is passed in (not read via `Date.now()`) so the filter is pure and
- * testable; callers pass the current time at render.
+ * A lens value outside the list behaves as `all`: saved `board_views.base_lens`
+ * rows and persisted last-locations still hold retired lens values, and a stale
+ * filter must degrade to showing everything, never hide rows or throw. Mirrors
+ * `parseLensParam`'s degrade.
  */
-export function matchesBoardLens(post: BoardPost, lens: BoardLens, nowMs: number): boolean {
+export function matchesBoardLens(post: BoardPost, lens: BoardLens): boolean {
   switch (lens) {
-    case "all":
-      return true
-    case "active":
-      return post.conversation.status === "active"
     case "decisions":
       return post.hasCapturedMemo === true
     case "mine":
       return post.isMine === true
-    case "needs-resolution": {
-      const { status, lastActivityAt, completenessScore } = post.conversation
-      if (status === "stalled") return true
-      // A resolved conversation is done, not a loose end — exclude it from the
-      // idle branch even if its completeness score was never bumped (matches the
-      // SQL `status <> 'resolved'` guard).
-      if (status === "resolved") return false
-      const hoursIdle = (nowMs - Date.parse(lastActivityAt)) / 3_600_000
-      return hoursIdle >= BOARD_LENS_STALE_HOURS && completenessScore < BOARD_LENS_MAX_COMPLETENESS
-    }
+    default:
+      return true
   }
 }

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -486,7 +486,7 @@ export const MAX_BOARD_VIEW_NAME_LENGTH = 60
  * must opt out of. Same signal for every viewer (personal lenses like Mine
  * come later). Ordered as they render in the lens picker.
  */
-export const BOARD_LENSES = ["all", "active", "needs-resolution", "decisions", "mine"] as const
+export const BOARD_LENSES = ["all", "decisions", "mine"] as const
 export type BoardLens = (typeof BOARD_LENSES)[number]
 
 /** The board's home view: everything, newest activity first, nothing hidden. */
@@ -512,19 +512,6 @@ export const MAX_BOARD_SCOPE_LABELS = 50
  */
 export const BOARD_SCOPE_STREAM_TYPES = ["channel", "dm", "scratchpad", "system"] as const
 export type BoardScopeStreamType = (typeof BOARD_SCOPE_STREAM_TYPES)[number]
-
-/**
- * Idle hours after which a still-incomplete conversation counts as a loose end
- * for the Needs-resolution lens. 12h ≈ temporalStaleness ≥ 3 (staleness.ts), so
- * a conversation that went quiet mid-workday resurfaces the next.
- */
-export const BOARD_LENS_STALE_HOURS = 12
-
-/**
- * Completeness (1–7, LLM-scored) below which an idle conversation reads as
- * unresolved. 4 is the midpoint — score 1–3 is "not yet half-settled".
- */
-export const BOARD_LENS_MAX_COMPLETENESS = 4
 
 // How a message's conversation was decided. Absent/null on a message means the
 // async boundary-extractor inferred (clustered) it — the default. A set value

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -97,8 +97,6 @@ export {
   MAX_BOARD_SCOPE_LABELS,
   BOARD_SCOPE_STREAM_TYPES,
   type BoardScopeStreamType,
-  BOARD_LENS_STALE_HOURS,
-  BOARD_LENS_MAX_COMPLETENESS,
   CONVERSATION_INTENTS,
   type ConversationIntent,
   ConversationIntents,


### PR DESCRIPTION
## Problem

The board's lenses and indicators surface the boundary-classifier's own judgments — `status` (Active / Needs-resolution lenses, badges, section headings) and `completeness_score` (the 7-segment indicator, the needs-resolution threshold) — and Kris ruled the current implementation isn't worth keeping (2026-07-30, settling-model doc §6). This is chunk 1 of the settling stack ([plan](https://seer.build/ws_vbyzjvdg6g/b/settling-stack-plan-c8dbe8/)).

## Solution

Remove the classifier-judgment surfaces; keep user-declared resolution; leave the wire shape and the extractor untouched.

- `BOARD_LENSES` → `all` / `decisions` / `mine`; `BOARD_LENS_STALE_HOURS` and `BOARD_LENS_MAX_COMPLETENESS` deleted (no refs remain).
- Retired lens values survive in three stores, each now degrades to `all` at its read boundary: URLs + persisted last-location via `parseLensParam` (single degrade authority), `board_views.base_lens` rows normalized in `BoardViewRepository`'s mapper, and the `GET conversations` `lens` param via a Zod transform instead of a 400 — frontend deploys before backend and SW-cached bundles linger, so old bundles sending `?lens=needs-resolution` must get the board, not an error page.
- `StatusBadge`, `CompletenessIndicator`, and the `temporalStaleness >= 3` dimming deleted; the stream page's Conversations panel drops its Active/Stalled/Resolved sections for one flat list by `lastActivityAt` (review finding — leaving "Stalled (2)" headings while removing badges would be incoherent).
- Sidebar board stats reduce to topic counts; `lensTotals` derives from `BOARD_LENSES` (INV-31/33).

Write paths (`POST /board-views`, `PATCH /preferences boardDefaultLens`) stay strict on retired lens values by design: degrading a write would store `all` when the user asked for a retired lens — silently wrong intent. A stale bundle's write 400s loudly and is retryable; only automatic reads degrade.

Kept deliberately: the card's resolved glyph, Mark resolved/Reopen, `status_locked_by_user`. Excluded: trimming the extractor's `completenessUpdates` emission (`summary` rides the same schema object; memos read `status`; eval surface INV-44/45) — follow-up.

## Test plan

- [x] Full monorepo typecheck; frontend 5404/5404; backend src+integration 4523 pass (22 pre-existing server-dependent access-log/P0 failures, identical on stashed clean tree); board-lens 4/4; board-views + conversation-repository integration 36/36 on the real schema (INV-68)
- [x] Adversarial review (Opus high): 3 findings, all fixed in-branch; new assertions neutralise-verified

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788044008&installation_model_id=20758&pr_number=1675&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1675&signature=de946efac599921825beb91e10fe29b2a9f12b6b7a12c484775b040a85ff185b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
