### PR TITLE
feat(memos): carry memo-embed summaries on the message payloads

### DIFF
--- a/apps/backend/src/features/memos/embed-summaries.ts
+++ b/apps/backend/src/features/memos/embed-summaries.ts
@@ -1,0 +1,34 @@
+import { collectMemoEmbedIds } from "@threa/prosemirror"
+import type { JSONContent, MemoEmbedSummary } from "@threa/types"
+import type { Querier } from "../../db"
+import { MemoRepository } from "./repository"
+
+/**
+ * Card content for every memo a message body references, for the payload that
+ * message ships on — so a memo embed card renders complete on its first frame
+ * and never fetches from the stream.
+ *
+ * Written in the same transaction as the message (INV-4/7) by both the create
+ * and the edit path: an edit that adds a reference has to carry the new memo's
+ * content, and one that removes a reference has to stop carrying the old one.
+ *
+ * Withheld ids simply don't appear. A card with no summary renders the label
+ * from the reference and stays that way — it does not fall back to a fetch,
+ * which would be exactly the lazy load this design exists to remove. Sealed
+ * (E2E) streams take that path for free: their stored `contentJson` is the
+ * placeholder, so there are no ids to collect here.
+ */
+export async function resolveMemoEmbedSummaries(
+  db: Querier,
+  workspaceId: string,
+  contentJson: JSONContent,
+  citingRootStreamId: string
+): Promise<MemoEmbedSummary[]> {
+  const memoIds = collectMemoEmbedIds(contentJson)
+  if (memoIds.length === 0) return []
+
+  const byId = await MemoRepository.findEmbedSummaries(db, workspaceId, memoIds, citingRootStreamId)
+  // Document order, so the cards below a message read in the order they are
+  // cited in it.
+  return memoIds.map((id) => byId.get(id)).filter((summary): summary is MemoEmbedSummary => summary !== undefined)
+}

--- a/apps/backend/src/features/memos/index.ts
+++ b/apps/backend/src/features/memos/index.ts
@@ -1,4 +1,5 @@
 export { MemoRepository } from "./repository"
+export { resolveMemoEmbedSummaries } from "./embed-summaries"
 export type {
   Memo,
   InsertMemoParams,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -2041,37 +2041,46 @@ export class EventService {
    * no message in it was edited. Without a scope (a caller that predates this)
    * the map is empty and payloads keep their create-time summaries.
    */
-  private async refreshEditedMemoEmbeds(
+  private async refreshMemoEmbeds(
     messagesMap: Map<string, Message>,
+    messageIdsLackingKey: Set<string>,
     scope?: { workspaceId: string; streamId: string }
   ): Promise<Map<string, MemoEmbedSummary[]>> {
     const refreshed = new Map<string, MemoEmbedSummary[]>()
     if (!scope) return refreshed
 
+    // Edited messages always land in the result — an edit that dropped the last
+    // reference must still push an empty array to clear the stale card. Legacy
+    // messages (payload written before summaries shipped, or when none were
+    // readable) land only when something resolves: there is no stale card to
+    // clear, and the created payload omits the key when empty.
     const edited = [...messagesMap.values()].filter((m) => m.editedAt && !m.deletedAt)
-    if (edited.length === 0) return refreshed
+    const legacyCiting = [...messagesMap.values()]
+      .filter((m) => !m.editedAt && !m.deletedAt && messageIdsLackingKey.has(m.id))
+      .map((m) => [m.id, collectMemoEmbedIds(m.contentJson)] as const)
+      .filter(([, ids]) => ids.length > 0)
+    if (edited.length === 0 && legacyCiting.length === 0) return refreshed
 
-    const byMessage = new Map(edited.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)]))
+    const byMessage = new Map([
+      ...edited.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)] as const),
+      ...legacyCiting,
+    ])
+    const legacyIds = new Set(legacyCiting.map(([id]) => id))
     const allIds = [...new Set([...byMessage.values()].flat())]
-    if (allIds.length === 0) {
-      // Every edited message dropped its references — the empty arrays still
-      // have to reach the payload to clear the stale cards.
-      for (const id of byMessage.keys()) refreshed.set(id, [])
-      return refreshed
-    }
 
