### PR TITLE
feat(board): staleness closure — reconnect reseed, archive/access propagation, merged-away stubs

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -65,6 +65,14 @@ interface BoardCardProps {
   scrollerRef?: RefObject<HTMLDivElement | null>
   /** virtua's imperative handle for the board feed, paired with `scrollerRef`. */
   listRef?: RefObject<VirtualizerHandle | null>
+  /**
+   * Render the card inert: the conversation it stands for is gone (merged away
+   * or emptied), so the content stays — the row keeps its exact footprint — but
+   * nothing in it is interactive, no composer opens, and auto-read never fires a
+   * read POST at a dead conversation. `BoardRemovedCard` owns the overlay that
+   * explains the state; this only makes the card underneath dead weight.
+   */
+  removed?: boolean
 }
 
 /** How many trailing messages a nested branch previews on a collapsed card; the
@@ -94,6 +102,7 @@ export function BoardCard({
   dmPeerUserId,
   scrollerRef,
   listRef,
+  removed = false,
 }: BoardCardProps) {
   const { conversation } = post
   const flash = useBoardFlash(conversation.id)
@@ -430,6 +439,7 @@ export function BoardCard({
     markRead: markReadSilently,
     registerExplicitUnread: setExplicitUnreadListener,
     getReadTruth,
+    disabled: removed,
   })
 
   // The card is a first-class reading surface (live message bodies, viewport
@@ -659,8 +669,10 @@ export function BoardCard({
           ref={cardRef}
           className={cn(
             "board-card-hover rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]",
-            flash && "board-post-flash"
+            flash && "board-post-flash",
+            removed && "pointer-events-none opacity-60"
           )}
+          aria-hidden={removed || undefined}
         >
           {/* Zero-height marker at the card top: drives the header's stuck state
               (see the observer above). In flow but h-0, so it shifts nothing. */}
@@ -807,6 +819,9 @@ export function BoardCard({
               )}
             </div>
 
