### PR TITLE
fix(frontend): give every memo-embed card state the same geometry

### DIFF
--- a/apps/frontend/src/components/memo-embed/card-body.test.tsx
+++ b/apps/frontend/src/components/memo-embed/card-body.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render } from "@testing-library/react"
+import * as hooksModule from "@/hooks"
+import { formatDisplayDate, formatFullDateTime, formatRelativeTime, formatTime } from "@/lib/dates"
+import { MemoEmbedCardBody, MemoEmbedDate } from "./card-body"
+import type { MemoEmbedSource } from "@/hooks/use-memo-embed-source"
+
+const RESOLVED: MemoEmbedSource = {
+  status: "resolved",
+  title: "Switched theme to light",
+  knowledgeType: "decision",
+  memoType: "conversation",
+  tags: ["settings", "preferences", "dropped"],
+  createdAt: "2026-07-01T10:00:00.000Z",
+  updatedAt: "2026-07-02T10:00:00.000Z",
+}
+const PENDING: MemoEmbedSource = { status: "pending" }
+const MISSING: MemoEmbedSource = { status: "missing" }
+
+function renderCard(source: MemoEmbedSource) {
+  const { container } = render(
+    <MemoEmbedCardBody source={source} fallbackTitle="Theme switch" trailing={<MemoEmbedDate source={source} />} />
+  )
+  const title = container.querySelector("p")
+  if (!title) throw new Error("card has no title element")
+  const eyebrow = title.previousElementSibling
+  if (!eyebrow) throw new Error("card has no eyebrow row above its title")
+  return { container, title, eyebrow }
+}
+
+describe("MemoEmbedCardBody", () => {
+  // The resolved state renders `RelativeTime`, which reads the workspace
+  // preferences context. Scoped spy, per INV-48.
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(hooksModule, "useFormattedDate").mockReturnValue({
+      formatDate: (date: Date) => formatDisplayDate(date),
+      formatTime: (date: Date) => formatTime(date),
+      formatRelative: (date: Date, now?: Date) => formatRelativeTime(date, now),
+      formatFull: (date: Date) => formatFullDateTime(date),
+    } as unknown as ReturnType<typeof hooksModule.useFormattedDate>)
+  })
+
+  // The defect: the card grew when its fetch landed. Every state has to reserve
+  // the same boxes. jsdom cannot measure them (see tests/browser for the height
+  // assertions) — what it can prove is that no state skips the reservation.
+  it.each([
+    ["resolved", RESOLVED],
+    ["pending", PENDING],
+    ["missing", MISSING],
+  ] as const)("reserves the eyebrow line and both title lines while %s", (_name, source) => {
+    const { title, eyebrow } = renderCard(source)
+
+    expect(eyebrow.className).toContain("h-4")
+    expect(title.className).toContain("min-h-[2.375rem]")
+    expect(title.className).toContain("line-clamp-2")
+  })
+
+  it("renders the date slot in every state, with a time only once resolved", () => {
+    const slotOf = (source: MemoEmbedSource) => {
+      const { container } = render(<MemoEmbedDate source={source} />)
+      return container.firstElementChild
+    }
+
+    expect(slotOf(PENDING)?.className).toContain("w-14")
+    expect(slotOf(MISSING)?.className).toContain("w-14")
+    expect(slotOf(PENDING)?.textContent).toBe("")
+    expect(slotOf(MISSING)?.textContent).toBe("")
+    expect(slotOf(RESOLVED)?.textContent).not.toBe("")
+  })
+
+  // The unavailable notice used to hang below the title as a third line, which
+  // made `missing` taller than every other state.
+  it("puts the unavailable notice in the eyebrow line, not below the title", () => {
+    const { title, eyebrow } = renderCard(MISSING)
+
+    expect(eyebrow.textContent).toContain("Memo no longer available")
+    expect(title.textContent).toBe("Theme switch")
+    expect(title.nextElementSibling).toBeNull()
+  })
+
+  it("shows the reference's own label until the memo resolves, then the memo's", () => {
+    expect(renderCard(PENDING).title.textContent).toBe("Theme switch")
+    expect(renderCard(RESOLVED).title.textContent).toBe("Switched theme to light")
+  })
+
+  it("shows the knowledge type and at most two tags once resolved", () => {
+    const { eyebrow } = renderCard(RESOLVED)
+
+    // Lowercased in CSS, so the DOM text keeps the config's own casing.
+    expect(eyebrow.textContent).toMatch(/decision/i)
+    expect(eyebrow.textContent).toContain("settings")
+    expect(eyebrow.textContent).toContain("preferences")
+    expect(eyebrow.textContent).not.toContain("dropped")
+  })
+})

