### PR TITLE
feat(board): expand/panel backfill flows through IDB, not straight to render

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -147,6 +147,7 @@ beforeEach(async () => {
   __clearConversationGraphRegistry()
   __resetCollapseCacheForTests()
   await db.events.clear()
+  await db.conversationMessages.clear()
   await db.conversations.clear()
   await db.streams.clear()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1022,3 +1022,29 @@ describe("BoardCard settling actions", () => {
     expect(success).not.toHaveBeenCalled()
   })
 })
+
+describe("BoardCard backfill invalidation", () => {
+  it("refetches when membership gains an id neither the rail nor the store can render", async () => {
+    // The card shares `useConversationBackfill` with the panel, so an expanded
+    // card revalidates on a genuinely new member instead of waiting out the 60s
+    // `staleTime`.
+    const getBoardMessages = vi
+      .fn()
+      .mockResolvedValue([
+        openingMessage(),
+        openingMessage({ id: "m_r1", contentMarkdown: "Reply body.", createdAt: "2026-06-22T12:00:10.000Z" }),
+      ])
+    const post = makePost({ messageIds: ["m_open", "m_r1"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 1
+    const { rerenderPost } = mountCard(post, { getBoardMessages })
+
+    await userEvent.click(await screen.findByText(/1 more message/))
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalledTimes(1))
+
+    const grown = makePost({ messageIds: ["m_open", "m_r1", "m_r2"] })
+    ;(grown as unknown as { totalReplies: number }).totalReplies = 2
+    act(() => rerenderPost(grown))
+
+    await waitFor(() => expect(getBoardMessages.mock.calls.length).toBeGreaterThan(1))
+  })
+})

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type { RefObject } from "react"
 import { Link } from "react-router-dom"
-import { useQuery } from "@tanstack/react-query"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, CircleCheck, PanelRight } from "lucide-react"
 import { DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT, DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT } from "@threa/types"
@@ -39,11 +38,11 @@ import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useBoardFlash } from "@/stores/board-flash-store"
-import { seedConversationMessages } from "@/stores/conversation-messages-store"
-import { useConversationService, usePanel, createConversationPanelId, usePreferences } from "@/contexts"
+import { usePanel, createConversationPanelId, usePreferences } from "@/contexts"
 import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
-import { conversationKeys, useSplitThread } from "@/hooks/use-conversations"
+import { useSplitThread } from "@/hooks/use-conversations"
 import { applySettlingAll, useBoardCardMessages, useStableReplyWindow } from "@/hooks/use-board-card-messages"
