### PR TITLE
feat(messaging): compose-trace capture behind the composeTraces flag

### DIFF
--- a/apps/backend/src/db/migrations/20260731094500_message_compose_traces.sql
+++ b/apps/backend/src/db/migrations/20260731094500_message_compose_traces.sql
@@ -1,0 +1,23 @@
+-- Compose-session provenance sidecar: what the author could have seen when they
+-- started writing, and how far the stream had moved by the time they sent.
+-- Analytical signal, not message state, so it lives beside `messages` rather
+-- than on it (INV-57). New data only — no backfill is possible for sends that
+-- predate client capture.
+CREATE TABLE message_compose_traces (
+  message_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  -- Destination: the stream the message landed in.
+  stream_id TEXT NOT NULL,
+  -- Horizon: the stream the two sequences were measured against (the surface the
+  -- author was reading). Sequences are per-stream and a send can route elsewhere,
+  -- so this is the only id the numbering is interpretable against.
+  horizon_stream_id TEXT NOT NULL,
+  opened_at TIMESTAMPTZ NOT NULL,
+  opened_at_sequence BIGINT,
+  sent_at_sequence BIGINT,
+  resumed_draft BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_message_compose_traces_workspace_stream
+  ON message_compose_traces (workspace_id, stream_id, created_at DESC);

--- a/apps/backend/src/features/messaging/compose-trace-repository.ts
+++ b/apps/backend/src/features/messaging/compose-trace-repository.ts
@@ -1,0 +1,88 @@
+import type { Querier } from "../../db"
+import { sql } from "../../db"
+
+interface MessageComposeTraceRow {
+  message_id: string
+  workspace_id: string
+  stream_id: string
+  horizon_stream_id: string
+  opened_at: Date
+  opened_at_sequence: string | null
+  sent_at_sequence: string | null
+  resumed_draft: boolean
+  created_at: Date
+}
+
+export interface MessageComposeTrace {
+  messageId: string
+  workspaceId: string
+  streamId: string
+  horizonStreamId: string
+  openedAt: Date
+  openedAtSequence: string | null
+  sentAtSequence: string | null
+  resumedDraft: boolean
+  createdAt: Date
+}
+
+export interface InsertComposeTraceParams {
+  messageId: string
+  workspaceId: string
+  /** Destination stream — where the message landed. */
+  streamId: string
+  /** Horizon stream — what the sequences were measured against. */
+  horizonStreamId: string
+  openedAt: string
+  openedAtSequence: number | null
+  sentAtSequence: number | null
+  resumedDraft: boolean
+}
+
+function mapRow(row: MessageComposeTraceRow): MessageComposeTrace {
+  return {
+    messageId: row.message_id,
+    workspaceId: row.workspace_id,
+    streamId: row.stream_id,
+    horizonStreamId: row.horizon_stream_id,
+    openedAt: row.opened_at,
+    openedAtSequence: row.opened_at_sequence,
+    sentAtSequence: row.sent_at_sequence,
+    resumedDraft: row.resumed_draft,
+    createdAt: row.created_at,
+  }
+}
+
+export const MessageComposeTraceRepository = {
+  /**
+   * Records one send's compose session. A retried send re-runs the whole create
+   * transaction, so the conflict is expected and silent — the first trace is the
+   * true one (INV-20).
+   */
+  async insert(db: Querier, params: InsertComposeTraceParams): Promise<void> {
+    await db.query(sql`
+      INSERT INTO message_compose_traces (
+        message_id, workspace_id, stream_id, horizon_stream_id, opened_at, opened_at_sequence, sent_at_sequence,
+        resumed_draft
+      )
+      VALUES (
+        ${params.messageId},
+        ${params.workspaceId},
+        ${params.streamId},
+        ${params.horizonStreamId},
+        ${params.openedAt},
+        ${params.openedAtSequence},
+        ${params.sentAtSequence},
+        ${params.resumedDraft}
+      )
+      ON CONFLICT (message_id) DO NOTHING
+    `)
+  },
+
+  async findByMessageId(db: Querier, workspaceId: string, messageId: string): Promise<MessageComposeTrace | null> {
+    const result = await db.query<MessageComposeTraceRow>(sql`
+      SELECT * FROM message_compose_traces
+      WHERE workspace_id = ${workspaceId} AND message_id = ${messageId}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+}

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -36,6 +36,7 @@ import {
   streamId as generateStreamId,
 } from "../../lib/id"
 import { MessageVersionRepository, type MessageVersion } from "./version-repository"
+import { MessageComposeTraceRepository } from "./compose-trace-repository"
 import { serializeBigInt } from "@threa/backend-common"
 import { messagesTotal } from "../../lib/observability"
 import { HttpError, MessageNotFoundError, StreamNotFoundError } from "../../lib/errors"
@@ -54,7 +55,9 @@ import {
   draftThreadScope,
   type AttachmentSummary,
   type AuthorType,
+  type ComposeTrace,
   type ConversationDirective,
+  type FeatureFlagValue,
   type EventType,
   type SourceItem,
   type JSONContent,
@@ -171,6 +174,13 @@ export interface CreateMessageParams {
    * leaves it locked). Omit to let the async extractor infer the conversation.
    */
   conversation?: ConversationDirective
+  /**
+   * Compose-session provenance captured by the client (see {@link ComposeTrace}).
+   * Persisted to the `message_compose_traces` sidecar only while the workspace's
+   * `composeTraces` flag is on; absent for API sends, old clients, and every
+   * non-user author, which is normal rather than an error.
+   */
+  composeTrace?: ComposeTrace
   /**
    * Present when the sharer has acknowledged a privacy warning in the
    * share modal. Backend still independently verifies whether the share
@@ -417,10 +427,19 @@ interface ThreadStreamStats {
   replyCount?: number
 }
 
+/**
+ * Resolves the workspace's `composeTraces` rollout value. Injected rather than
+ * read from a service locator so `EventService` stays constructed once with its
+ * collaborators (INV-13) and the messaging feature never imports the
+ * feature-flags feature's internals (INV-52).
+ */
+export type GetComposeTraceMode = (workspaceId: string) => Promise<FeatureFlagValue<"composeTraces">>
+
 export class EventService {
   constructor(
     private pool: Pool,
-    private conversationAssigner?: ConversationAssigner
+    private conversationAssigner?: ConversationAssigner,
+    private getComposeTraceMode?: GetComposeTraceMode
   ) {}
 
   /**
@@ -776,6 +795,22 @@ export class EventService {
       await StreamPersonaParticipantRepository.recordParticipation(client, params.streamId, params.authorId)
     }
 
+    // Compose-session provenance rides the send's own transaction so a trace can
+    // never outlive a rolled-back message. Already gated on the `composeTraces`
+    // flag by the caller (see `shouldCaptureComposeTrace`).
+    if (params.composeTrace) {
+      await MessageComposeTraceRepository.insert(client, {
+        messageId: msgId,
+        workspaceId: params.workspaceId,
+        streamId: params.streamId,
+        horizonStreamId: params.composeTrace.horizonStreamId,
+        openedAt: params.composeTrace.openedAt,
+        openedAtSequence: params.composeTrace.openedAtSequence,
+        sentAtSequence: params.composeTrace.sentAtSequence,
+        resumedDraft: params.composeTrace.resumedDraft,
+      })
+    }
+
     // First-time attachments were linked (attachToMessage) before the event
     // payload was built — see the summary re-read above. Re-referenced
     // attachments keep their owning `message_id`/`stream_id`: overwriting them
@@ -902,12 +937,27 @@ export class EventService {
     return { message, conversationId, created: true }
   }
 
+  /**
+   * Whether this send's client-supplied compose trace should be persisted.
+   * Resolved BEFORE the send's transaction opens: the lookup is an uncached
+   * query on its own pool connection, and issuing it while holding the send's
+   * client would have two connections outstanding per send (INV-41). No trace
+   * on the send means no lookup at all, so flag-off workspaces pay nothing.
+   */
+  private async shouldCaptureComposeTrace(params: CreateMessageParams): Promise<boolean> {
+    if (!params.composeTrace || !this.getComposeTraceMode) return false
+    return (await this.getComposeTraceMode(params.workspaceId)) === "capture"
+  }
+
   private async _createMessageTxn(
     params: CreateMessageParams,
     onCreated?: (client: PoolClient, message: Message) => Promise<void>
   ): Promise<{ message: Message; conversationId?: string; created: boolean }> {
+    // The trace is dropped here rather than inside the transaction, so
+    // `createMessageInTransaction` can persist whatever reaches it.
+    const gatedParams = (await this.shouldCaptureComposeTrace(params)) ? params : { ...params, composeTrace: undefined }
     return withTransaction(this.pool, async (client) => {
-      const result = await this.createMessageInTransaction(client, params)
+      const result = await this.createMessageInTransaction(client, gatedParams)
       if (result.created) await onCreated?.(client, result.message)
       return result
     })

--- a/apps/backend/src/features/messaging/handlers.compose-trace.test.ts
+++ b/apps/backend/src/features/messaging/handlers.compose-trace.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test"
+import { createMessageSchema } from "./handlers"
+
+const base = { streamId: "stream_1", contentJson: { type: "doc" as const, content: [] } }
+const trace = {
+  horizonStreamId: "stream_host",
+  openedAt: "2026-07-30T10:00:00.000Z",
+  openedAtSequence: 41,
+  sentAtSequence: 47,
+  resumedDraft: false,
+}
+
+function parse(composeTrace: unknown) {
+  return createMessageSchema.safeParse({ ...base, composeTrace })
+}
+
+describe("composeTrace validation", () => {
+  it("accepts a well-formed trace", () => {
+    expect(parse(trace).success).toBe(true)
+  })
+
+  it("accepts null sequences (nothing synced yet)", () => {
+    expect(parse({ ...trace, openedAtSequence: null, sentAtSequence: null }).success).toBe(true)
+  })
+
+  it("accepts a send with no trace at all", () => {
+    expect(createMessageSchema.safeParse(base).success).toBe(true)
+  })
+
+  it.each([
+    ["a negative sequence", { ...trace, openedAtSequence: -1 }],
+    ["a fractional sequence", { ...trace, sentAtSequence: 1.5 }],
+    ["a non-ISO openedAt", { ...trace, openedAt: "yesterday" }],
+    ["a missing openedAt", { openedAtSequence: 1, sentAtSequence: 2, resumedDraft: false }],
+    ["a missing resumedDraft", { openedAt: trace.openedAt, openedAtSequence: 1, sentAtSequence: 2 }],
+    // The sequences are per-stream: without the stream they were read from the
+    // numbers cannot be interpreted at all, so an absent/blank id is a reject.
+    ["a missing horizonStreamId", { ...trace, horizonStreamId: undefined }],
+    ["a blank horizonStreamId", { ...trace, horizonStreamId: "" }],
+    ["an unknown key", { ...trace, dwellMs: 4000 }],
+    ["a non-object trace", "2026-07-30T10:00:00.000Z"],
+  ])("rejects %s", (_label, composeTrace) => {
+    expect(parse(composeTrace).success).toBe(false)
+  })
+
+  it("accepts a trace on the E2E variant", () => {
+    expect(
+      createMessageSchema.safeParse({
+        streamId: "stream_1",
+        ciphertext: "Y2lwaGVydGV4dA==",
+        envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "msg_1" },
+        e2eVersion: 2,
+        composeTrace: trace,
+      }).success
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -10,6 +10,7 @@ import { OutboxRepository } from "../../lib/outbox"
 import type { CommandRegistry } from "../commands"
 import {
   type CommandDispatchedPayload,
+  type ComposeTrace,
   type ConversationDirective,
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
 } from "@threa/types"
@@ -52,12 +53,33 @@ const _directiveTypeToSchema = (d: ConversationDirective): z.infer<typeof conver
 void _directiveSchemaToType
 void _directiveTypeToSchema
 
+// Compose-session provenance (see `ComposeTrace`). Strict: an unrecognized key
+// means a client is sending a shape this build cannot interpret, and silently
+// dropping it would store a trace that means something else (INV-11).
+export const composeTraceSchema = z
+  .object({
+    horizonStreamId: z.string().min(1),
+    openedAt: z.string().datetime(),
+    openedAtSequence: z.number().int().nonnegative().nullable(),
+    sentAtSequence: z.number().int().nonnegative().nullable(),
+    resumedDraft: z.boolean(),
+  })
+  .strict()
+
+// INV-31 lock, same shape as the directive lock above: these fail the typecheck
+// if the wire schema and the published `ComposeTrace` type drift apart.
+const _composeTraceSchemaToType = (t: z.infer<typeof composeTraceSchema>): ComposeTrace => t
+const _composeTraceTypeToSchema = (t: ComposeTrace): z.infer<typeof composeTraceSchema> => t
+void _composeTraceSchemaToType
+void _composeTraceTypeToSchema
+
 const commonMessageOptionsSchema = {
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
   conversation: conversationDirectiveSchema.optional(),
   confirmedPrivacyWarning: z.boolean().optional(),
+  composeTrace: composeTraceSchema.optional(),
 }
 
 const contentJsonSchema = z.object({
@@ -159,6 +181,7 @@ const createMessageE2eToStreamSchema = z.object({
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   steer: z.literal(true).optional(),
+  composeTrace: composeTraceSchema.optional(),
 })
 
 // Plaintext-only union (used by `normalizeContent` and the post-E2E-gate
@@ -352,6 +375,7 @@ export function createMessageHandlers({
             e2eVersion: data.e2eVersion,
             attachmentIds: data.attachmentIds && data.attachmentIds.length > 0 ? data.attachmentIds : undefined,
             clientMessageId: data.clientMessageId,
+            composeTrace: data.composeTrace,
           },
           insertSteeredInvocations
         )
@@ -433,6 +457,7 @@ export function createMessageHandlers({
           clientMessageId: data.clientMessageId,
           metadata: data.metadata,
           conversation: data.conversation,
+          composeTrace: data.composeTrace,
           confirmedPrivacyWarning: data.confirmedPrivacyWarning,
         },
         insertSteeredInvocations

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -24,7 +24,9 @@ export { MessageVersionRepository } from "./version-repository"
 export type { MessageVersion } from "./version-repository"
 
 export { EventService } from "./event-service"
-export type { ConversationAssigner } from "./event-service"
+export type { ConversationAssigner, GetComposeTraceMode } from "./event-service"
+export { MessageComposeTraceRepository } from "./compose-trace-repository"
+export type { MessageComposeTrace } from "./compose-trace-repository"
 export type {
   MessageCreatedPayload,
   MessageEditedPayload,

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -300,7 +300,10 @@ export async function startServer(): Promise<ServerInstance> {
   const storage = createS3Storage(config.s3)
   const avatarService = new AvatarService(storage)
   const streamService = new StreamService(pool)
-  const eventService = new EventService(pool, conversationAssigner)
+  const featureFlagService = new FeatureFlagService(pool)
+  const eventService = new EventService(pool, conversationAssigner, (workspaceId) =>
+    featureFlagService.getWorkspaceFlag(workspaceId, "composeTraces")
+  )
   const authService = config.useStubAuth ? new StubAuthService() : new WorkosAuthService(config.workos)
 
   const malwareScanner = createMalwareScanner(storage, config.attachments)
@@ -326,7 +329,6 @@ export async function startServer(): Promise<ServerInstance> {
   const conversationService = new ConversationService(pool)
   const userPreferencesService = new UserPreferencesService(pool)
   const workspaceSettingsService = new WorkspaceSettingsService(pool)
-  const featureFlagService = new FeatureFlagService(pool)
   const platformAdminService = new PlatformAdminService(pool)
   const sidebarConfigService = new SidebarConfigService(pool)
   const userE2eKeysService = new UserE2eKeysService(pool)

--- a/apps/backend/tests/integration/message-compose-trace.test.ts
+++ b/apps/backend/tests/integration/message-compose-trace.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { EventService, type GetComposeTraceMode } from "../../src/features/messaging"
+import { MessageComposeTraceRepository } from "../../src/features/messaging"
+import { userId, workspaceId, streamId, messageId } from "../../src/lib/id"
+
+const trace = {
+  horizonStreamId: "stream_horizon",
+  openedAt: "2026-07-30T10:00:00.000Z",
+  openedAtSequence: 41,
+  sentAtSequence: 47,
+  resumedDraft: true,
+}
+
+describe("Compose-trace capture", () => {
+  let pool: Pool
+  let testUserId: string
+  let testWorkspaceId: string
+  let testStreamId: string
+
+  const capturing: GetComposeTraceMode = async () => "capture"
+  const off: GetComposeTraceMode = async () => "off"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+    testStreamId = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Test Workspace",
+        slug: `test-ws-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      await StreamRepository.insert(client, {
+        id: testStreamId,
+        workspaceId: testWorkspaceId,
+        type: "scratchpad",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  function send(service: EventService, extra: Record<string, unknown>) {
+    return service.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("traced send"),
+      ...extra,
+    })
+  }
+
+  test("flag capture + trace persists the session as sent", async () => {
+    const message = await send(new EventService(pool, undefined, capturing), { composeTrace: trace })
+
+    const stored = await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, message.id)
+    expect(stored).toEqual({
+      messageId: message.id,
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      horizonStreamId: "stream_horizon",
+      openedAt: new Date(trace.openedAt),
+      // BIGINT crosses the driver as a string; the sidecar keeps it lossless.
+      openedAtSequence: "41",
+      sentAtSequence: "47",
+      resumedDraft: true,
+      createdAt: stored!.createdAt,
+    })
+  })
+
+  test("null sequences are stored as null, not zero", async () => {
+    const message = await send(new EventService(pool, undefined, capturing), {
+      composeTrace: { ...trace, openedAtSequence: null, sentAtSequence: null, resumedDraft: false },
+    })
+
+    const stored = await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, message.id)
+    expect({
+      openedAtSequence: stored?.openedAtSequence,
+      sentAtSequence: stored?.sentAtSequence,
+      resumedDraft: stored?.resumedDraft,
+    }).toEqual({ openedAtSequence: null, sentAtSequence: null, resumedDraft: false })
+  })
+
+  test("a second insert for the same message is a silent no-op", async () => {
+    const id = messageId()
+    await MessageComposeTraceRepository.insert(pool, {
+      messageId: id,
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      horizonStreamId: "stream_horizon",
+      openedAt: trace.openedAt,
+      openedAtSequence: 1,
+      sentAtSequence: 2,
+      resumedDraft: false,
+    })
+    await MessageComposeTraceRepository.insert(pool, {
+      messageId: id,
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      horizonStreamId: "stream_horizon",
+      openedAt: "2026-07-30T11:00:00.000Z",
+      openedAtSequence: 9,
+      sentAtSequence: 9,
+      resumedDraft: true,
+    })
+
+    const stored = await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, id)
+    expect({ openedAtSequence: stored?.openedAtSequence, resumedDraft: stored?.resumedDraft }).toEqual({
+      openedAtSequence: "1",
+      resumedDraft: false,
+    })
+  })
+
+  test("the horizon stream is stored independently of the destination stream", async () => {
+    const message = await send(new EventService(pool, undefined, capturing), {
+      composeTrace: { ...trace, horizonStreamId: "stream_elsewhere" },
+    })
+
+    const stored = await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, message.id)
+    expect({ streamId: stored?.streamId, horizonStreamId: stored?.horizonStreamId }).toEqual({
+      streamId: testStreamId,
+      horizonStreamId: "stream_elsewhere",
+    })
+  })
+
+  test("flag off drops the trace instead of storing it", async () => {
+    const message = await send(new EventService(pool, undefined, off), { composeTrace: trace })
+
+    expect(await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, message.id)).toBeNull()
+  })
+
+  test("no trace on the send writes no row", async () => {
+    const message = await send(new EventService(pool, undefined, capturing), {})
+
+    expect(await MessageComposeTraceRepository.findByMessageId(pool, testWorkspaceId, message.id)).toBeNull()
+  })
+
+  test("a trace is not readable from another workspace", async () => {
+    const message = await send(new EventService(pool, undefined, capturing), { composeTrace: trace })
+
+    expect(await MessageComposeTraceRepository.findByMessageId(pool, workspaceId(), message.id)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -1,5 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { useState, type ReactElement, type ReactNode } from "react"
+import { useEffect, useState, type ReactElement, type ReactNode } from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { InlineComposerForm } from "./board-inline-composer"
@@ -15,7 +16,9 @@ import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as streamStoreModule from "@/stores/stream-store"
 import * as draftMessageModule from "@/hooks/use-draft-message"
 import type { MessageComposerProps } from "@/components/composer"
-import type { JSONContent } from "@threa/types"
+import type { FeatureFlagLayers, JSONContent, WorkspaceBootstrap } from "@threa/types"
+import * as streamSyncModule from "@/sync/stream-sync"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 
 // The behavior under test is the floating-anchor layer (portal placement,
 // slot exclusivity, close semantics, height publication) — not editor
@@ -113,13 +116,19 @@ beforeEach(() => {
 /** Anchor container + provider, the shape the board page / panel supply. */
 function Anchored({ children }: { children: ReactNode }) {
   const [el, setEl] = useState<HTMLElement | null>(null)
+  // The composer reads the workspace's `composeTraces` flag, which resolves out
+  // of the bootstrap query cache — so the form needs a client here as it has one
+  // everywhere it mounts in the app.
+  const [queryClient] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }))
   return (
-    <div>
-      <div data-testid="anchor" ref={setEl} />
-      <div data-testid="in-place">
-        <FloatingComposerAnchorProvider el={el}>{children}</FloatingComposerAnchorProvider>
+    <QueryClientProvider client={queryClient}>
+      <div>
+        <div data-testid="anchor" ref={setEl} />
+        <div data-testid="in-place">
+          <FloatingComposerAnchorProvider el={el}>{children}</FloatingComposerAnchorProvider>
+        </div>
       </div>
-    </div>
+    </QueryClientProvider>
   )
 }
 
@@ -427,5 +436,78 @@ describe("InlineComposerForm stash + schedule", () => {
     await trigger.props.onSchedule(new Date("2030-01-02T10:00:00.000Z"))
 
     expect(scheduleMutateAsync).not.toHaveBeenCalled()
+  })
+})
+
+describe("InlineComposerForm compose trace", () => {
+  /** Editor stand-in that focuses on mount (TipTap `autoFocus`) and can send on demand. */
+  const AutoFocusEditorStub = (props: MessageComposerProps) => {
+    useEffect(() => props.onComposerFocus?.(), [props.onComposerFocus])
+    return (
+      <button type="button" data-testid="send" onClick={() => void props.onSubmit()}>
+        send
+      </button>
+    )
+  }
+
+  function Capturing({ children }: { children: ReactNode }) {
+    const [queryClient] = useState(() => {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      const layers: FeatureFlagLayers = { workspace: { composeTraces: "capture" }, user: {} }
+      client.setQueryData(workspaceKeys.bootstrap("ws_1"), { featureFlags: layers } as WorkspaceBootstrap)
+      return client
+    })
+    return (
+      <QueryClientProvider client={queryClient}>
+        <FloatingComposerAnchorProvider el={null}>{children}</FloatingComposerAnchorProvider>
+      </QueryClientProvider>
+    )
+  }
+
+  beforeEach(() => {
+    editorSpy = vi.fn(AutoFocusEditorStub)
+    spyOnExport(composerModule, "MessageComposer").mockReturnValue(editorSpy as never)
+    spyOnExport(streamSyncModule, "getLatestPersistedSequence").mockReturnValue((async (id: string) =>
+      id === "stream_1" ? "77" : null) as never)
+  })
+
+  it("measures against the streamId prop even when the host is absent from the workspace cache", async () => {
+    // A thread host never appears in the workspace streams cache — resolving the
+    // horizon there is what left branch and panel replies unmeasured.
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    composerStub.canSend = true
+    render(<Capturing>{form({ onSubmit })}</Capturing>)
+
+    await userEvent.click(await screen.findByTestId("send"))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    expect(onSubmit.mock.calls[0][0].composeTrace).toMatchObject({
+      horizonStreamId: "stream_1",
+      openedAtSequence: 77,
+      sentAtSequence: 77,
+    })
+  })
+
+  it("opens the session only after the draft hydrates, so a resumed draft reports as resumed", async () => {
+    composerStub.isLoaded = false
+    composerStub.canSend = true
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { rerender } = render(<Capturing>{form({ onSubmit })}</Capturing>)
+    // Autofocus has already fired against an empty, not-yet-hydrated composer.
+    await screen.findByTestId("send")
+
+    const hydratedAt = new Date().toISOString()
+    composerStub.isLoaded = true
+    composerStub.content = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] }
+    rerender(<Capturing>{form({ onSubmit })}</Capturing>)
+    await userEvent.click(screen.getByTestId("send"))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    const trace = onSubmit.mock.calls[0][0].composeTrace
+    expect({ resumedDraft: trace.resumedDraft, afterHydration: trace.openedAt >= hydratedAt }).toEqual({
+      resumedDraft: true,
+      afterHydration: true,
+    })
   })
 })

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -16,7 +16,8 @@ import {
 import { useIsMobileOrCoarse } from "@/hooks/use-pointer"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
-import { useDraftComposer, useScheduleMessage, useStashComposer } from "@/hooks"
+import { useDraftComposer, useScheduleMessage, useStashComposer, hasDocContent } from "@/hooks"
+import { useComposeTrace } from "@/lib/compose-trace"
 import { relocateLoadedDraft } from "@/hooks/use-draft-message"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { usePreferences } from "@/contexts"
@@ -28,7 +29,7 @@ import { STREAM_ICONS } from "@/lib/streams"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
 import type { AttachmentSummary } from "@/hooks/create-optimistic-bootstrap"
-import type { JSONContent } from "@threa/types"
+import type { ComposeTrace, JSONContent } from "@threa/types"
 
 // Focus moving into one of these means a composer popover is open (inline
 // suggestion lists are `[role="listbox"]`; emoji/format/link popovers are Radix
@@ -41,6 +42,13 @@ export interface InlineComposerSubmit {
   contentJson: JSONContent
   attachmentIds?: string[]
   attachments?: AttachmentSummary[]
+  /**
+   * Compose-session provenance for this send (see {@link ComposeTrace}).
+   * Captured here rather than per call site so every inline surface this core
+   * backs — board card reply, branch tail reply, new sub-topic, panel footer —
+   * reports the same thing. Absent unless the workspace is capturing.
+   */
+  composeTrace?: ComposeTrace
 }
 
 interface InlineComposerFormProps {
@@ -163,6 +171,19 @@ export function InlineComposerForm({
   const hostIsE2e = hostStream?.e2eEnabled === true || idbHostStream?.e2eEnabled === true
 
   const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
+  const composerContentRef = useRef(composer.content)
+  composerContentRef.current = composer.content
+  // The host stream — the surface the author is reading — is what the horizon is
+  // measured against, whatever stream `onSubmit` ends up routing the send into.
+  // The prop is the authority: a thread host is absent from the workspace cache,
+  // so resolving it there would leave branch and panel replies unmeasured.
+  const { onComposerFocus, takeComposeTrace } = useComposeTrace({
+    workspaceId,
+    scopeId: draftKey,
+    horizonStreamId: streamId,
+    hasDraftContent: () => hasDocContent(composerContentRef.current),
+    draftReady: composer.isLoaded,
+  })
   const syncEngine = useOptionalSyncEngine()
   // "Save for later" pile scoped to this reply target — the same pointer-move
   // stash the timeline composer has, so a half-written inline reply survives
@@ -363,6 +384,8 @@ export function InlineComposerForm({
     const attachments = extractUploadedAttachments(normalizedContent)
     const attachmentIds = attachments.map((a) => a.id)
 
+    const composeTrace = await takeComposeTrace()
+
     composer.setIsSending(true)
     // Clear the editor up front so it empties in the same frame the optimistic
     // row appears; restored on failure so nothing typed is lost.
@@ -372,6 +395,7 @@ export function InlineComposerForm({
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
         attachments: attachments.length > 0 ? attachments : undefined,
+        composeTrace,
       })
       await composer.resolveDraft()
       composer.clearAttachments()
@@ -496,6 +520,7 @@ export function InlineComposerForm({
     onFileUpload: composer.uploadFile,
     imageCount: composer.imageCount,
     onSubmit: handleSubmit,
+    onComposerFocus,
     canSubmit,
     isSubmitting: composer.isSending,
     hasFailed: composer.hasFailed,

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -384,12 +384,14 @@ export function InlineComposerForm({
     const attachments = extractUploadedAttachments(normalizedContent)
     const attachmentIds = attachments.map((a) => a.id)
 
-    const composeTrace = await takeComposeTrace()
-
+    // Close the send window and clear BEFORE the trace's IDB read: a second
+    // Enter during that await must see canSend false, and the optimistic clear
+    // must not wait on a Dexie round-trip (#1640's dominant-latency path).
     composer.setIsSending(true)
     // Clear the editor up front so it empties in the same frame the optimistic
     // row appears; restored on failure so nothing typed is lost.
     composer.setContent(EMPTY_DOC)
+    const composeTrace = await takeComposeTrace()
     try {
       await onSubmit({
         contentJson: normalizedContent,
@@ -429,6 +431,10 @@ export function InlineComposerForm({
 
     composer.setIsSending(true)
     composer.setContent(EMPTY_DOC)
+    // A schedule finishes the composition like a send does — end the session so
+    // the next one can't inherit this one's openedAt/horizon. Trace discarded:
+    // scheduled sends carry none by design.
+    void takeComposeTrace()
     try {
       await scheduleMessage.mutateAsync({
         streamId: scheduleTarget.streamId,
@@ -453,7 +459,12 @@ export function InlineComposerForm({
   const stashPickerProps = {
     drafts: stash.drafts,
     canStashCurrent: composer.canSend,
-    onStashCurrent: stash.handleStashDraft,
+    // Stashing disposes of the current composition — end the compose session so
+    // the next one can't inherit its openedAt/horizon (trace discarded).
+    onStashCurrent: () => {
+      void takeComposeTrace()
+      return stash.handleStashDraft()
+    },
     onRestore: stash.handleRestoreStashed,
     onDelete: stash.handleDeleteStashed,
     controlsDisabled: composer.isSending,

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -216,7 +216,7 @@ function BoardReplyComposerForm({
   const rootReplyKey = boardReplyDraftKey(post.conversation.id)
 
   const onRootSubmit = useCallback(
-    async ({ contentJson, attachmentIds, attachments }: InlineComposerSubmit) => {
+    async ({ contentJson, attachmentIds, attachments, composeTrace }: InlineComposerSubmit) => {
       await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
@@ -226,6 +226,7 @@ function BoardReplyComposerForm({
         contentJson,
         attachmentIds,
         attachments,
+        composeTrace,
       })
     },
     [reply, post.conversation, post.openingMessage, hostStreamType, lastActiveStreamId]

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -240,6 +240,13 @@ export interface MessageComposerProps {
    */
   onEscapeBlur?: () => void
 
+  /**
+   * Called when the editor gains focus. Fires on every focus (clicks, tab-backs),
+   * so a consumer that only wants the FIRST focus of a session must dedupe —
+   * see `useComposeTrace`.
+   */
+  onComposerFocus?: () => void
+
   /** Called when the desktop expand button is clicked — opens fullscreen document editor */
   onExpandClick?: () => void
 
@@ -328,6 +335,7 @@ export function MessageComposer({
   scopeId,
   onEditLastMessage,
   onEscapeBlur,
+  onComposerFocus,
   onExpandClick,
   expanded = false,
   onCollapse,
@@ -766,6 +774,7 @@ export function MessageComposer({
       disableSelectionToolbar={disableSelectionToolbar}
       onEditLastMessage={onEditLastMessage}
       onEscapeBlur={onEscapeBlur}
+      onFocus={onComposerFocus}
       ariaLabel="Message input"
       ariaDescribedBy={instructionsId}
       blurOnEscape
@@ -945,6 +954,7 @@ export function MessageComposer({
                 staticToolbarOpen
                 disableSelectionToolbar
                 onEditLastMessage={onEditLastMessage}
+                onFocus={onComposerFocus}
                 toolbarTrailingContent={expandedTrailingContent}
                 ariaLabel="Fullscreen message editor"
                 ariaDescribedBy={instructionsId}

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -143,6 +143,8 @@ interface RichEditorProps {
   blurOnEscape?: boolean
   /** Called after Escape blurs the editor */
   onEscapeBlur?: () => void
+  /** Called when the editor gains focus. Fires on every focus, not only the first. */
+  onFocus?: () => void
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
   /**
@@ -239,6 +241,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     ariaDescribedBy,
     blurOnEscape = false,
     onEscapeBlur,
+    onFocus: onFocusProp,
     streamContext,
     memoAnchorStreamId,
     enableMentions = true,
@@ -413,6 +416,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
   // Ref to access editor instance from callbacks defined before useEditor returns
   const editorRef = useRef<ReturnType<typeof useEditor>>(null)
+  const onFocusRef = useRef(onFocusProp)
 
   // Argument option picker (e.g. `/model` → choose a model). Opens after a
   // command with advertised `args[].suggestions` is inserted; its keys are
@@ -596,7 +600,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       if (isInternalUpdate.current) return
       onChange(editor.getJSON())
     },
-    onFocus: () => setIsFocused(true),
+    onFocus: () => {
+      setIsFocused(true)
+      // Through a ref: `useEditor` captures these options once, so calling the
+      // prop directly would pin the first render's callback forever.
+      onFocusRef.current?.()
+    },
     onBlur: () => {
       setIsFocused(false)
       // Safety net: reset any stuck dropdown state when editor loses focus.
@@ -846,6 +855,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
   // Store editor in ref so callbacks defined inside useEditor options can access it
   editorRef.current = editor
+  onFocusRef.current = onFocusProp
 
   // Track whether the editor has a non-empty selection (drives toolbar visibility)
   // and whether the cursor is inside a table (keeps the table controls reachable

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -3,6 +3,9 @@ import type { ReactNode } from "react"
 import { act, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { Router } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 import { useState } from "react"
 import * as contextsModule from "@/contexts"
 import * as hooksModule from "@/hooks"
@@ -376,13 +379,18 @@ function Wrapper({ children }: { children: React.ReactNode }) {
     block: () => () => {},
   }
   return (
-    <Router
-      location={location}
-      navigator={navigator as unknown as Parameters<typeof Router>[0]["navigator"]}
-      navigationType={"POP" as Parameters<typeof Router>[0]["navigationType"]}
-    >
-      {children}
-    </Router>
+    // The composer reads the workspace's `composeTraces` flag out of the
+    // bootstrap query cache, so it needs a client here as it has one everywhere
+    // it mounts in the app. Inside `Wrapper` so `rerender(<Wrapper>…)` keeps it.
+    <QueryClientProvider client={queryClient}>
+      <Router
+        location={location}
+        navigator={navigator as unknown as Parameters<typeof Router>[0]["navigator"]}
+        navigationType={"POP" as Parameters<typeof Router>[0]["navigationType"]}
+      >
+        {children}
+      </Router>
+    </QueryClientProvider>
   )
 }
 

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
 import { useNavigate } from "react-router-dom"
 import {
+  hasDocContent,
   useDraftComposer,
   getDraftMessageKey,
   useStreamOrDraft,
@@ -11,6 +12,7 @@ import {
   useMentionStreamContext,
 } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useComposeTrace } from "@/lib/compose-trace"
 import { usePreferences } from "@/contexts"
 import { useConnectionState } from "@/components/layout/connection-status"
 import {
@@ -294,6 +296,14 @@ function MessageInputComponent({
   // Imperative handle for programmatic focus from outside (e.g. quote reply insertion)
   const composerFocusRef = useRef<ComposerControlHandle | null>(null)
 
+  const { onComposerFocus, takeComposeTrace } = useComposeTrace({
+    workspaceId,
+    scopeId: streamId,
+    horizonStreamId: streamId,
+    hasDraftContent: () => hasDocContent(composerRef.current.content),
+    draftReady: composer.isLoaded,
+  })
+
   // Register with QuoteReplyContext to insert quote reply nodes into the composer.
   // Stable deps: quoteReplyCtx is from context, composerRef is a ref.
   useEffect(() => {
@@ -545,6 +555,12 @@ function MessageInputComponent({
       composer.setIsSending(true)
       setError(null)
 
+      // Ends the compose session for EVERY submit, not just the flat send below:
+      // a command dispatch or a hand-off to the panel finishes what the author
+      // was writing here, so the next send must start from a fresh horizon
+      // rather than inherit this one's `openedAt`.
+      const composeTrace = await takeComposeTrace()
+
       const pendingAttachments = composer.getPendingAttachmentsSnapshot()
       const liveContent = editorContent ?? composer.content
       const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
@@ -656,6 +672,7 @@ function MessageInputComponent({
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
           attachments: attachments.length > 0 ? attachments : undefined,
           ...(steerDirective && { steer: true as const }),
+          composeTrace,
           // Armed by "Reply in conversation": file this send into the
           // conversation synchronously (Mechanism C). Cleared only on success —
           // a failed send keeps the filing armed alongside the restored content.
@@ -692,6 +709,7 @@ function MessageInputComponent({
       conversationReply,
       conversationReplyLastActiveStreamId,
       redirectReplyToPanel,
+      takeComposeTrace,
     ]
   )
 
@@ -801,6 +819,7 @@ function MessageInputComponent({
     hasFailed: composer.hasFailed,
     placeholder: composerPlaceholder,
     messageSendMode,
+    onComposerFocus,
     scopeId: streamId,
     onEditLastMessage: triggerEditLast
       ? () => {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -7,6 +7,7 @@ import type {
   ConversationDirective,
   E2eActor,
   EventType,
+  ComposeTrace,
   FeatureFlagLayers,
   JSONContent,
   NotificationLevel,
@@ -367,6 +368,13 @@ export interface PendingMessage {
    * Omitted on ordinary stream sends, which let the async extractor infer.
    */
   conversation?: ConversationDirective
+  /**
+   * Compose-session provenance captured while the author wrote this message
+   * (see {@link ComposeTrace}). Rides the durable queue row so a send that only
+   * reaches the server after a reload still carries the horizon it was composed
+   * against. Absent unless the workspace's `composeTraces` flag is on.
+   */
+  composeTrace?: ComposeTrace
   /** The draft ID to clean up after successful stream creation + message send */
   draftId?: string
   /** Set by the queue after stream creation succeeds — prevents duplicate creation on retry */

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -82,7 +82,12 @@ export { useMessageQueue } from "./use-message-queue"
 
 export { useAttachments, type PendingAttachment, type UseAttachmentsReturn } from "./use-attachments"
 
-export { useDraftComposer, type UseDraftComposerOptions, type DraftComposerState } from "./use-draft-composer"
+export {
+  useDraftComposer,
+  hasDocContent,
+  type UseDraftComposerOptions,
+  type DraftComposerState,
+} from "./use-draft-composer"
 
 export { useScrollBehavior } from "./use-scroll-behavior"
 

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -27,6 +27,7 @@ import type {
   BoardPost,
   BoardScopeStreamType,
   CompanionMode,
+  ComposeTrace,
   ConversationWithStaleness,
   ConversationStatus,
   JSONContent,
@@ -368,6 +369,8 @@ export interface ReplyToBoardPostInput {
   attachmentIds?: string[]
   /** Full attachment info for the optimistic event so files render in place. */
   attachments?: AttachmentSummary[]
+  /** Compose-session provenance for this send (see {@link ComposeTrace}). */
+  composeTrace?: ComposeTrace
 }
 
 /**
@@ -427,11 +430,13 @@ export function useReplyToBoardPost(workspaceId: string) {
       contentJson,
       attachmentIds,
       attachments,
+      composeTrace,
     }: ReplyToBoardPostInput): Promise<{ plan: BoardReplyPlan }> => {
       const input = {
         contentJson,
         attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
         attachments: attachments && attachments.length > 0 ? attachments : undefined,
+        composeTrace,
       }
 
       const plan = planBoardReply({ hostStreamType, messageCount, openingMessageId })

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -21,7 +21,7 @@ export interface UseDraftComposerOptions {
 }
 
 /** Check if a document is empty (no actual text content) */
-function hasDocContent(doc: JSONContent | undefined): boolean {
+export function hasDocContent(doc: JSONContent | undefined): boolean {
   if (!doc?.content) return false
   return doc.content.some((node) => {
     if (node.type === "paragraph") {

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -41,6 +41,15 @@ interface MockPendingMessage {
   createdAt: number
   retryCount: number
   retryAfter?: number
+  composeTrace?: {
+    openedAt: string
+    openedAtSequence: number | null
+    sentAtSequence: number | null
+    resumedDraft: boolean
+  }
+  ciphertext?: string
+  envelope?: unknown
+  e2eVersion?: number
 }
 
 let mockPendingMessages: MockPendingMessage[] = []
@@ -486,6 +495,66 @@ describe("useMessageQueue", () => {
     // B should have been sent successfully
     expect(mockMarkSent).toHaveBeenCalledWith("temp_b")
     expect(mockCreate).toHaveBeenCalledTimes(2)
+  })
+
+  it("carries a queued compose trace through to the send body", async () => {
+    const composeTrace = {
+      openedAt: "2026-07-30T10:00:00.000Z",
+      openedAtSequence: 41,
+      sentAtSequence: 47,
+      resumedDraft: true,
+    }
+    mockPendingMessages = [
+      {
+        clientId: "temp_traced",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Hello",
+        contentFormat: "markdown",
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Hello" }] }] },
+        createdAt: 1000,
+        retryCount: 0,
+        composeTrace,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith("ws_1", "stream_1", expect.objectContaining({ composeTrace }))
+  })
+
+  it("carries a queued compose trace through the E2E send body too", async () => {
+    const composeTrace = {
+      openedAt: "2026-07-30T10:00:00.000Z",
+      openedAtSequence: null,
+      sentAtSequence: 5,
+      resumedDraft: false,
+    }
+    mockPendingMessages = [
+      {
+        clientId: "temp_sealed",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Hello",
+        contentFormat: "markdown",
+        createdAt: 1000,
+        retryCount: 0,
+        ciphertext: "Y2lwaGVydGV4dA==",
+        envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "msg_1" },
+        e2eVersion: 2,
+        composeTrace,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith("ws_1", "stream_1", expect.objectContaining({ composeTrace }))
   })
 
   it("should process messages with attachmentIds", async () => {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -245,6 +245,7 @@ export function useMessageQueue(): void {
             e2eVersion: next.e2eVersion,
             attachmentIds: next.attachmentIds,
             clientMessageId: next.clientId,
+            composeTrace: next.composeTrace,
             ...(next.steer && { steer: true }),
           })
         } else {
@@ -255,6 +256,7 @@ export function useMessageQueue(): void {
             attachmentIds: next.attachmentIds,
             clientMessageId: next.clientId,
             confirmedPrivacyWarning: next.confirmedPrivacyWarning,
+            composeTrace: next.composeTrace,
             ...(next.steer && { steer: true }),
             // A board reply declares its conversation so the send attaches it
             // synchronously (in the message's transaction) instead of waiting on

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -4,7 +4,14 @@ import { useUser } from "@/auth"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { db, sequenceToNum, type CachedStream, type PendingStreamCreation } from "@/db"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import { StreamTypes, Visibilities, type ConversationDirective, type JSONContent, type StreamEvent } from "@threa/types"
+import {
+  StreamTypes,
+  Visibilities,
+  type ComposeTrace,
+  type ConversationDirective,
+  type JSONContent,
+  type StreamEvent,
+} from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { getLatestPersistedSequence, optimisticReplyCountUpdate } from "@/sync/stream-sync"
 import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
@@ -18,6 +25,8 @@ export interface QueueDraftMessageInput {
   contentJson: JSONContent
   attachmentIds?: string[]
   attachments?: AttachmentSummary[]
+  /** Compose-session provenance for this send (see {@link ComposeTrace}). */
+  composeTrace?: ComposeTrace
 }
 
 export interface QueueDraftMessageParams {
@@ -182,6 +191,7 @@ export function useQueueDraftMessage(workspaceId: string) {
             contentFormat: "markdown",
             contentJson: input.contentJson,
             attachmentIds: input.attachmentIds,
+            composeTrace: input.composeTrace,
             createdAt: Date.now(),
             retryCount: 0,
             streamCreation: params.streamCreation,

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -26,6 +26,7 @@ import type {
   StreamMember,
   StreamType,
   CompanionMode,
+  ComposeTrace,
   ConversationDirective,
   StreamEvent,
   JSONContent,
@@ -148,6 +149,12 @@ export interface SendMessageInput {
    * a stream that doesn't exist yet has no conversations to reply into.
    */
   conversation?: ConversationDirective
+  /**
+   * Compose-session provenance for this send (see {@link ComposeTrace}).
+   * Omitted when the workspace isn't capturing, and by every send the author
+   * didn't compose live (scheduled sends, retries, slash-command dispatch).
+   */
+  composeTrace?: ComposeTrace
 }
 
 export interface UseStreamOrDraftReturn {
@@ -670,6 +677,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
           contentJson: input.contentJson,
           attachmentIds: input.attachmentIds,
           conversation: input.conversation,
+          composeTrace: input.composeTrace,
           steer: input.steer,
           createdAt: Date.now(),
           retryCount: 0,

--- a/apps/frontend/src/lib/compose-trace.test.ts
+++ b/apps/frontend/src/lib/compose-trace.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { db } from "@/db"
+import { ComposeTraceRecorder } from "./compose-trace"
+
+// fake-indexeddb is loaded in test setup, so the sequence reads below run
+// against a real Dexie store — the point of the optimistic-exclusion case.
+const streamId = "stream_1"
+
+function persistedEvent(id: string, sequence: number, status?: "pending") {
+  return {
+    id,
+    streamId,
+    workspaceId: "ws_1",
+    sequence: String(sequence),
+    eventType: "message_created" as const,
+    payload: { messageId: id, contentMarkdown: "hi" },
+    actorId: "usr_1",
+    actorType: "user" as const,
+    createdAt: new Date().toISOString(),
+    _sequenceNum: sequence,
+    _cachedAt: Date.now(),
+    ...(status ? { _status: status } : {}),
+  }
+}
+
+describe("ComposeTraceRecorder", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("stamps the horizon once per session, not on every focus", async () => {
+    const readSequence = vi.fn<(id: string) => Promise<string | null>>().mockResolvedValue("100")
+    const recorder = new ComposeTraceRecorder(readSequence)
+
+    await recorder.open("scope_a", streamId, false)
+    readSequence.mockResolvedValue("140")
+    await recorder.open("scope_a", streamId, true)
+    await recorder.open("scope_a", streamId, true)
+
+    const trace = await recorder.take()
+    expect({ openedAtSequence: trace?.openedAtSequence, sentAtSequence: trace?.sentAtSequence }).toEqual({
+      openedAtSequence: 100,
+      sentAtSequence: 140,
+    })
+    // Three focuses + one send read the stream exactly twice.
+    expect(readSequence).toHaveBeenCalledTimes(2)
+  })
+
+  it("records a resumed draft, and reports it only for the session that saw it", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "1")
+
+    await recorder.open("scope_a", streamId, true)
+    expect((await recorder.take())?.resumedDraft).toBe(true)
+
+    await recorder.open("scope_a", streamId, false)
+    expect((await recorder.take())?.resumedDraft).toBe(false)
+  })
+
+  it("yields nothing when the author never focused the composer", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "1")
+    expect(await recorder.take()).toBeUndefined()
+  })
+
+  it("ends the session on send, so the next focus opens a fresh one", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "1")
+
+    await recorder.open("scope_a", streamId, false)
+    const first = await recorder.take()
+    expect(await recorder.take()).toBeUndefined()
+
+    await recorder.open("scope_a", streamId, false)
+    const second = await recorder.take()
+    expect(second?.openedAt).not.toBe(undefined)
+    expect(first?.openedAt).not.toBe(undefined)
+  })
+
+  it("drops a session when the composer's scope changes", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "1")
+
+    await recorder.open("scope_a", streamId, true)
+    recorder.reset()
+    expect(await recorder.take()).toBeUndefined()
+  })
+
+  it("replaces the session when focus lands in a different scope", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "1")
+
+    await recorder.open("scope_a", streamId, true)
+    await recorder.open("scope_b", streamId, false)
+
+    expect((await recorder.take())?.resumedDraft).toBe(false)
+  })
+
+  it("measures the horizon against synced events only, never the author's own optimistic rows", async () => {
+    await db.events.bulkPut([persistedEvent("evt_real", 200), persistedEvent("temp_mine", 9_999_999, "pending")])
+    const recorder = new ComposeTraceRecorder()
+
+    await recorder.open("scope_a", streamId, false)
+    const trace = await recorder.take()
+
+    expect({ openedAtSequence: trace?.openedAtSequence, sentAtSequence: trace?.sentAtSequence }).toEqual({
+      openedAtSequence: 200,
+      sentAtSequence: 200,
+    })
+  })
+
+  it("carries the stream the sequences were measured against, not the send's destination", async () => {
+    const recorder = new ComposeTraceRecorder(async () => "5")
+
+    await recorder.open("scope_a", "stream_host", false)
+
+    expect((await recorder.take())?.horizonStreamId).toBe("stream_host")
+  })
+
+  it("replaces the session when the same scope's horizon stream changes", async () => {
+    const readSequence = vi.fn<(id: string) => Promise<string | null>>().mockResolvedValue("1")
+    const recorder = new ComposeTraceRecorder(readSequence)
+
+    await recorder.open("scope_a", "stream_a", true)
+    await recorder.open("scope_a", "stream_b", false)
+    const trace = await recorder.take()
+
+    expect({ horizonStreamId: trace?.horizonStreamId, resumedDraft: trace?.resumedDraft }).toEqual({
+      horizonStreamId: "stream_b",
+      resumedDraft: false,
+    })
+    // Both sequence reads for the closing session hit its own stream.
+    expect(readSequence.mock.calls.at(-1)).toEqual(["stream_b"])
+  })
+
+  it("reports a null horizon when nothing has synced for the stream", async () => {
+    const recorder = new ComposeTraceRecorder()
+
+    await recorder.open("scope_a", "stream_empty", false)
+    const trace = await recorder.take()
+
+    expect({ openedAtSequence: trace?.openedAtSequence, sentAtSequence: trace?.sentAtSequence }).toEqual({
+      openedAtSequence: null,
+      sentAtSequence: null,
+    })
+  })
+})

--- a/apps/frontend/src/lib/compose-trace.ts
+++ b/apps/frontend/src/lib/compose-trace.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import type { ComposeTrace } from "@threa/types"
+import { sequenceToNum } from "@/db"
+import { getLatestPersistedSequence } from "@/sync/stream-sync"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
+
+/**
+ * A compose session: the window between the author focusing an idle composer and
+ * that composer's send landing in the queue. It records the causal horizon —
+ * what had already synced when they started writing, and how far the stream had
+ * moved by the time they sent — as weighted signal for a later classifier.
+ *
+ * `getLatestPersistedSequence` is the sequence source rather than a raw index
+ * read: it already excludes optimistic rows (`_status == null`), so the author's
+ * own in-flight sends never inflate the horizon.
+ */
+interface OpenSession {
+  scopeId: string
+  horizonStreamId: string
+  openedAt: string
+  openedAtSequence: number | null
+  resumedDraft: boolean
+}
+
+type ReadLatestSequence = (streamId: string) => Promise<string | null>
+
+export class ComposeTraceRecorder {
+  private session: OpenSession | null = null
+
+  constructor(private readLatestSequence: ReadLatestSequence = getLatestPersistedSequence) {}
+
+  /**
+   * Starts a session if none is open for `scopeId`. Focus fires on every click
+   * and every tab back into the composer, so a session already open for this
+   * scope is left alone — `openedAt` must be when the author STARTED writing,
+   * not the last time the caret landed. A focus in a different scope replaces
+   * the session outright: the previous composer's horizon says nothing about
+   * this one.
+   *
+   * `horizonStreamId` is the stream both sequences are read from — the surface
+   * the author was reading. It is NOT necessarily the stream the send lands in
+   * (a board reply can route into another stream, or into a thread that does
+   * not exist yet), so it travels on the trace rather than being inferred from
+   * the message.
+   */
+  async open(scopeId: string, horizonStreamId: string, resumedDraft: boolean): Promise<void> {
+    if (this.session?.scopeId === scopeId && this.session.horizonStreamId === horizonStreamId) return
+    const openedAt = new Date().toISOString()
+    const session: OpenSession = { scopeId, horizonStreamId, openedAt, openedAtSequence: null, resumedDraft }
+    this.session = session
+    const sequence = await this.readLatestSequence(horizonStreamId)
+    // A focus in another scope (or a send) may have landed while the read was in
+    // flight — only stamp the session this call actually started.
+    if (this.session === session) session.openedAtSequence = toSequenceNumber(sequence)
+  }
+
+  /** Drops any open session — the composer's scope changed, so its horizon is stale. */
+  reset(): void {
+    this.session = null
+  }
+
+  /**
+   * Closes the open session and returns its trace. Undefined when the author
+   * never focused this composer (a programmatic or restored send), which is a
+   * normal absence, not an error. The next focus starts a fresh session.
+   *
+   * Both sequences come from the session's own `horizonStreamId`, so a trace can
+   * never mix two streams' numbering.
+   */
+  async take(): Promise<ComposeTrace | undefined> {
+    const session = this.session
+    if (!session) return undefined
+    this.session = null
+    const sentAtSequence = toSequenceNumber(await this.readLatestSequence(session.horizonStreamId))
+    return {
+      horizonStreamId: session.horizonStreamId,
+      openedAt: session.openedAt,
+      openedAtSequence: session.openedAtSequence,
+      sentAtSequence,
+      resumedDraft: session.resumedDraft,
+    }
+  }
+}
+
+function toSequenceNumber(sequence: string | null): number | null {
+  if (sequence == null) return null
+  const value = sequenceToNum(sequence)
+  return Number.isFinite(value) ? value : null
+}
+
+export interface UseComposeTraceResult {
+  /** Wire to the composer's focus. Cheap and idempotent within a session. */
+  onComposerFocus: () => void
+  /** Call at send; spread the result onto the send input. */
+  takeComposeTrace: () => Promise<ComposeTrace | undefined>
+}
+
+const NO_CAPTURE: UseComposeTraceResult = {
+  onComposerFocus: () => {},
+  takeComposeTrace: async () => undefined,
+}
+
+export interface UseComposeTraceOptions {
+  workspaceId: string
+  /**
+   * The composer's target (stream, thread panel, or board card): when it changes
+   * the open session is dropped rather than carried into a different
+   * conversation.
+   */
+  scopeId: string
+  /**
+   * The stream the horizon is measured against — the surface the author is
+   * reading, which is the composer's own host stream, not wherever the send is
+   * routed. Undefined (or empty) until it resolves: no session opens, because a
+   * horizon with no stream is unreadable rather than merely null.
+   */
+  horizonStreamId: string | undefined
+  /** Read at session open only: "did they resume a draft", not "have they typed since". */
+  hasDraftContent: () => boolean
+  /**
+   * The draft store has hydrated. Autofocus fires during the composer's mount,
+   * before a persisted draft is loaded into it, so sampling `hasDraftContent`
+   * then reports every resumed draft as fresh. A focus that arrives early is
+   * held and opened once this flips.
+   */
+  draftReady: boolean
+}
+
+/**
+ * Compose-session capture for one composer. Off unless the workspace's
+ * `composeTraces` flag is set to `capture`, in which case the flag-off path does
+ * zero IDB reads and attaches nothing to the send.
+ *
+ * Scheduled sends and slash-command dispatches deliberately never call
+ * `takeComposeTrace` — neither is an author deciding to say something now, so a
+ * horizon captured for them would be noise.
+ */
+export function useComposeTrace({
+  workspaceId,
+  scopeId,
+  horizonStreamId,
+  hasDraftContent,
+  draftReady,
+}: UseComposeTraceOptions): UseComposeTraceResult {
+  const enabled = useFeatureFlag(workspaceId, "composeTraces") === "capture"
+  const recorderRef = useRef<ComposeTraceRecorder | null>(null)
+  const hasDraftContentRef = useRef(hasDraftContent)
+  hasDraftContentRef.current = hasDraftContent
+  const pendingFocusRef = useRef(false)
+
+  const recorder = useMemo(() => {
+    if (!enabled) return null
+    recorderRef.current ??= new ComposeTraceRecorder()
+    recorderRef.current.reset()
+    pendingFocusRef.current = false
+    return recorderRef.current
+    // Re-running on scope OR horizon-stream change is the reset: a composer that
+    // switches target — or whose host stream resolves to a different id — must
+    // not carry the previous target's horizon into its next send.
+  }, [enabled, scopeId, horizonStreamId])
+
+  const onComposerFocus = useCallback(() => {
+    if (!recorder || !horizonStreamId) return
+    if (!draftReady) {
+      pendingFocusRef.current = true
+      return
+    }
+    void recorder.open(scopeId, horizonStreamId, hasDraftContentRef.current())
+  }, [recorder, scopeId, horizonStreamId, draftReady])
+
+  useEffect(() => {
+    if (!recorder || !horizonStreamId || !draftReady || !pendingFocusRef.current) return
+    pendingFocusRef.current = false
+    void recorder.open(scopeId, horizonStreamId, hasDraftContentRef.current())
+  }, [recorder, scopeId, horizonStreamId, draftReady])
+
+  const takeComposeTrace = useCallback(async () => recorder?.take(), [recorder])
+
+  return enabled ? { onComposerFocus, takeComposeTrace } : NO_CAPTURE
+}

--- a/apps/frontend/src/lib/use-compose-trace.test.tsx
+++ b/apps/frontend/src/lib/use-compose-trace.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { FeatureFlagLayers, WorkspaceBootstrap } from "@threa/types"
+import { db } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useComposeTrace } from "./compose-trace"
+
+const workspaceId = "ws_1"
+const streamId = "stream_1"
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function clientWithFlag(value: "off" | "capture" | undefined): QueryClient {
+  const queryClient = new QueryClient()
+  const layers: FeatureFlagLayers = { workspace: value ? { composeTraces: value } : {}, user: {} }
+  queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), { featureFlags: layers } as WorkspaceBootstrap)
+  return queryClient
+}
+
+function renderTrace(queryClient: QueryClient, hasDraftContent = () => false) {
+  return renderHook(
+    ({ horizonStreamId, draftReady }: { horizonStreamId: string | undefined; draftReady: boolean }) =>
+      useComposeTrace({ workspaceId, scopeId: streamId, horizonStreamId, hasDraftContent, draftReady }),
+    {
+      wrapper: wrapper(queryClient),
+      initialProps: { horizonStreamId: streamId as string | undefined, draftReady: true },
+    }
+  )
+}
+
+async function seedEvent(id: string, stream: string, sequence: number) {
+  await db.events.put({
+    id,
+    streamId: stream,
+    workspaceId,
+    sequence: String(sequence),
+    eventType: "message_created",
+    payload: { messageId: id, contentMarkdown: "hi" },
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt: new Date().toISOString(),
+    _sequenceNum: sequence,
+    _cachedAt: Date.now(),
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("useComposeTrace", () => {
+  it("captures the session when the workspace is set to capture", async () => {
+    await db.events.clear()
+    await seedEvent("evt_1", streamId, 77)
+
+    const { result } = renderTrace(clientWithFlag("capture"), () => true)
+
+    await act(async () => result.current.onComposerFocus())
+    const trace = await result.current.takeComposeTrace()
+
+    expect({ ...trace, openedAt: typeof trace?.openedAt }).toEqual({
+      horizonStreamId: streamId,
+      openedAt: "string",
+      openedAtSequence: 77,
+      sentAtSequence: 77,
+      resumedDraft: true,
+    })
+  })
+
+  it("holds the focus until the draft has hydrated, so a resumed draft reports as resumed", async () => {
+    await db.events.clear()
+    await seedEvent("evt_1", streamId, 77)
+    let draftLoaded = false
+
+    const { result, rerender } = renderTrace(clientWithFlag("capture"), () => draftLoaded)
+    rerender({ horizonStreamId: streamId, draftReady: false })
+    // Autofocus fires during mount, before the persisted draft lands.
+    await act(async () => result.current.onComposerFocus())
+    expect(await result.current.takeComposeTrace()).toBeUndefined()
+
+    const hydratedAt = new Date().toISOString()
+    draftLoaded = true
+    await act(async () => {
+      rerender({ horizonStreamId: streamId, draftReady: true })
+    })
+    const trace = await result.current.takeComposeTrace()
+
+    expect({ resumedDraft: trace?.resumedDraft, afterHydration: (trace?.openedAt ?? "") >= hydratedAt }).toEqual({
+      resumedDraft: true,
+      afterHydration: true,
+    })
+  })
+
+  it("opens no session while the horizon stream is unresolved", async () => {
+    const { result, rerender } = renderTrace(clientWithFlag("capture"), () => true)
+    rerender({ horizonStreamId: undefined, draftReady: true })
+    await act(async () => result.current.onComposerFocus())
+
+    expect(await result.current.takeComposeTrace()).toBeUndefined()
+  })
+
+  it("drops the session when the horizon stream changes under the same scope", async () => {
+    await db.events.clear()
+    await seedEvent("evt_1", streamId, 77)
+    await seedEvent("evt_2", "stream_2", 5)
+
+    const { result, rerender } = renderTrace(clientWithFlag("capture"), () => false)
+    await act(async () => result.current.onComposerFocus())
+    await act(async () => {
+      rerender({ horizonStreamId: "stream_2", draftReady: true })
+    })
+
+    expect(await result.current.takeComposeTrace()).toBeUndefined()
+  })
+
+  it("captures nothing — and touches no IDB — while the flag is off", async () => {
+    const readEvents = vi.spyOn(db.events, "where")
+
+    const { result } = renderTrace(clientWithFlag("off"), () => true)
+    await act(async () => result.current.onComposerFocus())
+
+    expect(await result.current.takeComposeTrace()).toBeUndefined()
+    expect(readEvents).not.toHaveBeenCalled()
+  })
+
+  it("defaults to no capture when the workspace carries no override", async () => {
+    const { result } = renderTrace(clientWithFlag(undefined))
+    await act(async () => result.current.onComposerFocus())
+
+    expect(await result.current.takeComposeTrace()).toBeUndefined()
+  })
+})

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -388,6 +388,32 @@ export type ConversationDirective =
   | { intent: "newSubtopic" }
 
 /**
+ * The causal horizon of one compose session: what the author could already have
+ * seen when they started writing, and how far the stream had moved by the time
+ * they sent. Carried as weighted signal for later classification — never read as
+ * ground truth, and absent from every send by an old client, an API caller, a
+ * scheduled send, or a flag-off workspace. Absence is normal, never an error.
+ *
+ * Sequences are `horizonStreamId`'s newest locally-synced global sequence at
+ * each moment, `null` when the client had nothing synced yet.
+ */
+export interface ComposeTrace {
+  /**
+   * The stream both sequences were measured against — the surface the author was
+   * reading. Sequences are per-stream, and a send can land somewhere else (a
+   * board reply routed to another stream, a not-yet-created thread), so the
+   * numbering is only interpretable against this id, never the message's stream.
+   */
+  horizonStreamId: string
+  /** ISO timestamp of the moment the composer session started (focus while idle). */
+  openedAt: string
+  openedAtSequence: number | null
+  sentAtSequence: number | null
+  /** The composer already held non-empty draft content when the session started. */
+  resumedDraft: boolean
+}
+
+/**
  * JSON input format - used by rich clients sending ProseMirror JSON directly.
  */
 export interface CreateMessageInputJson {
@@ -411,6 +437,8 @@ export interface CreateMessageInputJson {
    * `SHARE_PRIVACY_CONFIRMATION_REQUIRED`.
    */
   confirmedPrivacyWarning?: boolean
+  /** Compose-session provenance for this send (see {@link ComposeTrace}); omitted by clients that don't capture it. */
+  composeTrace?: ComposeTrace
 }
 
 export interface CreateDmMessageInputJson {
@@ -426,6 +454,8 @@ export interface CreateDmMessageInputJson {
   conversation?: ConversationDirective
   /** Same semantics as `CreateMessageInputJson.confirmedPrivacyWarning`. */
   confirmedPrivacyWarning?: boolean
+  /** Compose-session provenance for this send (see {@link ComposeTrace}); omitted by clients that don't capture it. */
+  composeTrace?: ComposeTrace
 }
 
 /**
@@ -442,6 +472,8 @@ export interface CreateMessageInputMarkdown {
   steer?: true
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
+  /** Compose-session provenance for this send (see {@link ComposeTrace}); omitted by clients that don't capture it. */
+  composeTrace?: ComposeTrace
 }
 
 export interface CreateDmMessageInputMarkdown {
@@ -453,6 +485,8 @@ export interface CreateDmMessageInputMarkdown {
   clientMessageId?: string
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
+  /** Compose-session provenance for this send (see {@link ComposeTrace}); omitted by clients that don't capture it. */
+  composeTrace?: ComposeTrace
 }
 
 /**
@@ -479,6 +513,8 @@ export interface CreateMessageInputE2e {
   clientMessageId?: string
   /** Persist this message first, then dispatch `/steer` in the same transaction. */
   steer?: true
+  /** Compose-session provenance for this send (see {@link ComposeTrace}); omitted by clients that don't capture it. */
+  composeTrace?: ComposeTrace
 }
 
 /**

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -55,6 +55,7 @@ export function defineFlag<
  */
 export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
+  composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -542,6 +542,7 @@ export type {
   SyncCatchUpResponse,
   SyncHeartbeatPayload,
   // Messages
+  ComposeTrace,
   ConversationDirective,
   CreateMessageInput,
   CreateMessageInputJson,


### PR DESCRIPTION
## Problem

The boundary classifier reads messages in rendered order, but the timeline's total order lies about causality: a reply composed against message 10 can land after message 15, and the classifier has no way to know what the author had actually seen. Chunk 2 of the settling stack ([plan](https://seer.build/ws_vbyzjvdg6g/b/settling-stack-plan-c8dbe8/)): capture the compose-session horizon at write time as weighted signal. Nothing consumes it yet.

## Solution

- `ComposeTrace { openedAt, openedAtSequence, sentAtSequence, horizonStreamId, resumedDraft }`, optional on every create-message shape (json/markdown/E2E; sequences and timestamps only — nothing content-derived, so sealed streams carry it too). Strict Zod with the `conversationDirectiveSchema`-style compile-time type lock.
- **`horizonStreamId` is load-bearing** (review finding): `stream_events.sequence` is per-stream, and a board reply can send into a different stream than the author was reading (`lastActiveStreamId`, convert-to-thread into a not-yet-existing thread). The trace names the stream its sequences were measured against; the row's `stream_id` stays the destination. Without this the planned consumer reads empty ranges forever and the data is unrepairable.
- `message_compose_traces` sidecar (INV-57/8/1): written inside the send transaction so a trace can't outlive a rolled-back message; `ON CONFLICT DO NOTHING` for retried sends. The `composeTraces` workspace flag (default `off`) is resolved *before* the transaction opens (INV-41) and only when a trace is present, so flag-off workspaces and API/agent sends pay zero queries.
- Client recorder (`lib/compose-trace.ts`): one session per composer scope, opened on the first *post-hydration* focus (autofocus fires before draft hydration — sampling there reported every resumed draft as fresh), horizon read via the existing `getLatestPersistedSequence` (optimistic rows excluded by reuse). Session resets if the horizon stream changes; a trace can never mix two streams' numbering. Rides `db.pendingMessages`, so queued sends after a reload keep their trace. Fullscreen editor wired too.

Adversarial review (Opus high): 4 findings, all fixed in-branch, load-bearing guards falsification-checked.

## Test plan

- [x] Typecheck clean; frontend 5425/5425; backend 4543 pass (22 pre-existing server-dependent access-log/P0 fails, same set as base); messaging + new integration 170/170 on the real schema (INV-68); check:migrations clean
- [ ] Expanded-editor focus has no direct test — the composer suites stub `MessageComposer` and there is no TipTap-in-jsdom harness; wiring is one prop, verified by read

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788047047&installation_model_id=20758&pr_number=1676&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1676&signature=3aecdb6bdfb6ff9e93da2d7a8c2ccc03034e1d0541f24a5092f6d11aa1494aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->