--- a/apps/frontend/src/components/memo-embed/card-body.tsx
+++ b/apps/frontend/src/components/memo-embed/card-body.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode } from "react"
 import { Hash } from "lucide-react"
-import { Skeleton } from "@/components/ui/skeleton"
 import { RelativeTime } from "@/components/relative-time"
 import { getKnowledgeConfig } from "@/lib/memo-display"
 import { cn } from "@/lib/utils"
@@ -8,89 +7,94 @@ import type { MemoEmbedSource } from "@/hooks/use-memo-embed-source"
 
 /**
  * Body renderer for the memo-embed preview card (`MemoEmbedBlock`), rendered
- * below a message for each referenced memo. Shows the gold-accent icon +
- * eyebrow + title for each `MemoEmbedSource` status. `trailing` is the top-right
- * slot, used for the memo's date.
+ * below a message for each referenced memo.
  *
- * `fallbackTitle` is the pre-hydration label parsed from the reference so the
- * card reads sensibly before the live memo resolves.
+ * Every status renders the SAME three boxes — eyebrow line, title block, date
+ * slot — at the same size, so the card's geometry never depends on whether the
+ * memo has resolved (INV-21). Only their contents differ. This is load-bearing:
+ * the card used to be a line shorter until its fetch landed, so two of them
+ * above the fold pushed the whole timeline down on first paint.
+ *
+ * The three sizes are pinned in rem rather than left to `text-*` defaults so the
+ * arithmetic is exact — a one-line title reserving 2.375rem and a two-line title
+ * at 2 x 1.1875rem are the same number, not the same number give or take a
+ * subpixel.
  */
