### PR TITLE
feat(conversations): settling state for low-confidence assignments

### DIFF
--- a/apps/backend/src/db/migrations/20260731140000_message_conversation_state.sql
+++ b/apps/backend/src/db/migrations/20260731140000_message_conversation_state.sql
@@ -24,5 +24,8 @@ CREATE INDEX idx_message_conversation_state_conversation
 CREATE INDEX idx_message_conversation_state_stream
   ON message_conversation_state (stream_id, state);
 
-CREATE INDEX idx_message_conversation_state_workspace
-  ON message_conversation_state (workspace_id);
+-- The sweep backstop's read: still-settling rows by age. Partial — settled rows
+-- are the steady-state majority and the sweep never reads them.
+CREATE INDEX idx_message_conversation_state_settling_age
+  ON message_conversation_state (created_at)
+  WHERE state = 'settling';

--- a/apps/backend/src/db/migrations/20260731140000_message_conversation_state.sql
+++ b/apps/backend/src/db/migrations/20260731140000_message_conversation_state.sql
@@ -1,0 +1,28 @@
+-- Settling state for a message's conversation assignment: the extractor placed
+-- it with low confidence, so the placement is provisional until a human engages
+-- with the message or the extraction window moves past it. Transient workflow
+-- state, so it lives beside `messages` rather than on it (INV-57); absence of a
+-- row means settled/normal.
+CREATE TABLE message_conversation_state (
+  message_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  -- The conversation the message is provisionally in. Moves with the message
+  -- when a later pass (or a user) re-files it, so the row never points at a
+  -- conversation the message has left.
+  conversation_id TEXT NOT NULL,
+  state TEXT NOT NULL,
+  settled_by TEXT,
+  settled_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_message_conversation_state_conversation
+  ON message_conversation_state (conversation_id, state);
+
+CREATE INDEX idx_message_conversation_state_stream
+  ON message_conversation_state (stream_id, state);
+
+CREATE INDEX idx_message_conversation_state_workspace
+  ON message_conversation_state (workspace_id);

--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -4,6 +4,7 @@ import { StreamRepository } from "../streams"
 import { type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields } from "./staleness"
+import { MessageConversationStateRepository } from "./settling-repository"
 import { resolveConversationDelivery } from "./conversation-delivery"
 
 /**
@@ -33,6 +34,14 @@ export async function emitAssignmentEvents(
     throw new Error(`Conversation ${conversationId} vanished during assignment`)
   }
 
+  // The declared/agent assignment itself is never settling, but the conversation
+  // it joins may hold provisional members — the payload must carry the full set.
+  const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+    client,
+    workspaceId,
+    [refreshed.id]
+  )
+
   await OutboxRepository.insert(client, created ? "conversation:created" : "conversation:updated", {
     workspaceId,
     streamId: message.streamId,
@@ -40,6 +49,7 @@ export async function emitAssignmentEvents(
     conversation: addStalenessFields(refreshed),
     parentStreamId,
     streamVisibility,
+    settlingMessageIds: settlingByConversation.get(refreshed.id) ?? [],
   })
   await OutboxRepository.insert(client, "conversation:message_assigned", {
     workspaceId,
@@ -49,6 +59,7 @@ export async function emitAssignmentEvents(
     conversationId: refreshed.id,
     isPrimary: true,
     reason,
+    settling: false,
   })
 
   return refreshed

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -20,6 +20,8 @@ import type {
 import { HttpError } from "../../lib/errors"
 import { collectQuoteReplyMessageIds } from "@threa/prosemirror"
 import { addStalenessFields } from "./staleness"
+import { MessageConversationStateRepository } from "./settling-repository"
+import { SETTLING_CONFIDENCE_THRESHOLD } from "./boundary-extraction/config"
 import { resolveConversationDelivery } from "./conversation-delivery"
 import { emitAssignmentEvents } from "./assignment-events"
 import { conversationId } from "../../lib/id"
@@ -106,6 +108,10 @@ export class BoundaryExtractionService {
    * exists, otherwise creates a new one.
    */
   async processMessage(messageId: string, streamId: string, workspaceId: string): Promise<Conversation | null> {
+    // Bounds this pass's out-of-window settle to rows that already existed when
+    // it looked (INV-20): a concurrent pass's fresh settling row must survive.
+    const passStartedAt = await MessageConversationStateRepository.now(this.pool)
+
     // Phase 1: fetch context; collect new-message attachment IDs so their
     // processing can be awaited after the connection is released (INV-41), then
     // fetch extractions on the pool — mirrors streams/naming-service.ts.
@@ -541,6 +547,10 @@ export class BoundaryExtractionService {
           reassignedMessage?.authorId ?? null
         )
 
+        // A still-settling row must follow its message, never keep pointing at
+        // the conversation the message just left.
+        await MessageConversationStateRepository.moveConversation(client, workspaceId, [r.messageId], toConvId)
+
         touchedConversationIds.add(fromConvId)
         touchedConversationIds.add(toConvId)
         reassignmentEvents.push({
@@ -571,6 +581,36 @@ export class BoundaryExtractionService {
         }
         touchedConversationIds.add(a.conversationId)
       }
+
+      // Settling (chunk 3): a DERIVED assignment the model wasn't confident about
+      // is provisional until a human engages or the window moves past it. The
+      // paths that never reach here — declared sends and agent replies — are
+      // never settling by construction.
+      const contextWindowIds = validReassignmentMessageIds ?? new Set<string>()
+      const primaryConversationId = resolvedAssignments.find((a) => a.isPrimary)?.conversationId ?? null
+      const newMessageSettling = primaryConversationId !== null && decision.confidence < SETTLING_CONFIDENCE_THRESHOLD
+      if (newMessageSettling) {
+        await MessageConversationStateRepository.insertSettling(client, {
+          messageId,
+          workspaceId,
+          streamId,
+          conversationId: primaryConversationId,
+        })
+      }
+
+      // Anything of this stream the pass could no longer see will never be
+      // revisited by extraction — its placement is final.
+      const windowSettled = await MessageConversationStateRepository.settleStreamOutsideWindow(
+        client,
+        workspaceId,
+        streamId,
+        [messageId, ...contextWindowIds],
+        "llm-window",
+        passStartedAt
+      )
+      // Kept OUT of touchedConversationIds: these conversations saw no activity,
+      // only a settle, so bumping last_activity_at would falsely revive them.
+      const windowSettledConversationIds = new Set(windowSettled.map((row) => row.conversationId))
 
       if (decision.completenessUpdates) {
         for (const update of decision.completenessUpdates) {
@@ -630,11 +670,15 @@ export class BoundaryExtractionService {
         return resolved
       }
 
-      const primaryAssignment = resolvedAssignments.find((a) => a.isPrimary)
-      const primaryConvId = primaryAssignment?.conversationId ?? null
-
-      const touchedConversations = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
-      for (const conv of touchedConversations) {
+      const settledOnlyIds = [...windowSettledConversationIds].filter((id) => !touchedConversationIds.has(id))
+      const eventConversationIds = [...touchedIds, ...settledOnlyIds]
+      const eventConversations = await ConversationRepository.findByIds(client, workspaceId, eventConversationIds)
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        eventConversationIds
+      )
+      for (const conv of eventConversations) {
         const isNewThisCall = newConversation?.id === conv.id
         const eventType = isNewThisCall ? "conversation:created" : "conversation:updated"
         const { parentStreamId: convParentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
@@ -645,6 +689,7 @@ export class BoundaryExtractionService {
           conversation: addStalenessFields(conv),
           parentStreamId: convParentStreamId,
           streamVisibility,
+          settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
         })
       }
 
@@ -661,6 +706,7 @@ export class BoundaryExtractionService {
           conversationId: a.conversationId,
           isPrimary: a.isPrimary,
           reason: a.isPrimary ? "initial" : "secondary",
+          settling: a.isPrimary && newMessageSettling,
         })
       }
 
@@ -682,7 +728,7 @@ export class BoundaryExtractionService {
       logger.info(
         {
           messageId,
-          primaryConversationId: primaryConvId,
+          primaryConversationId: primaryConversationId,
           assignmentCount: resolvedAssignments.length,
           reassignmentCount: reassignmentEvents.length,
           confidence: decision.confidence,
@@ -690,8 +736,8 @@ export class BoundaryExtractionService {
         "Boundary extraction complete"
       )
 
-      if (!primaryConvId) return null
-      return touchedConversations.find((c) => c.id === primaryConvId) ?? null
+      if (!primaryConversationId) return null
+      return eventConversations.find((c) => c.id === primaryConversationId) ?? null
     })
   }
 

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -110,12 +110,15 @@ export class BoundaryExtractionService {
   async processMessage(messageId: string, streamId: string, workspaceId: string): Promise<Conversation | null> {
     // Bounds this pass's out-of-window settle to rows that already existed when
     // it looked (INV-20): a concurrent pass's fresh settling row must survive.
-    const passStartedAt = await MessageConversationStateRepository.now(this.pool)
+    // Assigned inside Phase 1's withClient so it rides the already-held
+    // connection instead of a separate pool checkout.
+    let passStartedAt!: Date
 
     // Phase 1: fetch context; collect new-message attachment IDs so their
     // processing can be awaited after the connection is released (INV-41), then
     // fetch extractions on the pool — mirrors streams/naming-service.ts.
     const fetchedData = await withClient(this.pool, async (client) => {
+      passStartedAt = await MessageConversationStateRepository.now(client)
       const message = await MessageRepository.findById(client, messageId)
       if (!message) {
         return { message: null, stream: null, extractionContextBase: null }

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -9,6 +9,22 @@ export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.6-luna"
 export const BOUNDARY_EXTRACTION_TEMPERATURE = 0.2
 
 /**
+ * Below this pass `confidence`, a DERIVED assignment (the author declared no
+ * conversation) is recorded as settling: the placement is provisional and
+ * renders as such until a human engages with the message or the extractor's
+ * context window moves past it. Derived from the extractor's existing top-level
+ * confidence — the response schema does not change.
+ */
+export const SETTLING_CONFIDENCE_THRESHOLD = 0.7
+
+/**
+ * Backstop for a stream that goes quiet: no further extraction pass will ever
+ * move its window past these rows, so the staleness sweep settles anything that
+ * has been settling this long.
+ */
+export const SETTLING_MAX_AGE_SECONDS = 30 * 60
+
+/**
  * Per-attachment character budget when rendering extracted text in the prompt.
  * The new message's attachments get a bigger window because they are the
  * payload most likely to change the classification decision; context messages

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -35,6 +35,8 @@ export {
   CONVERSATION_SPLIT_SYSTEM_PROMPT,
   CONVERSATION_SPLIT_PROMPT,
   conversationSplitResponseSchema,
+  SETTLING_CONFIDENCE_THRESHOLD,
+  SETTLING_MAX_AGE_SECONDS,
 } from "./boundary-extraction/config"
 export type { ExtractionResponse, ConversationSplitResponse } from "./boundary-extraction/config"
 
@@ -52,6 +54,13 @@ export {
 export type { StalenessSweepWorkerDeps } from "./staleness-sweep-worker"
 
 export { ConversationRepository } from "./repository"
+export {
+  MessageConversationStateRepository,
+  MESSAGE_CONVERSATION_STATES,
+  SETTLED_BY_REASONS,
+} from "./settling-repository"
+export type { MessageConversationState, SettledByReason, SettlingRow } from "./settling-repository"
+export { settleMessagesOnEngagement, emitSettledConversationUpdates } from "./settling-service"
 export { ConversationFeedbackRepository } from "./feedback-repository"
 export type { Conversation, InsertConversationParams, UpdateConversationParams } from "./repository"
 

--- a/apps/backend/src/features/conversations/service.test.ts
+++ b/apps/backend/src/features/conversations/service.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, spyOn, beforeEach, afterEach, mock } from "bun:
 import { ConversationService } from "./service"
 import * as dbModule from "../../db"
 import { ConversationRepository, type Conversation } from "./repository"
+import { MessageConversationStateRepository } from "./settling-repository"
 import { StreamRepository } from "../streams"
 import * as streamsModule from "../streams"
 import { MessageRepository, type Message } from "../messaging"
@@ -44,6 +45,7 @@ describe("ConversationService.updateConversation — user status lock", () => {
       streamVisibility: "private",
     } as never)
     spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    spyOn(MessageConversationStateRepository, "listSettlingByConversationIds").mockResolvedValue(new Map())
   })
 
   afterEach(() => mock.restore())

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -2,6 +2,7 @@ import { Pool } from "pg"
 import { withClient, withTransaction, type Querier } from "../../db"
 import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
+import { MessageConversationStateRepository } from "./settling-repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository, applySparseRead, applySparseUnread, type ReadStateSnapshot } from "../streams"
 import { ActivityRepository } from "../activity"
@@ -93,6 +94,8 @@ export interface BoardPost {
   streamIds: string[]
   /** Whether an active memo was captured from this conversation — the Decisions lens signal. */
   hasCapturedMemo: boolean
+  /** Members whose assignment is still provisional (low extractor confidence). */
+  settlingMessageIds: string[]
   /** Whether the requesting viewer authored/participates in or was @-mentioned in this conversation — the Mine lens signal. */
   isMine: boolean
   /** Effective root of the anchor (`COALESCE(root_stream_id, id)`) — the client's stream-scope filter matches on this. */
@@ -355,6 +358,14 @@ export class ConversationService {
     // (INV-56). Pinned to primary `message_ids` — the SAME set the SQL half
     // (`boardLensCondSql` mine branch) tests — so the seed boundary and the
     // rendered `isMine` can't disagree.
+    // Provisional (settling) members, one batched read (INV-56). A board-level
+    // field like `hasCapturedMemo` — not part of the conversation aggregate.
+    const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+      this.pool,
+      workspaceId,
+      conversations.map((c) => c.id)
+    )
+
     const mentionedMessageIds = await ActivityRepository.findMentionedMessageIds(this.pool, workspaceId, userId, [
       ...new Set(conversations.flatMap((c) => c.messageIds)),
     ])
@@ -384,6 +395,7 @@ export class ConversationService {
         totalReplies: plan.totalReplies,
         streamIds,
         hasCapturedMemo: conversationIdsWithMemos.has(conversation.id),
+        settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
         isMine:
           conversation.participantIds.includes(userId) ||
           conversation.messageIds.some((id) => mentionedMessageIds.has(id)),
@@ -546,6 +558,17 @@ export class ConversationService {
         userId,
       })
 
+      // A user re-filing a provisionally-placed message IS the human ruling:
+      // the row follows the message to its new home and settles there, so the
+      // emptied source can never be left holding a settling row.
+      await MessageConversationStateRepository.settleForConversationTarget(
+        client,
+        workspaceId,
+        messageId,
+        target.id,
+        "user"
+      )
+
       const touchedIds = previous ? [previous.id, target.id] : [target.id]
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
@@ -565,6 +588,11 @@ export class ConversationService {
       }
 
       const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        touchedIds
+      )
       for (const conv of touched) {
         const { parentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
         await OutboxRepository.insert(client, "conversation:updated", {
@@ -574,6 +602,7 @@ export class ConversationService {
           conversation: addStalenessFields(conv),
           parentStreamId,
           streamVisibility,
+          settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
         })
       }
 
@@ -645,6 +674,11 @@ export class ConversationService {
       }
       const stream = await StreamRepository.findById(client, updated.streamId)
       const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        [updated.id]
+      )
       await OutboxRepository.insert(client, "conversation:updated", {
         workspaceId,
         streamId: updated.streamId,
@@ -652,6 +686,7 @@ export class ConversationService {
         conversation: addStalenessFields(updated),
         parentStreamId,
         streamVisibility,
+        settlingMessageIds: settlingByConversation.get(updated.id) ?? [],
       })
       return { conversation: addStalenessFields(updated) }
     })
@@ -747,6 +782,8 @@ export class ConversationService {
 
       await ConversationRepository.removePrimaryMessages(client, workspaceId, source.id, moveIds, remainingAuthors)
       await ConversationRepository.addPrimaryMessages(client, workspaceId, newId, moveIds, movedAuthors)
+      // A user split is a human ruling on where these messages belong.
+      await MessageConversationStateRepository.settle(client, workspaceId, moveIds, "user")
       await ConversationRepository.bumpActivityForIds(client, workspaceId, [source.id, newId])
 
       // Feedback ground truth — one row per moved message (parity with
@@ -775,6 +812,11 @@ export class ConversationService {
       // Each aggregate event routes by its OWN access root (INV-62): the new
       // conversation lives in the thread (parent-channel discoverability), the
       // source in its anchor.
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        [newConversation.id, updatedSource.id]
+      )
       const threadDelivery = await resolveConversationDelivery(client, threadStream)
       await OutboxRepository.insert(client, "conversation:created", {
         workspaceId,
@@ -783,6 +825,7 @@ export class ConversationService {
         conversation: addStalenessFields(newConversation),
         parentStreamId: threadDelivery.parentStreamId,
         streamVisibility: threadDelivery.streamVisibility,
+        settlingMessageIds: settlingByConversation.get(newConversation.id) ?? [],
       })
 
       const sourceDelivery = await resolveConversationDelivery(client, sourceStream)
@@ -793,6 +836,7 @@ export class ConversationService {
         conversation: addStalenessFields(updatedSource),
         parentStreamId: sourceDelivery.parentStreamId,
         streamVisibility: sourceDelivery.streamVisibility,
+        settlingMessageIds: settlingByConversation.get(updatedSource.id) ?? [],
       })
 
       // Per-message move events route to each message's own stream (the thread),
@@ -1018,6 +1062,14 @@ export class ConversationService {
         distinctAuthors([...destination.messageIds, ...moveIds], memberMessages)
       )
       await ConversationRepository.reactivateIfInactive(client, workspaceId, destination.id)
+      // Same human ruling as the single-message re-file.
+      await MessageConversationStateRepository.settleForConversationTargets(
+        client,
+        workspaceId,
+        moveIds,
+        destination.id,
+        "user"
+      )
 
       const touchedIds = [destination.id, ...sourceRows.keys()]
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
@@ -1025,6 +1077,11 @@ export class ConversationService {
       // Re-read every touched row post-write so the events carry final membership.
       const finalById = new Map(
         (await ConversationRepository.findByIds(client, workspaceId, touchedIds)).map((c) => [c.id, c])
+      )
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        touchedIds
       )
       const finalDestination = finalById.get(destination.id)
       if (!finalDestination) {
@@ -1045,6 +1102,7 @@ export class ConversationService {
           conversation: addStalenessFields(finalDestination),
           parentStreamId,
           streamVisibility,
+          settlingMessageIds: settlingByConversation.get(finalDestination.id) ?? [],
         })
       }
 
@@ -1061,6 +1119,7 @@ export class ConversationService {
           conversation: addStalenessFields(conv),
           parentStreamId,
           streamVisibility,
+          settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
         })
       }
 
@@ -1226,6 +1285,13 @@ export class ConversationService {
           g.messageIds,
           distinctAuthors(g.messageIds, memberMessages)
         )
+        await MessageConversationStateRepository.settleForConversationTargets(
+          client,
+          workspaceId,
+          g.messageIds,
+          minted.id,
+          "user"
+        )
         mintedIds.push(minted.id)
         for (const id of g.messageIds) movedTo.set(id, minted.id)
       }
@@ -1251,6 +1317,11 @@ export class ConversationService {
       const finalById = new Map(
         (await ConversationRepository.findByIds(client, workspaceId, touchedIds)).map((c) => [c.id, c])
       )
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        touchedIds
+      )
       const finalSource = finalById.get(source.id)
       if (!finalSource) {
         throw new Error(`Conversation ${source.id} disappeared during split`)
@@ -1271,6 +1342,7 @@ export class ConversationService {
           conversation: addStalenessFields(minted),
           parentStreamId,
           streamVisibility,
+          settlingMessageIds: settlingByConversation.get(minted.id) ?? [],
         })
       }
 
@@ -1281,6 +1353,7 @@ export class ConversationService {
         conversation: addStalenessFields(finalSource),
         parentStreamId,
         streamVisibility,
+        settlingMessageIds: settlingByConversation.get(finalSource.id) ?? [],
       })
 
       // Per-message move events route to each message's own stream (for the

--- a/apps/backend/src/features/conversations/settling-repository.ts
+++ b/apps/backend/src/features/conversations/settling-repository.ts
@@ -99,15 +99,24 @@ export const MessageConversationStateRepository = {
     settledBy: SettledByReason,
     createdBefore: Date
   ): Promise<SettlingRow[]> {
+    // Strictly backwards-looking on BOTH axes. `created_at < createdBefore`
+    // (DB clock) protects rows a concurrent pass wrote after this one began;
+    // the sequence subquery protects rows for messages NEWER than this pass's
+    // window — a late pass (its LLM round-trip outlived several later sends)
+    // must not settle placements those messages' own passes still consider
+    // provisional. Passes only ever settle behind the window, never ahead.
     const result = await db.query<SettlingDbRow>(sql`
-      UPDATE message_conversation_state
+      UPDATE message_conversation_state mcs
       SET state = 'settled', settled_by = ${settledBy}, settled_at = NOW(), updated_at = NOW()
-      WHERE workspace_id = ${workspaceId}
-        AND stream_id = ${streamId}
-        AND state = 'settling'
-        AND created_at < ${createdBefore}
-        AND NOT (message_id = ANY(${keepMessageIds}::text[]))
-      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+      FROM messages m
+      WHERE mcs.workspace_id = ${workspaceId}
+        AND mcs.stream_id = ${streamId}
+        AND mcs.state = 'settling'
+        AND mcs.created_at < ${createdBefore}
+        AND NOT (mcs.message_id = ANY(${keepMessageIds}::text[]))
+        AND m.id = mcs.message_id
+        AND m.sequence < (SELECT MIN(mw.sequence) FROM messages mw WHERE mw.id = ANY(${keepMessageIds}::text[]) AND mw.stream_id = ${streamId})
+      RETURNING mcs.message_id, mcs.workspace_id, mcs.stream_id, mcs.conversation_id, mcs.state, mcs.settled_by, mcs.settled_at
     `)
     return result.rows.map(mapRow)
   },

--- a/apps/backend/src/features/conversations/settling-repository.ts
+++ b/apps/backend/src/features/conversations/settling-repository.ts
@@ -1,0 +1,227 @@
+import type { Querier } from "../../db"
+import { sql } from "../../db"
+
+export const MESSAGE_CONVERSATION_STATES = ["settling", "settled"] as const
+export type MessageConversationState = (typeof MESSAGE_CONVERSATION_STATES)[number]
+
+export const SETTLED_BY_REASONS = ["llm-window", "engagement", "user"] as const
+export type SettledByReason = (typeof SETTLED_BY_REASONS)[number]
+
+export interface SettlingRow {
+  messageId: string
+  workspaceId: string
+  streamId: string
+  conversationId: string
+  state: MessageConversationState
+  settledBy: SettledByReason | null
+  settledAt: Date | null
+}
+
+interface SettlingDbRow {
+  message_id: string
+  workspace_id: string
+  stream_id: string
+  conversation_id: string
+  state: string
+  settled_by: string | null
+  settled_at: Date | null
+}
+
+function mapRow(row: SettlingDbRow): SettlingRow {
+  return {
+    messageId: row.message_id,
+    workspaceId: row.workspace_id,
+    streamId: row.stream_id,
+    conversationId: row.conversation_id,
+    state: row.state as MessageConversationState,
+    settledBy: row.settled_by as SettledByReason | null,
+    settledAt: row.settled_at,
+  }
+}
+
+/**
+ * Provisional ("settling") conversation assignments. Absence of a row means the
+ * assignment is settled/normal, so nothing needs backfilling and a settle is
+ * always idempotent.
+ */
+export const MessageConversationStateRepository = {
+  /**
+   * Record a provisional assignment. An existing row wins (INV-20): a message
+   * that already settled must not be dragged back to settling by a re-delivered
+   * extraction pass.
+   */
+  async insertSettling(
+    db: Querier,
+    params: { messageId: string; workspaceId: string; streamId: string; conversationId: string }
+  ): Promise<void> {
+    await db.query(sql`
+      INSERT INTO message_conversation_state (message_id, workspace_id, stream_id, conversation_id, state)
+      VALUES (${params.messageId}, ${params.workspaceId}, ${params.streamId}, ${params.conversationId}, 'settling')
+      ON CONFLICT (message_id) DO NOTHING
+    `)
+  },
+
+  /** Settle every still-settling row among `messageIds`. Returns the rows it flipped. */
+  async settle(
+    db: Querier,
+    workspaceId: string,
+    messageIds: string[],
+    settledBy: SettledByReason
+  ): Promise<SettlingRow[]> {
+    if (messageIds.length === 0) return []
+    const result = await db.query<SettlingDbRow>(sql`
+      UPDATE message_conversation_state
+      SET state = 'settled', settled_by = ${settledBy}, settled_at = NOW(), updated_at = NOW()
+      WHERE workspace_id = ${workspaceId}
+        AND message_id = ANY(${messageIds}::text[])
+        AND state = 'settling'
+      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+    `)
+    return result.rows.map(mapRow)
+  },
+
+  /**
+   * Settle every still-settling row of `streamId` EXCEPT `keepMessageIds` — the
+   * pass's context window. A row the extractor can no longer see will never be
+   * revisited, so its placement is as good as it gets.
+   *
+   * `createdBefore` bounds the settle to rows that predate the pass's view: a
+   * concurrent pass (BOUNDARY_EXTRACT has no fairness key) can insert a settling
+   * row for a message this pass never saw, and settling it here would discard a
+   * placement that is still provisional. It must come from the DB's own clock
+   * (`SELECT NOW()` at pass start), never a JS `Date` (INV-66).
+   */
+  async settleStreamOutsideWindow(
+    db: Querier,
+    workspaceId: string,
+    streamId: string,
+    keepMessageIds: string[],
+    settledBy: SettledByReason,
+    createdBefore: Date
+  ): Promise<SettlingRow[]> {
+    const result = await db.query<SettlingDbRow>(sql`
+      UPDATE message_conversation_state
+      SET state = 'settled', settled_by = ${settledBy}, settled_at = NOW(), updated_at = NOW()
+      WHERE workspace_id = ${workspaceId}
+        AND stream_id = ${streamId}
+        AND state = 'settling'
+        AND created_at < ${createdBefore}
+        AND NOT (message_id = ANY(${keepMessageIds}::text[]))
+      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+    `)
+    return result.rows.map(mapRow)
+  },
+
+  /** The DB's own clock, for bounding a pass's settle to rows that predate its view. */
+  async now(db: Querier): Promise<Date> {
+    const result = await db.query<{ now: Date }>(sql`SELECT NOW() AS now`)
+    return result.rows[0]!.now
+  },
+
+  /**
+   * Re-file AND settle in one statement: the user moved the message, so the row
+   * must follow it rather than keep pointing at the conversation it left.
+   */
+  async settleForConversationTarget(
+    db: Querier,
+    workspaceId: string,
+    messageId: string,
+    conversationId: string,
+    settledBy: SettledByReason
+  ): Promise<SettlingRow | null> {
+    const result = await db.query<SettlingDbRow>(sql`
+      UPDATE message_conversation_state
+      SET conversation_id = ${conversationId},
+          state = 'settled',
+          settled_by = ${settledBy},
+          settled_at = NOW(),
+          updated_at = NOW()
+      WHERE workspace_id = ${workspaceId} AND message_id = ${messageId} AND state = 'settling'
+      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+    `)
+    const row = result.rows[0]
+    return row ? mapRow(row) : null
+  },
+
+  /** Set-based counterpart of {@link settleForConversationTarget} (INV-56). */
+  async settleForConversationTargets(
+    db: Querier,
+    workspaceId: string,
+    messageIds: string[],
+    conversationId: string,
+    settledBy: SettledByReason
+  ): Promise<SettlingRow[]> {
+    if (messageIds.length === 0) return []
+    const result = await db.query<SettlingDbRow>(sql`
+      UPDATE message_conversation_state
+      SET conversation_id = ${conversationId},
+          state = 'settled',
+          settled_by = ${settledBy},
+          settled_at = NOW(),
+          updated_at = NOW()
+      WHERE workspace_id = ${workspaceId}
+        AND message_id = ANY(${messageIds}::text[])
+        AND state = 'settling'
+      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+    `)
+    return result.rows.map(mapRow)
+  },
+
+  /** Move still-settling rows to another conversation without settling them (LLM re-file). */
+  async moveConversation(
+    db: Querier,
+    workspaceId: string,
+    messageIds: string[],
+    conversationId: string
+  ): Promise<void> {
+    if (messageIds.length === 0) return
+    await db.query(sql`
+      UPDATE message_conversation_state
+      SET conversation_id = ${conversationId}, updated_at = NOW()
+      WHERE workspace_id = ${workspaceId}
+        AND message_id = ANY(${messageIds}::text[])
+        AND state = 'settling'
+    `)
+  },
+
+  /** The wire read: settling message ids grouped by conversation. One query (INV-30). */
+  async listSettlingByConversationIds(
+    db: Querier,
+    workspaceId: string,
+    conversationIds: string[]
+  ): Promise<Map<string, string[]>> {
+    const byConversation = new Map<string, string[]>()
+    if (conversationIds.length === 0) return byConversation
+    const result = await db.query<{ conversation_id: string; message_id: string }>(sql`
+      SELECT conversation_id, message_id
+      FROM message_conversation_state
+      WHERE workspace_id = ${workspaceId}
+        AND state = 'settling'
+        AND conversation_id = ANY(${conversationIds}::text[])
+      ORDER BY created_at ASC
+    `)
+    for (const row of result.rows) {
+      const existing = byConversation.get(row.conversation_id)
+      if (existing) existing.push(row.message_id)
+      else byConversation.set(row.conversation_id, [row.message_id])
+    }
+    return byConversation
+  },
+
+  /** Sweep backstop: settle everything that has been settling longer than `olderThanSeconds`. */
+  async settleOlderThan(db: Querier, olderThanSeconds: number, limit: number): Promise<SettlingRow[]> {
+    const result = await db.query<SettlingDbRow>(sql`
+      UPDATE message_conversation_state
+      SET state = 'settled', settled_by = 'llm-window', settled_at = NOW(), updated_at = NOW()
+      WHERE message_id IN (
+        SELECT message_id FROM message_conversation_state
+        WHERE state = 'settling'
+          AND created_at < NOW() - (${olderThanSeconds}::int * INTERVAL '1 second')
+        ORDER BY created_at ASC
+        LIMIT ${limit}
+      )
+      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+    `)
+    return result.rows.map(mapRow)
+  },
+}

--- a/apps/backend/src/features/conversations/settling-service.ts
+++ b/apps/backend/src/features/conversations/settling-service.ts
@@ -49,6 +49,7 @@ export async function emitSettledConversationUpdates(
   )
 
   const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+  const events = []
   for (const conversation of conversations) {
     let delivery = deliveryByStreamId.get(conversation.streamId)
     if (!delivery) {
@@ -58,14 +59,18 @@ export async function emitSettledConversationUpdates(
       )
       deliveryByStreamId.set(conversation.streamId, delivery)
     }
-    await OutboxRepository.insert(client, "conversation:updated", {
-      workspaceId,
-      streamId: conversation.streamId,
-      conversationId: conversation.id,
-      conversation: addStalenessFields(conversation),
-      parentStreamId: delivery.parentStreamId,
-      streamVisibility: delivery.streamVisibility,
-      settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
+    events.push({
+      eventType: "conversation:updated" as const,
+      payload: {
+        workspaceId,
+        streamId: conversation.streamId,
+        conversationId: conversation.id,
+        conversation: addStalenessFields(conversation),
+        parentStreamId: delivery.parentStreamId,
+        streamVisibility: delivery.streamVisibility,
+        settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
+      },
     })
   }
+  await OutboxRepository.insertMany(client, events)
 }

--- a/apps/backend/src/features/conversations/settling-service.ts
+++ b/apps/backend/src/features/conversations/settling-service.ts
@@ -1,0 +1,71 @@
+import type { PoolClient } from "pg"
+import { ConversationRepository } from "./repository"
+import { MessageConversationStateRepository, type SettledByReason, type SettlingRow } from "./settling-repository"
+import { StreamRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+import { addStalenessFields } from "./staleness"
+import { resolveConversationDelivery } from "./conversation-delivery"
+
+/**
+ * A human engaged with a provisionally-placed message (reacted to it, saved it),
+ * which is the signal that the placement is now theirs to live with: settle it
+ * and re-broadcast the affected conversations so every board card drops the
+ * message from its settling set. Flip + events commit in the caller's
+ * transaction (INV-4/7), so callers pass the transaction client.
+ *
+ * No-op when none of the messages were settling — the common case.
+ */
+export async function settleMessagesOnEngagement(
+  client: PoolClient,
+  workspaceId: string,
+  messageIds: string[],
+  settledBy: SettledByReason = "engagement"
+): Promise<void> {
+  const settled = await MessageConversationStateRepository.settle(client, workspaceId, messageIds, settledBy)
+  await emitSettledConversationUpdates(client, workspaceId, settled)
+}
+
+/**
+ * Re-broadcast every conversation whose settling set just changed, so boards
+ * drop the settled messages without waiting for an unrelated refetch. Every
+ * settle path that isn't already emitting `conversation:updated` must call this
+ * in its own transaction (INV-4/7).
+ */
+export async function emitSettledConversationUpdates(
+  client: PoolClient,
+  workspaceId: string,
+  settled: SettlingRow[]
+): Promise<void> {
+  if (settled.length === 0) return
+
+  const conversationIds = [...new Set(settled.map((row) => row.conversationId))]
+  const conversations = await ConversationRepository.findByIds(client, workspaceId, conversationIds)
+  if (conversations.length === 0) return
+
+  const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+    client,
+    workspaceId,
+    conversationIds
+  )
+
+  const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+  for (const conversation of conversations) {
+    let delivery = deliveryByStreamId.get(conversation.streamId)
+    if (!delivery) {
+      delivery = await resolveConversationDelivery(
+        client,
+        await StreamRepository.findById(client, conversation.streamId)
+      )
+      deliveryByStreamId.set(conversation.streamId, delivery)
+    }
+    await OutboxRepository.insert(client, "conversation:updated", {
+      workspaceId,
+      streamId: conversation.streamId,
+      conversationId: conversation.id,
+      conversation: addStalenessFields(conversation),
+      parentStreamId: delivery.parentStreamId,
+      streamVisibility: delivery.streamVisibility,
+      settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
+    })
+  }
+}

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
@@ -4,6 +4,7 @@ import * as dbModule from "../../db"
 import { StreamRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
 import { ConversationRepository, type Conversation } from "./repository"
+import { MessageConversationStateRepository } from "./settling-repository"
 import { createStalenessSweepWorker } from "./staleness-sweep-worker"
 
 function makeConversation(overrides: Partial<Conversation>): Conversation {
@@ -44,6 +45,8 @@ describe("createStalenessSweepWorker", () => {
       },
     ] as never)
     const insertMany = spyOn(OutboxRepository, "insertMany").mockResolvedValue([] as never)
+    spyOn(MessageConversationStateRepository, "listSettlingByConversationIds").mockResolvedValue(new Map())
+    spyOn(MessageConversationStateRepository, "settleOlderThan").mockResolvedValue([])
     return { worker: createStalenessSweepWorker({ pool: {} as never }), insertMany }
   }
 

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.ts
@@ -4,6 +4,9 @@ import { withTransaction } from "../../db"
 import { StreamRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
 import { ConversationRepository } from "./repository"
+import { MessageConversationStateRepository } from "./settling-repository"
+import { emitSettledConversationUpdates } from "./settling-service"
+import { SETTLING_MAX_AGE_SECONDS } from "./boundary-extraction/config"
 import { addStalenessFields } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
 import { logger } from "../../lib/logger"
@@ -35,6 +38,31 @@ export function createStalenessSweepWorker(
   const { pool } = deps
 
   return async (job) => {
+    // Settling backstop: a quiet stream gets no further extraction pass, so
+    // nothing else will ever move its window past these rows. Own transaction —
+    // it must land even when no conversation transitioned.
+    const settled = await withTransaction(pool, async (client) => {
+      const rows = await MessageConversationStateRepository.settleOlderThan(
+        client,
+        SETTLING_MAX_AGE_SECONDS,
+        SWEEP_BATCH_LIMIT
+      )
+      // The sweep spans workspaces; the emit is workspace-scoped (INV-8).
+      const byWorkspace = new Map<string, typeof rows>()
+      for (const row of rows) {
+        const existing = byWorkspace.get(row.workspaceId)
+        if (existing) existing.push(row)
+        else byWorkspace.set(row.workspaceId, [row])
+      }
+      for (const [wsId, wsRows] of byWorkspace) {
+        await emitSettledConversationUpdates(client, wsId, wsRows)
+      }
+      return rows
+    })
+    if (settled.length > 0) {
+      logger.info({ jobId: job.id, settled: settled.length }, "Staleness sweep settled stale settling assignments")
+    }
+
     const swept = await withTransaction(pool, async (client) => {
       const transitioned = await ConversationRepository.sweepStale(client, {
         stalledAfterSeconds: SWEEP_STALLED_AFTER_SECONDS,
@@ -55,6 +83,24 @@ export function createStalenessSweepWorker(
       for (const id of streamIds) {
         deliveryByStreamId.set(id, await resolveConversationDelivery(client, streamById.get(id) ?? null))
       }
+      // The sweep spans workspaces, and the settling read is workspace-scoped
+      // (INV-8), so it runs once per workspace present in the batch.
+      const settlingByConversation = new Map<string, string[]>()
+      const idsByWorkspace = new Map<string, string[]>()
+      for (const conv of transitioned) {
+        const ids = idsByWorkspace.get(conv.workspaceId)
+        if (ids) ids.push(conv.id)
+        else idsByWorkspace.set(conv.workspaceId, [conv.id])
+      }
+      for (const [wsId, ids] of idsByWorkspace) {
+        for (const [convId, messageIds] of await MessageConversationStateRepository.listSettlingByConversationIds(
+          client,
+          wsId,
+          ids
+        )) {
+          settlingByConversation.set(convId, messageIds)
+        }
+      }
       await OutboxRepository.insertMany(
         client,
         transitioned.map((conv) => {
@@ -68,6 +114,7 @@ export function createStalenessSweepWorker(
               conversation: addStalenessFields(conv),
               parentStreamId: delivery?.parentStreamId,
               streamVisibility: delivery?.streamVisibility,
+              settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
               origin: "staleness-sweep" as const,
             },
           }

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -24,6 +24,7 @@ import {
 } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
 import { AgentSessionRepository, StreamPersonaParticipantRepository } from "../agents"
+import { settleMessagesOnEngagement } from "../conversations"
 import { DraftsRepository, toDraftView } from "../drafts"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { StreamContextRepository, contextRowsForMessage, contextSnippet } from "../stream-context"
@@ -1840,6 +1841,13 @@ export class EventService {
       })
 
       const message = await MessageRepository.addReaction(client, params.messageId, params.emoji, params.userId)
+
+      if (message && actorType === AuthorTypes.USER) {
+        // Reacting is engagement: a provisional conversation placement the
+        // reader just acknowledged stops being provisional (same transaction,
+        // INV-4/7).
+        await settleMessagesOnEngagement(client, params.workspaceId, [params.messageId])
+      }
 
       if (message) {
         await OutboxRepository.insert(client, "reaction:added", {

--- a/apps/backend/src/features/saved-messages/service.test.ts
+++ b/apps/backend/src/features/saved-messages/service.test.ts
@@ -6,7 +6,7 @@ import { SavedMessagesRepository } from "./repository"
 // Streams before messaging to avoid a latent circular-init in public-api/schemas.ts.
 import { StreamRepository, StreamMemberRepository } from "../streams"
 import { MessageRepository } from "../messaging"
-import { ConversationRepository } from "../conversations"
+import { ConversationRepository, MessageConversationStateRepository } from "../conversations"
 import { OutboxRepository } from "../../lib/outbox"
 import { QueueRepository } from "../../lib/queue"
 import * as dbModule from "../../db"
@@ -100,6 +100,9 @@ function fakeSaved(overrides: Partial<SavedMessage> = {}): SavedMessage {
 
 function setupService() {
   spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+  // Saving settles a provisional conversation assignment; nothing is settling in
+  // these fixtures, so the engagement hook short-circuits.
+  spyOn(MessageConversationStateRepository, "settle").mockResolvedValue([])
   // resolveSavedView is covered by its own tests; stub out here
   spyOn(viewModule, "resolveSavedView").mockImplementation(async (_db: any, _userId: string, rows: SavedMessage[]) =>
     rows.map((r) => ({

--- a/apps/backend/src/features/saved-messages/service.ts
+++ b/apps/backend/src/features/saved-messages/service.ts
@@ -11,7 +11,7 @@ import "../workspaces"
 import { OutboxRepository } from "../../lib/outbox"
 import { StreamRepository, StreamMemberRepository } from "../streams"
 import { MessageRepository } from "../messaging"
-import { ConversationRepository } from "../conversations"
+import { ConversationRepository, settleMessagesOnEngagement } from "../conversations"
 import { reminderQueueId } from "../../lib/id"
 import { JobQueues, QueueRepository, enqueueQueuedJob, type SavedReminderFireJobData } from "../../lib/queue"
 import { logger } from "../../lib/logger"
@@ -144,6 +144,10 @@ export class SavedMessagesService {
             remindAt: clampedRemindAt,
           })
         : upsert.saved
+
+      // Saving is engagement: a provisional conversation placement the user just
+      // acted on stops being provisional (same transaction, INV-4/7).
+      await settleMessagesOnEngagement(client, params.workspaceId, [params.messageId])
 
       const [view] = await resolveSavedView(client, params.userId, [finalRow])
 

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -540,6 +540,10 @@ export interface ConversationCreatedOutboxPayload extends StreamScopedPayload {
    *  workspace receives it (the board can show it); otherwise only the stream's
    *  own members do, via the stream room (INV-62). */
   streamVisibility?: Visibility
+  /** Members of this conversation whose assignment is still settling (provisional
+   *  low-confidence placement). Omitted by emitters that don't read the state;
+   *  an explicit `[]` means "nothing settling here". */
+  settlingMessageIds?: string[]
 }
 
 export interface ConversationUpdatedOutboxPayload extends StreamScopedPayload {
@@ -549,6 +553,8 @@ export interface ConversationUpdatedOutboxPayload extends StreamScopedPayload {
   parentStreamId?: string
   /** See {@link ConversationCreatedOutboxPayload.streamVisibility}. */
   streamVisibility?: Visibility
+  /** See {@link ConversationCreatedOutboxPayload.settlingMessageIds}. */
+  settlingMessageIds?: string[]
   /**
    * Set when the update is a pure status fade from the staleness sweep — no
    * new content. The memo accumulator skips these instead of re-queueing the
@@ -570,6 +576,8 @@ export interface ConversationMessageAssignedOutboxPayload extends StreamScopedPa
   /** For thread messages, the parent channel's stream ID so the parent-channel
    *  room also receives the membership update. */
   parentStreamId?: string
+  /** Whether this assignment is provisional (low extractor confidence). */
+  settling?: boolean
 }
 
 /**

--- a/apps/backend/tests/integration/conversation-settling.test.ts
+++ b/apps/backend/tests/integration/conversation-settling.test.ts
@@ -295,6 +295,41 @@ describe("conversation settling", () => {
     expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({ state: "settling", settledBy: null })
   })
 
+  test("a late pass never settles rows for messages newer than its window", async () => {
+    // Pass A's trigger lands first; by the time its (slow) pass runs, newer
+    // messages exist with their own settling rows — rows that predate the pass
+    // clock-wise but are AHEAD of it sequence-wise. The window settle is
+    // strictly backwards-looking, so they must survive.
+    const triggerMsgId = await insertMessage("Slow pass trigger")
+    for (let i = 0; i < 3; i++) await insertMessage(`Later filler ${i}`)
+    const newerMsgId = await insertMessage("Newer provisional message")
+    const newerConvId = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id: newerConvId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Newer",
+      })
+      await MessageConversationStateRepository.insertSettling(client, {
+        messageId: newerMsgId,
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        conversationId: newerConvId,
+      })
+    })
+
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Slow pass",
+      confidence: 0.95,
+    }
+    await service.processMessage(triggerMsgId, testStreamId, testWorkspaceId)
+
+    const row = await settlingRow(newerMsgId)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({ state: "settling", settledBy: null })
+  })
+
   test("an LLM reassignment moves the settling row without settling it", async () => {
     const msgId = await insertMessage("Uncertain message")
     extractor.next = {

--- a/apps/backend/tests/integration/conversation-settling.test.ts
+++ b/apps/backend/tests/integration/conversation-settling.test.ts
@@ -19,6 +19,7 @@ import {
   BoundaryExtractionService,
   createStalenessSweepWorker,
   SETTLING_CONFIDENCE_THRESHOLD,
+  SETTLING_MAX_AGE_SECONDS,
 } from "../../src/features/conversations"
 import { sql } from "../../src/db"
 import { userId, workspaceId, streamId, messageId, conversationId } from "../../src/lib/id"
@@ -488,9 +489,10 @@ describe("conversation settling", () => {
     }
     const conversation = await service.processMessage(msgId, testStreamId, testWorkspaceId)
 
+    // Derived from the constant so raising the threshold keeps this test honest.
     await pool.query(sql`
       UPDATE message_conversation_state
-      SET created_at = NOW() - INTERVAL '31 minutes'
+      SET created_at = NOW() - make_interval(secs => ${SETTLING_MAX_AGE_SECONDS + 60})
       WHERE message_id = ${msgId}
     `)
     await pool.query("DELETE FROM outbox")

--- a/apps/backend/tests/integration/conversation-settling.test.ts
+++ b/apps/backend/tests/integration/conversation-settling.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Settling state: a low-confidence DERIVED conversation assignment is
+ * provisional until a human engages with the message or the extraction window
+ * moves past it. Runs against the real schema (INV-68).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, addTestMember, setupTestDatabase, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { EventService } from "../../src/features/messaging"
+import { SavedMessagesService } from "../../src/features/saved-messages"
+import {
+  ConversationRepository,
+  MessageConversationStateRepository,
+  ConversationService,
+  BoundaryExtractionService,
+  createStalenessSweepWorker,
+  SETTLING_CONFIDENCE_THRESHOLD,
+} from "../../src/features/conversations"
+import { sql } from "../../src/db"
+import { userId, workspaceId, streamId, messageId, conversationId } from "../../src/lib/id"
+import type { BoundaryExtractor, ExtractionContext, ExtractionResult } from "../../src/features/conversations"
+
+class StubExtractor implements BoundaryExtractor {
+  next: ExtractionResult = {
+    assignments: [{ conversationId: null, isPrimary: true }],
+    newConversationTopic: "Topic",
+    confidence: 0.9,
+  }
+  lastContext: ExtractionContext | null = null
+  /** Runs between Phase 1's snapshot and Phase 3 — the seam a concurrent pass writes through. */
+  onExtract: (() => Promise<void>) | null = null
+  async extract(context: ExtractionContext): Promise<ExtractionResult> {
+    this.lastContext = context
+    if (this.onExtract) await this.onExtract()
+    return this.next
+  }
+}
+
+describe("conversation settling", () => {
+  let pool: Pool
+  let extractor: StubExtractor
+  let service: BoundaryExtractionService
+  let conversationService: ConversationService
+  let eventService: EventService
+  let savedMessagesService: SavedMessagesService
+  let testUserId: string
+  let testWorkspaceId: string
+  let testStreamId: string
+  let seq = 1n
+
+  const insertMessage = async (
+    text: string,
+    overrides: { authorType?: "user" | "persona"; conversationIntent?: string | null } = {}
+  ) => {
+    const id = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id,
+        streamId: testStreamId,
+        sequence: seq++,
+        authorId: testUserId,
+        authorType: overrides.authorType ?? "user",
+        conversationIntent: overrides.conversationIntent ?? null,
+        ...testMessageContent(text),
+      })
+    })
+    return id
+  }
+
+  const settlingRow = async (id: string) => {
+    const result = await pool.query(sql`SELECT * FROM message_conversation_state WHERE message_id = ${id}`)
+    return result.rows[0] ?? null
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+    testStreamId = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Settling Workspace",
+        slug: `settling-ws-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      await StreamRepository.insert(client, {
+        id: testStreamId,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+      await StreamMemberRepository.insert(client, testStreamId, testUserId)
+    })
+
+    extractor = new StubExtractor()
+    service = new BoundaryExtractionService(pool, extractor)
+    conversationService = new ConversationService(pool)
+    eventService = new EventService(pool)
+    savedMessagesService = new SavedMessagesService({ pool })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  afterEach(async () => {
+    await withTransaction(pool, async (client) => {
+      await client.query("DELETE FROM message_conversation_state")
+      await client.query("DELETE FROM outbox")
+      await client.query("DELETE FROM saved_messages")
+      await client.query("DELETE FROM conversation_feedback")
+      await client.query("DELETE FROM conversations")
+      await client.query("DELETE FROM stream_events")
+      await client.query("DELETE FROM messages")
+    })
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Topic",
+      confidence: 0.9,
+    }
+    extractor.onExtract = null
+  })
+
+  test("a low-confidence derived assignment is recorded as settling", async () => {
+    const msgId = await insertMessage("Low confidence message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Uncertain",
+      confidence: SETTLING_CONFIDENCE_THRESHOLD - 0.1,
+    }
+
+    const conversation = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    const row = await settlingRow(msgId)
+    expect({
+      workspaceId: row?.workspace_id,
+      streamId: row?.stream_id,
+      conversationId: row?.conversation_id,
+      state: row?.state,
+      settledBy: row?.settled_by,
+    }).toEqual({
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      conversationId: conversation!.id,
+      state: "settling",
+      settledBy: null,
+    })
+  })
+
+  test("a confident derived assignment records nothing", async () => {
+    const msgId = await insertMessage("Confident message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Sure",
+      confidence: SETTLING_CONFIDENCE_THRESHOLD,
+    }
+
+    await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    expect(await settlingRow(msgId)).toBeNull()
+  })
+
+  test("a declared send is never settling", async () => {
+    const declaredConvId = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id: declaredConvId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Declared",
+      })
+    })
+    const msgId = await insertMessage("Declared message", { conversationIntent: declaredConvId })
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.addPrimaryMessage(client, testWorkspaceId, declaredConvId, msgId, testUserId)
+    })
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      confidence: 0.1,
+    }
+
+    await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    expect(await settlingRow(msgId)).toBeNull()
+  })
+
+  test("an agent reply is never settling", async () => {
+    const msgId = await insertMessage("Agent reply", { authorType: "persona" })
+    extractor.next = { assignments: [{ conversationId: null, isPrimary: true }], confidence: 0.1 }
+
+    await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    expect(await settlingRow(msgId)).toBeNull()
+  })
+
+  test("a later pass settles out-of-window rows and leaves in-window ones settling", async () => {
+    const oldMsgId = await insertMessage("Old uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Old",
+      confidence: 0.4,
+    }
+    const oldConversation = await service.processMessage(oldMsgId, testStreamId, testWorkspaceId)
+
+    // A message just after it is still inside the surrounding-message window.
+    const nearMsgId = await insertMessage("Near uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Near",
+      confidence: 0.4,
+    }
+    await service.processMessage(nearMsgId, testStreamId, testWorkspaceId)
+
+    expect((await settlingRow(oldMsgId))?.state).toBe("settling")
+
+    // Push the old message far out of the window (MESSAGES_BEFORE = 5).
+    for (let i = 0; i < 8; i++) await insertMessage(`Filler ${i}`)
+    await pool.query("DELETE FROM outbox")
+    const farMsgId = await insertMessage("Far later message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Far",
+      confidence: 0.95,
+    }
+    await service.processMessage(farMsgId, testStreamId, testWorkspaceId)
+
+    const oldRow = await settlingRow(oldMsgId)
+    expect({ state: oldRow?.state, settledBy: oldRow?.settled_by }).toEqual({
+      state: "settled",
+      settledBy: "llm-window",
+    })
+
+    // The settled-only conversation is re-broadcast, so the board drops the
+    // message from its settling set without an unrelated refetch.
+    const events = await pool.query<{ payload: { conversationId: string; settlingMessageIds: string[] } }>(sql`
+      SELECT payload FROM outbox WHERE event_type = 'conversation:updated'
+    `)
+    expect(
+      events.rows.map((r) => ({
+        conversationId: r.payload.conversationId,
+        settlingMessageIds: r.payload.settlingMessageIds,
+      }))
+    ).toContainEqual({ conversationId: oldConversation!.id, settlingMessageIds: [] })
+
+    // ...without falsely reviving it: a settle is not activity.
+    const bumped = await pool.query<{ last_activity_at: Date }>(sql`
+      SELECT last_activity_at FROM conversations WHERE id = ${oldConversation!.id}
+    `)
+    expect(bumped.rows[0]!.last_activity_at).toEqual(oldConversation!.lastActivityAt)
+  })
+
+  test("a settling row written after the pass snapshot survives the pass's window settle", async () => {
+    const concurrentConvId = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id: concurrentConvId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Concurrent",
+      })
+    })
+
+    const msgId = await insertMessage("Pass A trigger")
+    let concurrentMsgId = ""
+    // Pass B lands between pass A's Phase 1 snapshot and its Phase 3 settle.
+    extractor.onExtract = async () => {
+      concurrentMsgId = await insertMessage("Pass B message")
+      await withTransaction(pool, async (client) => {
+        await MessageConversationStateRepository.insertSettling(client, {
+          messageId: concurrentMsgId,
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          conversationId: concurrentConvId,
+        })
+      })
+    }
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Pass A",
+      confidence: 0.95,
+    }
+
+    await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    const row = await settlingRow(concurrentMsgId)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({ state: "settling", settledBy: null })
+  })
+
+  test("an LLM reassignment moves the settling row without settling it", async () => {
+    const msgId = await insertMessage("Uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "First",
+      confidence: 0.4,
+    }
+    const first = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    const nextMsgId = await insertMessage("Follow-up that re-files the previous one")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Second",
+      confidence: 0.95,
+      reassignments: [{ messageId: msgId, toConversationId: null, reason: "belongs here" }],
+    }
+    const second = await service.processMessage(nextMsgId, testStreamId, testWorkspaceId)
+
+    expect(second!.id).not.toBe(first!.id)
+    const row = await settlingRow(msgId)
+    expect({ state: row?.state, conversationId: row?.conversation_id }).toEqual({
+      state: "settling",
+      conversationId: second!.id,
+    })
+  })
+
+  test("a reaction settles the message and re-broadcasts the conversation without it", async () => {
+    const msgId = await insertMessage("Uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "React",
+      confidence: 0.4,
+    }
+    const conversation = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+    await pool.query("DELETE FROM outbox")
+
+    await eventService.addReaction({
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      messageId: msgId,
+      emoji: "👍",
+      userId: testUserId,
+    })
+
+    const row = await settlingRow(msgId)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({
+      state: "settled",
+      settledBy: "engagement",
+    })
+
+    const events = await pool.query<{ payload: { conversationId: string; settlingMessageIds: string[] } }>(sql`
+      SELECT payload FROM outbox WHERE event_type = 'conversation:updated'
+    `)
+    expect(
+      events.rows.map((r) => ({
+        conversationId: r.payload.conversationId,
+        settlingMessageIds: r.payload.settlingMessageIds,
+      }))
+    ).toContainEqual({ conversationId: conversation!.id, settlingMessageIds: [] })
+  })
+
+  test("saving a message settles it", async () => {
+    const msgId = await insertMessage("Uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Save",
+      confidence: 0.4,
+    }
+    await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    await savedMessagesService.save({
+      workspaceId: testWorkspaceId,
+      userId: testUserId,
+      messageId: msgId,
+    })
+
+    const row = await settlingRow(msgId)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({
+      state: "settled",
+      settledBy: "engagement",
+    })
+  })
+
+  test("a user re-file moves the settling row to the target and settles it", async () => {
+    const msgId = await insertMessage("Uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Source",
+      confidence: 0.4,
+    }
+    const source = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    const targetConvId = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id: targetConvId,
+        streamId: testStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Target",
+      })
+    })
+
+    await conversationService.reassignMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: targetConvId,
+      messageId: msgId,
+      userId: testUserId,
+    })
+
+    const row = await settlingRow(msgId)
+    expect({ state: row?.state, settledBy: row?.settled_by, conversationId: row?.conversation_id }).toEqual({
+      state: "settled",
+      settledBy: "user",
+      conversationId: targetConvId,
+    })
+    // The emptied source is left holding no settling row (it was moved first).
+    const stranded = await pool.query(sql`
+      SELECT message_id FROM message_conversation_state
+      WHERE conversation_id = ${source!.id} AND state = 'settling'
+    `)
+    expect(stranded.rows).toEqual([])
+  })
+
+  test("board feed and single-post read report the settling members", async () => {
+    const msgId = await insertMessage("Uncertain message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Board",
+      confidence: 0.4,
+    }
+    const settling = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    const settledMsgId = await insertMessage("Confident message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Board confident",
+      confidence: 0.95,
+    }
+    const settled = await service.processMessage(settledMsgId, testStreamId, testWorkspaceId)
+
+    const single = await conversationService.getBoardPostById(testWorkspaceId, settling!.id, testUserId)
+    expect(single?.settlingMessageIds).toEqual([msgId])
+
+    const { posts } = await conversationService.listByWorkspace(testWorkspaceId, testUserId)
+    const byId = new Map(posts.map((p) => [p.conversation.id, p.settlingMessageIds]))
+    expect(byId.get(settling!.id)).toEqual([msgId])
+    expect(byId.get(settled!.id)).toEqual([])
+  })
+
+  test("the staleness sweep settles rows older than the max age", async () => {
+    const msgId = await insertMessage("Quiet stream message")
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Quiet",
+      confidence: 0.4,
+    }
+    const conversation = await service.processMessage(msgId, testStreamId, testWorkspaceId)
+
+    await pool.query(sql`
+      UPDATE message_conversation_state
+      SET created_at = NOW() - INTERVAL '31 minutes'
+      WHERE message_id = ${msgId}
+    `)
+    await pool.query("DELETE FROM outbox")
+
+    const sweep = createStalenessSweepWorker({ pool })
+    await sweep({ id: "sweep-1", data: {} } as never)
+
+    const row = await settlingRow(msgId)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({
+      state: "settled",
+      settledBy: "llm-window",
+    })
+
+    const events = await pool.query<{ payload: { conversationId: string; settlingMessageIds: string[] } }>(sql`
+      SELECT payload FROM outbox WHERE event_type = 'conversation:updated'
+    `)
+    expect(
+      events.rows.map((r) => ({
+        conversationId: r.payload.conversationId,
+        settlingMessageIds: r.payload.settlingMessageIds,
+      }))
+    ).toContainEqual({ conversationId: conversation!.id, settlingMessageIds: [] })
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -95,6 +95,7 @@ function makePost(): BoardPost {
     totalReplies: 1,
     streamIds: ["stream_1"],
     hasCapturedMemo: false,
+    settlingMessageIds: [],
     isMine: false,
   }
 }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -88,6 +88,7 @@ function makePost(
       ]),
     ],
     hasCapturedMemo: false,
+    settlingMessageIds: [],
     isMine: false,
   }
 }

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -59,6 +59,7 @@ function makePost(id: string, lastActivityAt: string, recentMessages: BoardPostM
     totalReplies: recentMessages.length,
     streamIds: [...new Set([conversation.streamId, openingMessage.streamId, ...recentMessages.map((m) => m.streamId)])],
     hasCapturedMemo: false,
+    settlingMessageIds: [],
     isMine: false,
   }
 }
@@ -109,6 +110,21 @@ describe("mergeBoardConversation", () => {
     // The event carries the aggregate, not message bodies — a member's cached
     // preview is preserved.
     expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r1"])
+  })
+
+  it("carries settlingMessageIds from the payload, and keeps the cached set when the event omits it", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1")])])
+    const conversation = { ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"), messageIds: ["m1", "r1"] }
+
+    await mergeBoardConversation("conv_1", conversation, ["r1"])
+    expect((await db.conversations.get("conv_1"))?.settlingMessageIds).toEqual(["r1"])
+
+    // An emitter that doesn't report the set must not silently clear it.
+    await mergeBoardConversation("conv_1", conversation)
+    expect((await db.conversations.get("conv_1"))?.settlingMessageIds).toEqual(["r1"])
+
+    await mergeBoardConversation("conv_1", conversation, [])
+    expect((await db.conversations.get("conv_1"))?.settlingMessageIds).toEqual([])
   })
 
   it("drops a re-filed message from the preview when it leaves the membership", async () => {
@@ -200,6 +216,7 @@ describe("putOptimisticBoardPost", () => {
       openingMessage: expect.objectContaining({ id: "msg_1", contentMarkdown: "just posted", authorId: "usr_1" }),
       isMine: true,
       rootStreamType: "channel",
+      settlingMessageIds: [],
     })
     expect(row?.conversation.status).toBe("active")
     expect(row?.conversation.messageIds).toEqual(["msg_1"])

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -292,7 +292,13 @@ export async function mergeBoardConversation(
       ...existing,
       conversation,
       recentMessages,
-      settlingMessageIds: settlingMessageIds ?? existing.settlingMessageIds ?? [],
+      // A kept cached set is still pruned to the new membership: an event that
+      // omits the field but moves a message out must not leave it marked.
+      settlingMessageIds:
+        settlingMessageIds ??
+        (memberIds
+          ? (existing.settlingMessageIds ?? []).filter((id) => memberIds.has(id))
+          : (existing.settlingMessageIds ?? [])),
       _lastActivityMs: lastActivityMs(conversation),
       _cachedAt: Date.now(),
       _status: undefined,

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -134,6 +134,8 @@ function buildOptimisticPost(workspaceId: string, input: OptimisticBoardPostInpu
     totalReplies: 0,
     streamIds: [input.streamId],
     hasCapturedMemo: false,
+    // An authored post is the author's own declaration — never provisional.
+    settlingMessageIds: [],
     // The author's own post is trivially theirs — shows on the Mine lens at once.
     isMine: true,
     rootStreamId: input.rootStreamId,
@@ -248,7 +250,11 @@ export async function addBoardConversationStream(conversationId: string, streamI
  */
 export async function mergeBoardConversation(
   conversationId: string,
-  conversation: ConversationWithStaleness
+  conversation: ConversationWithStaleness,
+  /** The event's board-level settling set. `settlingMessageIds` is a BoardPost
+   *  field, not part of the aggregate, so it is carried explicitly; `undefined`
+   *  (an emitter that doesn't report it) keeps the cached value. */
+  settlingMessageIds?: string[]
 ): Promise<boolean> {
   // Read-modify-write in one rw transaction so a concurrent optimistic write or
   // a second echo can't merge over a stale read of this row.
@@ -286,6 +292,7 @@ export async function mergeBoardConversation(
       ...existing,
       conversation,
       recentMessages,
+      settlingMessageIds: settlingMessageIds ?? existing.settlingMessageIds ?? [],
       _lastActivityMs: lastActivityMs(conversation),
       _cachedAt: Date.now(),
       _status: undefined,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2101,16 +2101,22 @@ export function registerWorkspaceSocketHandlers(
   // reopen) but only refetch the ones with active observers now. The viewer's own
   // sends are already reflected optimistically, and reconcile when their echo
   // merges here.
-  const handleConversationUpserted = (payload: { workspaceId: string; conversation: ConversationWithStaleness }) => {
+  const handleConversationUpserted = (payload: {
+    workspaceId: string
+    conversation: ConversationWithStaleness
+    settlingMessageIds?: string[]
+  }) => {
     if (payload.workspaceId !== workspaceId) return
-    void mergeBoardConversation(payload.conversation.id, payload.conversation).then((merged) => {
-      if (!merged) {
-        queryClient.invalidateQueries({
-          queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
-          refetchType: "active",
-        })
+    void mergeBoardConversation(payload.conversation.id, payload.conversation, payload.settlingMessageIds).then(
+      (merged) => {
+        if (!merged) {
+          queryClient.invalidateQueries({
+            queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
+            refetchType: "active",
+          })
+        }
       }
-    })
+    )
   }
 
   // A conversation can span its root + the root's threads (one root —

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -839,6 +839,15 @@ export interface BoardPost {
    */
   hasCapturedMemo: boolean
   /**
+   * Members of this conversation whose assignment is still SETTLING: the
+   * extractor placed them with low confidence, so the placement is provisional
+   * until a human engages with the message (reaction, save, re-file) or the
+   * extraction window moves past it. Absence from this list means settled —
+   * the wire never enumerates settled ids. Optional-free (always sent) so a
+   * card can render the state without a second fetch.
+   */
+  settlingMessageIds: string[]
+  /**
    * Whether this conversation is "mine" to the requesting viewer — they authored
    * or participate in it (`participant_ids`) or were `@`-mentioned on one of its
    * messages. The Mine lens signal. Like {@link hasCapturedMemo} this is a


### PR DESCRIPTION
## Problem

The settling model ([doc](https://seer.build/ws_vbyzjvdg6g/b/settling-model-1e3925/), [plan](https://seer.build/ws_vbyzjvdg6g/b/settling-stack-plan-c8dbe8/) chunk 3) needs a persisted answer to "is this message's conversation assignment still provisional?" — the state chunk 4 renders and chunk 5's chip resolves. Prod measurement: re-cuts only ever hit messages under ~80s old, so the settling window is short.

## Solution

- `message_conversation_state` sidecar (no FKs, TEXT state, workspace-scoped). Absence of a row = settled; the wire only ever lists settling ids.
- **No extractor schema change**: settling derives from the response's existing top-level `confidence < 0.7` (`SETTLING_CONFIDENCE_THRESHOLD`, colocated per INV-44). Declared sends, agent replies and scratchpads provably never settle (Phase 1 short-circuits before the write).
- Settlement paths, each emitting `conversation:updated` with a fresh `settlingMessageIds` in the same transaction (INV-4/7):
  - **engagement** — reaction add / save, USER actors only;
  - **user placement** — reassign, split, move-to-subtopic settle into the target (`settled_by='user'`);
  - **window passage** — each extraction pass settles rows outside its context window, bounded by DB `NOW()` captured at pass start so a concurrent pass (BOUNDARY_EXTRACT runs `fairness: NONE`) can't settle a row a newer pass just wrote — a JS timestamp would cross clocks (INV-66);
  - **sweep backstop** — 30 min for quiet streams, which never get another pass.
  - Settled-only conversations emit events but never feed `bumpActivityForIds` — a window settle must not resurface an idle card.
- Wire: `BoardPost.settlingMessageIds` (batched read, INV-56), `settling` on `message_assigned`. All 12 `conversation:*` emitters carry the field; both deploy-window directions tolerate the old shape. Frontend is passthrough only: optimistic default `[]`, echo merge keeps-cached on absent field.

Review (Opus high): 3 findings — all the same shape, *settled in the DB but nobody told the clients* — fixed and falsification-checked; concurrency covered by a new interleaved-pass integration test.

## Test plan

- [x] Typecheck clean; backend 4555 pass (22 pre-existing server-dependent, 0 new); conversations + settling integration 141/141 on the real schema (INV-68, event content asserted per INV-23); frontend stores/sync 658/658

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788049316&installation_model_id=20758&pr_number=1678&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1678&signature=a71af38054712fec6d5f286f53896510a4f77913a792200dbb8e0136fbdefafe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->