+import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
@@ -109,7 +108,6 @@ export function BoardCard({
   const flash = useBoardFlash(conversation.id)
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
-  const conversationService = useConversationService()
   const { openPanel, getPanelUrl } = usePanel()
   const [expanded, setExpanded] = useState(false)
   // A running session's Redirect bumps this nonce to expand + focus the card's
@@ -155,6 +153,7 @@ export function BoardCard({
     messagesById,
     taggedByConversation,
     settlingIds,
+    knownMessageIds,
     railCoversMembership,
   } = useBoardCardMessages(post, streamType, {
     branchStreamIds: inlineComposer.branchStreamIds,
@@ -370,29 +369,16 @@ export function BoardCard({
   // the full hydrated set from the server. Never blocks the first render: the
   // local replies show immediately, this only fills the gap when online.
   const incompleteLocally = source === "projection" || railReplies.length < totalReplies
-  // The fetch gate is RAIL coverage only: the backfill store renders those bodies
-  // but can't refresh them, so a warm store must not suppress the fetch that
-  // brings this conversation's out-of-rail edits/deletes/reactions. `staleTime`
-  // bounds the frequency; the predicate can't loop, since fetching seeds the
-  // store, never the rail.
-  const railIncomplete = !railCoversMembership
   const {
     data: allMessages,
     isError: expandFailed,
     refetch: refetchMessages,
-  } = useQuery({
-    queryKey: conversationKeys.boardMessages(conversation.id),
-    queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
-    enabled: expanded && railIncomplete,
-    staleTime: 60_000,
+  } = useConversationBackfill(workspaceId, conversation.id, {
+    enabled: expanded,
+    railCoversMembership,
+    memberIds: conversation.messageIds,
+    knownMessageIds,
   })
-  // Seed, don't render: the response lands in IDB and the card reads it back
-  // through the hook's merged view, so an edit/reaction/delete on a backfilled
-  // row patches in place instead of staying frozen until the next fetch.
-  useEffect(() => {
-    if (!allMessages) return
-    void seedConversationMessages(workspaceId, conversation.id, allMessages)
-  }, [allMessages, workspaceId, conversation.id])
 
   // Collapsed cards preview an append-only window over the local rail: trailing
   // replies at first reveal, growing (never sliding) as new ones land, so a

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -39,6 +39,7 @@ import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useBoardFlash } from "@/stores/board-flash-store"
+import { seedConversationMessages } from "@/stores/conversation-messages-store"
 import { useConversationService, usePanel, createConversationPanelId, usePreferences } from "@/contexts"
 import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { conversationKeys, useSplitThread } from "@/hooks/use-conversations"
@@ -154,6 +155,7 @@ export function BoardCard({
     messagesById,
     taggedByConversation,
     settlingIds,
+    railCoversMembership,
   } = useBoardCardMessages(post, streamType, {
     branchStreamIds: inlineComposer.branchStreamIds,
     extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
@@ -368,6 +370,12 @@ export function BoardCard({
   // the full hydrated set from the server. Never blocks the first render: the
   // local replies show immediately, this only fills the gap when online.
   const incompleteLocally = source === "projection" || railReplies.length < totalReplies
+  // The fetch gate is RAIL coverage only: the backfill store renders those bodies
+  // but can't refresh them, so a warm store must not suppress the fetch that
+  // brings this conversation's out-of-rail edits/deletes/reactions. `staleTime`
+  // bounds the frequency; the predicate can't loop, since fetching seeds the
+  // store, never the rail.
+  const railIncomplete = !railCoversMembership
   const {
     data: allMessages,
     isError: expandFailed,
@@ -375,9 +383,16 @@ export function BoardCard({
   } = useQuery({
     queryKey: conversationKeys.boardMessages(conversation.id),
     queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
-    enabled: expanded && incompleteLocally,
+    enabled: expanded && railIncomplete,
     staleTime: 60_000,
   })
+  // Seed, don't render: the response lands in IDB and the card reads it back
+  // through the hook's merged view, so an edit/reaction/delete on a backfilled
+  // row patches in place instead of staying frozen until the next fetch.
+  useEffect(() => {
+    if (!allMessages) return
+    void seedConversationMessages(workspaceId, conversation.id, allMessages)
+  }, [allMessages, workspaceId, conversation.id])
 
   // Collapsed cards preview an append-only window over the local rail: trailing
   // replies at first reveal, growing (never sliding) as new ones land, so a
@@ -386,17 +401,9 @@ export function BoardCard({
   // counted in `totalReplies` — the collapsed card reads "deleted", not "gone".
   const collapsedReplies = useStableReplyWindow(conversation.id, railReplies)
 
-  // Expanded: the full conversation minus the opening (server backfill when the
-  // local rail is incomplete, else the rail itself). Collapsed: the stable
-  // window of the local rail. Flat if-chain, not a nested ternary (INV-47).
-  let replies: RenderableMessage[]
-  if (!expanded) replies = collapsedReplies
-  // Prefer the server backfill only while the local rail is still incomplete;
-  // once the rail catches up, fall through to it so live edits keep flowing (the
-  // backfill's `data` lingers after `enabled` goes false).
-  else if (incompleteLocally && allMessages)
-    replies = (allMessages as RenderableMessage[]).filter((m) => m.id !== openingMessage?.id)
-  else replies = railReplies
+  // Expanded: the hook's merged view (rail > backfill store > projection).
+  // Collapsed: the stable window over it.
+  const replies: RenderableMessage[] = expanded ? railReplies : collapsedReplies
   // Merge this card's own just-sent replies with the confirmed set, skipping any
   // the rail or a backfill already carries, then sort by time: a pending reply
   // can be OLDER than a confirmed one (someone else's reply lands while yours is

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter, useNavigate } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { Socket } from "socket.io-client"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness, EventType } from "@threa/types"
-import { ConversationPanel } from "./conversation-panel"
+import { ConversationPanel, hasUnknownMembers } from "./conversation-panel"
 import { ServicesProvider, SidebarProvider, PanelProvider, TraceProvider, SKELETON_DELAY_MS } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { spyOnExport } from "@/test/spy"
@@ -216,7 +216,7 @@ function mountPanel(opts: {
     return null
   }
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  render(
+  const tree = () => (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <ServicesProvider services={{ conversations: { getBoardPost, getBoardMessages } as never }}>
@@ -234,10 +234,22 @@ function mountPanel(opts: {
       </TooltipProvider>
     </QueryClientProvider>
   )
-  return { getBoardPost, getBoardMessages, nav, queryClient }
+  // A fresh element per render: re-rendering the SAME element object lets React
+  // bail out of the subtree, and the new store snapshot would never be read.
+  const { rerender } = render(tree())
+  /** Push a new board-store snapshot (e.g. a `conversation:updated` membership
+   *  change) and re-render the mounted panel against it. */
+  const setCached = (post: BoardViewPost) => {
+    vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(post as never)
+    rerender(tree())
+  }
+  return { getBoardPost, getBoardMessages, nav, queryClient, setCached }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  // The panel seeds its backfill into IDB now, so a leaked conversation's rows
+  // would widen the next test's member set.
+  await db.conversationMessages.clear()
   // Default composer stub: the real form (desktop always-open since the
   // thread-semantics ruling) pulls auth/mention providers this harness doesn't
   // mount. Tests that inspect composer props install their own spy.
@@ -1530,5 +1542,62 @@ describe("ConversationPanel settle echo on a by-id fetched post", () => {
       expect(document.querySelector('[data-message-id="msg_1"]')?.hasAttribute("data-settling")).toBe(false)
     )
     cleanup()
+  })
+})
+
+describe("backfill invalidation — mounted panel", () => {
+  function withMembers(messageIds: string[]): BoardViewPost {
+    const post = makePost()
+    return asCached({ ...post, conversation: { ...post.conversation, messageIds } })
+  }
+  const bothMessages = async () => [
+    makeMessage({ id: "msg_1" }),
+    makeMessage({ id: "msg_2", contentMarkdown: "Reply two body." }),
+  ]
+  /** The mount-time fetch and the cold-start invalidation it answers both settle
+   *  before the assertions below, which are about what the MEMBERSHIP CHANGE adds:
+   *  wait until the response has landed in the store (the gate's "locally present"
+   *  condition), then let any in-flight refetch drain. */
+  async function settledCallCount(spy: ReturnType<typeof vi.fn>): Promise<number> {
+    await waitFor(async () =>
+      expect((await db.conversationMessages.toArray()).map((row) => row.messageId).sort()).toEqual(["msg_1", "msg_2"])
+    )
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    return spy.mock.calls.length
+  }
+
+  it("does not refetch when a membership change names only locally-present ids", async () => {
+    const { getBoardMessages, setCached } = mountPanel({
+      cached: withMembers(["msg_1", "msg_2"]),
+      getBoardMessages: bothMessages,
+    })
+    const baseline = await settledCallCount(getBoardMessages)
+
+    act(() => setCached(withMembers(["msg_2", "msg_1"])))
+
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(getBoardMessages).toHaveBeenCalledTimes(baseline)
+  })
+
+  it("refetches when a membership change gains an id in neither the rail nor the store", async () => {
+    const { getBoardMessages, setCached } = mountPanel({
+      cached: withMembers(["msg_1", "msg_2"]),
+      getBoardMessages: bothMessages,
+    })
+    const baseline = await settledCallCount(getBoardMessages)
+
+    act(() => setCached(withMembers(["msg_1", "msg_2", "msg_3"])))
+
+    await waitFor(() => expect(getBoardMessages.mock.calls.length).toBeGreaterThan(baseline))
+  })
+})
+
+describe("hasUnknownMembers — backfill invalidation gate", () => {
+  it("is false when every member is locally present (rail ∪ backfill store)", () => {
+    expect(hasUnknownMembers(["m1", "r1", "r2"], new Set(["m1", "r1", "r2", "other"]))).toBe(false)
+  })
+
+  it("is true when membership gains an id the browser can't render locally", () => {
+    expect(hasUnknownMembers(["m1", "r1", "r2"], new Set(["m1", "r1"]))).toBe(true)
   })
 })

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -1059,6 +1059,7 @@ describe("ConversationPanel", () => {
       const post = makePost()
       // Rail is short of the server's count → the panel backfills, growing the
       // row list after first paint.
+      post.conversation.messageIds = ["msg_1", "msg_2", "msg_3", "msg_4"]
       post.totalReplies = 3
       mountPanel({
         cached: asCached(post),
@@ -1294,33 +1295,32 @@ describe("ConversationPanel backfill merge", () => {
     await db.events.clear()
   })
 
-  it("unions the server backfill with the live rail instead of letting a stale snapshot win", async () => {
-    // The rail can never complete here (msg_9 is a member the snapshot lists and
-    // no rail carries), so the backfill stays enabled — the shape that used to pin
-    // the panel to a 60s-stale snapshot and hide a reply the browser already had.
+  it("renders every member, whichever cache holds its body", async () => {
+    // Membership comes from the conversation; bodies come from whichever layer has
+    // them. msg_3 rides the rail, msg_2 and msg_9 come off the backfill.
     const post = makePost()
     post.conversation.messageIds = ["msg_1", "msg_2", "msg_3", "msg_9"]
     post.totalReplies = 3
     await db.events.bulkPut([
       cachedMessageEvent("msg_1", "Opening message body.", 10),
-      cachedMessageEvent("msg_2", "Reply two body.", 20),
       cachedMessageEvent("msg_3", "Live reply the snapshot predates.", 30),
     ])
     mountPanel({
       cached: asCached(post),
       getBoardMessages: async () => [
         makeMessage({ id: "msg_2", contentMarkdown: "Reply two body.", createdAt: "2026-06-22T12:00:20.000Z" }),
+        makeMessage({ id: "msg_9", contentMarkdown: "Backfilled member.", createdAt: "2026-06-22T12:00:40.000Z" }),
       ],
     })
 
-    expect(await screen.findByText("Live reply the snapshot predates.")).toBeTruthy()
+    expect(await screen.findByText("Backfilled member.")).toBeTruthy()
+    expect(screen.getByText("Live reply the snapshot predates.")).toBeTruthy()
     expect(screen.getByText("Reply two body.")).toBeTruthy()
   })
 
-  it("drops the cached snapshot once the rail is complete", async () => {
-    // `useQuery` keeps serving `data` after `enabled` flips false, and an inactive
-    // query can't be refetched — so a snapshot unioned in forever keeps rendering a
-    // message that has since left the conversation.
+  it("never renders a backfilled row the membership doesn't list", async () => {
+    // Membership is the rendering authority: a fetched snapshot supplies bodies,
+    // never members, so a row the conversation no longer lists stays invisible.
     const post = makePost()
     post.conversation.messageIds = ["msg_1", "msg_2", "msg_3"]
     post.totalReplies = 2
@@ -1335,15 +1335,35 @@ describe("ConversationPanel backfill merge", () => {
         makeMessage({ id: "msg_9", contentMarkdown: "Moved away.", createdAt: "2026-06-22T12:00:40.000Z" }),
       ],
     })
-    expect(await screen.findByText("Moved away.")).toBeTruthy()
+    expect(await screen.findByText("Reply two body.")).toBeTruthy()
 
-    // The rail catches up: every member is local, so the snapshot has nothing left
-    // to fill and its stale extra must stop rendering.
     await act(async () => {
       await db.events.bulkPut([cachedMessageEvent("msg_3", "Reply three body.", 30)])
     })
     expect(await screen.findByText("Reply three body.")).toBeTruthy()
-    await waitFor(() => expect(screen.queryByText("Moved away.")).toBeNull())
+    expect(screen.queryByText("Moved away.")).toBeNull()
+  })
+
+  it("a response that predates a re-file cannot resurrect the moved row, and does not loop", async () => {
+    // The race: the fetch left the server BEFORE `msg_9` was re-filed elsewhere,
+    // so its rows name a non-member. It must not render, and because
+    // `hasUnknownMembers` reads membership (all local) there is no refetch loop.
+    const post = makePost()
+    post.conversation.messageIds = ["msg_1", "msg_2"]
+    post.totalReplies = 1
+    const { getBoardMessages } = mountPanel({
+      cached: asCached(post),
+      getBoardMessages: async () => [
+        makeMessage({ id: "msg_1", contentMarkdown: "Opening message body." }),
+        makeMessage({ id: "msg_2", contentMarkdown: "Reply two body.", createdAt: "2026-06-22T12:00:20.000Z" }),
+        makeMessage({ id: "msg_9", contentMarkdown: "Re-filed elsewhere.", createdAt: "2026-06-22T12:00:40.000Z" }),
+      ],
+    })
+
+    expect(await screen.findByText("Reply two body.")).toBeTruthy()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(screen.queryByText("Re-filed elsewhere.")).toBeNull()
+    expect(getBoardMessages).toHaveBeenCalledTimes(1)
   })
 
   it("does not let the cached board projection shadow the backfill's tombstone", async () => {
@@ -1565,6 +1585,19 @@ describe("backfill invalidation — mounted panel", () => {
     await new Promise((resolve) => setTimeout(resolve, 200))
     return spy.mock.calls.length
   }
+
+  it("fetches exactly once on a cold open", async () => {
+    // The baseline the other cases build on: keeping `conversation.messageIds` (a
+    // fresh array per render) in the invalidation effect's deps re-ran it every
+    // render, so the mount-time invalidation refetched the query the mount had
+    // just started. Asserting the absolute count is what makes that visible.
+    const { getBoardMessages } = mountPanel({
+      cached: withMembers(["msg_1", "msg_2"]),
+      getBoardMessages: bothMessages,
+    })
+    await settledCallCount(getBoardMessages)
+    expect(getBoardMessages).toHaveBeenCalledTimes(1)
+  })
 
   it("does not refetch when a membership change names only locally-present ids", async () => {
     const { getBoardMessages, setCached } = mountPanel({

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -6,7 +6,8 @@ import { MemoryRouter, useNavigate } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { Socket } from "socket.io-client"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness, EventType } from "@threa/types"
-import { ConversationPanel, hasUnknownMembers } from "./conversation-panel"
+import { ConversationPanel } from "./conversation-panel"
+import { hasUnknownMembers } from "@/hooks/use-conversation-backfill"
 import { ServicesProvider, SidebarProvider, PanelProvider, TraceProvider, SKELETON_DELAY_MS } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { spyOnExport } from "@/test/spy"
@@ -1285,6 +1286,23 @@ function postWithDeletedReply(): BoardPost {
   return post
 }
 
+/**
+ * The call count once it stops moving: polls until two consecutive reads agree,
+ * so "no further fetch" is decided by the query actually going idle rather than
+ * by a fixed sleep.
+ */
+async function stableCallCount(spy: { mock: { calls: unknown[] } }): Promise<number> {
+  let last = -1
+  let repeats = 0
+  await waitFor(() => {
+    const count = spy.mock.calls.length
+    repeats = count === last ? repeats + 1 : 0
+    last = count
+    expect(repeats).toBeGreaterThan(0)
+  })
+  return last
+}
+
 describe("ConversationPanel backfill merge", () => {
   beforeEach(async () => {
     __clearBoardRailRegistry()
@@ -1361,9 +1379,8 @@ describe("ConversationPanel backfill merge", () => {
     })
 
     expect(await screen.findByText("Reply two body.")).toBeTruthy()
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(await stableCallCount(getBoardMessages)).toBe(1)
     expect(screen.queryByText("Re-filed elsewhere.")).toBeNull()
-    expect(getBoardMessages).toHaveBeenCalledTimes(1)
   })
 
   it("does not let the cached board projection shadow the backfill's tombstone", async () => {
@@ -1582,8 +1599,7 @@ describe("backfill invalidation — mounted panel", () => {
     await waitFor(async () =>
       expect((await db.conversationMessages.toArray()).map((row) => row.messageId).sort()).toEqual(["msg_1", "msg_2"])
     )
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    return spy.mock.calls.length
+    return await stableCallCount(spy)
   }
 
   it("fetches exactly once on a cold open", async () => {
@@ -1608,8 +1624,7 @@ describe("backfill invalidation — mounted panel", () => {
 
     act(() => setCached(withMembers(["msg_2", "msg_1"])))
 
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    expect(getBoardMessages).toHaveBeenCalledTimes(baseline)
+    expect(await stableCallCount(getBoardMessages)).toBe(baseline)
   })
 
   it("refetches when a membership change gains an id in neither the rail nor the store", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -630,11 +630,25 @@ function ConversationPanelBody({
   // arriving message, including the ones the rail had already delivered.
   const queryClient = useQueryClient()
   const memberKey = conversation.messageIds.join(",")
+  // What the browser can already answer with: the hook's local set, plus the
+  // landed response itself — its rows reach `knownMessageIds` only after an async
+  // IDB seed, and treating that window as "unknown" refetched the very response
+  // being seeded.
+  const backfillKey = allMessages?.map((m) => m.id).join(",") ?? ""
+  const coveredMessageIds = useMemo<ReadonlySet<string>>(
+    () => new Set([...knownMessageIds, ...(allMessages?.map((m) => m.id) ?? [])]),
+    [knownMessageIds, backfillKey]
+  )
   useEffect(() => {
-    if (!hasUnknownMembers(conversation.messageIds, knownMessageIds)) return
+    // Before the first response lands, the fetch the mount already started IS the
+    // answer to every unknown member — invalidating here refetches it (the cold
+    // open's double fetch).
+    if (!allMessages) return
+    if (!hasUnknownMembers(conversation.messageIds, coveredMessageIds)) return
     void queryClient.invalidateQueries({ queryKey: conversationKeys.boardMessages(conversation.id) })
-    // `memberKey` proxies `conversation.messageIds` (a fresh array per render).
-  }, [queryClient, conversation.id, conversation.messageIds, memberKey, knownMessageIds])
+    // `memberKey` proxies `conversation.messageIds` (a fresh array per render) —
+    // keeping the array itself here re-ran the effect on EVERY render.
+  }, [queryClient, conversation.id, memberKey, coveredMessageIds, allMessages])
 
   const replies: RenderableMessage[] = railReplies
   // Merge the viewer's own just-sent replies (deduped), then sort by time — a

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
   ChevronLeft,
@@ -48,7 +47,6 @@ import { useInlineBranchComposer, type ArmBranchTarget } from "@/components/boar
 import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
-import { seedConversationMessages } from "@/stores/conversation-messages-store"
 import { useWorkspaceStreamReadStates, useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { cn } from "@/lib/utils"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
@@ -74,18 +72,12 @@ import { useStashedDrafts } from "@/hooks/use-stashed-drafts"
 import { boardReplyDraftKey, boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
-import {
-  useConversationService,
-  usePanel,
-  parseConversationPanel,
-  useSidebar,
-  useCoordinatedPhase,
-  type CoordinatedPhase,
-} from "@/contexts"
+import { usePanel, parseConversationPanel, useSidebar, useCoordinatedPhase, type CoordinatedPhase } from "@/contexts"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { consumeConversationReplyOpen, subscribeConversationReplyOpen } from "@/stores/conversation-reply-open-store"
-import { conversationKeys, useConversationBoardPost, useSplitThread } from "@/hooks/use-conversations"
+import { useConversationBoardPost, useSplitThread } from "@/hooks/use-conversations"
 import { applySettlingAll, useBoardCardMessages } from "@/hooks/use-board-card-messages"
+import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
 import { useScrollBehavior } from "@/hooks/use-scroll-behavior"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
 import { buildConversationLink } from "@/lib/stream-links"
@@ -482,15 +474,6 @@ interface ConversationPanelBodyProps {
 }
 
 /**
- * Whether the conversation lists a member the browser cannot render from IDB —
- * the only reason to mark the server backfill stale. Everything the rail or the
- * backfill store already holds needs no fetch.
- */
-export function hasUnknownMembers(messageIds: string[], knownMessageIds: ReadonlySet<string>): boolean {
-  return messageIds.some((id) => !knownMessageIds.has(id))
-}
-
-/**
  * The panel's header, message column and scoped composer. Always renders the
  * FULL conversation (the panel is permanently "expanded"): the live rail from
  * {@link useBoardCardMessages} for opening + recent + the viewer's pending
@@ -508,7 +491,6 @@ function ConversationPanelBody({
 }: ConversationPanelBodyProps) {
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
-  const conversationService = useConversationService()
   const splitThread = useSplitThread(workspaceId)
   const { conversation } = post
   // Per-row read state + the mark-read/unread actions for this conversation's
@@ -603,52 +585,17 @@ function ConversationPanelBody({
   // stream isn't synced yet); the live rail shows immediately, this only fills the
   // gap when online. Mirrors board-card's expand path.
   const incompleteLocally = source === "projection" || railReplies.length < totalReplies
-  // Same gate as the card: rail coverage only. A warm backfill store renders but
-  // never refreshes, so opening a conversation the rail doesn't fully carry always
-  // revalidates (within `staleTime`).
-  const railIncomplete = !railCoversMembership
+  // Same gate as the card: rail coverage only, and the panel is permanently open.
   const {
     data: allMessages,
     isError: backfillFailed,
     refetch: refetchMessages,
-  } = useQuery({
-    queryKey: conversationKeys.boardMessages(conversation.id),
-    queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
-    enabled: railIncomplete,
-    staleTime: 60_000,
+  } = useConversationBackfill(workspaceId, conversation.id, {
+    enabled: true,
+    railCoversMembership,
+    memberIds: conversation.messageIds,
+    knownMessageIds,
   })
-  // Seed, don't render: the response lands in IDB and the hook merges it under
-  // the rail, so a backfilled row keeps taking live edits/reactions/tombstones.
-  useEffect(() => {
-    if (!allMessages) return
-    void seedConversationMessages(workspaceId, conversation.id, allMessages)
-  }, [allMessages, workspaceId, conversation.id])
-
-  // The backfill is a 60s-stale snapshot of a growing conversation, so a member
-  // it doesn't cover marks it stale. Only a member the browser can't render
-  // locally does: following the raw member COUNT refetched the endpoint on every
-  // arriving message, including the ones the rail had already delivered.
-  const queryClient = useQueryClient()
-  const memberKey = conversation.messageIds.join(",")
-  // What the browser can already answer with: the hook's local set, plus the
-  // landed response itself — its rows reach `knownMessageIds` only after an async
-  // IDB seed, and treating that window as "unknown" refetched the very response
-  // being seeded.
-  const backfillKey = allMessages?.map((m) => m.id).join(",") ?? ""
-  const coveredMessageIds = useMemo<ReadonlySet<string>>(
-    () => new Set([...knownMessageIds, ...(allMessages?.map((m) => m.id) ?? [])]),
-    [knownMessageIds, backfillKey]
-  )
-  useEffect(() => {
-    // Before the first response lands, the fetch the mount already started IS the
-    // answer to every unknown member — invalidating here refetches it (the cold
-    // open's double fetch).
-    if (!allMessages) return
-    if (!hasUnknownMembers(conversation.messageIds, coveredMessageIds)) return
-    void queryClient.invalidateQueries({ queryKey: conversationKeys.boardMessages(conversation.id) })
-    // `memberKey` proxies `conversation.messageIds` (a fresh array per render) —
-    // keeping the array itself here re-ran the effect on EVERY render.
-  }, [queryClient, conversation.id, memberKey, coveredMessageIds, allMessages])
 
   const replies: RenderableMessage[] = railReplies
   // Merge the viewer's own just-sent replies (deduped), then sort by time — a

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -48,6 +48,7 @@ import { useInlineBranchComposer, type ArmBranchTarget } from "@/components/boar
 import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
+import { seedConversationMessages } from "@/stores/conversation-messages-store"
 import { useWorkspaceStreamReadStates, useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { cn } from "@/lib/utils"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
@@ -481,6 +482,15 @@ interface ConversationPanelBodyProps {
 }
 
 /**
+ * Whether the conversation lists a member the browser cannot render from IDB —
+ * the only reason to mark the server backfill stale. Everything the rail or the
+ * backfill store already holds needs no fetch.
+ */
+export function hasUnknownMembers(messageIds: string[], knownMessageIds: ReadonlySet<string>): boolean {
+  return messageIds.some((id) => !knownMessageIds.has(id))
+}
+
+/**
  * The panel's header, message column and scoped composer. Always renders the
  * FULL conversation (the panel is permanently "expanded"): the live rail from
  * {@link useBoardCardMessages} for opening + recent + the viewer's pending
@@ -582,6 +592,8 @@ function ConversationPanelBody({
     messagesById,
     taggedByConversation,
     settlingIds,
+    knownMessageIds,
+    railCoversMembership,
   } = useBoardCardMessages(post, hostStreamType, {
     branchStreamIds: inlineComposer.branchStreamIds,
     extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
@@ -591,6 +603,10 @@ function ConversationPanelBody({
   // stream isn't synced yet); the live rail shows immediately, this only fills the
   // gap when online. Mirrors board-card's expand path.
   const incompleteLocally = source === "projection" || railReplies.length < totalReplies
+  // Same gate as the card: rail coverage only. A warm backfill store renders but
+  // never refreshes, so opening a conversation the rail doesn't fully carry always
+  // revalidates (within `staleTime`).
+  const railIncomplete = !railCoversMembership
   const {
     data: allMessages,
     isError: backfillFailed,
@@ -598,41 +614,29 @@ function ConversationPanelBody({
   } = useQuery({
     queryKey: conversationKeys.boardMessages(conversation.id),
     queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
-    enabled: incompleteLocally,
+    enabled: railIncomplete,
     staleTime: 60_000,
   })
-  // The backfill is a 60s-stale snapshot of a growing conversation: without this
-  // a reply that arrives while the panel is open is never in it, and a rail the
-  // union below can't complete (an unsynced member latches `incompleteLocally`
-  // forever) would pin the panel to that snapshot. Follow membership instead —
-  // every change to the member set marks the snapshot stale, so the open panel
-  // refetches it.
-  const queryClient = useQueryClient()
-  const memberCount = conversation.messageIds.length
+  // Seed, don't render: the response lands in IDB and the hook merges it under
+  // the rail, so a backfilled row keeps taking live edits/reactions/tombstones.
   useEffect(() => {
-    void queryClient.invalidateQueries({ queryKey: conversationKeys.boardMessages(conversation.id) })
-  }, [queryClient, conversation.id, memberCount])
+    if (!allMessages) return
+    void seedConversationMessages(workspaceId, conversation.id, allMessages)
+  }, [allMessages, workspaceId, conversation.id])
 
-  // Union, not either/or: the snapshot only FILLS GAPS the rail hasn't synced,
-  // and the rail wins every id it holds (it carries live edits, reactions and
-  // tombstones the snapshot predates). An either/or here let a stale snapshot
-  // hide a message the browser already had in IDB.
-  // Union, but only while the rail is still incomplete: `useQuery` keeps serving
-  // cached `data` after `enabled` flips false, and an inactive query can't be
-  // refetched (v5 `refetchType: "active"`), so a completed rail merged with a
-  // frozen snapshot would keep rendering messages that left the conversation.
-  let replies: RenderableMessage[]
-  if (allMessages && incompleteLocally) {
-    // Only a live rail wins an id. On `source === "projection"` `railReplies` is the
-    // cached board projection, which is never patched on edit or soft-delete — letting
-    // it win would render a deleted message's body over the fresh backfill row.
-    const railById = new Map(source === "events" ? railReplies.map((m) => [m.id, m] as const) : [])
-    const merged = (allMessages as RenderableMessage[])
-      .filter((m) => m.id !== openingMessage?.id)
-      .map((m) => railById.get(m.id) ?? m)
-    const backfilledIds = new Set(merged.map((m) => m.id))
-    replies = [...merged, ...railReplies.filter((m) => !backfilledIds.has(m.id))]
-  } else replies = railReplies
+  // The backfill is a 60s-stale snapshot of a growing conversation, so a member
+  // it doesn't cover marks it stale. Only a member the browser can't render
+  // locally does: following the raw member COUNT refetched the endpoint on every
+  // arriving message, including the ones the rail had already delivered.
+  const queryClient = useQueryClient()
+  const memberKey = conversation.messageIds.join(",")
+  useEffect(() => {
+    if (!hasUnknownMembers(conversation.messageIds, knownMessageIds)) return
+    void queryClient.invalidateQueries({ queryKey: conversationKeys.boardMessages(conversation.id) })
+    // `memberKey` proxies `conversation.messageIds` (a fresh array per render).
+  }, [queryClient, conversation.id, conversation.messageIds, memberKey, knownMessageIds])
+
+  const replies: RenderableMessage[] = railReplies
   // Merge the viewer's own just-sent replies (deduped), then sort by time — a
   // pending reply can be older than a confirmed one.
   const seenReplyIds = new Set(replies.map((m) => m.id))

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -3,6 +3,7 @@ import type {
   Activity,
   AuthorType,
   BoardPost,
+  BoardPostMessage,
   CompanionMode,
   ConversationDirective,
   E2eActor,
@@ -968,6 +969,26 @@ export interface CachedBoardPost extends BoardPost {
   _status?: "pending"
 }
 
+/**
+ * One message of a conversation's server backfill (`GET /conversations/:id/
+ * board-messages`), cached so the expanded card and the panel render it from IDB
+ * instead of from a response body. Deliberately NOT `db.events`: row presence
+ * there is the sync engine's window bookkeeping, and sparse insertion would
+ * corrupt catch-up cursors.
+ *
+ * Replace-per-conversation on seed, patched in place by the live message/
+ * reaction/link-preview handlers, so a backfilled row stays as current as a
+ * railed one.
+ */
+export interface CachedConversationMessage extends BoardPostMessage {
+  /** The message id — the primary key (`id` is inherited and identical; the
+   *  explicit name keeps the key legible against the board post's `id`). */
+  messageId: string
+  conversationId: string
+  workspaceId: string
+  _cachedAt: number
+}
+
 /** A conversation the viewer hid from the board (board-view-design.md § "Hide & mute").
  *  `id` is the conversation id; `hiddenAt` (ms) is the snooze watermark. */
 export interface CachedBoardHiddenConversation {
@@ -1055,6 +1076,7 @@ export class ThreaDatabase extends Dexie {
   e2eDeviceKeys!: EntityTable<CachedE2eDeviceKey, "id">
   sidebarConfigs!: EntityTable<CachedSidebarConfig, "id">
   conversations!: EntityTable<CachedBoardPost, "id">
+  conversationMessages!: EntityTable<CachedConversationMessage, "messageId">
   boardHiddenConversations!: EntityTable<CachedBoardHiddenConversation, "id">
   boardMutedStreams!: EntityTable<CachedBoardMutedStream, "id">
   uploadJobs!: EntityTable<CachedUploadJob, "attachmentId">
@@ -1522,6 +1544,14 @@ export class ThreaDatabase extends Dexie {
         "key, workspaceId, streamId, rootStreamId, [workspaceId+sourceMessageId], [rootStreamId+occurredAt], [streamId+occurredAt], [groupRef+occurredAt]",
     })
 
+    // v46: the board-messages backfill gets its own store so an expanded card
+    // and the panel render it from IDB (live-patched) instead of straight from
+    // the response body. Keyed by message id; read per conversation, wiped per
+    // workspace. Starts empty and fills from the backfill fetch.
+    this.version(46).stores({
+      conversationMessages: "messageId, conversationId, workspaceId",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -1600,6 +1630,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.labelAssignments.clear(),
       db.sidebarConfigs.clear(),
       db.conversations.clear(),
+      db.conversationMessages.clear(),
       db.streamContextItems.clear(),
       db.slots.clear(),
       // The persisted device key seals this identity's private key for

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -36,6 +36,7 @@ export type {
   CachedLabelAssignment,
   CachedE2eDeviceKey,
   CachedBoardPost,
+  CachedConversationMessage,
   CachedUploadJob,
   CachedSlot,
   CachedStreamContextItem,

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -14,6 +14,7 @@ import {
   type BoardCardMessages,
 } from "./use-board-card-messages"
 import type { RenderableMessage } from "@/components/message/message-item"
+import { seedConversationMessages } from "@/stores/conversation-messages-store"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -92,6 +93,7 @@ beforeEach(async () => {
   __clearBoardRailRegistry()
   await db.events.clear()
   await db.streams.clear()
+  await db.conversationMessages.clear()
 })
 
 describe("useBoardCardMessages", () => {
@@ -1087,5 +1089,102 @@ describe("useBoardRailsReady", () => {
     await waitFor(() => expect(result.current).toBe(true))
     // The registry entry the gate created is the same one a mounting card uses.
     expect(__boardRailRegistrySize()).toBeGreaterThan(0)
+  })
+})
+
+describe("useBoardCardMessages — backfill-store merge precedence", () => {
+  function backfillMessage(id: string, contentMarkdown: string) {
+    return {
+      id,
+      streamId: STREAM,
+      authorId: "usr_1",
+      authorType: "user" as const,
+      contentMarkdown,
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: new Date(2).toISOString(),
+      editedAt: null,
+    }
+  }
+
+  it("renders the rail's copy for a message present in rail AND backfill AND projection", async () => {
+    // r2 is missing from the rail, so the backfill layer is subscribed; r1 is in
+    // all three layers and must render the rail's copy.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "rail body", 2)])
+    await seedConversationMessages(WS, "conv_1", [
+      backfillMessage("r1", "backfill body"),
+      backfillMessage("r2", "backfill r2"),
+    ])
+    const post = makePost({
+      messageIds: ["m1", "r1", "r2"],
+      openingId: "m1",
+      recentMessages: [projectionMessage("r1")],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.replies).toHaveLength(2))
+    expect(result.current.source).toBe("events")
+    expect(result.current.replies.map((m) => ({ id: m.id, contentMarkdown: m.contentMarkdown }))).toEqual([
+      { id: "r1", contentMarkdown: "rail body" },
+      { id: "r2", contentMarkdown: "backfill r2" },
+    ])
+  })
+
+  it("renders the backfill row over the projection snapshot for a member the rail never synced", async () => {
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1)])
+    await seedConversationMessages(WS, "conv_1", [backfillMessage("r1", "backfill body")])
+    const post = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      recentMessages: [projectionMessage("r1")],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() =>
+      expect(result.current.replies.map((m) => ({ id: m.id, contentMarkdown: m.contentMarkdown }))).toEqual([
+        { id: "r1", contentMarkdown: "backfill body" },
+      ])
+    )
+    expect(result.current.knownMessageIds.has("r1")).toBe(true)
+  })
+
+  it("reports the rail as not covering membership even when the store holds every out-of-rail member", async () => {
+    // The regression: a warm store used to make the surface look complete and
+    // suppress its own refresh. The store renders r_old; only the rail counts.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r_recent", "rail body", 2)])
+    await seedConversationMessages(WS, "conv_1", [backfillMessage("r_old", "backfill body")])
+    const post = makePost({
+      messageIds: ["m1", "r_old", "r_recent"],
+      openingId: "m1",
+      recentMessages: [projectionMessage("r_recent")],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["r_old", "r_recent"]))
+    expect(result.current.railCoversMembership).toBe(false)
+    expect(result.current.knownMessageIds.has("r_old")).toBe(true)
+  })
+
+  it("reports the rail as covering membership once every member is on the rail", async () => {
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "rail body", 2)])
+    const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1", recentMessages: [projectionMessage("r1")] })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.railCoversMembership).toBe(true))
+  })
+
+  it("stays on the projection when nothing has been backfilled yet (cold start)", async () => {
+    const post = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      recentMessages: [projectionMessage("r1")],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.source).toBe("projection"))
+    expect(result.current.replies.map((m) => ({ id: m.id, contentMarkdown: m.contentMarkdown }))).toEqual([
+      { id: "r1", contentMarkdown: "projection r1" },
+    ])
   })
 })

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -3,6 +3,7 @@ import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { RECENT_PREVIEW_CAP } from "@/stores/board-store"
+import { useConversationBackfillMessages } from "@/stores/conversation-messages-store"
 import type { RenderableMessage } from "@/components/message/message-item"
 import { StreamTypes, BOARD_EVENT_ROW_TYPES, type AuthorType, type EventType } from "@threa/types"
 import type { BoardViewPost } from "./use-stable-board-view"
@@ -596,9 +597,22 @@ export interface BoardCardMessages {
    *  in place so a just-sent reply shows immediately and stays put across the
    *  echo hand-off; each empties once its id appears in `messageIds`. */
   pendingReplies: RenderableMessage[]
-  /** Where the bodies came from: the live `db.events` rail, or the cached server
-   *  projection (a stream not yet synced into IDB — a cold/offline first open). */
-  source: "events" | "projection"
+  /** Where the bodies came from: the live `db.events` rail, the cached backfill
+   *  store (fetched + live-patched, for members the rail's window doesn't hold),
+   *  or the board projection snapshot — the last-resort cold-start layer before
+   *  any fetch lands. */
+  source: "events" | "backfill" | "projection"
+  /** Every member id the card can render locally — the rail's synced set (live
+   *  rows and tombstones) unioned with the backfill store's. The panel gates its
+   *  backfill invalidation on this: a membership change naming only ids already
+   *  here needs no refetch. */
+  knownMessageIds: ReadonlySet<string>
+  /** Whether the live `db.events` rail ALONE covers the conversation's current
+   *  membership. Deliberately excludes the backfill store: that store is a render
+   *  cache, not a fetch suppressor, so a warm store must not stop the surface from
+   *  refetching fresh edits/deletes/reactions for members the rail never carries.
+   *  This is the `enabled` input of the board-messages query on both surfaces. */
+  railCoversMembership: boolean
   /** Spec-eligible non-message rows across the conversation's streams (agent
    *  sessions, memo captures, follow-ups), unresolved — the card runs
    *  `resolveBoardEventRows` to filter+group them to this conversation. Always the
@@ -672,7 +686,7 @@ export function applySettlingAll(messages: RenderableMessage[], settlingIds: Rea
 // at the return boundary (they come straight off the merged rail, not the view).
 type BoardCardView = Omit<
   BoardCardMessages,
-  "messagesById" | "taggedByConversation" | "deletedById" | "settlingIds"
+  "messagesById" | "taggedByConversation" | "deletedById" | "settlingIds" | "knownMessageIds" | "railCoversMembership"
 > & {
   nextRetained: RenderableMessage[]
 }
@@ -767,6 +781,37 @@ export function useBoardCardMessages(
 
   const rail = useMergedStreamRail(gatingStreamIds, extraStreamIds)
   const conversationId = post.conversation.id
+
+  // The backfill store only matters while the rail's window is missing members —
+  // subscribing unconditionally would put a Dexie subscription behind every card
+  // on the board (the #1640 cost class). Gate on the rail having READ first: an
+  // unresolved rail knows nothing, and enabling on it would churn the
+  // subscription on every card mount.
+  const railKnowsEveryMember =
+    (openingId === null || rail.seen.has(openingId)) && replyIds.every((id) => rail.seen.has(id))
+  const backfillRows = useConversationBackfillMessages(conversationId, {
+    enabled: rail.resolved && !railKnowsEveryMember,
+  })
+  const backfillById = useMemo(() => {
+    if (backfillRows.length === 0) return null
+    const map = new Map<string, RenderableMessage>()
+    for (const row of backfillRows) {
+      map.set(row.messageId, {
+        id: row.id,
+        streamId: row.streamId,
+        authorId: row.authorId,
+        authorType: row.authorType,
+        contentMarkdown: row.contentMarkdown,
+        reactions: row.reactions,
+        attachments: row.attachments,
+        linkPreviews: row.linkPreviews,
+        createdAt: row.createdAt,
+        editedAt: row.editedAt,
+        deletedAt: row.deletedAt ?? null,
+      })
+    }
+    return map
+  }, [backfillRows])
   // One Set per card, rebuilt only when the post's settling set actually changes
   // (the `conversation:updated` echo carrying a settle) — never a per-row scan.
   const settlingKey = (post.settlingMessageIds ?? []).join(",")
@@ -820,7 +865,15 @@ export function useBoardCardMessages(
     // but a merged rail can pair one rail's fresh snapshot (echo present) with
     // another's stale one (temp still there) — without this the reply renders
     // doubled for that frame.
-    const replyIdSet = new Set(replyIds)
+    // The backfill fetch is the server's own member list, so it can name replies
+    // a stale `messageIds` snapshot doesn't — the panel used to render its rows
+    // wholesale for exactly that reason. Union the two so a fresher fetch still
+    // widens the conversation; the rail keeps precedence on every shared id.
+    const memberReplyIds =
+      backfillById === null
+        ? replyIds
+        : [...new Set([...replyIds, ...[...backfillById.keys()].filter((id) => id !== openingId)])]
+    const replyIdSet = new Set(memberReplyIds)
     const tagged = rail.taggedByConversation.get(conversationId)
     const unconfirmed = tagged
       ? tagged.filter((m) => !replyIdSet.has(m.id) && !rail.supersededClientIds.has(m.id))
@@ -839,15 +892,23 @@ export function useBoardCardMessages(
     // window keeps the cached preview.
     const openingSeen = openingId !== null && rail.seen.has(openingId)
     const conversationSeen = rail.resolved && (openingSeen || replyIds.some((id) => rail.seen.has(id)))
+    // The backfill store is the middle layer: fetched from the server for
+    // exactly the members the rail's window doesn't hold, and patched by the
+    // same live handlers, so it beats the projection snapshot (which only a
+    // board refetch ever rewrites) everywhere the rail is silent.
+    const backfillSeen =
+      backfillById !== null &&
+      ((openingId !== null && backfillById.has(openingId)) || replyIds.some((id) => backfillById.has(id)))
 
     let openingMessage = (post.openingMessage as RenderableMessage | null) ?? null
+    if (openingId !== null && backfillById?.has(openingId)) openingMessage = backfillById.get(openingId) ?? null
     // A deleted opener is in `seen` but not in `messages`; falling through to
     // null would show its tombstone from the projection and then drop the row
     // entirely once the rail syncs it.
     if (openingId !== null && rail.seen.has(openingId))
       openingMessage = rail.messages.get(openingId) ?? rail.deletedMessages.get(openingId) ?? null
 
-    if (!conversationSeen) {
+    if (!conversationSeen && !backfillSeen) {
       // Cold/unsynced: capture a fresh pending row but never drop a live bridge.
       const nextRetained = pendingReplies.length > 0 ? pendingReplies : retained
       return {
@@ -866,8 +927,12 @@ export function useBoardCardMessages(
     // surface (collapsed card, expanded card, panel) instead of vanishing and
     // silently shifting every row below it up.
     const liveReplies: RenderableMessage[] = []
-    for (const id of replyIds) {
-      const message = rail.messages.get(id) ?? rail.deletedMessages.get(id)
+    for (const id of memberReplyIds) {
+      // Precedence: rail (authoritative by id) > backfill store > nothing. The
+      // projection never reaches here — it is the whole-card fallback above.
+      const message = rail.seen.has(id)
+        ? (rail.messages.get(id) ?? rail.deletedMessages.get(id))
+        : backfillById?.get(id)
       if (message) liveReplies.push(message)
     }
     liveReplies.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
@@ -893,7 +958,7 @@ export function useBoardCardMessages(
     // it must not inflate the "N more" gap. Otherwise trust the server count, but never
     // below what's already on screen (a bridged reply fills its own slot, so it
     // mustn't also leave a phantom "1 more").
-    const fullySynced = replyIds.every((id) => rail.seen.has(id))
+    const fullySynced = memberReplyIds.every((id) => rail.seen.has(id) || backfillById?.has(id) === true)
     // `conversation:updated` can land BEFORE the message echo swaps the optimistic
     // row: `messageIds` then lists a real id the rail hasn't seen while the same
     // message is still on screen as a pending row under its client id. Counting
@@ -924,16 +989,16 @@ export function useBoardCardMessages(
       replies,
       totalReplies,
       pendingReplies,
-      source: "events" as const,
+      source: conversationSeen ? ("events" as const) : ("backfill" as const),
       events: rail.events,
       nextRetained,
     }
-  }, [rail, replyIds, openingId, messageIds, post, conversationId])
+  }, [rail, replyIds, openingId, messageIds, post, conversationId, backfillById])
 
   // Commit the bridge bookkeeping after render, never during it.
   useEffect(() => {
     retainedPendingRef.current = view.nextRetained
-    if (view.source === "events") lastLiveRef.current = { conversationId, view }
+    if (view.source !== "projection") lastLiveRef.current = { conversationId, view }
     if (view.pendingReplies.length > 0) {
       const episode = pendingEpisodeRef.current
       // Snapshot only on the 0→N transition — re-snapshotting mid-episode would
@@ -945,6 +1010,13 @@ export function useBoardCardMessages(
       pendingEpisodeRef.current = null
     }
   }, [view, conversationId, replyIds])
+
+  const knownMessageIds = useMemo<ReadonlySet<string>>(() => {
+    if (!backfillById) return rail.seen
+    const set = new Set(rail.seen)
+    for (const id of backfillById.keys()) set.add(id)
+    return set
+  }, [rail.seen, backfillById])
 
   // Expose the merged rail's message maps so the card can resolve its nested
   // branch conversations' bodies through the same rail (kept off the `view` memo
@@ -960,8 +1032,19 @@ export function useBoardCardMessages(
       taggedByConversation: rail.taggedByConversation,
       deletedById: rail.deletedMessages,
       settlingIds,
+      knownMessageIds,
+      railCoversMembership: rail.resolved && railKnowsEveryMember,
     }),
-    [view, settlingIds, rail.messages, rail.taggedByConversation, rail.deletedMessages]
+    [
+      view,
+      settlingIds,
+      rail.messages,
+      rail.taggedByConversation,
+      rail.deletedMessages,
+      rail.resolved,
+      railKnowsEveryMember,
+      knownMessageIds,
+    ]
   )
 }
 

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -865,15 +865,13 @@ export function useBoardCardMessages(
     // but a merged rail can pair one rail's fresh snapshot (echo present) with
     // another's stale one (temp still there) — without this the reply renders
     // doubled for that frame.
-    // The backfill fetch is the server's own member list, so it can name replies
-    // a stale `messageIds` snapshot doesn't — the panel used to render its rows
-    // wholesale for exactly that reason. Union the two so a fresher fetch still
-    // widens the conversation; the rail keeps precedence on every shared id.
-    const memberReplyIds =
-      backfillById === null
-        ? replyIds
-        : [...new Set([...replyIds, ...[...backfillById.keys()].filter((id) => id !== openingId)])]
-    const replyIdSet = new Set(memberReplyIds)
+    // Caches (rail, backfill store) supply BODIES; membership events supply
+    // MEMBERSHIP. A fetched snapshot can never widen the conversation — it may
+    // have left the server before a re-file and would replace-write a moved row
+    // back with no self-correction. Membership arrives through the event flow
+    // (or the panel's own fresh `getBoardPost`), so a backfill row renders only
+    // when `messageIds` lists it.
+    const replyIdSet = new Set(replyIds)
     const tagged = rail.taggedByConversation.get(conversationId)
     const unconfirmed = tagged
       ? tagged.filter((m) => !replyIdSet.has(m.id) && !rail.supersededClientIds.has(m.id))
@@ -927,7 +925,7 @@ export function useBoardCardMessages(
     // surface (collapsed card, expanded card, panel) instead of vanishing and
     // silently shifting every row below it up.
     const liveReplies: RenderableMessage[] = []
-    for (const id of memberReplyIds) {
+    for (const id of replyIds) {
       // Precedence: rail (authoritative by id) > backfill store > nothing. The
       // projection never reaches here — it is the whole-card fallback above.
       const message = rail.seen.has(id)
@@ -958,7 +956,7 @@ export function useBoardCardMessages(
     // it must not inflate the "N more" gap. Otherwise trust the server count, but never
     // below what's already on screen (a bridged reply fills its own slot, so it
     // mustn't also leave a phantom "1 more").
-    const fullySynced = memberReplyIds.every((id) => rail.seen.has(id) || backfillById?.has(id) === true)
+    const fullySynced = replyIds.every((id) => rail.seen.has(id) || backfillById?.has(id) === true)
     // `conversation:updated` can land BEFORE the message echo swaps the optimistic
     // row: `messageIds` then lists a real id the rail hasn't seen while the same
     // message is still on screen as a pending row under its client id. Counting

--- a/apps/frontend/src/hooks/use-conversation-backfill.ts
+++ b/apps/frontend/src/hooks/use-conversation-backfill.ts
@@ -1,0 +1,93 @@
+import { useEffect, useMemo } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import type { BoardPostMessage } from "@threa/types"
+import { useConversationService } from "@/contexts/services-context"
+import { conversationKeys } from "@/hooks/use-conversations"
+import { seedConversationMessages } from "@/stores/conversation-messages-store"
+
+/**
+ * Whether the conversation lists a member the browser cannot render from IDB —
+ * the only reason to mark the server backfill stale. Everything the rail or the
+ * backfill store already holds needs no fetch.
+ */
+export function hasUnknownMembers(messageIds: string[], knownMessageIds: ReadonlySet<string>): boolean {
+  return messageIds.some((id) => !knownMessageIds.has(id))
+}
+
+interface UseConversationBackfillOptions {
+  /** Consumer-side gate: the card adds `expanded`, the panel is always open. */
+  enabled: boolean
+  railCoversMembership: boolean
+  /** The conversation's server membership. */
+  memberIds: string[]
+  /** What the rail + backfill store can already render locally. */
+  knownMessageIds: ReadonlySet<string>
+}
+
+/**
+ * The conversation's full server window, fetched when the local rail doesn't
+ * carry every member, seeded into IDB (never rendered from the response), and
+ * revalidated when membership names a message nothing local can render.
+ *
+ * Shared by the expanded board card and the conversation panel so both fetch,
+ * seed and invalidate identically.
+ */
+export function useConversationBackfill(
+  workspaceId: string,
+  conversationId: string,
+  { enabled, railCoversMembership, memberIds, knownMessageIds }: UseConversationBackfillOptions
+): { data: BoardPostMessage[] | undefined; isError: boolean; refetch: () => void } {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+  // The fetch gate is RAIL coverage only: the backfill store renders those bodies
+  // but can't refresh them, so a warm store must not suppress the fetch that
+  // brings this conversation's out-of-rail edits/deletes/reactions. `staleTime`
+  // bounds the frequency; the predicate can't loop, since fetching seeds the
+  // store, never the rail.
+  const railIncomplete = !railCoversMembership
+  const {
+    data: allMessages,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: conversationKeys.boardMessages(conversationId),
+    queryFn: () => conversationService.getBoardMessages(workspaceId, conversationId),
+    enabled: enabled && railIncomplete,
+    staleTime: 60_000,
+  })
+
+  // Seed, don't render: the response lands in IDB and the merged view reads it
+  // back, so an edit/reaction/delete on a backfilled row patches in place instead
+  // of staying frozen until the next fetch.
+  useEffect(() => {
+    if (!allMessages) return
+    void seedConversationMessages(workspaceId, conversationId, allMessages)
+  }, [allMessages, workspaceId, conversationId])
+
+  // The backfill is a 60s-stale snapshot of a growing conversation, so a member
+  // it doesn't cover marks it stale. Only a member the browser can't render
+  // locally does: following the raw member COUNT refetched the endpoint on every
+  // arriving message, including the ones the rail had already delivered.
+  const memberKey = memberIds.join(",")
+  // What the browser can already answer with: the hook's local set, plus the
+  // landed response itself — its rows reach `knownMessageIds` only after an async
+  // IDB seed, and treating that window as "unknown" refetched the very response
+  // being seeded.
+  const backfillKey = allMessages?.map((m) => m.id).join(",") ?? ""
+  const coveredMessageIds = useMemo<ReadonlySet<string>>(
+    () => new Set([...knownMessageIds, ...(allMessages?.map((m) => m.id) ?? [])]),
+    [knownMessageIds, backfillKey]
+  )
+  useEffect(() => {
+    // Before the first response lands, the fetch the mount already started IS the
+    // answer to every unknown member — invalidating here refetches it (the cold
+    // open's double fetch).
+    if (!allMessages) return
+    if (!hasUnknownMembers(memberIds, coveredMessageIds)) return
+    void queryClient.invalidateQueries({ queryKey: conversationKeys.boardMessages(conversationId) })
+    // `memberKey` proxies `memberIds` (a fresh array per render) — keeping the
+    // array itself here re-ran the effect on EVERY render.
+  }, [queryClient, conversationId, memberKey, coveredMessageIds, allMessages])
+
+  return { data: allMessages, isError, refetch }
+}

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
+import { waitFor } from "@testing-library/react"
 import Dexie from "dexie"
 import { db } from "@/db"
 import {
@@ -10,6 +11,7 @@ import {
   setBoardRootArchived,
   removeBoardConversationsForStream,
 } from "./board-store"
+import { seedConversationMessages } from "./conversation-messages-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 
 const WORKSPACE_ID = "ws_1"
@@ -76,6 +78,7 @@ async function readBoard() {
 
 beforeEach(async () => {
   await db.conversations.clear()
+  await db.conversationMessages.clear()
 })
 
 describe("seedBoardPosts", () => {
@@ -399,5 +402,37 @@ describe("removeBoardConversationsForStream", () => {
     expect(await db.conversations.get("conv_anchor")).toBeUndefined()
     expect(await db.conversations.get("conv_other")).toBeDefined()
     expect(await db.conversations.get("conv_ws2")).toBeDefined()
+  })
+})
+
+describe("mergeBoardConversation — backfill-store pruning", () => {
+  it("drops a re-filed message's backfilled row so the merged view can't resurrect it", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r_old"), makeMessage("r_moved")]),
+    ])
+    await seedConversationMessages(WORKSPACE_ID, "conv_1", [makeMessage("r_old"), makeMessage("r_moved")])
+
+    await mergeBoardConversation("conv_1", {
+      ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"),
+      messageIds: ["m1", "r_old"],
+    })
+
+    await waitFor(async () =>
+      expect((await db.conversationMessages.toArray()).map((row) => row.messageId)).toEqual(["r_old"])
+    )
+    const board = await readBoard()
+    expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r_old"])
+  })
+
+  it("clears the backfilled rows of a conversation emptied to zero members", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1")])])
+    await seedConversationMessages(WORKSPACE_ID, "conv_1", [makeMessage("r1")])
+
+    await mergeBoardConversation("conv_1", {
+      ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"),
+      messageIds: [],
+    })
+
+    await waitFor(async () => expect(await db.conversationMessages.toArray()).toEqual([]))
   })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -1,6 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedBoardPost } from "@/db"
+import { deleteConversationMessages, pruneConversationMessagesToMembership } from "./conversation-messages-store"
 import type { AttachmentSummary, BoardPost, BoardScopeStreamType, ConversationWithStaleness } from "@threa/types"
 
 /**
@@ -274,6 +275,9 @@ export async function mergeBoardConversation(
     // partial/aggregate-only event) is not "known empty" — fall through to upsert.
     if (Array.isArray(conversation.messageIds) && conversation.messageIds.length === 0) {
       await db.conversations.delete(conversationId)
+      // A separate table, so it can't join this transaction's scope — run it
+      // outside the zone rather than letting Dexie reject a foreign-table write.
+      Dexie.ignoreTransaction(() => void deleteConversationMessages(conversationId))
       return true
     }
     const existing = await db.conversations.get(conversationId)
@@ -288,6 +292,10 @@ export async function mergeBoardConversation(
     const recentMessages = memberIds
       ? existing.recentMessages.filter((m) => memberIds.has(m.id))
       : existing.recentMessages
+    // The backfill store is the other snapshot of these bodies, and the merged
+    // view unions it with the rail — prune it on the same event or a re-filed
+    // message keeps rendering off a fetch nothing else would ever correct.
+    if (memberIds) Dexie.ignoreTransaction(() => void pruneConversationMessagesToMembership(conversationId, memberIds))
     // An opening that moved away can't be patched in place (its replacement's
     // body isn't in the event): merge what's known but report unhandled, so the
     // caller refetches the board head and re-seeds the card with its real new

--- a/apps/frontend/src/stores/conversation-messages-store.test.tsx
+++ b/apps/frontend/src/stores/conversation-messages-store.test.tsx
@@ -101,6 +101,35 @@ describe("patchConversationMessage", () => {
     await patchConversationMessage("m_absent", { contentMarkdown: "edited" })
     expect(await db.conversationMessages.toArray()).toEqual([])
   })
+
+  it("does not write when the resolved patch changes nothing — a duplicate reaction", async () => {
+    // A re-delivered reaction resolves to `{}`; writing it anyway would bump
+    // `_cachedAt` and wake every liveQuery watching this conversation.
+    await seedConversationMessages(WS, CONV_A, [message("m1", { reactions: { "👍": ["usr_1"] } })])
+    // Age the stamp so any write is visible: seeding and patching can land in the
+    // same millisecond, which would make an identical `_cachedAt` prove nothing.
+    await db.conversationMessages.update("m1", { _cachedAt: 1 })
+    const before = await db.conversationMessages.get("m1")
+
+    await patchConversationMessage("m1", (row) => {
+      const reactions = { ...row.reactions }
+      if ((reactions["👍"] ?? []).includes("usr_1")) return {}
+      reactions["👍"] = [...(reactions["👍"] ?? []), "usr_1"]
+      return { reactions }
+    })
+
+    expect(await db.conversationMessages.get("m1")).toEqual(before)
+  })
+
+  it("does not write when every patched field already holds that value", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("m1")])
+    await db.conversationMessages.update("m1", { _cachedAt: 1 })
+    const before = await db.conversationMessages.get("m1")
+
+    await patchConversationMessage("m1", { contentMarkdown: "body m1", editedAt: null })
+
+    expect(await db.conversationMessages.get("m1")).toEqual(before)
+  })
 })
 
 describe("useConversationBackfillMessages", () => {

--- a/apps/frontend/src/stores/conversation-messages-store.test.tsx
+++ b/apps/frontend/src/stores/conversation-messages-store.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { db, type CachedConversationMessage } from "@/db"
+import type { BoardPostMessage } from "@threa/types"
+import {
+  deleteConversationMessages,
+  patchConversationMessage,
+  pruneConversationMessagesToMembership,
+  seedConversationMessages,
+  useConversationBackfillMessages,
+} from "./conversation-messages-store"
+
+const WS = "ws_1"
+const CONV_A = "conv_a"
+const CONV_B = "conv_b"
+
+function message(id: string, overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
+  return {
+    id,
+    streamId: "stream_1",
+    authorId: "usr_1",
+    authorType: "user",
+    contentMarkdown: `body ${id}`,
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-07-01T10:00:00.000Z",
+    editedAt: null,
+    ...overrides,
+  }
+}
+
+/** The persisted row minus its write-time cache stamp, so a whole-row comparison
+ *  (INV-24) doesn't depend on the clock. */
+function rowsOf(rows: CachedConversationMessage[]): Omit<CachedConversationMessage, "_cachedAt">[] {
+  return rows.map(({ _cachedAt: _ignored, ...row }) => row).sort((a, b) => (a.messageId < b.messageId ? -1 : 1))
+}
+
+beforeEach(async () => {
+  await db.conversationMessages.clear()
+})
+
+describe("seedConversationMessages", () => {
+  it("replaces the conversation's prior rows — a stale member drops, the new one lands", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("m1"), message("m_stale")])
+    await seedConversationMessages(WS, CONV_A, [message("m1", { contentMarkdown: "edited" }), message("m_new")])
+
+    expect(rowsOf(await db.conversationMessages.toArray())).toEqual([
+      { ...message("m1", { contentMarkdown: "edited" }), messageId: "m1", conversationId: CONV_A, workspaceId: WS },
+      { ...message("m_new"), messageId: "m_new", conversationId: CONV_A, workspaceId: WS },
+    ])
+  })
+
+  it("clears the conversation's rows when the fetch comes back empty (replace, not skip)", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("m1")])
+    await seedConversationMessages(WS, CONV_B, [message("b1")])
+
+    await seedConversationMessages(WS, CONV_A, [])
+
+    expect(rowsOf(await db.conversationMessages.toArray())).toEqual([
+      { ...message("b1"), messageId: "b1", conversationId: CONV_B, workspaceId: WS },
+    ])
+  })
+
+  it("leaves another conversation's rows untouched", async () => {
+    await seedConversationMessages(WS, CONV_B, [message("b1")])
+    await seedConversationMessages(WS, CONV_A, [message("a1")])
+    await seedConversationMessages(WS, CONV_A, [message("a2")])
+
+    expect(rowsOf(await db.conversationMessages.where("conversationId").equals(CONV_B).toArray())).toEqual([
+      { ...message("b1"), messageId: "b1", conversationId: CONV_B, workspaceId: WS },
+    ])
+  })
+
+  it("stamps the workspace on every row so a workspace read scopes correctly (INV-8)", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("a1")])
+    await seedConversationMessages("ws_2", CONV_B, [message("b1")])
+
+    expect(rowsOf(await db.conversationMessages.where("workspaceId").equals(WS).toArray())).toEqual([
+      { ...message("a1"), messageId: "a1", conversationId: CONV_A, workspaceId: WS },
+    ])
+  })
+})
+
+describe("patchConversationMessage", () => {
+  it("merges the patch onto an existing row", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("m1")])
+    await patchConversationMessage("m1", { contentMarkdown: "edited", editedAt: "2026-07-02T10:00:00.000Z" })
+
+    expect(rowsOf(await db.conversationMessages.toArray())).toEqual([
+      {
+        ...message("m1", { contentMarkdown: "edited", editedAt: "2026-07-02T10:00:00.000Z" }),
+        messageId: "m1",
+        conversationId: CONV_A,
+        workspaceId: WS,
+      },
+    ])
+  })
+
+  it("is a no-op when the message isn't cached", async () => {
+    await patchConversationMessage("m_absent", { contentMarkdown: "edited" })
+    expect(await db.conversationMessages.toArray()).toEqual([])
+  })
+})
+
+describe("useConversationBackfillMessages", () => {
+  it("returns the conversation's rows live when enabled", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("a1")])
+    await seedConversationMessages(WS, CONV_B, [message("b1")])
+    const { result } = renderHook(() => useConversationBackfillMessages(CONV_A, { enabled: true }))
+
+    await waitFor(() => expect(result.current.map((row) => row.messageId)).toEqual(["a1"]))
+  })
+
+  it("returns [] and registers no Dexie subscription when disabled", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("a1")])
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders++
+      return useConversationBackfillMessages(CONV_A, { enabled: false })
+    })
+
+    await waitFor(() => expect(result.current).toEqual([]))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const rendersAfterMount = renders
+
+    // A write the disabled querier would have observed had it touched the table.
+    await seedConversationMessages(WS, CONV_A, [message("a1", { contentMarkdown: "edited" }), message("a2")])
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(result.current).toEqual([])
+    expect(renders).toBe(rendersAfterMount)
+  })
+})
+
+describe("pruneConversationMessagesToMembership", () => {
+  it("drops rows the new membership no longer names, keeping the rest", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("m1"), message("r_old"), message("r_moved")])
+    await seedConversationMessages(WS, CONV_B, [message("b1")])
+
+    await pruneConversationMessagesToMembership(CONV_A, new Set(["m1", "r_old"]))
+
+    expect(rowsOf(await db.conversationMessages.toArray())).toEqual([
+      { ...message("b1"), messageId: "b1", conversationId: CONV_B, workspaceId: WS },
+      { ...message("m1"), messageId: "m1", conversationId: CONV_A, workspaceId: WS },
+      { ...message("r_old"), messageId: "r_old", conversationId: CONV_A, workspaceId: WS },
+    ])
+  })
+})
+
+describe("deleteConversationMessages", () => {
+  it("clears the conversation's rows and no others", async () => {
+    await seedConversationMessages(WS, CONV_A, [message("a1"), message("a2")])
+    await seedConversationMessages(WS, CONV_B, [message("b1")])
+
+    await deleteConversationMessages(CONV_A)
+
+    expect(rowsOf(await db.conversationMessages.toArray())).toEqual([
+      { ...message("b1"), messageId: "b1", conversationId: CONV_B, workspaceId: WS },
+    ])
+  })
+})

--- a/apps/frontend/src/stores/conversation-messages-store.ts
+++ b/apps/frontend/src/stores/conversation-messages-store.ts
@@ -74,6 +74,13 @@ export async function patchConversationMessage(
     const existing = await db.conversationMessages.get(messageId)
     if (!existing) return
     const fields = typeof patch === "function" ? patch(existing) : patch
+    // A patch that changes nothing (a duplicate reaction, a re-delivered edit)
+    // must not write: the `_cachedAt` bump alone wakes every liveQuery watching
+    // this conversation.
+    const changed = Object.entries(fields).some(
+      ([key, value]) => !Object.is(existing[key as keyof CachedConversationMessage], value)
+    )
+    if (!changed) return
     await db.conversationMessages.put({ ...existing, ...fields, _cachedAt: Date.now() })
   })
 }

--- a/apps/frontend/src/stores/conversation-messages-store.ts
+++ b/apps/frontend/src/stores/conversation-messages-store.ts
@@ -1,0 +1,96 @@
+import { useLiveQuery } from "dexie-react-hooks"
+import { db, type CachedConversationMessage } from "@/db"
+import type { BoardPostMessage } from "@threa/types"
+
+const EMPTY: CachedConversationMessage[] = []
+
+function toCached(workspaceId: string, conversationId: string, message: BoardPostMessage): CachedConversationMessage {
+  return {
+    ...message,
+    messageId: message.id,
+    conversationId,
+    workspaceId,
+    _cachedAt: Date.now(),
+  }
+}
+
+/**
+ * Land a conversation's server backfill (`GET /conversations/:id/board-messages`)
+ * in IDB so the expanded card and the panel render it from the store instead of
+ * from the response body — live-patched afterwards, unlike a response.
+ *
+ * Replace-per-conversation in one transaction: the fetch is the authoritative
+ * membership list, so a message re-filed out of this conversation drops with the
+ * write rather than lingering as a row nothing would ever remove.
+ */
+export async function seedConversationMessages(
+  workspaceId: string,
+  conversationId: string,
+  messages: BoardPostMessage[]
+): Promise<void> {
+  await db.transaction("rw", db.conversationMessages, async () => {
+    await db.conversationMessages.where("conversationId").equals(conversationId).delete()
+    await db.conversationMessages.bulkPut(messages.map((message) => toCached(workspaceId, conversationId, message)))
+  })
+}
+
+/**
+ * Prune a conversation's backfilled rows to the membership a `conversation:updated`
+ * event just named. The event is fresher than any fetch that seeded these rows, so
+ * a message re-filed OUT drops here — without this the merged view's rail∪store
+ * union would keep resurrecting it after the board snapshot pruned it.
+ */
+export async function pruneConversationMessagesToMembership(
+  conversationId: string,
+  memberIds: ReadonlySet<string>
+): Promise<void> {
+  await db.transaction("rw", db.conversationMessages, async () => {
+    const rows = await db.conversationMessages.where("conversationId").equals(conversationId).toArray()
+    const stale = rows.filter((row) => !memberIds.has(row.messageId)).map((row) => row.messageId)
+    if (stale.length === 0) return
+    await db.conversationMessages.bulkDelete(stale)
+  })
+}
+
+/** Drop every backfilled row of a conversation — an emptied conversation is no
+ *  longer a card, so its cached bodies must go with it. */
+export async function deleteConversationMessages(conversationId: string): Promise<void> {
+  await db.conversationMessages.where("conversationId").equals(conversationId).delete()
+}
+
+type ConversationMessagePatch = Partial<Omit<CachedConversationMessage, "messageId" | "conversationId" | "workspaceId">>
+
+/**
+ * Apply a live message patch (edit, delete, reaction, link preview) onto a
+ * backfilled row. No-op when the row isn't cached — the sync handlers call this
+ * for every stream message, and only a conversation the viewer has expanded has
+ * rows here.
+ */
+export async function patchConversationMessage(
+  messageId: string,
+  patch: ConversationMessagePatch | ((row: CachedConversationMessage) => ConversationMessagePatch)
+): Promise<void> {
+  await db.transaction("rw", db.conversationMessages, async () => {
+    const existing = await db.conversationMessages.get(messageId)
+    if (!existing) return
+    const fields = typeof patch === "function" ? patch(existing) : patch
+    await db.conversationMessages.put({ ...existing, ...fields, _cachedAt: Date.now() })
+  })
+}
+
+/**
+ * A conversation's backfilled messages, live from IDB. Gated: `enabled: false`
+ * touches no table, so it registers no Dexie subscription and never re-fires on
+ * a write — a board full of collapsed cards pays nothing (the #1640 cost class).
+ */
+export function useConversationBackfillMessages(
+  conversationId: string,
+  opts: { enabled: boolean }
+): CachedConversationMessage[] {
+  const enabled = opts.enabled
+  const rows = useLiveQuery(
+    () => (enabled ? db.conversationMessages.where("conversationId").equals(conversationId).toArray() : EMPTY),
+    [conversationId, enabled]
+  )
+  return rows ?? EMPTY
+}

--- a/apps/frontend/src/sync/conversation-message-mirroring.test.ts
+++ b/apps/frontend/src/sync/conversation-message-mirroring.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import type { Socket } from "socket.io-client"
+import type { BoardPostMessage, LinkPreviewSummary } from "@threa/types"
+import { db } from "@/db"
+import { registerStreamSocketHandlers } from "./stream-sync"
+import { seedConversationMessages } from "@/stores/conversation-messages-store"
+
+const WS = "ws_1"
+const STREAM = "stream_mirror"
+const CONV = "conv_mirror"
+
+function createTestSocket() {
+  const handlers = new Map<string, Set<(payload: unknown) => void | Promise<void>>>()
+  const socket = {
+    on(event: string, handler: (payload: unknown) => void) {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return this
+    },
+    off(event: string, handler: (payload: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+      return this
+    },
+  } as unknown as Socket
+  return {
+    socket,
+    async emit(event: string, payload: unknown) {
+      await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+    },
+  }
+}
+
+function message(id: string): BoardPostMessage {
+  return {
+    id,
+    streamId: STREAM,
+    authorId: "usr_1",
+    authorType: "user",
+    contentMarkdown: `body ${id}`,
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-07-01T10:00:00.000Z",
+    editedAt: null,
+  }
+}
+
+async function row(messageId: string) {
+  const cached = await db.conversationMessages.get(messageId)
+  if (!cached) return null
+  const { _cachedAt, ...rest } = cached
+  return rest
+}
+
+const cachedShape = (overrides: Partial<BoardPostMessage> = {}) => ({
+  ...message("m1"),
+  ...overrides,
+  messageId: "m1",
+  conversationId: CONV,
+  workspaceId: WS,
+})
+
+let emit: ReturnType<typeof createTestSocket>["emit"]
+let cleanup: () => void
+
+beforeEach(async () => {
+  await db.events.clear()
+  await db.conversationMessages.clear()
+  cleanup?.()
+  const testSocket = createTestSocket()
+  emit = testSocket.emit
+  cleanup = registerStreamSocketHandlers(testSocket.socket, WS, STREAM, new QueryClient())
+  await seedConversationMessages(WS, CONV, [message("m1")])
+})
+
+describe("live patches mirror onto the conversation backfill store", () => {
+  it("applies message:edited", async () => {
+    await emit("message:edited", {
+      workspaceId: WS,
+      streamId: STREAM,
+      event: {
+        id: "evt_edit",
+        streamId: STREAM,
+        sequence: "2",
+        eventType: "message_edited",
+        createdAt: "2026-07-02T10:00:00.000Z",
+        payload: { messageId: "m1", contentJson: null, contentMarkdown: "edited body" },
+      },
+    })
+
+    expect(await row("m1")).toEqual(
+      cachedShape({ contentMarkdown: "edited body", editedAt: "2026-07-02T10:00:00.000Z" })
+    )
+  })
+
+  it("applies message:deleted", async () => {
+    await emit("message:deleted", {
+      workspaceId: WS,
+      streamId: STREAM,
+      messageId: "m1",
+      deletedAt: "2026-07-03T10:00:00.000Z",
+    })
+
+    expect(await row("m1")).toEqual(cachedShape({ deletedAt: "2026-07-03T10:00:00.000Z" }))
+  })
+
+  it("applies reaction:added then reaction:removed", async () => {
+    const reaction = { workspaceId: WS, streamId: STREAM, messageId: "m1", emoji: "👍", userId: "usr_2" }
+    await emit("reaction:added", reaction)
+    expect(await row("m1")).toEqual(cachedShape({ reactions: { "👍": ["usr_2"] } }))
+
+    await emit("reaction:removed", reaction)
+    expect(await row("m1")).toEqual(cachedShape({ reactions: {} }))
+  })
+
+  it("applies link_preview:ready", async () => {
+    const previews: LinkPreviewSummary[] = [
+      {
+        id: "lp_1",
+        position: 0,
+        url: "https://example.com",
+        title: "Example",
+        description: null,
+        siteName: null,
+        faviconUrl: null,
+        imageUrl: null,
+        previewType: null,
+        contentType: "website",
+      },
+    ]
+    await emit("link_preview:ready", { workspaceId: WS, streamId: STREAM, messageId: "m1", previews })
+
+    expect(await row("m1")).toEqual(cachedShape({ linkPreviews: previews }))
+  })
+
+  it("is a no-op for a message that isn't backfilled", async () => {
+    await emit("message:deleted", {
+      workspaceId: WS,
+      streamId: STREAM,
+      messageId: "m_absent",
+      deletedAt: "2026-07-03T10:00:00.000Z",
+    })
+
+    expect(await db.conversationMessages.toArray()).toHaveLength(1)
+    expect(await row("m1")).toEqual(cachedShape())
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -16,6 +16,7 @@ import {
   type SharedMessageSlot,
 } from "@threa/types"
 import { writeSlotCarrier } from "@/stores/slot-store"
+import { patchConversationMessage } from "@/stores/conversation-messages-store"
 import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import type { SyncEventSource } from "./socket-event-gate"
@@ -1313,6 +1314,12 @@ export function registerStreamSocketHandlers(
       }))
       await writeSlotCarrier({ database: db, workspaceId, streamId, carrier: payload, mode: "merge", cachedAt: now })
     })
+    // Mirror onto the backfill store so an expanded card's server-fetched row
+    // takes the edit too (no-op when the message isn't cached there).
+    await patchConversationMessage(editPayload.messageId, {
+      contentMarkdown: editPayload.contentMarkdown,
+      editedAt: editEvent.createdAt,
+    })
 
     // Replace, not patch: an edit can drop a link the message used to carry, so
     // the message's rows are rebuilt from the now-updated event (which still
@@ -1342,6 +1349,7 @@ export function registerStreamSocketHandlers(
       ...p,
       deletedAt: payload.deletedAt,
     }))
+    await patchConversationMessage(payload.messageId, { deletedAt: payload.deletedAt })
 
     // A deleted message holds no context rows — the server drops them in the
     // delete transaction with no separate event.
@@ -1466,6 +1474,13 @@ export function registerStreamSocketHandlers(
       }
       return { ...p, reactions }
     })
+    await patchConversationMessage(payload.messageId, (row) => {
+      const reactions = { ...row.reactions }
+      const existing = reactions[payload.emoji] || []
+      if (existing.includes(payload.userId)) return {}
+      reactions[payload.emoji] = [...existing, payload.userId]
+      return { reactions }
+    })
   }
 
   const handleReactionRemoved = async (payload: ReactionPayload) => {
@@ -1479,6 +1494,13 @@ export function registerStreamSocketHandlers(
         }
       }
       return { ...p, reactions }
+    })
+    await patchConversationMessage(payload.messageId, (row) => {
+      const reactions = { ...row.reactions }
+      if (!reactions[payload.emoji]) return {}
+      reactions[payload.emoji] = reactions[payload.emoji].filter((id) => id !== payload.userId)
+      if (reactions[payload.emoji].length === 0) delete reactions[payload.emoji]
+      return { reactions }
     })
 
     // Drop the held activity row this reaction produced (D4): the server deleted
@@ -1652,6 +1674,9 @@ export function registerStreamSocketHandlers(
     await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
       linkPreviews: preserveBakedInAppData(payload.previews, p.linkPreviews as LinkPreviewSummary[] | undefined),
+    }))
+    await patchConversationMessage(payload.messageId, (row) => ({
+      linkPreviews: preserveBakedInAppData(payload.previews, row.linkPreviews),
     }))
   }
 