-    const stream = await StreamRepository.findById(this.pool, scope.streamId)
-    const summaries = await MemoRepository.findEmbedSummaries(
-      this.pool,
-      scope.workspaceId,
-      allIds,
-      stream?.rootStreamId ?? scope.streamId
-    )
+    const summaries =
+      allIds.length > 0
+        ? await MemoRepository.findEmbedSummaries(
+            this.pool,
+            scope.workspaceId,
+            allIds,
+            (await StreamRepository.findById(this.pool, scope.streamId))?.rootStreamId ?? scope.streamId
+          )
+        : new Map<string, MemoEmbedSummary>()
     for (const [messageId, ids] of byMessage) {
-      refreshed.set(
-        messageId,
-        ids.map((id) => summaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
-      )
+      const resolved = ids.map((id) => summaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
+      if (legacyIds.has(messageId) && resolved.length === 0) continue
+      refreshed.set(messageId, resolved)
     }
     return refreshed
   }
@@ -2146,10 +2155,18 @@ export class EventService {
 
     // An edited message's payload is overlaid with the CURRENT content below, so
     // its create-time summaries can describe memos the body no longer cites (or
-    // miss ones it now does). The `message_edited` event that carries the right
-    // set is filtered out of this response, so it is recomputed here — for edited
-    // messages only, in one batch, against the same root the write path used.
-    const memoEmbedsByMessageId = await this.refreshEditedMemoEmbeds(messagesMap, memoEmbedScope)
+    // miss ones it now does); the `message_edited` event that carries the right
+    // set is filtered out of this response. A payload with NO memoEmbeds key at
+    // all predates summaries (or none were readable at write time) — its card
+    // would render label-only forever, a regression against the fetch this stack
+    // deletes. Both are recomputed here in one batch, against the same root the
+    // write path used.
+    const messageIdsLackingKey = new Set(
+      messageCreatedEvents
+        .filter((e) => (e.payload as MessageCreatedPayload).memoEmbeds === undefined)
+        .map((e) => (e.payload as MessageCreatedPayload).messageId)
+    )
+    const memoEmbedsByMessageId = await this.refreshMemoEmbeds(messagesMap, messageIdsLackingKey, memoEmbedScope)
 
     return events
       .filter((e) => e.eventType !== "message_edited" && e.eventType !== "message_deleted")
@@ -2206,11 +2223,12 @@ export class EventService {
           enrichments.editedAt = message.editedAt.toISOString()
           enrichments.contentJson = message.contentJson
           enrichments.contentMarkdown = message.contentMarkdown
-          const refreshed = memoEmbedsByMessageId.get(message.id)
-          // Set even when empty, so an edit that dropped the last reference
-          // doesn't leave the create-time card behind.
-          if (refreshed) enrichments.memoEmbeds = refreshed
         }
+        // Edited entries may be empty (an edit that dropped the last reference
+        // must clear the create-time card); legacy entries are only ever
+        // non-empty. Deleted messages never enter the map.
+        const refreshedMemoEmbeds = memoEmbedsByMessageId.get(payload.messageId)
+        if (refreshedMemoEmbeds) enrichments.memoEmbeds = refreshedMemoEmbeds
         if (message?.reactions && Object.keys(message.reactions).length > 0) {
           enrichments.reactions = message.reactions
         }

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -2043,29 +2043,32 @@ export class EventService {
    */
   private async refreshMemoEmbeds(
     messagesMap: Map<string, Message>,
-    messageIdsLackingKey: Set<string>,
+    messageIdsWithKey: Set<string>,
     scope?: { workspaceId: string; streamId: string }
   ): Promise<Map<string, MemoEmbedSummary[]>> {
     const refreshed = new Map<string, MemoEmbedSummary[]>()
     if (!scope) return refreshed
 
-    // Edited messages always land in the result — an edit that dropped the last
-    // reference must still push an empty array to clear the stale card. Legacy
-    // messages (payload written before summaries shipped, or when none were
-    // readable) land only when something resolves: there is no stale card to
-    // clear, and the created payload omits the key when empty.
+    // Every citing message is re-resolved against the predicate AS OF THIS
+    // read, never trusted from its stored payload. The stored summary is a
+    // snapshot of a past access decision: serving it after the memo's source
+    // went private would be a fresh delivery of withheld content, not
+    // tolerable staleness. Who gets the key set:
+    // - edited: always, even empty — an edit that dropped the last reference
+    //   must clear the stale card, and the stored payload predates the edit.
+    // - citing with a stored key: always, even empty — empty RETRACTS a
+    //   summary the room may no longer see.
+    // - citing without a key: only when something resolves — the created
+    //   payload omits the key when empty, and there is nothing to retract.
     const edited = [...messagesMap.values()].filter((m) => m.editedAt && !m.deletedAt)
-    const legacyCiting = [...messagesMap.values()]
-      .filter((m) => !m.editedAt && !m.deletedAt && messageIdsLackingKey.has(m.id))
+    const citing = [...messagesMap.values()]
+      .filter((m) => !m.editedAt && !m.deletedAt)
       .map((m) => [m.id, collectMemoEmbedIds(m.contentJson)] as const)
       .filter(([, ids]) => ids.length > 0)
-    if (edited.length === 0 && legacyCiting.length === 0) return refreshed
+    if (edited.length === 0 && citing.length === 0) return refreshed
 
-    const byMessage = new Map([
-      ...edited.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)] as const),
-      ...legacyCiting,
-    ])
-    const legacyIds = new Set(legacyCiting.map(([id]) => id))
+    const byMessage = new Map([...edited.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)] as const), ...citing])
+    const editedIds = new Set(edited.map((m) => m.id))
     const allIds = [...new Set([...byMessage.values()].flat())]
 
     const summaries =
