### PR TITLE
feat(memos): batch memo-embed summaries behind a room-uniform predicate

### DIFF
--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -1,5 +1,5 @@
 import { sql, type Querier } from "../../db"
-import type { MemoType, KnowledgeType, MemoStatus, AuthoredByKind, MemoScope } from "@threa/types"
+import type { MemoType, KnowledgeType, MemoStatus, AuthoredByKind, MemoScope, MemoEmbedSummary } from "@threa/types"
 import {
   MEMO_KNOWLEDGE_TYPE_BOOST,
   MEMO_STREAM_TYPE_BOOST,
@@ -314,6 +314,72 @@ export const MemoRepository = {
       WHERE id = ANY(${ids}) AND workspace_id = ${workspaceId}
     `)
     return new Map(result.rows.map((row) => [row.id, mapRowToMemo(row)]))
+  },
+
+  /**
+   * Card content for memos referenced by a message in `citingRootStreamId`,
+   * for the payload that message ships on (INV-56: one batch, never per card).
+   *
+   * The access predicate is ROOM-UNIFORM, not per-viewer, because the payload
+   * is delivered to a room: a summary is emitted only when every viewer of the
+   * citing stream can open the memo. That means the memo's source stream
+   * RESOLVED TO ITS ROOT is the citing root, or that root is public.
+   *
+   * Resolving to the root is the load-bearing part. A thread copies its root's
+   * `visibility` at creation and is never re-synced, so a thread of a channel
+   * that was later privatized still reads `public` on its own row —
+   * `messaging/sharing/access-check.ts` documents that trap and closes it the
+   * same way. Checking `s.visibility` here instead would leak exactly those
+   * memos.
+   *
+   * `scope <> 'user'` keeps the private tier (roadmap 6.4) off the wire
+   * unconditionally: a user-scoped memo is visible to its owner alone, and no
+   * room is uniformly its owner.
+   *
+   * No status filter — an archived or superseded memo resolves on the detail
+   * path today, so summarising it preserves behaviour rather than changing it.
+   */
+  async findEmbedSummaries(
+    db: Querier,
+    workspaceId: string,
+    memoIds: string[],
+    citingRootStreamId: string
+  ): Promise<Map<string, MemoEmbedSummary>> {
+    if (memoIds.length === 0) return new Map()
+    const result = await db.query<{
+      id: string
+      title: string
+      knowledge_type: string
+      memo_type: string
+      tags: string[]
+      updated_at: Date
+    }>(sql`
+      SELECT m.id, m.title, m.knowledge_type, m.memo_type, m.tags, m.updated_at
+      FROM memos m
+      LEFT JOIN messages src_msg ON src_msg.id = m.source_message_id
+      LEFT JOIN conversations src_conv ON src_conv.id = m.source_conversation_id
+      LEFT JOIN messages first_msg ON first_msg.id = m.source_message_ids[1]
+      LEFT JOIN streams s ON s.id = COALESCE(src_msg.stream_id, src_conv.stream_id, first_msg.stream_id)
+      LEFT JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)
+      WHERE m.id = ANY(${memoIds})
+        AND m.workspace_id = ${workspaceId}
+        AND m.scope <> 'user'
+        AND root.id IS NOT NULL
+        AND (root.id = ${citingRootStreamId} OR root.visibility = 'public')
+    `)
+    return new Map(
+      result.rows.map((row) => [
+        row.id,
+        {
+          memoId: row.id,
+          title: row.title,
+          knowledgeType: row.knowledge_type as KnowledgeType,
+          memoType: row.memo_type as MemoType,
+          tags: row.tags,
+          updatedAt: row.updated_at.toISOString(),
+        },
+      ])
+    )
   },
 
   async findByWorkspace(

--- a/apps/backend/tests/integration/memo-embed-summaries.test.ts
+++ b/apps/backend/tests/integration/memo-embed-summaries.test.ts
@@ -1,0 +1,279 @@
+/**
+ * `MemoRepository.findEmbedSummaries` — the room-uniform access predicate that
+ * decides which referenced memos get their card content put on a message
+ * payload.
+ *
+ * This is a security boundary, and it is one the codebase did not have before:
+ * `strip-inaccessible-agent-refs` says outright that per-recipient memo
+ * visibility "is still enforced at render time by the memo-detail endpoint, so
+ * we deliberately don't re-check stream reach here." Once the card renders from
+ * the payload there is no render-time fetch left to enforce it, so this query
+ * IS the check. Asserting its SQL text would prove nothing about any of that
+ * (INV-68) — every case below seeds real rows and reads back what the statement
+ * actually returns.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { MemoRepository } from "../../src/features/memos"
+import { userId, workspaceId, streamId, messageId, memoId } from "../../src/lib/id"
+
+describe("MemoRepository.findEmbedSummaries", () => {
+  let pool: Pool
+  let testWorkspaceId: string
+  let testUserId: string
+
+  /** The stream whose messages cite the memos — the "room" the payload goes to. */
+  let citingRoot: string
+  let publicChannel: string
+  let privateChannel: string
+  /** A thread of `citingRoot`. */
+  let citingThread: string
+  /**
+   * A thread whose OWN row says `visibility = 'public'` while its root is
+   * private — what a thread of a channel that was later privatized looks like,
+   * since a thread's visibility is copied at creation and never re-synced.
+   */
+  let stalePublicThread: string
+
+  let sequence = 1n
+
+  async function seedMemo(
+    sourceStreamId: string,
+    options: { title: string; scope?: "workspace" | "user"; tags?: string[] }
+  ): Promise<string> {
+    const id = memoId()
+    const msgId = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id: msgId,
+        streamId: sourceStreamId,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: msgId,
+        title: options.title,
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [msgId],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: options.tags ?? ["settings"],
+        status: "active",
+        scope: options.scope ?? "workspace",
+        scopeUserId: options.scope === "user" ? testUserId : null,
+      })
+    })
+    return id
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testWorkspaceId = workspaceId()
+    testUserId = userId()
+    citingRoot = streamId()
+    publicChannel = streamId()
+    privateChannel = streamId()
+    citingThread = streamId()
+    stalePublicThread = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Memo Embed Summaries",
+        slug: `memo-embed-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+
+      for (const [id, visibility] of [
+        [citingRoot, "private"],
+        [publicChannel, "public"],
+        [privateChannel, "private"],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: testWorkspaceId,
+          type: "channel",
+          visibility,
+          slug: `s-${id.slice(-8)}`,
+          createdBy: testUserId,
+        })
+      }
+
+      await StreamRepository.insert(client, {
+        id: citingThread,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        parentStreamId: citingRoot,
+        rootStreamId: citingRoot,
+        createdBy: testUserId,
+      })
+      await StreamRepository.insert(client, {
+        id: stalePublicThread,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        // The stale copy: the row says public, the root says private.
+        visibility: "public",
+        parentStreamId: privateChannel,
+        rootStreamId: privateChannel,
+        createdBy: testUserId,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("summarises a memo sourced in the citing stream itself", async () => {
+    const id = await seedMemo(citingRoot, { title: "Theme switch", tags: ["settings", "preferences"] })
+
+    const summaries = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+
+    expect(summaries.get(id)).toEqual({
+      memoId: id,
+      title: "Theme switch",
+      knowledgeType: "decision",
+      memoType: "message",
+      tags: ["settings", "preferences"],
+      updatedAt: expect.any(String),
+    })
+  })
+
+  test("summarises a memo sourced in a thread of the citing stream", async () => {
+    const id = await seedMemo(citingThread, { title: "Decided in a thread" })
+
+    const summaries = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+
+    expect(summaries.get(id)?.title).toBe("Decided in a thread")
+  })
+
+  test("summarises a memo sourced in a public stream, cited anywhere", async () => {
+    const id = await seedMemo(publicChannel, { title: "Public knowledge" })
+
+    const summaries = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+
+    expect(summaries.get(id)?.title).toBe("Public knowledge")
+  })
+
+  test("withholds a memo sourced in a private stream the room is not", async () => {
+    const id = await seedMemo(privateChannel, { title: "Acquisition target" })
+
+    const summaries = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+
+    expect(summaries.has(id)).toBe(false)
+  })
+
+  // The trap this predicate exists for. The thread's own row says `public`
+  // because it was created while its root was; resolving to the root is what
+  // keeps a privatized channel's knowledge off a public payload.
+  test("withholds a memo sourced in a stale-public thread of a private root", async () => {
+    const id = await seedMemo(stalePublicThread, { title: "Privatized after the thread was made" })
+
+    const viaThread = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+    expect(viaThread.has(id)).toBe(false)
+
+    // And it IS reachable from its own root, so the row is genuinely there —
+    // the case above is the predicate working, not an empty seed.
+    const viaOwnRoot = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], privateChannel)
+    expect(viaOwnRoot.get(id)?.title).toBe("Privatized after the thread was made")
+  })
+
+  test("withholds a user-scoped memo even from its own stream", async () => {
+    const id = await seedMemo(citingRoot, { title: "Private tier", scope: "user" })
+
+    const summaries = await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [id], citingRoot)
+
+    expect(summaries.has(id)).toBe(false)
+  })
+
+  test("withholds ids from another workspace and unknown ids", async () => {
+    const otherWorkspace = workspaceId()
+    const otherStream = streamId()
+    const otherUser = userId()
+    let otherUserId = otherUser
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: otherWorkspace,
+        name: "Other",
+        slug: `other-${otherWorkspace}`,
+        createdBy: otherUser,
+      })
+      otherUserId = (await addTestMember(client, otherWorkspace, otherUser)).id
+      await StreamRepository.insert(client, {
+        id: otherStream,
+        workspaceId: otherWorkspace,
+        type: "channel",
+        visibility: "public",
+        slug: `s-${otherStream.slice(-8)}`,
+        createdBy: otherUserId,
+      })
+    })
+    const foreignMsg = messageId()
+    const foreignMemo = memoId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id: foreignMsg,
+        streamId: otherStream,
+        sequence: sequence++,
+        authorId: otherUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: foreignMemo,
+        workspaceId: otherWorkspace,
+        memoType: "message",
+        sourceMessageId: foreignMsg,
+        title: "Someone else's",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [foreignMsg],
+        participantIds: [otherUserId],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+
+    const summaries = await MemoRepository.findEmbedSummaries(
+      pool,
+      testWorkspaceId,
+      [foreignMemo, memoId()],
+      citingRoot
+    )
+
+    expect(summaries.size).toBe(0)
+  })
+
+  test("resolves a batch in one call, dropping only what the predicate rejects", async () => {
+    const allowed = await seedMemo(citingRoot, { title: "Allowed" })
+    const alsoAllowed = await seedMemo(publicChannel, { title: "Also allowed" })
+    const withheld = await seedMemo(privateChannel, { title: "Withheld" })
+
+    const summaries = await MemoRepository.findEmbedSummaries(
+      pool,
+      testWorkspaceId,
+      [allowed, withheld, alsoAllowed],
+      citingRoot
+    )
+
+    expect([...summaries.keys()].sort()).toEqual([allowed, alsoAllowed].sort())
+  })
+
+  test("returns an empty map for no ids without touching the database", async () => {
+    expect(await MemoRepository.findEmbedSummaries(pool, testWorkspaceId, [], citingRoot)).toEqual(new Map())
+  })
+})

