### PR TITLE
feat(board): cold load lands at top — seed-gated first commit

### DIFF
--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -807,7 +807,7 @@ describe("useStableBoardView seed gate", () => {
   it("holds the stale feed until the seeded rows LAND in the feed, not merely until the query settles", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
-      initialProps: { seed: { settled: false, newestId: "conv_fresh" } },
+      initialProps: { seed: { settled: false, newest: { id: "conv_fresh", activityMs: 900 } } },
     })
     expect(result.current.posts).toEqual([])
     expect(result.current.isLoading).toBe(true)
@@ -816,14 +816,34 @@ describe("useStableBoardView seed gate", () => {
 
     // Query settled, but the un-awaited bulkPut + liveQuery re-emission haven't
     // landed yet: the feed is still last session's. Committing here is the bug.
-    rerender({ seed: { settled: true, newestId: "conv_fresh" } })
+    rerender({ seed: { settled: true, newest: { id: "conv_fresh", activityMs: 900 } } })
     expect(result.current.posts).toEqual([])
     expect(result.current.isLoading).toBe(true)
     expect(result.current.newCount).toBe(0)
 
     act(() => mockLive(feed(post("conv_fresh", 900), post("a", 300), post("b", 200))))
-    rerender({ seed: { settled: true, newestId: "conv_fresh" } })
+    rerender({ seed: { settled: true, newest: { id: "conv_fresh", activityMs: 900 } } })
     expect(result.current.posts.map((p) => p.id)).toEqual(["conv_fresh", "a", "b"])
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("holds when the seed's newest is a reply to an ALREADY-CACHED conversation, until its bumped activity lands", () => {
+    // Stale IDB: Y exists at its old activity. The workspace's newest activity is
+    // a reply to Y, so the seed's newest id is already present — id-presence alone
+    // would open the gate on the stale order.
+    mockLive(feed(post("x", 400), post("y", 200)))
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
+      initialProps: { seed: { settled: true, newest: { id: "y", activityMs: 900 } } },
+    })
+    expect(result.current.posts).toEqual([])
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.newCount).toBe(0)
+
+    // The bulkPut lands: y carries the bumped activity.
+    act(() => mockLive(feed(post("y", 900), post("x", 400))))
+    rerender({ seed: { settled: true, newest: { id: "y", activityMs: 900 } } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["y", "x"])
     expect(result.current.newCount).toBe(0)
     expect(result.current.isLoading).toBe(false)
   })
@@ -831,12 +851,12 @@ describe("useStableBoardView seed gate", () => {
   it("the offline/timeout escape hatch commits what it has, and buffers arrivals after it", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
-      initialProps: { seed: { settled: true, newestId: null } },
+      initialProps: { seed: { settled: true, newest: null } },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     act(() => mockLive(feed(post("fresh", 900), post("a", 300), post("b", 200))))
-    rerender({ seed: { settled: true, newestId: null } })
+    rerender({ seed: { settled: true, newest: null } })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
     expect(result.current.newCount).toBe(1)
   })
@@ -844,14 +864,14 @@ describe("useStableBoardView seed gate", () => {
   it("commits the LATEST live feed when the gate opens, not the snapshot it held", () => {
     mockLive(feed(post("a", 300)))
     const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
-      initialProps: { seed: { settled: false, newestId: "c" } },
+      initialProps: { seed: { settled: false, newest: { id: "c", activityMs: 500 } } },
     })
     act(() => mockLive(feed(post("b", 400))))
-    rerender({ seed: { settled: false, newestId: "c" } })
+    rerender({ seed: { settled: false, newest: { id: "c", activityMs: 500 } } })
     expect(result.current.posts).toEqual([])
 
     act(() => mockLive(feed(post("c", 500), post("b", 400))))
-    rerender({ seed: { settled: true, newestId: "c" } })
+    rerender({ seed: { settled: true, newest: { id: "c", activityMs: 500 } } })
     expect(result.current.posts.map((p) => p.id)).toEqual(["c", "b"])
     expect(result.current.newCount).toBe(0)
   })
@@ -859,12 +879,12 @@ describe("useStableBoardView seed gate", () => {
   it("a workspace switch re-arms the gate — the previous workspace's cached rows never commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(({ ws, seed }) => useStableBoardView(ws, ALL, undefined, seed), {
-      initialProps: { ws: "ws_1", seed: { settled: true, newestId: null } },
+      initialProps: { ws: "ws_1", seed: { settled: true, newest: null } },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     // ws_2's query is still loading; the liveQuery still returns ws_1's rows.
-    rerender({ ws: "ws_2", seed: { settled: false, newestId: null } })
+    rerender({ ws: "ws_2", seed: { settled: false, newest: null } })
     expect(result.current.posts).toEqual([])
     expect(result.current.isLoading).toBe(true)
     expect(result.current.newCount).toBe(0)
@@ -879,12 +899,12 @@ describe("useStableBoardView seed gate", () => {
     )
     const { result, rerender } = renderHook(
       ({ lens, seed }) => useStableBoardView("ws_1", lensFilter(lens), undefined, seed),
-      { initialProps: { lens: "all" as BoardLens, seed: { settled: true, newestId: null } as BoardSeedState } }
+      { initialProps: { lens: "all" as BoardLens, seed: { settled: true, newest: null } as BoardSeedState } }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["decided", "plain"])
 
     // The new lens's query is still fetching — the lens must still switch now.
-    rerender({ lens: "decisions" as BoardLens, seed: { settled: false, newestId: "x" } })
+    rerender({ lens: "decisions" as BoardLens, seed: { settled: false, newest: { id: "x", activityMs: 1 } } })
     expect(result.current.posts.map((p) => p.id)).toEqual(["decided"])
     expect(result.current.isLoading).toBe(false)
   })

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -9,6 +9,7 @@ import {
   useStableBoardView,
   type BoardExclusionState,
   type BoardViewFilter,
+  type BoardSeedState,
   type CommittedView,
 } from "./use-stable-board-view"
 
@@ -791,5 +792,107 @@ describe("useStableBoardView — unread filter", () => {
     // key, mirroring the label-scope re-resolution guarantee.
     rerender({ filter: unreadFilter(["stream_x", "stream_other"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+})
+
+describe("useStableBoardView seed gate", () => {
+  let liveValue: CachedBoardPost[] | undefined
+  function mockLive(value: CachedBoardPost[] | undefined) {
+    liveValue = value
+    vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
+  }
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("holds the stale feed until the seeded rows LAND in the feed, not merely until the query settles", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
+      initialProps: { seed: { settled: false, newestId: "conv_fresh" } },
+    })
+    expect(result.current.posts).toEqual([])
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.hasRawPosts).toBe(true)
+
+    // Query settled, but the un-awaited bulkPut + liveQuery re-emission haven't
+    // landed yet: the feed is still last session's. Committing here is the bug.
+    rerender({ seed: { settled: true, newestId: "conv_fresh" } })
+    expect(result.current.posts).toEqual([])
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.newCount).toBe(0)
+
+    act(() => mockLive(feed(post("conv_fresh", 900), post("a", 300), post("b", 200))))
+    rerender({ seed: { settled: true, newestId: "conv_fresh" } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["conv_fresh", "a", "b"])
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("the offline/timeout escape hatch commits what it has, and buffers arrivals after it", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
+      initialProps: { seed: { settled: true, newestId: null } },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    act(() => mockLive(feed(post("fresh", 900), post("a", 300), post("b", 200))))
+    rerender({ seed: { settled: true, newestId: null } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+    expect(result.current.newCount).toBe(1)
+  })
+
+  it("commits the LATEST live feed when the gate opens, not the snapshot it held", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
+      initialProps: { seed: { settled: false, newestId: "c" } },
+    })
+    act(() => mockLive(feed(post("b", 400))))
+    rerender({ seed: { settled: false, newestId: "c" } })
+    expect(result.current.posts).toEqual([])
+
+    act(() => mockLive(feed(post("c", 500), post("b", 400))))
+    rerender({ seed: { settled: true, newestId: "c" } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["c", "b"])
+    expect(result.current.newCount).toBe(0)
+  })
+
+  it("a workspace switch re-arms the gate — the previous workspace's cached rows never commit", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(({ ws, seed }) => useStableBoardView(ws, ALL, undefined, seed), {
+      initialProps: { ws: "ws_1", seed: { settled: true, newestId: null } },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    // ws_2's query is still loading; the liveQuery still returns ws_1's rows.
+    rerender({ ws: "ws_2", seed: { settled: false, newestId: null } })
+    expect(result.current.posts).toEqual([])
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.newCount).toBe(0)
+  })
+
+  it("commits a filter switch instantly once this workspace has committed (the gate is per-workspace)", () => {
+    mockLive(
+      feed(
+        lensPost("decided", 300, { hasCapturedMemo: true }),
+        lensPost("plain", 200, { status: "active", completenessScore: 5 })
+      )
+    )
+    const { result, rerender } = renderHook(
+      ({ lens, seed }) => useStableBoardView("ws_1", lensFilter(lens), undefined, seed),
+      { initialProps: { lens: "all" as BoardLens, seed: { settled: true, newestId: null } as BoardSeedState } }
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["decided", "plain"])
+
+    // The new lens's query is still fetching — the lens must still switch now.
+    rerender({ lens: "decisions" as BoardLens, seed: { settled: false, newestId: "x" } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["decided"])
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("no seed argument means no gating (existing call sites commit immediately)", () => {
+    mockLive(feed(post("a", 300)))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL))
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+    expect(result.current.isLoading).toBe(false)
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -133,16 +133,20 @@ const NO_EXCLUSIONS: BoardExclusionState = { hidden: new Map(), muted: new Set()
 
 /**
  * The network seed's state, as the board page knows it. `settled` is "the query
- * is no longer loading (or the escape-hatch timeout fired)"; `newestId` is the
- * newest conversation id the settled query returned, or null when there is
- * nothing to wait for (timeout, error, empty). The hook holds its first commit
- * until the seed has SETTLED *and* `newestId` is actually visible in the IDB
- * feed — the query settling only means the response arrived, while the rows land
- * one or more renders later through an un-awaited bulkPut + liveQuery re-emission.
+ * is no longer loading (or the escape-hatch timeout fired)"; `newest` is the
+ * newest conversation the settled query returned (id + its `lastActivityAt` in
+ * ms), or null when there is nothing to wait for (timeout, error, empty). The
+ * hook holds its first commit until the seed has SETTLED *and* that SNAPSHOT —
+ * not merely the id — is visible in the IDB feed: when the newest activity is a
+ * reply to an old conversation the id is already cached at its stale activity,
+ * so an id-presence check opens the gate before the bulkPut lands and commits
+ * the stale order. Matching the activity proves the seeded rows arrived (they
+ * land one or more renders later through an un-awaited bulkPut + liveQuery
+ * re-emission).
  */
 export interface BoardSeedState {
   settled: boolean
-  newestId: string | null
+  newest: { id: string; activityMs: number } | null
 }
 
 function matchesScope(post: CachedBoardPost, scope: BoardScope | null): boolean {
@@ -461,10 +465,13 @@ export function useStableBoardView(
   // Persisted IDB resolves in milliseconds, long before the network seed page
   // lands: committing then would freeze last session's feed and classify
   // everything created since as buffered ("N new" on a cold load).
+  const seedNewest = seed?.newest ?? null
   const seedLanded =
     seed !== undefined &&
     seed.settled &&
-    (seed.newestId === null || (rawLive?.some((post) => post.conversation.id === seed.newestId) ?? false))
+    (seedNewest === null ||
+      (rawLive?.some((post) => post.conversation.id === seedNewest.id && postMs(post) >= seedNewest.activityMs) ??
+        false))
   const holdingForSeed = seed !== undefined && !seedLanded && !hasCommittedForWorkspaceRef.current
   if (live && !holdingForSeed) {
     liveRef.current = live

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -131,6 +131,20 @@ export interface BoardExclusionState {
 
 const NO_EXCLUSIONS: BoardExclusionState = { hidden: new Map(), muted: new Set(), muteActive: true }
 
+/**
+ * The network seed's state, as the board page knows it. `settled` is "the query
+ * is no longer loading (or the escape-hatch timeout fired)"; `newestId` is the
+ * newest conversation id the settled query returned, or null when there is
+ * nothing to wait for (timeout, error, empty). The hook holds its first commit
+ * until the seed has SETTLED *and* `newestId` is actually visible in the IDB
+ * feed — the query settling only means the response arrived, while the rows land
+ * one or more renders later through an un-awaited bulkPut + liveQuery re-emission.
+ */
+export interface BoardSeedState {
+  settled: boolean
+  newestId: string | null
+}
+
 function matchesScope(post: CachedBoardPost, scope: BoardScope | null): boolean {
   if (!scope) return true
   // Cached rows predating `rootStreamId` fall back to the anchor itself — a
@@ -326,7 +340,8 @@ export interface StableBoardView {
 export function useStableBoardView(
   workspaceId: string,
   filter: BoardViewFilter,
-  exclusions: BoardExclusionState = NO_EXCLUSIONS
+  exclusions: BoardExclusionState = NO_EXCLUSIONS,
+  seed?: BoardSeedState
 ): StableBoardView {
   const { lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, unread, showArchived } = filter
   const { hidden, muted, muteActive } = exclusions
@@ -426,23 +441,47 @@ export function useStableBoardView(
     if (buffered.length > 0) setBuffered([])
   }
 
+  // The seed gate is per-WORKSPACE, not per-view: once this workspace has
+  // committed once, a lens/scope switch commits its new subset instantly even
+  // while that view's query is still fetching. Switching workspace re-arms the
+  // gate in the render phase, so the previous workspace's still-cached liveQuery
+  // rows can never commit into the new workspace's view.
+  const seedWorkspaceRef = useRef(workspaceId)
+  const hasCommittedForWorkspaceRef = useRef(false)
+  if (seedWorkspaceRef.current !== workspaceId) {
+    seedWorkspaceRef.current = workspaceId
+    hasCommittedForWorkspaceRef.current = false
+  }
+
   // Fold the live feed into the committed view during render (deriving state from
   // props/inputs, not an effect — the render reads `committed`/`buffered` below,
   // so an effect would paint one frame stale). `setState` during render bails out
   // and re-renders synchronously; the equality guards keep it from looping once
   // converged.
-  if (live) {
+  // Persisted IDB resolves in milliseconds, long before the network seed page
+  // lands: committing then would freeze last session's feed and classify
+  // everything created since as buffered ("N new" on a cold load).
+  const seedLanded =
+    seed !== undefined &&
+    seed.settled &&
+    (seed.newestId === null || (rawLive?.some((post) => post.conversation.id === seed.newestId) ?? false))
+  const holdingForSeed = seed !== undefined && !seedLanded && !hasCommittedForWorkspaceRef.current
+  if (live && !holdingForSeed) {
     liveRef.current = live
     for (const post of live) retainedRef.current.set(postId(post), post)
     // `reconcileStableView` reveals the viewer's own pending post (at top) and
     // paged-in older rows; everything else stays buffered behind the pill.
     const next = reconcileStableView(committedInput, live)
-    if (next.committed !== committedInput) setCommitted(next.committed)
+    if (next.committed !== committedInput) {
+      hasCommittedForWorkspaceRef.current = true
+      setCommitted(next.committed)
+    }
     if (!sameIds(bufferedInput, next.buffered)) setBuffered(next.buffered)
   }
 
   const commit = useCallback(() => {
     const snap = snapshot(liveRef.current)
+    hasCommittedForWorkspaceRef.current = true
     setCommitted(snap)
     setBuffered([])
     const keep = new Set(snap.order)
@@ -475,7 +514,7 @@ export function useStableBoardView(
     activityById: committed.activityById,
     newCount: buffered.length,
     commit,
-    isLoading: live === undefined,
+    isLoading: live === undefined || holdingForSeed,
     hasRawPosts: (rawLive?.length ?? 0) > 0,
   }
 }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -78,6 +78,8 @@ const SELF_POST_VISIBLE_LENSES = new Set<BoardLens>(["all", "mine"])
  *  anything the viewer sees. */
 const REVEAL_PREWARM_CARDS = 12
 
+const SEED_COMMIT_TIMEOUT_MS = 2500
+
 /** Empty-state copy per lens — an empty Decisions view isn't "nothing on the board". */
 const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {
   all: {
@@ -333,6 +335,28 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     () => ({ hidden, muted, muteActive: scopeStreamIds.length === 0 }),
     [hidden, muted, scopeStreamIds.length]
   )
+  // The seed gate: hold the board's first commit until the seeded rows are
+  // actually in IDB, so a cold load doesn't freeze last session's order and
+  // strand everything since behind an "N new" pill. The timeout is the offline
+  // escape hatch — `newestId: null` then means "commit whatever you have".
+  const [seedTimedOut, setSeedTimedOut] = useState(false)
+  const seedWorkspaceRef = useRef(workspaceId)
+  // A render-phase `setState` doesn't update this render's binding, so the
+  // switch render must read the local value, not `seedTimedOut`.
+  let timedOut = seedTimedOut
+  if (seedWorkspaceRef.current !== workspaceId) {
+    seedWorkspaceRef.current = workspaceId
+    timedOut = false
+    if (seedTimedOut) setSeedTimedOut(false)
+  }
+  useEffect(() => {
+    const timer = setTimeout(() => setSeedTimedOut(true), SEED_COMMIT_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [workspaceId])
+  const newestSeedId = data?.pages[0]?.posts[0]?.conversation.id ?? null
+  const seedSettled = !isLoading || timedOut
+  const seedNewestId = timedOut ? null : newestSeedId
+  const seed = useMemo(() => ({ settled: seedSettled, newestId: seedNewestId }), [seedSettled, seedNewestId])
   const {
     posts,
     activityById,
@@ -340,7 +364,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     commit,
     isLoading: viewLoading,
     hasRawPosts,
-  } = useStableBoardView(workspaceId, filter, exclusions)
+  } = useStableBoardView(workspaceId, filter, exclusions, seed)
   // After a refetch settles, `isLoading` is already false but the seed effect
   // writes IDB on the next tick, so the IDB feed can be momentarily empty while
   // the query already holds posts. Treat that window as loading so the feed

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -338,7 +338,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // The seed gate: hold the board's first commit until the seeded rows are
   // actually in IDB, so a cold load doesn't freeze last session's order and
   // strand everything since behind an "N new" pill. The timeout is the offline
-  // escape hatch — `newestId: null` then means "commit whatever you have".
+  // escape hatch — `newest: null` then means "commit whatever you have".
   const [seedTimedOut, setSeedTimedOut] = useState(false)
   const seedWorkspaceRef = useRef(workspaceId)
   // A render-phase `setState` doesn't update this render's binding, so the
@@ -353,10 +353,20 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     const timer = setTimeout(() => setSeedTimedOut(true), SEED_COMMIT_TIMEOUT_MS)
     return () => clearTimeout(timer)
   }, [workspaceId])
-  const newestSeedId = data?.pages[0]?.posts[0]?.conversation.id ?? null
+  const newestSeedPost = data?.pages[0]?.posts[0]
+  const newestSeedId = newestSeedPost?.conversation.id ?? null
+  const newestSeedActivityMs = newestSeedPost ? Date.parse(newestSeedPost.conversation.lastActivityAt) : null
   const seedSettled = !isLoading || timedOut
-  const seedNewestId = timedOut ? null : newestSeedId
-  const seed = useMemo(() => ({ settled: seedSettled, newestId: seedNewestId }), [seedSettled, seedNewestId])
+  const seed = useMemo(
+    () => ({
+      settled: seedSettled,
+      newest:
+        timedOut || newestSeedId === null || newestSeedActivityMs === null
+          ? null
+          : { id: newestSeedId, activityMs: newestSeedActivityMs },
+    }),
+    [seedSettled, timedOut, newestSeedId, newestSeedActivityMs]
+  )
   const {
     posts,
     activityById,


### PR DESCRIPTION
## Problem

A cold board load froze last session's IDB feed as the committed order: `db.conversations` resolves in milliseconds, so `useStableBoardView`'s wholesale-commit branch ran before the network seed page reached IDB, and everything created since the last visit classified as buffered — the board opened with a stale feed and an "N new" pill instead of landing at top (plan chunk 1, https://seer.build/ws_vbyzjvdg6g/b/board-stack-plan-105043/).

## Solution

Gate the first commit on the seed *provably landing in IDB*, not on the query settling.

- `useStableBoardView` takes `seed?: BoardSeedState { settled, newestId }`; it holds while `settled` is false or `newestId` is absent from the raw IDB feed. The query settling is one render too early — the seed effect's un-awaited `bulkPut` + Dexie liveQuery re-emission land later, so a settle-keyed gate re-ships the bug (caught by the adversarial verify; the first implementation had exactly that hole).
- The gate is per-workspace (`hasCommittedForWorkspaceRef`, render-phase reset): lens/filter switches keep committing instantly even mid-fetch; a workspace switch re-arms the hold in the same render, so the previous workspace's still-cached liveQuery rows can never commit into the new view.
- `SEED_COMMIT_TIMEOUT_MS = 2500` in `board.tsx` is the offline escape: commit what's local; later arrivals buffer behind the pill, which is the pill's designed meaning (arrived after you started looking).
- While holding, the hook reports loading, so the skeleton shows — the empty state is unreachable.
- Omitting `seed` means no gating (back-compat for non-board callers/tests).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | `BoardSeedState`, landed-check hold, per-workspace commit latch |
| `apps/frontend/src/pages/board.tsx` | seed state from the conversations query + timeout escape |
| `apps/frontend/src/hooks/use-stable-board-view.test.tsx` | seed-gate describe block (6 tests) |

## Test plan

- [x] Hook test file 52/52; full frontend suite 5457/5457; `tsc --noEmit` clean
- [x] Adversarial verify: 3 findings (settle-vs-land ordering 92, dead workspace reset 85, tests certifying the bug 84) — all fixed; decisive test verified red under a settled-only neutralization (1 failed/51 passed), restored green

## Owned tradeoffs

- A cold fetch slower than `SEED_COMMIT_TIMEOUT_MS` (2.5s) commits the local feed and the late seed buffers behind the pill — the original symptom, deliberately kept as the offline/slow escape rather than an unbounded skeleton.
- The board.tsx seed derivation (timer, render-phase switch reset) is covered at the hook level with hand-fed `BoardSeedState`; no page-level jsdom test.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088777&installation_model_id=20758&pr_number=1682&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1682&signature=61ac2b49182857209ce25405a74dc17c5e1ffffaa2683bbf51a35bc9cf2c63f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