@@ -2079,7 +2082,8 @@ export class EventService {
         : new Map<string, MemoEmbedSummary>()
     for (const [messageId, ids] of byMessage) {
       const resolved = ids.map((id) => summaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
-      if (legacyIds.has(messageId) && resolved.length === 0) continue
+      const mustSet = editedIds.has(messageId) || messageIdsWithKey.has(messageId)
+      if (!mustSet && resolved.length === 0) continue
       refreshed.set(messageId, resolved)
     }
     return refreshed
@@ -2153,20 +2157,20 @@ export class EventService {
         ? await AgentSessionRepository.findProgressSnapshotsByIds(this.pool, startedSessionIds)
         : new Map()
 
-    // An edited message's payload is overlaid with the CURRENT content below, so
-    // its create-time summaries can describe memos the body no longer cites (or
-    // miss ones it now does); the `message_edited` event that carries the right
-    // set is filtered out of this response. A payload with NO memoEmbeds key at
-    // all predates summaries (or none were readable at write time) — its card
-    // would render label-only forever, a regression against the fetch this stack
-    // deletes. Both are recomputed here in one batch, against the same root the
-    // write path used.
-    const messageIdsLackingKey = new Set(
+    // Stored payloads snapshot a PAST access decision and a past memo state:
+    // an edit can change what the body cites, the memo's source can go private
+    // after the citation (serving the old summary then would be a fresh
+    // delivery of withheld content), a retitle can land between the create and
+    // this read, and a pre-summaries row has no key at all. Every citing
+    // message is therefore re-resolved here in one batch, against the same
+    // root the write path used; the stored key only decides whether an empty
+    // resolution must be pushed to retract.
+    const messageIdsWithKey = new Set(
       messageCreatedEvents
-        .filter((e) => (e.payload as MessageCreatedPayload).memoEmbeds === undefined)
+        .filter((e) => (e.payload as MessageCreatedPayload).memoEmbeds !== undefined)
         .map((e) => (e.payload as MessageCreatedPayload).messageId)
     )
-    const memoEmbedsByMessageId = await this.refreshMemoEmbeds(messagesMap, messageIdsLackingKey, memoEmbedScope)
+    const memoEmbedsByMessageId = await this.refreshMemoEmbeds(messagesMap, messageIdsWithKey, memoEmbedScope)
 
     return events
       .filter((e) => e.eventType !== "message_edited" && e.eventType !== "message_deleted")

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -28,6 +28,7 @@ import { settleMessagesOnEngagement } from "../conversations"
 import { DraftsRepository, toDraftView } from "../drafts"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { StreamContextRepository, contextRowsForMessage, contextSnippet } from "../stream-context"
+import { MemoRepository, resolveMemoEmbedSummaries } from "../memos"
 import {
   attachmentReferenceId,
   eventId,
@@ -38,6 +39,7 @@ import {
 } from "../../lib/id"
 import { MessageVersionRepository, type MessageVersion } from "./version-repository"
 import { MessageComposeTraceRepository } from "./compose-trace-repository"
+import { collectMemoEmbedIds } from "@threa/prosemirror"
 import { serializeBigInt } from "@threa/backend-common"
 import { messagesTotal } from "../../lib/observability"
 import { HttpError, MessageNotFoundError, StreamNotFoundError } from "../../lib/errors"
@@ -59,6 +61,7 @@ import {
   type ComposeTrace,
   type ConversationDirective,
   type FeatureFlagValue,
+  type MemoEmbedSummary,
   type EventType,
   type SourceItem,
   type JSONContent,
@@ -129,12 +132,27 @@ export interface MessageCreatedPayload {
   ciphertext?: string
   envelope?: unknown
   e2eVersion?: number
+  /**
+   * Card content for the memos this body references, so each embed card renders
+   * complete on its first frame instead of fetching (INV-21, and the rule it
+   * serves: content may change only when the memo changed). Omitted when the
+   * body cites none. Ids the room can't uniformly read are absent — those cards
+   * render the reference's own label and stay there.
+   */
+  memoEmbeds?: MemoEmbedSummary[]
 }
 
 export interface MessageEditedPayload {
   messageId: string
   contentJson: JSONContent
   contentMarkdown: string
+  /**
+   * Always present, empty array included — unlike the create payload. The client
+   * applies an edit by spreading it over the stored payload, so an omitted key
+   * would leave the pre-edit summaries in place: a removed reference would keep
+   * its card content, and one swapped for another would show the wrong memo.
+   */
+  memoEmbeds: MemoEmbedSummary[]
 }
 
 export interface MessageDeletedPayload {
@@ -729,6 +747,15 @@ export class EventService {
     const declaredConversationId =
       params.conversation?.intent === ConversationIntents.EXISTING ? params.conversation.conversationId : undefined
 
+    // Resolved against the citing stream's ROOT: a thread inherits its root's
+    // audience (INV-62), and this payload is delivered to that whole room.
+    const memoEmbeds = await resolveMemoEmbedSummaries(
+      client,
+      params.workspaceId,
+      params.contentJson,
+      stream?.rootStreamId ?? params.streamId
+    )
+
     const event = await StreamEventRepository.insert(client, {
       id: evtId,
       streamId: params.streamId,
@@ -743,6 +770,7 @@ export class EventService {
         ...(params.clientMessageId && { clientMessageId: params.clientMessageId }),
         ...(params.sentVia && { sentVia: params.sentVia }),
         ...(declaredConversationId && { declaredConversationId }),
+        ...(memoEmbeds.length > 0 && { memoEmbeds }),
         ...(metadata && { metadata }),
         ...(params.ciphertext && { ciphertext: params.ciphertext.toString("base64") }),
         ...(params.envelope !== undefined && { envelope: params.envelope }),
@@ -1008,6 +1036,14 @@ export class EventService {
         editedBy: params.actorId,
       })
 
+      const editStream = await StreamRepository.findById(client, params.streamId)
+      const memoEmbeds = await resolveMemoEmbedSummaries(
+        client,
+        params.workspaceId,
+        params.contentJson,
+        editStream?.rootStreamId ?? params.streamId
+      )
+
       const event = await StreamEventRepository.insert(client, {
         id: eventId(),
         streamId: params.streamId,
@@ -1016,6 +1052,7 @@ export class EventService {
           messageId: params.messageId,
           contentJson: params.contentJson,
           contentMarkdown: params.contentMarkdown,
+          memoEmbeds,
         } satisfies MessageEditedPayload,
         actorId: params.actorId,
         actorType,
@@ -1999,6 +2036,47 @@ export class EventService {
   }
 
   /**
+   * Memo-embed summaries for the edited messages in a bootstrap window, keyed by
+   * message id — one batch for the whole window (INV-56), and nothing at all when
+   * no message in it was edited. Without a scope (a caller that predates this)
+   * the map is empty and payloads keep their create-time summaries.
+   */
+  private async refreshEditedMemoEmbeds(
+    messagesMap: Map<string, Message>,
+    scope?: { workspaceId: string; streamId: string }
+  ): Promise<Map<string, MemoEmbedSummary[]>> {
+    const refreshed = new Map<string, MemoEmbedSummary[]>()
+    if (!scope) return refreshed
+
+    const edited = [...messagesMap.values()].filter((m) => m.editedAt && !m.deletedAt)
+    if (edited.length === 0) return refreshed
+
+    const byMessage = new Map(edited.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)]))
+    const allIds = [...new Set([...byMessage.values()].flat())]
+    if (allIds.length === 0) {
+      // Every edited message dropped its references — the empty arrays still
+      // have to reach the payload to clear the stale cards.
+      for (const id of byMessage.keys()) refreshed.set(id, [])
+      return refreshed
+    }
+
+    const stream = await StreamRepository.findById(this.pool, scope.streamId)
+    const summaries = await MemoRepository.findEmbedSummaries(
+      this.pool,
+      scope.workspaceId,
+      allIds,
+      stream?.rootStreamId ?? scope.streamId
+    )
+    for (const [messageId, ids] of byMessage) {
+      refreshed.set(
+        messageId,
+        ids.map((id) => summaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
+      )
+    }
+    return refreshed
+  }
+
+  /**
    * Enrich bootstrap events with projection state for display.
    *
    * Filters out operational events (message_edited, message_deleted) that are
@@ -2010,7 +2088,8 @@ export class EventService {
   async enrichBootstrapEvents(
     events: StreamEvent[],
     threadDataMap: Map<string, { threadId: string; replyCount: number }>,
-    threadSummaryMap: Map<string, ThreadSummary> = new Map()
+    threadSummaryMap: Map<string, ThreadSummary> = new Map(),
+    memoEmbedScope?: { workspaceId: string; streamId: string }
   ): Promise<StreamEvent[]> {
     const messageCreatedEvents = events.filter((e) => e.eventType === "message_created")
     const messageIds = messageCreatedEvents.map((e) => (e.payload as MessageCreatedPayload).messageId)
@@ -2064,6 +2143,13 @@ export class EventService {
       startedSessionIds.length > 0
         ? await AgentSessionRepository.findProgressSnapshotsByIds(this.pool, startedSessionIds)
         : new Map()
+
+    // An edited message's payload is overlaid with the CURRENT content below, so
+    // its create-time summaries can describe memos the body no longer cites (or
+    // miss ones it now does). The `message_edited` event that carries the right
+    // set is filtered out of this response, so it is recomputed here — for edited
+    // messages only, in one batch, against the same root the write path used.
+    const memoEmbedsByMessageId = await this.refreshEditedMemoEmbeds(messagesMap, memoEmbedScope)
 
     return events
       .filter((e) => e.eventType !== "message_edited" && e.eventType !== "message_deleted")
@@ -2120,6 +2206,10 @@ export class EventService {
           enrichments.editedAt = message.editedAt.toISOString()
           enrichments.contentJson = message.contentJson
           enrichments.contentMarkdown = message.contentMarkdown
+          const refreshed = memoEmbedsByMessageId.get(message.id)
+          // Set even when empty, so an edit that dropped the last reference
+          // doesn't leave the create-time card behind.
+          if (refreshed) enrichments.memoEmbeds = refreshed
         }
         if (message?.reactions && Object.keys(message.reactions).length > 0) {
           enrichments.reactions = message.reactions

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -806,7 +806,10 @@ export function createStreamHandlers({
         streamService.getThreadsWithReplyCounts(streamId, candidateAnchorIds),
         streamService.getThreadSummaries(streamId, candidateAnchorIds),
       ])
-      const enrichedEvents = await eventService.enrichBootstrapEvents(result.events, threadDataMap, threadSummaryMap)
+      const enrichedEvents = await eventService.enrichBootstrapEvents(result.events, threadDataMap, threadSummaryMap, {
+        workspaceId,
+        streamId,
+      })
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(
         linkPreviewService,
         workspaceId,
@@ -1108,7 +1111,10 @@ export function createStreamHandlers({
             }))
           : undefined
 
-      const enrichedEvents = await eventService.enrichBootstrapEvents(events, threadDataMap, threadSummaryMap)
+      const enrichedEvents = await eventService.enrichBootstrapEvents(events, threadDataMap, threadSummaryMap, {
+        workspaceId,
+        streamId,
+      })
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(
         linkPreviewService,
         workspaceId,

--- a/apps/backend/tests/integration/memo-embed-payloads.test.ts
+++ b/apps/backend/tests/integration/memo-embed-payloads.test.ts
@@ -282,6 +282,54 @@ describe("memo embed summaries on message payloads", () => {
       expect(payload.memoEmbeds).toEqual([])
     })
 
+    // A message stored before summaries shipped has no memoEmbeds key at all.
+    // With the per-card fetch deleted up-stack, its card would render label-only
+    // forever — enrichment has to resolve it, not just edited messages.
+    test("resolves summaries for a message stored before summaries shipped", async () => {
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("stored before summaries existed", [sameStreamMemo]),
+      })
+      await pool.query(`UPDATE stream_events SET payload = payload - 'memoEmbeds' WHERE payload->>'messageId' = $1`, [
+        message.id,
+      ])
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds?.map((s) => s.memoId)).toEqual([sameStreamMemo])
+    })
+
+    test("leaves a message citing only an unreachable memo without the key", async () => {
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("cites what this room can't read", [unreachableMemo]),
+      })
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds).toBeUndefined()
+    })
+
     test("leaves an unedited message's create-time summaries alone", async () => {
       const message = await eventService.createMessage({
         workspaceId: testWorkspaceId,

--- a/apps/backend/tests/integration/memo-embed-payloads.test.ts
+++ b/apps/backend/tests/integration/memo-embed-payloads.test.ts
@@ -330,14 +330,19 @@ describe("memo embed summaries on message payloads", () => {
       expect(payload.memoEmbeds).toBeUndefined()
     })
 
-    test("leaves an unedited message's create-time summaries alone", async () => {
+    // The stored payload is a snapshot; a retitle that never touched the
+    // message must still reach a cold load. This is also what heals a first
+    // citation that raced a concurrent memo edit.
+    test("re-resolves an unedited message rather than trusting its stored summary", async () => {
+      const retitled = await seedMemo(channel, "Before the retitle")
       const message = await eventService.createMessage({
         workspaceId: testWorkspaceId,
         streamId: channel,
         authorId: testUserId,
         authorType: "user",
-        ...bodyCiting("untouched", [sameStreamMemo]),
+        ...bodyCiting("untouched", [retitled]),
       })
+      await pool.query(`UPDATE memos SET title = 'After the retitle' WHERE id = $1`, [retitled])
 
       const events = await eventService.listEvents(channel, { limit: 200 })
       const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
@@ -348,7 +353,47 @@ describe("memo embed summaries on message payloads", () => {
       const payload = enriched.find(
         (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
       )?.payload as MessageCreatedPayload
-      expect(payload.memoEmbeds?.map((s) => s.memoId)).toEqual([sameStreamMemo])
+      expect(payload.memoEmbeds?.map((s) => s.title)).toEqual(["After the retitle"])
+    })
+
+    // Serving a stored summary after the memo's source went private is a fresh
+    // delivery of withheld content to whoever bootstraps next — the retraction
+    // must be an explicit empty array, or the client keeps the stored card.
+    test("retracts a stored summary once the memo's source goes private", async () => {
+      const publicElsewhere = streamId()
+      await withTransaction(pool, async (client) => {
+        await StreamRepository.insert(client, {
+          id: publicElsewhere,
+          workspaceId: testWorkspaceId,
+          type: "channel",
+          visibility: "public",
+          slug: `s-${publicElsewhere.slice(-8)}`,
+          createdBy: testUserId,
+        })
+      })
+      const memoGoingPrivate = await seedMemo(publicElsewhere, "Public while cited")
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("cited while public", [memoGoingPrivate]),
+      })
+      const stored = (await payloadOf(message.id, "message_created")) as MessageCreatedPayload
+      expect(stored.memoEmbeds?.map((s) => s.memoId)).toEqual([memoGoingPrivate])
+
+      await pool.query(`UPDATE streams SET visibility = 'private' WHERE id = $1`, [publicElsewhere])
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds).toEqual([])
     })
   })
 })

--- a/apps/backend/tests/integration/memo-embed-payloads.test.ts
+++ b/apps/backend/tests/integration/memo-embed-payloads.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Memo-embed summaries on the message payloads.
+ *
+ * The card renders from the payload and never fetches, so every path that can
+ * change which memos a message cites has to put the right set there — and a
+ * wrong set is not a cosmetic bug, it is a card describing a different memo
+ * than the one it links to.
+ *
+ * The edit cases are the ones worth the fixture cost: the client applies an
+ * edit by SPREADING the payload over the stored one, so `memoEmbeds` has to be
+ * present-and-empty rather than omitted, or a removed reference keeps its card.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { EventService, MessageRepository } from "../../src/features/messaging"
+import { MemoRepository } from "../../src/features/memos"
+import type { MessageCreatedPayload, MessageEditedPayload } from "../../src/features/messaging"
+import { userId, workspaceId, streamId, messageId, memoId } from "../../src/lib/id"
+import type { JSONContent } from "@threa/types"
+
+/** A body citing `memoIds`, as the composer and the markdown parser both build it. */
+function bodyCiting(text: string, memoIds: string[]): { contentJson: JSONContent; contentMarkdown: string } {
+  return {
+    contentJson: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text },
+            ...memoIds.map((memoId) => ({ type: "memoEmbed", attrs: { memoId, title: "Cited" } })),
+          ],
+        },
+      ],
+    },
+    contentMarkdown: `${text}${memoIds.map((id) => ` [Cited](memo:${id})`).join("")}`,
+  }
+}
+
+describe("memo embed summaries on message payloads", () => {
+  let pool: Pool
+  let eventService: EventService
+  let testWorkspaceId: string
+  let testUserId: string
+  let channel: string
+  let privateElsewhere: string
+  let sameStreamMemo: string
+  let unreachableMemo: string
+  let secondMemo: string
+  let sequence = 1n
+
+  async function seedMemo(sourceStreamId: string, title: string): Promise<string> {
+    const id = memoId()
+    const msgId = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id: msgId,
+        streamId: sourceStreamId,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: msgId,
+        title,
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [msgId],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: ["settings"],
+        status: "active",
+      })
+    })
+    return id
+  }
+
+  async function payloadOf(messageIdToFind: string, eventType: string): Promise<Record<string, unknown>> {
+    const events = await eventService.listEvents(channel, { limit: 200 })
+    const match = events.find(
+      (e) => e.eventType === eventType && (e.payload as { messageId?: string }).messageId === messageIdToFind
+    )
+    if (!match) throw new Error(`no ${eventType} event for ${messageIdToFind}`)
+    return match.payload as Record<string, unknown>
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    eventService = new EventService(pool)
+    testWorkspaceId = workspaceId()
+    testUserId = userId()
+    channel = streamId()
+    privateElsewhere = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Memo Embed Payloads",
+        slug: `memo-payloads-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      for (const id of [channel, privateElsewhere]) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: testWorkspaceId,
+          type: "channel",
+          visibility: "private",
+          slug: `s-${id.slice(-8)}`,
+          createdBy: testUserId,
+        })
+      }
+    })
+
+    sameStreamMemo = await seedMemo(channel, "Theme switch")
+    secondMemo = await seedMemo(channel, "Timezone change")
+    unreachableMemo = await seedMemo(privateElsewhere, "Acquisition target")
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("a created message carries the summary for a memo the room can read", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("see this", [sameStreamMemo]),
+    })
+
+    const payload = (await payloadOf(message.id, "message_created")) as MessageCreatedPayload
+    expect(payload.memoEmbeds).toEqual([
+      {
+        memoId: sameStreamMemo,
+        title: "Theme switch",
+        knowledgeType: "decision",
+        memoType: "message",
+        tags: ["settings"],
+        updatedAt: expect.any(String),
+      },
+    ])
+  })
+
+  test("a created message omits a memo the room cannot read", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("pasted from elsewhere", [unreachableMemo]),
+    })
+
+    const payload = (await payloadOf(message.id, "message_created")) as MessageCreatedPayload
+    expect(payload.memoEmbeds).toBeUndefined()
+  })
+
+  test("summaries follow the order the memos are cited in", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("both, and one nobody can read", [secondMemo, unreachableMemo, sameStreamMemo]),
+    })
+
+    const payload = (await payloadOf(message.id, "message_created")) as MessageCreatedPayload
+    expect(payload.memoEmbeds?.map((s) => s.memoId)).toEqual([secondMemo, sameStreamMemo])
+  })
+
+  test("an edit that adds a reference carries the new summary", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("nothing cited yet"),
+    })
+
+    await eventService.editMessage({
+      workspaceId: testWorkspaceId,
+      messageId: message.id,
+      streamId: channel,
+      actorId: testUserId,
+      ...bodyCiting("now with a memo", [sameStreamMemo]),
+    })
+
+    const payload = (await payloadOf(message.id, "message_edited")) as MessageEditedPayload
+    expect(payload.memoEmbeds.map((s) => s.memoId)).toEqual([sameStreamMemo])
+  })
+
+  // The spread-over-stored-payload trap: omitting the key would leave the card
+  // for a memo the body no longer mentions.
+  test("an edit that removes every reference carries an empty array, not nothing", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("cited", [sameStreamMemo]),
+    })
+
+    await eventService.editMessage({
+      workspaceId: testWorkspaceId,
+      messageId: message.id,
+      streamId: channel,
+      actorId: testUserId,
+      ...testMessageContent("no longer cited"),
+    })
+
+    const payload = (await payloadOf(message.id, "message_edited")) as MessageEditedPayload
+    expect(payload).toHaveProperty("memoEmbeds")
+    expect(payload.memoEmbeds).toEqual([])
+  })
+
+  describe("bootstrap enrichment", () => {
+    // `message_edited` is filtered out of a bootstrap response and the create
+    // payload is overlaid with current content, so without a refresh the window
+    // would describe the memos the message cited BEFORE the edit.
+    test("re-resolves an edited message's summaries against its current body", async () => {
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("first", [sameStreamMemo]),
+      })
+      await eventService.editMessage({
+        workspaceId: testWorkspaceId,
+        messageId: message.id,
+        streamId: channel,
+        actorId: testUserId,
+        ...bodyCiting("swapped", [secondMemo]),
+      })
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds?.map((s) => s.memoId)).toEqual([secondMemo])
+    })
+
+    test("clears the summaries when the edit dropped every reference", async () => {
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("cited", [sameStreamMemo]),
+      })
+      await eventService.editMessage({
+        workspaceId: testWorkspaceId,
+        messageId: message.id,
+        streamId: channel,
+        actorId: testUserId,
+        ...testMessageContent("dropped"),
+      })
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds).toEqual([])
+    })
+
+    test("leaves an unedited message's create-time summaries alone", async () => {
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+        authorId: testUserId,
+        authorType: "user",
+        ...bodyCiting("untouched", [sameStreamMemo]),
+      })
+
+      const events = await eventService.listEvents(channel, { limit: 200 })
+      const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+        workspaceId: testWorkspaceId,
+        streamId: channel,
+      })
+
+      const payload = enriched.find(
+        (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+      )?.payload as MessageCreatedPayload
+      expect(payload.memoEmbeds?.map((s) => s.memoId)).toEqual([sameStreamMemo])
+    })
+  })
+})


### PR DESCRIPTION
## Problem

C1 ([#1686](https://github.com/threahq/threa/pull/1686)) resolves which memos a room may see summarised. Nothing consumes it yet — the cards still fetch, which is what makes them change after paint.

## Solution

`memoEmbeds` on `message_created` and `message_edited`, written in the message's own transaction (INV-4/7) and resolved against the citing stream's **root** — a thread inherits its root's audience (INV-62), and the payload goes to that whole room.

Two asymmetries, both deliberate, both from the adversarial review:

- **The edit payload always carries the key, empty array included; the create payload omits it when empty.** The client applies an edit by *spreading* the payload over the stored one, so an omitted key leaves the pre-edit summaries in place — an edit that drops a reference would keep its card, and one that swaps references would render the wrong memo under the right link. There is nothing to overwrite on create, so absence is fine there.
- **Bootstrap re-resolves edited messages.** `enrichBootstrapEvents` filters `message_edited` out of the window *and* overlays the create payload with current content, so create-time summaries would describe the pre-edit body. One batch per window (INV-56), edited messages only, skipped entirely when a window has none.

`listEvents` is deliberately left alone: it serves historical payload content without the projection overlay, so its create-time summaries already match the body beside them. Enrichment placed there would scan the *current* body and pair it with the *old* content — the mismatch this chunk exists to avoid, inverted.

**Sealed streams need no branch.** An E2E message stores `E2E_PLACEHOLDER_CONTENT_MARKDOWN` and placeholder JSON, so no ids are collected, no summary is written, and the card renders the label from the reference and stays there. That is the designed floor for every path that cannot produce a summary — it does not fall back to a fetch.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/memos/embed-summaries.ts` | **new** — shared resolve, document order, used by both write paths |
| `apps/backend/src/features/messaging/event-service.ts` | payload fields; create + edit writes; `refreshEditedMemoEmbeds` for bootstrap |
| `apps/backend/src/features/streams/handlers.ts` | pass the workspace/stream scope at both bootstrap sites |
| `apps/backend/tests/integration/memo-embed-payloads.test.ts` | **new** — create, edit, and bootstrap behaviour |

## Test plan

- [x] **Integration — 11 pass.** Create with a readable memo, create with an unreadable one, citation order across a mixed set, edit that adds, edit that removes, bootstrap after a swap, bootstrap after a removal, bootstrap leaving an unedited message alone, bootstrap resolving a pre-summaries row (legacy payload stripped via SQL), bootstrap leaving an unreachable-only citation without the key, bootstrap re-resolving an unedited message (retitle heals cold), bootstrap retracting a stored summary after the source stream goes private.
- [x] `apps/backend` unit **3833 pass** · integration **776 pass** · `bun run typecheck` 0 · `bun run lint` 0
- [x] **Mutation-checked.** Reverting the edit payload to omit-when-empty reddens "carries an empty array, not nothing". Removing the bootstrap refresh reddens both edit-then-bootstrap cases and leaves the unedited case green. Killing the legacy filter reddens only the pre-summaries case; dropping the empty-skip reddens only the unreachable-only case; reverting to trust-stored-summaries reddens exactly the retitle and retraction cases.
- [ ] The frontend still fetches; nothing reads these fields yet. C4 consumes them and deletes the query.

**Also here:** bootstrap enrichment re-resolves EVERY citing message against the predicate as of the read — a stored summary is a snapshot of a past access decision, and a Sol adversarial pass showed that trusting it (a) freshly delivers withheld content after the memo's source goes private, and (b) freezes retitles and raced first-citations into the payload forever. A stored `memoEmbeds` key forces even an empty resolution through, which is the retraction; a keyless message gains the field only when something resolves (pre-summaries rows heal, unreachable-only citations stay keyless). IDB-warm clients keep their stored payload until the next cold read.

## Notes for the stack

Sits on #1686 (the resolver) → #1681 (card geometry). Design: https://seer.build/ws_vbyzjvdg6g/b/memo-cards-scope-d842fe/ (v3)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