--- a/packages/prosemirror/src/extractors.test.ts
+++ b/packages/prosemirror/src/extractors.test.ts
@@ -5,6 +5,7 @@ import {
   collectChannelStreamIds,
   collectGiphyEmbeds,
   collectLinkUrls,
+  collectMemoEmbedIds,
   collectMentionActorRefs,
   collectQuoteReplyMessageIds,
   collectUnresolvedChannelLinkSlugs,
@@ -775,5 +776,49 @@ describe("collectGiphyEmbeds", () => {
     expect(collectGiphyEmbeds(doc)).toEqual([
       { giphyUrl: "https://media.giphy.com/real.gif", title: "", width: undefined, height: undefined },
     ])
+  })
+})
+
+const memoEmbed = (memoId: string, title = "Memo"): JSONContent => ({
+  type: "memoEmbed",
+  attrs: { memoId, title },
+})
+
+describe("collectMemoEmbedIds", () => {
+  it("collects nested memo ids in document order", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "see " }, memoEmbed("memo_a", "Auth rewrite")] },
+        {
+          type: "blockquote",
+          content: [{ type: "paragraph", content: [memoEmbed("memo_b")] }],
+        },
+      ],
+    }
+
+    expect(collectMemoEmbedIds(doc)).toEqual(["memo_a", "memo_b"])
+  })
+
+  it("dedupes repeated references to the same memo", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [memoEmbed("memo_a"), memoEmbed("memo_a")] }],
+    }
+
+    expect(collectMemoEmbedIds(doc)).toEqual(["memo_a"])
+  })
+
+  it("ignores nodes without a usable memo id", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "memoEmbed", attrs: { memoId: "" } }] },
+        { type: "paragraph", content: [{ type: "memoEmbed", attrs: {} }] },
+        { type: "paragraph", content: [{ type: "text", text: "[Auth](memo:memo_z)" }] },
+      ],
+    }
+
+    expect(collectMemoEmbedIds(doc)).toEqual([])
   })
 })