+const EYEBROW_ROW = "flex h-4 min-w-0 items-center gap-1.5 text-[11px] leading-4 text-muted-foreground"
+const TITLE_BLOCK = "mt-0.5 line-clamp-2 min-h-[2.375rem] font-medium leading-[1.1875rem]"
+/** Wide enough for the widest terse relative time ("yesterday", "Jan 15, 25"). */
+const DATE_SLOT = "mt-0.5 w-14 shrink-0 text-right text-[10px] leading-4 tabular-nums text-muted-foreground/70"
+
+const ICON_TONE: Record<MemoEmbedSource["status"], string> = {
+  resolved: "text-primary",
+  pending: "text-primary/60",
+  missing: "text-muted-foreground",
+}
+
 export function MemoEmbedCardBody({
   source,
   fallbackTitle,
   trailing,
 }: {
   source: MemoEmbedSource
+  /** Label parsed from the reference — what the card shows until the memo resolves. */
   fallbackTitle: string
   trailing?: ReactNode
 }) {
-  if (source.status === "missing") {
-    return (
-      <Row
-        icon={<Hash className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />}
-        trailing={trailing}
-      >
-        <p className="font-medium leading-snug text-foreground/80 line-clamp-2">{fallbackTitle || "Memo"}</p>
-        <p className="mt-0.5 text-xs italic text-muted-foreground">Memo no longer available</p>
-      </Row>
-    )
-  }
+  const resolved = source.status === "resolved" ? source : null
+  const Icon = resolved ? getKnowledgeConfig(resolved.knowledgeType).icon : Hash
 
-  if (source.status === "pending") {
-    return (
-      <Row icon={<Hash className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" aria-hidden="true" />} trailing={trailing}>
-        {source.showSkeleton ? (
-          <>
-            <Skeleton className="h-3 w-20" />
-            <Skeleton className="mt-1.5 h-3.5 w-48" />
-          </>
-        ) : (
-          // Before the staggered-skeleton threshold, render the cached title so
-          // the fast path (memo resolves within 300ms) doesn't flash a loader.
-          <p className="font-medium leading-snug text-foreground line-clamp-2">{fallbackTitle || "Memo"}</p>
-        )}
-      </Row>
-    )
-  }
-
-  const config = getKnowledgeConfig(source.knowledgeType)
-  const Icon = config.icon
-  const tags = source.tags.slice(0, 2)
-
-  return (
-    <Row icon={<Icon className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />} trailing={trailing}>
-      <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-        <span className="font-medium lowercase text-primary/90">{config.label}</span>
-        {tags.map((tag) => (
-          <span key={tag} className="inline-flex min-w-0 items-center gap-0.5 text-muted-foreground/70">
-            <Hash className="h-2.5 w-2.5 shrink-0" />
-            <span className="truncate lowercase">{tag}</span>
-          </span>
-        ))}
-      </div>
-      <p className="mt-0.5 font-medium leading-snug text-foreground line-clamp-2">{source.title || fallbackTitle}</p>
-    </Row>
-  )
-}
-
-function Row({ icon, trailing, children }: { icon: ReactNode; trailing?: ReactNode; children: ReactNode }) {
   return (
     <div className="flex min-w-0 items-start gap-2.5">
-      {icon}
-      <div className="min-w-0 flex-1">{children}</div>
+      <Icon className={cn("mt-0.5 h-4 w-4 shrink-0", ICON_TONE[source.status])} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className={EYEBROW_ROW}>
+          <Eyebrow source={source} />
+        </div>
+        <p className={cn(TITLE_BLOCK, source.status === "missing" ? "text-foreground/80" : "text-foreground")}>
+          {resolved?.title || fallbackTitle || "Memo"}
+        </p>
+      </div>
       {trailing}
     </div>
   )
 }
 
-/** The memo's date for the display-block trailing slot. */
-export function MemoEmbedDate({ source }: { source: MemoEmbedSource }) {
-  if (source.status !== "resolved") return null
+/**
+ * Contents of the eyebrow line. A pending card leaves it empty rather than
+ * showing a loader: the row already holds its height, so a skeleton would only
+ * add a flash to a card that is not moving.
+ */
+function Eyebrow({ source }: { source: MemoEmbedSource }) {
+  if (source.status === "missing") {
+    return <span className="truncate italic">Memo no longer available</span>
+  }
+  if (source.status === "pending") return null
+
+  const config = getKnowledgeConfig(source.knowledgeType)
   return (
-    <RelativeTime
-      date={source.updatedAt}
-      terse
-      className={cn("mt-0.5 shrink-0 text-[10px] tabular-nums text-muted-foreground/70")}
-    />
+    <>
+      <span className="font-medium lowercase text-primary/90">{config.label}</span>
+      {source.tags.slice(0, 2).map((tag) => (
+        <span key={tag} className="inline-flex min-w-0 items-center gap-0.5 text-muted-foreground/70">
+          <Hash className="h-2.5 w-2.5 shrink-0" />
+          <span className="truncate lowercase">{tag}</span>
+        </span>
+      ))}
+    </>
+  )
+}
+
+/**
+ * The memo's date for the display-block trailing slot. The slot is always
+ * rendered at a fixed width, empty until the memo resolves — otherwise the
+ * title's available width changes when the date arrives and the text reflows
+ * under the reader.
+ */
+export function MemoEmbedDate({ source }: { source: MemoEmbedSource }) {
+  return (
+    <div className={DATE_SLOT}>
+      {source.status === "resolved" ? <RelativeTime date={source.updatedAt} terse /> : null}
+    </div>
   )
 }

--- a/apps/frontend/src/hooks/use-memo-embed-source.ts
+++ b/apps/frontend/src/hooks/use-memo-embed-source.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo } from "react"
 import { useParams } from "react-router-dom"
 import type { KnowledgeType, MemoType } from "@threa/types"
 import { useMemoDetail } from "./use-memos"
@@ -23,20 +23,18 @@ export interface MemoEmbedMissing {
 }
 
 export interface MemoEmbedPending {
-  /** Still resolving. UI stays blank until the staggered-skeleton delay. */
+  /** Still resolving. The card renders the label it already has, at full size. */
   status: "pending"
-  /** Becomes true once the staggered-skeleton delay has elapsed. */
-  showSkeleton: boolean
 }
 
 export type MemoEmbedSource = MemoEmbedResolved | MemoEmbedMissing | MemoEmbedPending
 
-const SKELETON_DELAY_MS = 300
-
 /**
- * Resolve a memo-embed pointer's card content from the memo detail API, with
- * the same staggered-skeleton semantics as `useSharedMessageSource`: stay blank
- * until 300ms, then show a skeleton, so the common fast path doesn't flicker.
+ * Resolve a memo-embed pointer's card content from the memo detail API.
+ *
+ * There is no loading state to stagger: `MemoEmbedCardBody` gives every status
+ * the same geometry and falls back to the title parsed from the reference, so a
+ * pending card is a complete card with a thinner eyebrow, not a placeholder.
  *
  * The viewer's read access is enforced server-side — the detail endpoint 404s
  * for memos the viewer can't see, which surfaces here as `missing`.
@@ -45,7 +43,7 @@ export function useMemoEmbedSource(memoId: string): MemoEmbedSource {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const { data, isError } = useMemoDetail(workspaceId ?? "", memoId)
 
-  const resolved = useMemo<MemoEmbedSource | null>(() => {
+  return useMemo<MemoEmbedSource>(() => {
     const memo = data?.memo?.memo
     if (memo) {
       return {
@@ -59,23 +57,6 @@ export function useMemoEmbedSource(memoId: string): MemoEmbedSource {
       }
     }
     if (isError) return { status: "missing" }
-    return null
+    return { status: "pending" }
   }, [data, isError])
-
-  const [showSkeleton, setShowSkeleton] = useState(false)
-
-  useEffect(() => {
-    if (resolved) {
-      setShowSkeleton(false)
-      return
-    }
-    // Reset + restart the delay whenever the memo changes, so a new pointer
-    // doesn't inherit the previous one's elapsed skeleton timer.
-    setShowSkeleton(false)
-    const timer = setTimeout(() => setShowSkeleton(true), SKELETON_DELAY_MS)
-    return () => clearTimeout(timer)
-  }, [resolved, memoId])
-
-  if (resolved) return resolved
-  return { status: "pending", showSkeleton }
 }

--- a/tests/browser/memo-embed-card.spec.ts
+++ b/tests/browser/memo-embed-card.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect, type Page } from "@playwright/test"
+import { createChannel, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * The memo embed card's geometry, asserted in a real browser.
+ *
+ * This is the defect the suite exists for: the card used to be a line shorter
+ * until its detail fetch landed, so a message carrying two of them pushed the
+ * whole timeline down on first paint. jsdom has no layout engine and cannot
+ * measure a box, so a unit test can only check that the reserved classes are
+ * present — never that the result is the same height.
+ *
+ * The memo detail response is served from here rather than from a real memo:
+ * the claim under test is the card's geometry across `pending` / `resolved` /
+ * `missing`, and only a controlled response can hold a card in `pending` long
+ * enough to measure it.
+ */
+
+const RESOLVED_MEMO_ID = "memo_01SLOTRESOLVED"
+const MISSING_MEMO_ID = "memo_01SLOTMISSING"
+
+/** A resolved detail payload, shaped like `serializeMemoDetail`. */
+function memoDetail(memoId: string) {
+  const now = new Date().toISOString()
+  return {
+    memo: {
+      memo: {
+        id: memoId,
+        workspaceId: "ws_test",
+        memoType: "conversation",
+        sourceMessageId: null,
+        sourceConversationId: null,
+        // Long enough to take both title lines, so `resolved` is the TALLEST
+        // this card can be — the state every other one has to match.
+        title: "Switched the workspace theme to light and the timezone to Europe/Stockholm for the new region",
+        abstract: "",
+        keyPoints: [],
+        sourceMessageIds: [],
+        participantIds: [],
+        knowledgeType: "decision",
+        tags: ["settings", "preferences"],
+        parentMemoId: null,
+        status: "active",
+        version: 1,
+        revisionReason: null,
+        authoredByKind: "agent",
+        sourceSessionId: null,
+        scope: "workspace",
+        scopeUserId: null,
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+      },
+      distance: null,
+      sourceStream: null,
+      rootStream: null,
+      successorMemoId: null,
+      capturedByPersonaName: null,
+      sourceMessages: [],
+    },
+  }
+}
+
+function memoCards(page: Page) {
+  return page.locator('[data-type="memo-embed"]')
+}
+
+async function heightOf(page: Page, index: number): Promise<number> {
+  const box = await memoCards(page).nth(index).boundingBox()
+  if (!box) throw new Error(`memo card ${index} has no box`)
+  return box.height
+}
+
+/** The title's own box — proves the date slot doesn't reflow the text beside it. */
+async function titleBoxOf(page: Page, index: number) {
+  return memoCards(page)
+    .nth(index)
+    .locator("p")
+    .first()
+    .evaluate((el) => {
+      const box = el.getBoundingClientRect()
+      return { width: Math.round(box.width), left: Math.round(box.left) }
+    })
+}
+
+test.describe("memo embed card geometry", () => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test("every state occupies the same box", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "memo-slots")
+    await createChannel(page, `memo-slots-${Date.now()}`)
+
+    const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+    if (!match) throw new Error(`no workspace/stream in URL: ${page.url()}`)
+    const [, workspaceId, streamId] = match
+
+    // The resolved memo is held until `release` fires, so the card can be
+    // measured while it is genuinely still pending.
+    let release: () => void = () => {}
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    await page.route(`**/api/workspaces/*/memos/${RESOLVED_MEMO_ID}`, async (route) => {
+      await held
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(memoDetail(RESOLVED_MEMO_ID)),
+      })
+    })
+    await page.route(`**/api/workspaces/*/memos/${MISSING_MEMO_ID}`, (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "NOT_FOUND" } }),
+      })
+    )
+
+    const post = (content: string) =>
+      page.request.post(`/api/workspaces/${workspaceId}/messages`, { data: { streamId, content } })
+
+    expect((await post(`Card one [Theme switch](memo:${RESOLVED_MEMO_ID})`)).ok()).toBeTruthy()
+    expect((await post(`Card two [Gone](memo:${MISSING_MEMO_ID})`)).ok()).toBeTruthy()
+
+    await expect(memoCards(page)).toHaveCount(2, { timeout: 30_000 })
+
+    // Pending: the first card's detail is still held.
+    const pendingHeight = await heightOf(page, 0)
+    const pendingTitle = await titleBoxOf(page, 0)
+
+    // Missing: the second card's detail already 404'd.
+    await expect(
+      memoCards(page)
+        .nth(1)
+        .getByText(/no longer available/i)
+    ).toBeVisible({ timeout: 15_000 })
+    const missingHeight = await heightOf(page, 1)
+
+    release()
+    await expect(
+      memoCards(page)
+        .nth(0)
+        .getByText(/decision/i)
+    ).toBeVisible({ timeout: 15_000 })
+    const resolvedHeight = await heightOf(page, 0)
+    const resolvedTitle = await titleBoxOf(page, 0)
+
+    // The whole point: resolving a memo must not change the card's height.
+    expect(resolvedHeight).toBe(pendingHeight)
+    expect(missingHeight).toBe(pendingHeight)
+
+    // And the date arriving must not reflow the title beside it.
+    expect(resolvedTitle).toEqual(pendingTitle)
+  })
+
+  test("a two-line title does not make the card taller than a one-line one", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "memo-slots-wrap")
+    await createChannel(page, `memo-slots-wrap-${Date.now()}`)
+    await page.setViewportSize({ width: 390, height: 900 })
+
+    const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+    if (!match) throw new Error(`no workspace/stream in URL: ${page.url()}`)
+    const [, workspaceId, streamId] = match
+
+    await page.route(`**/api/workspaces/*/memos/${MISSING_MEMO_ID}`, (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "NOT_FOUND" } }),
+      })
+    )
+
+    const post = (content: string) =>
+      page.request.post(`/api/workspaces/${workspaceId}/messages`, { data: { streamId, content } })
+
+    // Same memo id, so both cards land in the same `missing` state — the only
+    // difference is the label length, which is what must not move the box.
+    expect((await post(`Short [Auth](memo:${MISSING_MEMO_ID})`)).ok()).toBeTruthy()
+    expect(
+      (
+        await post(
+          `Long [A considerably longer memo label that has to wrap onto a second line on a narrow phone viewport](memo:${MISSING_MEMO_ID})`
+        )
+      ).ok()
+    ).toBeTruthy()
+
+    await expect(memoCards(page)).toHaveCount(2, { timeout: 30_000 })
+    await expect(
+      memoCards(page)
+        .nth(1)
+        .getByText(/no longer available/i)
+    ).toBeVisible({ timeout: 15_000 })
+
+    expect(await heightOf(page, 1)).toBe(await heightOf(page, 0))
+  })
+})