### PR DESCRIPTION
## Problem

The `GET /conversations/:id/board-messages` backfill was render-from-response (plan chunk 3, https://seer.build/ws_vbyzjvdg6g/b/board-stack-plan-105043/): an expanded card rendered server rows that never touched the local store, the panel refetched the endpoint on **every membership change** (one HTTP round-trip per arriving reply), and cold-stream cards rendered `post.recentMessages` snapshots that only a feed reseed ever rewrote — edits, deletes, and reactions on them were stale until reload. Writing into `db.events` instead is off the table by design: row presence there is the sync engine's window bookkeeping (catch-up cursors, replace-mode pruning).

## Solution

- New `conversationMessages` Dexie table (schema v46) + `conversation-messages-store.ts`: `board-messages` responses seed it with replace-per-conversation semantics (an empty response clears — replace, not skip). Wiped on logout.
- Merge precedence in `useBoardCardMessages`: rail rows (`db.events`) > backfill store > projection snapshots; `source` gains `"backfill"`. Card and panel render only the merged view.
- `stream-sync` mirrors `message:edited`/`deleted`, `reaction:added`/`removed`, `link_preview:ready` into the store by messageId (no-op when absent).
- **Membership events prune the store** (`mergeBoardConversation` → `pruneConversationMessagesToMembership` / `deleteConversationMessages`, via `Dexie.ignoreTransaction` since it's a foreign table to that transaction): the verify pass reproduced a re-filed message being resurrected on its old card by the stale fetch snapshot — event authority separates the two staleness directions (a fresh fetch may widen a stale board snapshot; a fresh membership event must shrink the stale store).
- **Fetch gates are rail-only** (`railCoversMembership`): the store is a render cache and never suppresses a refresh — expanding/opening with an incomplete rail always fetches (staleTime 60s), so offline-missed patches to out-of-rail members can't persist indefinitely. The membership-change invalidation keeps the rail∪store gate, which is what kills the refetch-per-message loop.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/database.ts` | `conversationMessages` table, v46, wipe entry |
| `apps/frontend/src/stores/conversation-messages-store.ts` | **new** — seed/patch/prune/delete + gated read hook |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | backfill merge layer, `railCoversMembership`, `knownMessageIds` |
| `apps/frontend/src/components/board/board-card.tsx` | seeds response; rail-only fetch gate |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | seeds; rail-only enabled; gated invalidation |
| `apps/frontend/src/sync/stream-sync.ts` | patch mirroring (5 handlers) |
| `apps/frontend/src/stores/board-store.ts` | membership-event pruning call sites |

## Test plan

- [x] Full frontend suite 5497/5497; typecheck + lint clean
- [x] Adversarial verify: 3 findings (re-file resurrection 93 — reproduced, then fixed with the reproduction as the test; warm-store refresh suppression 85; predicate-only panel coverage 80) — all fixed; mounted-panel spy tests assert both invalidation directions; three guards mutation-checked

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788094962&installation_model_id=20758&pr_number=1685&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1685&signature=9a509f0317c9ce02eaf6cc9a62785ff6387eace0ed6ef72c62b7d438d35cb9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->