--- a/packages/prosemirror/src/extractors.ts
+++ b/packages/prosemirror/src/extractors.ts
@@ -251,6 +251,37 @@ export function collectGiphyEmbeds(content: JSONContent): GiphyEmbedRef[] {
 }
 
 /**
+ * Memo ids from inline `memoEmbed` nodes, de-duplicated in first-seen order.
+ *
+ * Reads the node attrs, not the `[title](memo:…)` markdown: `contentJson` is
+ * canonical (INV-58), and it carries the nodes whatever the author was — the
+ * markdown parser builds a `memoEmbed` for a raw `memo:` link too, so an
+ * API-authored reference is visible here exactly like a picker-inserted one.
+ */
+export function collectMemoEmbedIds(content: JSONContent): string[] {
+  const ids: string[] = []
+  const seen = new Set<string>()
+
+  const walk = (node: JSONContent): void => {
+    if (node.type === "memoEmbed") {
+      const memoId = node.attrs?.memoId
+      if (typeof memoId === "string" && memoId.length > 0 && !seen.has(memoId)) {
+        seen.add(memoId)
+        ids.push(memoId)
+      }
+    }
+    if (node.content) {
+      for (const child of node.content) {
+        walk(child)
+      }
+    }
+  }
+
+  walk(content)
+  return ids
+}
+
+/**
  * External (http/https) URLs the document points at, in document order,
  * INCLUDING duplicates — callers dedup and ref-count.
  *

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -48,6 +48,7 @@ export {
   collectGiphyEmbeds,
   collectLinkUrls,
   collectQuoteReplyMessageIds,
+  collectMemoEmbedIds,
   collectMentionActorRefs,
   collectChannelStreamIds,
   collectUnresolvedMentionSlugs,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -17,6 +17,7 @@ import type {
   E2eKeyWrapRecipientKind,
   AgentStepType,
   KnowledgeType,
+  MemoType,
   DelegationStatus,
 } from "./constants"
 import type { WorkspaceInvitableRole } from "./workspace-permissions"
@@ -1236,6 +1237,25 @@ export interface CapturedMemoSummary {
   knowledgeType: KnowledgeType
   /** The exact messages this memo was derived from. */
   sourceMessageIds: string[]