### PR DESCRIPTION
## Problem

Memo embed cards change height when their detail fetch lands, so a message carrying them pushes the rest of the timeline down on first paint. Reported from staging with a video; a `layout-shift` PerformanceObserver on a cold reload confirmed the card, not the neighbouring agent-effect grid.

`MemoEmbedCardBody` rendered three different heights for one card: the title alone for the first 300ms, two skeleton bars after `SKELETON_DELAY_MS`, then the resolved layout — which adds an eyebrow row (knowledge type + up to two tags) *and* a trailing date that `MemoEmbedDate` returned `null` for in every other state. A slow fetch grew the card twice. The `missing` state was off-height in a fourth way, hanging "Memo no longer available" below the title as a third line.

## Solution

Every status renders the same three boxes — eyebrow line, title block, date slot — and only their contents differ (INV-21). Nothing about the card's size depends on whether the memo resolved.

- **Sizes pinned in rem, not inherited.** `h-4`/`leading-4` on the eyebrow, and a title block of `min-h-[2.375rem]` against `leading-[1.1875rem]`, so one line and two lines are the *same* number rather than the same number ±a subpixel. `line-clamp-2` already caps the top.
- **The unavailable notice moves into the eyebrow.** Kept below the title it stayed a third line, which is why `missing` was taller than everything else.
- **The date slot is always mounted at a fixed width** (`w-14`, sized for the widest terse relative time — "yesterday", "Jan 15, 25"). Empty until resolved. Rendering `null` changed the title's available width when the date arrived and reflowed the text sideways even though the height held.
- **The staggered skeleton is deleted**, along with `SKELETON_DELAY_MS` and its timer. With the geometry fixed there is nothing to stagger: a pending card is a complete card showing the label parsed from the reference, so the skeleton could only add a flash to a card that is not moving.