+            {/* Rendered even when `removed`: the inert layer above kills interaction,
+                and dropping the composer would shrink the row — the live→removed swap
+                must hold the card's exact footprint. */}
             {!bodyCollapsed && (
               <BoardReplyComposer
                 workspaceId={workspaceId}

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -664,15 +664,18 @@ export function BoardCard({
         {/* Rest shadow lifts the card off the page — the light-mode card/bg
             lightness delta is ~1%, so the border alone left cards reading flat.
             Board-scoped; global tokens untouched. Dark leans on a deeper shadow
-            since the fill delta reads weakly on the charcoal canvas. */}
+            since the fill delta reads weakly on the charcoal canvas.
+            Removed cards use `inert`, not pointer-events-none + aria-hidden: only
+            inert also removes the card's buttons and composer from the tab order —
+            a keyboard user could otherwise focus into the dead conversation. */}
         <div
           ref={cardRef}
           className={cn(
             "board-card-hover rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]",
             flash && "board-post-flash",
-            removed && "pointer-events-none opacity-60"
+            removed && "opacity-60"
           )}
-          aria-hidden={removed || undefined}
+          inert={removed || undefined}
         >
           {/* Zero-height marker at the card top: drives the header's stuck state
               (see the observer above). In flow but h-0, so it shifts nothing. */}

--- a/apps/frontend/src/components/board/board-removed-card.test.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { BoardPostMessage } from "@threa/types"
+import { BoardRemovedCard } from "./board-removed-card"
+import type { BoardViewPost, RemovedSuccessor } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+import { __resetCollapseCacheForTests } from "@/lib/markdown/collapse-cache"
+// eslint-disable-next-line no-restricted-imports -- test clears IDB directly; the card reads the real rail path
+import { db } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+const STREAM = "stream_1"
+
+function opening(): BoardPostMessage {
+  return {
+    id: "m_open",
+    streamId: STREAM,
+    authorId: "usr_other",
+    authorType: "user",
+    contentMarkdown: "Opening body.",
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-06-22T12:00:00.000Z",
+    editedAt: null,
+  }
+}
+
+function ghostPost(): BoardViewPost {
+  return {
+    id: "conv_ghost",
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    conversation: {
+      id: "conv_ghost",
+      streamId: STREAM,
+      messageIds: ["m_open"],
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+    },
+    openingMessage: opening(),
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as BoardViewPost
+}
+
+function renderCard(successor: RemovedSuccessor | null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardRemovedCard
+                  workspaceId={WS}
+                  post={ghostPost()}
+                  contextLabel="#general"
+                  streamType="channel"
+                  successor={successor}
+                />
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(async () => {
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  __resetCollapseCacheForTests()
+  await db.events.clear()
+  await db.conversations.clear()
+  await db.streams.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn(),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() },
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardRemovedCard", () => {
+  it("keeps the retained card's content and links into the successor", () => {
+    renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
+
+    // The retained body still renders — the row holds its footprint.
+    expect(screen.getByText("Opening body.")).toBeTruthy()
+    expect(screen.getByText(/Merged into/)).toBeTruthy()
+    expect(screen.getByRole("link", { name: "Deploy plan" }).getAttribute("href")).toContain("panel=")
+  })
+
+  it("offers no interactive affordance but the successor link", () => {
+    renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
+
+    // The card underneath is aria-hidden + pointer-events-none, so the overlay's
+    // link is the ONLY reachable control: no card actions, no reply composer.
+    expect(screen.getAllByRole("link")).toHaveLength(1)
+    expect(screen.queryByRole("button")).toBeNull()
+    expect(screen.queryByRole("textbox")).toBeNull()
+  })
+
+  it("says the card is gone when nothing holds the opening message", () => {
+    renderCard(null)
+
+    expect(screen.getByText("No longer on your board.")).toBeTruthy()
+    expect(screen.queryByRole("link")).toBeNull()
+    expect(screen.queryByRole("button")).toBeNull()
+    expect(screen.queryByRole("textbox")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-removed-card.test.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.test.tsx
@@ -136,21 +136,29 @@ describe("BoardRemovedCard", () => {
   })
 
   it("offers no interactive affordance but the successor link", () => {
-    renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
+    const { container } = renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
 
-    // The card underneath is aria-hidden + pointer-events-none, so the overlay's
-    // link is the ONLY reachable control: no card actions, no reply composer.
-    expect(screen.getAllByRole("link")).toHaveLength(1)
-    expect(screen.queryByRole("button")).toBeNull()
-    expect(screen.queryByRole("textbox")).toBeNull()
+    // The card underneath is `inert` — out of the a11y tree AND the tab order
+    // (aria-hidden alone would satisfy role queries while leaving every button
+    // keyboard-reachable). jsdom implements neither inert focus nor its a11y
+    // pruning, so the contract asserted here is: the inert wrapper exists, and
+    // every interactive element except the successor link lives inside it.
+    const inert = container.querySelector("[inert]")
+    expect(inert).not.toBeNull()
+    const outside = (role: string) => screen.queryAllByRole(role).filter((el) => !inert!.contains(el))
+    expect(outside("link")).toHaveLength(1)
+    expect(outside("button")).toHaveLength(0)
+    expect(outside("textbox")).toHaveLength(0)
   })
 
   it("says the card is gone when nothing holds the opening message", () => {
-    renderCard(null)
+    const { container } = renderCard(null)
 
     expect(screen.getByText("No longer on your board.")).toBeTruthy()
-    expect(screen.queryByRole("link")).toBeNull()
-    expect(screen.queryByRole("button")).toBeNull()
-    expect(screen.queryByRole("textbox")).toBeNull()
+    const inert = container.querySelector("[inert]")
+    expect(inert).not.toBeNull()
+    for (const role of ["link", "button", "textbox"]) {
+      expect(screen.queryAllByRole(role).filter((el) => !inert!.contains(el))).toHaveLength(0)
+    }
   })
 })

--- a/apps/frontend/src/components/board/board-removed-card.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.tsx
@@ -43,20 +43,24 @@ export function BoardRemovedCard({
         dmPeerUserId={dmPeerUserId}
         removed
       />
-      <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-background/60 text-xs text-muted-foreground">
-        {successor ? (
-          <span>
-            Merged into{" "}
-            <Link
-              to={getPanelUrl(createConversationPanelId(successor.conversationId))}
-              className="font-medium text-foreground underline-offset-2 hover:underline"
-            >
-              {successor.topicSummary ?? "another conversation"}
-            </Link>
-          </span>
-        ) : (
-          <span>No longer on your board.</span>
-        )}
+      {/* Top-pinned + sticky: tall cards pin their own header to the viewport, so a
+          centered line — and the only successor link — could sit off-screen. */}
+      <div className="absolute inset-0 flex items-start justify-center rounded-xl bg-background/60 text-xs text-muted-foreground">
+        <div className="sticky top-2 py-2">
+          {successor ? (
+            <span>
+              Merged into{" "}
+              <Link
+                to={getPanelUrl(createConversationPanelId(successor.conversationId))}
+                className="font-medium text-foreground underline-offset-2 hover:underline"
+              >
+                {successor.topicSummary ?? "another conversation"}
+              </Link>
+            </span>
+          ) : (
+            <span>No longer on your board.</span>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/frontend/src/components/board/board-removed-card.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router-dom"
+import { BoardCard } from "@/components/board/board-card"
+import { usePanel, createConversationPanelId } from "@/contexts"
+import type { BoardViewPost, RemovedSuccessor } from "@/hooks/use-stable-board-view"
+
+interface BoardRemovedCardProps {
+  workspaceId: string
+  /** The last retained copy of the conversation whose row is gone. */
+  post: BoardViewPost
+  /** Where the post lived — the same header locator the live card renders. */
+  contextLabel: string
+  streamType: string | undefined
+  dmPeerUserId?: string | null
+  /** The conversation that now holds the opening message, or null when none does. */
+  successor: RemovedSuccessor | null
+}
+
+/**
+ * A committed card whose conversation left the store — merged into another
+ * conversation or emptied. The retained card still renders underneath at its
+ * exact height, so the swap shifts nothing below it (INV-21); it is inert
+ * (`removed`), so no reply composer opens and no read POST goes to a
+ * conversation that no longer exists. The overlay is the only live surface:
+ * it names where the content went. Pruned by the next commit.
+ */
+export function BoardRemovedCard({
+  workspaceId,
+  post,
+  contextLabel,
+  streamType,
+  dmPeerUserId,
+  successor,
+}: BoardRemovedCardProps) {
+  const { getPanelUrl } = usePanel()
+
+  return (
+    <div className="relative">
+      <BoardCard
+        workspaceId={workspaceId}
+        post={post}
+        contextLabel={contextLabel}
+        streamType={streamType}
+        dmPeerUserId={dmPeerUserId}
+        removed
+      />
+      <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-background/60 text-xs text-muted-foreground">
+        {successor ? (
+          <span>
+            Merged into{" "}
+            <Link
+              to={getPanelUrl(createConversationPanelId(successor.conversationId))}
+              className="font-medium text-foreground underline-offset-2 hover:underline"
+            >
+              {successor.topicSummary ?? "another conversation"}
+            </Link>
+          </span>
+        ) : (
+          <span>No longer on your board.</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -59,6 +59,10 @@ interface UseConversationAutoReadOptions {
    * overlay ids, diffed to catch a cross-device mark-unread. See the pin notes
    * on the hook doc for why this is raw truth and not derived row state. */
   getReadTruth: (streamId: string) => { lastReadSequence: string | null; readMessageIds: readonly string[] }
+  /** Mount the hook inert: no dwell observation and no mark-read, ever. For a
+   *  surface rendering a conversation that no longer exists (the board's
+   *  merged-away card), where a read POST would target a dead id. */
+  disabled?: boolean
 }
 
 /**
@@ -126,8 +130,11 @@ export function useConversationAutoRead({
   markRead,
   registerExplicitUnread,
   getReadTruth,
+  disabled = false,
 }: UseConversationAutoReadOptions): void {
-  const canAutoRead = useAutoReadAttention()
+  const canAutoRead = useAutoReadAttention() && !disabled
+  const disabledRef = useRef(disabled)
+  disabledRef.current = disabled
   const canAutoReadRef = useRef(canAutoRead)
   canAutoReadRef.current = canAutoRead
 
@@ -162,6 +169,7 @@ export function useConversationAutoRead({
 
   const evaluate = useCallback(() => {
     debounceRef.current = null
+    if (disabledRef.current) return
     // An active pin blocks firing entirely (not just for the pinned rows): the
     // cutoff means marking through ANY newer row would undo the explicit unread.
     if (suppressedRef.current.size > 0) {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -88,8 +88,8 @@ export const conversationKeys = {
       limit?: number
     }
   ) => [...conversationKeys.all, "workspaceList", workspaceId, options ?? {}] as const,
-  /** Every board feed list, whatever workspace/filters — the invalidation prefix. */
-  workspaceListAll: [...conversationKeysRoot, "workspaceList"] as const,
+  /** One workspace's board feed lists, whatever filters — the invalidation prefix. */
+  workspaceLists: (workspaceId: string) => [...conversationKeysRoot, "workspaceList", workspaceId] as const,
   byId: (workspaceId: string, conversationId: string) =>
     [...conversationKeys.all, "detail", workspaceId, conversationId] as const,
   messages: (conversationId: string) => ["conversations", conversationId, "messages"] as const,

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -67,8 +67,10 @@ export function boardPostLastActiveStreamId(post: Pick<BoardPost, "recentMessage
   return post.recentMessages?.at(-1)?.streamId ?? post.conversation.streamId
 }
 
+const conversationKeysRoot = ["conversations"] as const
+
 export const conversationKeys = {
-  all: ["conversations"] as const,
+  all: conversationKeysRoot,
   list: (workspaceId: string, streamId: string, options?: { status?: string; limit?: number }) =>
     [...conversationKeys.all, "list", workspaceId, streamId, options ?? {}] as const,
   workspaceList: (
@@ -86,6 +88,8 @@ export const conversationKeys = {
       limit?: number
     }
   ) => [...conversationKeys.all, "workspaceList", workspaceId, options ?? {}] as const,
+  /** Every board feed list, whatever workspace/filters — the invalidation prefix. */
+  workspaceListAll: [...conversationKeysRoot, "workspaceList"] as const,
   byId: (workspaceId: string, conversationId: string) =>
     [...conversationKeys.all, "detail", workspaceId, conversationId] as const,
   messages: (conversationId: string) => ["conversations", conversationId, "messages"] as const,

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -230,17 +230,69 @@ describe("useStableBoardView", () => {
     expect(result.current.newCount).toBe(2)
   })
 
-  it("keeps a vanished committed card rendering in place until the next commit", () => {
+  it("marks a committed card that left the raw feed as removed, keeping its slot until the next commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
-    // "b" loses access / is deleted — it drops out of the live feed.
+    // "b" is merged away / emptied — its IDB row is gone.
     act(() => mockLive(feed(post("a", 300))))
     rerender()
-    // Still rendered (last-known content), so nothing below it shifts.
+    // Still occupying its slot, so nothing below it shifts, but marked so the
+    // feed draws a stub instead of an interactive card.
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+    expect([...result.current.removedIds]).toEqual(["b"])
     // A commit drops it.
     act(() => result.current.commit())
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+    expect([...result.current.removedIds]).toEqual([])
+  })
+
+  it("resolves the successor holding a removed card's opening message", () => {
+    const ghost = {
+      ...post("b", 200),
+      openingMessage: { id: "m_open" },
+    } as unknown as CachedBoardPost
+    mockLive(feed(post("a", 300), ghost))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
+    // "b" merged into "c", which now carries its opening message.
+    const successor = {
+      ...post("c", 400),
+      conversation: {
+        id: "c",
+        lastActivityAt: new Date(400).toISOString(),
+        messageIds: ["m_open"],
+        topicSummary: "Deploy plan",
+      },
+    } as unknown as CachedBoardPost
+    act(() => mockLive(feed(post("a", 300), successor)))
+    rerender()
+    expect([...result.current.removedIds]).toEqual(["b"])
+    expect(result.current.removedSuccessorById.get("b")).toEqual({
+      conversationId: "c",
+      topicSummary: "Deploy plan",
+    })
+  })
+
+  it("reports no successor when nothing holds the removed card's opening message", () => {
+    const ghost = { ...post("b", 200), openingMessage: { id: "m_open" } } as unknown as CachedBoardPost
+    mockLive(feed(post("a", 300), ghost))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
+    act(() => mockLive(feed(post("a", 300))))
+    rerender()
+    expect([...result.current.removedIds]).toEqual(["b"])
+    expect(result.current.removedSuccessorById.get("b")).toBeNull()
+  })
+
+  it("does not mark a committed card that is merely filtered out of the live subset", () => {
+    const withMemo = { ...post("m", 300), hasCapturedMemo: true } as CachedBoardPost
+    const plain = { ...post("a", 200), hasCapturedMemo: true } as CachedBoardPost
+    mockLive(feed(withMemo, plain))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", lensFilter("decisions")))
+    expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
+    // "a" stops matching the lens but its row is still in the raw feed.
+    act(() => mockLive(feed(withMemo, { ...plain, hasCapturedMemo: false } as CachedBoardPost)))
+    rerender()
+    expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
+    expect([...result.current.removedIds]).toEqual([])
   })
 
   it("resets the committed view when the workspace changes", () => {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -298,6 +298,12 @@ export function reconcileStableView(
   }
 }
 
+/** The conversation a merged-away card's opening message now belongs to. */
+export interface RemovedSuccessor {
+  conversationId: string
+  topicSummary: string | null
+}
+
 export interface StableBoardView {
   /** Frozen-order posts to render — position is the committed snapshot's, content is live. */
   posts: CachedBoardPost[]
@@ -317,6 +323,21 @@ export interface StableBoardView {
    * perpetual skeleton when the viewer filters down to zero.
    */
   hasRawPosts: boolean
+  /**
+   * Committed ids whose row is gone from the RAW feed — merged away or emptied,
+   * so the conversation no longer exists rather than merely falling out of the
+   * active filters. They keep their slot: the retained copy still renders, inert,
+   * at its full height under an overlay, so nothing below it shifts.
+   * Empty while the feed is still loading.
+   */
+  removedIds: ReadonlySet<string>
+  /**
+   * Per removed id, the conversation that now holds its opening message (a merge
+   * target), or null when nothing does. Resolved once here off the same raw feed
+   * the removal verdict comes from — never per card, which would put a full-feed
+   * subscription behind every stub.
+   */
+  removedSuccessorById: ReadonlyMap<string, RemovedSuccessor | null>
 }
 
 /**
@@ -495,9 +516,14 @@ export function useStableBoardView(
     for (const id of [...retainedRef.current.keys()]) if (!keep.has(id)) retainedRef.current.delete(id)
   }, [])
 
-  const posts = useMemo(() => {
+  const { posts, removedIds, removedSuccessorById } = useMemo(() => {
     const liveById = new Map((live ?? []).map((post) => [postId(post), post]))
+    // Raw membership, not the filtered subset: a card the filters (or the
+    // nested-view fold) dropped is still a real conversation, while one absent
+    // from the raw feed was deleted out of IDB.
+    const rawIds = rawLive ? new Set(rawLive.map(postId)) : null
     const out: CachedBoardPost[] = []
+    const removed = new Set<string>()
     for (const id of committed.order) {
       const post = liveById.get(id) ?? retainedRef.current.get(id)
       if (!post) continue
@@ -511,10 +537,33 @@ export function useStableBoardView(
       // view, so it must vanish immediately rather than linger until commit.
       if (isExcluded(post)) continue
       if (!matchesUnread(post, unread)) continue
+      if (rawIds !== null && !rawIds.has(id)) removed.add(id)
       out.push(post)
     }
-    return out
-  }, [committed, live, unread, isExcluded])
+    // Successor resolution runs here, once, off the same raw feed — and only when
+    // something was actually removed (the common case scans nothing).
+    const successorById = new Map<string, RemovedSuccessor | null>()
+    if (removed.size > 0 && rawLive) {
+      const removedPosts = out.filter((post) => removed.has(postId(post)))
+      for (const post of removedPosts) {
+        const openingId = post.openingMessage?.id ?? null
+        const successor = openingId
+          ? (rawLive.find((row) => row.conversation.messageIds?.includes(openingId)) ?? null)
+          : null
+        successorById.set(
+          postId(post),
+          successor
+            ? { conversationId: successor.conversation.id, topicSummary: successor.conversation.topicSummary ?? null }
+            : null
+        )
+      }
+    }
+    return {
+      posts: out,
+      removedIds: removed as ReadonlySet<string>,
+      removedSuccessorById: successorById as ReadonlyMap<string, RemovedSuccessor | null>,
+    }
+  }, [committed, live, rawLive, unread, isExcluded])
 
   return {
     posts,
@@ -523,5 +572,7 @@ export function useStableBoardView(
     commit,
     isLoading: live === undefined || holdingForSeed,
     hasRawPosts: (rawLive?.length ?? 0) > 0,
+    removedIds,
+    removedSuccessorById,
   }
 }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -36,6 +36,7 @@ import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/
 import { BoardCard, BoardCardSkeleton } from "@/components/board/board-card"
 import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
+import { BoardRemovedCard } from "@/components/board/board-removed-card"
 import { openCompose, registerComposeOnPosted } from "@/stores/compose-overlay-store"
 import { setBoardFlash } from "@/stores/board-flash-store"
 import { boardHomeHref } from "@/components/board/board-saved-views"
@@ -374,6 +375,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     commit,
     isLoading: viewLoading,
     hasRawPosts,
+    removedIds,
+    removedSuccessorById,
   } = useStableBoardView(workspaceId, filter, exclusions, seed)
   // After a refetch settles, `isLoading` is already false but the seed effect
   // writes IDB on the next tick, so the IDB feed can be momentarily empty while
@@ -638,6 +641,20 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
           )
         }
         const { contextLabel, streamType, dmPeerUserId } = labelsFor(row.post.conversation)
+        if (removedIds.has(row.post.conversation.id)) {
+          return (
+            <div key={row.key} className="pb-3">
+              <BoardRemovedCard
+                workspaceId={workspaceId}
+                post={row.post}
+                contextLabel={contextLabel}
+                streamType={streamType}
+                dmPeerUserId={dmPeerUserId}
+                successor={removedSuccessorById.get(row.post.conversation.id) ?? null}
+              />
+            </div>
+          )
+        }
         return (
           <div key={row.key} className="pb-3">
             <BoardCard
@@ -652,7 +669,17 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
           </div>
         )
       }),
-    [feedRows, labelsFor, isFetchNextPageError, isFetchingNextPage, fetchNextPage, loadMoreLabel, workspaceId]
+    [
+      feedRows,
+      labelsFor,
+      removedIds,
+      removedSuccessorById,
+      isFetchNextPageError,
+      isFetchingNextPage,
+      fetchNextPage,
+      loadMoreLabel,
+      workspaceId,
+    ]
   )
 
   // Non-feed states (error / skeleton / empty) render as a single centered block

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -7,6 +7,8 @@ import {
   putOptimisticBoardPost,
   reconcileOptimisticBoardPost,
   deleteOptimisticBoardPost,
+  setBoardRootArchived,
+  removeBoardConversationsForStream,
 } from "./board-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 
@@ -348,5 +350,54 @@ describe("deleteOptimisticBoardPost", () => {
   it("no-ops when the card doesn't exist", async () => {
     await deleteOptimisticBoardPost("conv_absent")
     expect(await db.conversations.get("conv_absent")).toBeUndefined()
+  })
+})
+
+/** A post anchored in `streamId` whose effective root is `rootStreamId`. */
+function scopedPost(id: string, streamId: string, rootStreamId: string): BoardPost {
+  const base = makePost(id, "2026-06-22T12:00:00.000Z")
+  return { ...base, conversation: { ...base.conversation, streamId }, rootStreamId }
+}
+
+describe("setBoardRootArchived", () => {
+  it("flips only the rows of this workspace whose anchor or root is the stream", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      scopedPost("conv_root", "thread_1", "chan_1"),
+      scopedPost("conv_anchor", "chan_1", "chan_1"),
+      scopedPost("conv_other", "chan_2", "chan_2"),
+    ])
+    await seedBoardPosts("ws_2", [scopedPost("conv_ws2", "chan_1", "chan_1")])
+
+    await setBoardRootArchived(WORKSPACE_ID, "chan_1", true)
+
+    expect(await db.conversations.get("conv_root")).toMatchObject({ rootArchived: true })
+    expect(await db.conversations.get("conv_anchor")).toMatchObject({ rootArchived: true })
+    expect((await db.conversations.get("conv_other"))?.rootArchived).toBeUndefined()
+    expect((await db.conversations.get("conv_ws2"))?.rootArchived).toBeUndefined()
+  })
+
+  it("clears the flag on unarchive", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [scopedPost("conv_root", "thread_1", "chan_1")])
+    await setBoardRootArchived(WORKSPACE_ID, "chan_1", true)
+    await setBoardRootArchived(WORKSPACE_ID, "chan_1", false)
+    expect(await db.conversations.get("conv_root")).toMatchObject({ rootArchived: false })
+  })
+})
+
+describe("removeBoardConversationsForStream", () => {
+  it("deletes only the rows of this workspace the stream contributes", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      scopedPost("conv_root", "thread_1", "chan_1"),
+      scopedPost("conv_anchor", "chan_1", "chan_1"),
+      scopedPost("conv_other", "chan_2", "chan_2"),
+    ])
+    await seedBoardPosts("ws_2", [scopedPost("conv_ws2", "chan_1", "chan_1")])
+
+    await removeBoardConversationsForStream(WORKSPACE_ID, "chan_1")
+
+    expect(await db.conversations.get("conv_root")).toBeUndefined()
+    expect(await db.conversations.get("conv_anchor")).toBeUndefined()
+    expect(await db.conversations.get("conv_other")).toBeDefined()
+    expect(await db.conversations.get("conv_ws2")).toBeDefined()
   })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -312,3 +312,39 @@ export async function mergeBoardConversation(
     return !openingMoved
   })
 }
+
+/** Rows of this workspace whose anchor OR effective root is `streamId` — the
+ *  anchor-or-root rule the board's own scope filters use. */
+async function boardRowsForStream(workspaceId: string, streamId: string): Promise<CachedBoardPost[]> {
+  const rows = await db.conversations.where("workspaceId").equals(workspaceId).toArray()
+  return rows.filter(
+    (row) => (row.rootStreamId ?? row.conversation.streamId) === streamId || row.conversation.streamId === streamId
+  )
+}
+
+/**
+ * Carry a stream's archive state onto the board rows it covers, so archiving a
+ * channel drops its cards from the feed (and unarchiving restores them) without
+ * waiting for a board refetch. `rootArchived` is the server's per-card verdict
+ * the read-side filter gates on.
+ */
+export async function setBoardRootArchived(workspaceId: string, streamId: string, archived: boolean): Promise<void> {
+  await db.transaction("rw", db.conversations, async () => {
+    const rows = await boardRowsForStream(workspaceId, streamId)
+    const changed = rows.filter((row) => (row.rootArchived === true) !== archived)
+    if (changed.length === 0) return
+    await db.conversations.bulkPut(changed.map((row) => ({ ...row, rootArchived: archived })))
+  })
+}
+
+/**
+ * Drop the board rows a stream contributes — the viewer lost read access to it,
+ * so its cards must not keep rendering off the cache.
+ */
+export async function removeBoardConversationsForStream(workspaceId: string, streamId: string): Promise<void> {
+  await db.transaction("rw", db.conversations, async () => {
+    const rows = await boardRowsForStream(workspaceId, streamId)
+    if (rows.length === 0) return
+    await db.conversations.bulkDelete(rows.map((row) => row.id))
+  })
+}

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1416,15 +1416,17 @@ describe("SyncEngine sync cursor (active mode)", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["scheduled"] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["activity"] })
     // The board feed is seeded by its own workspace-list query, not the
-    // bootstrap, so it heals here too — every filter variant, no per-id keys.
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: conversationKeys.workspaceListAll })
+    // bootstrap, so it heals here too — THIS workspace's filter variants only
+    // (the queryClient is shared across workspaces), no per-id keys.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: conversationKeys.workspaceLists("ws_1") })
     // …and that prefix really is one: a family rename that unmatched the board
-    // feed keys would break here rather than silently invalidating nothing.
+    // feed keys would break here rather than silently invalidating nothing —
+    // while another workspace's feed key stays unmatched.
+    const wsPrefix = conversationKeys.workspaceLists("ws_1")
     const oneWorkspaceList = conversationKeys.workspaceList("ws_1", {})
-    expect(oneWorkspaceList.length).toBeGreaterThan(conversationKeys.workspaceListAll.length)
-    expect(oneWorkspaceList.slice(0, conversationKeys.workspaceListAll.length)).toEqual([
-      ...conversationKeys.workspaceListAll,
-    ])
+    expect(oneWorkspaceList.length).toBeGreaterThan(wsPrefix.length)
+    expect(oneWorkspaceList.slice(0, wsPrefix.length)).toEqual([...wsPrefix])
+    expect(conversationKeys.workspaceList("ws_2", {}).slice(0, wsPrefix.length)).not.toEqual([...wsPrefix])
     // Collapsing re-derives via the (already atomic) bootstrap, so it never opens
     // a replay apply-window.
     applyWindow.stop()

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -7,6 +7,7 @@ import { SyncStatusStore } from "./sync-status"
 import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
+import { conversationKeys } from "@/hooks/use-conversations"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
@@ -1414,6 +1415,16 @@ describe("SyncEngine sync cursor (active mode)", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["saved"] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["scheduled"] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["activity"] })
+    // The board feed is seeded by its own workspace-list query, not the
+    // bootstrap, so it heals here too — every filter variant, no per-id keys.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: conversationKeys.workspaceListAll })
+    // …and that prefix really is one: a family rename that unmatched the board
+    // feed keys would break here rather than silently invalidating nothing.
+    const oneWorkspaceList = conversationKeys.workspaceList("ws_1", {})
+    expect(oneWorkspaceList.length).toBeGreaterThan(conversationKeys.workspaceListAll.length)
+    expect(oneWorkspaceList.slice(0, conversationKeys.workspaceListAll.length)).toEqual([
+      ...conversationKeys.workspaceListAll,
+    ])
     // Collapsing re-derives via the (already atomic) bootstrap, so it never opens
     // a replay apply-window.
     applyWindow.stop()

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -30,6 +30,7 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
 import { activityKeys } from "@/hooks/use-activity"
+import { conversationKeys } from "@/hooks/use-conversations"
 import { isServerStreamId } from "@/lib/stream-ids"
 import type { WorkspaceBootstrap } from "@threa/types"
 
@@ -1419,10 +1420,13 @@ export class SyncEngine {
    * own. Saved and scheduled lists aren't carried by the workspace bootstrap and
    * gate off `refetchOnReconnect` in sync mode (use-saved / use-scheduled), so
    * they are healed only by catch-up replaying their sync-log entries; the
-   * activity feed list is likewise handler-invalidated, not bootstrapped. When a
+   * activity feed list is likewise handler-invalidated, not bootstrapped; the
+   * board's workspace conversation list is seeded by its own query, not the
+   * workspace bootstrap. When a
    * large gap (or the below-floor case) collapses to a bootstrap, replay is
    * skipped — without this an already-open Saved / Scheduled / Activity view
-   * would sit stale until it remounts. Invalidation is a no-op for unmounted
+   * would sit stale until it remounts (and the board feed would keep last
+   * session's cards). Invalidation is a no-op for unmounted
    * queries (they refetch on next mount) and refetches the open ones.
    */
   private invalidateReplayHealedQueries(): void {
@@ -1430,6 +1434,7 @@ export class SyncEngine {
     queryClient.invalidateQueries({ queryKey: savedKeys.all })
     queryClient.invalidateQueries({ queryKey: scheduledKeys.all })
     queryClient.invalidateQueries({ queryKey: activityKeys.all })
+    queryClient.invalidateQueries({ queryKey: conversationKeys.workspaceListAll })
   }
 
   /**

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -1434,7 +1434,7 @@ export class SyncEngine {
     queryClient.invalidateQueries({ queryKey: savedKeys.all })
     queryClient.invalidateQueries({ queryKey: scheduledKeys.all })
     queryClient.invalidateQueries({ queryKey: activityKeys.all })
-    queryClient.invalidateQueries({ queryKey: conversationKeys.workspaceListAll })
+    queryClient.invalidateQueries({ queryKey: conversationKeys.workspaceLists(this.workspaceId) })
   }
 
   /**

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2823,6 +2823,37 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 
+  it("carries stream:archived / stream:unarchived onto the board rows the stream covers", async () => {
+    await db.conversations.clear()
+    await seedBoardRow("conv_arch", "ws_1", "thread_1", "stream_arch_board")
+    await seedBoardRow("conv_elsewhere", "ws_1", "chan_other", "chan_other")
+
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("stream:archived", {
+      workspaceId: "ws_1",
+      streamId: "stream_arch_board",
+      stream: makeStream("stream_arch_board", { archivedAt: "2026-01-01T00:00:00Z" }),
+    })
+    await vi.waitFor(async () => {
+      expect(await db.conversations.get("conv_arch")).toMatchObject({ rootArchived: true })
+    })
+    expect((await db.conversations.get("conv_elsewhere"))?.rootArchived).toBeUndefined()
+
+    emit("stream:unarchived", {
+      workspaceId: "ws_1",
+      streamId: "stream_arch_board",
+      stream: makeStream("stream_arch_board", { archivedAt: null }),
+    })
+    await vi.waitFor(async () => {
+      expect(await db.conversations.get("conv_arch")).toMatchObject({ rootArchived: false })
+    })
+
+    cleanup()
+  })
+
   it("preserves an existing row's lastMessagePreview on stream:unarchived", async () => {
     await db.streams.put({
       ...makeStream("stream_unarch2", { archivedAt: "2026-01-01T00:00:00Z" }),
@@ -3567,6 +3598,87 @@ describe("agent-activity sidebar socket handlers", () => {
     })
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_p"])
 
+    cleanup()
+  })
+})
+
+/** A board row anchored in `streamId` under `rootStreamId`, as the board store writes it. */
+async function seedBoardRow(id: string, workspaceId: string, streamId: string, rootStreamId: string) {
+  await db.conversations.put({
+    id,
+    workspaceId,
+    rootStreamId,
+    conversation: { id, streamId, lastActivityAt: "2026-06-20T12:00:00.000Z" },
+    openingMessage: null,
+    recentMessages: [],
+    totalReplies: 0,
+    _lastActivityMs: Date.parse("2026-06-20T12:00:00.000Z"),
+    _cachedAt: Date.now(),
+  } as never)
+}
+
+describe("stream:member_removed board cleanup", () => {
+  const handlerRefs = {
+    getCurrentStreamId: () => undefined,
+    getCurrentUser: () => ({ id: "workos_1" }),
+    subscribeStream: vi.fn(),
+  }
+
+  function seededClient(visibility: "public" | "private") {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({
+        users: [makeWorkspaceUser()] as never,
+        streams: [{ ...makeStream("chan_x", { visibility }), lastMessagePreview: null }] as StreamWithPreview[],
+        streamMemberships: [
+          { streamId: "chan_x", memberId: "member_1", notificationLevel: null, joinedAt: new Date().toISOString() },
+        ] as StreamMember[],
+      })
+    )
+    return queryClient
+  }
+
+  beforeEach(async () => {
+    await db.conversations.clear()
+  })
+
+  it("drops the stream's board rows when the viewer loses access to a private stream", async () => {
+    await seedBoardRow("conv_x", "ws_1", "thread_x", "chan_x")
+    await seedBoardRow("conv_keep", "ws_1", "chan_y", "chan_y")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", seededClient("private"), handlerRefs)
+
+    emit("stream:member_removed", { workspaceId: "ws_1", streamId: "chan_x", memberId: "member_1" })
+
+    await vi.waitFor(async () => {
+      expect(await db.conversations.get("conv_x")).toBeUndefined()
+    })
+    expect(await db.conversations.get("conv_keep")).toBeDefined()
+    cleanup()
+  })
+
+  it("keeps the board rows of a PUBLIC stream — a public root grants read without membership (INV-62)", async () => {
+    await seedBoardRow("conv_x", "ws_1", "thread_x", "chan_x")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", seededClient("public"), handlerRefs)
+
+    emit("stream:member_removed", { workspaceId: "ws_1", streamId: "chan_x", memberId: "member_1" })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(await db.conversations.get("conv_x")).toBeDefined()
+    cleanup()
+  })
+
+  it("leaves the board alone when someone else is removed", async () => {
+    await seedBoardRow("conv_x", "ws_1", "thread_x", "chan_x")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", seededClient("private"), handlerRefs)
+
+    emit("stream:member_removed", { workspaceId: "ws_1", streamId: "chan_x", memberId: "member_2" })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(await db.conversations.get("conv_x")).toBeDefined()
     cleanup()
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -66,7 +66,12 @@ import { conversationKeys } from "@/hooks/use-conversations"
 import { addIncomingCall, settleIncomingCall } from "@/stores/incoming-call-store"
 import type { CallMode } from "@/calls/config"
 import { personaKeys } from "@/hooks/use-personas"
-import { mergeBoardConversation, addBoardConversationStream } from "@/stores/board-store"
+import {
+  mergeBoardConversation,
+  addBoardConversationStream,
+  setBoardRootArchived,
+  removeBoardConversationsForStream,
+} from "@/stores/board-store"
 import { putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
 import { activityKeys } from "@/hooks/use-activity"
 import { memoKeys } from "@/hooks/use-memos"
@@ -911,6 +916,10 @@ export function registerWorkspaceSocketHandlers(
     // Upsert IndexedDB — partial merge preserves lastMessagePreview etc.; a
     // missing row (swept while archived) is restored rather than silently lost.
     void upsertStreamRow(payload.stream)
+    // The board gates on each card's own `rootArchived`, so the cards this
+    // stream covers must carry the new verdict or they keep showing until a
+    // refetch.
+    void setBoardRootArchived(workspaceId, payload.stream.id, true)
   }
 
   const handleStreamUnarchived = (payload: StreamPayload) => {
@@ -939,6 +948,7 @@ export function registerWorkspaceSocketHandlers(
     // Upsert IndexedDB — partial merge preserves lastMessagePreview etc.; a
     // missing row (swept while archived) is restored rather than silently lost.
     void upsertStreamRow(payload.stream)
+    void setBoardRootArchived(workspaceId, payload.stream.id, false)
   }
 
   const handleWorkspaceUserAdded = (payload: WorkspaceUserAddedPayload) => {
@@ -1558,6 +1568,9 @@ export function registerWorkspaceSocketHandlers(
       if (shouldRemoveFromSidebar) {
         db.streams.delete(payload.streamId)
         void deleteStreamSlots(db, payload.streamId)
+        // The cards this stream contributed are unreadable now — drop them
+        // rather than leave them rendering off the cache.
+        void removeBoardConversationsForStream(workspaceId, payload.streamId)
       }
 
       return {


### PR DESCRIPTION
## Problem

Four ways the board silently diverged from reality (inventory: https://seer.build/ws_vbyzjvdg6g/b/board-reactivity-aa1f62/ ; plan chunk 2, https://seer.build/ws_vbyzjvdg6g/b/board-stack-plan-105043/):

- After a catch-up collapse or forced bootstrap, `invalidateReplayHealedQueries` reseeded saved/scheduled/activity but never the board feed — cards stayed at pre-gap state (INV-53).
- `stream:archived`/`unarchived` never touched cached `post.rootArchived`, so archived streams' cards kept rendering until an unrelated refetch; losing access to a private stream left its cards behind entirely.
- A conversation deleted from IDB (merged away / emptied) kept rendering from `retainedRef` as a fully interactive ghost — working reply composer into a dead conversation.

## Solution

- `conversationKeys.workspaceListAll` (derived from the family root, not a literal — a rename breaks the prefix-guard test instead of silently unmatching) added to the replay-healed invalidation set.
- `setBoardRootArchived` / `removeBoardConversationsForStream` in the board store (workspace-scoped, anchor-or-root match); wired from the archive and self-member-removed handlers. Public streams keep their rows — public roots grant read without membership (INV-62).
- Ghost → explanatory stub that holds the exact footprint: the retained card renders inert (`pointer-events-none`, dimmed, `aria-hidden`, auto-read disabled so no read POSTs to a dead conversation, collapsed composer still rendered for pixel parity) under an `inset-0` overlay saying "Merged into <topic>" (link to the successor's panel) or "No longer on your board". Successor = the raw-feed post whose `messageIds` contains the ghost's opening-message id, resolved inside the stable-view memo — no per-stub Dexie subscriptions (the #1640 cost class). Raw-absent (deleted) is distinguished from merely-filtered (lens/scope) — filtered cards keep today's behavior.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | board feed key in replay-healed invalidation |
| `apps/frontend/src/hooks/use-conversations.ts` | derived `workspaceListAll` key |
| `apps/frontend/src/stores/board-store.ts` | `setBoardRootArchived`, `removeBoardConversationsForStream` |
| `apps/frontend/src/sync/workspace-sync.ts` | archive/unarchive/member-removed wiring |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | `removedIds` + `removedSuccessorById` |
| `apps/frontend/src/components/board/board-removed-card.tsx` | **new** — inert card + overlay |
| `apps/frontend/src/components/board/board-card.tsx` | `removed` prop (inert layer, auto-read off) |
| `apps/frontend/src/hooks/use-conversation-auto-read.ts` | `disabled` option |
| `apps/frontend/src/pages/board.tsx` | removed-row rendering |

## Test plan

- [x] Full frontend suite 5471/5471; typecheck 0; lint clean
- [x] Adversarial verify: 4 findings (derived-key drift 84, row-collapse vs no-shift contract 82, per-stub subscriptions 80, affordance test on wrong branch 80) — all fixed; `removed=false` neutralization reds 2/3 stub tests

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788091667&installation_model_id=20758&pr_number=1683&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1683&signature=5ae5e2b5e143cc0aa5ce3a1f68888506a4333e2f99c2084a1115fb8a12c16874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->