### PR TITLE
feat(board): the confirm chip on settling rows

### DIFF
--- a/apps/backend/src/features/access-log/operations.ts
+++ b/apps/backend/src/features/access-log/operations.ts
@@ -147,6 +147,7 @@ export const ACCESS_LOG_OPERATIONS = [
   "conversations.mute_stream",
   "conversations.unmute_stream",
   "conversations.reassign_message",
+  "conversations.settle_message",
   "conversations.split_thread",
   "conversations.reassign_messages",
   "conversations.propose_split",

--- a/apps/backend/src/features/conversations/feedback-repository.ts
+++ b/apps/backend/src/features/conversations/feedback-repository.ts
@@ -15,7 +15,9 @@ export interface InsertConversationFeedbackParams {
  * Durable record of user corrections to conversation membership. Write-only
  * from the product surface; read offline (scripts/analyze-conversation-
  * boundaries.ts and future extractor evals) as ground truth for where the
- * boundary extractor drew the wrong line.
+ * boundary extractor drew the wrong line. Not every row is an error: a row whose
+ * `from_conversation_id` equals its `to_conversation_id` is written by
+ * `settleMessage` and means the user CONFIRMED the placement.
  */
 export const ConversationFeedbackRepository = {
   async insert(db: Querier, params: InsertConversationFeedbackParams): Promise<void> {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -97,6 +97,11 @@ const reassignMessageParamsSchema = z.object({
   messageId: z.string().min(1),
 })
 
+const settleMessageParamsSchema = z.object({
+  conversationId: z.string().min(1),
+  messageId: z.string().min(1),
+})
+
 const splitThreadSchema = z.object({
   threadStreamId: z.string().min(1),
 })
@@ -342,6 +347,30 @@ export function createConversationHandlers({
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const result = await conversationService.reassignMessage({ workspaceId, conversationId, messageId, userId })
+      res.json(result)
+    },
+
+    /**
+     * "Keep here": the user confirms a provisionally-placed message belongs in
+     * this conversation. Same access posture as {@link reassignMessage} —
+     * workspace-scoped conversation lookup, then stream access resolved through
+     * the thread root (INV-62).
+     */
+    async settleMessage(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { conversationId, messageId } = validateRequest(settleMessageParamsSchema, req.params)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.settleMessage({ workspaceId, conversationId, messageId, userId })
       res.json(result)
     },
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -12,6 +12,7 @@ import { MemoRepository } from "../memos"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
+import { emitSettledConversationUpdates } from "./settling-service"
 import { effectiveRootId } from "./conversation-assigner"
 import { conversationFeedbackId, conversationId as generateConversationId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
@@ -120,6 +121,25 @@ export interface ReassignMessageResult {
   conversation: ConversationWithStaleness
   /** The conversation the message left, or null if it had no primary before. */
   previousConversation: ConversationWithStaleness | null
+}
+
+export interface SettleMessageParams {
+  workspaceId: string
+  /** The conversation the message is being confirmed into. */
+  conversationId: string
+  messageId: string
+  /** The confirming user — recorded with the feedback row. */
+  userId: string
+}
+
+export interface SettleMessageResult {
+  conversation: ConversationWithStaleness
+  /** Always null — a confirm moves nothing. Present so the client can merge the
+   *  response with the same code path as {@link ReassignMessageResult}. */
+  previousConversation: null
+  /** The conversation's remaining settling set, so the caller can drop the row's
+   *  mark without waiting for the socket echo. */
+  settlingMessageIds: string[]
 }
 
 export interface SplitThreadParams {
@@ -639,6 +659,59 @@ export class ConversationService {
       return {
         conversation: addStalenessFields(updatedTarget),
         previousConversation: updatedPrevious ? addStalenessFields(updatedPrevious) : null,
+      }
+    })
+  }
+
+  /**
+   * The other half of the correction pair: the user confirms a provisionally-
+   * placed message belongs where the extractor put it. Settles the row (the mark
+   * fades) and records the confirmation as `conversation_feedback` with
+   * `from == to` — a confirmed placement is ground truth for the extractor just
+   * as a correction is.
+   *
+   * Idempotent by construction (INV-20): the settle is the guard, so a row that
+   * settled between render and tap writes no feedback and emits no event, and
+   * the response still carries the current aggregate.
+   */
+  async settleMessage(params: SettleMessageParams): Promise<SettleMessageResult> {
+    const { workspaceId, conversationId, messageId, userId } = params
+
+    return withTransaction(this.pool, async (client) => {
+      const conversation = await ConversationRepository.findById(client, conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+
+      const message = await MessageRepository.findById(client, messageId)
+      if (!message || !conversation.messageIds.includes(messageId)) {
+        throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+      }
+
+      const settled = await MessageConversationStateRepository.settle(client, workspaceId, [messageId], "user")
+      if (settled.length > 0) {
+        await ConversationFeedbackRepository.insert(client, {
+          id: conversationFeedbackId(),
+          workspaceId,
+          streamId: message.streamId,
+          messageId,
+          fromConversationId: conversation.id,
+          toConversationId: conversation.id,
+          userId,
+        })
+        await emitSettledConversationUpdates(client, workspaceId, settled)
+      }
+
+      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+        client,
+        workspaceId,
+        [conversation.id]
+      )
+
+      return {
+        conversation: addStalenessFields(conversation),
+        previousConversation: null,
+        settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
       }
     })
   }

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1075,6 +1075,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     conversation.reassignMessage
   )
   app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/settle",
+    ...authed,
+    audit("conversations.settle_message", "write"),
+    conversation.settleMessage
+  )
+  app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/split-thread",
     ...authed,
     audit("conversations.split_thread", "write"),

--- a/apps/backend/tests/integration/conversation-settle-endpoint.test.ts
+++ b/apps/backend/tests/integration/conversation-settle-endpoint.test.ts
@@ -1,0 +1,305 @@
+/**
+ * "Keep here": the user confirms a provisionally-placed message belongs where
+ * the extractor put it. Real schema (INV-68) — the settle flip, the from==to
+ * feedback row, the `conversation:updated` event, and the endpoint's access
+ * posture (which mirrors reassign, INV-62).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, addTestMember, setupTestDatabase, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository, StreamService } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import {
+  ConversationRepository,
+  ConversationService,
+  MessageConversationStateRepository,
+  createConversationHandlers,
+} from "../../src/features/conversations"
+import { sql } from "../../src/db"
+import { userId, workspaceId, streamId, messageId, conversationId } from "../../src/lib/id"
+
+function mockReq(overrides: Record<string, unknown>) {
+  return { query: {}, body: {}, params: {}, ...overrides } as never
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    locals: {} as Record<string, unknown>,
+    status(code: number) {
+      res.statusCode = code
+      return res
+    },
+    json(data: unknown) {
+      res.body = data
+      return res
+    },
+  }
+  return res
+}
+
+describe("settle message endpoint", () => {
+  let pool: Pool
+  let service: ConversationService
+  let handlers: ReturnType<typeof createConversationHandlers>
+  let testUserId: string
+  let outsiderId: string
+  let testWorkspaceId: string
+  let otherWorkspaceId: string
+  let testStreamId: string
+  let threadStreamId: string
+  let seq = 1n
+
+  const insertMessage = async (streamIdForRow: string, text: string) => {
+    const id = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id,
+        streamId: streamIdForRow,
+        sequence: seq++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent(text),
+      })
+    })
+    return id
+  }
+
+  /** A conversation holding one message, whose placement is still settling. */
+  const seedSettling = async (convStreamId: string, msgStreamId = convStreamId) => {
+    const convId = conversationId()
+    const msgId = await insertMessage(msgStreamId, "Provisionally placed")
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id: convId,
+        streamId: convStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Uncertain",
+      })
+      await ConversationRepository.addPrimaryMessage(client, testWorkspaceId, convId, msgId, testUserId)
+      await MessageConversationStateRepository.insertSettling(client, {
+        messageId: msgId,
+        workspaceId: testWorkspaceId,
+        streamId: msgStreamId,
+        conversationId: convId,
+      })
+    })
+    return { convId, msgId }
+  }
+
+  const stateRow = async (id: string) => {
+    const result = await pool.query(sql`SELECT * FROM message_conversation_state WHERE message_id = ${id}`)
+    return result.rows[0] ?? null
+  }
+  const feedbackRows = async () => (await pool.query("SELECT * FROM conversation_feedback")).rows
+  const updatedEvents = async () =>
+    (await pool.query("SELECT payload FROM outbox WHERE event_type = 'conversation:updated'")).rows
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testUserId = userId()
+    outsiderId = userId()
+    testWorkspaceId = workspaceId()
+    otherWorkspaceId = workspaceId()
+    testStreamId = streamId()
+    threadStreamId = streamId()
+
+    await withTransaction(pool, async (client) => {
+      for (const [id, name] of [
+        [testWorkspaceId, "Settle Workspace"],
+        [otherWorkspaceId, "Other Workspace"],
+      ] as const) {
+        await WorkspaceRepository.insert(client, {
+          id,
+          name,
+          slug: `settle-ws-${id}`,
+          createdBy: testUserId,
+        })
+      }
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      outsiderId = (await addTestMember(client, testWorkspaceId, outsiderId)).id
+      await StreamRepository.insert(client, {
+        id: testStreamId,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+      await StreamMemberRepository.insert(client, testStreamId, testUserId)
+      // A thread under the private channel: access is inherited from the root
+      // (INV-62), so a channel member reaches it without a membership row of
+      // its own and an outsider reaches neither.
+      await StreamRepository.insert(client, {
+        id: threadStreamId,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+        parentStreamId: testStreamId,
+        rootStreamId: testStreamId,
+      })
+    })
+
+    service = new ConversationService(pool)
+    handlers = createConversationHandlers({
+      conversationService: service,
+      boundaryExtractionService: {} as never,
+      boardExclusionService: {} as never,
+      streamService: new StreamService(pool),
+    } as never)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  afterEach(async () => {
+    await withTransaction(pool, async (client) => {
+      await client.query("DELETE FROM message_conversation_state")
+      await client.query("DELETE FROM outbox")
+      await client.query("DELETE FROM conversation_feedback")
+      await client.query("DELETE FROM conversations")
+      await client.query("DELETE FROM messages")
+    })
+  })
+
+  test("a keep-here settles the row, records from==to feedback, and drops it from the settling set", async () => {
+    const { convId, msgId } = await seedSettling(testStreamId)
+
+    const result = await service.settleMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convId,
+      messageId: msgId,
+      userId: testUserId,
+    })
+
+    const row = await stateRow(msgId)
+    expect({ state: row?.state, settledBy: row?.settled_by, conversationId: row?.conversation_id }).toEqual({
+      state: "settled",
+      settledBy: "user",
+      conversationId: convId,
+    })
+
+    const feedback = await feedbackRows()
+    expect(feedback.length).toBe(1)
+    expect({
+      from: feedback[0].from_conversation_id,
+      to: feedback[0].to_conversation_id,
+      messageId: feedback[0].message_id,
+      userId: feedback[0].user_id,
+      streamId: feedback[0].stream_id,
+    }).toEqual({
+      from: convId,
+      to: convId,
+      messageId: msgId,
+      userId: testUserId,
+      streamId: testStreamId,
+    })
+
+    // INV-23: assert on the event's content, not a count.
+    const events = await updatedEvents()
+    const forConversation = events.map((r) => r.payload).filter((p) => p.conversationId === convId)
+    expect(forConversation.length).toBe(1)
+    expect(forConversation[0].settlingMessageIds).toEqual([])
+
+    expect(result.settlingMessageIds).toEqual([])
+    expect(result.previousConversation).toBeNull()
+    expect(result.conversation.id).toBe(convId)
+  })
+
+  test("an already-settled row writes no feedback and emits no event", async () => {
+    const { convId, msgId } = await seedSettling(testStreamId)
+    await withTransaction(pool, async (client) => {
+      await MessageConversationStateRepository.settle(client, testWorkspaceId, [msgId], "llm-window")
+    })
+    await pool.query("DELETE FROM outbox")
+
+    const result = await service.settleMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convId,
+      messageId: msgId,
+      userId: testUserId,
+    })
+
+    expect(await feedbackRows()).toEqual([])
+    expect(await updatedEvents()).toEqual([])
+    expect((await stateRow(msgId))?.settled_by).toBe("llm-window")
+    expect(result.conversation.id).toBe(convId)
+    expect(result.settlingMessageIds).toEqual([])
+  })
+
+  test("a conversation in another workspace is not found", async () => {
+    const { convId, msgId } = await seedSettling(testStreamId)
+
+    const res = mockRes()
+    await handlers.settleMessage(
+      mockReq({
+        user: { id: testUserId },
+        workspaceId: otherWorkspaceId,
+        params: { conversationId: convId, messageId: msgId },
+      }),
+      res as never
+    )
+
+    expect({ status: res.statusCode, body: res.body }).toEqual({
+      status: 404,
+      body: { error: "Conversation not found" },
+    })
+    expect((await stateRow(msgId))?.state).toBe("settling")
+  })
+
+  test("a non-member of the private channel is refused", async () => {
+    const { convId, msgId } = await seedSettling(testStreamId)
+
+    const res = mockRes()
+    await expect(
+      handlers.settleMessage(
+        mockReq({
+          user: { id: outsiderId },
+          workspaceId: testWorkspaceId,
+          params: { conversationId: convId, messageId: msgId },
+        }),
+        res as never
+      )
+    ).rejects.toThrow()
+
+    expect((await stateRow(msgId))?.state).toBe("settling")
+  })
+
+  test("a channel member reaches a conversation anchored in the channel's thread (INV-62)", async () => {
+    const { convId, msgId } = await seedSettling(threadStreamId)
+
+    const res = mockRes()
+    await handlers.settleMessage(
+      mockReq({
+        user: { id: testUserId },
+        workspaceId: testWorkspaceId,
+        params: { conversationId: convId, messageId: msgId },
+      }),
+      res as never
+    )
+
+    expect(res.statusCode).toBe(200)
+    expect((await stateRow(msgId))?.settled_by).toBe("user")
+  })
+
+  test("a message that isn't in the conversation is not found", async () => {
+    const { convId } = await seedSettling(testStreamId)
+    const strayId = await insertMessage(testStreamId, "Elsewhere")
+
+    await expect(
+      service.settleMessage({
+        workspaceId: testWorkspaceId,
+        conversationId: convId,
+        messageId: strayId,
+        userId: testUserId,
+      })
+    ).rejects.toThrow("Message not found")
+    expect(await feedbackRows()).toEqual([])
+  })
+})

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -194,6 +194,24 @@ export const conversationsApi = {
   },
 
   /**
+   * "Keep here": confirm a provisionally-placed message belongs in
+   * `conversationId`. Settles the row and records the confirmation as
+   * extraction feedback; the response carries the conversation's remaining
+   * settling set so the mark can fade without waiting for the socket echo.
+   */
+  async settleMessage(
+    workspaceId: string,
+    conversationId: string,
+    messageId: string
+  ): Promise<{
+    conversation: ConversationWithStaleness
+    previousConversation: null
+    settlingMessageIds: string[]
+  }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/messages/${messageId}/settle`)
+  },
+
+  /**
    * User correction: reassign a set of selected messages to another conversation.
    * A `targetConversationId` reassigns into that existing conversation; omit it to
    * mint a new one (the split gesture). The backend applies every move in one

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { toast } from "sonner"
 import type { Socket } from "socket.io-client"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -24,6 +25,7 @@ import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as inlineComposerModule from "@/components/board/board-inline-composer"
 import * as inputModeModule from "@/hooks/use-input-mode"
+import * as boardStoreModule from "@/stores/board-store"
 import { setBoardFlash, resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { spyOnExport } from "@/test/spy"
 import { MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
@@ -935,5 +937,87 @@ describe("BoardCard settling mark", () => {
     expect(container.querySelector('[data-message-id="m_r1"]')).toBeNull()
     // The settling id names a row the card doesn't render — it must not conjure one.
     expect(container.querySelectorAll("[data-settling]").length).toBe(1)
+  })
+})
+
+describe("BoardCard settling actions", () => {
+  function settlingPost(ids: string[]) {
+    const post = makePost()
+    ;(post as unknown as { settlingMessageIds: string[] }).settlingMessageIds = ids
+    return post
+  }
+
+  it("puts the keep-here button leftmost in the hover toolbar of a settling row", async () => {
+    const { container } = mountCard(settlingPost(["m_open"]), { settleMessage: vi.fn() })
+    await screen.findByText("Opening body.")
+
+    const toolbar = container.querySelector(".reveal-actions-hover-only > div") as HTMLElement
+    const first = toolbar.firstElementChild as HTMLElement
+    expect(first.getAttribute("aria-label")).toBe("Keep here")
+  })
+
+  it("leaves a settled row's toolbar exactly as it was — no settling buttons at all", async () => {
+    const { container } = mountCard(settlingPost([]), { settleMessage: vi.fn() })
+    await screen.findByText("Opening body.")
+
+    const toolbar = container.querySelector(".reveal-actions-hover-only > div") as HTMLElement
+    expect(
+      [...toolbar.children]
+        .map((el) => el.getAttribute("aria-label"))
+        .filter((l) => l === "Keep here" || l === "Not this topic…")
+    ).toEqual([])
+  })
+
+  it("hides 'Not this topic' when the row has no other topic to move to (never a dead menu item)", async () => {
+    mountCard(settlingPost(["m_open"]), { settleMessage: vi.fn() })
+    await screen.findByText("Opening body.")
+
+    expect(screen.queryByLabelText("Not this topic…")).toBeNull()
+  })
+
+  it("offers the stream's other conversations as 'Not this topic' targets, with no duplicate 'Move to sub-topic…' beside it", async () => {
+    // The common case: a channel's main conversation, no sub-topics. Without the
+    // sibling widening the correction half of the chip would never render; with
+    // both entries wired it would render twice (same icon, same dialog).
+    const boardPosts = vi.spyOn(boardStoreModule, "useBoardPosts").mockReturnValue([
+      { id: "conv_1", workspaceId: WS, conversation: { id: "conv_1", streamId: STREAM, messageIds: ["m_open"] } },
+      {
+        id: "conv_sibling",
+        workspaceId: WS,
+        conversation: {
+          id: "conv_sibling",
+          streamId: STREAM,
+          topicSummary: "Deploy plan",
+          messageIds: ["m_other"],
+        },
+        _lastActivityMs: 1,
+      },
+    ] as never)
+    mountCard(settlingPost(["m_open"]), { settleMessage: vi.fn() })
+    await screen.findByText("Opening body.")
+
+    expect(screen.getAllByLabelText("Not this topic…")).toHaveLength(1)
+    await userEvent.click(screen.getAllByLabelText("Message actions")[0])
+    const entries = (await screen.findAllByRole("menuitem")).map((el) => el.textContent)
+    expect(entries.filter((t) => t?.includes("Not this topic") || t?.includes("Move to sub-topic"))).toEqual([
+      "Not this topic…",
+    ])
+    boardPosts.mockRestore()
+  })
+
+  it("settles the message on click and stays silent about it (INV-63)", async () => {
+    const settleMessage = vi.fn().mockResolvedValue({
+      conversation: { id: "conv_1", streamId: STREAM, messageIds: ["m_open"] },
+      previousConversation: null,
+      settlingMessageIds: [],
+    })
+    const success = vi.spyOn(toast, "success")
+    mountCard(settlingPost(["m_open"]), { settleMessage })
+    await screen.findByText("Opening body.")
+
+    await userEvent.click(screen.getByLabelText("Keep here"))
+
+    await waitFor(() => expect(settleMessage).toHaveBeenCalledWith(WS, "conv_1", "m_open"))
+    expect(success).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -340,7 +340,12 @@ export function BoardCard({
   // "Move to sub-topic" re-file: membership move between this conversation and
   // its nested sub-topics (one root). The hook hides the action when a row has
   // nowhere to go.
-  const moveToSubtopic = useMoveToSubtopic({ workspaceId, conversation, branchesByForkMessageId })
+  const moveToSubtopic = useMoveToSubtopic({
+    workspaceId,
+    conversation,
+    branchesByForkMessageId,
+    hasSettlingRows: settlingIds.size > 0,
+  })
   // A spanning-overflow row from a card opens the whole conversation in the panel.
   const continueThreadTo = () => getPanelUrl(createConversationPanelId(conversation.id))
   // Heal a soft-thread seam into its own topic (the card re-forms as a nested

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -496,7 +496,7 @@ export function BoardCard({
         surfaceClassName="bg-card px-3 sm:px-4"
         rowInsetClassName="-mx-3 sm:-mx-4"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
-        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id)}
+        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
       />
     )
   }
@@ -536,7 +536,9 @@ export function BoardCard({
               : undefined
           }
           onMoveToSubtopic={
-            branch.pending ? undefined : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId)
+            branch.pending
+              ? undefined
+              : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId, message.settling)
           }
         />
       </ConversationReadProvider>

--- a/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
@@ -24,19 +24,47 @@ function branch(overrides: Partial<BranchConversationView>): BranchConversationV
   }
 }
 
+/** A board-store row as `useBoardPosts` returns it — only the fields the sibling
+ *  target list reads. */
+function post(
+  id: string,
+  overrides: {
+    streamId?: string
+    topicSummary?: string | null
+    messageIds?: string[]
+    status?: "pending"
+    lastActivityMs?: number
+  } = {}
+) {
+  return {
+    id,
+    workspaceId: WS,
+    conversation: {
+      id,
+      streamId: overrides.streamId ?? "chan_1",
+      topicSummary: overrides.topicSummary === undefined ? `Topic ${id}` : overrides.topicSummary,
+      messageIds: overrides.messageIds ?? ["m_x"],
+    },
+    _status: overrides.status,
+    _lastActivityMs: overrides.lastActivityMs ?? 0,
+  } as never
+}
+
 function MoveSurface({
   branches,
   currentConversationId,
+  settling,
 }: {
   branches: BranchConversationView[]
   currentConversationId: string
+  settling?: boolean
 }) {
   const move = useMoveToSubtopic({
     workspaceId: WS,
     conversation: { id: "conv_main", streamId: "chan_1", topicSummary: "Main thing" },
     branchesByForkMessageId: new Map([["m1", branches]]),
   })
-  const handler = move.moveHandlerFor("m_target", currentConversationId)
+  const handler = move.moveHandlerFor("m_target", currentConversationId, settling)
   return (
     <>
       {handler ? (
@@ -55,15 +83,17 @@ function Harness({
   branches,
   currentConversationId,
   reassignMessage,
+  settling,
 }: {
   branches: BranchConversationView[]
   currentConversationId: string
   reassignMessage: (...args: unknown[]) => Promise<unknown>
+  settling?: boolean
 }) {
   return (
     <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
       <ServicesProvider services={{ conversations: { reassignMessage } as never }}>
-        <MoveSurface branches={branches} currentConversationId={currentConversationId} />
+        <MoveSurface branches={branches} currentConversationId={currentConversationId} settling={settling} />
       </ServicesProvider>
     </QueryClientProvider>
   )
@@ -144,5 +174,69 @@ describe("useMoveToSubtopic", () => {
     await userEvent.click(screen.getByRole("button", { name: /Main thing/ }))
 
     await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_main", "m_target"))
+  })
+})
+
+describe("useMoveToSubtopic on a settling row", () => {
+  function stubBoard(posts: unknown[]) {
+    return vi.spyOn(boardStoreModule, "useBoardPosts").mockReturnValue(posts as never)
+  }
+
+  it("offers the stream's other conversations when the row has no sub-topics, and re-files into the picked sibling", async () => {
+    const spy = stubBoard([post("conv_main"), post("conv_sibling", { topicSummary: "Deploy plan" })])
+    const reassignMessage = vi
+      .fn()
+      .mockResolvedValue({ conversation: { id: "conv_sibling" }, previousConversation: null })
+    render(<Harness branches={[]} currentConversationId="conv_main" reassignMessage={reassignMessage} settling />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    await userEvent.click(screen.getByRole("button", { name: /Deploy plan/ }))
+
+    await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_sibling", "m_target"))
+    spy.mockRestore()
+  })
+
+  it("skips other streams, the row's own conversation, and pending or empty rows", () => {
+    const spy = stubBoard([
+      post("conv_main"),
+      post("conv_other_stream", { streamId: "chan_2", topicSummary: "Elsewhere" }),
+      post("conv_pending", { topicSummary: "Pending", status: "pending" }),
+      post("conv_empty", { topicSummary: "Empty", messageIds: [] }),
+    ])
+    render(<Harness branches={[]} currentConversationId="conv_main" reassignMessage={vi.fn()} settling />)
+
+    expect(screen.getByText("no action")).toBeDefined()
+    spy.mockRestore()
+  })
+
+  it("caps the sibling list at eight, newest activity first", async () => {
+    const spy = stubBoard([
+      post("conv_main"),
+      ...Array.from({ length: 12 }, (_, i) => post(`conv_s${i}`, { topicSummary: `Sibling ${i}`, lastActivityMs: i })),
+    ])
+    render(<Harness branches={[]} currentConversationId="conv_main" reassignMessage={vi.fn()} settling />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+
+    const titles = screen.getAllByRole("button").map((b) => b.textContent)
+    expect(titles.filter((t) => t?.startsWith("Sibling"))).toEqual([
+      "Sibling 11",
+      "Sibling 10",
+      "Sibling 9",
+      "Sibling 8",
+      "Sibling 7",
+      "Sibling 6",
+      "Sibling 5",
+      "Sibling 4",
+    ])
+    spy.mockRestore()
+  })
+
+  it("leaves a settled row's targets untouched — siblings are a settling-only widening", () => {
+    const spy = stubBoard([post("conv_main"), post("conv_sibling", { topicSummary: "Deploy plan" })])
+    render(<Harness branches={[]} currentConversationId="conv_main" reassignMessage={vi.fn()} />)
+
+    expect(screen.getByText("no action")).toBeDefined()
+    spy.mockRestore()
   })
 })

--- a/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
@@ -63,6 +63,7 @@ function MoveSurface({
     workspaceId: WS,
     conversation: { id: "conv_main", streamId: "chan_1", topicSummary: "Main thing" },
     branchesByForkMessageId: new Map([["m1", branches]]),
+    hasSettlingRows: settling ?? false,
   })
   const handler = move.moveHandlerFor("m_target", currentConversationId, settling)
   return (

--- a/apps/frontend/src/components/board/use-move-to-subtopic.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 import { GitBranch, Layers } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { useReassignConversationMessage } from "@/hooks/use-conversations"
+import { useBoardPosts } from "@/stores/board-store"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
 interface MoveTarget {
@@ -10,6 +11,14 @@ interface MoveTarget {
   title: string
   kind: "main" | "branch"
 }
+
+/**
+ * How many sibling same-stream conversations a settling row offers. This is a
+ * picker, not an index: the board store holds only the paginated head, so the
+ * cache may not contain every conversation of the stream — offering the eight
+ * most recently active is the intended ceiling, not a truncation bug.
+ */
+const SETTLING_SIBLING_TARGET_CAP = 8
 
 /**
  * The board's "Move to sub-topic" re-file gesture, shared by the card and the
@@ -20,7 +29,9 @@ interface MoveTarget {
  *
  * `moveHandlerFor` yields a row-action handler only when the row has somewhere
  * to go (≥1 other non-pending conversation under the root); the action hides
- * otherwise, the same field-one-side-sets gate as `onNewSubtopic`. Selecting a
+ * otherwise, the same field-one-side-sets gate as `onNewSubtopic`. Passing
+ * `settling` widens that list with the stream's other cached conversations —
+ * see {@link SETTLING_SIBLING_TARGET_CAP}. Selecting a
  * target fires the move and closes — membership moves are reversible, so
  * there's no confirm step; a failure restores nothing and reports via toast.
  */
@@ -29,11 +40,15 @@ export function useMoveToSubtopic(params: {
   conversation: { id: string; streamId: string; topicSummary: string | null }
   branchesByForkMessageId: Map<string, BranchConversationView[]>
 }): {
-  moveHandlerFor: (messageId: string, currentConversationId: string) => (() => void) | undefined
+  moveHandlerFor: (messageId: string, currentConversationId: string, settling?: boolean) => (() => void) | undefined
   moveDialog: ReactNode
 } {
   const { workspaceId, conversation, branchesByForkMessageId } = params
-  const [pendingMove, setPendingMove] = useState<{ messageId: string; currentConversationId: string } | null>(null)
+  const [pendingMove, setPendingMove] = useState<{
+    messageId: string
+    currentConversationId: string
+    settling: boolean
+  } | null>(null)
   const reassign = useReassignConversationMessage(workspaceId, conversation.streamId)
 
   // Every branch at any depth (sub-topics nest to depth 2 — a grandchild is as
@@ -52,22 +67,53 @@ export function useMoveToSubtopic(params: {
     return out
   }, [branchesByForkMessageId])
 
+  // A still-settling row is the one asking "does this belong here?", and in the
+  // common case — a channel's main conversation with no sub-topics — the branch
+  // list is empty, so the correction would have nowhere to go. Widen it to the
+  // OTHER conversations of the same stream held by the board store: the server's
+  // same-effective-root guard passes trivially for a same-stream target, so
+  // these are legal re-file destinations. Settled rows never see them.
+  const boardPosts = useBoardPosts(workspaceId)
+  const siblings = useMemo(() => {
+    if (!boardPosts) return []
+    return boardPosts
+      .filter(
+        (post) =>
+          post.conversation.streamId === conversation.streamId &&
+          post.conversation.id !== conversation.id &&
+          post._status !== "pending" &&
+          post.conversation.messageIds.length > 0
+      )
+      .sort((a, b) => b._lastActivityMs - a._lastActivityMs)
+      .slice(0, SETTLING_SIBLING_TARGET_CAP)
+      .map((post) => ({
+        conversationId: post.conversation.id,
+        title: post.conversation.topicSummary ?? "Untitled topic",
+        kind: "main" as const,
+      }))
+  }, [boardPosts, conversation.streamId, conversation.id])
+
   const targetsFor = useCallback(
-    (currentConversationId: string): MoveTarget[] => [
-      ...(currentConversationId !== conversation.id
-        ? [
-            {
-              conversationId: conversation.id,
-              title: conversation.topicSummary ?? "Main topic",
-              kind: "main" as const,
-            },
-          ]
-        : []),
-      ...branches
-        .filter((b) => b.conversationId !== currentConversationId)
-        .map((b) => ({ conversationId: b.conversationId, title: b.title, kind: "branch" as const })),
-    ],
-    [conversation.id, conversation.topicSummary, branches]
+    (currentConversationId: string, settling = false): MoveTarget[] => {
+      const targets: MoveTarget[] = [
+        ...(currentConversationId !== conversation.id
+          ? [
+              {
+                conversationId: conversation.id,
+                title: conversation.topicSummary ?? "Main topic",
+                kind: "main" as const,
+              },
+            ]
+          : []),
+        ...branches
+          .filter((b) => b.conversationId !== currentConversationId)
+          .map((b) => ({ conversationId: b.conversationId, title: b.title, kind: "branch" as const })),
+      ]
+      if (!settling) return targets
+      const seen = new Set([currentConversationId, ...targets.map((t) => t.conversationId)])
+      return [...targets, ...siblings.filter((s) => !seen.has(s.conversationId))]
+    },
+    [conversation.id, conversation.topicSummary, branches, siblings]
   )
 
   // Ignore opens and picks while a move is already in flight (mirrors the
@@ -75,11 +121,11 @@ export function useMoveToSubtopic(params: {
   // mutation response, but a rapid re-tap before it settles must not enqueue a
   // second correction.
   const moveHandlerFor = useCallback(
-    (messageId: string, currentConversationId: string): (() => void) | undefined => {
-      if (targetsFor(currentConversationId).length === 0) return undefined
+    (messageId: string, currentConversationId: string, settling = false): (() => void) | undefined => {
+      if (targetsFor(currentConversationId, settling).length === 0) return undefined
       return () => {
         if (reassign.isPending) return
-        setPendingMove({ messageId, currentConversationId })
+        setPendingMove({ messageId, currentConversationId, settling })
       }
     },
     [targetsFor, reassign.isPending]
@@ -97,7 +143,7 @@ export function useMoveToSubtopic(params: {
     [pendingMove, reassign]
   )
 
-  const targets = pendingMove ? targetsFor(pendingMove.currentConversationId) : []
+  const targets = pendingMove ? targetsFor(pendingMove.currentConversationId, pendingMove.settling) : []
 
   const moveDialog = (
     <Dialog open={pendingMove !== null} onOpenChange={(open) => !open && setPendingMove(null)}>

--- a/apps/frontend/src/components/board/use-move-to-subtopic.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.tsx
@@ -39,11 +39,15 @@ export function useMoveToSubtopic(params: {
   workspaceId: string
   conversation: { id: string; streamId: string; topicSummary: string | null }
   branchesByForkMessageId: Map<string, BranchConversationView[]>
+  /** Whether this surface currently renders any settling row. Gates the sibling
+   *  feed subscription: only settling rows read siblings, and a full-feed
+   *  liveQuery per card re-fires on every board write (#1640's cost class). */
+  hasSettlingRows?: boolean
 }): {
   moveHandlerFor: (messageId: string, currentConversationId: string, settling?: boolean) => (() => void) | undefined
   moveDialog: ReactNode
 } {
-  const { workspaceId, conversation, branchesByForkMessageId } = params
+  const { workspaceId, conversation, branchesByForkMessageId, hasSettlingRows = false } = params
   const [pendingMove, setPendingMove] = useState<{
     messageId: string
     currentConversationId: string
@@ -73,7 +77,10 @@ export function useMoveToSubtopic(params: {
   // OTHER conversations of the same stream held by the board store: the server's
   // same-effective-root guard passes trivially for a same-stream target, so
   // these are legal re-file destinations. Settled rows never see them.
-  const boardPosts = useBoardPosts(workspaceId)
+  // Gated on the card actually rendering a settling row: only those read
+  // siblings, and an ungated full-feed liveQuery per card re-fires on every
+  // board write (#1640's cost class).
+  const boardPosts = useBoardPosts(workspaceId, { enabled: hasSettlingRows })
   const siblings = useMemo(() => {
     if (!boardPosts) return []
     return boardPosts
@@ -149,9 +156,11 @@ export function useMoveToSubtopic(params: {
     <Dialog open={pendingMove !== null} onOpenChange={(open) => !open && setPendingMove(null)}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>Move to sub-topic</DialogTitle>
+          <DialogTitle>{pendingMove?.settling ? "Move to another topic" : "Move to sub-topic"}</DialogTitle>
           <DialogDescription>
-            Re-file this message into another topic of this conversation. The message stays where it was posted.
+            {pendingMove?.settling
+              ? "Re-file this message into the topic it belongs to. The message stays where it was posted."
+              : "Re-file this message into another topic of this conversation. The message stays where it was posted."}
           </DialogDescription>
         </DialogHeader>
         <div className="flex max-h-[50dvh] flex-col gap-1 overflow-y-auto">

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -855,7 +855,7 @@ function ConversationPanelBody({
         surfaceClassName="bg-background px-3 sm:px-6"
         rowInsetClassName="-mx-3 sm:-mx-6"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
-        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id)}
+        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
       />
     )
   }
@@ -889,7 +889,9 @@ function ConversationPanelBody({
               : undefined
           }
           onMoveToSubtopic={
-            branch.pending ? undefined : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId)
+            branch.pending
+              ? undefined
+              : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId, message.settling)
           }
         />
       </ConversationReadProvider>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -826,7 +826,12 @@ function ConversationPanelBody({
   const rows = injectUnreadDivider(baseRows, markerMessageId, isDimmed)
   // "Move to sub-topic" re-file — same gesture as the board card (membership move
   // within one root; the hook hides the action when a row has nowhere to go).
-  const moveToSubtopic = useMoveToSubtopic({ workspaceId, conversation, branchesByForkMessageId })
+  const moveToSubtopic = useMoveToSubtopic({
+    workspaceId,
+    conversation,
+    branchesByForkMessageId,
+    hasSettlingRows: settlingIds.size > 0,
+  })
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
     // Each row renders against its own stream so reactions and the permalink
     // target where the message actually lives (one root, many streams); fall

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { toast } from "sonner"
-import { Quote } from "lucide-react"
+import { Quote, Check, FolderInput } from "lucide-react"
 import {
   LabelableResourceTypes,
   type AttachmentSummary,
@@ -45,6 +45,7 @@ import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useDeleteMessage } from "@/hooks/use-delete-message"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
+import { useSettleConversationMessage } from "@/hooks/use-conversations"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { parseMarkdown } from "@threa/prosemirror"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
@@ -312,6 +313,23 @@ export function MessageItem({
     })
   }, [startDiscussWithAriadne, conversationId, conversationRootStreamId, message.id])
 
+  // The settling pair. Both are wired only while the row is still settling and
+  // the surface knows the conversation, so a settled row's menus and toolbar are
+  // exactly what they were before this existed. "Not this topic" reuses the
+  // existing move-to-sub-topic picker (INV-35) — undefined when the row has
+  // nowhere to go, so the entry hides rather than dead-ending.
+  const settleMessage = useSettleConversationMessage(workspaceId, conversationRootStreamId ?? streamId)
+  const isSettling = Boolean(message.settling && conversationId)
+  const handleKeepInConversation = useCallback(() => {
+    if (!conversationId || settleMessage.isPending) return
+    settleMessage.mutate(
+      { messageId: message.id, conversationId },
+      { onError: () => toast.error("Couldn't confirm the message. Please try again.") }
+    )
+  }, [settleMessage, conversationId, message.id])
+  const onKeepInConversation = isSettling ? handleKeepInConversation : undefined
+  const onNotThisTopic = isSettling ? onMoveToSubtopic : undefined
+
   // Save / Set reminder — the same shared registry actions the in-stream row
   // exposes (`MessageEvent`). A save from a conversation surface passes
   // `conversationId` so the saved row (and its reminder) deep-links back into
@@ -455,7 +473,11 @@ export function MessageItem({
     },
     onLabelMessage: () => setLabelPickerOpen(true),
     onNewSubtopic,
-    onMoveToSubtopic,
+    // A settling row surfaces the same picker as "Not this topic…"; showing
+    // "Move to sub-topic…" too would be a second entry, same icon, same dialog.
+    onMoveToSubtopic: isSettling ? undefined : onMoveToSubtopic,
+    onKeepInConversation,
+    onNotThisTopic,
     onMarkReadUpToHere:
       conversationRead && rowRead !== "read" ? () => conversationRead.markReadUpToHere(message.id) : undefined,
     onMarkUnread: conversationRead && rowRead !== "unread" ? () => conversationRead.markUnread(message.id) : undefined,
@@ -475,6 +497,41 @@ export function MessageItem({
   const overflowMenu = (
     <div className="reveal-actions-hover-only absolute right-4 bottom-[calc(100%-20px)] z-10 hidden sm:block">
       <div className="flex items-center gap-0.5 rounded-md border border-border/60 bg-popover/95 px-1 py-1 shadow-md backdrop-blur-sm">
+        {/* The settling pair, leftmost. The toolbar is right-anchored, so this
+            grows leftward and displaces nothing (INV-21); a settled row renders
+            the toolbar exactly as it did before. */}
+        {onKeepInConversation && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Keep here"
+                onClick={onKeepInConversation}
+              >
+                <Check className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Keep here</TooltipContent>
+          </Tooltip>
+        )}
+        {onNotThisTopic && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Not this topic…"
+                onClick={onNotThisTopic}
+              >
+                <FolderInput className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Not this topic…</TooltipContent>
+          </Tooltip>
+        )}
         <ReactionEmojiPicker
           workspaceId={workspaceId}
           onSelect={handleAddReaction}

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -636,3 +636,66 @@ describe("groupVisibleActions", () => {
     expect(linkRow).toBeDefined()
   })
 })
+
+describe("the settling pair", () => {
+  const settlingCtx = createContext({
+    viewInStream: { href: "/w/ws_1/s/stream_1?m=msg_1", label: "View in channel" },
+    onKeepInConversation: vi.fn(),
+    onNotThisTopic: vi.fn(),
+  })
+
+  it("puts both entries ahead of View in channel, so they head the drawer and the overflow menu", () => {
+    const ids = getVisibleActions(settlingCtx).map((a) => a.id)
+
+    expect(ids.slice(0, 3)).toEqual(["keep-in-conversation", "not-this-topic", "view-in-stream"])
+  })
+
+  it("shows exactly one picker entry on a settling row with a move target — the conversation surfaces suppress 'Move to sub-topic…' in favour of 'Not this topic…' (same icon, same dialog)", () => {
+    // The full list, not a prefix: a duplicate would appear anywhere in it.
+    const ids = getVisibleActions(settlingCtx).map((a) => a.id)
+
+    expect(ids).toEqual([
+      "keep-in-conversation",
+      "not-this-topic",
+      "view-in-stream",
+      "reply-in-thread",
+      "copy-as-markdown",
+      "copy-as-plain-text",
+    ])
+  })
+
+  it("reads exactly 'Keep here' / 'Not this topic…'", () => {
+    const byId = new Map(getVisibleActions(settlingCtx).map((a) => [a.id, resolveActionLabel(a, settlingCtx)]))
+
+    expect([byId.get("keep-in-conversation"), byId.get("not-this-topic")]).toEqual(["Keep here", "Not this topic…"])
+  })
+
+  it("hides both on a settled row, and hides 'Not this topic' on its own when the row has nowhere to go", () => {
+    const settled = getVisibleActions(createContext()).map((a) => a.id)
+    const noTarget = getVisibleActions(createContext({ onKeepInConversation: vi.fn() })).map((a) => a.id)
+
+    expect({
+      settled: settled.filter((id) => id === "keep-in-conversation" || id === "not-this-topic"),
+      noTarget: noTarget.filter((id) => id === "keep-in-conversation" || id === "not-this-topic"),
+    }).toEqual({ settled: [], noTarget: ["keep-in-conversation"] })
+  })
+
+  it("survives the drawer's grouping pass as the first two entries (message-action-drawer renders groupVisibleActions)", () => {
+    const items = groupVisibleActions(getVisibleActions(settlingCtx))
+
+    expect(items.slice(0, 2)).toEqual([
+      { kind: "single", action: expect.objectContaining({ id: "keep-in-conversation" }) },
+      { kind: "single", action: expect.objectContaining({ id: "not-this-topic" }) },
+    ])
+  })
+
+  it("invokes its handler (the drawer/menu action path)", () => {
+    const onKeepInConversation = vi.fn()
+    const ctx = createContext({ onKeepInConversation })
+    const action = messageActions.find((a) => a.id === "keep-in-conversation")!
+
+    action.action?.(ctx)
+
+    expect(onKeepInConversation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -23,6 +23,7 @@ import {
   PanelRight,
   GitBranch,
   FolderInput,
+  Check,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -119,6 +120,18 @@ export interface MessageActionContext {
    * conversation panel), and only when the row has somewhere to go.
    */
   onMoveToSubtopic?: () => void
+  /**
+   * Confirm the extractor's provisional placement — the message stays put and
+   * the settling mark fades. Set only by conversation surfaces for rows still
+   * settling.
+   */
+  onKeepInConversation?: () => void
+  /**
+   * Reject the provisional placement: opens the same re-file picker as
+   * `onMoveToSubtopic`. Set only by conversation surfaces for rows still
+   * settling, and only when the row has somewhere to go.
+   */
+  onNotThisTopic?: () => void
   /**
    * Share-to-root fast path: queue a pointer share into the top-level non-thread
    * ancestor (channel/dm/scratchpad) and navigate there. Always preferred over
@@ -311,6 +324,23 @@ async function copyToClipboard(text: string): Promise<void> {
 }
 
 export const messageActions: MessageAction[] = [
+  {
+    // The settling pair, first so they land at the top of the long-press drawer
+    // and the overflow menu — a provisional placement is the one thing the row
+    // is asking about. Both handlers are set only on a still-settling row.
+    id: "keep-in-conversation",
+    label: "Keep here",
+    icon: Check,
+    when: (ctx) => !!ctx.onKeepInConversation,
+    action: (ctx) => ctx.onKeepInConversation?.(),
+  },
+  {
+    id: "not-this-topic",
+    label: "Not this topic…",
+    icon: FolderInput,
+    when: (ctx) => !!ctx.onNotThisTopic,
+    action: (ctx) => ctx.onNotThisTopic?.(),
+  },
   {
     // Board card / conversation panel / label page → the message's home
     // stream. Gated on `viewInStream`, which only those out-of-stream surfaces

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -73,6 +73,7 @@ export interface ConversationService {
   markRead: typeof conversationsApi.markRead
   markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
+  settleMessage: typeof conversationsApi.settleMessage
   reassignMessages: typeof conversationsApi.reassignMessages
   proposeSplit: typeof conversationsApi.proposeSplit
   applySplit: typeof conversationsApi.applySplit

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -15,6 +15,7 @@ import {
   useConversations,
   useCreateBoardPost,
   useReplyToBoardPost,
+  useSettleConversationMessage,
   planBoardReply,
   conversationKeys,
 } from "./use-conversations"
@@ -618,5 +619,71 @@ describe("useReplyToBoardPost", () => {
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
     )
+  })
+})
+
+describe("useSettleConversationMessage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("merges the confirmed aggregate and the shrunken settling set into the list cache, the board store and the by-id post", async () => {
+    const conversation = makeConversation("conv_1")
+    const settleMessage = vi.fn().mockResolvedValue({
+      conversation,
+      previousConversation: null,
+      settlingMessageIds: ["m_2"],
+    })
+    vi.spyOn(contextsModule, "useConversationService").mockReturnValue({
+      settleMessage,
+    } as unknown as contextsModule.ConversationService)
+    const merge = vi.spyOn(boardStoreModule, "mergeBoardConversation").mockResolvedValue(true)
+
+    const { queryClient, wrapper } = createWrapper()
+    queryClient.setQueryData(conversationKeys.list(WORKSPACE_ID, STREAM_ID, {}), [
+      makeConversation("conv_0"),
+      { id: "conv_1", topicSummary: "stale" } as unknown as ConversationWithStaleness,
+    ])
+    queryClient.setQueryData(conversationKeys.boardPost("conv_1"), {
+      conversation: { id: "conv_1", topicSummary: "stale" },
+      settlingMessageIds: ["m_1", "m_2"],
+      recentMessages: [],
+    })
+
+    const { result } = renderHook(() => useSettleConversationMessage(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ messageId: "m_1", conversationId: "conv_1" })
+    })
+
+    expect(settleMessage).toHaveBeenCalledWith(WORKSPACE_ID, "conv_1", "m_1")
+    expect(merge).toHaveBeenCalledWith("conv_1", conversation, ["m_2"])
+    expect(queryClient.getQueryData(conversationKeys.list(WORKSPACE_ID, STREAM_ID, {}))).toEqual([
+      makeConversation("conv_0"),
+      conversation,
+    ])
+    expect(queryClient.getQueryData(conversationKeys.boardPost("conv_1"))).toEqual({
+      conversation,
+      settlingMessageIds: ["m_2"],
+      recentMessages: [],
+    })
+  })
+
+  it("leaves an uncached by-id post uncached rather than seeding a partial row", async () => {
+    vi.spyOn(contextsModule, "useConversationService").mockReturnValue({
+      settleMessage: vi.fn().mockResolvedValue({
+        conversation: makeConversation("conv_1"),
+        previousConversation: null,
+        settlingMessageIds: [],
+      }),
+    } as unknown as contextsModule.ConversationService)
+    vi.spyOn(boardStoreModule, "mergeBoardConversation").mockResolvedValue(true)
+
+    const { queryClient, wrapper } = createWrapper()
+    const { result } = renderHook(() => useSettleConversationMessage(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ messageId: "m_1", conversationId: "conv_1" })
+    })
+
+    expect(queryClient.getQueryData(conversationKeys.boardPost("conv_1"))).toBeUndefined()
   })
 })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -719,6 +719,37 @@ export function useReassignConversationMessage(workspaceId: string, streamId: st
 }
 
 /**
+ * The confirm half of the settling pair: "Keep here" settles the row where it
+ * already sits. Nothing moves, so only the settling set changes — the returned
+ * aggregate and set are written into the list cache, the board store and the
+ * by-id post cache so the mark fades on the response rather than the socket
+ * echo (which then lands as an idempotent overwrite). Success is silent
+ * (INV-63): the mark fading IS the confirmation.
+ */
+export function useSettleConversationMessage(workspaceId: string, streamId: string) {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ messageId, conversationId }: { messageId: string; conversationId: string }) =>
+      conversationService.settleMessage(workspaceId, conversationId, messageId),
+    onSuccess: ({ conversation, settlingMessageIds }) => {
+      queryClient.setQueryData(
+        conversationKeys.list(workspaceId, streamId, {}),
+        (old: ConversationWithStaleness[] | undefined) => old?.map((c) => (c.id === conversation.id ? conversation : c))
+      )
+      void mergeBoardConversation(conversation.id, conversation, settlingMessageIds)
+      const boardPostKey = conversationKeys.boardPost(conversation.id)
+      if (queryClient.getQueryData(boardPostKey)) {
+        queryClient.setQueryData<BoardPost>(boardPostKey, (prev) =>
+          prev ? { ...prev, conversation, settlingMessageIds } : prev
+        )
+      }
+    },
+  })
+}
+
+/**
  * Batch counterpart of {@link useReassignConversationMessage}: reassign a set of
  * selected messages to another conversation, or split them into a new one
  * (`targetConversationId` omitted). The response carries the destination and

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -34,15 +34,21 @@ function toCached(workspaceId: string, post: BoardPost, status?: "pending"): Cac
  * without a refetch. Returns `undefined` until the first IDB read resolves
  * (loading), `[]` when the store is genuinely empty.
  */
-export function useBoardPosts(workspaceId: string): CachedBoardPost[] | undefined {
+export function useBoardPosts(workspaceId: string, opts?: { enabled?: boolean }): CachedBoardPost[] | undefined {
+  const enabled = opts?.enabled ?? true
   return useLiveQuery(
+    // A disabled querier touches no table, so it registers no Dexie
+    // subscription and never re-fires on board writes — callers that read the
+    // feed conditionally (per-card sibling pickers) pay nothing when off.
     () =>
-      db.conversations
-        .where("[workspaceId+_lastActivityMs]")
-        .between([workspaceId, Dexie.minKey], [workspaceId, Dexie.maxKey])
-        .reverse()
-        .toArray(),
-    [workspaceId]
+      enabled
+        ? db.conversations
+            .where("[workspaceId+_lastActivityMs]")
+            .between([workspaceId, Dexie.minKey], [workspaceId, Dexie.maxKey])
+            .reverse()
+            .toArray()
+        : [],
+    [workspaceId, enabled]
   )
 }
 


### PR DESCRIPTION
## Problem

Final chunk of the settling stack ([plan](https://seer.build/ws_vbyzjvdg6g/b/settling-stack-plan-c8dbe8/)): the explicit affordance on settling rows — Kris's design-3 ruling: actions live in the existing menus, leftmost on desktop hover, high in the long-press drawer, nothing new floating. Ground truth: prod shows ~4.5 human corrections/day vs 2 LLM re-cuts/week, so this chip is the settling model's workhorse.

## Solution

- `POST …/conversations/:id/messages/:id/settle`: guards byte-parallel to `reassignMessage` (workspace 404 → `validateStreamAccess`, INV-62 thread→root, audited); in one transaction flips the row to `settled_by='user'`, writes a `from==to` `conversation_feedback` row — a confirmed keep is ground truth too, and the repo docstring now says so — and emits `conversation:updated` with the fresh settling set. Already-settled: 200, no feedback, no event; idempotent by construction. The from==to poisoning race is closed upstream: every path that moves a settling row moves membership in the same transaction, so a stale tap 404s instead of confirming the wrong conversation.
- Registry: `keep-in-conversation` ("Keep here", Check) and `not-this-topic` ("Not this topic…", FolderInput) inserted at the head — top of overflow menu and drawer by construction. Context callbacks set only for settling rows on board card + panel; `move-to-subtopic` suppressed on settling rows so the menu never shows the same dialog twice (review finding, falsification-tested).
- Toolbar: two compact buttons, leftmost inside the right-anchored hover chip — grows left, displaces nothing, settled rows byte-identical (INV-21). Success is silent; the mark fading is the confirmation (INV-63).
- **"Not this topic…" works where settling actually happens** (review finding): a settling message in a branch-less main conversation had zero move targets while the server accepts same-stream siblings. Settling rows widen the picker with cached same-stream conversations (newest-first, cap 8; the board cache may not hold every stream conversation — a picker, not an index).

## Test plan

- [x] Typecheck clean; frontend full 5452/5452; backend 4562 pass (22 pre-existing server-dependent); settle endpoint 6/6 integration on the real schema (INV-68, event content per INV-23); duplicate-entry and settled-row-unchanged assertions falsification-verified
- [ ] Browser pass (toolbar pixels, drawer order) in the whole-stack verification, next

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788054030&installation_model_id=20758&pr_number=1680&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1680&signature=6ec1596f8ff195e5056d9f0d17f82b6bc5c70cada64f9901de1834a89b117770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->