+}
+
+/**
+ * A referenced memo's card content, carried on the message payload that cites
+ * it so the embed card renders complete on its first frame — no per-card fetch
+ * anywhere in the stream, and therefore no content that changes without an
+ * underlying change (`memo:updated` is the only thing that may move it).
+ *
+ * Only what the card draws. The memo's substance (abstract, key points, source
+ * messages) stays behind the access-checked detail endpoint, which is what the
+ * card's click opens.
+ */
+export interface MemoEmbedSummary {
+  memoId: string
+  title: string
+  knowledgeType: KnowledgeType
+  memoType: MemoType
+  tags: string[]
+  updatedAt: string
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -561,6 +561,7 @@ export type {
   MessagesMovedEventPayload,
   MovedFromProvenance,
   CapturedMemoSummary,
+  MemoEmbedSummary,
   MemosCapturedEventPayload,
   AgentFollowUpScheduledEventPayload,
   AgentFollowUpCancelledEventPayload,


### PR DESCRIPTION
## Problem

Memo embed cards fetch their own content per card, which is what makes them change size after paint (#1681 stops the movement; it does not stop the fetch). The fix is to put the card's content on the message payload — and that requires deciding, server-side, **which referenced memos may be summarised into a payload that goes to a whole room**.

That check does not exist today. `messaging/event-service.ts` has no memo handling at all: attachments are author-validated at create and share nodes re-validated at edit, but a `memoEmbed` passes unexamined. The system currently gets away with it because the card fetches, and `strip-inaccessible-agent-refs` says so in as many words — per-recipient memo visibility *"is still enforced at render time by the memo-detail endpoint, so we deliberately don't re-check stream reach here."* Remove the render-time fetch without replacing that, and nothing is checking.

## Solution

`MemoRepository.findEmbedSummaries(db, workspaceId, memoIds, citingRootStreamId)` — one batch (INV-56), returning card content only for memos the whole room can open.

- **Room-uniform, not per-viewer.** A payload is delivered to a room, so the predicate is "every viewer of the citing stream can open this": the memo's source stream **resolved to its root** is the citing root, or that root is public. Per-user membership is the wrong question for a broadcast — the same reasoning `listRoomReadableStreamIds` already encodes.
- **Resolving to the root is the load-bearing part.** A thread copies its root's `visibility` at creation and is never re-synced, so a thread of a channel privatized afterwards still reads `public` on its own row. `messaging/sharing/access-check.ts` documents that trap verbatim and closes it the same way; `getPublicStreams` (which backs the `public_only` agent/picker access spec) does **not** — that is a live INV-62 bug, out of scope here, and this predicate is deliberately written so v3 does not depend on it being fixed.
- **`scope <> 'user'`** keeps the roadmap-6.4 private tier off the wire unconditionally: a user-scoped memo is visible to its owner alone, and no room is uniformly its owner.
- **No status filter** — archived and superseded memos resolve on the detail path today, so summarising them preserves behaviour instead of quietly changing it.

`collectMemoEmbedIds` reads ids from `contentJson` rather than regexing markdown (INV-58). That also means an API- or MCP-authored raw `[t](memo:id)` link is seen exactly like a picker insertion, since the markdown parser builds the same node.

`MemoEmbedSummary` carries only what the card draws. The memo's substance stays behind the access-checked detail endpoint, which is what a click opens.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/memos/repository.ts` | `findEmbedSummaries` — the batch + the predicate |
| `packages/prosemirror/src/extractors.ts` | `collectMemoEmbedIds` |
| `packages/types/src/api.ts` | `MemoEmbedSummary` |
| `apps/backend/tests/integration/memo-embed-summaries.test.ts` | **new** — the predicate against a real schema |
| `packages/prosemirror/src/extractors.test.ts` | nesting, dedup, and ids that must not count |

## Test plan

- [x] **Integration, real schema — 9 pass** (INV-68). Seeds every case as rows: same stream, thread-of-the-citing-stream, public elsewhere, private elsewhere, **stale-public thread of a private root**, user-scoped, foreign workspace, mixed batch.
- [x] `packages/prosemirror` 45 pass · `bun run typecheck` 0 · `bun run lint` 0
- [x] **Mutation-checked.** Checking `s.visibility` instead of `root.visibility` reddens exactly the stale-public-thread case (8/1) — the leak this predicate exists to stop. Dropping `scope <> 'user'` reddens exactly the private-tier case (8/1). Restored: 9/9. The stale-thread case also asserts the memo IS returned from its own root, so the withhold is the predicate working rather than an empty seed.
- [ ] Nothing consumes this yet — C2 puts it on the payload. Shipping the boundary before the thing that needs it is deliberate: it is the piece that must be right.

## Notes for the stack

Sits on #1681 (card geometry). C4 later deletes that PR's `min-h` floor, which only exists to survive a pending state this stack removes.

Design: https://seer.build/ws_vbyzjvdg6g/b/memo-cards-scope-d842fe/ (v3) · adversarial review that produced it: https://seer.build/ws_vbyzjvdg6g/b/memo-cards-review-cc009b/

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788096504&installation_model_id=20758&pr_number=1686&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1686&signature=1419c7cdd14529c2cdd4913a0c8916e7c9595f9a65ac9b53831f52ce6773aea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->