Reserving the slot removes the jump; it does **not** remove the per-card fetch. Doing that means the summary rides the message payload, which is a separate and much larger piece — scoped, adversarially reviewed by Claude Fable 5 and GPT-5.6 Sol, and not started. The card body is the surface it will land on either way.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/memo-embed/card-body.tsx` | one layout for all four states; notice into the eyebrow; permanent date slot |
| `apps/frontend/src/hooks/use-memo-embed-source.ts` | skeleton delay and `showSkeleton` deleted |
| `apps/frontend/src/components/memo-embed/card-body.test.tsx` | **new** — every state reserves the boxes; notice placement; label fallback |
| `tests/browser/memo-embed-card.spec.ts` | **new** — the height claims, measured in a real browser |

## Test plan

- [x] `apps/frontend` vitest — **5458 pass / 0 fail** (whole suite) · `bun run typecheck` 0 · `bun run lint` 0
- [x] **Playwright `memo-embed-card.spec.ts` — 2 pass**, driving `pending` (detail response held open), `resolved` and `missing` against a real stack
- [x] **Mutation-checked, including the neutralisation itself.** Dropping `min-h-[2.375rem]` reddens the browser test at `expect(resolvedHeight).toBe(pendingHeight)` — received **74**, expected **55**, the one-line delta this PR exists to remove — and reddens three unit cases. Moving the unavailable notice back below the title reddens the placement test. A first attempt (rendering the eyebrow only when resolved) reddened the spec at a *visibility precondition* instead of the height assertion, which proves nothing about the geometry; it was replaced with the mutation above.
- [ ] Not covered: the card still fetches per render, so a memo that resolves in a stream you opened cold still round-trips. Out of scope here by design — the jump is what this PR fixes.

Known neighbour, untouched: `shared-messages/card-body.tsx` carries the same staggered-skeleton pattern on a different embed type.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788087970&installation_model_id=20758&pr_number=1681&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1681&signature=41ede409fdf6b5d2178426e180ae0c46f7cf06ac4cba81a2e63dcad844347cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->